### PR TITLE
DEV: Do not include passkey metadata needlessly

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -182,7 +182,7 @@ class UserSerializer < UserCardSerializer
   end
 
   def include_user_passkeys?
-    SiteSetting.enable_passkeys?
+    SiteSetting.enable_passkeys? && user_is_current_user
   end
 
   def bio_raw

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -471,7 +471,14 @@ RSpec.describe UserSerializer do
       expect(json[:user_passkeys]).to eq(nil)
     end
 
-    it "includes passkeys if feature is enabled" do
+    it "does not include them if requesting user isn't current user" do
+      SiteSetting.enable_passkeys = true
+      json = UserSerializer.new(user, scope: Guardian.new(), root: false).as_json
+
+      expect(json[:user_passkeys]).to eq(nil)
+    end
+
+    it "includes passkeys if feature is enabled for current user" do
       SiteSetting.enable_passkeys = true
 
       json = UserSerializer.new(user, scope: Guardian.new(user), root: false).as_json


### PR DESCRIPTION
Only current user should see passkey metadata.