### PR TITLE
DEV: Improvements to auto grid images

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -733,7 +733,20 @@ export default class UppyComposerUpload {
   #autoGridImages() {
     const reply = this.composerModel.get("reply");
     const imagesToWrapGrid = new Set(this.#consecutiveImages);
-    const uploadingImagePattern = /\[Uploading: ([^\]]+?)\.\w+…\]\(\)/g;
+
+    const uploadingText = I18n.t("uploading_filename", {
+      filename: "%placeholder%",
+    });
+    const uploadingTextMatch = uploadingText.match(/^.*(?=: %placeholder%…)/);
+
+    if (!uploadingTextMatch || !uploadingTextMatch[0]) {
+      return;
+    }
+
+    const uploadingImagePattern = new RegExp(
+      "\\[" + uploadingTextMatch[0].trim() + ": ([^\\]]+?)\\.\\w+…\\]\\(\\)",
+      "g"
+    );
 
     const matches = reply.match(uploadingImagePattern) || [];
     const foundImages = [];
@@ -743,9 +756,12 @@ export default class UppyComposerUpload {
 
     matches.forEach((imagePlaceholder) => {
       imagePlaceholder = imagePlaceholder.trim();
-      const filenameMatch = imagePlaceholder.match(
-        /\[Uploading: ([^\]]+?)\…\]\(\)/
+
+      const filenamePattern = new RegExp(
+        "\\[" + uploadingTextMatch[0].trim() + ": ([^\\]]+?)\\…\\]\\(\\)"
       );
+
+      const filenameMatch = imagePlaceholder.match(filenamePattern);
 
       if (filenameMatch && filenameMatch[1]) {
         const filename = filenameMatch[1];

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -263,5 +263,24 @@ describe "Uploading files in the composer", type: :system do
         %r{\[grid\].*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*?\[/grid\]}m,
       )
     end
+
+    it "automatically wraps images in [grid] when site language is different" do
+      SiteSetting.default_locale = "es"
+
+      visit "/new-topic"
+      expect(composer).to be_opened
+
+      file_path_1 = file_from_fixtures("logo.png", "images").path
+      file_path_2 = file_from_fixtures("logo.jpg", "images").path
+      file_path_3 = file_from_fixtures("downsized.png", "images").path
+      attach_file([file_path_1, file_path_2, file_path_3]) do
+        composer.click_toolbar_button("upload")
+      end
+
+      expect(composer).to have_no_in_progress_uploads
+      expect(composer.composer_input.value).to match(
+        %r{\[grid\].*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*?\[/grid\]}m,
+      )
+    end
   end
 end


### PR DESCRIPTION
## 🔍 Overview
This PR is a follow-up to https://github.com/discourse/discourse/commit/ea1473e53260e8a458f8118b89e7b07b5cc50507. When we initially added the experimental feature for automatically adding `[grid]` to images, we add the [grid] surrounding images after all the uploads have been completed.

This can lead to confusion when `[grid]` is delayed to be added in the composer, as users may try to add grid manually leading to breakage. This also leads to issues with Discourse AI's automatic image caption feature.

**In this PR**: we simply move the logic to be added when the images are uploaded and processing. This way, `[grid]` surrounding images is added immediately. We also apply a fix for an edge-case to prevent images from being wrapped in `[grid]` when they are already inside `[grid]` tags.

No new tests added for auto grid image upload ordering, but new test case added for the edge-case fix.

## 🎥 Preview
https://github.com/user-attachments/assets/89f4b62c-426b-4b8f-a494-8f2ea1f40eb8

