### PR TITLE
A11Y: close sidebar "more..." menu on esc and focusOut

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.gjs
@@ -28,7 +28,7 @@ export default class SidebarMoreSectionLinks extends Component {
 
   willDestroy() {
     super.willDestroy(...arguments);
-    this.#removeEventListeners();
+    this.removeEventListeners();
     this.router.off("routeDidChange", this, this.#setActiveSectionLink);
   }
 
@@ -120,26 +120,18 @@ export default class SidebarMoreSectionLinks extends Component {
     }
   }
 
-  #addEventListeners() {
+  @action
+  addEventListeners() {
     document.addEventListener("click", this.closeDetails);
     document.addEventListener("keydown", this.closeOnEscape);
     document.addEventListener("focusout", this.closeOnFocusOut);
   }
 
-  #removeEventListeners() {
+  @action
+  removeEventListeners() {
     document.removeEventListener("click", this.closeDetails);
     document.removeEventListener("keydown", this.closeOnEscape);
     document.removeEventListener("focusout", this.closeOnFocusOut);
-  }
-
-  @action
-  registerEventListeners() {
-    this.#addEventListeners();
-  }
-
-  @action
-  unregisterEventListeners() {
-    this.#removeEventListeners();
   }
 
   #isOutsideDetailsClick(event) {
@@ -189,8 +181,8 @@ export default class SidebarMoreSectionLinks extends Component {
     {{#if this.open}}
       <div class="sidebar-more-section-links-details">
         <div
-          {{didInsert this.registerEventListeners}}
-          {{willDestroy this.unregisterEventListeners}}
+          {{didInsert this.addEventListeners}}
+          {{willDestroy this.removeEventListeners}}
           class="sidebar-more-section-links-details-content-wrapper"
         >
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -1135,7 +1135,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
     );
 
-    assert.ok(exists(".sidebar-more-section-links-details-content"));
+    assert.dom(".sidebar-more-section-links-details-content").exists();
 
     const event = new KeyboardEvent("keydown", { key: "Escape" });
     document.dispatchEvent(event);

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -1140,15 +1140,17 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     const event = new KeyboardEvent("keydown", { key: "Escape" });
     document.dispatchEvent(event);
 
-    assert.notOk(exists(".sidebar-more-section-links-details-content"));
+    assert.dom(".sidebar-more-section-links-details-content").doesNotExist();
 
-    assert.strictEqual(
-      query(
+    assert
+      .dom(
         ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
-      ).getAttribute("aria-expanded"),
-      "false",
-      "aria-expanded is set to false after closing the menu"
-    );
+      )
+      .hasAria(
+        "expanded",
+        "false",
+        "aria-expanded is set to false after closing the menu"
+      );
   });
 
   test("first link is focused when the more menu is opened", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -1160,15 +1160,9 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
     );
 
-    const firstLink = query(
-      ".sidebar-more-section-links-details-content-wrapper a"
-    );
-
-    assert.strictEqual(
-      document.activeElement,
-      firstLink,
-      "first link is focused"
-    );
+    assert
+      .dom(".sidebar-more-section-links-details-content-wrapper a")
+      .isFocused("first link is focused");
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -90,13 +90,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       ),
       "additional section links are hidden when clicking outside"
     );
-
-    assert.ok(
-      exists(
-        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary[aria-expanded='false']"
-      ),
-      "aria-expanded toggles to false when additional links are hidden"
-    );
   });
 
   test("clicking on everything link", async function (assert) {
@@ -1133,6 +1126,47 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     await click(".btn-sidebar-toggle");
 
     assert.ok(teardownCalled, "section link teardown callback was called");
+  });
+
+  test("pressing esc closes the more menu", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+    );
+
+    assert.ok(exists(".sidebar-more-section-links-details-content"));
+
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(event);
+
+    assert.notOk(exists(".sidebar-more-section-links-details-content"));
+
+    assert.strictEqual(
+      query(
+        ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+      ).getAttribute("aria-expanded"),
+      "false",
+      "aria-expanded is set to false after closing the menu"
+    );
+  });
+
+  test("first link is focused when the more menu is opened", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section[data-section-name='community'] .sidebar-more-section-links-details-summary"
+    );
+
+    const firstLink = query(
+      ".sidebar-more-section-links-details-content-wrapper a"
+    );
+
+    assert.strictEqual(
+      document.activeElement,
+      firstLink,
+      "first link is focused"
+    );
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -2,6 +2,7 @@ import {
   click,
   currentRouteName,
   currentURL,
+  triggerKeyEvent,
   visit,
 } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -1137,8 +1138,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
     assert.dom(".sidebar-more-section-links-details-content").exists();
 
-    const event = new KeyboardEvent("keydown", { key: "Escape" });
-    document.dispatchEvent(event);
+    await triggerKeyEvent(document, "keydown", "Escape");
 
     assert.dom(".sidebar-more-section-links-details-content").doesNotExist();
 


### PR DESCRIPTION
This ensures that:

* the menu can be closed with <kbd>esc</kbd>
* the menu closes when keyboard focus leaves it via tabbing (but not when tabbing backwards to the original trigger)
* when opened, focus is moved to the menu's first link

For this menu: 

![image](https://github.com/user-attachments/assets/fbd8c473-d79d-4f0a-beed-efa3e805382a)


