### PR TITLE
DEV: restore custom route for custom homepage

### DIFF
--- a/app/serializers/auth_provider_serializer.rb
+++ b/app/serializers/auth_provider_serializer.rb
@@ -20,4 +20,9 @@ class AuthProviderSerializer < ApplicationSerializer
     return SiteSetting.get(object.pretty_name_setting) if object.pretty_name_setting
     object.pretty_name
   end
+
+  def custom_url
+    # ensures that the "/custom" route doesn't trigger the magic custom_url helper in ActionDispatch
+    object.custom_url
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1615,6 +1615,8 @@ Discourse::Application.routes.draw do
          constraints: HomePageConstraint.new("custom"),
          as: "custom_index"
 
+    get "/custom" => "custom_homepage#index"
+
     get "/user-api-key/new" => "user_api_keys#new"
     post "/user-api-key" => "user_api_keys#create"
     post "/user-api-key/revoke" => "user_api_keys#revoke"


### PR DESCRIPTION
Some context in https://github.com/discourse/discourse/pull/29131 

The "/custom" route should be exposed because plugins and themes may want to link directly to it. The frontend responds to that route anyways, so this would be good for parity. 

However, without the change to the AuthProviderSerializer, the route was causing test errors. Rails magic would invoke a custom URL helper for the `custom_url` attribute, and result in this error: 

```
ArgumentError: Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true    /Users/pmusaraj/.gem/ruby/3.2.1/gems/actionpack-7.1.4.1/lib/action_dispatch/http/url.rb:65:in `full_url_for'
    /Users/pmusaraj/.gem/ruby/3.2.1/gems/actionpack-7.1.4.1/lib/action_dispatch/http/url.rb:54:in `url_for'
```

I'm not sure whether we need the `custom_url` attribute in auth providers, it's hard to see whether it is being consumed anywhere, a search in core and plugins returned no results. Using a custom methods avoids the test error, though, and should leave existing functionality intact. 