### PR TITLE
FIX: Make subcategories page more like categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -36,6 +36,7 @@ const globalComponents = {
 };
 
 export default class CategoriesDisplay extends Component {
+  @service router;
   @service siteSettings;
   @service site;
 
@@ -69,7 +70,10 @@ export default class CategoriesDisplay extends Component {
   }
 
   get categoriesComponent() {
-    if (this.args.parentCategory) {
+    if (
+      this.args.parentCategory &&
+      this.router.currentRouteName === "discovery.category"
+    ) {
       return this.#componentForSubcategories;
     } else {
       return this.#globalComponent;

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -133,22 +133,15 @@ class CategoryList
 
   def find_categories
     query = Category.includes(CategoryList.included_associations).secured(@guardian)
-
-    query =
-      query.where(
-        "categories.parent_category_id = ?",
-        @options[:parent_category_id].to_i,
-      ) if @options[:parent_category_id].present?
-
     query = self.class.order_categories(query)
 
+    if @options[:parent_category_id].present? || @guardian.can_lazy_load_categories?
+      query = query.where(parent_category_id: @options[:parent_category_id])
+    end
+
     page = [1, @options[:page].to_i].max
-    if @guardian.can_lazy_load_categories? && @options[:parent_category_id].blank?
-      query =
-        query
-          .where(parent_category_id: nil)
-          .limit(CATEGORIES_PER_PAGE)
-          .offset((page - 1) * CATEGORIES_PER_PAGE)
+    if @guardian.can_lazy_load_categories?
+      query = query.limit(CATEGORIES_PER_PAGE).offset((page - 1) * CATEGORIES_PER_PAGE)
     elsif page > 1
       # Pagination is supported only when lazy load is enabled. If it is not,
       # everything is returned on page 1.


### PR DESCRIPTION
The subcategories page was not paginated and it was using the subcategory style from the category settings. The same page style should be used for categories and subcategories page.

Categories page (both before and after):

<img width="1508" alt="Screenshot 2024-10-17 at 19 41 44" src="https://github.com/user-attachments/assets/5a40b431-af9c-4417-b16b-779b955c57a4">

Subcategories page (before - not using set desktop style):

<img width="1508" alt="Screenshot 2024-10-17 at 19 42 04" src="https://github.com/user-attachments/assets/b9d6d358-0651-4baf-bca7-e1017e510915">

Subcategories page (after - using set desktop style, same as categories page):

<img width="1508" alt="Screenshot 2024-10-17 at 19 41 51" src="https://github.com/user-attachments/assets/82e2f45e-b58e-4e8b-a8c5-0077d4ec02f1">

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->