### PR TITLE
FIX: Support idempotent admin notice dismissal

### DIFF
--- a/app/services/admin_notices/dismiss.rb
+++ b/app/services/admin_notices/dismiss.rb
@@ -3,7 +3,7 @@
 class AdminNotices::Dismiss
   include Service::Base
 
-  model :admin_notice
+  model :admin_notice, optional: true
 
   policy :invalid_access
 
@@ -23,10 +23,14 @@ class AdminNotices::Dismiss
   end
 
   def destroy(admin_notice:)
+    return if admin_notice.blank?
+
     admin_notice.destroy!
   end
 
   def reset_problem_check(admin_notice:)
+    return if admin_notice.blank?
+
     ProblemCheckTracker.find_by(identifier: admin_notice.identifier)&.reset
   end
 end

--- a/spec/services/admin_notices/dismiss_spec.rb
+++ b/spec/services/admin_notices/dismiss_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe(AdminNotices::Dismiss) do
     it { is_expected.to fail_a_policy(:invalid_access) }
   end
 
+  context "when the admin notice has already been dismissed" do
+    fab!(:current_user) { Fabricate(:admin) }
+
+    before { admin_notice.destroy! }
+
+    it { is_expected.to run_successfully }
+  end
+
   context "when user is allowed to perform the action" do
     fab!(:current_user) { Fabricate(:admin) }
 


### PR DESCRIPTION
### What is the problem?

If you have the admin dashboard open, and one of the admin notices listed has already been dismissed (e.g. in another tab, or by another admin) we would show an ugly "FAILED" modal.

<img width="503" alt="Screenshot 2024-10-07 at 12 28 47 PM" src="https://github.com/user-attachments/assets/7f1610f8-cf4d-45d1-8b3d-81c1b4c6426d">

### How does this fix it?

Make the admin dismiss endpoint idempotent. If the admin notice is already destroyed, then respond with 200. This will also correctly remove it from the list in the front-end.