### PR TITLE
FIX: Don’t raise on some search terms

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -228,7 +228,7 @@ class Search
 
   def self.need_segmenting?(data)
     return false if data.match?(/\A\d+\z/)
-    !URI.parse(data).path.start_with?("/")
+    !URI.parse(data).path.to_s.start_with?("/")
   rescue URI::InvalidURIError
     true
   end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Search do
         it { is_expected.not_to be_need_segmenting(data) }
       end
 
+      context "when data makes `URI#path` return `nil`" do
+        let(:data) { "in:solved%20category:50%20order:likes" }
+
+        it "doesn’t raise an error" do
+          expect { search.need_segmenting?(data) }.not_to raise_error
+        end
+      end
+
       context "when data is something else" do
         let(:data) { "text" }
 


### PR DESCRIPTION
Currently, when certain search terms are provided, this can lead to `Search.need_segmenting?` raising an error because it makes `URI#path` to return `nil` instead of a string.

This PR forces a cast to string so it won’t raise anymore.
