### PR TITLE
UX: Add link to /about in the about config page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/config-about.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-about.hbs
@@ -1,6 +1,9 @@
 <AdminPageHeader
   @titleLabel="admin.config_areas.about.header"
-  @descriptionLabel="admin.config_areas.about.description"
+  @descriptionLabelTranslated={{i18n
+    "admin.config_areas.about.description"
+    (hash basePath=(base-path))
+  }}
   @hideTabs={{true}}
 >
   <:breadcrumbs>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5604,7 +5604,7 @@ en:
       config_areas:
         about:
           header: "About your site"
-          description: "Provide information here about this site and your team so that people can learn what your community is about, who is behind it, and how to reach you in case there is an issue."
+          description: "Provide information here about this site and your team so that people can learn what your community is about, who is behind it, and how to reach you in case there is an issue. Displayed on your site's <a href='%{basePath}/about'>About page</a>."
           general_settings: "General settings"
           community_name: "Community name"
           community_name_placeholder: "Example Community"


### PR DESCRIPTION
This PR changes the description for the about config page so it contains a link to the /about page itself for easy access when editing the page.

<img src="https://github.com/user-attachments/assets/048712ff-6471-418f-99c8-9c99163cb815" width=400>