### PR TITLE
FIX: flaky flags system spec

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
@@ -96,20 +96,26 @@ export default class AdminFlagItem extends Component {
   @action
   delete() {
     this.isSaved = false;
-    this.dialog.yesNoConfirm({
+    return this.dialog.yesNoConfirm({
       message: i18n("admin.config_areas.flags.delete_confirm", {
         name: this.args.flag.name,
       }),
       didConfirm: () => {
-        this.args.deleteFlagCallback(this.args.flag).finally(() => {
-          this.isSaved = true;
-        });
+        this.args
+          .deleteFlagCallback(this.args.flag)
+          .then(() => {
+            this.isSaved = true;
+            this.dMenu.close();
+          })
+          .catch((error) => {
+            popupAjaxError(error);
+          });
       },
       didCancel: () => {
         this.isSaved = true;
+        this.dMenu.close();
       },
     });
-    this.dMenu.close();
   }
 
   <template>

--- a/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
@@ -96,20 +96,18 @@ export default class AdminFlagItem extends Component {
   @action
   delete() {
     this.isSaved = false;
-    return this.dialog.yesNoConfirm({
+    this.dialog.yesNoConfirm({
       message: i18n("admin.config_areas.flags.delete_confirm", {
         name: this.args.flag.name,
       }),
-      didConfirm: () => {
-        this.args
-          .deleteFlagCallback(this.args.flag)
-          .then(() => {
-            this.isSaved = true;
-            this.dMenu.close();
-          })
-          .catch((error) => {
-            popupAjaxError(error);
-          });
+      didConfirm: async () => {
+        try {
+          await this.args.deleteFlagCallback(this.args.flag);
+          this.isSaved = true;
+          this.dMenu.close();
+        } catch (error) {
+          popupAjaxError(error);
+        }
       },
       didCancel: () => {
         this.isSaved = true;

--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -17,14 +17,12 @@ class PostActionType < ActiveRecord::Base
       *I18n.available_locales.map do |locale|
         Discourse.cache.normalize_key("post_action_types_#{locale}")
       end,
-    )
-    Discourse.cache.redis.del(
       *I18n.available_locales.map do |locale|
         Discourse.cache.normalize_key("post_action_flag_types_#{locale}")
       end,
+      Discourse.cache.normalize_key(POST_ACTION_TYPE_ALL_FLAGS_KEY),
+      Discourse.cache.normalize_key(POST_ACTION_TYPE_PUBLIC_TYPE_IDS_KEY),
     )
-    Discourse.cache.delete(POST_ACTION_TYPE_ALL_FLAGS_KEY)
-    Discourse.cache.delete(POST_ACTION_TYPE_PUBLIC_TYPE_IDS_KEY)
   end
 
   class << self

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -15,7 +15,7 @@ describe "Admin Flags Page", type: :system do
     SiteSetting.custom_flags_limit = 1
   end
 
-  xit "allows admin to disable, change order, create, update and delete flags" do
+  it "allows admin to disable, change order, create, update and delete flags" do
     # disable
     topic_page.visit_topic(post.topic).open_flag_topic_modal
 
@@ -146,38 +146,6 @@ describe "Admin Flags Page", type: :system do
       "It's Illegal",
       "Something Else",
     )
-
-    # custom flag with same name as system flag
-    admin_flags_page.visit.toggle("inappropriate")
-    admin_flags_page.click_add_flag
-    admin_flag_form_page
-      .fill_in_name("Inappropriate")
-      .fill_in_description("New flag description")
-      .select_applies_to("Topic")
-      .select_applies_to("Post")
-      .click_save
-
-    expect(admin_flags_page).to have_flags(
-      "Send @%{username} a message",
-      "Off-Topic",
-      "Inappropriate",
-      "Spam",
-      "Illegal",
-      "Something Else",
-      "Inappropriate",
-    )
-
-    topic_page.visit_topic(post.topic).open_flag_topic_modal
-
-    expect(flag_modal).to have_choices(
-      "It's Spam",
-      "It's Illegal",
-      "Something Else",
-      "Inappropriate",
-    )
-
-    Flag.system.where(name: "inappropriate").update!(enabled: true)
-    admin_flags_page.visit.click_delete_flag("custom_inappropriate").confirm_delete
   end
 
   it "has settings tab" do
@@ -202,6 +170,39 @@ describe "Admin Flags Page", type: :system do
         "tl4 additional flags per day multiplier",
       ],
     )
+  end
+
+  it "allows to create custom flag with same name as system flag" do
+    admin_flags_page.visit
+    admin_flags_page.click_add_flag
+    admin_flag_form_page
+      .fill_in_name("Inappropriate")
+      .fill_in_description("New flag description")
+      .select_applies_to("Topic")
+      .select_applies_to("Post")
+      .click_save
+
+    expect(admin_flags_page).to have_flags(
+      "Send @%{username} a message",
+      "Off-Topic",
+      "Inappropriate",
+      "Spam",
+      "Illegal",
+      "Something Else",
+      "Inappropriate",
+    )
+
+    topic_page.visit_topic(post.topic).open_flag_topic_modal
+
+    expect(flag_modal).to have_choices(
+      "It's Inappropriate",
+      "It's Spam",
+      "It's Illegal",
+      "Something Else",
+      "Inappropriate",
+    )
+
+    admin_flags_page.visit.click_delete_flag("custom_inappropriate").confirm_delete
   end
 
   it "does not allow to move notify user flag" do

--- a/spec/system/page_objects/pages/admin_flag_form.rb
+++ b/spec/system/page_objects/pages/admin_flag_form.rb
@@ -23,6 +23,11 @@ module PageObjects
 
       def click_save
         form.submit
+        expect(page).to have_no_css(
+          ".admin-config.flags.new",
+          wait: Capybara.default_max_wait_time * 3,
+        )
+        expect(page).to have_css(".admin-flag-item__name", wait: Capybara.default_max_wait_time * 3)
       end
 
       def form

--- a/spec/system/page_objects/pages/admin_flags.rb
+++ b/spec/system/page_objects/pages/admin_flags.rb
@@ -60,7 +60,7 @@ module PageObjects
       end
 
       def has_no_flag?(flag)
-        has_no_css?(".admin-flag-item.#{flag}")
+        has_no_css?(".admin-flag-item.#{flag}", wait: Capybara.default_max_wait_time * 3)
       end
 
       def has_saved_flag?(key)
@@ -103,6 +103,7 @@ module PageObjects
 
       def confirm_delete
         find(".dialog-footer .btn-primary").click
+        expect(page).to have_no_css(".dialog-body", wait: Capybara.default_max_wait_time * 3)
         self
       end
 


### PR DESCRIPTION
Because of unreliability, the spec was temporarily disabled. However, it is ensuring that the custom flags system is working correctly. Therefore it would be great to enable it again.

I made a few fixes to try to mitigate this situation:
- Reduced amount of Redis calls;
- When deleting, ensure that the modal is closed before checking the result;
- Moved duplicated name tests to a separate block;
- Increased wait time to 3 times the default because I noticed that sometimes it gets stuck for a moment. Most of the time it is fast, but sometimes when I run tests in a loop 50 times I see slowness.
