### PR TITLE
DEV: Stop injecting a service result object in the caller object

### DIFF
--- a/app/controllers/admin/config/flags_controller.rb
+++ b/app/controllers/admin/config/flags_controller.rb
@@ -27,9 +27,9 @@ class Admin::Config::FlagsController < Admin::AdminController
 
   def create
     Flags::CreateFlag.call(service_params) do
-      on_success do
+      on_success do |flag:|
         Discourse.request_refresh!
-        render json: result.flag, serializer: FlagSerializer, used_flag_ids: Flag.used_flag_ids
+        render json: flag, serializer: FlagSerializer, used_flag_ids: Flag.used_flag_ids
       end
       on_failure { render(json: failed_json, status: 422) }
       on_failed_policy(:invalid_access) { raise Discourse::InvalidAccess }
@@ -42,9 +42,9 @@ class Admin::Config::FlagsController < Admin::AdminController
 
   def update
     Flags::UpdateFlag.call(service_params) do
-      on_success do
+      on_success do |flag:|
         Discourse.request_refresh!
-        render json: result.flag, serializer: FlagSerializer, used_flag_ids: Flag.used_flag_ids
+        render json: flag, serializer: FlagSerializer, used_flag_ids: Flag.used_flag_ids
       end
       on_failure { render(json: failed_json, status: 422) }
       on_model_not_found(:message) { raise Discourse::NotFound }

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -40,9 +40,9 @@ class Admin::SiteSettingsController < Admin::AdminController
     previous_value = value_or_default(SiteSetting.get(id)) if update_existing_users
 
     SiteSetting::Update.call(service_params.merge(setting_name: id, new_value: value)) do
-      on_success do
+      on_success do |contract:|
         if update_existing_users
-          SiteSettingUpdateExistingUsers.call(id, result.contract.new_value, previous_value)
+          SiteSettingUpdateExistingUsers.call(id, contract.new_value, previous_value)
         end
         render body: nil
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -121,13 +121,13 @@ class Admin::UsersController < Admin::StaffController
 
   def suspend
     User::Suspend.call(service_params) do
-      on_success do
+      on_success do |contract:, user:, full_reason:|
         render_json_dump(
           suspension: {
-            suspend_reason: result.contract.reason,
-            full_suspend_reason: result.full_reason,
-            suspended_till: result.user.suspended_till,
-            suspended_at: result.user.suspended_at,
+            suspend_reason: contract.reason,
+            full_suspend_reason: full_reason,
+            suspended_till: user.suspended_till,
+            suspended_at: user.suspended_at,
             suspended_by: BasicUserSerializer.new(current_user, root: false).as_json,
           },
         )
@@ -316,13 +316,13 @@ class Admin::UsersController < Admin::StaffController
 
   def silence
     User::Silence.call(service_params) do
-      on_success do
+      on_success do |full_reason:, user:|
         render_json_dump(
           silence: {
             silenced: true,
-            silence_reason: result.full_reason,
-            silenced_till: result.user.silenced_till,
-            silenced_at: result.user.silenced_at,
+            silence_reason: full_reason,
+            silenced_till: user.silenced_till,
+            silenced_at: user.silenced_at,
             silenced_by: BasicUserSerializer.new(current_user, root: false).as_json,
           },
         )

--- a/app/services/experiments/toggle.rb
+++ b/app/services/experiments/toggle.rb
@@ -4,14 +4,11 @@ class Experiments::Toggle
   include Service::Base
 
   policy :current_user_is_admin
-
   contract do
     attribute :setting_name, :string
     validates :setting_name, presence: true
   end
-
   policy :setting_is_available
-
   transaction { step :toggle }
 
   private

--- a/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
@@ -2,7 +2,7 @@
 
 class Chat::Api::ChannelThreadMessagesController < Chat::ApiController
   def index
