### PR TITLE
DEV: Fix flaky specs related to flag services

### DIFF
--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe(Flags::DestroyFlag) do
   subject(:result) { described_class.call(**params, **dependencies) }
 
-  fab!(:flag)
   fab!(:current_user) { Fabricate(:admin) }
 
+  let(:flag) { Fabricate(:flag) }
   let(:params) { { id: flag_id } }
   let(:dependencies) { { guardian: current_user.guardian } }
   let(:flag_id) { flag.id }

--- a/spec/services/flags/toggle_flag_spec.rb
+++ b/spec/services/flags/toggle_flag_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe(Flags::ToggleFlag) do
   describe ".call" do
     subject(:result) { described_class.call(**params, **dependencies) }
 
-    fab!(:flag)
     fab!(:current_user) { Fabricate(:admin) }
 
+    let(:flag) { Fabricate(:flag) }
     let(:flag_id) { flag.id }
     let(:params) { { flag_id: flag_id } }
     let(:dependencies) { { guardian: current_user.guardian } }

--- a/spec/services/flags/update_flag_spec.rb
+++ b/spec/services/flags/update_flag_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe(Flags::UpdateFlag) do
   describe ".call" do
     subject(:result) { described_class.call(**params, **dependencies) }
 
-    fab!(:flag)
     fab!(:current_user) { Fabricate(:admin) }
 
+    let(:flag) { Fabricate(:flag) }
     let(:params) { { id: flag_id, name:, description:, applies_to:, require_message:, enabled: } }
     let(:dependencies) { { guardian: current_user.guardian } }
     let(:flag_id) { flag.id }


### PR DESCRIPTION
Creating or updating flags generates global side effects. Sometimes it seems the state can leak from the flag specs.

This is probably related to the use of `fab!`. This PR replaces those calls with standard `let`s. While the overall performances of these tests will be a little less good, their state should not leak anymore.