### PR TITLE
DEV: Improve error messages for legacy theme helpers in gjs

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/theme-i18n.js
+++ b/app/assets/javascripts/discourse/app/helpers/theme-i18n.js
@@ -3,5 +3,12 @@ import I18n from "discourse-i18n";
 
 registerRawHelper("theme-i18n", themeI18n);
 export default function themeI18n(themeId, key, params) {
+  if (typeof themeId !== "number") {
+    throw new Error(
+      `The theme-i18n helper is not supported in this context.\n\n` +
+        `In a theme .gjs file, use '{{i18n (themePrefix "${themeId}")}}' instead.\n\n` +
+        `'themePrefix' is available automatically, and does not need to be imported.\n`
+    );
+  }
   return I18n.t(`theme_translations.${themeId}.${key}`, params);
 }

--- a/app/assets/javascripts/discourse/app/helpers/theme-setting.js
+++ b/app/assets/javascripts/discourse/app/helpers/theme-setting.js
@@ -3,5 +3,12 @@ import { registerRawHelper } from "discourse-common/lib/helpers";
 
 registerRawHelper("theme-setting", themeSetting);
 export default function themeSetting(themeId, key) {
+  if (typeof themeId !== "number") {
+    throw new Error(
+      `The theme-setting helper is not supported in this context.\n\n` +
+        `In a theme .gjs file, use '{{settings.${themeId}}}' instead.\n\n` +
+        `'settings' is available automatically, and does not need to be imported.\n`
+    );
+  }
   return getThemeSetting(themeId, key);
 }


### PR DESCRIPTION
theme-setting and theme-i18n are not needed in `.gjs` files. This commit adds more helpful error messages to direct developers to the modern alternatives.

<img width="740" alt="SCR-20241014-kvmu" src="https://github.com/user-attachments/assets/810218e7-ca70-4611-b0af-85d4323543b2">

<img width="722" alt="SCR-20241014-kvau" src="https://github.com/user-attachments/assets/219ed2bc-7a39-46ac-9f07-46aa798db319">

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->