-    ::Chat::ListChannelThreadMessages.call(service_params) do
+    ::Chat::ListChannelThreadMessages.call(service_params) do |result|
       on_success do
         render_serialized(
           result,

--- a/plugins/chat/app/controllers/chat/api/channel_threads_current_user_notifications_settings_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_threads_current_user_notifications_settings_controller.rb
@@ -3,17 +3,13 @@
 class Chat::Api::ChannelThreadsCurrentUserNotificationsSettingsController < Chat::ApiController
   def update
     Chat::UpdateThreadNotificationSettings.call(service_params) do
+      on_success do |membership:|
+        render_serialized(membership, Chat::BaseThreadMembershipSerializer, root: "membership")
+      end
+      on_failure { render(json: failed_json, status: 422) }
       on_failed_policy(:threading_enabled_for_channel) { raise Discourse::NotFound }
       on_failed_policy(:can_view_channel) { raise Discourse::InvalidAccess }
       on_model_not_found(:thread) { raise Discourse::NotFound }
-      on_success do
-        render_serialized(
-          result.membership,
-          Chat::BaseThreadMembershipSerializer,
-          root: "membership",
-        )
-      end
-      on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
       end

--- a/plugins/chat/app/controllers/chat/api/channel_threads_current_user_title_prompt_seen_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_threads_current_user_title_prompt_seen_controller.rb
@@ -3,17 +3,13 @@
 class Chat::Api::ChannelThreadsCurrentUserTitlePromptSeenController < Chat::ApiController
   def update
     Chat::MarkThreadTitlePromptSeen.call(service_params) do
+      on_success do |membership:|
+        render_serialized(membership, Chat::BaseThreadMembershipSerializer, root: "membership")
+      end
+      on_failure { render(json: failed_json, status: 422) }
       on_failed_policy(:threading_enabled_for_channel) { raise Discourse::NotFound }
       on_failed_policy(:can_view_channel) { raise Discourse::InvalidAccess }
       on_model_not_found(:thread) { raise Discourse::NotFound }
-      on_success do
-        render_serialized(
-          result.membership,
-          Chat::BaseThreadMembershipSerializer,
-          root: "membership",
-        )
-      end
-      on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
       end

--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -57,24 +57,19 @@ class Chat::Api::ChannelsController < Chat::ApiController
     Chat::CreateCategoryChannel.call(
       service_params.merge(channel_params.merge(category_id: channel_params[:chatable_id])),
     ) do
-      on_success do
-        render_serialized(
-          result.channel,
-          Chat::ChannelSerializer,
-          root: "channel",
-          membership: result.membership,
-        )
+      on_success do |channel:, membership:|
+        render_serialized(channel, Chat::ChannelSerializer, root: "channel", membership:)
       end
       on_model_not_found(:category) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:can_create_channel) { raise Discourse::InvalidAccess }
       on_failed_policy(:category_channel_does_not_exist) do
         raise Discourse::InvalidParameters.new(I18n.t("chat.errors.channel_exists_for_category"))
       end
-      on_model_errors(:channel) do
-        render_json_error(result.channel, type: :record_invalid, status: 422)
+      on_model_errors(:channel) do |model|
+        render_json_error(model, type: :record_invalid, status: 422)
       end
-      on_model_errors(:membership) do
-        render_json_error(result.membership, type: :record_invalid, status: 422)
+      on_model_errors(:membership) do |model|
+        render_json_error(model, type: :record_invalid, status: 422)
       end
       on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|
@@ -101,12 +96,12 @@ class Chat::Api::ChannelsController < Chat::ApiController
     end
 
     Chat::UpdateChannel.call(service_params.merge(params_to_edit)) do
-      on_success do
+      on_success do |channel:|
         render_serialized(
-          result.channel,
+          channel,
           Chat::ChannelSerializer,
           root: "channel",
-          membership: result.channel.membership_for(current_user),
+          membership: channel.membership_for(current_user),
         )
       end
       on_model_not_found(:channel) { raise ActiveRecord::RecordNotFound }

--- a/plugins/chat/app/controllers/chat/api/channels_current_user_membership_follows_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_current_user_membership_follows_controller.rb
@@ -3,18 +3,14 @@
 class Chat::Api::ChannelsCurrentUserMembershipFollowsController < Chat::Api::ChannelsController
   def destroy
     Chat::UnfollowChannel.call(service_params) do
