### PR TITLE
Add link to meta to forwarded emails behaviour desc

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2324,7 +2324,7 @@ en:
     blocked_attachment_content_types: "List of keywords used to blocklist attachments based on the content type."
     blocked_attachment_filenames: "List of keywords used to blocklist attachments based on the filename."
 
-    forwarded_emails_behaviour: "How to treat a forwarded email to Discourse"
+    forwarded_emails_behaviour: "How to treat a forwarded email to Discourse. <a href='https://meta.discourse.org/t/-/62977' target='_blank'>Learn more</a>"
     always_show_trimmed_content: "Always show trimmed part of incoming emails. WARNING: might reveal email addresses."
     trim_incoming_emails: "Trim part of the incoming emails that isn't relevant."
     private_email: "Don't include content from posts or topics in email title or email body. NOTE: also disables digest emails."


### PR DESCRIPTION
Added a link to https://meta.discourse.org/t/configuring-incoming-email-to-create-new-topics-or-group-messages/62977 to the `forwarded emails behaviour` setting description, to help admins learn how email forwarding works.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->