### PR TITLE
DEV: Fix failing system tests

### DIFF
--- a/plugins/discourse-narrative-bot/spec/system/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/system/user_spec.rb
@@ -11,12 +11,14 @@ describe "Narrative Bot PM", type: :system do
       Jobs.run_immediately!
       SiteSetting.enable_user_tips = true
       SiteSetting.discourse_narrative_bot_enabled = true
-      # shortcut to generate welcome post since we're not going through user creation or first login
-      user.enqueue_bot_welcome_post
     end
 
     it "does not delete the narrative bot PM when skipping all tips" do
       sign_in user
+
+      # shortcut to generate welcome post since we're not going through user creation or first login
+      user.enqueue_bot_welcome_post
+
       visit "/"
 
       tooltip = PageObjects::Components::Tooltips.new("user-tip")


### PR DESCRIPTION
We are seeing the following error on CI:

```
Errno::EADDRNOTAVAIL:
  Failed to open TCP connection to localhost:31337 (Cannot assign requested address - connect(2) for "localhost" port 31337)
```

This is because the job being enqueued makes a HTTP request to the Rails
server but Capybara doesn't start the Rails server until a session is
actually required. Therefore, we need to enqueue the job after we are
sure that a session has been started.
