### PR TITLE
DEV: Remove FileStore#download deprecation warning

### DIFF
--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -105,12 +105,6 @@ module FileStore
     end
 
     def download(object, max_file_size_kb: nil, print_deprecation: true)
-      Discourse.deprecate(<<~MESSAGE) if print_deprecation
-          In a future version `FileStore#download` will no longer raise an error when the
-          download fails, and will instead return `nil`. If you need a method that raises
-          an error, use `FileStore#download!`, which raises a `FileStore::DownloadError`.
-        MESSAGE
-
       DistributedMutex.synchronize("download_#{object.sha1}", validity: 3.minutes) do
         extension =
           File.extname(


### PR DESCRIPTION
### What is this change?

At a point we split `FileStore#download` into two methods, one which returns `nil` (`#download`) and one which raises an exception (`#download!`) if there's a download error.

When we did this we added a deprecation warning to the `#download` method.

It has now been over a year and I have checked all relevant internal cases, so I think it's about time we remove this warning.