### PR TITLE
FIX: allows to use open attribute with details

### DIFF
--- a/plugins/discourse-details/assets/javascripts/lib/discourse-markdown/details.js
+++ b/plugins/discourse-details/assets/javascripts/lib/discourse-markdown/details.js
@@ -2,8 +2,11 @@ const rule = {
   tag: "details",
   before(state, tagInfo) {
     const attrs = tagInfo.attrs;
-    state.push("bbcode_open", "details", 1);
-    state.push("bbcode_open", "summary", 1);
+    const details = state.push("bbcode_open", "details", 1);
+
+    if (attrs.open === "") {
+      details.attrs = [["open", ""]];
+    }
 
     let token = state.push("text", "", 0);
     token.content = attrs["_default"] || "";

--- a/plugins/discourse-details/assets/javascripts/lib/discourse-markdown/details.js
+++ b/plugins/discourse-details/assets/javascripts/lib/discourse-markdown/details.js
@@ -3,6 +3,7 @@ const rule = {
   before(state, tagInfo) {
     const attrs = tagInfo.attrs;
     const details = state.push("bbcode_open", "details", 1);
+    state.push("bbcode_open", "summary", 1);
 
     if (attrs.open === "") {
       details.attrs = [["open", ""]];

--- a/plugins/discourse-details/spec/components/pretty_text_spec.rb
+++ b/plugins/discourse-details/spec/components/pretty_text_spec.rb
@@ -20,10 +20,24 @@ RSpec.describe PrettyText do
     HTML
   end
 
+  it "supports open attribute" do
+    cooked_html = PrettyText.cook <<~MARKDOWN
+      [details open]
+      bar
+      [/details]
+    MARKDOWN
+
+    expect(cooked_html).to match_html <<~HTML
+      <details open>
+        <p>bar</p>
+      </details>
+    HTML
+  end
+
   it "deletes elided content" do
     cooked_html = PrettyText.cook <<~MARKDOWN
       Hello World
-      
+
       <details class='elided'>42</details>
     MARKDOWN
 

--- a/plugins/discourse-details/spec/components/pretty_text_spec.rb
+++ b/plugins/discourse-details/spec/components/pretty_text_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe PrettyText do
     MARKDOWN
 
     expect(cooked_html).to match_html <<~HTML
-      <details open>
+      <details open="">
+      <summary></summary>
         <p>bar</p>
       </details>
     HTML


### PR DESCRIPTION
Supporting `open` allows to show a `details` block open by default.

Usage:

```
[details open]
my visible content
[/details]
```

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->