### PR TITLE
FEATURE: Unconditionally paginate categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -76,17 +76,13 @@ export default class CategoriesDisplay extends Component {
     }
   }
 
-  get canLoadMore() {
-    return this.site.lazy_load_categories && this.args.loadMore;
-  }
-
   <template>
     <PluginOutlet
       @name="above-discovery-categories"
       @connectorTagName="div"
       @outletArgs={{hash categories=@categories topics=@topics}}
     />
-    {{#if this.canLoadMore}}
+    {{#if @loadMore}}
       <LoadMore
         @selector=".category:not(.muted-categories *)"
         @action={{@loadMore}}

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe CategoriesController do
       let!(:category2) { Fabricate(:category, user: admin) }
       let!(:category3) { Fabricate(:category, user: admin) }
 
-      it "paginates results wihen lazy_load_categories is enabled" do
+      it "paginates results" do
         SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
 
         stub_const(CategoryList, "CATEGORIES_PER_PAGE", 2) { get "/categories.json?page=1" }
@@ -414,16 +414,6 @@ RSpec.describe CategoriesController do
         stub_const(CategoryList, "CATEGORIES_PER_PAGE", 2) { get "/categories.json?page=2" }
         expect(response.status).to eq(200)
         expect(response.parsed_body["category_list"]["categories"].count).to eq(2)
-      end
-
-      it "does not paginate results when lazy_load_categories is disabled" do
-        stub_const(CategoryList, "CATEGORIES_PER_PAGE", 2) { get "/categories.json?page=1" }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["category_list"]["categories"].count).to eq(4)
-
-        stub_const(CategoryList, "CATEGORIES_PER_PAGE", 2) { get "/categories.json?page=2" }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["category_list"]["categories"].count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Categories page used to be paginated only when lazy load categories is enabled.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->