### PR TITLE
UX: chat index mini refactor

### DIFF
--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -34,7 +34,6 @@
 @import "chat-reply";
 @import "chat-replying-indicator";
 @import "chat-selection-manager";
-@import "chat-side-panel";
 @import "chat-skeleton";
 @import "chat-thread";
 @import "chat-side-panel-resizer";

--- a/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
@@ -1,7 +1,6 @@
 #main-chat-outlet.chat-view {
   min-height: 0;
   display: grid;
-  grid-template-rows: 100%;
   grid-template-areas: "main threads";
   grid-template-columns: 1fr auto;
 }

--- a/plugins/chat/assets/stylesheets/desktop/index.scss
+++ b/plugins/chat/assets/stylesheets/desktop/index.scss
@@ -8,4 +8,5 @@
 @import "chat-channel-info";
 @import "chat-message-creator";
 @import "chat-message-thread-indicator";
+@import "chat-side-panel";
 @import "sidebar-extensions";

--- a/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
@@ -1,5 +1,7 @@
 .full-page-chat {
   #main-chat-outlet.chat-view {
+    display: grid;
+    grid-template-rows: 1fr auto;
     grid-template-areas:
       "list"
       "footer";

--- a/plugins/chat/assets/stylesheets/mobile/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-index.scss
@@ -6,6 +6,10 @@
   .chat-channel-name {
     font-size: var(--font-up-1-rem);
   }
+
+  .chat-channel-row:last-of-type {
+    border-bottom: 0;
+  }
 }
 
 .c-routes.--direct-messages,
@@ -13,4 +17,5 @@
 .c-routes.--threads {
   background: var(--primary-very-low);
   max-width: 100vw;
+  padding-bottom: 1rem;
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-side-panel.scss
@@ -1,3 +1,0 @@
-.chat-side-panel {
-  border-left: 0;
-}

--- a/plugins/chat/assets/stylesheets/mobile/index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/index.scss
@@ -8,7 +8,6 @@
 @import "chat-selection-manager";
 @import "chat-emoji-picker";
 @import "chat-composer-upload";
-@import "chat-side-panel";
 @import "chat-thread";
 @import "chat-threads-list";
 @import "chat-message-thread-indicator";


### PR DESCRIPTION
Chat sidepanel css was being applied on mobile too, causing mild spacing issues, while it serves no purpose as we never show a sidepanel.

This commit:
* scopes css to desktop
* removes unnecessary `grid-template-row` property
* tweaks grid layout for footer on mobile
* tweaks styling to make sure last item is perceived as last item

### Before
![image](https://github.com/user-attachments/assets/54f403ee-35d1-4543-885e-dcca8179b065)

### After
![CleanShot 2024-10-04 at 16 25 12](https://github.com/user-attachments/assets/cdf25ff3-87bd-427e-b3e4-b977def3042a)
