### PR TITLE
FIX: do not override trigger when equals 0

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -2,6 +2,7 @@ import { cached, tracked } from "@glimmer/tracking";
 import Controller, { inject as controller } from "@ember/controller";
 import { action, getProperties } from "@ember/object";
 import { service } from "@ember/service";
+import { isNone } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import getURL from "discourse-common/lib/get-url";
@@ -83,15 +84,15 @@ export default class AdminBadgesShowController extends Controller {
     // this is needed because the model doesnt have default values
     // Using `set` here isn't ideal, but we don't know that tracking is set up on the model yet.
     if (this.model) {
-      if (!this.model.badge_type_id) {
+      if (isNone(this.model.badge_type_id)) {
         this.model.set("badge_type_id", this.badgeTypes?.[0]?.id);
       }
 
-      if (!this.model.badge_grouping_id) {
+      if (isNone(this.model.badge_grouping_id)) {
         this.model.set("badge_grouping_id", this.badgeGroupings?.[0]?.id);
       }
 
-      if (!this.model.trigger) {
+      if (isNone(this.model.trigger)) {
         this.model.set("trigger", this.badgeTriggers?.[0]?.id);
       }
     }

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select/option.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select/option.gjs
@@ -1,12 +1,11 @@
 import Component from "@glimmer/component";
+import { isNone } from "@ember/utils";
 import { eq } from "truth-helpers";
 import { NO_VALUE_OPTION } from "discourse/form-kit/lib/constants";
 
 export default class FKControlSelectOption extends Component {
   get value() {
-    return typeof this.args.value === "undefined"
-      ? NO_VALUE_OPTION
-      : this.args.value;
+    return isNone(this.args.value) ? NO_VALUE_OPTION : this.args.value;
   }
 
   <template>

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -92,6 +92,18 @@ describe "Admin Badges Page", type: :system do
       expect(badges_page.form.field("auto_revoke")).to be_unchecked
       expect(badges_page.form.field("target_posts")).to be_unchecked
     end
+
+    context "when trigger is 0" do
+      fab!(:badge) do
+        Fabricate(:badge, enabled: true, icon: "trick-medial", query: "a query", trigger: 0)
+      end
+
+      it "doesn't override the trigger value" do
+        badges_page.visit_page(badge.id)
+
+        expect(badges_page.form.field("trigger").value).to eq("0")
+      end
+    end
   end
 
   context "when deleting a badge" do


### PR DESCRIPTION
This commit is fixing the path which sets a default value to trigger. We were doing `if (!this.model.trigger)` but `this.model.trigger` can have `0` as value, which would trigger this codepath and this codepath was setting the first value of badgeTriggers as a default value for trigger.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->