### PR TITLE
DEV: Create the DB before migration in the Docker environment

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -122,6 +122,7 @@ echo "pnpm install..."
 
 if [ "${initialize}" = "initialize" ]; then
     echo "Migrating database..."
+    "${SCRIPTPATH}/rake" db:create
     "${SCRIPTPATH}/rake" db:migrate
     RAILS_ENV=test "${SCRIPTPATH}/rake" db:migrate
 


### PR DESCRIPTION
## ✨ What's Happening?

When attempting to [set up the Docker development environment](https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009), I was seeing the following error when running `d/boot_dev --init`:

```
ActiveRecord::NoDatabaseError: We could not find your database: discourse_development. Available database configurations can be found in config/database.yml. (ActiveRecord::NoDatabaseError)
```

Running `db:create` before the `db:migrate` fixed this issue for me. It appears to be safe to run `db:create` even if the database already exists, running `d/rake db:create` locally shows an info message at the database already exists, but doesn't exit with an error.

## 👑 Testing

If you already have a Docker dev environment setup, you will need to run `docker stop discourse_dev && docker rm discourse_dev` first to remove it.

Before switching to this PR, run through the [Docker setup instructions](https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009) to confirm that you run into this error.

After switching to this PR, run `docker stop discourse_dev && docker rm discourse_dev`, then follow the Docker setup instructions again.