### PR TITLE
FIX: Only render admin notice dismiss button for admins

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-notice.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-notice.gjs
@@ -1,13 +1,20 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import icon from "discourse-common/helpers/d-icon";
 
 export default class AdminNotice extends Component {
+  @service currentUser;
+
   @action
   dismiss() {
     this.args.dismissCallback(this.args.problem);
+  }
+
+  get canDismiss() {
+    return this.currentUser.admin;
   }
 
   <template>
@@ -16,10 +23,12 @@ export default class AdminNotice extends Component {
         {{if @icon (icon @icon)}}
         {{htmlSafe @problem.message}}
       </div>
-      <DButton
-        @action={{this.dismiss}}
-        @label="admin.dashboard.dismiss_notice"
-      />
+      {{#if this.canDismiss}}
+        <DButton
+          @action={{this.dismiss}}
+          @label="admin.dashboard.dismiss_notice"
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/spec/system/admin_notices_spec.rb
+++ b/spec/system/admin_notices_spec.rb
@@ -1,25 +1,43 @@
 # frozen_string_literal: true
 
 describe "Admin Notices", type: :system do
-  fab!(:admin)
-
   let(:admin_dashboard) { PageObjects::Pages::AdminDashboard.new }
 
   before do
     Fabricate(:admin_notice)
 
     I18n.backend.store_translations(:en, dashboard: { problem: { test_notice: "Houston" } })
-
-    sign_in(admin)
   end
 
-  it "supports dismissing admin notices" do
-    admin_dashboard.visit
+  context "when signed in as admin" do
+    fab!(:admin)
 
-    expect(admin_dashboard).to have_admin_notice(I18n.t("dashboard.problem.test_notice"))
+    before { sign_in(admin) }
 
-    admin_dashboard.dismiss_notice(I18n.t("dashboard.problem.test_notice"))
+    it "supports dismissing admin notices" do
+      admin_dashboard.visit
 
-    expect(admin_dashboard).to have_no_admin_notice(I18n.t("dashboard.problem.test_notice"))
+      expect(admin_dashboard).to have_admin_notice(I18n.t("dashboard.problem.test_notice"))
+
+      admin_dashboard.dismiss_notice(I18n.t("dashboard.problem.test_notice"))
+
+      expect(admin_dashboard).to have_no_admin_notice(I18n.t("dashboard.problem.test_notice"))
+    end
+  end
+
+  context "when signed in as moderator" do
+    fab!(:moderator)
+
+    before { sign_in(moderator) }
+
+    it "doesn't render dismiss button on admin notices" do
+      admin_dashboard.visit
+
+      expect(admin_dashboard).to have_admin_notice(I18n.t("dashboard.problem.test_notice"))
+      expect(admin_dashboard).to have_no_css(
+        ".dashboard-problem .btn",
+        text: I18n.t("admin_js.admin.dashboard.dismiss_notice"),
+      )
+    end
   end
 end


### PR DESCRIPTION
### What is the problem?

Dismissing admin notices is an admin-only action. This is enforced on the back-end both by a routing constraint and a policy in the relevant service.

However, we still unconditionally display the "Dismiss" button to anyone with access to the admin dashboard. When clicked, it results in a 404 modal (due to the routing constraint.)

<img width="419" alt="Screenshot 2024-10-07 at 12 54 13 PM" src="https://github.com/user-attachments/assets/1b497bf9-d067-4ded-b431-fff383f0717a">

### How does this fix it?

Only render the dismiss button for admins.