-      on_success do
-        render_serialized(
-          result.membership,
-          Chat::UserChannelMembershipSerializer,
-          root: "membership",
-        )
+      on_success do |membership:|
+        render_serialized(membership, Chat::UserChannelMembershipSerializer, root: "membership")
       end
-      on_model_not_found(:channel) { raise Discourse::NotFound }
-      on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
       end
+      on_model_not_found(:channel) { raise Discourse::NotFound }
+      on_failure { render(json: failed_json, status: 422) }
     end
   end
 end

--- a/plugins/chat/app/controllers/chat/api/channels_read_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_read_controller.rb
@@ -20,9 +20,7 @@ class Chat::Api::ChannelsReadController < Chat::ApiController
 
   def update_all
     Chat::MarkAllUserChannelsRead.call(service_params) do
-      on_success do
-        render(json: success_json.merge(updated_memberships: result.updated_memberships))
-      end
+      on_success { |updated_memberships:| render(json: success_json.merge(updated_memberships:)) }
       on_failure { render(json: failed_json, status: 422) }
     end
   end

--- a/plugins/chat/app/controllers/chat/api/channels_status_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_status_controller.rb
@@ -3,7 +3,7 @@
 class Chat::Api::ChannelsStatusController < Chat::Api::ChannelsController
   def update
     Chat::UpdateChannelStatus.call(service_params) do
-      on_success { render_serialized(result.channel, Chat::ChannelSerializer, root: "channel") }
+      on_success { |channel:| render_serialized(channel, Chat::ChannelSerializer, root: "channel") }
       on_model_not_found(:channel) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:check_channel_permission) { raise Discourse::InvalidAccess }
       on_failure { render(json: failed_json, status: 422) }

--- a/plugins/chat/app/controllers/chat/api/chatables_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/chatables_controller.rb
@@ -4,7 +4,7 @@ class Chat::Api::ChatablesController < Chat::ApiController
   before_action :ensure_logged_in
 
   def index
-    ::Chat::SearchChatable.call(service_params) do
+    ::Chat::SearchChatable.call(service_params) do |result|
       on_success { render_serialized(result, ::Chat::ChatablesSerializer, root: false) }
       on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|

--- a/plugins/chat/app/controllers/chat/api/current_user_channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/current_user_channels_controller.rb
@@ -3,12 +3,12 @@
 class Chat::Api::CurrentUserChannelsController < Chat::ApiController
   def index
     Chat::ListUserChannels.call(service_params) do
-      on_success do
+      on_success do |structured:, post_allowed_category_ids:|
         render_serialized(
-          result.structured,
+          structured,
           Chat::ChannelIndexSerializer,
           root: false,
-          post_allowed_category_ids: result.post_allowed_category_ids,
+          post_allowed_category_ids: post_allowed_category_ids,
         )
       end
       on_failure { render(json: failed_json, status: 422) }

--- a/plugins/chat/app/controllers/chat/api/current_user_threads_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/current_user_threads_controller.rb
@@ -3,26 +3,26 @@
 class Chat::Api::CurrentUserThreadsController < Chat::ApiController
   def index
     ::Chat::LookupUserThreads.call(service_params) do
-      on_success do
+      on_success do |threads:, tracking:, memberships:, load_more_url:, participants:|
         render_serialized(
           ::Chat::ThreadsView.new(
             user: guardian.user,
-            threads: result.threads,
-            channel: result.channel,
-            tracking: result.tracking,
-            memberships: result.memberships,
-            load_more_url: result.load_more_url,
-            threads_participants: result.participants,
+            threads_participants: participants,
+            channel: nil,
+            threads:,
+            tracking:,
+            memberships:,
+            load_more_url:,
           ),
           ::Chat::ThreadListSerializer,
           root: false,
         )
       end
-      on_model_not_found(:threads) { render json: success_json.merge(threads: []) }
-      on_failure { render(json: failed_json, status: 422) }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
       end
+      on_model_not_found(:threads) { render json: success_json.merge(threads: []) }
+      on_failure { render(json: failed_json, status: 422) }
     end
   end
 end

