### PR TITLE
UX: fallback max-height for modal style

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -26,9 +26,9 @@
     pointer-events: auto;
     box-sizing: border-box;
     margin: 0 auto;
-    max-height: 80vh;
     background-color: var(--secondary);
     box-shadow: var(--shadow-modal);
+    max-height: var(--modal-max-height, 80vh); // unset, optional theme utility
   }
 
   &__header {

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -5,9 +5,7 @@
   &__container {
     max-width: var(--modal-max-width);
     min-width: var(--modal-min-width);
-    // height values add optional theme utility
-    max-height: var(--modal-max-height);
-    min-height: var(--modal-min-height);
+    min-height: var(--modal-min-height); // unset, optional theme utility
     .d-modal.-large & {
       max-width: 800px;
     }


### PR DESCRIPTION
follow-up fix to 4cb46ecb0fd41c183daeca4153cecf4487027cb5

this new css var was unintentionally un-setting max-height, so I'm including that max-height as the fallback for when the var is unset — also slightly clearer comment (indicating that it's been added unset: without a corresponding `--modal-max-height: x;` definition) 

before (too tall):

![image](https://github.com/user-attachments/assets/e4701dff-c3ac-42fa-a59c-d59e806c6657)


after (falls back to 80vh):

![image](https://github.com/user-attachments/assets/cd6a321f-ae76-4f6a-a34a-b9f6b791711b)
