### PR TITLE
DEV: Fix flaky login wizard redirect spec

### DIFF
--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -63,7 +63,7 @@ shared_examples "login scenarios" do
       visit activation_link
 
       activate_account.click_activate_account
-      expect(page).to have_current_path("/wizard")
+      expect(page).to have_current_path(%r{/wizard})
     end
 
     it "shows error when when activation link is invalid" do


### PR DESCRIPTION
### Why is this flaky?

The `/wizard` route redirects to one of the steps. If that happens fast enough, the assertion on `/wizard` will fail.

This commit fixes that by using a regular expression. I chose this because the spec, as it is worded, should only be concerned with the fact that it is redirected to the wizard, not which step.