### PR TITLE
A11Y: add aria-label to user profile link in topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/list/posters-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/list/posters-column.hbr
@@ -3,7 +3,7 @@
   {{#if poster.moreCount}}
     <a class="posters-more-count">{{poster.moreCount}}</a>
   {{else}}
-    <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}" aria-label="{{i18n "user.profile_possessive" username=poster.user.username}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small" alt=poster.user.username }}</a>
+    <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}" aria-label="{{i18n "user.profile_possessive" username=poster.user.username}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small"}}</a>
   {{/if}}
 {{/each}}
 </td>

--- a/app/assets/javascripts/discourse/app/raw-templates/list/posters-column.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/list/posters-column.hbr
@@ -3,7 +3,7 @@
   {{#if poster.moreCount}}
     <a class="posters-more-count">{{poster.moreCount}}</a>
   {{else}}
-    <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small"}}</a>
+    <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}" aria-label="{{i18n "user.profile_possessive" username=poster.user.username}}">{{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" namePath="user.name" imageSize="small" alt=poster.user.username }}</a>
   {{/if}}
 {{/each}}
 </td>


### PR DESCRIPTION
This adds an aria-label to the link, which is useful due to `alt=""` on the avatar itself (the blank alt is intentional, because the avatar is decorative). 

This means screenreaders will read the link's purpose in absence of having visible content within it. 