### PR TITLE
A11Y: announce "link copied!" confirmation for screen readers

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -62,6 +62,10 @@ export const ButtonClass = {
       attributes["aria-pressed"] = attrs.ariaPressed;
     }
 
+    if (attrs.ariaLive) {
+      attributes["aria-live"] = attrs.ariaLive;
+    }
+
     if (attrs.tabAttrs) {
       const tab = attrs.tabAttrs;
       attributes["aria-selected"] = tab["aria-selected"];

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -354,6 +354,7 @@ registerButton("copyLink", () => {
     icon: "d-post-share",
     className: "post-action-menu__copy-link",
     title: "post.controls.copy_title",
+    ariaLive: "polite",
   };
 });
 


### PR DESCRIPTION
When this "link copied!" text appears, it should be read by screen readers — adding `aria-live="polite"` to the button accomplishes this 

![image](https://github.com/user-attachments/assets/32561916-404b-47ae-a426-c16939a759d2)
