### PR TITLE
UX: ensure ios font size is always min 16px with max() fn

### DIFF
--- a/app/assets/stylesheets/common/font-variables.scss
+++ b/app/assets/stylesheets/common/font-variables.scss
@@ -29,8 +29,7 @@
   --font-down-2-rem: 0.7579rem;
 
   // inputs/textareas in iOS need to be at least 16px to avoid triggering zoom on focus
-  // with base at 15px, the below gives 16.05px
-  --font-size-ios-input: 1.07em;
+  --font-size-ios-input: max(1em, 16px);
 
   // Common line-heights
   --line-height-small: 1;


### PR DESCRIPTION
Using the max() function will ensure the font-size is always 16px at minimum, and switches to 1em if that's larger than 16px.
This to prevent reported zooming when the text size setting is smaller or smallest.

https://meta.discourse.org/t/reply-button-not-visible-when-composing-on-ios/322220/2