### PR TITLE
DEV: allow optional modal height vars to be set

### DIFF
--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -5,6 +5,8 @@
   &__container {
     max-width: var(--modal-max-width);
     min-width: var(--modal-min-width);
+    max-height: var(--modal-max-height);
+    min-height: var(--modal-min-height);
     .d-modal.-large & {
       max-width: 800px;
     }

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -5,6 +5,7 @@
   &__container {
     max-width: var(--modal-max-width);
     min-width: var(--modal-min-width);
+    // height values add optional theme utility
     max-height: var(--modal-max-height);
     min-height: var(--modal-min-height);
     .d-modal.-large & {


### PR DESCRIPTION
This allows a theme to do something like:

```
.d-modal.foo-modal {
  --modal-min-height: 100px;
  --modal-max-height: 200px;
}
```

I'm intentionally not adding a default value here, so they're entirely optional.