### PR TITLE
DEV: Extract leave logic to the `Chat::Channel` models

### DIFF
--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -141,6 +141,7 @@ module Chat
     def remove(user)
       Chat::ChannelMembershipManager.new(self).unfollow(user)
     end
+    alias leave remove
 
     def url
       "#{Discourse.base_url}/chat/c/#{self.slug || "-"}/#{self.id}"

--- a/plugins/chat/app/services/chat/leave_channel.rb
+++ b/plugins/chat/app/services/chat/leave_channel.rb
@@ -33,14 +33,7 @@ module Chat
     end
 
     def leave(channel:, guardian:)
-      ActiveRecord::Base.transaction do
-        if channel.direct_message_channel? && channel.chatable&.group
-          channel.membership_for(guardian.user)&.destroy!
-          channel.chatable.direct_message_users.where(user_id: guardian.user.id).destroy_all
-        else
-          channel.remove(guardian.user)
-        end
-      end
+      channel.leave(guardian.user)
     end
 
     def recompute_users_count(channel:)

--- a/plugins/chat/spec/models/chat/category_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/category_channel_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe Chat::CategoryChannel do
     end
   end
 
+  describe "#leave" do
+    let(:original_method) { channel.method(:remove) }
+    let(:aliased_method) { channel.method(:leave) }
+
+    it "is an alias to '#remove'" do
+      expect(original_method.original_name).to eq(aliased_method.original_name)
+      expect(original_method.source_location).to eq(aliased_method.source_location)
+    end
+  end
+
   describe "slug generation" do
     subject(:channel) { Fabricate(:category_channel) }
 


### PR DESCRIPTION
Extracted from https://github.com/discourse/discourse/pull/29129.