### PR TITLE
FEATURE: theme_modifiers can depend on theme settings (add serialize_post_user_badges)

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -1152,6 +1152,10 @@ export default class PostStream extends RestModel {
       headers,
     }).then((result) => {
       this._setSuggestedTopics(result);
+      if (result.user_badges) {
+        this.topic.user_badges ??= {};
+        Object.assign(this.topic.user_badges, result.user_badges);
+      }
 
       const posts = get(result, "post_stream.posts");
 

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -478,4 +478,14 @@ export default class Post extends RestModel {
   get topicNotificationLevel() {
     return this.topic.details.notification_level;
   }
+
+  get userBadges() {
+    if (!this.topic?.user_badges) {
+      return;
+    }
+    const badgeIds = this.topic.user_badges.users[this.user_id]?.badge_ids;
+    if (badgeIds) {
+      return badgeIds.map((badgeId) => this.topic.user_badges.badges[badgeId]);
+    }
+  }
 }

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -756,9 +756,7 @@ class Theme < ActiveRecord::Base
   def update_setting(setting_name, new_value)
     target_setting = settings[setting_name.to_sym]
     raise Discourse::NotFound unless target_setting
-
     target_setting.value = new_value
-
     self.theme_setting_requests_refresh = true if target_setting.requests_refresh?
   end
 

--- a/app/models/theme_modifier_set.rb
+++ b/app/models/theme_modifier_set.rb
@@ -91,6 +91,7 @@ class ThemeModifierSet < ActiveRecord::Base
 
         value =
           target_setting_name.present? ? target_setting_value : theme.settings[setting_name]&.value
+        value = coerce_setting_value(modifier_name, value)
         if read_attribute(modifier_name) != value
           write_attribute(modifier_name, value)
           changed = true
@@ -101,6 +102,15 @@ class ThemeModifierSet < ActiveRecord::Base
   end
 
   private
+
+  def coerce_setting_value(modifier_name, value)
+    type = ThemeModifierSet.modifiers.dig(modifier_name, :type)
+    if type == :boolean
+      value.to_s != "false"
+    elsif type == :string_array
+      value.is_a?(Array) ? value : value.to_s.split("|")
+    end
+  end
 
   # Build the list of modifiers from the DB schema.
   # This allows plugins to introduce new modifiers by adding columns to the table

--- a/app/models/theme_setting.rb
+++ b/app/models/theme_setting.rb
@@ -22,6 +22,13 @@ class ThemeSetting < ActiveRecord::Base
     if self.data_type == ThemeSetting.types[:upload] && saved_change_to_value?
       UploadReference.ensure_exist!(upload_ids: [self.value], target: self)
     end
+
+    if theme.theme_modifier_set.refresh_theme_setting_modifiers(
+         target_setting_name: self.name,
+         target_setting_value: self.value,
+       )
+      theme.theme_modifier_set.save!
+    end
   end
 
   def clear_settings_cache

--- a/app/serializers/post_stream_serializer_mixin.rb
+++ b/app/serializers/post_stream_serializer_mixin.rb
@@ -4,6 +4,7 @@ module PostStreamSerializerMixin
   def self.included(klass)
     klass.attributes :post_stream
     klass.attributes :timeline_lookup
+    klass.attributes :user_badges
   end
 
   def include_stream?
@@ -12,6 +13,18 @@ module PostStreamSerializerMixin
 
   def include_gaps?
     true
+  end
+
+  def include_user_badges?
+    badges_to_include.present?
+  end
+
+  def user_badges
+    object.user_badges(badges_to_include)
+  end
+
+  def badges_to_include
+    @badges_to_include ||= theme_modifier_helper.serialize_post_user_badges
   end
 
   def post_stream
@@ -54,5 +67,9 @@ module PostStreamSerializerMixin
           serializer.as_json
         end
       end
+  end
+
+  def theme_modifier_helper
+    @theme_modifier_helper ||= ThemeModifierHelper.new(request: scope.request)
   end
 end

--- a/db/migrate/20241011033602_add_post_badges_to_theme_modifiers.rb
+++ b/db/migrate/20241011033602_add_post_badges_to_theme_modifiers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddPostBadgesToThemeModifiers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :theme_modifier_sets, :serialize_post_user_badges, :string, array: true
+    add_column :theme_modifier_sets, :theme_setting_modifiers, :jsonb
+  end
+end

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -25,7 +25,11 @@ RSpec.describe RemoteTheme do
             }
           },
           "modifiers": {
-            "serialize_topic_excerpts": true
+            "serialize_topic_excerpts": true,
+            "custom_homepage": {
+              "type": "setting",
+              "value": "boolean_setting"
+            }
           }
         }
       JSON
@@ -175,6 +179,7 @@ RSpec.describe RemoteTheme do
       expect(remote.minimum_discourse_version).to eq("1.0.0")
 
       expect(theme.theme_modifier_set.serialize_topic_excerpts).to eq(true)
+      expect(theme.theme_modifier_set.custom_homepage).to eq(true)
 
       expect(theme.theme_fields.length).to eq(12)
 
