### PR TITLE
DEV: update compile steps

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -61,10 +61,6 @@ task "assets:precompile:before": %w[
   STDERR.puts "Purging temp files"
   `rm -fr #{Rails.root}/tmp/cache`
 
-  # Ensure we clear emoji cache before pretty-text/emoji/data.js.es6.erb
-  # is recompiled
-  Emoji.clear_cache
-
   $node_compress = !ENV["SKIP_NODE_UGLIFY"]
 
   unless ENV["USE_SPROCKETS_UGLIFY"]
@@ -96,7 +92,7 @@ task "assets:precompile:css" => "environment" do
   # cause CSS uses asset_path
   Rails.application.assets_manifest.reload
 
-  if ENV["DONT_PRECOMPILE_CSS"] == "1"
+  if ENV["DONT_PRECOMPILE_CSS"] == "1" || ENV["SKIP_DB_AND_REDIS"] == "1"
     STDERR.puts "Skipping CSS precompilation, ensure CSS lives in a shared directory across hosts"
   else
     STDERR.puts "Start compiling CSS: #{Time.zone.now}"


### PR DESCRIPTION
Remove emoji.clear cache calls as data.js.es6.erb hasn't existed in a while. Emoji data is now compiled separately via javascript rake tasks. Would like confirmation but this call seems generally unnecessary here and I'd like to revisit removing this.

skip precompiling of css if db and redis are skipped.

I'm fairly sure in this way we'll be able to run `SKIP_DB_AND_REDIS=1 bundle exec rake assets:precompile` and it'll be able to build most assets, no db connection required.

`asset:compile:css` would be the only asset task missing after the above call, and it is very quick to do relative to the rest of the build.