### PR TITLE
FIX: Don't override other sidebar panels when opening/closing the chat drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/init-sidebar-state.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/init-sidebar-state.js
@@ -1,4 +1,4 @@
-import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
+import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";
 
 export const CHAT_PANEL = "chat";
@@ -15,7 +15,10 @@ export function initSidebarState(api, user) {
     api.hideSidebarSwitchPanelButtons();
   }
 
-  if (api.getSidebarPanel()?.key === ADMIN_PANEL) {
+  if (
+    api.getSidebarPanel()?.key !== MAIN_PANEL &&
+    api.getSidebarPanel()?.key !== CHAT_PANEL
+  ) {
     return;
   }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -89,14 +89,14 @@ export default class ChatStateManager extends Service {
 
   didCloseDrawer() {
     withPluginApi("1.8.0", (api) => {
-      const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
-        this.currentUser
-      );
-
       if (
         api.getSidebarPanel()?.key === MAIN_PANEL ||
         api.getSidebarPanel()?.key === CHAT_PANEL
       ) {
+        const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
+          this.currentUser
+        );
+
         api.setSidebarPanel(MAIN_PANEL);
 
         if (chatSeparateSidebarMode.fullscreen) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -5,6 +5,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";
+import { CHAT_PANEL } from "discourse/plugins/chat/discourse/lib/init-sidebar-state";
 
 const PREFERRED_MODE_KEY = "preferred_mode";
 const PREFERRED_MODE_STORE_NAMESPACE = "discourse_chat_";
@@ -62,13 +63,9 @@ export default class ChatStateManager extends Service {
 
   didOpenDrawer(url = null) {
     withPluginApi("1.8.0", (api) => {
-      const adminSidebarStateManager = api.container.lookup(
-        "service:admin-sidebar-state-manager"
-      );
-
       if (
-        adminSidebarStateManager === undefined ||
-        !adminSidebarStateManager.maybeForceAdminSidebar()
+        api.getSidebarPanel()?.key === MAIN_PANEL ||
+        api.getSidebarPanel()?.key === CHAT_PANEL
       ) {
         if (getUserChatSeparateSidebarMode(this.currentUser).always) {
           api.setSeparatedSidebarMode();
@@ -92,17 +89,13 @@ export default class ChatStateManager extends Service {
 
   didCloseDrawer() {
     withPluginApi("1.8.0", (api) => {
-      const adminSidebarStateManager = api.container.lookup(
-        "service:admin-sidebar-state-manager"
-      );
-
       const chatSeparateSidebarMode = getUserChatSeparateSidebarMode(
         this.currentUser
       );
 
       if (
-        adminSidebarStateManager === undefined ||
-        !adminSidebarStateManager.maybeForceAdminSidebar()
+        api.getSidebarPanel()?.key === MAIN_PANEL ||
+        api.getSidebarPanel()?.key === CHAT_PANEL
       ) {
         api.setSidebarPanel(MAIN_PANEL);
 


### PR DESCRIPTION
This PR fixes an issue where the following happens:

1. The user opens a page where an alternative sidebar panel is displayed like /admin or other page where a plugin is displaying an alternative sidebar like the `docs-categories` plugin
2. Clicking the chat icon in the header and opening the drawer, or if you just minimize chat into drawer after it opens full-screen
3. The alternative sidebar panel is lost and reverted to the main panel.

There are no additional tests added because this use case should already be covered by the test for the admin sidebar in:
https://github.com/discourse/discourse/blob/53f9c81790ca232b8dbfa9b04b7f0863cf0d16c2/plugins/chat/spec/system/admin_sidebar_navigation_spec.rb#L63-L79