### PR TITLE
DEV: add topic-list-after-columns outlet to mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/mobile/list/topic-list-item.hbr
@@ -58,4 +58,5 @@
         </span>
       </div>
   </div>
+  {{~raw-plugin-outlet name="topic-list-after-columns"}}
 </td>


### PR DESCRIPTION
We've already got the sibling outlet `topic-list-before-columns` here, so this adds the after equivalent too (using this in a theme component refactor) 