### PR TITLE
DEV: Allow `ChatSDK.create` to take extra parameters

### DIFF
--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -116,6 +116,7 @@ module ChatSDK
       enforce_membership: false,
       force_thread: false,
       strip_whitespaces: true,
+      **params,
       &block
     )
       message =
@@ -131,6 +132,7 @@ module ChatSDK
           force_thread: force_thread,
           strip_whitespaces: strip_whitespaces,
           created_by_sdk: true,
+          **params,
         ) do
           on_model_not_found(:channel) { raise "Couldn't find channel with id: `#{channel_id}`" }
           on_model_not_found(:membership) do


### PR DESCRIPTION
Currently, `ChatSDK.create` restricts what parameters can be provided to the underlying service. This prevents the `discourse-ai` plugin from using it in one of its specs (https://github.com/discourse/discourse-ai/blob/main/spec/lib/modules/ai_bot/playground_spec.rb#L436).

This patch allows extra parameters to be provided.