--- a/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/direct_messages_controller.rb
@@ -3,14 +3,7 @@
 class Chat::Api::DirectMessagesController < Chat::ApiController
   def create
     Chat::CreateDirectMessageChannel.call(service_params) do
-      on_success do
-        render_serialized(
-          result.channel,
-          Chat::ChannelSerializer,
-          root: "channel",
-          membership: result.membership,
-        )
-      end
+      on_success { |channel:| render_serialized(channel, Chat::ChannelSerializer, root: "channel") }
       on_model_not_found(:target_users) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:satisfies_dms_max_users_limit) do |policy|
         render_json_dump({ error: policy.reason }, status: 400)

--- a/plugins/chat/app/jobs/regular/chat/auto_join_channel_batch.rb
+++ b/plugins/chat/app/jobs/regular/chat/auto_join_channel_batch.rb
@@ -9,8 +9,8 @@ module Jobs
           on_failed_contract do |contract|
             Rails.logger.error(contract.errors.full_messages.join(", "))
           end
-          on_model_not_found(:channel) do
-            Rails.logger.error("Channel not found (id=#{result.contract.channel_id})")
+          on_model_not_found(:channel) do |contract:|
+            Rails.logger.error("Channel not found (id=#{contract.channel_id})")
           end
         end
       end

--- a/plugins/chat/lib/chat_sdk/channel.rb
+++ b/plugins/chat/lib/chat_sdk/channel.rb
@@ -17,7 +17,7 @@ module ChatSDK
 
     def messages(channel_id:, guardian:, **params)
       Chat::ListChannelMessages.call(channel_id:, guardian:, **params, direction: "future") do
-        on_success { result.messages }
+        on_success { |messages:| messages }
         on_failure { raise "Unexpected error" }
         on_failed_policy(:can_view_channel) { raise "Guardian can't view channel" }
         on_failed_policy(:target_message_exists) { raise "Target message doesn't exist" }

--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -90,7 +90,7 @@ module ChatSDK
 
     def stop_stream(message_id:, guardian:)
       Chat::StopMessageStreaming.call(message_id:, guardian:) do
-        on_success { result.message }
+        on_success { |message:| message }
         on_model_not_found(:message) { raise "Couldn't find message with id: `#{message_id}`" }
         on_model_not_found(:membership) do
           raise "Couldn't find membership for user with id: `#{guardian.user.id}`"
@@ -145,7 +145,7 @@ module ChatSDK
             raise "User with id: `#{guardian.user.id}` can't join this channel"
           end
           on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
-          on_success { result.message_instance }
+          on_success { |message_instance:| message_instance }
           on_failure { raise "Unexpected error" }
         end
 

--- a/plugins/chat/lib/chat_sdk/thread.rb
+++ b/plugins/chat/lib/chat_sdk/thread.rb
@@ -75,7 +75,7 @@ module ChatSDK
 
     def messages(thread_id:, guardian:, direction: "future", **params)
       Chat::ListChannelThreadMessages.call(thread_id:, guardian:, direction:, **params) do
-        on_success { result.messages }
+        on_success { |messages:| messages }
         on_failed_policy(:can_view_thread) { raise "Guardian can't view thread" }
         on_failed_policy(:target_message_exists) { raise "Target message doesn't exist" }
         on_failure { raise "Unexpected error" }
@@ -96,7 +96,7 @@ module ChatSDK
           raise "Threading is not enabled for this channel"
         end
         on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
-        on_success { result.thread_instance }
+        on_success { |thread:| thread }
         on_failure { raise "Unexpected error" }
       end
     end

--- a/plugins/chat/spec/plugin_helper.rb
+++ b/plugins/chat/spec/plugin_helper.rb
@@ -67,49 +67,49 @@ module ChatSpecHelpers
   end
 
   def update_message!(message, text: nil, user: Discourse.system_user, upload_ids: nil)
