### PR TITLE
FIX: create-invite-uploader following uppy-upload mixin changes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-invite-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/create-invite-uploader.js
@@ -35,7 +35,6 @@ export default class CreateInviteUploader extends Component.extend(
 
   @action
   setElement(element) {
-    this.set("fileInputEl", element);
-    this._initialize();
+    this.uppyUpload.setup(element);
   }
 }


### PR DESCRIPTION
This component will soon be updated to remove the mixin entirely (and add a regression test for it). But for now, this is a quick fix to get it working again.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->