### PR TITLE
UX: simplify and shorten new script flow for automations

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
@@ -6,14 +6,12 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
 import I18n from "discourse-i18n";
-import { UNNAMED_AUTOMATION_PLACEHOLDER } from "../utils/automation-placeholder";
 
 export default class AutomationEdit extends Controller {
   @service dialog;
   error = null;
   isUpdatingAutomation = false;
   isTriggeringAutomation = false;
-  unnamedAutomationPlaceholder = UNNAMED_AUTOMATION_PLACEHOLDER;
 
   @reads("model.automation") automation;
   @filterBy("automationForm.fields", "targetType", "script") scriptFields;

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
@@ -9,6 +9,7 @@ import I18n from "discourse-i18n";
 
 export default class AutomationEdit extends Controller {
   @service dialog;
+  @service router;
   error = null;
   isUpdatingAutomation = false;
   isTriggeringAutomation = false;
@@ -26,7 +27,7 @@ export default class AutomationEdit extends Controller {
   }
 
   @action
-  saveAutomation() {
+  saveAutomation(routeToIndex = false) {
     this.setProperties({ error: null, isUpdatingAutomation: true });
 
     const updatedAutomationForm = {
@@ -45,6 +46,9 @@ export default class AutomationEdit extends Controller {
     )
       .then(() => {
         this.send("refreshRoute");
+        if (routeToIndex) {
+          this.router.transitionTo("adminPlugins.discourse-automation.index");
+        }
       })
       .catch((e) => this._showError(e))
       .finally(() => {

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
@@ -6,12 +6,14 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
 import I18n from "discourse-i18n";
+import { UNNAMED_AUTOMATION_PLACEHOLDER } from "../utils/automation-placeholder";
 
 export default class AutomationEdit extends Controller {
   @service dialog;
   error = null;
   isUpdatingAutomation = false;
   isTriggeringAutomation = false;
+  unnamedAutomationPlaceholder = UNNAMED_AUTOMATION_PLACEHOLDER;
 
   @reads("model.automation") automation;
   @filterBy("automationForm.fields", "targetType", "script") scriptFields;
@@ -29,11 +31,16 @@ export default class AutomationEdit extends Controller {
   saveAutomation() {
     this.setProperties({ error: null, isUpdatingAutomation: true });
 
+    const updatedAutomationForm = {
+      ...this.automationForm,
+      name: this.automationForm.name,
+    };
+
     return ajax(
       `/admin/plugins/discourse-automation/automations/${this.model.automation.id}.json`,
       {
         type: "PUT",
-        data: JSON.stringify({ automation: this.automationForm }),
+        data: JSON.stringify({ automation: updatedAutomationForm }),
         dataType: "json",
         contentType: "application/json",
       }

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-edit.js
@@ -30,16 +30,11 @@ export default class AutomationEdit extends Controller {
   saveAutomation(routeToIndex = false) {
     this.setProperties({ error: null, isUpdatingAutomation: true });
 
-    const updatedAutomationForm = {
-      ...this.automationForm,
-      name: this.automationForm.name,
-    };
-
     return ajax(
       `/admin/plugins/discourse-automation/automations/${this.model.automation.id}.json`,
       {
         type: "PUT",
-        data: JSON.stringify({ automation: updatedAutomationForm }),
+        data: JSON.stringify({ automation: this.automationForm }),
         dataType: "json",
         contentType: "application/json",
       }

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -5,8 +5,8 @@ import { inject as service } from "@ember/service";
 
 export default class AutomationNew extends Controller {
   @service router;
-
   @tracked filterText = "";
+  redirected = false;
 
   @action
   updateFilterText(event) {

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -2,7 +2,6 @@ import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { UNNAMED_AUTOMATION_PLACEHOLDER } from "../utils/automation-placeholder";
 
 export default class AutomationNew extends Controller {
   @service router;
@@ -32,13 +31,11 @@ export default class AutomationNew extends Controller {
 
   @action
   selectScriptToEdit(newScript) {
-    this.model.automation
-      .save({ name: UNNAMED_AUTOMATION_PLACEHOLDER, script: newScript.id })
-      .then(() => {
-        this.router.transitionTo(
-          "adminPlugins.discourse-automation.edit",
-          this.model.automation.id
-        );
-      });
+    this.model.automation.save({ script: newScript.id }).then(() => {
+      this.router.transitionTo(
+        "adminPlugins.discourse-automation.edit",
+        this.model.automation.id
+      );
+    });
   }
 }

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -13,6 +13,11 @@ export default class AutomationNew extends Controller {
     this.filterText = event.target.value;
   }
 
+  @action
+  resetFilterText() {
+    this.filterText = "";
+  }
+
   get scriptableContent() {
     let scripts = this.model.scriptables.content;
     let filter = this.filterText.toLowerCase();

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -1,38 +1,44 @@
+import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
-import EmberObject, { action } from "@ember/object";
-import { service } from "@ember/service";
-import { extractError } from "discourse/lib/ajax-error";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+import { UNNAMED_AUTOMATION_PLACEHOLDER } from "../utils/automation-placeholder";
 
 export default class AutomationNew extends Controller {
   @service router;
 
-  form = null;
-  error = null;
+  @tracked filterText = "";
 
-  init() {
-    super.init(...arguments);
-    this._resetForm();
+  @action
+  updateFilterText(event) {
+    this.filterText = event.target.value;
+  }
+
+  get scriptableContent() {
+    let scripts = this.model.scriptables.content;
+    let filter = this.filterText.toLowerCase();
+
+    if (!filter) {
+      return scripts;
+    }
+
+    return scripts.filter((script) => {
+      return (
+        script.name.toLowerCase().includes(filter) ||
+        script.description.toLowerCase().includes(filter)
+      );
+    });
   }
 
   @action
-  saveAutomation() {
-    this.set("error", null);
-
+  selectScriptToEdit(newScript) {
     this.model.automation
-      .save(this.form.getProperties("name", "script"))
+      .save({ name: UNNAMED_AUTOMATION_PLACEHOLDER, script: newScript.id })
       .then(() => {
-        this._resetForm();
         this.router.transitionTo(
           "adminPlugins.discourse-automation.edit",
           this.model.automation.id
         );
-      })
-      .catch((e) => {
-        this.set("error", extractError(e));
       });
-  }
-
-  _resetForm() {
-    this.set("form", EmberObject.create({ name: null, script: null }));
   }
 }

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -27,10 +27,11 @@ export default class AutomationNew extends Controller {
     }
 
     return scripts.filter((script) => {
-      return (
-        script.name.toLowerCase().includes(filter) ||
-        script.description.toLowerCase().includes(filter)
-      );
+      const name = script.name ? script.name.toLowerCase() : "";
+      const description = script.description
+        ? script.description.toLowerCase()
+        : "";
+      return name.includes(filter) || description.includes(filter);
     });
   }
 

--- a/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/controllers/admin-plugins-discourse-automation-new.js
@@ -6,7 +6,6 @@ import { inject as service } from "@ember/service";
 export default class AutomationNew extends Controller {
   @service router;
   @tracked filterText = "";
-  redirected = false;
 
   @action
   updateFilterText(event) {

--- a/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
+++ b/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
@@ -1,8 +1,17 @@
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AutomationIndex extends DiscourseRoute {
+  @service router;
+
   controllerName = "admin-plugins-discourse-automation-index";
+
+  afterModel(model) {
+    if (!model.length) {
+      this.router.transitionTo("adminPlugins.discourse-automation.new");
+    }
+  }
 
   model() {
     return this.store.findAll("discourse-automation-automation");

--- a/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
+++ b/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
@@ -7,18 +7,14 @@ export default class AutomationIndex extends DiscourseRoute {
 
   controllerName = "admin-plugins-discourse-automation-index";
 
-  afterModel(model) {
-    if (!model.length) {
-      const controller = this.controllerFor(
-        "adminPlugins.discourse-automation.new"
-      );
-      controller.set("redirected", true);
-      this.router.transitionTo("adminPlugins.discourse-automation.new");
-    }
-  }
-
   model() {
     return this.store.findAll("discourse-automation-automation");
+  }
+
+  afterModel(model) {
+    if (!model.length) {
+      this.router.transitionTo("adminPlugins.discourse-automation.new");
+    }
   }
 
   @action

--- a/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
+++ b/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-index.js
@@ -9,6 +9,10 @@ export default class AutomationIndex extends DiscourseRoute {
 
   afterModel(model) {
     if (!model.length) {
+      const controller = this.controllerFor(
+        "adminPlugins.discourse-automation.new"
+      );
+      controller.set("redirected", true);
       this.router.transitionTo("adminPlugins.discourse-automation.new");
     }
   }

--- a/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-new.js
+++ b/plugins/automation/admin/assets/javascripts/admin/routes/admin-plugins-discourse-automation-new.js
@@ -6,6 +6,7 @@ export default class AutomationNew extends DiscourseRoute {
 
   model() {
     return hash({
+      scripts: this.store.findAll("discourse-automation-automation"),
       scriptables: this.store.findAll("discourse-automation-scriptable"),
       automation: this.store.createRecord("discourse-automation-automation"),
     });

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -10,9 +10,9 @@
 
         <div class="controls">
           <TextField
-            @value={{automationForm.name}}
+            @value={{this.automationForm.name}}
             @type="text"
-            @autofocus="autofocus"
+            @autofocus={{true}}
             @name="automation-name"
             class="input-large"
             @input={{with-event-value (fn (mut this.automationForm.name))}}
@@ -27,9 +27,9 @@
 
         <div class="controls">
           <ComboBox
-            @value={{automationForm.script}}
-            @content={{model.scriptables}}
-            @onChange={{action "onChangeScript"}}
+            @value={{this.automationForm.script}}
+            @content={{this.model.scriptables}}
+            @onChange={{this.onChangeScript}}
             @options={{hash filterable=true}}
             class="scriptables"
           />
@@ -43,7 +43,7 @@
       </h2>
 
       <div class="control-group">
-        {{#if model.automation.script.forced_triggerable}}
+        {{#if this.model.automation.script.forced_triggerable}}
           <div class="alert alert-warning">
             {{i18n
               "discourse_automation.edit_automation.trigger_section.forced"
@@ -57,47 +57,50 @@
 
         <div class="controls">
           <ComboBox
-            @value={{automationForm.trigger}}
-            @content={{model.triggerables}}
-            @onChange={{action "onChangeTrigger"}}
+            @value={{this.automationForm.trigger}}
+            @content={{this.model.triggerables}}
+            @onChange={{this.onChangeTrigger}}
             @options={{hash
               filterable=true
               none="discourse_automation.select_trigger"
-              disabled=model.automation.script.forced_triggerable
+              disabled=this.model.automation.script.forced_triggerable
             }}
             class="triggerables"
           />
         </div>
       </div>
 
-      {{#if automationForm.trigger}}
-        {{#if model.automation.trigger.doc}}
+      {{#if this.automationForm.trigger}}
+        {{#if this.model.automation.trigger.doc}}
           <div class="alert alert-info">
-            <p>{{model.automation.trigger.doc}}</p>
+            <p>{{this.model.automation.trigger.doc}}</p>
           </div>
         {{/if}}
 
         {{#if
           (and
-            model.automation.enabled
-            model.automation.trigger.settings.manual_trigger
+            this.model.automation.enabled
+            this.model.automation.trigger.settings.manual_trigger
           )
         }}
           <div class="alert alert-info next-trigger">
 
-            {{#if nextPendingAutomationAtFormatted}}
+            {{#if this.nextPendingAutomationAtFormatted}}
               <p>
                 {{i18n
                   "discourse_automation.edit_automation.trigger_section.next_pending_automation"
-                  date=nextPendingAutomationAtFormatted
+                  date=this.nextPendingAutomationAtFormatted
                 }}
               </p>
             {{/if}}
 
             <DButton
               @label="discourse_automation.edit_automation.trigger_section.trigger_now"
-              @isLoading={{isTriggeringAutomation}}
-              @action={{action "onManualAutomationTrigger" model.automation.id}}
+              @isLoading={{this.isTriggeringAutomation}}
+              @action={{fn
+                this.onManualAutomationTrigger
+                this.model.automation.id
+              }}
               class="btn-primary trigger-now-btn"
             />
           </div>
@@ -105,50 +108,50 @@
 
         {{#each triggerFields as |field|}}
           <AutomationField
-            @automation={{automation}}
+            @automation={{this.automation}}
             @field={{field}}
-            @saveAutomation={{action "saveAutomation" automation}}
+            @saveAutomation={{fn this.saveAutomation this.automation}}
           />
         {{/each}}
       {{/if}}
     </section>
 
-    {{#if automationForm.trigger}}
-      {{#if scriptFields}}
+    {{#if this.automationForm.trigger}}
+      {{#if this.scriptFields}}
         <section class="fields-section form-section edit">
           <h2 class="title">
             {{i18n "discourse_automation.edit_automation.fields_section.title"}}
           </h2>
 
-          {{#if model.automation.script.with_trigger_doc}}
+          {{#if this.model.automation.script.with_trigger_doc}}
             <div class="alert alert-info">
-              <p>{{model.automation.script.with_trigger_doc}}</p>
+              <p>{{this.model.automation.script.with_trigger_doc}}</p>
             </div>
           {{/if}}
 
           <div class="control-group">
-            {{#each scriptFields as |field|}}
+            {{#each this.scriptFields as |field|}}
               <AutomationField
-                @automation={{automation}}
+                @automation={{this.automation}}
                 @field={{field}}
-                @saveAutomation={{action "saveAutomation" automation}}
+                @saveAutomation={{fn this.saveAutomation this.automation}}
               />
             {{/each}}
           </div>
         </section>
       {{/if}}
 
-      {{#if automationForm.trigger}}
+      {{#if this.automationForm.trigger}}
         <div class="control-group automation-enabled alert alert-warning">
           <span>{{i18n
               "discourse_automation.models.automation.enabled.label"
             }}</span>
           <Input
             @type="checkbox"
-            @checked={{automationForm.enabled}}
+            @checked={{this.automationForm.enabled}}
             {{on
               "click"
-              (action (mut automationForm.enabled) value="target.checked")
+              (action (mut this.automationForm.enabled) value="target.checked")
             }}
           />
         </div>
@@ -156,7 +159,7 @@
 
       <div class="control-group">
         <DButton
-          @isLoading={{isUpdatingAutomation}}
+          @isLoading={{this.isUpdatingAutomation}}
           @label="discourse_automation.update"
           @type="submit"
           @action={{fn this.saveAutomation this.automation true}}

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -10,11 +10,16 @@
 
         <div class="controls">
           <TextField
-            @value={{automationForm.name}}
+            @value={{if
+              (eq automationForm.name this.unnamedAutomationPlaceholder)
+              ""
+              automationForm.name
+            }}
             @type="text"
             @autofocus="autofocus"
             @name="automation-name"
             class="input-large"
+            @input={{action (mut automationForm.name) value="target.value"}}
           />
         </div>
       </div>

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -159,7 +159,7 @@
           @isLoading={{isUpdatingAutomation}}
           @label="discourse_automation.update"
           @type="submit"
-          @action={{action "saveAutomation" automation}}
+          @action={{fn this.saveAutomation automation true}}
           class="btn-primary update-automation"
         />
       </div>

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -142,7 +142,10 @@
       {{/if}}
 
       {{#if this.automationForm.trigger}}
-        <div class="control-group automation-enabled alert alert-warning">
+        <div
+          class="control-group automation-enabled alert
+            {{if this.automationForm.enabled 'alert-info' 'alert-warning'}}"
+        >
           <span>{{i18n
               "discourse_automation.models.automation.enabled.label"
             }}</span>

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -15,7 +15,7 @@
             @autofocus="autofocus"
             @name="automation-name"
             class="input-large"
-            @input={{action (mut automationForm.name) value="target.value"}}
+            @input={{with-event-value (fn (mut this.automationForm.name))}}
           />
         </div>
       </div>
@@ -159,7 +159,7 @@
           @isLoading={{isUpdatingAutomation}}
           @label="discourse_automation.update"
           @type="submit"
-          @action={{fn this.saveAutomation automation true}}
+          @action={{fn this.saveAutomation this.automation true}}
           class="btn-primary update-automation"
         />
       </div>

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-edit.hbs
@@ -10,11 +10,7 @@
 
         <div class="controls">
           <TextField
-            @value={{if
-              (eq automationForm.name this.unnamedAutomationPlaceholder)
-              ""
-              automationForm.name
-            }}
+            @value={{automationForm.name}}
             @type="text"
             @autofocus="autofocus"
             @name="automation-name"

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
@@ -45,8 +45,8 @@
               {{on "keypress" (fn this.editAutomation automation)}}
               {{on "click" (fn this.editAutomation automation)}}
             >{{if
-                this.automation.name
-                this.automation.name
+                automation.name
+                automation.name
                 (i18n "discourse_automation.unnamed_automation")
               }}</td>
             <td

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
@@ -44,7 +44,11 @@
               role="button"
               {{on "keypress" (fn this.editAutomation automation)}}
               {{on "click" (fn this.editAutomation automation)}}
-            >{{automation.name}}</td>
+            >{{if
+                automation.name
+                automation.name
+                (i18n "discourse_automation.unnamed_automation")
+              }}</td>
             <td
               role="button"
               {{on "click" (fn this.editAutomation automation)}}

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
@@ -45,8 +45,8 @@
               {{on "keypress" (fn this.editAutomation automation)}}
               {{on "click" (fn this.editAutomation automation)}}
             >{{if
-                automation.name
-                automation.name
+                this.automation.name
+                this.automation.name
                 (i18n "discourse_automation.unnamed_automation")
               }}</td>
             <td

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
@@ -33,6 +33,7 @@
             </td>
           {{else}}
             <td
+              class="automations__status"
               role="button"
               {{on "click" (fn this.editAutomation automation)}}
             >{{format-enabled-automation
@@ -40,6 +41,7 @@
                 automation.trigger
               }}</td>
             <td
+              class="automations__name"
               tabindex="0"
               role="button"
               {{on "keypress" (fn this.editAutomation automation)}}
@@ -50,10 +52,12 @@
                 (i18n "discourse_automation.unnamed_automation")
               }}</td>
             <td
+              class="automations__script"
               role="button"
               {{on "click" (fn this.editAutomation automation)}}
             >{{if automation.trigger.id automation.trigger.name "-"}}</td>
             <td
+              class="automations__version"
               role="button"
               {{on "click" (fn this.editAutomation automation)}}
             >{{automation.script.name}} (v{{automation.script.version}})</td>
@@ -68,7 +72,7 @@
             </td>
           {{/if}}
 
-          <td>
+          <td class="automations__delete">
             <DButton
               @icon="trash-can"
               @action={{action "destroyAutomation" automation}}

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-index.hbs
@@ -75,14 +75,4 @@
       {{/each}}
     </tbody>
   </table>
-{{else}}
-  <div class="alert alert-info">
-    <p>{{i18n "discourse_automation.no_automation_yet"}}</p>
-    <DButton
-      @label="discourse_automation.create"
-      @icon="plus"
-      @action={{action "newAutomation"}}
-      class="btn-primary"
-    />
-  </div>
 {{/if}}

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
@@ -14,6 +14,12 @@
     />
   </div>
 
+  {{#if this.redirected}}
+    <div class="alert alert-info">
+      <p>{{i18n "discourse_automation.no_automation_yet"}}</p>
+    </div>
+  {{/if}}
+
   <div class="admin-section-landing__wrapper">
     {{#each this.scriptableContent as |script|}}
       <AdminSectionLandingItem

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
@@ -14,11 +14,11 @@
     />
   </div>
 
-  {{#if this.redirected}}
+  {{#unless this.model.scripts.length}}
     <div class="alert alert-info">
       <p>{{i18n "discourse_automation.no_automation_yet"}}</p>
     </div>
-  {{/if}}
+  {{/unless}}
 
   <div class="admin-section-landing__wrapper">
     {{#each this.scriptableContent as |script|}}

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
@@ -1,52 +1,24 @@
 <section class="discourse-automation-form new">
-  <form class="form-horizontal">
-    <FormError @error={{error}} />
 
-    <div class="control-group">
-      <label class="control-label">
-        {{i18n "discourse_automation.models.automation.name.label"}}
-      </label>
+  <div class="admin-section-landing__header">
+    <h2>{{i18n "discourse_automation.select_script"}}</h2>
 
-      <div class="controls">
-        <TextField
-          @value={{form.name}}
-          @type="text"
-          @autofocus="autofocus"
-          @name="automation-name"
-          class="input-large"
-        />
-      </div>
-    </div>
+    <input
+      type="text"
+      placeholder={{i18n "discourse_automation.filter_placeholder"}}
+      {{on "input" this.updateFilterText}}
+      class="admin-section-landing__header-filter"
+    />
+  </div>
 
-    <div class="control-group">
-      <label class="control-label">
-        {{i18n "discourse_automation.models.automation.script.label"}}
-      </label>
+  <div class="admin-section-landing__wrapper">
+    {{#each this.scriptableContent as |script|}}
+      <AdminSectionLandingItem
+        {{on "click" (fn this.selectScriptToEdit script)}}
+        @titleLabelTranslated={{script.name}}
+        @descriptionLabelTranslated={{script.description}}
+      />
+    {{/each}}
+  </div>
 
-      <div class="controls">
-        <DropdownSelectBox
-          @value={{form.script}}
-          @content={{model.scriptables.content}}
-          @onChange={{fn (mut form.script)}}
-          @options={{hash
-            showCaret=true
-            filterable=true
-            none="discourse_automation.select_script"
-          }}
-          class="scriptables"
-        />
-      </div>
-    </div>
-
-    <div class="control-group">
-      <div class="controls">
-        <DButton
-          @icon="plus"
-          @label="discourse_automation.create"
-          @action={{this.saveAutomation}}
-          class="btn-primary create-automation"
-        />
-      </div>
-    </div>
-  </form>
 </section>

--- a/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
+++ b/plugins/automation/admin/assets/javascripts/admin/templates/admin-plugins-discourse-automation-new.hbs
@@ -1,6 +1,9 @@
 <section class="discourse-automation-form new">
 
-  <div class="admin-section-landing__header">
+  <div
+    class="admin-section-landing__header"
+    {{did-insert this.resetFilterText}}
+  >
     <h2>{{i18n "discourse_automation.select_script"}}</h2>
 
     <input

--- a/plugins/automation/admin/assets/javascripts/admin/utils/automation-placeholder.js
+++ b/plugins/automation/admin/assets/javascripts/admin/utils/automation-placeholder.js
@@ -1,1 +1,0 @@
-export const UNNAMED_AUTOMATION_PLACEHOLDER = "unnamed automation";

--- a/plugins/automation/admin/assets/javascripts/admin/utils/automation-placeholder.js
+++ b/plugins/automation/admin/assets/javascripts/admin/utils/automation-placeholder.js
@@ -1,0 +1,1 @@
+export const UNNAMED_AUTOMATION_PLACEHOLDER = "unnamed automation";

--- a/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
@@ -10,7 +10,7 @@ module DiscourseAutomation
         ActiveModel::ArraySerializer.new(
           automations,
           each_serializer: DiscourseAutomation::AutomationSerializer,
-          root: "automations",
+          root: "automations"
         ).as_json
       render_json_dump(serializer)
     end
@@ -21,15 +21,16 @@ module DiscourseAutomation
     end
 
     def create
-      automation_params = params.require(:automation).permit(:name, :script, :trigger)
+      automation_params = params.require(:automation).permit(:script, :trigger)
 
       automation =
         DiscourseAutomation::Automation.new(
-          automation_params.merge(last_updated_by_id: current_user.id),
+          automation_params.merge(last_updated_by_id: current_user.id)
         )
 
       if automation.scriptable&.forced_triggerable
-        automation.trigger = automation.scriptable.forced_triggerable[:triggerable].to_s
+        automation.trigger =
+          automation.scriptable.forced_triggerable[:triggerable].to_s
       end
 
       automation.save!
@@ -42,13 +43,19 @@ module DiscourseAutomation
 
       automation = DiscourseAutomation::Automation.find(params[:id])
       if automation.scriptable.forced_triggerable
-        params[:trigger] = automation.scriptable.forced_triggerable[:triggerable].to_s
+        params[:trigger] = automation.scriptable.forced_triggerable[
+          :triggerable
+        ].to_s
       end
 
       attributes =
-        request.parameters[:automation].slice(:name, :id, :script, :trigger, :enabled).merge(
-          last_updated_by_id: current_user.id,
-        )
+        request.parameters[:automation].slice(
+          :name,
+          :id,
+          :script,
+          :trigger,
+          :enabled
+        ).merge(last_updated_by_id: current_user.id)
 
       if automation.trigger != params[:automation][:trigger]
         params[:automation][:fields] = []
@@ -61,7 +68,9 @@ module DiscourseAutomation
         params[:automation][:fields] = []
         attributes[:enabled] = false
         automation.fields.destroy_all
-        automation.tap { |r| r.assign_attributes(attributes) }.save!(validate: false)
+        automation
+          .tap { |r| r.assign_attributes(attributes) }
+          .save!(validate: false)
       else
         Array(params[:automation][:fields])
           .reject(&:empty?)
@@ -70,7 +79,7 @@ module DiscourseAutomation
               field[:name],
               field[:component],
               field[:metadata],
-              target: field[:target],
+              target: field[:target]
             )
           end
 
@@ -90,7 +99,10 @@ module DiscourseAutomation
 
     def render_serialized_automation(automation)
       serializer =
-        DiscourseAutomation::AutomationSerializer.new(automation, root: "automation").as_json
+        DiscourseAutomation::AutomationSerializer.new(
+          automation,
+          root: "automation"
+        ).as_json
       render_json_dump(serializer)
     end
   end

--- a/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
@@ -10,7 +10,7 @@ module DiscourseAutomation
         ActiveModel::ArraySerializer.new(
           automations,
           each_serializer: DiscourseAutomation::AutomationSerializer,
-          root: "automations"
+          root: "automations",
         ).as_json
       render_json_dump(serializer)
     end
@@ -25,12 +25,11 @@ module DiscourseAutomation
 
       automation =
         DiscourseAutomation::Automation.new(
-          automation_params.merge(last_updated_by_id: current_user.id)
+          automation_params.merge(last_updated_by_id: current_user.id),
         )
 
       if automation.scriptable&.forced_triggerable
-        automation.trigger =
-          automation.scriptable.forced_triggerable[:triggerable].to_s
+        automation.trigger = automation.scriptable.forced_triggerable[:triggerable].to_s
       end
 
       automation.save!
@@ -43,19 +42,13 @@ module DiscourseAutomation
 
       automation = DiscourseAutomation::Automation.find(params[:id])
       if automation.scriptable.forced_triggerable
-        params[:trigger] = automation.scriptable.forced_triggerable[
-          :triggerable
-        ].to_s
+        params[:trigger] = automation.scriptable.forced_triggerable[:triggerable].to_s
       end
 
       attributes =
-        request.parameters[:automation].slice(
-          :name,
-          :id,
-          :script,
-          :trigger,
-          :enabled
-        ).merge(last_updated_by_id: current_user.id)
+        request.parameters[:automation].slice(:name, :id, :script, :trigger, :enabled).merge(
+          last_updated_by_id: current_user.id,
+        )
 
       if automation.trigger != params[:automation][:trigger]
         params[:automation][:fields] = []
@@ -68,9 +61,7 @@ module DiscourseAutomation
         params[:automation][:fields] = []
         attributes[:enabled] = false
         automation.fields.destroy_all
-        automation
-          .tap { |r| r.assign_attributes(attributes) }
-          .save!(validate: false)
+        automation.tap { |r| r.assign_attributes(attributes) }.save!(validate: false)
       else
         Array(params[:automation][:fields])
           .reject(&:empty?)
@@ -79,7 +70,7 @@ module DiscourseAutomation
               field[:name],
               field[:component],
               field[:metadata],
-              target: field[:target]
+              target: field[:target],
             )
           end
 
@@ -99,10 +90,7 @@ module DiscourseAutomation
 
     def render_serialized_automation(automation)
       serializer =
-        DiscourseAutomation::AutomationSerializer.new(
-          automation,
-          root: "automation"
-        ).as_json
+        DiscourseAutomation::AutomationSerializer.new(automation, root: "automation").as_json
       render_json_dump(serializer)
     end
   end

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -31,7 +31,7 @@ module DiscourseAutomation
     end
 
     MAX_NAME_LENGTH = 100
-    validates :name, length: { maximum: MAX_NAME_LENGTH }, on: :update
+    validates :name, length: { maximum: MAX_NAME_LENGTH }
 
     def add_id_to_custom_field(target, custom_field_key)
       if ![Topic, Post, User].any? { |m| target.is_a?(m) }

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -30,9 +30,8 @@ module DiscourseAutomation
       @running_in_background = true
     end
 
-    MIN_NAME_LENGTH = 5
     MAX_NAME_LENGTH = 100
-    validates :name, length: { in: MIN_NAME_LENGTH..MAX_NAME_LENGTH }, on: :update
+    validates :name, length: { maximum: MAX_NAME_LENGTH }, on: :update
 
     def add_id_to_custom_field(target, custom_field_key)
       if ![Topic, Post, User].any? { |m| target.is_a?(m) }

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -21,9 +21,7 @@ module DiscourseAutomation
     validate :validate_trigger_fields
 
     after_destroy do |automation|
-      UserCustomField.where(
-        name: automation.new_user_custom_field_name
-      ).destroy_all
+      UserCustomField.where(name: automation.new_user_custom_field_name).destroy_all
     end
 
     attr_accessor :running_in_background
@@ -34,11 +32,7 @@ module DiscourseAutomation
 
     MIN_NAME_LENGTH = 5
     MAX_NAME_LENGTH = 100
-    validates :name,
-              length: {
-                in: MIN_NAME_LENGTH..MAX_NAME_LENGTH
-              },
-              on: :update
+    validates :name, length: { in: MIN_NAME_LENGTH..MAX_NAME_LENGTH }, on: :update
 
     def add_id_to_custom_field(target, custom_field_key)
       if ![Topic, Post, User].any? { |m| target.is_a?(m) }
@@ -89,12 +83,7 @@ module DiscourseAutomation
     end
 
     def upsert_field!(name, component, metadata, target: "script")
-      field =
-        fields.find_or_initialize_by(
-          name: name,
-          component: component,
-          target: target
-        )
+      field = fields.find_or_initialize_by(name: name, component: component, target: target)
       field.update!(metadata: metadata)
     end
 
@@ -122,15 +111,9 @@ module DiscourseAutomation
       new_context = {}
       context.each do |k, v|
         if v.is_a?(Symbol)
-          new_context["_serialized_#{k}"] = {
-            "class" => "Symbol",
-            "value" => v.to_s
-          }
+          new_context["_serialized_#{k}"] = { "class" => "Symbol", "value" => v.to_s }
         elsif v.is_a?(ActiveRecord::Base)
-          new_context["_serialized_#{k}"] = {
-            "class" => v.class.name,
-            "id" => v.id
-          }
+          new_context["_serialized_#{k}"] = { "class" => v.class.name, "id" => v.id }
         else
           new_context[k] = v
         end
@@ -142,7 +125,7 @@ module DiscourseAutomation
       Jobs.enqueue(
         Jobs::DiscourseAutomation::Trigger,
         automation_id: id,
-        context: self.class.serialize_context(context)
+        context: self.class.serialize_context(context),
       )
     end
 
@@ -170,13 +153,11 @@ module DiscourseAutomation
     end
 
     def triggerable
-      trigger &&
-        @triggerable ||= DiscourseAutomation::Triggerable.new(trigger, self)
+      trigger && @triggerable ||= DiscourseAutomation::Triggerable.new(trigger, self)
     end
 
     def scriptable
-      script &&
-        @scriptable ||= DiscourseAutomation::Scriptable.new(script, self)
+      script && @scriptable ||= DiscourseAutomation::Scriptable.new(script, self)
     end
 
     def serialized_fields
@@ -207,7 +188,7 @@ module DiscourseAutomation
     def change_automation_ids_custom_field_in_mutex(target, key)
       DistributedMutex.synchronize(
         "automation_custom_field_#{key}_#{target.class.table_name}_#{target.id}",
-        validity: 5.seconds
+        validity: 5.seconds,
       ) { yield }
     end
   end

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -21,7 +21,9 @@ module DiscourseAutomation
     validate :validate_trigger_fields
 
     after_destroy do |automation|
-      UserCustomField.where(name: automation.new_user_custom_field_name).destroy_all
+      UserCustomField.where(
+        name: automation.new_user_custom_field_name
+      ).destroy_all
     end
 
     attr_accessor :running_in_background
@@ -32,7 +34,11 @@ module DiscourseAutomation
 
     MIN_NAME_LENGTH = 5
     MAX_NAME_LENGTH = 100
-    validates :name, length: { in: MIN_NAME_LENGTH..MAX_NAME_LENGTH }
+    validates :name,
+              length: {
+                in: MIN_NAME_LENGTH..MAX_NAME_LENGTH
+              },
+              on: :update
 
     def add_id_to_custom_field(target, custom_field_key)
       if ![Topic, Post, User].any? { |m| target.is_a?(m) }
@@ -83,7 +89,12 @@ module DiscourseAutomation
     end
 
     def upsert_field!(name, component, metadata, target: "script")
-      field = fields.find_or_initialize_by(name: name, component: component, target: target)
+      field =
+        fields.find_or_initialize_by(
+          name: name,
+          component: component,
+          target: target
+        )
       field.update!(metadata: metadata)
     end
 
@@ -111,9 +122,15 @@ module DiscourseAutomation
       new_context = {}
       context.each do |k, v|
         if v.is_a?(Symbol)
-          new_context["_serialized_#{k}"] = { "class" => "Symbol", "value" => v.to_s }
+          new_context["_serialized_#{k}"] = {
+            "class" => "Symbol",
+            "value" => v.to_s
+          }
         elsif v.is_a?(ActiveRecord::Base)
-          new_context["_serialized_#{k}"] = { "class" => v.class.name, "id" => v.id }
+          new_context["_serialized_#{k}"] = {
+            "class" => v.class.name,
+            "id" => v.id
+          }
         else
           new_context[k] = v
         end
@@ -125,7 +142,7 @@ module DiscourseAutomation
       Jobs.enqueue(
         Jobs::DiscourseAutomation::Trigger,
         automation_id: id,
-        context: self.class.serialize_context(context),
+        context: self.class.serialize_context(context)
       )
     end
 
@@ -153,11 +170,13 @@ module DiscourseAutomation
     end
 
     def triggerable
-      trigger && @triggerable ||= DiscourseAutomation::Triggerable.new(trigger, self)
+      trigger &&
+        @triggerable ||= DiscourseAutomation::Triggerable.new(trigger, self)
     end
 
     def scriptable
-      script && @scriptable ||= DiscourseAutomation::Scriptable.new(script, self)
+      script &&
+        @scriptable ||= DiscourseAutomation::Scriptable.new(script, self)
     end
 
     def serialized_fields
@@ -188,7 +207,7 @@ module DiscourseAutomation
     def change_automation_ids_custom_field_in_mutex(target, key)
       DistributedMutex.synchronize(
         "automation_custom_field_#{key}_#{target.class.table_name}_#{target.id}",
-        validity: 5.seconds,
+        validity: 5.seconds
       ) { yield }
     end
   end

--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -7,6 +7,10 @@
     td[role="button"] {
       cursor: pointer;
     }
+
+    &__name {
+      word-break: break-all;
+    }
   }
 
   .admin-section-landing__header {

--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -88,24 +88,6 @@
 
   .alert {
     padding: 1em;
-    background: var(--primary-very-low);
-    border-left-style: solid;
-    border-left-width: 5px;
-
-    &.alert-info {
-      border-left-color: var(--tertiary-low);
-    }
-
-    &.alert-warning {
-      border-left-color: var(--highlight);
-      background: var(--highlight-low);
-    }
-
-    &.alert-error {
-      border-left-color: var(--danger);
-      background: var(--danger-low);
-    }
-
     p {
       margin: 0;
     }

--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -8,6 +8,42 @@
       cursor: pointer;
     }
   }
+
+  .admin-section-landing__header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    h2 {
+      margin: 0 auto 0 0;
+    }
+    &-filter {
+      margin: 0;
+      flex: 0 1 15em;
+    }
+  }
+
+  .admin-section-landing__wrapper {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(16em, 1fr));
+    gap: 1em 2em;
+    margin-top: 1em;
+    border-top: 3px solid var(--primary-low); // matches tbody border
+    padding-top: 1em;
+  }
+
+  .admin-section-landing-item {
+    cursor: pointer;
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 4;
+    gap: 0;
+    &__buttons {
+      display: none; // empty container
+    }
+    &__description {
+      max-width: 18.75em;
+    }
+  }
 }
 
 .discourse-automation-title {

--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -9,7 +9,7 @@
     }
 
     &__name {
-      word-break: break-all;
+      word-break: break-word;
     }
   }
 
@@ -80,6 +80,10 @@
     .select-kit-body {
       max-height: 250px;
     }
+  }
+
+  .alert-info {
+    margin-top: 1em;
   }
 
   .alert {

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -8,7 +8,7 @@ en:
       select_trigger: Select a trigger
       confirm_automation_reset: This action will reset script and trigger options, new state will be saved, do you want to proceed?
       confirm_automation_trigger: This action will trigger the automation, do you want to proceed?
-      no_automation_yet: You haven’t created any automation yet.
+      no_automation_yet: You haven’t created any automations yet. Choose an option below to get started.
       filter_placeholder: Filter by name or description...
       edit_automation:
         trigger_section:

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -385,6 +385,7 @@ en:
           fields:
             custom_field_name:
               label: "User Custom Field name"
+      unnamed_automation: "Unnamed automation"
 
       models:
         script:

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -9,6 +9,7 @@ en:
       confirm_automation_reset: This action will reset script and trigger options, new state will be saved, do you want to proceed?
       confirm_automation_trigger: This action will trigger the automation, do you want to proceed?
       no_automation_yet: You haven’t created any automation yet.
+      filter_placeholder: Filter by name or description...
       edit_automation:
         trigger_section:
           forced: This trigger is forced by script.

--- a/plugins/automation/config/locales/server.en.yml
+++ b/plugins/automation/config/locales/server.en.yml
@@ -99,6 +99,7 @@ en:
         doc: Allows to send multiple pms to a user. Each PM accepts a delay.
       suspend_user_by_email:
         title: Suspend user by email
+        description: Automatically suspend an account based on email address 
       user_global_notice:
         title: User global notice
         description: Allows to display a global notice for a user
@@ -135,6 +136,13 @@ en:
         button_text: Done
       add_user_to_group_through_custom_field:
         title: "Add user to group through User Custom Field"
+        description: "Automatically add users to groups when they log in or with a recurring check"
       group_category_notification_default:
         title: "Group Category Notification Default"
         description: "Set the default notification level of a category for members of a group"
+      send_chat_message:
+        title: "Send Chat Message"
+        description: "Send a custom chat message to a channel"
+      random_assign: 
+        title: "Random Assign"
+        description: "Randomly assign topics to a group"

--- a/plugins/automation/db/migrate/20241016174732_remove_name_requirement_from_automations.rb
+++ b/plugins/automation/db/migrate/20241016174732_remove_name_requirement_from_automations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNameRequirementFromAutomations < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :discourse_automation_automations, :name, true
+  end
+end

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -187,10 +187,6 @@ describe DiscourseAutomation::Automation do
       expect(automation).not_to be_valid
       expect(automation.errors[:name]).to eq(["is too long (maximum is 100 characters)"])
 
-      automation = Fabricate.build(:automation, name: "b" * 4)
-      expect(automation).not_to be_valid
-      expect(automation.errors[:name]).to eq(["is too short (minimum is 5 characters)"])
-
       automation = Fabricate.build(:automation, name: "c" * 50)
       expect(automation).to be_valid
     end

--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -28,6 +28,8 @@ describe "DiscourseAutomation | error", type: :system, js: true do
           { name: "topic", target: "script", target_name: "post" },
         ),
       )
+
+      expect(find('input[name="automation-name"]').value).to eq("aaaaa")
     end
   end
 end

--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -11,13 +11,9 @@ describe "DiscourseAutomation | error", type: :system do
   context "when saving the form with an error" do
     it "shows the error correctly" do
       visit("/admin/plugins/discourse-automation")
-
-      find(".new-automation").click
+      find(".admin-section-landing__header-filter").set("create a post")
+      find(".admin-section-landing-item__content", match: :first).click
       fill_in("automation-name", with: "aaaaa")
-      select_kit = PageObjects::Components::SelectKit.new(".scriptables")
-      select_kit.expand
-      select_kit.select_row_by_value("post")
-      find(".create-automation").click
       select_kit = PageObjects::Components::SelectKit.new(".triggerables")
       select_kit.expand
       select_kit.select_row_by_value("recurring")

--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "DiscourseAutomation | error", type: :system do
+describe "DiscourseAutomation | error", type: :system, js: true do
   fab!(:admin)
 
   before do
@@ -10,10 +10,13 @@ describe "DiscourseAutomation | error", type: :system do
 
   context "when saving the form with an error" do
     it "shows the error correctly" do
-      visit("/admin/plugins/discourse-automation")
+      visit("/admin/plugins/discourse-automation/new")
       find(".admin-section-landing__header-filter").set("create a post")
-      find(".admin-section-landing-item__content", match: :first).click
-      fill_in("automation-name", with: "aaaaa")
+      find(".admin-section-landing-item", match: :first).click
+
+      expect(page).to have_selector("input[name='automation-name']")
+
+      find('input[name="automation-name"]').set("aaaaa")
       select_kit = PageObjects::Components::SelectKit.new(".triggerables")
       select_kit.expand
       select_kit.select_row_by_value("recurring")

--- a/plugins/automation/spec/system/new_automation_spec.rb
+++ b/plugins/automation/spec/system/new_automation_spec.rb
@@ -10,11 +10,13 @@ describe "DiscourseAutomation | New automation", type: :system, js: true do
 
   let(:new_automation_page) { PageObjects::Pages::NewAutomation.new }
 
-  context "when the script is not selected" do
-    it "shows an error" do
-      new_automation_page.visit.fill_name("aaaaa").create
+  context "when a script is clicked" do
+    it "navigates to automation edit route" do
+      new_automation_page.visit
 
-      expect(new_automation_page).to have_error(I18n.t("errors.messages.blank"))
+      find(".admin-section-landing-item__content", match: :first).click
+
+      expect(page).to have_css(".scriptables")
     end
   end
 end

--- a/plugins/automation/spec/system/smoke_test_spec.rb
+++ b/plugins/automation/spec/system/smoke_test_spec.rb
@@ -36,7 +36,6 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
   it "works" do
     visit("/admin/plugins/discourse-automation")
 
-    find(".new-automation").click
     find(".admin-section-landing__header-filter").set("user group membership through badge")
     find(".admin-section-landing-item__content", match: :first).click
     fill_in("automation-name", with: "aaaaa")

--- a/plugins/automation/spec/system/smoke_test_spec.rb
+++ b/plugins/automation/spec/system/smoke_test_spec.rb
@@ -22,13 +22,9 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
 
     it "populate correctly" do
       visit("/admin/plugins/discourse-automation")
-      find(".new-automation").click
+      find(".admin-section-landing__header-filter").set("test")
+      find(".admin-section-landing-item__content", match: :first).click
       fill_in("automation-name", with: "aaaaa")
-      select_kit = PageObjects::Components::SelectKit.new(".scriptables")
-      select_kit.expand
-      select_kit.select_row_by_value("test")
-      find(".create-automation").click
-
       select_kit = PageObjects::Components::SelectKit.new(".triggerables")
       select_kit.expand
       select_kit.select_row_by_value("post_created_edited")
@@ -41,11 +37,9 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
     visit("/admin/plugins/discourse-automation")
 
     find(".new-automation").click
+    find(".admin-section-landing__header-filter").set("user group membership through badge")
+    find(".admin-section-landing-item__content", match: :first).click
     fill_in("automation-name", with: "aaaaa")
-    select_kit = PageObjects::Components::SelectKit.new(".scriptables")
-    select_kit.expand
-    select_kit.select_row_by_value("user_group_membership_through_badge")
-    find(".create-automation").click
     select_kit = PageObjects::Components::SelectKit.new(".triggerables")
     select_kit.expand
     select_kit.select_row_by_value("user_first_logged_in")
@@ -58,6 +52,6 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
     find(".automation-enabled input").click
     find(".update-automation").click
 
-    expect(page).to have_field("automation-name", with: "aaaaa")
+    expect(page).to have_css('[role="button"]', text: "aaaaa")
   end
 end


### PR DESCRIPTION
This simplifies the workflow of creating automations and gives scripts and their descriptions more space. It also removes the "blank" state before any scripts are created and instead shows the grid of scripts to get started. 

If you don't have an automation created yet, we'll present you with a grid of script options for browsing. 

![image](https://github.com/user-attachments/assets/aefe5dd5-6115-4d11-95fb-7e14084b4fe9)

This is also filterable:

![image](https://github.com/user-attachments/assets/4111c67f-1d1a-4ef0-9858-1c36424cf96f)

When you select a script, you get the edit form:

![image](https://github.com/user-attachments/assets/bb5bbaac-cc92-4fe3-88ea-48f2459b53a3)

and when you already have scripts, nothing has changed... when you click "create" from here, you're presented with the grid of script options again. 

![image](https://github.com/user-attachments/assets/90e45d64-aee8-4936-9be2-968532cb4eac)
