### PR TITLE
UX: consistent chat message date format

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
@@ -143,7 +143,7 @@ export default class ChatMessageInfo extends Component {
         {{/if}}
 
         <span class="chat-message-info__date">
-          {{formatChatDate @message (hash threadContext=@threadContext)}}
+          {{formatChatDate @message (hash threadContext=@threadContext) }}
         </span>
 
         {{#if @message.bookmark}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
@@ -143,7 +143,7 @@ export default class ChatMessageInfo extends Component {
         {{/if}}
 
         <span class="chat-message-info__date">
-          {{formatChatDate @message (hash threadContext=@threadContext) }}
+          {{formatChatDate @message (hash threadContext=@threadContext)}}
         </span>
 
         {{#if @message.bookmark}}

--- a/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
@@ -12,7 +12,7 @@ export default function formatChatDate(message, options = {}) {
   const display =
     options.mode === "tiny"
       ? date.format(I18n.t("chat.dates.time_tiny"))
-      : date.format(I18n.t("dates.time"));
+      : date.format(I18n.t("chat.dates.time"));
 
   if (message.staged) {
     return htmlSafe(

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -45,6 +45,7 @@ en:
       deleted_chat_username: deleted
       dates:
         yesterday: "Yesterday"
+        time: "h:mm a"
         time_tiny: "h:mm"
       all_loaded: "Showing all messages"
       already_enabled: "Chat is already enabled on this topic. Please refresh."


### PR DESCRIPTION
In certain locales like English (GB), If a user posted 2 subsequent messages, the first would have a date displayed in 24 hour format, while the second message would be shown in 12 hour format (when hovering the message).

This change forces both messages to display in 12 hour format, the first message showing the am/pm, and the second showing the smaller version without am/pm:

<img width="223" alt="Screenshot 2024-10-16 at 9 38 30 PM" src="https://github.com/user-attachments/assets/063f96a2-1d5e-4ed8-8b3b-742988ac9519">
