### PR TITLE
DEV: Fix problem check tracker unique index not respecting NULLs

### DIFF
--- a/db/migrate/20241011054348_fix_unique_constraint_on_problem_check_trackers.rb
+++ b/db/migrate/20241011054348_fix_unique_constraint_on_problem_check_trackers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class FixUniqueConstraintOnProblemCheckTrackers < ActiveRecord::Migration[7.1]
+  def up
+    remove_index :problem_check_trackers, %i[identifier target], if_exists: true
+
+    # Remove any existing duplicates that might have slipped by to prevent
+    # the creation of the new unique index from failing.
+    #
+    execute(<<~SQL)
+      DELETE FROM problem_check_trackers
+      WHERE id IN(
+        SELECT pct1.id
+        FROM problem_check_trackers pct1
+        JOIN problem_check_trackers pct2
+        ON pct1.identifier = pct2.identifier
+        AND pct1.target IS NULL
+        AND pct2.target IS NULL
+        WHERE pct1.id > pct2.id
+      )
+    SQL
+
+    add_index :problem_check_trackers, %i[identifier target], unique: true, nulls_not_distinct: true
+  end
+
+  def down
+    remove_index :problem_check_trackers, %i[identifier target], if_exists: true
+    add_index :problem_check_trackers, %i[identifier target], unique: true
+  end
+end


### PR DESCRIPTION
### What is the problem?

By default, when checking uniqueness on a tuple for the purposes of enforcing a unique index, PostgreSQL considers `NULL`s to be distinct values. Because of this we could incorrectly have multiple entries with `{ identifier: "rails_env", target: nil }` created due to race conditions. This would then cause errors at runtime.

### How does this solve it?

Drop the existing index and recreate it with the `NULLS NOT DISTINCT` option.

### Is it safe to run this migration?

The `problem_check_trackers` table is constrained by the number of problem check Ruby classes in the codebase, and will be in the range of 10-100.