### PR TITLE
FIX: setting new password should reset password_expired_at

### DIFF
--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -59,6 +59,7 @@ class UserPassword < ActiveRecord::Base
     self.password_salt = SecureRandom.hex(PASSWORD_SALT_LENGTH)
     self.password_algorithm = TARGET_PASSWORD_ALGORITHM
     self.password_hash = hash_password(@raw_password, password_salt, password_algorithm)
+    self.password_expired_at = nil
   end
 
   def regen_password!(pw)


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/28746.

I missed out trying to logging out and logging again with the new password after the test scenario I did in the original PR:
> Expire password via UserPasswordExpirer in console and attempt login which triggers the same flow as Step 3.

Currently, doing a logout/login would still trigger the password expired UI since setting the password never nulls out `password_expired_at`. 

I've added some tests, and did a manual test of the above-described flow to ensure the fix works. Any time we set a new password, it's expected that it would null out the `password_expired_at` timestamp.

