### PR TITLE
FEATURE: Add links to searchable user fields in users directory and user profile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/edit-user-directory-columns.js
+++ b/app/assets/javascripts/discourse/app/components/modal/edit-user-directory-columns.js
@@ -22,7 +22,7 @@ export default class EditUserDirectoryColumns extends Component {
   @action
   async setupColumns() {
     try {
-      const response = await ajax("edit-directory-columns.json");
+      const response = await ajax("/edit-directory-columns.json");
       this.loading = false;
       this.columns = response.directory_columns
         .sort((a, b) => (a.position > b.position ? 1 : -1))
@@ -45,7 +45,7 @@ export default class EditUserDirectoryColumns extends Component {
     };
 
     try {
-      await ajax("edit-directory-columns.json", { type: "PUT", data });
+      await ajax("/edit-directory-columns.json", { type: "PUT", data });
       reload();
     } catch (e) {
       this.loading = false;

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
@@ -359,7 +359,13 @@
                   <span class="user-field-value">
                     {{#each uf.value as |v|}}
                       {{! some values are arrays }}
-                      <span class="user-field-value-list-item">{{v}}</span>
+                    <span class="user-field-value-list-item">
+                      {{#if uf.field.searchable}}
+                        {{html-safe (generate-users-link v)}}
+                      {{else}}
+                        {{v}}
+                      {{/if}}
+                    </span>
                     {{else}}
                       {{uf.value}}
                     {{/each}}

--- a/app/assets/javascripts/discourse/app/helpers/directory-item-user-field-value.js
+++ b/app/assets/javascripts/discourse/app/helpers/directory-item-user-field-value.js
@@ -1,11 +1,14 @@
 import { htmlSafe } from "@ember/template";
+import { generateUsersLink } from "discourse/helpers/generate-users-link";
 
-export default function directoryItemUserFieldValue(args) {
-  // Args should include key/values { item, column }
-  const value =
-    args.item.user && args.item.user.user_fields
-      ? args.item.user.user_fields[args.column.user_field_id]
-      : null;
+export default function directoryItemUserFieldValue({ item, column }) {
+  const userFields = item?.user?.user_fields;
+  const fieldData = userFields ? userFields[column.user_field_id] : null;
+
+  const value = fieldData?.searchable
+    ? fieldData.value.map(generateUsersLink)
+    : fieldData?.value;
+
   const content = value || "-";
   return htmlSafe(
     `<span class='directory-table__value--user-field'>${content}</span>`

--- a/app/assets/javascripts/discourse/app/helpers/generate-users-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/generate-users-link.js
@@ -1,0 +1,9 @@
+import { helper } from "@ember/component/helper";
+import getUrl from "discourse-common/lib/get-url";
+
+export function generateUsersLink(val) {
+  const url = getUrl(`/u?name=${encodeURIComponent(val)}`);
+  return `<a href="${url}">${val}</a>`;
+}
+
+export default helper(generateUsersLink);

--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -123,6 +123,9 @@ class DirectoryItemsController < ApplicationController
     end
 
     serializer_opts[:attributes] = active_directory_column_names
+    serializer_opts[:searchable_fields] = UserField.where(searchable: true) if serializer_opts[
+      :user_custom_field_map
+    ].present?
 
     serialized = serialize_data(result, DirectoryItemSerializer, serializer_opts)
     render_json_dump(

--- a/spec/serializers/directory_item_serializer_spec.rb
+++ b/spec/serializers/directory_item_serializer_spec.rb
@@ -2,32 +2,96 @@
 
 RSpec.describe DirectoryItemSerializer do
   fab!(:user)
+  fab!(:directory_column) do
+    DirectoryColumn.create!(name: "topics_entered", enabled: true, position: 1)
+  end
+  fab!(:user_field_1) { Fabricate(:user_field, name: "user_field_1", searchable: true) }
+  fab!(:user_field_2) { Fabricate(:user_field, name: "user_field_2", searchable: false) }
 
   before { DirectoryItem.refresh! }
 
-  let :serializer do
-    directory_item =
-      DirectoryItem.find_by(user: user, period_type: DirectoryItem.period_types[:all])
-    DirectoryItemSerializer.new(directory_item, { attributes: DirectoryColumn.active_column_names })
+  context "when serializing user fields" do
+    it "serializes user fields with searchable and non-searchable values" do
+      user.user_custom_fields.create!(name: "user_field_1", value: "Value 1")
+      user.user_custom_fields.create!(name: "user_field_2", value: "Value 2")
+
+      user_fields =
+        serialized_payload(
+          attributes: DirectoryColumn.active_column_names,
+          user_custom_field_map: {
+            "user_field_1" => user_field_1.id,
+            "user_field_2" => user_field_2.id,
+          },
+          searchable_fields: [user_field_1],
+        )
+
+      expect(user_fields).to eq(
+        user_field_1.id => {
+          value: ["Value 1"],
+          searchable: true,
+        },
+        user_field_2.id => {
+          value: ["Value 2"],
+          searchable: false,
+        },
+      )
+    end
+
+    it "handles multiple values for the same field" do
+      user.user_custom_fields.create!(name: "user_field_1", value: "Value 1")
+      user.user_custom_fields.create!(name: "user_field_1", value: "Another Value")
+
+      user_fields =
+        serialized_payload(
+          attributes: DirectoryColumn.active_column_names,
+          user_custom_field_map: {
+            "user_field_1" => user_field_1.id,
+          },
+          searchable_fields: [],
+        )
+
+      expect(user_fields[user_field_1.id]).to eq(
+        value: ["Value 1", "Another Value"],
+        searchable: false,
+      )
+    end
   end
 
-  it "Serializes attributes for enabled directory_columns" do
-    DirectoryColumn.update_all(enabled: true)
+  context "when serializing directory columns" do
+    let :serializer do
+      directory_item =
+        DirectoryItem.find_by(user: user, period_type: DirectoryItem.period_types[:all])
+      DirectoryItemSerializer.new(
+        directory_item,
+        { attributes: DirectoryColumn.active_column_names },
+      )
+    end
 
-    payload = serializer.as_json
-    expect(payload[:directory_item].keys).to include(*DirectoryColumn.pluck(:name).map(&:to_sym))
+    it "serializes attributes for enabled directory_columns" do
+      DirectoryColumn.update_all(enabled: true)
+
+      payload = serializer.as_json
+      expect(payload[:directory_item].keys).to include(*DirectoryColumn.pluck(:name).map(&:to_sym))
+    end
+
+    it "doesn't serialize attributes for disabled directory columns" do
+      DirectoryColumn.update_all(enabled: false)
+      directory_column = DirectoryColumn.first
+      directory_column.update(enabled: true)
+
+      payload = serializer.as_json
+      expect(payload[:directory_item].keys.count).to eq(4)
+      expect(payload[:directory_item]).to have_key(directory_column.name.to_sym)
+      expect(payload[:directory_item]).to have_key(:id)
+      expect(payload[:directory_item]).to have_key(:user)
+      expect(payload[:directory_item]).to have_key(:time_read)
+    end
   end
 
-  it "Doesn't serialize attributes for disabled directory columns" do
-    DirectoryColumn.update_all(enabled: false)
-    directory_column = DirectoryColumn.first
-    directory_column.update(enabled: true)
+  private
 
-    payload = serializer.as_json
-    expect(payload[:directory_item].keys.count).to eq(4)
-    expect(payload[:directory_item]).to have_key(directory_column.name.to_sym)
-    expect(payload[:directory_item]).to have_key(:id)
-    expect(payload[:directory_item]).to have_key(:user)
-    expect(payload[:directory_item]).to have_key(:time_read)
+  def serialized_payload(serializer_opts)
+    serializer = DirectoryItemSerializer.new(DirectoryItem.find_by(user: user), serializer_opts)
+    serializer.as_json.dig(:directory_item, :user, :user_fields)
   end
 end


### PR DESCRIPTION
This feature introduces the ability to render searchable user fields as clickable links in both the users directory, user profile and user cards. 
The back-end serializer has been updated to flag fields as searchable, and a front-end helper was added to convert field values into clickable links. This includes support for multi-value fields on the user directory, ensuring all entries are appropriately rendered.