### PR TITLE
FIX: Add back user custom field plugin outlet that was accidentally removed

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -133,6 +133,11 @@
             </group.Field>
           </form.CheckboxGroup>
 
+          <PluginOutlet
+            @name="after-admin-user-fields"
+            @outletArgs={{hash userField=@userField form=form}}
+          />
+
           <form.Actions>
             <form.Submit
               class="save"


### PR DESCRIPTION
### What is the problem?

When converting the user custom fields admin form in #29070, I accidentally removed the plugin outlet `after-admin-user-fields`. This is used by the `discourse-authentication-validations` plugin, which is now broken on `main` core.

### How does this fix it?

Regardless of what we do, the outlet arguments have to change, because it is no longer a `bufferedProperty`, and we need to pass the `form` for plugins to use the FormKit components.

This commit adds back the plugin outlet in core.

A PR for fixing the plugin is incoming.