### PR TITLE
DEV: Don't ask admin to re-confirm 'for all users' when requirement didn't change

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
@@ -19,6 +19,8 @@ export default class AdminUserFieldItem extends Component {
   @tracked
   editableDisabled = this.args.userField.requirement === "for_all_users";
 
+  originalRequirement = this.args.userField.requirement;
+
   get fieldName() {
     return UserField.fieldTypeById(this.fieldType)?.name;
   }
@@ -85,7 +87,10 @@ export default class AdminUserFieldItem extends Component {
   async save(data) {
     let confirm = true;
 
-    if (data.requirement === "for_all_users") {
+    if (
+      data.requirement === "for_all_users" &&
+      this.originalRequirement !== "for_all_users"
+    ) {
       confirm = await this._confirmChanges();
     }
 
@@ -100,6 +105,7 @@ export default class AdminUserFieldItem extends Component {
           return;
         }
 
+        this.originalRequirement = data.requirement;
         this.isEditing = false;
       })
       .catch(popupAjaxError);

--- a/spec/system/admin_user_fields_spec.rb
+++ b/spec/system/admin_user_fields_spec.rb
@@ -59,4 +59,22 @@ describe "Admin User Fields", type: :system, js: true do
 
     expect(page).to have_text(I18n.t("admin_js.admin.user_fields.requirement.confirmation"))
   end
+
+  context "when editing an existing user field" do
+    fab!(:user_field) { Fabricate(:user_field, requirement: "for_all_users") }
+
+    it "does not require confirmation if the field already applies to all users" do
+      user_fields_page.visit
+
+      page.find(".user-field .edit").click
+
+      form = page.find(".user-field")
+
+      form.find(".user-field-name").fill_in(with: "Favourite Transformer")
+
+      form.find(".btn-primary").click
+
+      expect(page).to have_no_text(I18n.t("admin_js.admin.user_fields.requirement.confirmation"))
+    end
+  end
 end


### PR DESCRIPTION
### What is this change?

When adding or updating a custom user field to apply to all users (retroactively) we want to alert the admin that this will force all existing users to fill up the field before they are able to access the forum again.

However, we currently show this prompt when making changes only to other attributes on the custom field, i.e. the requirement hasn't changed.

This commit fixes that.