### PR TITLE
FEATURE: Added post_moved Webhook Event

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -40,6 +40,7 @@ class WebHook < ActiveRecord::Base
         WebHookEventType::TYPES[:post_edited],
         WebHookEventType::TYPES[:post_destroyed],
         WebHookEventType::TYPES[:post_recovered],
+        WebHookEventType::TYPES[:post_moved],
         WebHookEventType::TYPES[:category_experts_approved],
         WebHookEventType::TYPES[:category_experts_unapproved],
       ],

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -48,6 +48,7 @@ class WebHookEventType < ActiveRecord::Base
     post_edited: 202,
     post_destroyed: 203,
     post_recovered: 204,
+    post_moved: 205,
     user_logged_in: 301,
     user_logged_out: 302,
     user_confirmed_email: 303,

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -124,6 +124,10 @@ class WebHookEventType < ActiveRecord::Base
         [TYPES[:category_experts_approved], TYPES[:category_experts_unapproved]],
       )
     end
+    unless defined?(SiteSetting.discourse_global_communities_enabled) &&
+             SiteSetting.discourse_global_communities_enabled
+      ids_to_exclude.concat([TYPES[:post_moved]])
+    end
     self.where.not(id: ids_to_exclude)
   end
 end

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -124,10 +124,6 @@ class WebHookEventType < ActiveRecord::Base
         [TYPES[:category_experts_approved], TYPES[:category_experts_unapproved]],
       )
     end
-    unless defined?(SiteSetting.discourse_global_communities_enabled) &&
-             SiteSetting.discourse_global_communities_enabled
-      ids_to_exclude.concat([TYPES[:post_moved]])
-    end
     self.where.not(id: ids_to_exclude)
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5411,6 +5411,7 @@ en:
           post_edited: "Post is updated"
           post_destroyed: "Post is deleted"
           post_recovered: "Post is recovered"
+          post_moved: "Post is moved from one topic to another"
           category_experts_approved: "Post marked as category experts post"
           category_experts_unapproved: "Post unmarked as category experts post"
         group_event:

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -46,6 +46,11 @@ WebHookEventType.seed do |b|
   b.group = WebHookEventType.groups[:post]
 end
 WebHookEventType.seed do |b|
+  b.id = WebHookEventType::TYPES[:post_moved]
+  b.name = "post_moved"
+  b.group = WebHookEventType.groups[:post]
+end
+WebHookEventType.seed do |b|
   b.id = WebHookEventType::TYPES[:user_logged_in]
   b.name = "user_logged_in"
   b.group = WebHookEventType.groups[:user]

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe WebHookEventType do
           post_edited
           post_destroyed
           post_recovered
+          post_moved
           user_logged_in
           user_logged_out
           user_confirmed_email

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe WebHookEventType do
           post_edited
           post_destroyed
           post_recovered
-          post_moved
           user_logged_in
           user_logged_out
           user_confirmed_email
@@ -51,6 +50,7 @@ RSpec.describe WebHookEventType do
       SiteSetting.stubs(:topic_voting_enabled).returns(true)
       SiteSetting.stubs(:chat_enabled).returns(true)
       SiteSetting.stubs(:enable_category_experts).returns(true)
+      SiteSetting.stubs(:discourse_global_communities_enabled).returns(true)
       plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
       expect(plugins_event_types).to match_array(
         %w[
@@ -66,6 +66,7 @@ RSpec.describe WebHookEventType do
           chat_message_restored
           category_experts_approved
           category_experts_unapproved
+          post_moved
         ],
       )
     end

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe WebHookEventType do
       SiteSetting.stubs(:topic_voting_enabled).returns(true)
       SiteSetting.stubs(:chat_enabled).returns(true)
       SiteSetting.stubs(:enable_category_experts).returns(true)
-      SiteSetting.stubs(:discourse_global_communities_enabled).returns(true)
       plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
       expect(plugins_event_types).to match_array(
         %w[


### PR DESCRIPTION
### Changes 

This PR is adding a WebHook Event for the post that is moved from one topic to another.

This is the screenshot for the `post_moved` webhook event option:
<img width="1084" alt="Screenshot 2024-10-04 at 4 59 51 PM" src="https://github.com/user-attachments/assets/312633a6-998e-4700-8afe-00e3720f59b0">
