### PR TITLE
DEV: Fix build by removing custom route that triggers error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1607,8 +1607,6 @@ Discourse::Application.routes.draw do
          constraints: HomePageConstraint.new("custom"),
          as: "custom_index"
 
-    get "/custom" => "custom_homepage#index"
-
     get "/user-api-key/new" => "user_api_keys#new"
     post "/user-api-key" => "user_api_keys#create"
     post "/user-api-key/revoke" => "user_api_keys#revoke"


### PR DESCRIPTION
This route was added for parity, it is not used. Adding it is causing internal test runs to fail with: 

```
ArgumentError: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true
```

Locally I can repro this, but only after resetting the test env's DB. We could probably also fix this by setting 

```
Rails.application.routes.default_url_options[:host] = 'localhost:3000'
```

but I am not sure if that has other side effects. Right now opting to remove the route, it's not essential anyway. (But odd it triggers this issue in the test env?) 