### PR TITLE
A11Y: add aria-labels to sidebar footer buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.gjs
@@ -53,6 +53,7 @@ export default class SidebarFooter extends Component {
               @icon="plus"
               @action={{this.manageSections}}
               @title="sidebar.sections.custom.add"
+              @ariaLabel="sidebar.sections.custom.add"
               class="btn-flat sidebar-footer-actions-button add-section"
             />
           {{/if}}
@@ -61,6 +62,11 @@ export default class SidebarFooter extends Component {
             <DButton
               @action={{this.toggleMobileView}}
               @title={{if this.site.mobileView "desktop_view" "mobile_view"}}
+              @ariaLabel={{if
+                this.site.mobileView
+                "desktop_view"
+                "mobile_view"
+              }}
               @icon={{if this.site.mobileView "desktop" "mobile-screen-button"}}
               class="btn-flat sidebar-footer-actions-button sidebar-footer-actions-toggle-mobile-view"
             />
@@ -70,6 +76,7 @@ export default class SidebarFooter extends Component {
             <DButton
               @action={{this.showKeyboardShortcuts}}
               @title="keyboard_shortcuts_help.title"
+              @ariaLabel="keyboard_shortcuts_help.title"
               @icon="keyboard"
               class="btn-flat sidebar-footer-actions-button sidebar-footer-actions-keyboard-shortcuts"
             />


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/a11y-certain-buttons-remain-unlabeled/332053

These buttons lack accessible text, so they need aria labels 