### PR TITLE
FIX: show lightbox for small images

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -184,8 +184,7 @@ class CookedPostProcessor
     end
 
     generate_thumbnail =
-      original_width >= SiteSetting.max_image_width ||
-        original_height >= SiteSetting.max_image_height
+      original_width > SiteSetting.max_image_width || original_height > SiteSetting.max_image_height
 
     user_width, user_height = [original_width, original_height] if user_width.to_i <= 0 &&
       user_height.to_i <= 0

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -183,9 +183,9 @@ class CookedPostProcessor
       img.add_class("animated")
     end
 
-    skip_thumbnail =
-      original_width <= SiteSetting.max_image_width &&
-        original_height <= SiteSetting.max_image_height
+    generate_thumbnail =
+      original_width >= SiteSetting.max_image_width ||
+        original_height >= SiteSetting.max_image_height
 
     user_width, user_height = [original_width, original_height] if user_width.to_i <= 0 &&
       user_height.to_i <= 0
@@ -202,7 +202,7 @@ class CookedPostProcessor
     end
 
     if upload.present?
-      unless skip_thumbnail
+      if generate_thumbnail
         upload.create_thumbnail!(width, height, crop: crop)
 
         each_responsive_ratio do |ratio|
@@ -221,7 +221,7 @@ class CookedPostProcessor
         add_lightbox!(img, original_width, original_height, upload)
       end
 
-      optimize_image!(img, upload, cropped: crop) unless skip_thumbnail
+      optimize_image!(img, upload, cropped: crop) if generate_thumbnail
     end
   end
 
@@ -277,8 +277,8 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src_url = Upload.secure_uploads_url?(img["src"]) ? upload&.url : img["src"]
-    src = UrlHelper.cook_url(src_url || img["src"], secure: @should_secure_uploads)
+    src_url = Upload.secure_uploads_url?(img["src"]) ? img["src"] : upload&.url
+    src = UrlHelper.cook_url(src_url, secure: @should_secure_uploads)
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -277,8 +277,9 @@ class CookedPostProcessor
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src_url = Upload.secure_uploads_url?(img["src"]) ? img["src"] : upload&.url
+    src_url = Upload.secure_uploads_url?(img["src"]) ? upload&.url || img["src"] : img["src"]
     src = UrlHelper.cook_url(src_url, secure: @should_secure_uploads)
+
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)
 

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -412,27 +412,21 @@ RSpec.describe CookedPostProcessor do
 
         it "shows the lightbox when both dimensions are above the minimum" do
           cpp.post_process
-          expect(cpp.html).to match_html <<~HTML
-            <p><div class="lightbox-wrapper"><a class="lightbox" href="//test.localhost#{upload.url}" data-download-href="//test.localhost/#{upload_path}/#{upload.sha1}" title="logo.png"><img src="//test.localhost/#{upload_path}/original/1X/#{upload.sha1}.png" width="150" height="150"><div class="meta"><svg class="fa d-icon d-icon-far-image svg-icon" aria-hidden="true"><use href="#far-image"></use></svg><span class="filename">logo.png</span><span class="informations">150×150 1.21 KB</span><svg class="fa d-icon d-icon-discourse-expand svg-icon" aria-hidden="true"><use href="#discourse-expand"></use></svg></div></a></div></p>
-          HTML
+          expect(cpp.html).to match(/<div class="lightbox-wrapper">/)
         end
 
         it "does not show lightbox when both dimensions are below the minimum" do
           upload.update!(width: 50, height: 50)
           cpp.post_process
 
-          expect(cpp.html).to match_html <<~HTML
-            <p><img src="//test.localhost#{upload.url}" width="50" height="50"></p>
-          HTML
+          expect(cpp.html).not_to match(/<div class="lightbox-wrapper">/)
         end
 
         it "does not show lightbox when either dimension is below the minimum" do
           upload.update!(width: 50, height: 150)
           cpp.post_process
 
-          expect(cpp.html).to match_html <<~HTML
-            <p><img src="//test.localhost#{upload.url}" width="50" height="150"></p>
-          HTML
+          expect(cpp.html).not_to match(/<div class="lightbox-wrapper">/)
         end
 
         it "does not create thumbnails for small images" do

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -434,6 +434,11 @@ RSpec.describe CookedPostProcessor do
             <p><img src="//test.localhost#{upload.url}" width="50" height="150"></p>
           HTML
         end
+
+        it "does not create thumbnails for small images" do
+          Upload.any_instance.expects(:create_thumbnail!).never
+          cpp.post_process
+        end
       end
 
       context "with large images" do

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -666,7 +666,7 @@ RSpec.describe Email::Sender do
 
           @secure_image_2 =
             UploadCreator.new(
-              file_from_fixtures("logo-dev.png", "images"),
+              file_from_fixtures("logo.png", "images"),
               "something-cool.png",
             ).create_for(Discourse.system_user.id)
           @secure_image_2.update_secure_status(override: true)

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -636,7 +636,7 @@ RSpec.describe Email::Sender do
           @secure_image_2 =
             UploadCreator.new(
               file_from_fixtures("logo-dev.png", "images"),
-              "secuere_logo_2.png",
+              "secure_logo_2.png",
             ).create_for(Discourse.system_user.id)
           @secure_image_2.update_secure_status(override: true)
           @secure_image_2.update(access_control_post_id: reply.id)
@@ -701,6 +701,7 @@ RSpec.describe Email::Sender do
           expect(summary.attachments.map(&:filename)).to include(
             *[@secure_image, @secure_image_2, @secure_image_3].map(&:original_filename),
           )
+          expect(summary.attachments.size).to eq(3)
           expect(summary.to_s.scan("Content-Type: text/html;").length).to eq(1)
           expect(summary.to_s.scan("Content-Type: text/plain;").length).to eq(1)
           expect(summary.to_s.scan(/cid:[\w\-@.]+/).length).to eq(3)


### PR DESCRIPTION
We want to allow lightboxing of smaller images, even if they are below the minimum size for image thumbnail generation.

This change sets a minimum threshold of 100 x 100 pixels for triggering the lightbox.