### PR TITLE
DEV: Improve `array` type in service contracts

### DIFF
--- a/lib/active_support_type_extensions/array.rb
+++ b/lib/active_support_type_extensions/array.rb
@@ -9,7 +9,7 @@ module ActiveSupportTypeExtensions
     def cast_value(value)
       case value
       when String
-        value.split(",")
+        cast_value(value.split(/,(?!.*\|)|\|(?!.*,)/))
       when ::Array
         value.map { |item| Integer(item, exception: false) || item }
       else

--- a/spec/lib/active_support_type_extensions/array_spec.rb
+++ b/spec/lib/active_support_type_extensions/array_spec.rb
@@ -14,6 +14,30 @@ RSpec.describe ActiveSupportTypeExtensions::Array do
       end
     end
 
+    context "when 'value' is a string of numbers" do
+      let(:value) { "1,2,3" }
+
+      it "splits it with strings casted as integers" do
+        expect(casted_value).to eq([1, 2, 3])
+      end
+    end
+
+    context "when 'value' is a string of numbers separated by '|'" do
+      let(:value) { "1|2|3" }
+
+      it "splits it with strings casted as integers" do
+        expect(casted_value).to eq([1, 2, 3])
+      end
+    end
+
+    context "when 'value' has mixed separators" do
+      let(:value) { "1,2,3|4" }
+
+      it "splits only on one of the separators" do
+        expect(casted_value).to eq(["1,2,3", 4])
+      end
+    end
+
     context "when 'value' is an array" do
       let(:value) { %w[existing array] }
 


### PR DESCRIPTION
This PR improves the custom `array` type available in contracts. It’s now able to split strings on `|` on top of `,`, and to be more consistent, it also tries to cast the resulting items to integers.

---

Extracted from https://github.com/discourse/discourse/pull/29129