### PR TITLE
FEATURE: Enable image optimization on iOS >= 18

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1751,7 +1751,7 @@ files:
     client: true
     hidden: true
   composer_ios_media_optimisation_image_enabled:
-    default: false
+    default: true
     client: true
     hidden: true
   video_thumbnails_enabled:


### PR DESCRIPTION
Follow-up to [fd57a64](https://github.com/discourse/discourse/commit/fd57a641744efca6f8ccc8ea530a5615cb7edf5d) that fixed iOS issues with this feature.