### PR TITLE
FIX: trashed channel thread view bug

### DIFF
--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -98,7 +98,7 @@ module Chat
     end
 
     def can_preview_chat_channel?(chat_channel)
-      return false unless chat_channel.chatable
+      return false if !chat_channel&.chatable
 
       if chat_channel.direct_message_channel?
         chat_channel.chatable.user_can_access?(@user)

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe Chat::Api::ChannelThreadsController do
         end
       end
 
+      context "when channel was deleted" do
+        before { thread.channel.trash! }
+
+        it "returns 403" do
+          get "/chat/api/channels/#{thread.channel_id}/threads/#{thread.id}"
+          expect(response.status).to eq(403)
+        end
+      end
+
       context "when user cannot access the channel" do
         before do
           thread.channel.update!(chatable: Fabricate(:private_category, group: Fabricate(:group)))


### PR DESCRIPTION
When chat channels are deleted, some users may be able to click the thread before it gets removed from the UI. This leads to a serverside error (a 500 error causing unwanted log noise) as chat_channel will be `nil` due to the `deleted_at` constraint on `Chat::LookupThread`.

We can use the safe navigational operator to prevent calling `chatable` when the channel is not found. This allows our failed policy to work correctly and raise `Discourse::InvalidAccess` (giving a 403 response code).