### PR TITLE
DEV: Trigger an event after updating topic hot scores

### DIFF
--- a/app/models/topic_hot_score.rb
+++ b/app/models/topic_hot_score.rb
@@ -145,6 +145,8 @@ class TopicHotScore < ActiveRecord::Base
     SQL
 
     DB.exec(sql, args)
+
+    DiscourseEvent.trigger(:topic_hot_scores_updated)
   end
 end
 

--- a/spec/models/topic_hot_scores_spec.rb
+++ b/spec/models/topic_hot_scores_spec.rb
@@ -124,5 +124,20 @@ RSpec.describe TopicHotScore do
         TopicHotScore.where(topic_id: topic1.id).pluck(:recent_likes)
       }
     end
+
+    it "triggers an event after updating" do
+      triggered = false
+      blk = Proc.new { triggered = true }
+
+      begin
+        DiscourseEvent.on(:topic_hot_scores_updated, &blk)
+
+        TopicHotScore.update_scores
+
+        expect(triggered).to eq(true)
+      ensure
+        DiscourseEvent.off(:topic_hot_scores_updated, &blk)
+      end
+    end
   end
 end


### PR DESCRIPTION
Handy for `discourse-ai` to inmediately generate summaries of these topics.
