### PR TITLE
DEV: Output failing MF keys when compilation fails

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -163,7 +163,17 @@ module JsLocaleHelper
       require("discourse-mf");
     JS
   rescue => e
-    Rails.logger.error("Failed to compile message formats for #{locale} '#{e}'")
+    message_formats[locale.to_s]
+      .filter_map do |key, value|
+        next if MessageFormat.compile(locale, value, strict: false)
+      rescue StandardError
+        key
+      end
+      .then do |strings|
+        Rails.logger.error(
+          "Failed to compile message formats for #{locale}.\n\nBroken strings are: #{strings.join(", ")}\n\nError: #{e}",
+        )
+      end
     <<~JS
       console.error("Failed to compile message formats for #{locale}. Some translation strings will be missing.");
     JS


### PR DESCRIPTION
Currently, when the MessageFormat compiler fails on some translations, we just have the raw output from the compiler in the logs and that’s not always very helpful.

Now, when there is an error, we iterate over the translation keys and try to compile them one by one. When we detect one that is failing, it’s added to a list that is now outputted in the logs. That way, it’s easier to know which keys are not properly translated, and the problems can be addressed quicker.