### PR TITLE
UX: fix missing text overflow ellipsis in chat index pages

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -7,16 +7,13 @@
   }
 
   &__label {
-    display: flex;
-    align-items: center;
-    white-space: nowrap;
-    gap: 0.5rem;
+    @include ellipsis;
   }
 
   .emoji {
     height: 1em;
     width: 1em;
-    vertical-align: baseline;
+    vertical-align: middle;
   }
 
   .chat-channel-unread-indicator {


### PR DESCRIPTION
Due to a change in #28731, the chat channel label on the index pages was being flexed, presumably to better align with emojis included in the names. This conflicts with `text-overflow:ellipsis` so I've removed flex. The lesser of 2 evils is a mildly misaligned emoji.

The other solution would involve separating these two elements, so label has its own wrapper element
```
    <div class="chat-channel-name">
      <div class="chat-channel-name__label">
        {{replaceEmoji this.channelTitle}}
```

but thats not easily done.