### PR TITLE
DEV: Update warning when deleting associated accounts

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6706,7 +6706,7 @@ en:
         post_edits_count: "Post Edits"
         anonymize: "Anonymize User"
         anonymize_confirm: "Are you SURE you want to anonymize this account? This will change the username and email, and reset all profile information."
-        delete_associated_accounts_confirm: "Are you SURE you want to delete associated accounts from this account? They may not be able to log in."
+        delete_associated_accounts_confirm: "Are you SURE you want to delete all associated accounts from this account? The user may not be able to log in if their email has changed."
         anonymize_yes: "Yes, anonymize this account"
         anonymize_failed: "There was a problem anonymizing the account."
         delete: "Delete User"


### PR DESCRIPTION
Updating the warning from https://github.com/discourse/discourse/pull/29018. Requested in t/328633, it makes sense to be more verbose rather than to suggest a copy edit in /admin/customize/site_texts