### PR TITLE
FEAT: Allow admin delete user's associated accounts

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -321,18 +321,11 @@ export default class AdminUserIndexController extends Controller.extend(
 
   @action
   deleteAssociatedAccounts() {
-    const performDelete = () => {
-      this.model
-        .deleteAssociatedAccounts()
-        .then(() => {
-          this.model.set("associated_accounts", []);
-        })
-        .catch(popupAjaxError);
-    };
-
     this.dialog.yesNoConfirm({
       message: I18n.t("admin.user.delete_associated_accounts_confirm"),
-      didConfirm: () => performDelete(),
+      didConfirm: () => {
+        this.model.deleteAssociatedAccounts().catch(popupAjaxError);
+      },
     });
   }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -78,8 +78,8 @@ export default class AdminUserIndexController extends Controller.extend(
   @discourseComputed("model.associated_accounts")
   associatedAccounts(associatedAccounts) {
     return associatedAccounts
-      .map((provider) => `${provider.name} (${provider.description})`)
-      .join(", ");
+      ?.map((provider) => `${provider.name} (${provider.description})`)
+      ?.join(", ");
   }
 
   @discourseComputed("model.user_fields.[]")
@@ -317,6 +317,23 @@ export default class AdminUserIndexController extends Controller.extend(
   @action
   silence() {
     return this.model.silence();
+  }
+
+  @action
+  deleteAssociatedAccounts() {
+    const performDelete = () => {
+      this.model
+        .deleteAssociatedAccounts()
+        .then(() => {
+          this.model.set("associated_accounts", []);
+        })
+        .catch(popupAjaxError);
+    };
+
+    this.dialog.yesNoConfirm({
+      message: I18n.t("admin.user.delete_associated_accounts_confirm"),
+      didConfirm: () => performDelete(),
+    });
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -287,6 +287,15 @@ export default class AdminUser extends User {
     });
   }
 
+  deleteAssociatedAccounts() {
+    return ajax(`/admin/users/${this.id}/delete_associated_accounts`, {
+      type: "PUT",
+      data: {
+        context: window.location.pathname,
+      },
+    });
+  }
+
   destroy(formData) {
     return ajax(`/admin/users/${this.id}.json`, {
       type: "DELETE",

--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -293,6 +293,8 @@ export default class AdminUser extends User {
       data: {
         context: window.location.pathname,
       },
+    }).then(() => {
+      this.set("associated_accounts", []);
     });
   }
 

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -157,6 +157,17 @@
           />
         {{/if}}
       </div>
+      {{#if (and this.currentUser.admin this.associatedAccounts)}}
+        <div class="controls">
+          <DButton
+            @action={{this.deleteAssociatedAccounts}}
+            @icon="trash-can"
+            @label="admin.users.delete_associated_accounts.text"
+            @title="admin.users.delete_associated_accounts.title"
+            class="btn-danger"
+          />
+        </div>
+      {{/if}}
     </div>
   {{/if}}
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -529,12 +529,12 @@ class Admin::UsersController < Admin::StaffController
           }.to_s
         end
         .join(",")
-    StaffActionLogger.new(current_user).log_delele_associated_accounts(
+    StaffActionLogger.new(current_user).log_delete_associated_accounts(
       @user,
       previous_value:,
       context: params[:context],
     )
-    @user.user_associated_accounts.destroy_all
+    @user.user_associated_accounts.delete_all
     render json: success_json
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,6 +26,7 @@ class Admin::UsersController < Admin::StaffController
                   disable_second_factor
                   delete_posts_batch
                   sso_record
+                  delete_associated_accounts
                 ]
 
   def index
@@ -511,6 +512,29 @@ class Admin::UsersController < Admin::StaffController
   def sso_record
     guardian.ensure_can_delete_sso_record!(@user)
     @user.single_sign_on_record.destroy!
+    render json: success_json
+  end
+
+  def delete_associated_accounts
+    guardian.ensure_can_delete_user_associated_accounts!(@user)
+    previous_value =
+      @user
+        .user_associated_accounts
+        .select(:provider_name, :provider_uid, :info)
+        .map do |associated_account|
+          {
+            provider: associated_account.provider_name,
+            uid: associated_account.provider_uid,
+            info: associated_account.info,
+          }.to_s
+        end
+        .join(",")
+    StaffActionLogger.new(current_user).log_delele_associated_accounts(
+      @user,
+      previous_value:,
+      context: params[:context],
+    )
+    @user.user_associated_accounts.destroy_all
     render json: success_json
   end
 

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -155,7 +155,7 @@ class UserHistory < ActiveRecord::Base
         tag_group_create: 116,
         tag_group_destroy: 117,
         tag_group_change: 118,
-        delele_associated_accounts: 119,
+        delete_associated_accounts: 119,
       )
   end
 
@@ -273,7 +273,7 @@ class UserHistory < ActiveRecord::Base
       tag_group_create
       tag_group_destroy
       tag_group_change
-      delele_associated_accounts
+      delete_associated_accounts
     ]
   end
 

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -155,6 +155,7 @@ class UserHistory < ActiveRecord::Base
         tag_group_create: 116,
         tag_group_destroy: 117,
         tag_group_change: 118,
+        delele_associated_accounts: 119,
       )
   end
 
@@ -272,6 +273,7 @@ class UserHistory < ActiveRecord::Base
       tag_group_create
       tag_group_destroy
       tag_group_change
+      delele_associated_accounts
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -1079,6 +1079,17 @@ class StaffActionLogger
     )
   end
 
