### PR TITLE
DEV: Attempt to fix `about` model flakes

### DIFF
--- a/lib/redis_snapshot.rb
+++ b/lib/redis_snapshot.rb
@@ -15,7 +15,7 @@ class RedisSnapshot
 
     values = redis.pipelined { |batch| keys.each { |key| batch.dump(key) } }
 
-    new(keys.zip(values).delete_if { |k, v| v.nil? })
+    new(keys.zip(values))
   end
 
   def initialize(dump)


### PR DESCRIPTION
My theory is that there were nil entries (that we were filtering out) that then changed and we weren't resetting them properly.

(the failure no longer repro'd in 30 CI runs in this PR)