### PR TITLE
UX: Bump up chat delete messages limit

### DIFF
--- a/plugins/chat/app/services/chat/trash_messages.rb
+++ b/plugins/chat/app/services/chat/trash_messages.rb
@@ -22,7 +22,7 @@ module Chat
       attribute :message_ids, :array
 
       validates :channel_id, presence: true
-      validates :message_ids, length: { minimum: 1, maximum: 50 }
+      validates :message_ids, length: { minimum: 1, maximum: 200 }
     end
     model :messages
     policy :can_delete_all_chat_messages

--- a/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
@@ -12,7 +12,7 @@ import I18n from "discourse-i18n";
 import DeleteMessagesConfirm from "discourse/plugins/chat/discourse/components/chat/modal/delete-messages-confirm";
 import ChatModalMoveMessageToChannel from "discourse/plugins/chat/discourse/components/chat/modal/move-message-to-channel";
 
-const DELETE_COUNT_LIMIT = 50;
+const DELETE_COUNT_LIMIT = 200;
 
 export default class ChatSelectionManager extends Component {
   @service("composer") topicComposer;


### PR DESCRIPTION
50 is pretty restrictive, let's do 200 for now
