### PR TITLE
FIX: Use full column name to prevent ambiguous query

### DIFF
--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -240,11 +240,11 @@ class DiscoursePoll::Poll
       SELECT poll_id, digest, rank, user_id
         FROM (
           SELECT pv.poll_id
-               , digest
-               , CASE rank WHEN 0 THEN 'Abstain' ELSE CAST(rank AS text) END AS rank
-               , user_id
-               , username
-               , ROW_NUMBER() OVER (PARTITION BY poll_option_id ORDER BY pv.created_at) AS row
+               , po.digest
+               , CASE pv.rank WHEN 0 THEN 'Abstain' ELSE CAST(pv.rank AS text) END AS rank
+               , pv.user_id
+               , u.username
+               , ROW_NUMBER() OVER (PARTITION BY pv.poll_option_id ORDER BY pv.created_at) AS row
           FROM poll_votes pv
           JOIN poll_options po ON pv.poll_id = po.poll_id AND pv.poll_option_id = po.id
           JOIN users u ON pv.user_id = u.id


### PR DESCRIPTION
This can happen when other plugins, for example discourse-rainbow, are installed and add columns with same names.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->