### PR TITLE
UX: Change AdminPageSubheader to H2

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-page-subheader.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-page-subheader.gjs
@@ -38,7 +38,7 @@ export default class AdminPageSubheader extends Component {
   <template>
     <div class="admin-page-subheader">
       <div class="admin-page-subheader__title-row">
-        <h3 class="admin-page-subheader__title">{{this.title}}</h3>
+        <h2 class="admin-page-subheader__title">{{this.title}}</h2>
         {{#if (has-block "actions")}}
           <div class="admin-page-subheader__actions">
             {{#if this.site.mobileView}}

--- a/app/assets/stylesheets/common/admin/admin_page_header.scss
+++ b/app/assets/stylesheets/common/admin/admin_page_header.scss
@@ -7,8 +7,12 @@
     margin-bottom: var(--space-2);
 
     h1,
-    h3 {
+    h2 {
       margin: 0;
+    }
+
+    h2 {
+      font-size: var(--font-up-2);
     }
 
     .admin-page-header__actions {


### PR DESCRIPTION
Since the AdminPageHeader is H1, it is more semantically
correct to progress to H2 after it rather than skipping
a level to H3
