### PR TITLE
FEATURE: Revive legacy pageview reports

### DIFF
--- a/app/models/concerns/reports/consolidated_page_views.rb
+++ b/app/models/concerns/reports/consolidated_page_views.rb
@@ -4,8 +4,10 @@ module Reports::ConsolidatedPageViews
   extend ActiveSupport::Concern
 
   class_methods do
-    # NOTE: This report is deprecated, once use_legacy_pageviews is
-    # always false or no longer needed we can delete this.
+    # NOTE: This report is superseded by "SiteTraffic". Eventually once
+    # use_legacy_pageviews is always false or no longer needed, and users
+    # no longer rely on the data in this old report in the transition period,
+    # we can delete this.
     def report_consolidated_page_views(report)
       filters = %w[page_view_logged_in page_view_anon page_view_crawler]
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1353,13 +1353,15 @@ en:
       yaxis: "Day"
       description: "Number of users who increased their Trust Level during this period."
     consolidated_page_views:
-      title: "Consolidated Pageviews"
+      title: "Legacy Consolidated Pageviews"
+      title_legacy: "Consolidated Pageviews"
       xaxis:
         page_view_crawler: "Crawlers"
         page_view_anon: "Anonymous users"
         page_view_logged_in: "Logged in users"
       yaxis: "Day"
-      description: "Pageviews for logged in users, anonymous users and crawlers."
+      description: "Legacy report showing pageviews for logged in users, anonymous users and crawlers. This has been superseded by the 'Site traffic' report."
+      description_legacy: "Pageviews for logged in users, anonymous users and crawlers."
       labels:
         post: Post
         editor: Editor
@@ -1374,13 +1376,15 @@ en:
       description: "API requests for regular API keys and user API keys."
     consolidated_page_views_browser_detection:
       title: "Consolidated Pageviews with Browser Detection (Experimental)"
+      title_legacy: "Consolidated Pageviews with Browser Detection (Experimental)"
       xaxis:
         page_view_anon_browser: "Anonymous Browser"
         page_view_logged_in_browser: "Logged In Browser"
         page_view_crawler: "Known Crawler"
         page_view_other: "Other pageviews"
       yaxis: "Day"
-      description: "Pageviews for logged in users, anonymous users, known crawlers and other. This experimental report ensures logged-in/anon requests are coming from real browsers before counting them. Historical data for this report is unavailable, for historical data see the ‘Consolidated Pageviews' report."
+      description: "Pageviews for logged in users, anonymous users, known crawlers and other. This experimental report ensures logged-in/anon requests are coming from real browsers before counting them. Historical data for this report is unavailable, for historical data see the 'Legacy Consolidated Pageviews' report."
+      description_legacy: "Pageviews for logged in users, anonymous users, known crawlers and other. This experimental report ensures logged-in/anon requests are coming from real browsers before counting them. Historical data for this report is unavailable, for historical data see the ‘Consolidated Pageviews' report."
     site_traffic:
       title: "Site traffic"
       xaxis:
@@ -1541,6 +1545,11 @@ en:
       xaxis: "Day"
       yaxis: "Total Pageviews"
       description: "Number of new pageviews from all visitors."
+    page_view_legacy_total_reqs:
+      title: "Legacy Pageviews"
+      xaxis: "Day"
+      yaxis: "Total Pageviews"
+      description: "Legacy report showing the number of new pageviews from all visitors."
     page_view_logged_in_mobile_reqs:
       title: "Logged In Pageviews"
       xaxis: "Day"

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Admin::ReportsController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["reports"].count).to eq(5)
         expect(response.parsed_body["reports"][0]["type"]).to eq("site_traffic")
-        expect(response.parsed_body["reports"][1]).to include("error" => "not_found", "data" => nil)
+        expect(response.parsed_body["reports"][1]["type"]).to eq("consolidated_page_views")
         expect(response.parsed_body["reports"][2]).to include("error" => "not_found", "data" => nil)
         expect(response.parsed_body["reports"][3]).to include("error" => "not_found", "data" => nil)
         expect(response.parsed_body["reports"][4]).to include("error" => "not_found", "data" => nil)
@@ -366,6 +366,11 @@ RSpec.describe Admin::ReportsController do
           expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
         end
       end
+
+      it "does not allow running the page_view_legacy_total_reqs report" do
+        get "/admin/reports/page_view_legacy_total_reqs.json"
+        expect(response.status).to eq(404)
+      end
     end
 
     context "when use_legacy_pageviews is false" do
@@ -380,6 +385,11 @@ RSpec.describe Admin::ReportsController do
           expect(response.status).to eq(404)
           expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
         end
+      end
+
+      it "does allow running the page_view_legacy_total_reqs report" do
+        get "/admin/reports/page_view_legacy_total_reqs.json"
+        expect(response.status).to eq(200)
       end
     end
   end


### PR DESCRIPTION
This commit brings back some reports hidden or changed
by the commit in 14b436923c5b582cea454b69441a28e16f2f191e if
the site setting `use_legacy_pageviews` is false.

* Unhide the old “Consolidated Pageviews” report and rename it
  to “Legacy Consolidated Pageviews”
* Add a legacy_page_view_total_reqs report called “Legacy Pageviews”,
  which calculates pageviews in the same way the old page_view_total_reqs
  report did.

This will allow admins to better compare old and new pageview
stats which are based on browser detection if they have switched
over to _not_ use legacy pageviews.

**use_legacy_pageviews is false**

![image](https://github.com/user-attachments/assets/1cbdef62-09f8-45c6-b3a0-d26de50aca64)

**use_legacy_pageviews is true**

![image](https://github.com/user-attachments/assets/94b7c639-ef39-4319-8847-ff3d2caaf3cb)
