### PR TITLE
DEV: move chat time formats to core locales

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,6 +25,8 @@ en:
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       time: "h:mm a"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
+      time_short: "h:mm"
+      # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       time_with_zone: "hh:mm a (z)"
       # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
       time_short_day: "ddd, h:mm a"

--- a/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
@@ -11,8 +11,8 @@ export default function formatChatDate(message, options = {}) {
   const title = date.format(I18n.t("dates.long_with_year"));
   const display =
     options.mode === "tiny"
-      ? date.format(I18n.t("chat.dates.time_tiny"))
-      : date.format(I18n.t("chat.dates.time"));
+      ? date.format(I18n.t("dates.time_short"))
+      : date.format(I18n.t("dates.time"));
 
   if (message.staged) {
     return htmlSafe(

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -45,8 +45,6 @@ en:
       deleted_chat_username: deleted
       dates:
         yesterday: "Yesterday"
-        time: "h:mm a"
-        time_tiny: "h:mm"
       all_loaded: "Showing all messages"
       already_enabled: "Chat is already enabled on this topic. Please refresh."
       disabled_for_topic: "Chat is disabled on this topic."


### PR DESCRIPTION
This change moves the date/time formats to core locales, so that they can be used outside of the plugin.