### PR TITLE
UX: Make emails use complete view-area

### DIFF
--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -1,4 +1,4 @@
-<div id='main' class=<%= classes %>>
+<div id='main' class="email-wrapper <%= classes %>">
   <%- if reply_above_line.present? %>
   <div class="reply-above-line">
     <%= t('user_notifications.reply_above_line') %>

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -221,7 +221,7 @@ module Email
 
       html_lang = SiteSetting.default_locale.sub("_", "-")
       style("html", nil, :lang => html_lang, "xml:lang" => html_lang)
-      style("body", "line-height: 1.4; text-align:#{Rtl.new(nil).enabled? ? "right" : "left"};")
+      style("body", "margin: 0; padding: 0; line-height: 1.4; text-align:#{Rtl.new(nil).enabled? ? "right" : "left"};")
       style("body", nil, dir: Rtl.new(nil).enabled? ? "rtl" : "ltr")
 
       style(

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -221,7 +221,10 @@ module Email
 
       html_lang = SiteSetting.default_locale.sub("_", "-")
       style("html", nil, :lang => html_lang, "xml:lang" => html_lang)
-      style("body", "margin: 0; padding: 0; line-height: 1.4; text-align:#{Rtl.new(nil).enabled? ? "right" : "left"};")
+      style(
+        "body",
+        "margin: 0; padding: 0; line-height: 1.4; text-align:#{Rtl.new(nil).enabled? ? "right" : "left"};",
+      )
       style("body", nil, dir: Rtl.new(nil).enabled? ? "rtl" : "ltr")
 
       style(

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -233,6 +233,8 @@ module Email
         dir: Rtl.new(nil).enabled? ? "rtl" : "ltr",
       )
 
+      style(".email-wrapper", "margin: 12px;")
+
       style("blockquote > :first-child", "margin-top: 0;")
       style("blockquote > :last-child", "margin-bottom: 0;")
       style("blockquote > p", "padding: 0;")


### PR DESCRIPTION
This removes any default styles `margin`/`padding` from the `body`-tag in emails.

The notification email-template relies on some given default body-margin of 12px surrounding the content. The 12px-margin is re-added via an introduced `email-wrapper` class. 

#### Digest email

We do not want the extra space around - marked in red:

![grafik](https://github.com/user-attachments/assets/a9d88735-fffc-44b5-8aa8-c094c3088b53)

#### E.g. notification email

We want some space around the content. When the default body-margin is removed, we need to add extra spacing.

(Just ignore how the dark-mode looks like.)

![grafik](https://github.com/user-attachments/assets/803dd4f6-8af2-4098-bcc7-2fc9395aa18b)

