### PR TITLE
FEATURE: highlight current user own posts

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/highlight-posts.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/highlight-posts.js
@@ -1,0 +1,19 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  initialize() {
+    withPluginApi("1.36.0", (api) => {
+      const username = api.getCurrentUser()?.username;
+      if (!username) {
+        return;
+      }
+
+      const style = document.createElement("style");
+      style.type = "text/css";
+      const cssRule = `.inline-onebox[data-author="${username}"] { background: var(--tertiary-400); }`;
+      style.appendChild(document.createTextNode(cssRule));
+
+      document.head.appendChild(style);
+    });
+  },
+};

--- a/app/assets/javascripts/pretty-text/addon/allow-lister.js
+++ b/app/assets/javascripts/pretty-text/addon/allow-lister.js
@@ -120,6 +120,7 @@ export const DEFAULT_LIST = [
   "a.mention-group",
   "a.onebox",
   `a.inline-onebox`,
+  `a.inline-onebox[data-author]`,
   `a.inline-onebox-loading`,
   "a[data-bbcode]",
   "a[data-word]",

--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -319,6 +319,10 @@ module CookedProcessorMixin
       element.add_class("inline-onebox")
     end
 
+    if author = inline_onebox&.dig(:author)
+      element.set_attribute("data-author", author)
+    end
+
     remove_inline_onebox_loading_class(element)
   end
 

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe CookedPostProcessor do
 
       describe "internal links" do
         fab!(:topic)
+        fab!(:topic_post) { Fabricate(:post, topic: topic) }
         fab!(:post) { Fabricate(:post, user: user_with_auto_groups, raw: "Hello #{topic.url}") }
         let(:url) { topic.url }
 
@@ -153,6 +154,7 @@ RSpec.describe CookedPostProcessor do
             "a",
             with: {
               href: UrlHelper.cook_url(url),
+              "data-author": topic_post.user.username,
             },
             without: {
               class: "inline-onebox-loading",

--- a/spec/lib/inline_oneboxer_spec.rb
+++ b/spec/lib/inline_oneboxer_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe InlineOneboxer do
 
   it "can onebox a topic" do
     topic = Fabricate(:topic)
+    post = Fabricate(:post, topic: topic)
     results = InlineOneboxer.new([topic.url], skip_cache: true).process
     expect(results).to be_present
     expect(results[0][:url]).to eq(topic.url)
     expect(results[0][:title]).to eq(topic.title)
+    expect(results[0][:author]).to eq(post.user.username)
   end
 
   it "doesn't onebox private messages" do


### PR DESCRIPTION
This commit will highlight link to internal posts in posts when this post has been created by the current user.

To achieve this goal, three changes have been made:

- `InlineOneboxer.lookup` will always attempt to get the author of a post (even for first post), unless the post is not visible
- `cooked_processor_mixin` will add this author attribute to the links as a data attribute when available 
- an `highlight-posts` initializer will generate and append a custom style rule to target and style the posts of the current user:

```
.inline-onebox[data-author="${CURRENT_USERNAME}"] {
  background: var(--tertiary-400);
}
```

Note that we could add support for this in `inline-oneboxer.js` but this feature seems un-necessary in composer preview.