### PR TITLE
DEV: Remove discourse-encrypt from core CI suite

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -29,7 +29,6 @@ class Plugin::Metadata
         discourse-data-explorer
         discourse-details
         discourse-docs
-        discourse-encrypt
         discourse-follow
         discourse-fontawesome-pro
         discourse-gamification


### PR DESCRIPTION
This plugin is prone to causing flaky test runs, and is in the process of being deprecated

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->