### PR TITLE
DEV: Allow enabling safe-mode even when missing required fields

### DIFF
--- a/app/assets/javascripts/discourse/app/services/restricted-routing.js
+++ b/app/assets/javascripts/discourse/app/services/restricted-routing.js
@@ -9,7 +9,7 @@ export default class RestrictedRouting extends Service {
   }
 
   isAllowedRoute(path) {
-    const alwaysAllowed = ["faq", "about", "tos", "privacy"];
+    const alwaysAllowed = ["faq", "about", "tos", "privacy", "safe-mode"];
 
     if (alwaysAllowed.includes(path)) {
       return true;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -928,7 +928,7 @@ class ApplicationController < ActionController::Base
 
     redirect_path = path("/u/#{current_user.encoded_username}/preferences/profile")
     second_factor_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
-    allowed_paths = [redirect_path, second_factor_path, path("/admin")]
+    allowed_paths = [redirect_path, second_factor_path, path("/admin"), path("/safe-mode")]
     if allowed_paths.none? { |p| request.fullpath.start_with?(p) }
       rate_limiter = RateLimiter.new(current_user, "redirect_to_required_fields_log", 1, 24.hours)
 

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -77,5 +77,15 @@ describe "User preferences | Profile", type: :system do
 
       expect(page).to have_current_path("/")
     end
+
+    it "allows enabling safe-mode" do
+      visit("/safe-mode")
+
+      expect(page).to have_current_path("/safe-mode")
+
+      page.find("#btn-enter-safe-mode").click
+
+      expect(page).to have_current_path("/u/#{user.username}/preferences/profile")
+    end
   end
 end


### PR DESCRIPTION
### What is this change?

When a user is missing required fields, they are required to fill those up before continuing to interact with the forum. This applies to admins as well.

We keep a whitelist of paths that can still be visited in this mode: FAQ, About, 2FA setup, and any admin route for admins.

We concluded that admins should still be able to enable safe mode even with missing required fields. Since plugins etc. can potentially mess with the ability to fill those up.