### PR TITLE
DEV: Add `SearchMenu::Results::Assistant` plugin outlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.hbs
@@ -1,6 +1,7 @@
 <ul class="search-menu-assistant">
   {{! suggestion type keywords are mapped to SUGGESTION_KEYWORD_MAP }}
   {{#if (eq this.suggestionType "tagIntersection")}}
+    <PluginOutlet @name="search-menu-results-assistant-tag-intersection-top" />
     {{#each @results as |result|}}
       <SearchMenu::Results::AssistantItem
         @tag={{result.tagName}}
@@ -16,6 +17,7 @@
       />
     {{/each}}
   {{else if (eq this.suggestionType "categoryOrTag")}}
+    <PluginOutlet @name="search-menu-results-assistant-category-or-tag-top" />
     {{#each @results as |result|}}
       {{#if result.model}}
         {{! render category }}
@@ -42,6 +44,7 @@
       {{/if}}
     {{/each}}
   {{else if (eq this.suggestionType "user")}}
+    <PluginOutlet @name="search-menu-results-assistant-user-top" />
     {{#if this.userMatchesInTopic}}
       <SearchMenu::Results::AssistantItem
         @extraHint={{true}}
@@ -75,6 +78,10 @@
       {{/each}}
     {{/if}}
   {{else}}
+    <PluginOutlet
+      @name="search-menu-results-assistant-shortcut-top"
+      @outletArgs={{hash suggestionShortcuts=this.suggestionShortcuts}}
+    />
     {{#each this.suggestionShortcuts as |item|}}
       <SearchMenu::Results::AssistantItem
         @slug={{concat this.prefix item}}


### PR DESCRIPTION
Add plugin outlets for each assistant result type - User, Tag and Categories, Groups, etc. This gives us the ability to add content for each _type_ of search suggestion: 

<img width="216" alt="Screenshot 2024-10-16 at 10 01 09 AM" src="https://github.com/user-attachments/assets/fbbc71fe-a8fe-499b-8377-480dd0ed5f75">


I would have preferred to add a single plugin outlet at the top of the template and pass `this.suggestionType` and `@results`, but that would then require that we carry over a ton of core logic to plugins to calculate which _type_ is being rendered, and it would get unnecessarily messy quick. So instead I opted to create a plugin outlet for each _type_. 
