### PR TITLE
UX: chat index flex issues

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
@@ -69,10 +69,6 @@ export default class ChatChannelName extends Component {
       <div class="chat-channel-name__label">
         {{replaceEmoji this.channelTitle}}
 
-        {{#if this.unreadIndicator}}
-          <ChatChannelUnreadIndicator @channel={{@channel}} />
-        {{/if}}
-
         {{#if this.showUserStatus}}
           <UserStatusMessage
             @status={{get this.users "0.status"}}
@@ -94,6 +90,10 @@ export default class ChatChannelName extends Component {
           {{yield}}
         {{/if}}
       </div>
+
+      {{#if this.unreadIndicator}}
+        <ChatChannelUnreadIndicator @channel={{@channel}} />
+      {{/if}}
     </div>
   </template>
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -2,6 +2,12 @@
   @include ellipsis;
   color: var(--primary);
 
+  .chat-channel-row__info & {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
+
   .has-unread & {
     font-weight: bold;
   }


### PR DESCRIPTION
Followup for #29150 
Recent indicator position changes and flex moving around caused some issues.  

This should hopefully fix everything:
* indicator moved outside of the `chat-channel-name__label`
* flex applied to `chat-channel-name` when inside a `chat-channel-row__info`

## Before
<img width="381" alt="CleanShot 2024-10-10 at 19 41 26@2x" src="https://github.com/user-attachments/assets/ea41fc02-97ee-4a11-8600-89f50565ecd7">
<img width="395" alt="CleanShot 2024-10-10 at 19 42 31@2x" src="https://github.com/user-attachments/assets/b75776a7-bd8a-4365-87f7-23e606bfb4b0">


## After
<img width="404" alt="CleanShot 2024-10-10 at 19 38 30@2x" src="https://github.com/user-attachments/assets/a2a40b8d-6bbd-40d6-bd9d-34ca99f0cba3">

<img width="392" alt="CleanShot 2024-10-10 at 19 38 12@2x" src="https://github.com/user-attachments/assets/40eecc27-2051-45f4-8a51-0a00be592783">
