### PR TITLE
UX: Minor admin mobile fixes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-filtered-site-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-filtered-site-settings.gjs
@@ -61,7 +61,7 @@ export default class AdminFilteredSiteSettings extends Component {
     />
 
     <ConditionalLoadingSpinner @condition={{this.loading}}>
-      <section class="form-horizontal settings">
+      <section class="admin-filtered-site-settings form-horizontal settings">
         {{#each this.visibleSettings as |setting|}}
           <SiteSetting @setting={{setting}} />
         {{/each}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -1083,6 +1083,7 @@ a.inline-editable-field {
 @import "common/admin/api";
 @import "common/admin/backups";
 @import "common/admin/plugins";
+@import "common/admin/site-settings";
 @import "common/admin/admin_config_area";
 @import "common/admin/admin_reports";
 @import "common/admin/admin_report";

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -10,13 +10,13 @@
   .admin-plugins-list {
     @media screen and (min-width: 550px) {
       .admin-plugins-list__row {
-        grid-template-columns: 0.25fr repeat(4, 1fr);
+        grid-template-columns: 0fr repeat(4, 1fr);
       }
     }
 
     @include breakpoint(mobile-extra-large) {
       .admin-plugins-list__row {
-        grid-template-columns: 0.25fr repeat(3, 1fr);
+        grid-template-columns: 0fr repeat(3, 1fr);
       }
 
       .admin-plugins-list {
@@ -175,16 +175,6 @@
 }
 
 .admin-plugin-config-area {
-  &__settings {
-    .admin-site-settings-filter-controls {
-      margin-bottom: 1em;
-    }
-
-    .setting-label {
-      margin-left: 18px;
-    }
-  }
-
   &__empty-list {
     padding: 1em;
     border: 1px solid var(--primary-low);

--- a/app/assets/stylesheets/common/admin/site-settings.scss
+++ b/app/assets/stylesheets/common/admin/site-settings.scss
@@ -1,0 +1,25 @@
+.admin-controls.admin-site-settings-filter-controls
+  .controls
+  .admin-site-settings-filter-controls__input {
+  max-width: 300px;
+}
+
+.admin-controls.admin-site-settings-filter-controls .menu-toggle {
+  margin-left: 0.5em;
+}
+
+.admin-plugin-config-area {
+  &__settings {
+    .admin-site-settings-filter-controls {
+      margin-bottom: 1em;
+    }
+
+    .admin-filtered-site-settings {
+      padding: 0.5em 1em;
+    }
+
+    .setting-label {
+      margin-left: 18px;
+    }
+  }
+}


### PR DESCRIPTION
* Fixes big gap at the left of the plugins list.
* Fixes plugin settings list padding, the yellow overridden
  dot was cut off on mobile.
* Also increased settings filter input size and settings
  sidebar button margin.


Before

![image](https://github.com/user-attachments/assets/ee6c711c-9628-454f-a013-4792df7d74ad)
![image](https://github.com/user-attachments/assets/12660056-9173-4583-b77d-eb2927abe6ed)
![image](https://github.com/user-attachments/assets/aab6a69c-e388-4c62-9547-297adba587de)

After

![image](https://github.com/user-attachments/assets/372f61e3-860a-4661-a05a-283de7942869)
![image](https://github.com/user-attachments/assets/c5081497-f9b7-4f35-a983-bb2743b2874f)
![image](https://github.com/user-attachments/assets/3dd13e2e-9f3b-4004-864d-b92500bd22b7)

