### PR TITLE
UX: raises max delete messages to 100

### DIFF
--- a/plugins/chat/app/services/chat/trash_messages.rb
+++ b/plugins/chat/app/services/chat/trash_messages.rb
@@ -22,7 +22,7 @@ module Chat
       attribute :message_ids, :array
 
       validates :channel_id, presence: true
-      validates :message_ids, length: { minimum: 1, maximum: 50 }
+      validates :message_ids, length: { minimum: 1, maximum: 100 }
     end
     model :messages
     policy :can_delete_all_chat_messages

--- a/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
@@ -12,7 +12,7 @@ import I18n from "discourse-i18n";
 import DeleteMessagesConfirm from "discourse/plugins/chat/discourse/components/chat/modal/delete-messages-confirm";
 import ChatModalMoveMessageToChannel from "discourse/plugins/chat/discourse/components/chat/modal/move-message-to-channel";
 
-const DELETE_COUNT_LIMIT = 50;
+const DELETE_COUNT_LIMIT = 100;
 
 export default class ChatSelectionManager extends Component {
   @service("composer") topicComposer;


### PR DESCRIPTION
The previous value was 50.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->