### PR TITLE
FIX: Support add_directory_column in glimmered table header toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/table-header-toggle.gjs
+++ b/app/assets/javascripts/discourse/app/components/table-header-toggle.gjs
@@ -64,12 +64,11 @@ export default class TableHeaderToggle extends Component {
   }
 
   get label() {
-    const labelKey = this.args.labelKey || `directory.${this.args.field}`;
+    const labelKey = this.labelKey || `directory.${this.args.field}`;
+
     return this.args.translated
       ? this.args.field
-      : I18n.t(`${labelKey}_long`, {
-          defaultValue: I18n.t(labelKey),
-        });
+      : I18n.t(labelKey + "_long", { defaultValue: I18n.t(labelKey) });
   }
 
   @action

--- a/spec/system/user_page/users_directory_spec.rb
+++ b/spec/system/user_page/users_directory_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+describe "Users /u", type: :system do
+  fab!(:user)
+
+  before { Array.new(DirectoryItemsController::PAGE_SIZE + 10) { Fabricate(:user) } }
+
+  describe "shows a table of users" do
+    it "renders successfully for a logged-in user" do
+      DirectoryItem.refresh!
+      sign_in(user)
+
+      visit("/u")
+
+      expect(page).to have_css(".users-directory")
+      expect(page).not_to have_css(".spinner")
+      header_texts =
+        page
+          .all(".directory-table__column-header .header-contents")
+          .map { |element| element.text.strip }
+
+      expect(header_texts).to eq(
+        [
+          "Username",
+          "Received",
+          "Given",
+          "Topics Created",
+          "Replies Posted",
+          "Topics Viewed",
+          "Posts Read",
+          "Days Visited",
+        ],
+      )
+    end
+
+    it "renders successfully for an anonymous user" do
+      DirectoryItem.refresh!
+      visit("/u")
+
+      expect(page).to have_css(".users-directory")
+      expect(page).not_to have_css(".spinner")
+      header_texts =
+        page
+          .all(".directory-table__column-header .header-contents")
+          .map { |element| element.text.strip }
+
+      expect(header_texts).to eq(
+        [
+          "Username",
+          "Received",
+          "Given",
+          "Topics Created",
+          "Replies Posted",
+          "Topics Viewed",
+          "Posts Read",
+          "Days Visited",
+        ],
+      )
+    end
+  end
+
+  describe "new directory item" do
+    let!(:plugin) { Plugin::Instance.new }
+    let!(:initial_directory_events) { [] }
+
+    before do
+      initial_directory_events.replace(DiscourseEvent.events["before_directory_refresh"].to_a)
+      DB.exec("ALTER TABLE directory_items ADD COLUMN IF NOT EXISTS links integer")
+    end
+
+    after do
+      DiscourseEvent.events["before_directory_refresh"].delete(
+        (DiscourseEvent.events["before_directory_refresh"].to_a - initial_directory_events).last,
+      )
+      DB.exec("ALTER TABLE directory_items DROP COLUMN IF EXISTS links")
+    end
+
+    it "shows the directory column with the appropriate label" do
+      plugin.add_directory_column(
+        "links",
+        query: "SELECT id, RANDOM() AS random_number FROM users;",
+      )
+      DirectoryItem.refresh!
+      DirectoryColumn.find_by(name: "links").update!(enabled: true)
+
+      sign_in(user)
+
+      visit("/u")
+
+      expect(page).to have_css(".users-directory")
+      expect(page).not_to have_css(".spinner")
+      header_texts =
+        page
+          .all(".directory-table__column-header .header-contents")
+          .map { |element| element.text.strip }
+
+      expect(header_texts).to eq(
+        [
+          "Username",
+          "Received",
+          "Given",
+          "Topics Created",
+          "Replies Posted",
+          "Topics Viewed",
+          "Posts Read",
+          "Days Visited",
+          "Links",
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/29209 introduced a bug where columns to the directory added via add_directory_column are not being translated properly.

![image](https://github.com/user-attachments/assets/e892e3fa-d144-441c-aef8-16e10ed2c1eb)

This fixes the issue and adds an integration test.

<img width="1055" alt="Screenshot 2024-10-16 at 9 23 40 PM" src="https://github.com/user-attachments/assets/698384e3-1b05-4ab2-b4aa-133d9b70d66c">
