### PR TITLE
FIX: Safari below 18 detection for media optimization

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
@@ -24,10 +24,9 @@ export default {
       }
 
       // prior to v18, Safari has WASM memory growth bugs
+      // using `document.startViewTransition` as a proxy for Safari 18+
       // eg https://github.com/emscripten-core/emscripten/issues/19144
-      let match = window.navigator.userAgent.match(/Mobile\/([0-9]+)\./);
-      let safariVersion = match ? parseInt(match[1], 10) : null;
-      if (capabilities.isSafari && safariVersion && safariVersion < 18) {
+      if (capabilities.isSafari && document.startViewTransition === undefined) {
         return;
       }
 


### PR DESCRIPTION
Previous regex wasn't working correctly. 