### PR TITLE
DEV: Allow icons in FormKit Submit button

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
@@ -9,6 +9,7 @@ export default class FKSubmit extends Component {
   <template>
     <DButton
       @label={{this.label}}
+      @icon={{@icon}}
       @action={{@onSubmit}}
       @forwardEvent="true"
       class="btn-primary form-kit__button"


### PR DESCRIPTION
### What is this change?

This change forwards the `@icon` attribute from `FKSubmit` to `DButton`, allowing icons on submit buttons. This is used e.g. on the admin user fields form:

<img width="197" alt="Screenshot 2024-10-02 at 11 00 15 AM" src="https://github.com/user-attachments/assets/944bdcd2-c3a7-40e8-88c2-6a9b43f1fdaa">

### Should we have this ability?

I suspect we want to allow this, but I have asked Ella, who is in charge with Admin UI styleguide, just in case.

### Is there a problem if we pass a blank icon?

The `DButton` component handles this using the `@notEmpty` decorator.