### PR TITLE
FIX: adds post_quote as placeholder

### DIFF
--- a/plugins/automation/lib/discourse_automation/scriptable.rb
+++ b/plugins/automation/lib/discourse_automation/scriptable.rb
@@ -205,6 +205,26 @@ module DiscourseAutomation
         end
       end
 
+      def self.build_quote(post)
+        return "" if post.nil? || post.raw.nil?
+
+        full_name = post.user.name
+        name =
+          if SiteSetting.display_name_on_posts && !SiteSetting.prioritize_username_in_ux
+            full_name || post.username
+          else
+            post.username
+          end
+
+        params = [name, "post:#{post.post_number}", "topic:#{post.topic_id}"]
+
+        if SiteSetting.display_name_on_posts && !SiteSetting.prioritize_username_in_ux && full_name
+          params.push("username:#{post.username}")
+        end
+
+        "[quote=#{params.join(", ")}]\n#{post.raw.strip}\n[/quote]\n\n"
+      end
+
       def self.send_pm(
         pm,
         sender: Discourse.system_user.username,

--- a/plugins/automation/spec/lib/scriptable_spec.rb
+++ b/plugins/automation/spec/lib/scriptable_spec.rb
@@ -214,6 +214,8 @@ describe DiscourseAutomation::Scriptable do
     end
 
     describe ".build_quote" do
+      subject(:quote) { DiscourseAutomation::Scriptable::Utils.build_quote(post) }
+
       fab!(:user) { Fabricate(:user, name: "John Doe", username: "johndoe") }
       fab!(:post) { Fabricate(:post, user: user, raw: "This is a post content", post_number: 1) }
 
@@ -221,8 +223,6 @@ describe DiscourseAutomation::Scriptable do
         SiteSetting.display_name_on_posts = false
         SiteSetting.prioritize_username_in_ux = false
       end
-
-      subject(:quote) { DiscourseAutomation::Scriptable::Utils.build_quote(post) }
 
       context "when post is nil" do
         let(:post) { nil } # Define post as nil in this context

--- a/plugins/automation/spec/lib/scriptable_spec.rb
+++ b/plugins/automation/spec/lib/scriptable_spec.rb
@@ -213,6 +213,81 @@ describe DiscourseAutomation::Scriptable do
       end
     end
 
+    describe ".build_quote" do
+      fab!(:user) { Fabricate(:user, name: "John Doe", username: "johndoe") }
+      fab!(:post) { Fabricate(:post, user: user, raw: "This is a post content", post_number: 1) }
+
+      before do
+        SiteSetting.display_name_on_posts = false
+        SiteSetting.prioritize_username_in_ux = false
+      end
+
+      context "when post is nil" do
+        it "returns an empty string" do
+          expect(DiscourseAutomation::Scriptable::Utils.build_quote(nil)).to eq("")
+        end
+      end
+
+      context "when post.raw is nil" do
+        it "returns an empty string" do
+          post.raw = nil
+          expect(DiscourseAutomation::Scriptable::Utils.build_quote(post)).to eq("")
+        end
+      end
+
+      context "when display_name_on_posts is true and prioritize_username_in_ux is false" do
+        before do
+          SiteSetting.display_name_on_posts = true
+          SiteSetting.prioritize_username_in_ux = false
+        end
+
+        it "returns a quote with display name" do
+          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
+          expect(quote).to eq(
+            "[quote=John Doe, post:#{post.post_number}, topic:#{post.topic_id}, username:johndoe]\nThis is a post content\n[/quote]\n\n",
+          )
+        end
+      end
+
+      context "when display_name_on_posts is false or prioritize_username_in_ux is true" do
+        it "returns a quote with username" do
+          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
+          expect(quote).to eq(
+            "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
+          )
+        end
+      end
+
+      context "when full_name is nil and display_name_on_posts is true" do
+        before do
+          user.update(name: nil)
+          SiteSetting.display_name_on_posts = true
+          SiteSetting.prioritize_username_in_ux = false
+        end
+
+        it "returns a quote with username" do
+          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
+          expect(quote).to eq(
+            "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
+          )
+        end
+      end
+
+      context "when display_name_on_posts is true and prioritize_username_in_ux is true" do
+        before do
+          SiteSetting.display_name_on_posts = true
+          SiteSetting.prioritize_username_in_ux = true
+        end
+
+        it "returns a quote with username prioritized" do
+          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
+          expect(quote).to eq(
+            "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
+          )
+        end
+      end
+    end
+
     describe ".send_pm" do
       let(:user) { Fabricate(:user) }
 

--- a/plugins/automation/spec/lib/scriptable_spec.rb
+++ b/plugins/automation/spec/lib/scriptable_spec.rb
@@ -222,6 +222,8 @@ describe DiscourseAutomation::Scriptable do
         SiteSetting.prioritize_username_in_ux = false
       end
 
+      subject(:quote) { DiscourseAutomation::Scriptable::Utils.build_quote(post) }
+
       context "when post is nil" do
         it "returns an empty string" do
           expect(DiscourseAutomation::Scriptable::Utils.build_quote(nil)).to eq("")
@@ -229,9 +231,10 @@ describe DiscourseAutomation::Scriptable do
       end
 
       context "when post.raw is nil" do
+        before { post.raw = nil }
+
         it "returns an empty string" do
-          post.raw = nil
-          expect(DiscourseAutomation::Scriptable::Utils.build_quote(post)).to eq("")
+          expect(quote).to eq("")
         end
       end
 
@@ -242,7 +245,6 @@ describe DiscourseAutomation::Scriptable do
         end
 
         it "returns a quote with display name" do
-          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
           expect(quote).to eq(
             "[quote=John Doe, post:#{post.post_number}, topic:#{post.topic_id}, username:johndoe]\nThis is a post content\n[/quote]\n\n",
           )
@@ -251,7 +253,6 @@ describe DiscourseAutomation::Scriptable do
 
       context "when display_name_on_posts is false or prioritize_username_in_ux is true" do
         it "returns a quote with username" do
-          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
           expect(quote).to eq(
             "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
           )
@@ -266,7 +267,6 @@ describe DiscourseAutomation::Scriptable do
         end
 
         it "returns a quote with username" do
-          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
           expect(quote).to eq(
             "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
           )
@@ -280,7 +280,6 @@ describe DiscourseAutomation::Scriptable do
         end
 
         it "returns a quote with username prioritized" do
-          quote = DiscourseAutomation::Scriptable::Utils.build_quote(post)
           expect(quote).to eq(
             "[quote=johndoe, post:#{post.post_number}, topic:#{post.topic_id}]\nThis is a post content\n[/quote]\n\n",
           )

--- a/plugins/automation/spec/lib/scriptable_spec.rb
+++ b/plugins/automation/spec/lib/scriptable_spec.rb
@@ -225,8 +225,10 @@ describe DiscourseAutomation::Scriptable do
       subject(:quote) { DiscourseAutomation::Scriptable::Utils.build_quote(post) }
 
       context "when post is nil" do
+        let(:post) { nil } # Define post as nil in this context
+
         it "returns an empty string" do
-          expect(DiscourseAutomation::Scriptable::Utils.build_quote(nil)).to eq("")
+          expect(quote).to eq("")
         end
       end
 

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -463,6 +463,7 @@ after_initialize do
     field :sender, component: :user
 
     placeholder :channel_name
+    placeholder :post_quote, triggerable: :post_created_edited
 
     triggerables %i[recurring topic_tags_changed post_created_edited]
 
@@ -470,6 +471,10 @@ after_initialize do
       sender = User.find_by(username: fields.dig("sender", "value")) || Discourse.system_user
       channel = Chat::Channel.find_by(id: fields.dig("chat_channel_id", "value"))
       placeholders = { channel_name: channel.title(sender) }.merge(context["placeholders"] || {})
+
+      if context["kind"] == "post_created_edited"
+        placeholders[:post_quote] = utils.build_quote(context["post"])
+      end
 
       creator =
         ::Chat::CreateMessage.call(

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -412,21 +412,16 @@ describe Chat do
         automation_1.upsert_field!(
           "message",
           "message",
-          { value: "[{{topic_title}}]({{topic_url}})" },
+          { value: "[{{topic_title}}]({{topic_url}})\n{{post_quote}}" },
           target: "script",
         )
       end
 
       it "sends the message" do
-        PostCreator.create(
-          user_1,
-          { title: "hello world topic", raw: "my name is fred", archetype: Archetype.default },
-        )
-
-        topic_1 = Topic.last
+        post = PostCreator.create(user_1, { title: "hello world topic", raw: "my name is fred" })
 
         expect(channel_1.chat_messages.last.message).to eq(
-          "[#{topic_1.title}](#{topic_1.relative_url})",
+          "[#{post.topic.title}](#{post.topic.relative_url})\n[quote=#{post.username}, post:#{post.post_number}, topic:#{post.topic_id}]\nmy name is fred\n[/quote]",
         )
       end
     end


### PR DESCRIPTION
The script `send_chat_message` when used with the `post_created_edited` trigger now accepts `{{post_quote}}` as placeholder for the value of `message`.

This is made possible by a new method in `utils`. Usage:

```ruby
placeholders["foo"] = utils.build_quote(post)
```