### PR TITLE
DEV: uses hasNoErrors for field as used on form

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/form-kit-assertions.js
+++ b/app/assets/javascripts/discourse/tests/helpers/form-kit-assertions.js
@@ -174,7 +174,7 @@ class FieldHelper {
       .includesText(error, message);
   }
 
-  hasNoError(message) {
+  hasNoErrors(message) {
     this.context
       .dom(this.element.querySelector(".form-kit__errors"))
       .doesNotExist(message);

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-number-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-number-test.gjs
@@ -53,7 +53,7 @@ module(
 
       await fillIn("input", "0");
       await formKit().submit();
-      assert.form().field("foo").hasNoError();
+      assert.form().field("foo").hasNoErrors();
     });
   }
 );

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -187,7 +187,7 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     await formKit().reset();
 
-    assert.form().field("foo").hasNoError("it resets the errors");
+    assert.form().field("foo").hasNoErrors("it resets the errors");
   });
 
   test("immutable by default", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -83,7 +83,7 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     await formKit().field("foo").fillIn("");
 
-    assert.form().field("foo").hasNoError();
+    assert.form().field("foo").hasNoErrors();
 
     await formKit().submit();
 
@@ -96,7 +96,7 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     await formKit().field("foo").fillIn("t");
 
-    assert.form().field("foo").hasNoError();
+    assert.form().field("foo").hasNoErrors();
     assert.form().field("bar").hasError("Required");
     assert.form().hasErrors({
       bar: "Required",


### PR DESCRIPTION
This commit simply ensures the API is similar for fields and form.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->