### PR TITLE
FIX: flaky flags spec after refactoring

### DIFF
--- a/spec/services/flags/create_flag_spec.rb
+++ b/spec/services/flags/create_flag_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe(Flags::CreateFlag) do
         )
       end
 
-      after { Flag.destroy_by(name: "custom flag name") }
+      after { flag.destroy! }
 
       it { is_expected.to run_successfully }
 

--- a/spec/services/flags/create_flag_spec.rb
+++ b/spec/services/flags/create_flag_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe(Flags::CreateFlag) do
       let!(:flag) { Fabricate(:flag, name:) }
 
       it { is_expected.to fail_a_policy(:unique_name) }
+
+      after { flag.destroy! }
     end
 
     context "when everything's ok" do
@@ -53,6 +55,8 @@ RSpec.describe(Flags::CreateFlag) do
           OpenStruct.new(enabled?: true),
         )
       end
+
+      after { Flag.destroy_by(name: "custom flag name") }
 
       it { is_expected.to run_successfully }
 

--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe(Flags::DestroyFlag) do
   let(:dependencies) { { guardian: current_user.guardian } }
   let(:flag_id) { flag.id }
 
+  after { flag.destroy }
+
   context "when model is not found" do
     let(:flag_id) { 0 }
 

--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -10,27 +10,29 @@ RSpec.describe(Flags::DestroyFlag) do
   let(:dependencies) { { guardian: current_user.guardian } }
   let(:flag_id) { flag.id }
 
-  after { flag.destroy }
-
   context "when model is not found" do
+    after { flag.destroy! }
     let(:flag_id) { 0 }
 
     it { is_expected.to fail_to_find_a_model(:flag) }
   end
 
   context "when the flag is a system one" do
+    after { flag.destroy! }
     let(:flag) { Flag.first }
 
     it { is_expected.to fail_a_policy(:not_system) }
   end
 
   context "when the flag has been used" do
+    after { flag.destroy! }
     let!(:post_action) { Fabricate(:post_action, post_action_type_id: flag.id) }
 
     it { is_expected.to fail_a_policy(:not_used) }
   end
 
   context "when user is not allowed to perform the action" do
+    after { flag.destroy! }
     fab!(:current_user) { Fabricate(:user) }
 
     it { is_expected.to fail_a_policy(:invalid_access) }

--- a/spec/services/flags/reorder_flag_spec.rb
+++ b/spec/services/flags/reorder_flag_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe(Flags::ReorderFlag) do
     end
 
     context "when everything's ok" do
+      after do
+        described_class.call(flag_id: flag.id, guardian: current_user.guardian, direction: "down")
+      end
+
       it { is_expected.to run_successfully }
 
       it "moves the flag" do

--- a/spec/services/flags/toggle_flag_spec.rb
+++ b/spec/services/flags/toggle_flag_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe(Flags::ToggleFlag) do
     end
 
     context "when everything's ok" do
+      after { flag.reload.update!(enabled: true) }
+
       it { is_expected.to run_successfully }
 
       it "toggles the flag" do

--- a/spec/services/flags/update_flag_spec.rb
+++ b/spec/services/flags/update_flag_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe(Flags::UpdateFlag) do
     let(:enabled) { false }
     let(:auto_action_type) { true }
 
-    after { flag.destroy }
+    after { flag.destroy! }
 
     context "when contract is invalid" do
       let(:name) { nil }
@@ -73,7 +73,7 @@ RSpec.describe(Flags::UpdateFlag) do
 
       it { is_expected.to fail_a_policy(:unique_name) }
 
-      after { flag_2.destroy }
+      after { flag_2.destroy! }
     end
 
     context "when everything's ok" do

--- a/spec/services/flags/update_flag_spec.rb
+++ b/spec/services/flags/update_flag_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe(Flags::UpdateFlag) do
     let(:enabled) { false }
     let(:auto_action_type) { true }
 
+    after { flag.destroy }
+
     context "when contract is invalid" do
       let(:name) { nil }
 
@@ -70,6 +72,8 @@ RSpec.describe(Flags::UpdateFlag) do
       let!(:flag_2) { Fabricate(:flag, name:) }
 
       it { is_expected.to fail_a_policy(:unique_name) }
+
+      after { flag_2.destroy }
     end
 
     context "when everything's ok" do


### PR DESCRIPTION
The bug was introduced here https://github.com/discourse/discourse/pull/29258

It is very important for flags to reset to their original state because they are cached and shared between specs.