### PR TITLE
FIX: Unicorn master and Sidekiq reopening logs at the same time

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -150,7 +150,7 @@ module Jobs
       end
 
       def enabled?
-        ENV["DISCOURSE_LOG_SIDEKIQ"] == "1"
+        Discourse.enable_sidekiq_logging?
       end
 
       def live_slots_limit

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1223,4 +1223,8 @@ module Discourse
       ) if SiteSetting.set_locale_from_accept_language_header
     locale
   end
+
+  def self.enable_sidekiq_logging?
+    ENV["DISCOURSE_LOG_SIDEKIQ"] == "1"
+  end
 end


### PR DESCRIPTION
## What is the context of this change?

In our production environment, we have been seeing Sidekiq processes
getting stuck randomly when a USR1 signal is sent to the Unicorn master
process. We have not been able to identify the root cause of why the
Sidekiq process gets stuck. We however noticed that when the Unicorn
master process receives a USR1 signal, it will reopen the logs for the
Unicorn master process first before sending a USR1 signal for the
Unicorn worker processes to reopen the logs. We figured that we should
do the same for the Sidekiq process as well when a USR1 signal.

## What is the change?

In this commit, we introduce an arbitrary delay of 1 second before we
the Sidekiq process reopens its log files so as to allow enough time for the Unicorn
master to finish reopening it logs first.

We also do not send reopen logs for the Sidekiq process if the `DISCOURSE_LOG_SIDEKIQ`
env is not present because there is no need to reopen any logs.

## Reviewer notes

There is unfortunately no automated tests we can write for this change. We therefore have to resort to manually testing which you can verify by running the following steps:

1. Run `DISCOURSE_LOG_SIDEKIQ=1 UNICORN_WORKERS=2 UNICORN_SIDEKIQS=1 bin/unicorn` and wait for the 2 Unicorn worker processes and the Sidekiq process to be ready. You should see something like the following:
    ```
    I, [2024-10-10T07:44:25.928795 #14164]  INFO -- : listening on addr=127.0.0.1:9292 fd=20
    I, [2024-10-10T07:44:26.938245 #14164]  INFO -- : starting 1 supervised sidekiqs
    I, [2024-10-10T07:44:27.057254 #14164]  INFO -- : master process ready
    I, [2024-10-10T07:44:27.070405 #14250]  INFO -- : Loading Sidekiq in process id 14250
    I, [2024-10-10T07:44:27.073539 #14251]  INFO -- : worker=0 ready
    I, [2024-10-10T07:44:27.073633 #14252]  INFO -- : worker=1 ready
    ```

2. Run `kill -USR1 $(ps aux | grep "unicorn master" | grep -v "grep" | awk '{print $2}')` once. You should see that the Sidekiq process only reopens its logs 1 second after the Unicorn master process.
    ```
    I, [2024-10-09T10:56:56.406875 #19334]  INFO -- : master reopening logs...
    I, [2024-10-09T10:56:56.412623 #19334]  INFO -- : master done reopening logs
    I, [2024-10-09T10:56:57.415923 #19446]  INFO -- : Sidekiq reopening logs...
    I, [2024-10-09T10:56:57.425247 #19446]  INFO -- : Sidekiq done reopening logs...
    ```