### PR TITLE
UX: change thread button in chat nav to use btn-transparent

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/threads-list-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/threads-list-button.gjs
@@ -30,7 +30,7 @@ export default class ChatNavbarThreadsListButton extends Component {
           "c-navbar__threads-list-button"
           "btn"
           "no-text"
-          "btn-flat"
+          "btn-transparent"
           (if @channel.threadsManager.unreadThreadCount "has-unreads")
         }}
       >


### PR DESCRIPTION
Changing the thread button from using `btn-flat` to the new `btn-transparent` so it's consistent with the other buttons.

### Before
https://github.com/user-attachments/assets/5d47b386-eab8-4bbe-9b0d-56a73a1d3dd4


### After
https://github.com/user-attachments/assets/215faf41-68b4-41fe-a6c9-23af3ff8e0bd

