### PR TITLE
UX: prevent unread indicator from shrinking in flexbox

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
@@ -271,6 +271,7 @@
       height: 8px;
       background: var(--tertiary);
       border-radius: 100%;
+      flex-shrink: 0;
 
       &.-urgent {
         background: var(--success);


### PR DESCRIPTION
Adding `flex-shrink:0` to make sure the unread indicator never gets squashed in the CMD-k modal.

### Before

![image](https://github.com/user-attachments/assets/861c3197-e8ce-4586-8073-e2ce3f4fb2e7)

### After

<img width="696" alt="CleanShot 2024-10-15 at 16 49 03@2x" src="https://github.com/user-attachments/assets/46ec1e3c-4b6a-4089-83dd-a0e740383b60">