+  def log_delele_associated_accounts(user, previous_value:, context:)
+    UserHistory.create!(
+      params.merge(
+        action: UserHistory.actions[:delele_associated_accounts],
+        target_user_id: user.id,
+        previous_value:,
+        context:,
+      ),
+    )
+  end
+
   private
 
   def json_params(previous_value, new_value)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -1079,10 +1079,10 @@ class StaffActionLogger
     )
   end
 
-  def log_delele_associated_accounts(user, previous_value:, context:)
+  def log_delete_associated_accounts(user, previous_value:, context:)
     UserHistory.create!(
       params.merge(
-        action: UserHistory.actions[:delele_associated_accounts],
+        action: UserHistory.actions[:delete_associated_accounts],
         target_user_id: user.id,
         previous_value:,
         context:,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6345,7 +6345,7 @@ en:
             tag_group_create: "create tag group"
             tag_group_destroy: "delete tag group"
             tag_group_change: "change tag group"
-            delele_associated_accounts: "delete associated accounts"
+            delete_associated_accounts: "delete associated accounts"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6345,6 +6345,7 @@ en:
             tag_group_create: "create tag group"
             tag_group_destroy: "delete tag group"
             tag_group_change: "change tag group"
+            delele_associated_accounts: "delete associated accounts"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."
@@ -6574,6 +6575,9 @@ en:
         check_sso:
           title: "Reveal SSO payload"
           text: "Show"
+        delete_associated_accounts:
+          title: "Delete all associated accounts for this user"
+          text: "Delete associated accounts"
 
       user:
         suspend_failed: "Something went wrong suspending this user %{error}"
@@ -6691,6 +6695,7 @@ en:
         post_edits_count: "Post Edits"
         anonymize: "Anonymize User"
         anonymize_confirm: "Are you SURE you want to anonymize this account? This will change the username and email, and reset all profile information."
+        delete_associated_accounts_confirm: "Are you SURE you want to delete associated accounts from this account? They may not be able to log in."
         anonymize_yes: "Yes, anonymize this account"
         anonymize_failed: "There was a problem anonymizing the account."
         delete: "Delete User"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Discourse::Application.routes.draw do
         put "disable_second_factor"
         delete "sso_record"
         get "similar-users.json" => "users#similar_users"
+        put "delete_associated_accounts"
       end
       get "users/:id.json" => "users#show", :defaults => { format: "json" }
       get "users/:id/:username" => "users#show",

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -204,6 +204,10 @@ module UserGuardian
     SiteSetting.enable_discourse_connect && user && is_admin?
   end
 
+  def can_delete_user_associated_accounts?(user)
+    user && is_admin?
+  end
+
   def can_change_tracking_preferences?(user)
     (SiteSetting.allow_changing_staged_user_tracking || !user.staged) && can_edit_user?(user)
   end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2440,6 +2440,58 @@ RSpec.describe Admin::UsersController do
     end
   end
 
+  describe "#delete_associated_accounts" do
+    fab!(:user_associated_accounts) do
+      UserAssociatedAccount.create!(
+        provider_name: "github",
+        provider_uid: "123456789",
+        user_id: user.id,
+        last_used: 1.seconds.ago,
+      )
+    end
+
+    context "when logged in as an admin" do
+      before { sign_in(admin) }
+
+      it "deletes the record and logs the deletion" do
+        put "/admin/users/#{user.id}/delete_associated_accounts.json"
+
+        expect(response.status).to eq(200)
+        expect(user.user_associated_accounts).to eq([])
+        expect(UserHistory.last).to have_attributes(
+          acting_user_id: admin.id,
+          target_user_id: user.id,
+          action: UserHistory.actions[:delele_associated_accounts],
+        )
+        expect(UserHistory.last.previous_value).to include(':uid=>"123456789"')
+      end
+    end
+
+    context "when logged in as a moderator" do
+      before { sign_in(moderator) }
+
+      it "prevents deletion of associated accounts with a 403 response" do
+        put "/admin/users/#{user.id}/delete_associated_accounts.json"
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(user.user_associated_accounts).to be_present
+      end
+    end
+
+    context "when logged in as a non-staff user" do
+      before { sign_in(user) }
+
+      it "prevents deletion of associated accounts with a 404 response" do
+        put "/admin/users/#{user.id}/delete_associated_accounts.json"
+
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
+        expect(user.user_associated_accounts).to be_present
+      end
+    end
+  end
+
   describe "#anonymize" do
     shared_examples "user anonymization possible" do
       it "will make the user anonymous" do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2461,7 +2461,7 @@ RSpec.describe Admin::UsersController do
         expect(UserHistory.last).to have_attributes(
           acting_user_id: admin.id,
           target_user_id: user.id,
-          action: UserHistory.actions[:delele_associated_accounts],
+          action: UserHistory.actions[:delete_associated_accounts],
         )
         expect(UserHistory.last.previous_value).to include(':uid=>"123456789"')
       end


### PR DESCRIPTION
This commit introduces a feature that allows an admin to delete a user's associated account. After deletion, a log will be recorded in staff actions.

ref=t/136675

## Screenshots
![image](https://github.com/user-attachments/assets/c794e482-437b-44df-a5b8-8dcda649c4d0)
![image](https://github.com/user-attachments/assets/8ce2b296-6891-436c-963e-9295fc15b45e)
![image](https://github.com/user-attachments/assets/73278b9e-254b-4740-847a-e89b373ddf60)

Log:
![image](https://github.com/user-attachments/assets/814a1e8b-4884-48db-8704-a9a6b35b339f)




<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->