### PR TITLE
DEV: Improve isolation and concurrency for minio-based upload specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -325,6 +325,16 @@ RSpec.configure do |config|
             ["discoursetest"]
           end
         )
+
+      test_i = ENV["TEST_ENV_NUMBER"].to_i
+
+      data_dir = "#{Rails.root}/tmp/test_data_#{test_i}/minio"
+      FileUtils.rm_rf(data_dir)
+      FileUtils.mkdir_p(data_dir)
+      minio_runner_config.minio_data_directory = data_dir
+
+      minio_runner_config.minio_port = 9_000 + 2 * test_i
+      minio_runner_config.minio_console_port = 9_001 + 2 * test_i
     end
 
     WebMock.disable_net_connect!(

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -144,13 +144,6 @@ module SystemHelpers
   end
 
   def skip_unless_s3_system_specs_enabled!
-    if ENV["CI"]
-      return(
-        skip(
-          "S3 system specs are temporarily disabled in this environment to address parallel spec issues",
-        )
-      )
-    end
     if !ENV["CI"] && !ENV["RUN_S3_SYSTEM_SPECS"]
       skip(
         "S3 system specs are disabled in this environment, set CI=1 or RUN_S3_SYSTEM_SPECS=1 to enable them.",


### PR DESCRIPTION
- Uses a temporary, clean, per-test-process directory for minio data
- Runs a separate minio instance for each test process
- Unskips minio-based tests in CI

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->