### PR TITLE
Revert "DEV: Fix github workflow yaml syntax (#29217)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,10 +306,10 @@ jobs:
         shell: bash
 
       - name: Upload failed system test screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO (tgxworld): V4 doesn't allow us to upload multiple uploads to the same artifact name so keep at V3 for now.
         if: always() && steps.check-failed-system-test-screenshots.outputs.exists == 'true'
         with:
-          name: failed-system-test-screenshots-${{ matrix.build_type }}-${{ matrix.target }}
+          name: failed-system-test-screenshots
           path: tmp/capybara/*.png
 
       - name: Check for flaky tests report
@@ -335,10 +335,10 @@ jobs:
         run: cp tmp/turbo_rspec_flaky_tests.json tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ steps.fetch-job-id.outputs.job_id }}.json
 
       - name: Upload flaky tests report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # TODO (tgxworld): V4 doesn't allow us to upload multiple uploads to the same artifact name so keep at V3 for now
         if: always() && steps.check-flaky-spec-report.outputs.exists == 'true'
         with:
-          name: flaky-test-reports-${{ matrix.build_type }}-${{ matrix.target }}
+          name: flaky-test-reports
           path: tmp/turbo_rspec_flaky_tests-${{ matrix.build_type }}-${{ matrix.target }}-${{ steps.fetch-job-id.outputs.job_id }}.json
 
       - name: Check Annotations
@@ -408,24 +408,3 @@ jobs:
         with:
           name: ember-exam-execution-${{ matrix.browser }}-${{ hashFiles('./app/assets/javascripts/discourse/test-execution-*.json') }}
           path: ./app/assets/javascripts/discourse/test-execution-*.json
-
-  merge:
-    if: github.repository == 'discourse/discourse' && github.ref == 'refs/heads/main'
-    runs-on: debian-12
-    needs: build
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: failed-system-test-screenshots
-          pattern: failed-system-test-screenshots-*
-          delete-merged: true
-          separate-directories: false
-
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: flaky-test-reports
-          pattern: flaky-test-reports-*
-          delete-merged: true
-          separate-directories: false


### PR DESCRIPTION
This reverts commit 387f2c52e65ef48ea734fbfdfa34f2e28d3493fb.

Merging fails if there are no artifacts matching the pattern. Reverting while we work out a path forward

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->