@@ -199,6 +204,13 @@ RSpec.describe RemoteTheme do
 
       expect(theme.settings.length).to eq(1)
       expect(theme.settings[:boolean_setting].value).to eq(true)
+
+      # lets change the setting to see modifier reflects
+      theme.update_setting(:boolean_setting, false)
+      theme.save!
+      theme.reload
+
+      expect(theme.theme_modifier_set.custom_homepage).to eq(false)
 
       expect(remote.remote_updated_at).to eq_time(time)
 

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe RemoteTheme do
             "custom_homepage": {
               "type": "setting",
               "value": "boolean_setting"
+            },
+            "serialize_post_user_badges": {
+              "type": "setting",
+              "value": "list_setting"
             }
           }
         }
@@ -46,6 +50,12 @@ RSpec.describe RemoteTheme do
       JS
 
     let :initial_repo do
+      settings = <<~YAML
+        boolean_setting: true
+        list_setting:
+          type: list
+          default: ""
+      YAML
       setup_git_repo(
         "about.json" => about_json,
         "desktop/desktop.scss" => scss_data,
@@ -59,7 +69,7 @@ RSpec.describe RemoteTheme do
         "common/embedded.scss" => "EMBED",
         "common/color_definitions.scss" => ":root{--color-var: red}",
         "assets/font.woff2" => "FAKE FONT",
-        "settings.yaml" => "boolean_setting: true",
+        "settings.yaml" => settings,
         "locales/en.yml" => "sometranslations",
         "migrations/settings/0001-some-migration.js" => migration_js,
       )
@@ -192,7 +202,9 @@ RSpec.describe RemoteTheme do
 
       expect(mapped["0-font"]).to eq("")
 
-      expect(mapped["3-yaml"]).to eq("boolean_setting: true")
+      expect(mapped["3-yaml"]).to eq(
+        "boolean_setting: true\nlist_setting:\n  type: list\n  default: \"\"\n",
+      )
 
       expect(mapped["4-en"]).to eq("sometranslations")
       expect(mapped["7-acceptance/theme-test.js"]).to eq("assert.ok(true);")
@@ -202,16 +214,18 @@ RSpec.describe RemoteTheme do
 
       expect(mapped.length).to eq(12)
 
-      expect(theme.settings.length).to eq(1)
+      expect(theme.settings.length).to eq(2)
       expect(theme.settings[:boolean_setting].value).to eq(true)
+      expect(theme.settings[:list_setting].value).to eq("")
 
       # lets change the setting to see modifier reflects
       theme.update_setting(:boolean_setting, false)
+      theme.update_setting(:list_setting, "badge1|badge2")
       theme.save!
       theme.reload
 
       expect(theme.theme_modifier_set.custom_homepage).to eq(false)
-
+      expect(theme.theme_modifier_set.serialize_post_user_badges).to eq(%w[badge1 badge2])
       expect(remote.remote_updated_at).to eq_time(time)
 
       scheme = ColorScheme.find_by(theme_id: theme.id)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2455,6 +2455,44 @@ RSpec.describe TopicsController do
       expect(user_options_queries.size).to eq(1) # for all mentioned users
     end
 
+    context "with serialize_post_user_badges" do
+      fab!(:badge)
+
+      it "correcntly returns user badges that are registred" do
+        first_post = topic.posts.order(:post_number).first
+        first_post.user.user_badges.create!(
+          badge_id: badge.id,
+          granted_at: Time.zone.now,
+          granted_by: Discourse.system_user,
+        )
+
+        ThemeModifierSet.update_all(serialize_post_user_badges: [badge.name])
+        SiteSetting.default_theme_id = Theme.first.id
+
+        expected_payload = {
+          "users" => [{ "id" => first_post.user.id, "badge_ids" => [badge.id] }],
+          "badges" => [
+            {
+              "id" => badge.id,
+              "name" => badge.name,
+              "description" => badge.description,
+              "icon" => badge.icon,
+              "image_url" => badge.image_url,
+              "badge_grouping_id" => badge.badge_grouping_id,
+            },
+          ],
+        }
+
+        get "/t/#{topic.slug}/#{topic.id}.json"
+        user_badges = response.parsed_body["user_badges"]
+        expect(user_badges).to eq(expected_payload)
+
+        get "/t/#{topic.id}/posts.json?post_ids[]=#{first_post.id}"
+        user_badges = response.parsed_body["user_badges"]
+        expect(user_badges).to eq(expected_payload)
+      end
+    end
+
     context "with registered redirect_to_correct_topic_additional_query_parameters" do
       let(:modifier_block) { Proc.new { |allowed_params| allowed_params << :silly_param } }
 


### PR DESCRIPTION
This change allows theme to define modifiers that can be changed by site operator. 


New syntax is:

```
{
    ...
   "modifiers": {
      "modifier_name": {
         "type": "setting",
         "value": "setting_name"
      }
   }
}
```

This also introduces a new theme modifier for `serialize_post_user_badges`. Name of badge must match the name of the badge in the badges table.



