### PR TITLE
FIX: Don't error out on nested topic show id param

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -51,7 +51,7 @@ class TopicsController < ApplicationController
   end
 
   def show
-    if params[:id].is_a?(Array)
+    if params[:id].is_a?(Array) || params[:id].is_a?(ActionController::Parameters)
       raise Discourse::InvalidParameters.new("Show only accepts a single ID")
     end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2344,6 +2344,12 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(400)
     end
 
+    it "does not raise an unhandled exception when receiving a nested ID parameter" do
+      get "/t/#{topic.id}/summary?id[foo]=a"
+
+      expect(response.status).to eq(400)
+    end
+
     it "keeps the post_number parameter around when redirecting" do
       get "/t/#{topic.slug}", params: { post_number: 42 }
       expect(response).to redirect_to(topic.relative_url + "/42")


### PR DESCRIPTION
### What is the problem?

We're expecting the ID param to be something that neatly coerces into an ID. If we receive something like a nested parameter, this will blow up. (We already handle the case of arrays.)

### How does this fix it?

This commit raises an `InvalidParameters` exception in the case of a nested ID.