### PR TITLE
DEV: Fix flaky request tracker system spec

### DIFF
--- a/app/models/topic_view_item.rb
+++ b/app/models/topic_view_item.rb
@@ -11,7 +11,8 @@ class TopicViewItem < ActiveRecord::Base
 
   def self.add(topic_id, ip, user_id = nil, at = nil, skip_redis = false)
     # Only store a view once per day per thing per (user || ip)
-    at ||= Date.today
+    at ||= Time.zone.today
+
     redis_key = +"view:#{topic_id}:#{at}"
     if user_id
       redis_key << ":user-#{user_id}"


### PR DESCRIPTION
`Date.today` relies on the system's timezone instead of
`Rails.configuration.time_zone`. This can cause tests to fail when we
assert against the date of a record. Just use `Time.zone.today` instead
so that we always follow `Rails.configuration.time_zone`.
