### PR TITLE
DEV: Add PluginRegistry modifiers to #review and #recalculate

### DIFF
--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -12,7 +12,7 @@ class Promotion
   # Returns true if the user was promoted, false otherwise.
   def review
     result = DiscoursePluginRegistry.apply_modifier(:review_trust_level, @user)
-    return result if !result.nil?
+    return result if !result.nil? && result != @user
 
     # nil users are never promoted
     return false if @user.blank? || !@user.manual_locked_trust_level.nil?
@@ -151,8 +151,8 @@ class Promotion
 
     promotion = Promotion.new(user)
 
-    result = DiscoursePluginRegistry.apply_modifier(:recalculate_trust_level, user)
-    return result if !result.nil?
+    result = DiscoursePluginRegistry.apply_modifier(:recalculate_trust_level, user, promotion)
+    return result if !result.nil? && result != user
 
     promotion.review_tl0 if granted_trust_level < TrustLevel[1]
     promotion.review_tl1 if granted_trust_level < TrustLevel[2]

--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -11,6 +11,9 @@ class Promotion
   # Review a user for a promotion. Delegates work to a review_#{trust_level} method.
   # Returns true if the user was promoted, false otherwise.
   def review
+    result = DiscoursePluginRegistry.apply_modifier(:review_trust_level, @user)
+    return result if !result.nil?
+
     # nil users are never promoted
     return false if @user.blank? || !@user.manual_locked_trust_level.nil?
 
@@ -147,6 +150,9 @@ class Promotion
     return if user.manual_locked_trust_level.present?
 
     promotion = Promotion.new(user)
+
+    result = DiscoursePluginRegistry.apply_modifier(:recalculate_trust_level, user)
+    return result if !result.nil?
 
     promotion.review_tl0 if granted_trust_level < TrustLevel[1]
     promotion.review_tl1 if granted_trust_level < TrustLevel[2]

--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -11,8 +11,8 @@ class Promotion
   # Review a user for a promotion. Delegates work to a review_#{trust_level} method.
   # Returns true if the user was promoted, false otherwise.
   def review
-    result = DiscoursePluginRegistry.apply_modifier(:review_trust_level, @user)
-    return result if !result.nil? && result != @user
+    override = DiscoursePluginRegistry.apply_modifier(:review_trust_level, false, @user)
+    return override if override
 
     # nil users are never promoted
     return false if @user.blank? || !@user.manual_locked_trust_level.nil?
@@ -151,8 +151,9 @@ class Promotion
 
     promotion = Promotion.new(user)
 
-    result = DiscoursePluginRegistry.apply_modifier(:recalculate_trust_level, user, promotion)
-    return result if !result.nil? && result != user
+    override =
+      DiscoursePluginRegistry.apply_modifier(:recalculate_trust_level, false, user, promotion)
+    return override if override
 
     promotion.review_tl0 if granted_trust_level < TrustLevel[1]
     promotion.review_tl1 if granted_trust_level < TrustLevel[2]

--- a/spec/lib/promotion_spec.rb
+++ b/spec/lib/promotion_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Promotion do
       it "allows plugins to control promotion #recalculate" do
         DiscoursePluginRegistry.register_modifier(plugin, recalculate_modifier, &deny_block)
         action = Promotion.recalculate(user)
-        expect(action).to eq(false)
+        expect(action).to eq(nil)
 
         DiscoursePluginRegistry.register_modifier(plugin, recalculate_modifier, &allow_block)
         action = Promotion.recalculate(user)

--- a/spec/lib/promotion_spec.rb
+++ b/spec/lib/promotion_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Promotion do
   describe "newuser" do
     fab!(:user) { Fabricate(:user, trust_level: TrustLevel[0], created_at: 2.days.ago) }
     let(:promotion) { Promotion.new(user) }
+    let!(:plugin) { Plugin::Instance.new }
+    let!(:review_modifier) { :review_trust_level }
+    let!(:recalculate_modifier) { :recalculate_trust_level }
+    let!(:deny_block) { Proc.new { false } }
+    let!(:allow_block) { Proc.new { true } }
 
     it "doesn't raise an error with a nil user" do
       expect { Promotion.new(nil).review }.not_to raise_error
@@ -48,6 +53,33 @@ RSpec.describe Promotion do
 
       it "has upgraded the user to basic" do
         expect(user.trust_level).to eq(TrustLevel[1])
+      end
+
+      it "allows plugins to control promotion #review" do
+        DiscoursePluginRegistry.register_modifier(plugin, :review_trust_level, &deny_block)
+        action = Promotion.new(user).review
+        expect(action).to eq(false)
+
+        DiscoursePluginRegistry.register_modifier(plugin, review_modifier, &allow_block)
+        action = Promotion.new(user).review
+        expect(action).to eq(true)
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(plugin, review_modifier, &deny_block)
+        DiscoursePluginRegistry.unregister_modifier(plugin, review_modifier, &allow_block)
+      end
+
+      it "allows plugins to control promotion #recalculate" do
+        DiscoursePluginRegistry.register_modifier(plugin, recalculate_modifier, &deny_block)
+        action = Promotion.recalculate(user)
+        expect(action).to eq(false)
+
+        DiscoursePluginRegistry.register_modifier(plugin, recalculate_modifier, &allow_block)
+        action = Promotion.recalculate(user)
+
+        expect(action).to eq(true)
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(plugin, recalculate_modifier, &deny_block)
+        DiscoursePluginRegistry.unregister_modifier(plugin, recalculate_modifier, &allow_block)
       end
     end
 


### PR DESCRIPTION
**Description**
The Promotion class is in charge of checking the requirements for each trust level and promoting users. Currently, there is no way to customize the trust level requirements without doing a monkey patch on the Promotion class.
**Problem**
We are doing customer work that requires trust level requirements customization, to avoid monkey patches, these 2 modifiers are added. 