### PR TITLE
A11Y: Label site setting buttons

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.hbs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.hbs
@@ -58,11 +58,13 @@
       @action={{this.update}}
       @icon="check"
       @disabled={{this.disableSaveButton}}
+      @ariaLabel="admin.settings.save"
       class="ok setting-controls__ok"
     />
     <DButton
       @action={{this.cancel}}
       @icon="xmark"
+      @ariaLabel="admin.settings.cancel"
       class="cancel setting-controls__cancel"
     />
   </div>
@@ -71,6 +73,7 @@
     <DButton
       @action={{this.toggleSecret}}
       @icon="far-eye-slash"
+      @ariaLabel="admin.settings.unmask"
       class="setting-toggle-secret"
     />
   {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6989,6 +6989,9 @@ en:
         history: "View change history"
         reset: "reset"
         none: "none"
+        save: "save"
+        cancel: "cancel"
+        unmask: "unmask input"
       site_settings:
         emoji_list:
           invalid_input: "Emoji list should only contain valid emoji names, eg: hugs"


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/a11y-certain-buttons-remain-unlabeled/332053

Currently the ok, cancel, and unmask buttons all lack accessible label because they're icon-only, this adds appropriate aria-labels  

![image](https://github.com/user-attachments/assets/bff8e951-a6d5-41bc-987a-9362fd73ee40)
![image](https://github.com/user-attachments/assets/c11455e8-5782-4ade-ab70-683e88ffbe06)
