### PR TITLE
DEV: Attempt to fix a flaky spec

### DIFF
--- a/spec/integration/smtp_spec.rb
+++ b/spec/integration/smtp_spec.rb
@@ -12,17 +12,15 @@ RSpec.describe "SMTP Settings Integration" do
     ActionMailer::Base.delivery_method = @original_action_mailer_delivery_method
   end
 
-  it "should send out the email successfully using the SMTP settings" do
-    global_setting :smtp_address, "some.host"
+  it "should attempt to send out an email without raising any SMTP argument errors" do
+    global_setting :smtp_address, "1.2.3.4"
     global_setting :smtp_port, 12_345
+    global_setting :smtp_open_timeout, 0.00001
 
     ActionMailer::Base.smtp_settings = GlobalSetting.smtp_settings
 
     message = TestMailer.send_test("some_email")
 
-    expect do Email::Sender.new(message, :test_message).send end.to raise_error(
-      StandardError,
-      /some.host/,
-    )
+    expect do Email::Sender.new(message, :test_message).send end.to raise_error(Net::OpenTimeout)
   end
 end


### PR DESCRIPTION
We some times get the following failure on Github CI:

```
expected StandardError with message matching /some.host/, got #<Socket::ResolutionError: getaddrinfo: Temporary failure in name resolution> with backtrace:
```
