### PR TITLE
UX: Improve bottom padding to chat index on mobile

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-index.scss
@@ -28,7 +28,6 @@
 
 .channels-list,
 .channels-list-container {
-  padding-bottom: env(safe-area-inset-bottom);
   position: relative;
   @include chat-scrollbar();
   height: 100%;

--- a/plugins/chat/assets/stylesheets/mobile/chat-index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-index.scss
@@ -17,5 +17,4 @@
 .c-routes.--threads {
   background: var(--primary-very-low);
   max-width: 100vw;
-  padding-bottom: 1rem;
 }


### PR DESCRIPTION
Minor followup to #29082

Before

![image](https://github.com/user-attachments/assets/ecef818d-9278-45a6-b8da-2d4a041180c8)

After

![image](https://github.com/user-attachments/assets/fda1fe8a-a20f-4d84-9a1d-3c044e53dc12)
