### PR TITLE
FIX: Restoring backup could fail due to missing `discourse_functions`

### DIFF
--- a/spec/lib/backup_restore/database_restorer_spec.rb
+++ b/spec/lib/backup_restore/database_restorer_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe BackupRestore::DatabaseRestorer do
 
   describe "readonly functions" do
     before do
-      BackupRestore::DatabaseRestorer.stubs(:core_migration_files).returns(
+      BackupRestore::DatabaseRestorer.stubs(:all_migration_files).returns(
         Dir[Rails.root.join("spec/fixtures/db/post_migrate/drop_column/**/*.rb")],
       )
     end


### PR DESCRIPTION
Database dumps sometimes reference functions in the `discourse_functions` schema. It's possible that some of these functions have been dropped in a newer version of Discourse. In that case, restoring an older backup will fail with a `ERROR:  function discourse_functions.something_something() does not exist` error. The restore functionality contains a workaround for that problem, but it didn't work with functions created in plugin migrations.

This commit adds support for temporarily creating missing `discourse_functions` from plugins. And it adds a simple check if the DB migration file even contains the required `DROPPED_TABLES` or `DROPPED_COLUMNS` constant. We don't need to create an instance of the DB migration class unless one of those constants is used. This makes the restore slightly faster and works around a problem with migrations that execute without `up` or `down` methods (e.g. `BackfillChatChannelAndThreadLastMessageIdsPostMigrate`).