### PR TITLE
DEV: serialize image upload thumbnail

### DIFF
--- a/app/serializers/upload_serializer.rb
+++ b/app/serializers/upload_serializer.rb
@@ -16,6 +16,12 @@ class UploadSerializer < ApplicationSerializer
              :human_filesize,
              :dominant_color
 
+  has_one :thumbnail,
+          serializer: UploadThumbnailSerializer,
+          root: false,
+          embed: :object,
+          if: -> { SiteSetting.create_thumbnails && object.has_thumbnail? }
+
   def url
     if object.for_site_setting
       object.url

--- a/app/serializers/upload_thumbnail_serializer.rb
+++ b/app/serializers/upload_thumbnail_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UploadThumbnailSerializer < ApplicationSerializer
+  attributes :id, :upload_id, :width, :height, :url, :extension, :filesize
+end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -272,12 +272,6 @@ after_initialize do
     object.chat_separate_sidebar_mode
   end
 
-  add_to_serializer(
-    :upload,
-    :thumbnail,
-    include_condition: -> { SiteSetting.chat_enabled && SiteSetting.create_thumbnails },
-  ) { object.thumbnail }
-
   on(:site_setting_changed) do |name, old_value, new_value|
     user_option_field = Chat::RETENTION_SETTINGS_TO_USER_OPTION_FIELDS[name.to_sym]
     begin

--- a/spec/requests/api/schemas/json/upload_create_response.json
+++ b/spec/requests/api/schemas/json/upload_create_response.json
@@ -42,6 +42,33 @@
     },
     "dominant_color": {
       "type": ["string", "null"]
+    },
+    "thumbnail": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "upload_id": {
+          "type": "integer"
+        },
+        "url": {
+          "type": "string"
+        },
+        "extension": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "filesize": {
+          "type": "integer"
+        }
+      }
     }
   },
   "required": [


### PR DESCRIPTION
Since [block accidental serialization of AR models](https://github.com/discourse/discourse/pull/27668) we are getting a 500 error in some cases with thumbnails. We can fix this by serializing the thumbnail, previously we just returned a raw `OptimizedImage` object.

Since thumbnails should probably be attached to the serializer in core, we no longer need to use `add_to_serializer` within the chat plugin to use thumbnails within chat message uploads.