### PR TITLE
DEV: Add app webview event when triggering login

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -11,6 +11,7 @@ import logout from "discourse/lib/logout";
 import mobile from "discourse/lib/mobile";
 import identifySource, { consolePrefix } from "discourse/lib/source-identifier";
 import DiscourseURL from "discourse/lib/url";
+import { postRNWebviewMessage } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
 import { findAll } from "discourse/models/login-method";
@@ -26,6 +27,7 @@ function isStrictlyReadonly(site) {
 }
 
 export default class ApplicationRoute extends DiscourseRoute {
+  @service capabilities;
   @service clientErrorHandler;
   @service composer;
   @service currentUser;
@@ -290,6 +292,9 @@ export default class ApplicationRoute extends DiscourseRoute {
   }
 
   handleShowLogin() {
+    if (this.capabilities.isAppWebview) {
+      postRNWebviewMessage("showLogin", true);
+    }
     if (this.siteSettings.enable_discourse_connect) {
       const returnPath = cookie("destination_url")
         ? getURL("/")

--- a/app/assets/javascripts/discourse/tests/acceptance/modal/login/login-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal/login/login-test.js
@@ -126,9 +126,8 @@ acceptance("Login button", function () {
     await visit("/");
     await click("header .login-button");
 
-    assert.strictEqual(
+    assert.true(
       webviewSpy.withArgs('{"showLogin":true}').calledOnce,
-      true,
       "triggers postmessage event"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal/login/login-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal/login/login-test.js
@@ -111,3 +111,27 @@ acceptance("Modal - Login - With no way to login", function (needs) {
     assert.dom(".no-login-methods-configured").exists();
   });
 });
+
+acceptance("Login button", function () {
+  test("with custom event on webview", async function (assert) {
+    const capabilities = this.container.lookup("service:capabilities");
+    sinon.stub(capabilities, "isAppWebview").value(true);
+
+    window.ReactNativeWebView = {
+      postMessage: () => {},
+    };
+
+    const webviewSpy = sinon.spy(window.ReactNativeWebView, "postMessage");
+
+    await visit("/");
+    await click("header .login-button");
+
+    assert.strictEqual(
+      webviewSpy.withArgs('{"showLogin":true}').calledOnce,
+      true,
+      "triggers postmessage event"
+    );
+
+    delete window.ReactNativeWebView;
+  });
+});


### PR DESCRIPTION
Mobile app can capture event and launch a separate login flow. Should help resolve issues with passkeys (which aren't available in webviews) and non-local login methods.
