### PR TITLE
DEV: Fix state leak in spec

### DIFF
--- a/spec/models/global_setting_spec.rb
+++ b/spec/models/global_setting_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe GlobalSetting do
         Discourse.stubs(:redis).returns(nil)
       end
 
+      after { GlobalSetting.skip_redis = false }
+
       it "generates a new random key in memory without redis" do
         GlobalSetting.reset_secret_key_base!
         token = GlobalSetting.safe_secret_key_base


### PR DESCRIPTION
`GlobalSetting.skip_redis` sets a class instance variable so we need
to reset it.

Follow-up to 7d441e378285fa37431ab49a001fc57eb75bb469
