### PR TITLE
DEV: drop password-related columns from users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,9 @@
 
 class User < ActiveRecord::Base
   self.ignored_columns = [
-    :old_seen_notification_id, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
-    :salt, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
-    :password_hash, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
-    :password_algorithm, # TODO: Remove when column is dropped. At this point, the migration to drop the column has not been written.
+    :salt, # TODO: Remove when DropPasswordColumnsFromUsers has been promoted to pre-deploy.
+    :password_hash, # TODO: Remove when DropPasswordColumnsFromUsers has been promoted to pre-deploy.
+    :password_algorithm, # TODO: Remove when DropPasswordColumnsFromUsers has been promoted to pre-deploy.
     :old_seen_notification_id, # TODO: Remove once 20240829140226_drop_old_notification_id_columns has been promoted to pre-deploy
   ]
 

--- a/db/post_migrate/20241011080517_drop_password_columns_from_users.rb
+++ b/db/post_migrate/20241011080517_drop_password_columns_from_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class DropPasswordColumnsFromUsers < ActiveRecord::Migration[7.1]
+  DROPPED_COLUMNS ||= { users: %i[password_hash salt password_algorithm] }
+
+  def up
+    DROPPED_COLUMNS.each { |table, columns| Migration::ColumnDropper.execute_drop(table, columns) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Follows up on https://github.com/discourse/discourse/pull/28746 to drop password-related columns from the users table. These are now in the table user_passwords.