### PR TITLE
UX: allow FormKit submit button to have icon

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
@@ -6,9 +6,14 @@ export default class FKSubmit extends Component {
     return this.args.label ?? "submit";
   }
 
+  get icon() {
+    return this.args.icon ?? null;
+  }
+
   <template>
     <DButton
       @label={{this.label}}
+      @icon={{this.icon}}
       @action={{@onSubmit}}
       @forwardEvent="true"
       class="btn-primary form-kit__button"

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/submit-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/submit-test.gjs
@@ -24,6 +24,7 @@ module("Integration | Component | FormKit | Layout | Submit", function (hooks) {
     await click("button");
 
     assert.dom(".form-kit__button.btn-primary").hasText(I18n.t("submit"));
+    assert.dom(".form-kit__button svg").doesNotExist();
     assert.deepEqual(value, 1);
   });
 
@@ -37,6 +38,16 @@ module("Integration | Component | FormKit | Layout | Submit", function (hooks) {
     assert
       .dom(".form-kit__button")
       .hasText(I18n.t("cancel"), "it allows to override the label");
+  });
+
+  test("@icon", async function (assert) {
+    await render(<template>
+      <Form as |form|>
+        <form.Submit @label="cancel" @icon="check" />
+      </Form>
+    </template>);
+
+    assert.dom(".form-kit__button svg.d-icon-check").exists();
   });
 
   test("@isLoading", async function (assert) {


### PR DESCRIPTION
Optional `@icon` parameter for submit button.

<img width="378" alt="Screenshot 2024-10-03 at 9 38 48 am" src="https://github.com/user-attachments/assets/bdfb16a4-02e2-4a20-97ed-b280f4c5bec7">
