### PR TITLE
FIX: _uploadDropTargetOptions is now public

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-uploads.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-uploads.js
@@ -80,7 +80,7 @@ export default class ChatComposerUploads extends Component.extend(
     this._triggerUploadsChanged();
   }
 
-  _uploadDropTargetOptions() {
+  uploadDropTargetOptions() {
     return {
       target: this.uploadDropZone || document.body,
     };

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -20,25 +20,19 @@ describe "Uploading files in chat messages", type: :system do
     it "allows to drag files to start upload" do
       chat.visit_channel(channel_1)
 
-      drop_zone = find(".chat-channel")
-
       # Define the JavaScript to simulate dragging an external image
       page.execute_script(<<-JS)
-        function simulateExternalImageDrop(target) {
-          const dataTransfer = new DataTransfer();
+        const target = document.querySelector('.chat-channel');
+        const dataTransfer = new DataTransfer();
+        const file = new File(['dummy content'], 'test-image.png', { type: 'image/png' });
 
-          const file = new File(['dummy content'], 'test-image.png', { type: 'image/png' });
-          dataTransfer.items.add(file);
+        dataTransfer.items.add(file);
 
-          const dragEnterEvent = new DragEvent('dragenter', { dataTransfer: dataTransfer });
-          target.dispatchEvent(dragEnterEvent);
+        const dragEnterEvent = new DragEvent('dragenter', { dataTransfer: dataTransfer });
+        target.dispatchEvent(dragEnterEvent);
 
-          const dragOverEvent = new DragEvent('dragover', { dataTransfer: dataTransfer });
-          target.dispatchEvent(dragOverEvent);
-        }
-
-        const dropZone = document.querySelector('.chat-channel');
-        simulateExternalImageDrop(dropZone);
+        const dragOverEvent = new DragEvent('dragover', { dataTransfer: dataTransfer });
+        target.dispatchEvent(dragOverEvent);
       JS
 
       expect(find(".chat-upload-drop-zone__text__title")).to have_content(

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -17,6 +17,35 @@ describe "Uploading files in chat messages", type: :system do
       sign_in(current_user)
     end
 
+    it "allows to drag files to start upload" do
+      chat.visit_channel(channel_1)
+
+      drop_zone = find(".chat-channel")
+
+      # Define the JavaScript to simulate dragging an external image
+      page.execute_script(<<-JS)
+        function simulateExternalImageDrop(target) {
+          const dataTransfer = new DataTransfer();
+
+          const file = new File(['dummy content'], 'test-image.png', { type: 'image/png' });
+          dataTransfer.items.add(file);
+
+          const dragEnterEvent = new DragEvent('dragenter', { dataTransfer: dataTransfer });
+          target.dispatchEvent(dragEnterEvent);
+
+          const dragOverEvent = new DragEvent('dragover', { dataTransfer: dataTransfer });
+          target.dispatchEvent(dragOverEvent);
+        }
+
+        const dropZone = document.querySelector('.chat-channel');
+        simulateExternalImageDrop(dropZone);
+      JS
+
+      expect(find(".chat-upload-drop-zone__text__title")).to have_content(
+        I18n.t("js.chat.upload_to_channel", { title: channel_1.title }),
+      )
+    end
+
     it "allows uploading a single file" do
       chat.visit_channel(channel_1)
       file_path = file_from_fixtures("logo.png", "images").path


### PR DESCRIPTION
Chat was using a private function which has now been made public.

This commit also adds a test for this codepath.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->