### PR TITLE
FIX: Imports of upload-only chat messages

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -1908,7 +1908,7 @@ class BulkImport::Base
     message[:id] = @last_chat_message_id += 1
     message[:user_id] ||= Discourse::SYSTEM_USER_ID
     message[:last_editor_id] ||= message[:user_id]
-    message[:message] = (message[:message] || "").scrub.strip.presence || "<Empty imported message>"
+    message[:message] = (message[:message] || "").scrub.strip
     message[:message] = normalize_text(message[:message])
     message[:cooked] = ::Chat::Message.cook(message[:message], user_id: message[:last_editor_id])
     message[:cooked_version] = ::Chat::Message::BAKED_VERSION

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2669,6 +2669,7 @@ class BulkImport::Generic < BulkImport::Base
       user_id = user_id_from_imported_id(row["user_id"])
 
       next if channel_id.blank? || user_id.blank?
+      next if row["message"].blank? && row["upload_ids"].blank?
 
       last_editor_id = user_id_from_imported_id(row["last_editor_id"])
       thread_id = chat_thread_id_from_original_id(row["thread_id"])


### PR DESCRIPTION
The current implementation adds a "note" for chat messages with empty messages, however chat messages with only uploads  are allowed. This change allows such messages to be imported.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->