### PR TITLE
UX: fix sidebar styling on tablet

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -1,24 +1,4 @@
 .sidebar-section-wrapper {
-  .discourse-no-touch & {
-    padding-block: 0.35rem;
-    border-bottom: 1px solid var(--secondary-very-high);
-    &:first-child {
-      padding-top: 0;
-    }
-    &[data-section-name="user-threads"] {
-      padding-bottom: 0;
-    }
-
-    &:hover {
-      .sidebar-section-header-wrapper {
-        .btn.dropdown-select-box-header,
-        .sidebar-section-header-button {
-          opacity: 1;
-        }
-      }
-    }
-  }
-
   .sidebar-section-header-wrapper {
     display: flex;
 

--- a/app/assets/stylesheets/desktop/components/_index.scss
+++ b/app/assets/stylesheets/desktop/components/_index.scss
@@ -1,4 +1,5 @@
 @import "more-topics";
 @import "sidebar/edit-navigation-menu/tags-modal";
+@import "sidebar/sidebar-section";
 @import "user-card";
 @import "user-info";

--- a/app/assets/stylesheets/desktop/components/sidebar/sidebar-section.scss
+++ b/app/assets/stylesheets/desktop/components/sidebar/sidebar-section.scss
@@ -17,13 +17,6 @@
     }
   }
 
-  .btn.dropdown-select-box-header,
-  .sidebar-section-header-button {
-    .discourse-touch & {
-      opacity: 1;
-    }
-  }
-
   .sidebar-section-header-wrapper {
     padding-right: calc(var(--d-sidebar-row-horizontal-padding) / 3);
   }

--- a/app/assets/stylesheets/desktop/components/sidebar/sidebar-section.scss
+++ b/app/assets/stylesheets/desktop/components/sidebar/sidebar-section.scss
@@ -1,0 +1,30 @@
+.sidebar-section-wrapper {
+  padding-block: 0.35rem;
+  border-bottom: 1px solid var(--secondary-very-high);
+  &:first-child {
+    padding-top: 0;
+  }
+  &[data-section-name="user-threads"] {
+    padding-bottom: 0;
+  }
+
+  &:hover {
+    .sidebar-section-header-wrapper {
+      .btn.dropdown-select-box-header,
+      .sidebar-section-header-button {
+        opacity: 1;
+      }
+    }
+  }
+
+  .btn.dropdown-select-box-header,
+  .sidebar-section-header-button {
+    .discourse-touch & {
+      opacity: 1;
+    }
+  }
+
+  .sidebar-section-header-wrapper {
+    padding-right: calc(var(--d-sidebar-row-horizontal-padding) / 3);
+  }
+}


### PR DESCRIPTION
Followup of #29119 to address tablet styling, mentioned in https://meta.discourse.org/t/new-sidebar-design-on-tablets/330162

* Add missing dividers between sections
* mini alignment tweak for desktop/tablet for section-header

| Before | After |
|--------|--------|
| ![CleanShot 2024-10-17 at 14 18 50@2x](https://github.com/user-attachments/assets/57bf81b4-8937-4323-810a-949a011f207e) | ![CleanShot 2024-10-17 at 14 16 22@2x](https://github.com/user-attachments/assets/115aaa25-87c0-486b-b956-adcb5dd8da6d) | 



