### PR TITLE
UX: Add label for delete own post button in review queue

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -73,7 +73,9 @@ class ReviewableQueuedPost < Reviewable
       end
     end
 
-    actions.add(:delete) if guardian.can_delete?(self)
+    actions.add(:delete) do |a|
+      a.label = "reviewables.actions.delete_single.title"
+    end if guardian.can_delete?(self)
   end
 
   def build_editable_fields(fields, guardian, args)


### PR DESCRIPTION
this adds a missing button label when a category moderator can delete their own queued post, reported here: https://meta.discourse.org/t/review-queue-displays-translation-missing-button/327651

Before:
![image](https://github.com/user-attachments/assets/5d1da400-84d9-4697-887f-060d9e706003)


After:
![image](https://github.com/user-attachments/assets/2e078c65-d080-4f15-965b-ea341d3bac6b)
