### PR TITLE
FIX: .badge-posts alignment on mobile glimmer topic list

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -359,7 +359,8 @@ td .main-link {
   .num.posts-map {
     font-size: var(--font-up-2);
     padding: 0;
-    button {
+    > button,
+    > a {
       padding: 0;
     }
   }


### PR DESCRIPTION
Regressed in 3eada7b572a4b6c015e98d96e6b7815221ab9bd3

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->