### PR TITLE
FIX: Don't error out on nested categories index page param

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -620,7 +620,7 @@ class CategoriesController < ApplicationController
       include_topics: include_topics,
       include_subcategories: include_subcategories,
       tag: params[:tag],
-      page: params[:page].to_i,
+      page: params[:page].try(:to_i) || 1,
     }
 
     @category_list = CategoryList.new(guardian, category_options)

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -425,6 +425,11 @@ RSpec.describe CategoriesController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["category_list"]["categories"].count).to eq(0)
       end
+
+      it "does not error out if page is a nested parameter" do
+        get "/categories.json?page[foo]=2"
+        expect(response.status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
### What is the problem?

We're expecting the `page` param to be something that neatly coerces into an integer. If we receive something like a nested parameter, this will blow up. (I'm sure there are other examples as well.)

### How does this fix it?

This commit falls back to a `page` value of `1` if the coercion fails.