### PR TITLE
DEV: Don’t provide an array to site settings group lists in specs

### DIFF
--- a/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
@@ -20,7 +20,7 @@ describe Chat::ChannelFetcher do
     Chat::UserChatChannelMembership.where(user: user1)
   end
 
-  before { SiteSetting.chat_allowed_groups = [chatters] }
+  before { SiteSetting.chat_allowed_groups = chatters }
 
   describe ".structured" do
     it "returns open channel only" do

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Chat::GuardianExtensions do
   let(:guardian) { Guardian.new(user) }
   let(:staff_guardian) { Guardian.new(staff) }
 
-  before { SiteSetting.chat_allowed_groups = [chatters] }
+  before { SiteSetting.chat_allowed_groups = chatters }
 
   describe "#can_chat?" do
     context "when the user is not in allowed to chat" do

--- a/plugins/chat/spec/lib/chat/message_bookmarkable_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_bookmarkable_spec.rb
@@ -14,7 +14,7 @@ describe Chat::MessageBookmarkable do
   before do
     register_test_bookmarkable(described_class)
     Chat::UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
-    SiteSetting.chat_allowed_groups = [chatters]
+    SiteSetting.chat_allowed_groups = chatters
   end
 
   after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }

--- a/plugins/chat/spec/lib/chat_sdk/message_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/message_spec.rb
@@ -60,7 +60,7 @@ describe ChatSDK::Message do
 
     context "when membership is enforced" do
       it "works" do
-        SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+        SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
         params[:enforce_membership] = true
         params[:guardian] = Fabricate(:user).guardian
 
@@ -115,7 +115,7 @@ describe ChatSDK::Message do
     fab!(:message_1) { Fabricate(:chat_message, message: "first") }
 
     before do
-      SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
       message_1.chat_channel.add(message_1.user)
       message_1.update!(streaming: true)
     end

--- a/plugins/chat/spec/requests/chat/api/channels_messages_flags_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_messages_flags_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Chat::Api::ChannelsMessagesFlagsController do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
-    SiteSetting.chat_message_flag_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+    SiteSetting.chat_message_flag_allowed_groups = Group::AUTO_GROUPS[:everyone]
     sign_in(current_user)
   end
 

--- a/plugins/chat/spec/requests/core_ext/bookmarks_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/bookmarks_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BookmarksController do
 
   before do
     register_test_bookmarkable(Chat::MessageBookmarkable)
-    SiteSetting.chat_allowed_groups = [chatters]
+    SiteSetting.chat_allowed_groups = chatters
     sign_in(current_user)
   end
 

--- a/plugins/chat/spec/requests/core_ext/notifications_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/notifications_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NotificationsController do
     before do
       Jobs.run_immediately!
       SiteSetting.chat_enabled = true
-      SiteSetting.chat_allowed_groups = [chatters.id]
+      SiteSetting.chat_allowed_groups = chatters.id
       sign_in(user)
     end
 

--- a/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
@@ -31,7 +31,7 @@ describe UsersController do
 
     before do
       register_test_bookmarkable(Chat::MessageBookmarkable)
-      SiteSetting.chat_allowed_groups = [chatters]
+      SiteSetting.chat_allowed_groups = chatters
       sign_in(current_user)
     end
 

--- a/plugins/chat/spec/services/auto_remove/handle_user_removed_from_group_spec.rb
+++ b/plugins/chat/spec/services/auto_remove/handle_user_removed_from_group_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Chat::AutoRemove::HandleUserRemovedFromGroup do
         before do
           group_1.add(removed_user)
           group_2.add(removed_user)
-          SiteSetting.chat_allowed_groups = group_1.id.to_s + "|" + group_2.id.to_s
+          SiteSetting.chat_allowed_groups = [group_1.id, group_2.id].join("|")
           CategoryGroup.create(
             category: private_category,
             group: group_2,

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Chat::CreateMessage do
             fab!(:user) { Fabricate(:user) }
 
             before do
-              SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+              SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
               params[:enforce_membership] = true
             end
 

--- a/plugins/chat/spec/services/chat/invite_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/invite_users_to_channel_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Chat::InviteUsersToChannel do
 
   before do
     group_1.add(user_1)
-    SiteSetting.chat_allowed_groups = [group_1].map(&:id).join("|")
+    SiteSetting.chat_allowed_groups = group_1.id
   end
 
   context "when all steps pass" do

--- a/plugins/chat/spec/services/chat/stop_message_streaming_spec.rb
+++ b/plugins/chat/spec/services/chat/stop_message_streaming_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Chat::StopMessageStreaming do
 
     before do
       channel_1.add(current_user)
-      SiteSetting.chat_allowed_groups = [Group::AUTO_GROUPS[:everyone]]
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
     end
 
     context "with valid params" do

--- a/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Chat::UpdateUserChannelLastRead do
     let(:guardian) { Guardian.new(current_user) }
     let(:params) { { guardian: guardian, channel_id: channel.id, message_id: message_1.id } }
 
-    before { SiteSetting.chat_allowed_groups = [chatters] }
+    before { SiteSetting.chat_allowed_groups = chatters }
 
     context "when params are not valid" do
       before { params.delete(:message_id) }

--- a/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_thread_last_read_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Chat::UpdateUserThreadLastRead do
 
     before do
       thread.add(current_user)
-      SiteSetting.chat_allowed_groups = [chatters]
+      SiteSetting.chat_allowed_groups = chatters
     end
 
     context "when params are not valid" do


### PR DESCRIPTION
This is extracted from https://github.com/discourse/discourse/pull/29129.

In some chat specs, we provide an array as a value for group lists like `chat_allowed_groups`, which is wrong. This results in a value like `"1|2|[3]"` instead of `"1|2|3"`.