### PR TITLE
DEV: UppyUpload improvements

### DIFF
--- a/app/assets/javascripts/discourse/app/components/pick-files-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/pick-files-button.hbs
@@ -7,6 +7,7 @@
 {{/if}}
 {{#if this.acceptsAllFormats}}
   <input
+    {{did-insert (or @registerFileInput (noop))}}
     type="file"
     id={{this.fileInputId}}
     class={{this.fileInputClass}}
@@ -15,6 +16,7 @@
   />
 {{else}}
   <input
+    {{did-insert (or @registerFileInput (noop))}}
     type="file"
     id={{this.fileInputId}}
     class={{this.fileInputClass}}

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -74,7 +74,7 @@ export default Mixin.create({
 function configShim(component) {
   return {
     get autoStartUploads() {
-      return component.autoStartUploads || true;
+      return component.autoStartUploads ?? true;
     },
     get id() {
       return component.id;


### PR DESCRIPTION
These tweaks will help adoption of the non-mixin-based uppy patterns.

- Add `type:`  to default arguments list
- Update pick-files-button to support explicit element registration
- Make `cancelSingleUpload` a public API, and add `cancelAllUploads`
- Remove `isDestroyed` logic - it doesn't do anything outside a component
- Add `@bind` to `setup()`

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->