### PR TITLE
DEV: Add discourse-hcaptcha plugin to the metadata list of official plugins

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -38,6 +38,7 @@ class Plugin::Metadata
         discourse-gradle-issue
         discourse-graphviz
         discourse-group-tracker
+        discourse-hcaptcha
         discourse-invite-tokens
         discourse-jira
         discourse-lazy-videos


### PR DESCRIPTION
Adding `discourse-hcaptcha` to the plugin metadata list as part of making it an official plugin 