### PR TITLE
UX: remove alias from chat direct message channel titles

### DIFF
--- a/plugins/chat/app/models/chat/direct_message.rb
+++ b/plugins/chat/app/models/chat/direct_message.rb
@@ -67,7 +67,7 @@ module Chat
           if prefers_name
             users.map { |u| u.name.presence || u.username }.sort_by { |name| name[1..-1] }
           else
-            users.sort_by(&:username).map { |u| u.username }
+            users.map(&:username).sort
           end
         )
 

--- a/plugins/chat/app/models/chat/direct_message.rb
+++ b/plugins/chat/app/models/chat/direct_message.rb
@@ -50,9 +50,9 @@ module Chat
             username:
               (
                 if prefers_name
-                  acting_user.name.presence || "@#{acting_user.username}"
+                  acting_user.name.presence || acting_user.username
                 else
-                  "@#{acting_user.username}"
+                  acting_user.username
                 end
               ),
           )
@@ -65,9 +65,9 @@ module Chat
       formatted_names =
         (
           if prefers_name
-            users.map { |u| u.name.presence || "@#{u.username}" }.sort_by { |name| name[1..-1] }
+            users.map { |u| u.name.presence || u.username }.sort_by { |name| name[1..-1] }
           else
-            users.sort_by(&:username).map { |u| "@#{u.username}" }
+            users.sort_by(&:username).map { |u| u.username }
           end
         )
 

--- a/plugins/chat/spec/models/chat/direct_message_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_spec.rb
@@ -19,7 +19,7 @@ describe Chat::DirectMessage do
         I18n.t(
           "chat.channel.dm_title.multi_user",
           comma_separated_usernames:
-            [user3, user2].map { |u| "@#{u.username}" }.join(I18n.t("word_connector.comma")),
+            [user3, user2].map { |u| u.username }.join(I18n.t("word_connector.comma")),
         ),
       )
     end
@@ -38,7 +38,7 @@ describe Chat::DirectMessage do
           comma_separated_usernames:
             users[1..6]
               .sort_by(&:username)
-              .map { |u| "@#{u.username}" }
+              .map { |u| u.username }
               .join(I18n.t("word_connector.comma")),
           count: 2,
         ),
@@ -49,7 +49,7 @@ describe Chat::DirectMessage do
       direct_message = Fabricate(:direct_message, users: [user1, user2])
 
       expect(direct_message.chat_channel_title_for_user(chat_channel, user1)).to eq(
-        I18n.t("chat.channel.dm_title.single_user", username: "@#{user2.username}"),
+        I18n.t("chat.channel.dm_title.single_user", username: user2.username),
       )
     end
 
@@ -57,7 +57,7 @@ describe Chat::DirectMessage do
       direct_message = Fabricate(:direct_message, users: [user1])
 
       expect(direct_message.chat_channel_title_for_user(chat_channel, user1)).to eq(
-        I18n.t("chat.channel.dm_title.single_user", username: "@#{user1.username}"),
+        I18n.t("chat.channel.dm_title.single_user", username: user1.username),
       )
     end
 
@@ -68,7 +68,7 @@ describe Chat::DirectMessage do
         direct_message.reload
 
         expect(direct_message.chat_channel_title_for_user(chat_channel, user1)).to eq(
-          "@#{I18n.t("chat.deleted_chat_username")}",
+          I18n.t("chat.deleted_chat_username"),
         )
       end
     end
@@ -112,7 +112,7 @@ describe Chat::DirectMessage do
         expect(direct_message.chat_channel_title_for_user(chat_channel, user1)).to eq(
           I18n.t(
             "chat.channel.dm_title.multi_user",
-            comma_separated_usernames: ["@#{user2.username}", new_user.name].join(
+            comma_separated_usernames: [user2.username, new_user.name].join(
               I18n.t("word_connector.comma"),
             ),
           ),

--- a/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
+++ b/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Sidebar navigation menu", type: :system do
         visit("/")
 
         expect(sidebar_page.dms_section.find(".channel-#{dm_channel_1.id}")["title"]).to eq(
-          "Chat with @&lt;script&gt;alert(&#x27;hello&#x27;)&lt;/script&gt;",
+          "Chat with &lt;script&gt;alert(&#x27;hello&#x27;)&lt;/script&gt;",
         )
       end
     end


### PR DESCRIPTION
Makes usernames in Chat Direct Message channels consistent with other areas of the app by removing the alias.

Before:
<img width="394" alt="Screenshot 2024-09-18 at 12 47 25 PM" src="https://github.com/user-attachments/assets/59b2d4d3-a770-4219-8cc9-228f9fb3a9a6">


After: 
<img width="396" alt="Screenshot 2024-09-18 at 12 46 15 PM" src="https://github.com/user-attachments/assets/79f963b7-5d8f-4e89-b36f-9e9cf0b403dd">
