### PR TITLE
FIX: permanent delete of posts by deleted users

### DIFF
--- a/app/services/user_action_manager.rb
+++ b/app/services/user_action_manager.rb
@@ -60,8 +60,8 @@ class UserActionManager
   end
 
   def self.post_rows(post)
-    # first post gets nada
-    return [] if post.is_first_post? || post.topic.blank?
+    # first post gets nada or if the author has been deleted
+    return [] if post.is_first_post? || post.topic.blank? || post.user.blank?
 
     row = {
       action_type: UserAction::REPLY,

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1145,6 +1145,15 @@ RSpec.describe PostDestroyer do
       expect { regular_post.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "destroys the post when force_destroy is true for posts by deleted users" do
+      regular_post = Fabricate(:post, post_number: 2)
+      UserDestroyer.new(admin).destroy(regular_post.user, delete_posts: true)
+      regular_post.reload
+
+      PostDestroyer.new(moderator, regular_post, force_destroy: true).destroy
+      expect { regular_post.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 
   describe "publishes messages to subscribers" do


### PR DESCRIPTION
Permanently deleting posts that no longer have a user associated was not working as expected because of UserAction.log which expected user_id to be present.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->