### PR TITLE
DEV: Add comments in flags specs

### DIFF
--- a/spec/services/flags/create_flag_spec.rb
+++ b/spec/services/flags/create_flag_spec.rb
@@ -40,9 +40,11 @@ RSpec.describe(Flags::CreateFlag) do
     context "when name is not unique" do
       let!(:flag) { Fabricate(:flag, name:) }
 
-      it { is_expected.to fail_a_policy(:unique_name) }
-
+      # DO NOT REMOVE: flags have side effects and their state will leak to
+      # other examples otherwise.
       after { flag.destroy! }
+
+      it { is_expected.to fail_a_policy(:unique_name) }
     end
 
     context "when everything's ok" do
@@ -56,6 +58,8 @@ RSpec.describe(Flags::CreateFlag) do
         )
       end
 
+      # DO NOT REMOVE: flags have side effects and their state will leak to
+      # other examples otherwise.
       after { flag.destroy! }
 
       it { is_expected.to run_successfully }

--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -4,35 +4,35 @@ RSpec.describe(Flags::DestroyFlag) do
   subject(:result) { described_class.call(**params, **dependencies) }
 
   fab!(:current_user) { Fabricate(:admin) }
+  fab!(:flag)
 
-  let(:flag) { Fabricate(:flag) }
   let(:params) { { id: flag_id } }
   let(:dependencies) { { guardian: current_user.guardian } }
   let(:flag_id) { flag.id }
 
+  # DO NOT REMOVE: flags have side effects and their state will leak to
+  # other examples otherwise.
+  after { flag.destroy! }
+
   context "when model is not found" do
-    after { flag.destroy! }
     let(:flag_id) { 0 }
 
     it { is_expected.to fail_to_find_a_model(:flag) }
   end
 
   context "when the flag is a system one" do
-    after { flag.destroy! }
     let(:flag) { Flag.first }
 
     it { is_expected.to fail_a_policy(:not_system) }
   end
 
   context "when the flag has been used" do
-    after { flag.destroy! }
     let!(:post_action) { Fabricate(:post_action, post_action_type_id: flag.id) }
 
     it { is_expected.to fail_a_policy(:not_used) }
   end
 
   context "when user is not allowed to perform the action" do
-    after { flag.destroy! }
     fab!(:current_user) { Fabricate(:user) }
 
     it { is_expected.to fail_a_policy(:invalid_access) }

--- a/spec/services/flags/reorder_flag_spec.rb
+++ b/spec/services/flags/reorder_flag_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe(Flags::ReorderFlag) do
     end
 
     context "when everything's ok" do
-      after do
-        described_class.call(flag_id: flag.id, guardian: current_user.guardian, direction: "down")
-      end
+      # DO NOT REMOVE: flags have side effects and their state will leak to
+      # other examples otherwise.
+      after { described_class.call(**params.merge(direction: "down"), **dependencies) }
 
       it { is_expected.to run_successfully }
 

--- a/spec/services/flags/toggle_flag_spec.rb
+++ b/spec/services/flags/toggle_flag_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe(Flags::ToggleFlag) do
     subject(:result) { described_class.call(**params, **dependencies) }
 
     fab!(:current_user) { Fabricate(:admin) }
+    fab!(:flag)
 
-    let(:flag) { Fabricate(:flag) }
     let(:flag_id) { flag.id }
     let(:params) { { flag_id: flag_id } }
     let(:dependencies) { { guardian: current_user.guardian } }
+
+    # DO NOT REMOVE: flags have side effects and their state will leak to
+    # other examples otherwise.
+    after { flag.destroy! }
 
     context "when user is not allowed to perform the action" do
       fab!(:current_user) { Fabricate(:user) }
@@ -34,8 +38,6 @@ RSpec.describe(Flags::ToggleFlag) do
     end
 
     context "when everything's ok" do
-      after { flag.reload.update!(enabled: true) }
-
       it { is_expected.to run_successfully }
 
       it "toggles the flag" do

--- a/spec/services/flags/update_flag_spec.rb
+++ b/spec/services/flags/update_flag_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe(Flags::UpdateFlag) do
     subject(:result) { described_class.call(**params, **dependencies) }
 
     fab!(:current_user) { Fabricate(:admin) }
+    fab!(:flag)
 
-    let(:flag) { Fabricate(:flag) }
     let(:params) do
       {
         id: flag_id,
@@ -36,6 +36,8 @@ RSpec.describe(Flags::UpdateFlag) do
     let(:enabled) { false }
     let(:auto_action_type) { true }
 
+    # DO NOT REMOVE: flags have side effects and their state will leak to
+    # other examples otherwise.
     after { flag.destroy! }
 
     context "when contract is invalid" do
@@ -71,9 +73,11 @@ RSpec.describe(Flags::UpdateFlag) do
     context "when title is not unique" do
       let!(:flag_2) { Fabricate(:flag, name:) }
 
-      it { is_expected.to fail_a_policy(:unique_name) }
-
+      # DO NOT REMOVE: flags have side effects and their state will leak to
+      # other examples otherwise.
       after { flag_2.destroy! }
+
+      it { is_expected.to fail_a_policy(:unique_name) }
     end
 
     context "when everything's ok" do


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse/pull/29325.

This PR adds comments to tell why we need to destroy created flags in specs once the examples have run.