### PR TITLE
FIX: Bring back the login-required page for fullpage login

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -35,6 +35,7 @@ export default class LoginPageController extends Controller {
   @tracked loggingIn = false;
   @tracked loggedIn = false;
   @tracked showLoginButtons = true;
+  @tracked showLogin = false;
   @tracked showSecondFactor = false;
   @tracked loginPassword = "";
   @tracked loginName = "";
@@ -113,6 +114,11 @@ export default class LoginPageController extends Controller {
 
   get adminLoginPath() {
     return getURL("/u/admin-login");
+  }
+
+  @action
+  showLoginPage() {
+    this.showLogin = true;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -21,9 +21,7 @@ export default class LoginRoute extends DiscourseRoute {
   }
 
   model() {
-    if (!this.siteSettings.experimental_full_page_login) {
-      return StaticPage.find("login");
-    }
+    return StaticPage.find("login");
   }
 
   setupController(controller) {

--- a/app/assets/javascripts/discourse/app/templates/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/login.hbs
@@ -1,4 +1,4 @@
-{{#if this.siteSettings.experimental_full_page_login}}
+{{#if (and this.siteSettings.experimental_full_page_login this.showLogin)}}
   {{hide-application-header-buttons "search" "login" "signup" "menu"}}
   {{hide-application-sidebar}}
 
@@ -163,7 +163,11 @@
           {{/if}}
 
           <DButton
-            @action={{route-action "showLogin"}}
+            @action={{if
+              this.siteSettings.experimental_full_page_login
+              this.showLoginPage
+              (route-action "showLogin")
+            }}
             @icon="user"
             @label="log_in"
             class="btn-primary login-button"

--- a/app/assets/javascripts/discourse/app/templates/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/login.hbs
@@ -1,4 +1,9 @@
-{{#if (and this.siteSettings.experimental_full_page_login this.showLogin)}}
+{{#if
+  (and
+    this.siteSettings.experimental_full_page_login
+    (or this.showLogin (not this.siteSettings.login_required))
+  )
+}}
   {{hide-application-header-buttons "search" "login" "signup" "menu"}}
   {{hide-application-sidebar}}
 

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -115,14 +115,9 @@ shared_examples "login scenarios" do |login_page_object|
 
     it "cannot browse annonymously" do
       visit "/"
-
-      if SiteSetting.experimental_full_page_login
-        expect(page).to have_css(".login-fullpage")
-      else
-        expect(page).to have_css(".login-welcome")
-        expect(page).to have_css(".site-logo")
-        find(".login-welcome .login-button").click
-      end
+      expect(page).to have_css(".login-welcome")
+      expect(page).to have_css(".site-logo")
+      find(".login-welcome .login-button").click
 
       EmailToken.confirm(Fabricate(:email_token, user: user).token)
       login_form.fill(username: "john", password: "supersecurepassword").click_login


### PR DESCRIPTION
This restores the login-required page when the `experimental_full_page_login` and `login_required` settings are enabled