### PR TITLE
DEV: Fix an event reference in widget hooks

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -1,4 +1,3 @@
-/*eslint no-loop-func:0*/
 import $ from "jquery";
 
 const CLICK_ATTRIBUTE_NAME = "_discourse_click_widget";
@@ -134,7 +133,7 @@ function dragStart(e) {
 
 function drag(e) {
   const widget = _currentlyDraggingElement[DRAG_ATTRIBUTE_NAME];
-  if (event.type === "mousemove") {
+  if (e.type === "mousemove") {
     widget.drag(e);
   } else {
     const tt = e.targetTouches[0];


### PR DESCRIPTION
(and drop an unused eslint setting)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->