### PR TITLE
DEV: Clear duplicate admin problem notices

### DIFF
--- a/db/post_migrate/20241023041126_clear_duplicate_admin_notices.rb
+++ b/db/post_migrate/20241023041126_clear_duplicate_admin_notices.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class ClearDuplicateAdminNotices < ActiveRecord::Migration[7.1]
+  def up
+    problem_subject_id = 0
+
+    DB.exec(<<~SQL)
+      DELETE FROM admin_notices
+      WHERE subject = #{problem_subject_id}
+    SQL
+  end
+end


### PR DESCRIPTION
### What is this fix?

In #29272 we added a backwards-compatible way to prevent duplicate **problem check trackers**. However, there was a mistake in the PR that would instead create duplicate **admin notices**. As a result, a number of admins now have multiple copies of the same admin notice in their dashboard.

The root cause was fixed in #29329, preventing new duplicates.

This PR is here to clean up notices that were already created.

### Why do we delete all notices, not just duplicates?

Admin notices are meant to be ephemeral. Instead of going through hoops to delete duplicates and update the remaining notices' unstructured field with the correct `target`, it is a lot less error-prone to delete all notices and let the problem check system re-create them.

The real-time checks run every time the dashboard is loaded, so they will appear to never have been deleted. Any notices related to scheduled checks will be added back on the next run. This will happen within at most one hour, and isn't time sensitive.