### PR TITLE
DEV: Remove NULLS NOT DISTINCT from problem check trackers

### DIFF
--- a/db/migrate/20241022022326_remove_nulls_not_distinct_from_problem_check_trackers.rb
+++ b/db/migrate/20241022022326_remove_nulls_not_distinct_from_problem_check_trackers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RemoveNullsNotDistinctFromProblemCheckTrackers < ActiveRecord::Migration[7.1]
+  def up
+    remove_index :problem_check_trackers, %i[identifier target], if_exists: true
+    add_index :problem_check_trackers, %i[identifier target], unique: true
+  end
+
+  def down
+    remove_index :problem_check_trackers, %i[identifier target], if_exists: true
+    add_index :problem_check_trackers, %i[identifier target], unique: true, nulls_not_distinct: true
+  end
+end


### PR DESCRIPTION
### What is this change?

We added `NULLS NOT DISTINCT` to a unique index on `problem_check_trackers`.

This option is only available in PG15+. It does not in itself break PG13, but restoring a PG15+ backup to PG13 currently errors out. It seems this is an operation that's more common than we first thought.

This commit fixes that by removing the `NULLS NOT DISTINCT`.

### Don't we need it, since we added it?

We already have another, backwards-compatible approach to do the same thing in place, so this shouldn't change existing behaviour.