### PR TITLE
FIX: Avoid duplicate problem admin notices

### DIFF
--- a/app/models/problem_check_tracker.rb
+++ b/app/models/problem_check_tracker.rb
@@ -62,7 +62,7 @@ class ProblemCheckTracker < ActiveRecord::Base
   def sound_the_alarm
     admin_notice.create_with(
       priority: check.priority,
-      details: details.merge(target:),
+      details: details.merge(target: target || ProblemCheck::NO_TARGET),
     ).find_or_create_by(identifier:)
   end
 


### PR DESCRIPTION
### What is the problem?

As part of #29272 we made a unique index work on PG13 by introducing a dummy string to represent "NULL".

We missed one spot, leading to a potential for duplicate admin notices for problems without a target.

This fixes that.