### PR TITLE
DEV: Add missing x icon to `svg_sprite.rb`

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -109,6 +109,7 @@ module SvgSprite
         fab-threads-square
         fab-twitter
         fab-twitter-square
+        fab-x-twitter
         fab-wikipedia-w
         fab-windows
         far-bell


### PR DESCRIPTION
This PR is a follow up to https://github.com/discourse/discourse/pull/29056 where it adds `fab-x-twitter` icon to the SVG sprite so it will be available for users. No tests as we have no testing for adding specific icons to the sprite.

## Before
<img width="620" alt="Screenshot 2024-10-02 at 13 07 45" src="https://github.com/user-attachments/assets/1f9af953-301d-40b8-a61f-26d5f7f20e5c">

## After
<img width="623" alt="Screenshot 2024-10-02 at 13 08 07" src="https://github.com/user-attachments/assets/948bb944-4fba-4f13-8a21-dd514212059d">
