### PR TITLE
FEATURE: add `trigger_with_pms` option to `topic tags changed` automation trigger

### DIFF
--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -223,6 +223,9 @@ en:
             watching_tags:
               label: Watching tags
               description: Will trigger only if the topic has any of these tags
+            trigger_with_pms:
+              label: Trigger with PMs
+              description: Will trigger even if the tags were changed in a PM
         after_post_cook:
           fields:
             valid_trust_levels:

--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -224,6 +224,10 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
+          if topic.private_message?
+            next if !automation.trigger_field("trigger_with_pms")["value"]
+          end
+
           watching_categories = automation.trigger_field("watching_categories")
           if watching_categories["value"]
             next if !watching_categories["value"].include?(topic.category_id)

--- a/plugins/automation/lib/discourse_automation/triggers/topic_tags_changed.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/topic_tags_changed.rb
@@ -3,6 +3,7 @@
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED) do
   field :watching_categories, component: :categories
   field :watching_tags, component: :tags
+  field :trigger_with_pms, component: :boolean
 
   placeholder :topic_url
   placeholder :topic_title

--- a/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
+++ b/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
@@ -19,6 +19,7 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
     SiteSetting.tagging_enabled = true
     SiteSetting.create_tag_allowed_groups = Group::AUTO_GROUPS[:everyone]
     SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:everyone]
   end
 
   context "when watching a cool tag" do
@@ -184,6 +185,39 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
       expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED)
       expect(list[0]["added_tags"]).to eq([another_tag.name])
       expect(list[0]["removed_tags"]).to eq([])
+    end
+
+    it "should not fire the trigger on PMs by default" do
+      pm = Fabricate(:private_message_topic)
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(
+            pm,
+            Guardian.new(user),
+            [cool_tag.name, another_tag.name],
+          )
+        end
+      expect(list.length).to eq(0)
+    end
+
+    it "should fire the trigger on PMs if trigger_with_pms is set" do
+      automation.upsert_field!(
+        "trigger_with_pms",
+        "boolean",
+        { "value" => true },
+        target: "trigger",
+      )
+
+      pm = Fabricate(:private_message_topic)
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(
+            pm,
+            Guardian.new(user),
+            [cool_tag.name, another_tag.name],
+          )
+        end
+      expect(list.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
continuation of https://github.com/discourse/discourse-chat-integration/pull/223

<img width="969" alt="Screenshot 2024-10-08 at 09 53 49" src="https://github.com/user-attachments/assets/54638238-f29a-4853-a1c8-5fb5f63e617f">

