### PR TITLE
Fix nginx Warnung: duplicate extension wasm

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -1,7 +1,6 @@
 # Additional MIME types that you'd like nginx to handle go in here
 types {
     text/csv csv;
-    application/wasm wasm;
 }
 
 upstream discourse {


### PR DESCRIPTION
this small fix fixes the warning message in nginx