### PR TITLE
FIX: Don’t try to serialize associations in `PostRevisionSerializer`

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -219,8 +219,13 @@ class PostRevisionSerializer < ApplicationSerializer
 
     # Retrieve any `tracked_topic_fields`
     PostRevisor.tracked_topic_fields.each_key do |field|
-      next if field == :tags
-      latest_modifications[field.to_s] = [topic.public_send(field)] if topic.respond_to?(field)
+      next unless topic.respond_to?(field)
+      topic
+        .public_send(field)
+        .then do |value|
+          next if value.try(:proxy_association)
+          latest_modifications[field.to_s] = [value]
+        end
     end
 
     latest_modifications["featured_link"] = [

--- a/spec/serializers/post_revision_serializer_spec.rb
+++ b/spec/serializers/post_revision_serializer_spec.rb
@@ -127,4 +127,20 @@ RSpec.describe PostRevisionSerializer do
       expect(json[:tags_changes]).to_not be_present
     end
   end
+
+  context "when some tracked topic fields are associations" do
+    let(:serializer) { described_class.new(post_revision, scope: guardian, root: false) }
+    let(:post_revision) { Fabricate(:post_revision, post:) }
+    let(:guardian) { Discourse.system_user.guardian }
+
+    before do
+      allow(PostRevisor).to receive(:tracked_topic_fields).and_wrap_original do |original_method|
+        original_method.call.merge(allowed_users: -> {}, allowed_groups: -> {})
+      end
+    end
+
+    it "skips them" do
+      expect { serializer.as_json }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Currently, if an association is added as a tracked field in `PostRevisor`, the `PostRevisionSerializer` class will try to serialize it somehow. This will raise an error as ActiveRecord collection proxies can't be serialized.

This patch addresses this issue by skipping any association tracked by the `PostRevisor` class.
