### PR TITLE
UX: prevent user stream title from overflowing page

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -33,6 +33,10 @@
 
   .user-stream-item__details {
     flex-grow: 1;
+    min-width: 0;
+    .badge-category__wrapper {
+      width: 100%;
+    }
   }
 
   .stream-topic-title {


### PR DESCRIPTION
In some cases the category badge could overflow the page and create horizontal scroll, this fixes it! 


before:
![image](https://github.com/user-attachments/assets/f4150f08-f485-4d36-9892-9679d34d7e05)


after:
![image](https://github.com/user-attachments/assets/48b1831a-9417-4ab4-a39a-ad653769576a)
