### PR TITLE
DEV: Set priorities on user tips

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
@@ -64,6 +64,7 @@ export default class Notifications extends Component {
         @titleText={{i18n "user_tips.first_notification.title"}}
         @contentText={{i18n "user_tips.first_notification.content"}}
         @showSkipButton={{true}}
+        @priority={{1}}
       />
     {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
@@ -64,7 +64,7 @@ export default class Notifications extends Component {
         @titleText={{i18n "user_tips.first_notification.title"}}
         @contentText={{i18n "user_tips.first_notification.content"}}
         @showSkipButton={{true}}
-        @priority={{1}}
+        @priority={{40}}
       />
     {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/suggested-topics.hbs
@@ -12,7 +12,7 @@
       @titleText={{i18n "user_tips.suggested_topics.title"}}
       @contentText={{i18n "user_tips.suggested_topics.content"}}
       @placement="top-start"
-      @priority={{4}}
+      @priority={{10}}
     />
   {{/unless}}
 

--- a/app/assets/javascripts/discourse/app/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/app/components/suggested-topics.hbs
@@ -12,6 +12,7 @@
       @titleText={{i18n "user_tips.suggested_topics.title"}}
       @contentText={{i18n "user_tips.suggested_topics.content"}}
       @placement="top-start"
+      @priority={{4}}
     />
   {{/unless}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -97,7 +97,7 @@
       @triggerSelector=".notifications-button"
       @titleText={{i18n "user_tips.topic_notification_levels.title"}}
       @contentText={{i18n "user_tips.topic_notification_levels.content"}}
-      @priority={{3}}
+      @priority={{20}}
     />
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -97,6 +97,7 @@
       @triggerSelector=".notifications-button"
       @titleText={{i18n "user_tips.topic_notification_levels.title"}}
       @contentText={{i18n "user_tips.topic_notification_levels.content"}}
+      @priority={{3}}
     />
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -67,7 +67,7 @@
     @contentText={{i18n "user_tips.topic_timeline.content"}}
     @placement="left"
     @triggerSelector=".timeline-scrollarea-wrapper"
-    @priority={{2}}
+    @priority={{30}}
   />
 
   <div class="timeline-scrollarea-wrapper">

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -67,6 +67,7 @@
     @contentText={{i18n "user_tips.topic_timeline.content"}}
     @placement="left"
     @triggerSelector=".timeline-scrollarea-wrapper"
+    @priority={{2}}
   />
 
   <div class="timeline-scrollarea-wrapper">


### PR DESCRIPTION
Currently the topic timeline tip appears before the suggested topics one only due to a small implementation detail in the latter.

This ensures that tips appear in the expected order when more than one of these components is rendered at the same time.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->