### PR TITLE
DEV: Fix flaky chat system tests

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -80,7 +80,7 @@ module PageObjects
       end
 
       def has_no_loading_skeleton?
-        has_no_css?(".chat-thread__messages .chat-skeleton")
+        has_no_css?(".chat-thread .chat-skeleton")
       end
 
       def type_in_composer(input)


### PR DESCRIPTION
`PageObjects::Pages::ChatThread#has_no_loading_skeleton?` was broken
because `.chat-thread__messages` is no longer a valid class.

## Reviewers Notes

Flaked in https://github.com/discourse/discourse/actions/runs/11205370509/job/31144816341?pr=29091