### PR TITLE
DEV: fix flakey spec in sidebar

### DIFF
--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -251,7 +251,7 @@ describe "Custom sidebar sections", type: :system do
     )
   end
 
-  it "does not allow to drag on mobile" do
+  it "does not allow to drag on mobile", mobile: true do
     sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
 
     Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags").tap do |sidebar_url|
@@ -264,7 +264,7 @@ describe "Custom sidebar sections", type: :system do
 
     sign_in user
 
-    visit("/latest?mobile_view=1")
+    visit("/latest")
 
     sidebar.open_on_mobile
     sidebar.edit_custom_section("My section")

--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -190,11 +190,17 @@ module PageObjects
         def edit_custom_section(name)
           name = name.parameterize
 
-          find(".sidebar-section[data-section-name='#{name}']").hover
-
-          find(
-            ".sidebar-section[data-section-name='#{name}'] button.sidebar-section-header-button",
-          ).click
+          if page.has_css?("html.mobile-view", wait: 0)
+            find(
+              ".sidebar-section[data-section-name='#{name}'] button.sidebar-section-header-button",
+              visible: false,
+            ).click
+          else
+            find(".sidebar-section[data-section-name='#{name}']").hover
+            find(
+              ".sidebar-section[data-section-name='#{name}'] button.sidebar-section-header-button",
+            ).click
+          end
         end
 
         private


### PR DESCRIPTION
Technically we don't show the edit custom section button on mobile, but the button is present so I just fixed it so the finder works on mobile. We should probably remove this test or find a way to make the button visible on mobile.

Also used `mobile: true` instead of manual url.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->