### PR TITLE
FEATURE: enable threading in chat DM channels

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 class Chat::Api::ChannelsController < Chat::ApiController
-  CHANNEL_EDITABLE_PARAMS ||= %i[name description slug]
-  CATEGORY_CHANNEL_EDITABLE_PARAMS ||= %i[
-    auto_join_users
-    allow_channel_wide_mentions
-    threading_enabled
-  ]
+  CHANNEL_EDITABLE_PARAMS ||= %i[name description slug threading_enabled]
+  CATEGORY_CHANNEL_EDITABLE_PARAMS ||= %i[auto_join_users allow_channel_wide_mentions]
 
   def index
     permitted = params.permit(:filter, :limit, :offset, :status)

--- a/plugins/chat/app/models/chat/direct_message_channel.rb
+++ b/plugins/chat/app/models/chat/direct_message_channel.rb
@@ -3,6 +3,7 @@
 module Chat
   class DirectMessageChannel < Channel
     alias_method :direct_message, :chatable
+    before_validation(on: :create) { self.threading_enabled = true }
 
     def direct_message_channel?
       true

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-settings.gjs
@@ -98,8 +98,12 @@ export default class ChatRouteChannelInfoSettings extends Component {
     return this.args.channel.isCategoryChannel && this.args.channel.isOpen;
   }
 
-  get toggleThreadingAvailable() {
+  get toggleThreadingCategoryChannel() {
     return this.args.channel.isCategoryChannel && this.args.channel.isOpen;
+  }
+
+  get toggleThreadingDirectMessage() {
+    return this.args.channel.isDirectMessageChannel && this.args.channel.isOpen;
   }
 
   get channelWideMentionsDescription() {
@@ -420,6 +424,28 @@ export default class ChatRouteChannelInfoSettings extends Component {
                   </:action>
                 </section.row>
               {{/if}}
+
+              {{#if this.toggleThreadingDirectMessage}}
+                <section.row @label={{this.toggleThreadingLabel}}>
+                  <:action>
+                    <DToggleSwitch
+                      @state={{@channel.threadingEnabled}}
+                      class="c-channel-settings__threading-switch"
+                      {{on
+                        "click"
+                        (fn
+                          this.onToggleThreadingEnabled
+                          @channel.threadingEnabled
+                        )
+                      }}
+                    />
+                  </:action>
+
+                  <:description>
+                    {{this.toggleThreadingDescription}}
+                  </:description>
+                </section.row>
+              {{/if}}
             </form.section>
           {{/if}}
 
@@ -482,7 +508,7 @@ export default class ChatRouteChannelInfoSettings extends Component {
                 </section.row>
               {{/if}}
 
-              {{#if this.toggleThreadingAvailable}}
+              {{#if this.toggleThreadingCategoryChannel}}
                 <section.row @label={{this.toggleThreadingLabel}}>
                   <:action>
                     <DToggleSwitch

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -108,9 +108,7 @@ export default class ChatChannelsManager extends Service {
 
   @cached
   get hasThreadedChannels() {
-    return this.publicMessageChannels?.some(
-      (channel) => channel.threadingEnabled
-    );
+    return this.allChannels?.some((channel) => channel.threadingEnabled);
   }
 
   get allChannels() {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -108,7 +108,9 @@ export default class ChatChannelsManager extends Service {
 
   @cached
   get hasThreadedChannels() {
-    return this.allChannels?.some((channel) => channel.threadingEnabled);
+    return this.publicMessageChannels?.some(
+      (channel) => channel.threadingEnabled
+    );
   }
 
   get allChannels() {

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -44,7 +44,7 @@ module Chat
     # name and description can be edited.
     def can_edit_chat_channel?(channel)
       if channel.direct_message_channel?
-        channel.chatable.group && (is_staff? || channel.chatable.user_can_access?(@user))
+        is_staff? || channel.chatable.user_can_access?(@user)
       elsif channel.category_channel?
         is_staff?
       end

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -43,6 +43,7 @@ Fabricator(:direct_message_channel, from: :chat_channel) do
   end
   status { :open }
   name nil
+  threading_enabled true
   after_create do |channel, attrs|
     if attrs[:with_membership]
       channel.chatable.users.each do |user|

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Chat::GuardianExtensions do
         context "when not group" do
           it "doesn’t allow  to edit the channel" do
             Chat::DirectMessageUser.create(user: user, direct_message: dm_channel.chatable)
-            expect(user.guardian.can_edit_chat_channel?(dm_channel)).to eq(false)
+            expect(user.guardian.can_edit_chat_channel?(dm_channel)).to eq(true)
           end
         end
       end

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Chat::GuardianExtensions do
         end
 
         context "when not group" do
-          it "doesn’t allow  to edit the channel" do
+          it "allows to edit the channel" do
             Chat::DirectMessageUser.create(user: user, direct_message: dm_channel.chatable)
             expect(user.guardian.can_edit_chat_channel?(dm_channel)).to eq(true)
           end

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Chat::DirectMessageChannel do
     end
   end
 
+  describe "#threading_enabled" do
+    it "defaults to true" do
+      expect(channel.threading_enabled).to be(true)
+    end
+  end
+
   describe "#title" do
     subject(:title) { channel.title(user) }
 

--- a/plugins/chat/spec/system/channel_settings_page_spec.rb
+++ b/plugins/chat/spec/system/channel_settings_page_spec.rb
@@ -166,6 +166,23 @@ RSpec.describe "Channel - Info - Settings page", type: :system do
         ).to eq(false)
       end
     end
+
+    context "when direct message channel" do
+      fab!(:channel_1) do
+        Fabricate(:direct_message_channel, users: [current_user, Fabricate(:user)])
+      end
+
+      before { channel_1.add(current_user) }
+
+      it "can toggle threading" do
+        chat_page.visit_channel_settings(channel_1)
+
+        expect {
+          PageObjects::Components::DToggleSwitch.new(".c-channel-settings__threading-switch").toggle
+          expect(toasts).to have_success(I18n.t("js.saved"))
+        }.to change { channel_1.reload.threading_enabled }.from(true).to(false)
+      end
+    end
   end
 
   context "as staff" do


### PR DESCRIPTION
Support threads in DMs and group chats so members can keep their conversations organized.

This change adds a new toggle switch for threads within the Chat Channel Settings screen. For new direct message channels threading is enabled by default.

We have made a decision to exclude direct message threads from the My Threads screen for now.

How the settings screen looks in chat drawer:

<img width="394" alt="Screenshot 2024-10-11 at 10 55 35 AM" src="https://github.com/user-attachments/assets/52a8dcf5-82b3-467d-858d-c17638df7f4a">

And the chat view looks with threads:

<img width="391" alt="Screenshot 2024-10-11 at 11 48 45 AM" src="https://github.com/user-attachments/assets/9baf7860-acd8-47a9-958c-6f1fa6a6e8f3">
