### PR TITLE
DEV: Skip `plugin:pull_compatible_all` when running against `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
         run: rm -rf plugins/discourse-ai
 
       - name: Pull compatible versions of plugins
-        if: matrix.target == 'plugins'
+        if: matrix.target == 'plugins' && (github.ref_name != 'main' && github.base_ref != 'main')
         run: bin/rake plugin:pull_compatible_all
 
       - name: Plugin gems cache


### PR DESCRIPTION
Plugins are expected to always be compatible against the main `branch`
so we can skip the `plugin:pull_compatible_all rake task.
