### PR TITLE
FIX: participating users statistics...

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -303,6 +303,7 @@ class User < ActiveRecord::Base
   scope :not_suspended, -> { where("suspended_till IS NULL OR suspended_till <= ?", Time.zone.now) }
   scope :activated, -> { where(active: true) }
   scope :not_staged, -> { where(staged: false) }
+  scope :approved, -> { where(approved: true) }
 
   scope :filter_by_username,
         ->(filter) do

--- a/lib/statistics.rb
+++ b/lib/statistics.rb
@@ -142,7 +142,7 @@ class Statistics
   private
 
   def self.valid_users
-    users = User.real.activated.not_staged.not_suspended.not_silenced
+    users = User.real.activated.not_suspended.not_silenced
     users = users.approved if SiteSetting.must_approve_users
     users
   end

--- a/spec/lib/statistics_spec.rb
+++ b/spec/lib/statistics_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Statistics do
   describe ".users" do
     before { User.real.destroy_all }
 
-    it "doesn't count inactive, silenced, suspended, or staged users" do
+    it "doesn't count inactive, silenced, or suspended users" do
       res = described_class.users
       expect(res[:last_day]).to eq(0)
       expect(res[:"7_days"]).to eq(0)
@@ -66,15 +66,6 @@ RSpec.describe Statistics do
       user = Fabricate(:user, active: true)
       user2 = Fabricate(:user, active: true)
       user3 = Fabricate(:user, active: true)
-      user4 = Fabricate(:user, active: true)
-
-      res = described_class.users
-      expect(res[:last_day]).to eq(4)
-      expect(res[:"7_days"]).to eq(4)
-      expect(res[:"30_days"]).to eq(4)
-      expect(res[:count]).to eq(4)
-
-      user.update!(active: false)
 
       res = described_class.users
       expect(res[:last_day]).to eq(3)
@@ -82,7 +73,7 @@ RSpec.describe Statistics do
       expect(res[:"30_days"]).to eq(3)
       expect(res[:count]).to eq(3)
 
-      user2.update!(silenced_till: 1.month.from_now)
+      user.update!(active: false)
 
       res = described_class.users
       expect(res[:last_day]).to eq(2)
@@ -90,7 +81,7 @@ RSpec.describe Statistics do
       expect(res[:"30_days"]).to eq(2)
       expect(res[:count]).to eq(2)
 
-      user3.update!(suspended_till: 1.month.from_now)
+      user2.update!(silenced_till: 1.month.from_now)
 
       res = described_class.users
       expect(res[:last_day]).to eq(1)
@@ -98,7 +89,7 @@ RSpec.describe Statistics do
       expect(res[:"30_days"]).to eq(1)
       expect(res[:count]).to eq(1)
 
-      user4.update!(staged: true)
+      user3.update!(suspended_till: 1.month.from_now)
 
       res = described_class.users
       expect(res[:last_day]).to eq(0)

--- a/spec/lib/statistics_spec.rb
+++ b/spec/lib/statistics_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Statistics do
   describe ".users" do
     before { User.real.destroy_all }
 
-    it "doesn't count silenced or inactive users" do
+    it "doesn't count inactive, silenced, suspended, or staged users" do
       res = described_class.users
       expect(res[:last_day]).to eq(0)
       expect(res[:"7_days"]).to eq(0)
@@ -65,6 +65,24 @@ RSpec.describe Statistics do
 
       user = Fabricate(:user, active: true)
       user2 = Fabricate(:user, active: true)
+      user3 = Fabricate(:user, active: true)
+      user4 = Fabricate(:user, active: true)
+
+      res = described_class.users
+      expect(res[:last_day]).to eq(4)
+      expect(res[:"7_days"]).to eq(4)
+      expect(res[:"30_days"]).to eq(4)
+      expect(res[:count]).to eq(4)
+
+      user.update!(active: false)
+
+      res = described_class.users
+      expect(res[:last_day]).to eq(3)
+      expect(res[:"7_days"]).to eq(3)
+      expect(res[:"30_days"]).to eq(3)
+      expect(res[:count]).to eq(3)
+
+      user2.update!(silenced_till: 1.month.from_now)
 
       res = described_class.users
       expect(res[:last_day]).to eq(2)
@@ -72,7 +90,7 @@ RSpec.describe Statistics do
       expect(res[:"30_days"]).to eq(2)
       expect(res[:count]).to eq(2)
 
-      user.update!(active: false)
+      user3.update!(suspended_till: 1.month.from_now)
 
       res = described_class.users
       expect(res[:last_day]).to eq(1)
@@ -80,7 +98,7 @@ RSpec.describe Statistics do
       expect(res[:"30_days"]).to eq(1)
       expect(res[:count]).to eq(1)
 
-      user2.update!(silenced_till: 1.month.from_now)
+      user4.update!(staged: true)
 
       res = described_class.users
       expect(res[:last_day]).to eq(0)
@@ -187,6 +205,11 @@ RSpec.describe Statistics do
     it "returns users who have created a new PM" do
       Fabricate(:user_action, action_type: UserAction::NEW_PRIVATE_MESSAGE)
       expect(described_class.participating_users[:last_day]).to eq(1)
+    end
+
+    it "doesn't count bots" do
+      Fabricate(:user_action, action_type: UserAction::LIKE, user: Discourse.system_user)
+      expect(described_class.participating_users[:last_day]).to eq(0)
     end
   end
 


### PR DESCRIPTION
... was (mis-)counting

- bots
- anonymous users
- suspended users

There's now a "valid_users" function that holds the AR query for valid users and which is used in all "users", "active_users", and "participating_users" queries.

Internal ref - t/138435

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->