### PR TITLE
UX: DMenu modal add grip and min-height

### DIFF
--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -91,6 +91,7 @@ export default class DMenu extends Component {
           data-identifier={{@instance.options.identifier}}
           data-content
         >
+          <div class="fk-d-menu-modal__grip" aria-hidden="true"></div>
           {{#if (has-block)}}
             {{yield this.componentArgs}}
           {{else if (has-block "content")}}

--- a/app/assets/stylesheets/mobile/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu.scss
@@ -1,6 +1,17 @@
 .fk-d-menu-modal {
+  &__grip {
+    position: absolute;
+    top: 2.5px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--primary-medium);
+    height: 5px;
+    width: 15vw;
+    max-width: 100px;
+    border-radius: 10px;
+  }
   .d-modal__body {
-    padding: 0.5em 0;
+    padding: 1em 0;
   }
 
   h3 {

--- a/app/assets/stylesheets/mobile/list-controls.scss
+++ b/app/assets/stylesheets/mobile/list-controls.scss
@@ -61,12 +61,6 @@
 }
 
 .fk-d-menu-modal.list-control-toggle-link-content {
-  .d-modal {
-    &__body {
-      padding-block: 0.75rem;
-    }
-  }
-
   .dropdown-menu {
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -33,6 +33,7 @@ html:not(.keyboard-visible.mobile-view) {
 
     width: 100%;
     max-width: 100%;
+    min-height: 45svh;
     max-height: calc(var(--composer-vh, var(--1dvh)) * 85);
   }
 


### PR DESCRIPTION
To prevent the DMenu on mobile to be too minimal, we're adding a minimum height of 45% viewport.
In addition, we're implementing a small grip element to highlight the pulldown/swipedown functionality that is already implemented, to close the menu.

<img width="361" alt="CleanShot 2024-10-21 at 17 17 37@2x" src="https://github.com/user-attachments/assets/9a13abf1-a20d-462e-b148-89905aa11ef4">
