### PR TITLE
DEV: Add helpers to customize poster title

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.hbs
@@ -39,7 +39,10 @@
       <div class="badge-set-title {{if this.hiddenSetTitle 'hidden' ''}}">
         <PluginOutlet
           @name="selectable-user-badges"
-          @outletArgs={{hash selectableUserBadges=this.selectableUserBadges closeAction=this.closeAction}}
+          @outletArgs={{hash
+            selectableUserBadges=this.selectableUserBadges
+            closeAction=this.closeAction
+          }}
         >
           <BadgeTitle
             @selectableUserBadges={{this.selectableUserBadges}}

--- a/app/assets/javascripts/discourse/app/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.hbs
@@ -41,7 +41,7 @@
           @name="selectable-user-badges"
           @outletArgs={{hash
             selectableUserBadges=this.selectableUserBadges
-            closeAction=this.closeAction
+            closeAction=this.toggleSetUserTitle
           }}
         >
           <BadgeTitle

--- a/app/assets/javascripts/discourse/app/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.hbs
@@ -37,10 +37,15 @@
 
     {{#if this.canSelectTitle}}
       <div class="badge-set-title {{if this.hiddenSetTitle 'hidden' ''}}">
-        <BadgeTitle
-          @selectableUserBadges={{this.selectableUserBadges}}
-          @closeAction={{this.toggleSetUserTitle}}
-        />
+        <PluginOutlet
+          @name="selectable-user-badges"
+          @outletArgs={{hash selectableUserBadges=this.selectableUserBadges closeAction=this.closeAction}}
+        >
+          <BadgeTitle
+            @selectableUserBadges={{this.selectableUserBadges}}
+            @closeAction={{this.toggleSetUserTitle}}
+          />
+        </PluginOutlet>
       </div>
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -167,8 +167,20 @@ export default createWidget("poster-name", {
       );
     }
 
+    this.buildTitleObject(attrs, contents);
+
+    if (this.siteSettings.enable_user_status) {
+      this.addUserStatus(contents, attrs);
+    }
+
+    return contents;
+  },
+
+  buildTitleObject(attrs, contents) {
+    const primaryGroupName = attrs.primary_group_name;
     const title = attrs.user_title,
       titleIsGroup = attrs.title_is_group;
+
     if (title && title.length) {
       contents.push(
         this.attach("poster-name-title", {
@@ -178,12 +190,6 @@ export default createWidget("poster-name", {
         })
       );
     }
-
-    if (this.siteSettings.enable_user_status) {
-      this.addUserStatus(contents, attrs);
-    }
-
-    return contents;
   },
 
   addUserStatus(contents, attrs) {


### PR DESCRIPTION
- This PR adds an outlet wrapper for the badge title and extracts a function outside the `html` method for poster-widget to help customize the badge title for posters. Nothing was changed in terms of functionality.