### PR TITLE
DEV: Use flaky-test-retry in PRs as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' || matrix.build_type == 'system' }}
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
       MINIO_RUNNER_LOG_LEVEL: DEBUG
-      DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && github.ref == 'refs/heads/main' && '1' }}
+      DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') }}
       CHEAP_SOURCE_MAPS: "1"
       TESTEM_DEFAULT_BROWSER: Chrome
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner


### PR DESCRIPTION
The aim of the flaky-tests-rerun system is to reduce the amount of time developers have to spend manually restarting CI jobs. That means that, to get the benefit, we need to run it for PRs as well as on `main`.

Our internal reporting system only looks at the data from runs on `main`, so that it's not polluted by legitimately failing tests in PRs.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->