### PR TITLE
UX: Move "watching topic" user-tip to the other button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -91,17 +91,20 @@
 <PinnedButton @pinned={{this.topic.pinned}} @topic={{this.topic}} />
 
 {{#if this.showNotificationsButton}}
+  <TopicNotificationsButton
+    @topic={{this.topic}}
+    class="notifications-button-footer"
+  />
+
   {{#if this.showNotificationUserTip}}
     <UserTip
       @id="topic_notification_levels"
-      @triggerSelector=".notifications-button"
+      @triggerSelector=".notifications-button-footer details"
       @titleText={{i18n "user_tips.topic_notification_levels.title"}}
       @contentText={{i18n "user_tips.topic_notification_levels.content"}}
       @priority={{20}}
     />
   {{/if}}
-
-  <TopicNotificationsButton @topic={{this.topic}} />
 {{/if}}
 
 <PluginOutlet

--- a/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.gjs
@@ -113,7 +113,7 @@ export default class TopicNotificationsButton extends Component {
   }
 
   <template>
-    <div class="topic-notifications-button">
+    <div class="topic-notifications-button" ...attributes>
       {{#if this.appendReason}}
         <p class="reason">
           <TopicNotificationsOptions


### PR DESCRIPTION
Moves the user-tip from the topic-timeline notifications button to the one at the bottom of the topic page.

Three reasons:
1. new users are more likely to use the button that has the full text (and description) rather than the icon-only one
2. we hide the timeline button when scrolled all the way to the bottom of the page, and then the tip doesn't seems to be attached to anything
3. we might be removing the timeline button altogether in the near future

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->