### PR TITLE
PERF: Optimize themes:update task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -243,8 +243,6 @@ if ENV["IMPORT"] == "1"
   gem "reverse_markdown"
   gem "tiny_tds"
   gem "csv"
-
-  gem "parallel", require: false
 end
 
 group :generic_import, optional: true do
@@ -289,3 +287,5 @@ group :migrations, optional: true do
 end
 
 gem "dry-initializer", "~> 3.1"
+
+gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -677,6 +677,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-oauth2
   omniauth-twitter
+  parallel
   parallel_tests
   pg
   pry-byebug


### PR DESCRIPTION
- Add concurrency when running on multisite clusters (default 10, configurable via THEME_UPDATE_CONCURRENCY env)

- Add a version cache for the duration of the rake task. This avoids duplicating work when many sites in the cluster have the same theme installed, and it is already up-to-date

- Updates output to be more concurrent friendly (all `puts`, no `print`)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->