-    result =
-      Chat::UpdateMessage.call(
-        guardian: user.guardian,
-        message_id: message.id,
-        upload_ids: upload_ids,
-        message: text,
-        process_inline: true,
-      )
-    service_failed!(result) if result.failure?
-    result.message_instance
+    Chat::UpdateMessage.call(
+      guardian: user.guardian,
+      message_id: message.id,
+      upload_ids: upload_ids,
+      message: text,
+      process_inline: true,
+    ) do |result|
+      on_success { result.message_instance }
+      on_failure { service_failed!(result) }
+    end
   end
 
   def trash_message!(message, user: Discourse.system_user)
-    result =
-      Chat::TrashMessage.call(
-        message_id: message.id,
-        channel_id: message.chat_channel_id,
-        guardian: user.guardian,
-      )
-    service_failed!(result) if result.failure?
-    result
+    Chat::TrashMessage.call(
+      message_id: message.id,
+      channel_id: message.chat_channel_id,
+      guardian: user.guardian,
+    ) do |result|
+      on_success { result }
+      on_failure { service_failed!(result) }
+    end
   end
 
   def restore_message!(message, user: Discourse.system_user)
-    result =
-      Chat::RestoreMessage.call(
-        message_id: message.id,
-        channel_id: message.chat_channel_id,
-        guardian: user.guardian,
-      )
-    service_failed!(result) if result.failure?
-    result
+    Chat::RestoreMessage.call(
+      message_id: message.id,
+      channel_id: message.chat_channel_id,
+      guardian: user.guardian,
+    ) do |result|
+      on_success { result }
+      on_failure { service_failed!(result) }
+    end
   end
 
   def add_users_to_channel(users, channel, user: Discourse.system_user)
-    result =
-      ::Chat::AddUsersToChannel.call(
-        guardian: user.guardian,
-        channel_id: channel.id,
-        usernames: Array(users).map(&:username),
-      )
-    service_failed!(result) if result.failure?
-    result
+    ::Chat::AddUsersToChannel.call(
+      guardian: user.guardian,
+      channel_id: channel.id,
+      usernames: Array(users).map(&:username),
+    ) do |result|
+      on_success { result }
+      on_failure { service_failed!(result) }
+    end
   end
 
   def create_draft(channel, thread: nil, user: Discourse.system_user, data: { message: "draft" })
@@ -119,15 +119,15 @@ module ChatSpecHelpers
       end
     end
 
-    result =
-      ::Chat::UpsertDraft.call(
-        guardian: user.guardian,
-        channel_id: channel.id,
-        thread_id: thread&.id,
-        data: data.to_json,
-      )
-    service_failed!(result) if result.failure?
-    result
+    ::Chat::UpsertDraft.call(
+      guardian: user.guardian,
+      channel_id: channel.id,
+      thread_id: thread&.id,
+      data: data.to_json,
+    ) do |result|
+      on_success { result }
+      on_failure { service_failed!(result) }
+    end
   end
 end
 

--- a/plugins/chat/spec/requests/chat/api/current_user_threads_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/current_user_threads_spec.rb
@@ -11,10 +11,20 @@ describe Chat::Api::CurrentUserThreadsController do
 
   describe "#index" do
     describe "success" do
+      let!(:thread) do
+        Fabricate(
+          :chat_thread,
+          original_message_user: current_user,
+          with_replies: 2,
+          use_service: true,
+        )
+      end
+
       it "works" do
         get "/chat/api/me/threads"
 
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body[:threads]).not_to be_empty
       end
     end
 


### PR DESCRIPTION
Currently, when calling a service with its block form, a `#result` method is automatically created on the caller object. Even if it never clashed so far, this could happen.

This PR removes that method, and instead uses a more classical way of doing things: the result object is now provided as an argument to the main block. This means if we need to access the result object in an outcome block, it will be done like this from now on:
```ruby
MyService.call(params) do |result|
  on_success do
    # do something with the result object
    do_something(result)
  end
end
```

In the same vein, this PR introduces the ability to match keys from the result object in the outcome blocks, like we already do with step definitions in a service. For example:
```ruby
on_success do |model:, contract:|
  do_something(model, contract)
end
```
Instead of
```ruby
on_success do
  do_something(result.model, result.contract)
end
```