### PR TITLE
FIX: Fix broken client-side review actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -49,7 +49,7 @@ export default class ReviewableItem extends Component {
   @service siteSettings;
   @service currentUser;
   @service composer;
-  @optionalService adminTools;
+  @optionalService("admin-tools") adminTools;
 
   updating = null;
   editing = false;

--- a/spec/fabricators/reviewable_fabricator.rb
+++ b/spec/fabricators/reviewable_fabricator.rb
@@ -96,6 +96,7 @@ Fabricator(:reviewable_flagged_post) do
   reviewable_by_moderator true
   type "ReviewableFlaggedPost"
   created_by { Fabricate(:user) }
+  target_created_by { Fabricate(:user) }
   topic
   target_type "Post"
   target { Fabricate(:post) }

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -54,6 +54,21 @@ describe "Reviewables", type: :system do
         expect(composer).to be_opened
         expect(composer.composer_input.value).to eq(post.raw)
       end
+
+      it "should open a modal when suspending a user" do
+        visit("/review")
+
+        select_kit =
+          PageObjects::Components::SelectKit.new(".dropdown-select-box.post-agree-and-hide")
+        select_kit.expand
+
+        select_kit.select_row_by_value("post-agree_and_suspend")
+
+        expect(review_page).to have_css(
+          "#discourse-modal-title",
+          text: I18n.t("js.flagging.take_action_options.suspend.title"),
+        )
+      end
     end
   end
 


### PR DESCRIPTION
### What is the problem?

After #28603, the options "agree and suspend" and "agree and silence" in the review queue weren't working. This was happening because the `optionalService`, when used as a decorator, needs a name argument to work properly. We were also lacking tests for this.

### How does this fix it?

Provide a name to the `optionalService` decorator, which fixes the issue, and add a system test to prevent regressions.