### PR TITLE
UX: change twitter share link to X

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/sharing-sources.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/sharing-sources.js
@@ -7,10 +7,10 @@ export default {
 
     Sharing.addSource({
       id: "twitter",
-      icon: "fab-twitter",
+      icon: "fab-x-twitter",
       generateUrl(link, title, quote = "") {
         const text = quote ? `"${quote}" -- ` : title;
-        return `http://twitter.com/intent/tweet?url=${encodeURIComponent(
+        return `http://x.com/intent/tweet?url=${encodeURIComponent(
           link
         )}&text=${encodeURIComponent(text)}`;
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -157,7 +157,7 @@ en:
       topic_html: 'Topic: <span class="topic-title">%{topicTitle}</span>'
       post: "post #%{postNumber} by @%{username}"
       close: "close"
-      twitter: "Share on Twitter"
+      twitter: "Share on X"
       facebook: "Share on Facebook"
       email: "Send via email"
       url: "Copy and share URL"


### PR DESCRIPTION
change icon/wording/url of share link to reflect twitter's rebranding.

before:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/8becd36f-2c49-4a81-a692-393458745ae7">

after:
<img width="616" alt="image" src="https://github.com/user-attachments/assets/3b0fe5ad-225e-4c57-a552-903fd986301c">

(there are no tests per se in core for validating share links wording/icons)
