### PR TITLE
FIX: bump the number of svg icons we return to first 500

### DIFF
--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -48,8 +48,9 @@ class SvgSpriteController < ApplicationController
     filter = params[:filter] || ""
     only_available = params[:only_available]
 
-    icons = SvgSprite.icon_picker_search(filter, only_available)
-    render json: icons.take(200), root: false
+    icons = SvgSprite.icon_picker_search(filter, only_available).take(500)
+
+    render json: icons, root: false
   end
 
   def svg_icon

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -426,12 +426,10 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
   end
 
   def self.icon_picker_search(keyword, only_available = false)
-    icons = all_icons(SiteSetting.default_theme_id) if only_available
-
     symbols = svgs_for(SiteSetting.default_theme_id)
-    symbols.slice!(*icons) if only_available
-    symbols.reject! { |icon_id, sym| !icon_id.include?(keyword) } unless keyword.empty?
-    symbols.sort_by(&:first).map { |icon_id, symbol| { id: icon_id, symbol: symbol } }
+    symbols.slice!(*all_icons(SiteSetting.default_theme_id)) if only_available
+    symbols.reject! { |icon_id, _sym| !icon_id.include?(keyword) } if keyword.present?
+    symbols.sort_by(&:first).map { |id, symbol| { id:, symbol: } }
   end
 
   # For use in no_ember .html.erb layouts

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -85,14 +85,14 @@ RSpec.describe SvgSpriteController do
       expect(response.status).to eq(403)
     end
 
-    it "should work with no filter and max out at 200 results" do
+    it "should work with no filter and max out at 500 results" do
       sign_in(user)
       get "/svg-sprite/picker-search"
 
       expect(response.status).to eq(200)
 
       data = response.parsed_body
-      expect(data.length).to eq(200)
+      expect(data.length).to be <= 500
       expect(data[0]["id"]).to eq("0")
     end
 
@@ -120,7 +120,7 @@ RSpec.describe SvgSpriteController do
       data = response.parsed_body
       beer_icon = response.parsed_body.find { |i| i["id"] == "beer-mug-empty" }
       expect(beer_icon).to be nil
-      expect(data.length).to eq(200)
+      expect(data.length).to eq(250)
     end
   end
 


### PR DESCRIPTION
instead of the first 200 which would "hide" some icons from the list when picking an icon for a badge or a sidebar link.

Internal ref - t/119652

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->