### PR TITLE
UX: fix footnote causing horizontal scroll on narrow screens

### DIFF
--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -48,6 +48,7 @@
   z-index: z("modal", "tooltip");
   max-width: 400px;
   overflow-wrap: break-word;
+  box-sizing: border-box;
 
   .mobile-view & {
     // tooltips are positioned 5px from the left


### PR DESCRIPTION
Missing box-sizing property interfered with correct positioning, which caused horizontal scrolling.