### PR TITLE
FIX: skips caching a generated secret key base token if `skip_redis` is true.

### DIFF
--- a/spec/models/global_setting_spec.rb
+++ b/spec/models/global_setting_spec.rb
@@ -46,6 +46,22 @@ RSpec.describe GlobalSetting do
       new_token = Discourse.redis.without_namespace.get(GlobalSetting::REDIS_SECRET_KEY)
       expect(new_token).to eq(token)
     end
+
+    context "when a secret key is not provided and redis is not used" do
+      before do
+        GlobalSetting.skip_redis = true
+        GlobalSetting.stubs(:secret_key_base).returns("")
+        # Fail tests if redis calls are made
+        Discourse.stubs(:redis).returns(nil)
+      end
+
+      it "generates a new random key in memory without redis" do
+        GlobalSetting.reset_secret_key_base!
+        token = GlobalSetting.safe_secret_key_base
+        new_token = GlobalSetting.safe_secret_key_base
+        expect(new_token).to eq(token)
+      end
+    end
   end
 
   describe ".add_default" do


### PR DESCRIPTION
Allows for `SKIP_DB_AND_REDIS` env var to be used without a secret key setup in global setting env.

Currently if secret key is unset, this results in errors such as the following despite `SKIP_DB_AND_REDIS` being set:

```
Redis::CannotConnectError: Error connecting to Redis on localhost:6379 (Errno::ECONNREFUSED) (Redis::CannotConnectError)
/Users/jwong/discourse/app/models/global_setting.rb:41:in `safe_secret_key_base'
/Users/jwong/discourse/config/initializers/100-secret_token.rb:6:in `<main>'
/Users/jwong/discourse/config/environment.rb:7:in `<main>'
...
```