### PR TITLE
FIX: create an automation with forced_triggerable enabled

### DIFF
--- a/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
@@ -29,7 +29,7 @@ module DiscourseAutomation
         )
 
       if automation.scriptable&.forced_triggerable
-        automation.trigger = scriptable.forced_triggerable[:triggerable].to_s
+        automation.trigger = automation.scriptable.forced_triggerable[:triggerable].to_s
       end
 
       automation.save!

--- a/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
+++ b/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
@@ -48,6 +48,48 @@ describe DiscourseAutomation::AdminAutomationsController do
     end
   end
 
+  describe "#create" do
+    let(:script) { "forced_triggerable" }
+
+    before do
+      DiscourseAutomation::Scriptable.add(script) do
+        triggerable! :recurring, { recurrence: { interval: 1, frequency: "day" } }
+      end
+    end
+
+    after { DiscourseAutomation::Scriptable.remove(script) }
+
+    context "when logged in as an admin" do
+      before { sign_in(Fabricate(:admin)) }
+
+      it "creates the 'forced triggerable' automation" do
+        post "/admin/plugins/discourse-automation/automations.json",
+             params: {
+               automation: {
+                 name: "foobar",
+                 script:,
+               },
+             }
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when logged in as a regular user" do
+      before { sign_in(Fabricate(:user)) }
+
+      it "raises a 404" do
+        post "/admin/plugins/discourse-automation/automations.json",
+             params: {
+               automation: {
+                 name: "foobar",
+                 script:,
+               },
+             }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   describe "#update" do
     context "when logged in as an admin" do
       before { sign_in(Fabricate(:admin)) }


### PR DESCRIPTION
When trying to create a new automation based on a scriptable that has "force_triggerable" enable, it would break because of a typo in the code.

This fixes the typo and add a spec to ensure this code path is tested.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->