### PR TITLE
FEATURE: improve the suppression for admins when required

### DIFF
--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -39,7 +39,7 @@ module CategoryGuardian
 
   def can_see_category?(category)
     return false unless category
-    return true if is_admin?
+    return true if is_admin? && !SiteSetting.suppress_secured_categories_from_admin
     return true if !category.read_restricted
     return true if is_staged? && category.email_in.present? && category.email_in_allow_strangers
     secure_category_ids.include?(category.id)

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -224,7 +224,7 @@ module TopicGuardian
   def can_see_topic_ids(topic_ids: [], hide_deleted: true)
     topic_ids = topic_ids.compact
 
-    return topic_ids if is_admin?
+    return topic_ids if is_admin? && !SiteSetting.suppress_secured_categories_from_admin
     return [] if topic_ids.blank?
 
     default_scope = Topic.unscoped.where(id: topic_ids)
@@ -268,7 +268,7 @@ module TopicGuardian
 
   def can_see_topic?(topic, hide_deleted = true)
     return false unless topic
-    return true if is_admin?
+    return true if is_admin? && !SiteSetting.suppress_secured_categories_from_admin
     return false if hide_deleted && topic.deleted_at && !can_see_deleted_topics?(topic.category)
 
     if topic.private_message?

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -291,6 +291,8 @@ RSpec.describe TopicGuardian do
         list = guardian.filter_allowed_categories(list)
 
         expect(list.count).to eq(0)
+
+        expect(guardian.can_see?(private_topic)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Previously admins could still click on topics when `suppress_secured_categories_from_admin` was set

This change improves the block so admins without permission will not be allowed to click through till they add themselves to appropriate groups

Keep in mind this setting is a quality of life setting and not a SECURITY
setting, admins have an infinite way of bypassing visiblity limits
