### PR TITLE
DEV: Publish DiscourseEvent after top topic period is calculated

### DIFF
--- a/app/models/top_topic.rb
+++ b/app/models/top_topic.rb
@@ -212,6 +212,8 @@ class TopTopic < ActiveRecord::Base
     SQL
 
     DB.exec(sql, from: start_of(period))
+
+    DiscourseEvent.trigger(:top_score_computed, period: period)
   end
 
   def self.start_of(period)

--- a/spec/models/top_topic_spec.rb
+++ b/spec/models/top_topic_spec.rb
@@ -152,5 +152,12 @@ RSpec.describe TopTopic do
         0.0000000001,
       ).of(10.602059991328)
     end
+
+    it "triggers a DiscourseEvent for each refreshed period" do
+      events = DiscourseEvent.track_events(:top_score_computed) { TopTopic.refresh! }
+      periods = events.map { |e| e[:params].first[:period] }
+
+      expect(periods).to match_array(%i[daily weekly monthly quarterly yearly all])
+    end
   end
 end


### PR DESCRIPTION
I'm working on a private plugin which adjusts TopTopic records after they have been calculated. This event will trigger once a period is calculated for plugins to listen for.