### PR TITLE
DEV: Remove long-deprecated test helpers

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -438,43 +438,12 @@ export function acceptance(name, optionsOrCallback) {
   }
 }
 
-export function controllerFor(controller, model) {
-  deprecated(
-    'controllerFor is deprecated. Use the standard `getOwner(this).lookup("controller:NAME")` instead',
-    {
-      id: "discourse.controller-for",
-      since: "3.0.0.beta14",
-    }
-  );
-
-  controller = getOwnerWithFallback(this).lookup("controller:" + controller);
-  if (model) {
-    controller.set("model", model);
-  }
-  return controller;
-}
-
 export function fixture(selector) {
   if (selector) {
     return document.querySelector(`#qunit-fixture ${selector}`);
   }
   return document.querySelector("#qunit-fixture");
 }
-
-QUnit.assert.not = function (actual, message) {
-  deprecated("assert.not() is deprecated. Use assert.false() instead.", {
-    since: "2.9.0.beta1",
-    dropFrom: "2.10.0.beta1",
-    id: "discourse.qunit.assert-not",
-  });
-
-  this.pushResult({
-    result: !actual,
-    actual,
-    expected: !actual,
-    message,
-  });
-};
 
 QUnit.assert.blank = function (actual, message) {
   this.pushResult({


### PR DESCRIPTION
nothing in all-the* is using them anymore

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->