### PR TITLE
FIX: Unscoped plugin config page actions outlet

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
@@ -24,6 +24,10 @@ export default class AdminPluginConfigPage extends Component {
     return classes.join(" ");
   }
 
+  get actionsOutletName() {
+    return `admin-plugin-config-page-actions-${this.args.plugin.kebabCaseName}`;
+  }
+
   linkText(navLink) {
     if (navLink.label) {
       return i18n(navLink.label);
@@ -68,10 +72,12 @@ export default class AdminPluginConfigPage extends Component {
           {{/if}}
         </:tabs>
         <:actions as |actions|>
-          <PluginOutlet
-            @name="admin-plugin-config-page-actions"
-            @outletArgs={{hash plugin=@plugin actions=actions}}
-          />
+          <div class={{this.actionsOutletName}}>
+            <PluginOutlet
+              @name={{this.actionsOutletName}}
+              @outletArgs={{hash plugin=@plugin actions=actions}}
+            />
+          </div>
         </:actions>
       </AdminPageHeader>
 

--- a/app/assets/javascripts/admin/addon/models/admin-plugin.js
+++ b/app/assets/javascripts/admin/addon/models/admin-plugin.js
@@ -24,6 +24,10 @@ export default class AdminPlugin {
     return this.name.replaceAll("-", "_");
   }
 
+  get kebabCaseName() {
+    return this.name.replaceAll(" ", "-").replaceAll("_", "-");
+  }
+
   get translatedCategoryName() {
     // We do this because the site setting list is grouped by category,
     // with plugins that have their root site setting key defined as `plugins:`

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
@@ -20,7 +20,7 @@ export default {
       ]);
 
       api.renderInOutlet(
-        "admin-plugin-config-page-actions",
+        "admin-plugin-config-page-actions-chat",
         ChatAdminPluginActions
       );
     });


### PR DESCRIPTION
In 61c1d35f17468b3666c966839da911d9f96dad19 I added a
PluginOutlet to AdminPluginConfigPage. This was intended to be
used as a way to render actions buttons inside the header of
a plugin that has a custom admin UI page. This worked, but
since the outlet was generically named, as soon as one plugin
used it the button would show on all plugins.

This fixes the immediate issue by naming the outlet based
on the plugin, then having each plugin specify their own
outlet to render into. There may be a nicer way to do this,
but for now this stops the bleeding.
