### PR TITLE
FIX: visual regression for new features

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -85,15 +85,15 @@ export default class DiscourseNewFeatureItem extends Component {
           {{/if}}
         </div>
 
-        <div class="admin-new-feature-item__body">
-          {{#if @item.screenshot_url}}
-            <img
-              src={{@item.screenshot_url}}
-              class="admin-new-feature-item__screenshot"
-              alt={{@item.title}}
-            />
-          {{/if}}
+        {{#if @item.screenshot_url}}
+          <img
+            src={{@item.screenshot_url}}
+            class="admin-new-feature-item__screenshot"
+            alt={{@item.title}}
+          />
+        {{/if}}
 
+        <div class="admin-new-feature-item__body">
           <div class="admin-new-feature-item__feature-description">
             <CookText @rawText={{@item.description}} />
 

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -662,6 +662,7 @@
 .admin-new-feature-item__body {
   display: flex;
   justify-content: space-between;
+  margin-bottom: 1em;
   .d-toggle-switch {
     margin-left: 1em;
     align-items: flex-start;
@@ -669,6 +670,10 @@
   p {
     margin-top: 0;
   }
+}
+
+.admin-new-feature-item__screenshot {
+  margin-bottom: 1em;
 }
 .admin-new-feature-item__tooltip-header {
   font-weight: bold;

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -165,7 +165,7 @@ module DiscourseUpdates
               Discourse.has_needed_version?(current_version, item["discourse_version"])
 
           valid_plugin_name =
-            item["plugin_name"].nil? || Discourse.plugins_by_name[item["plugin_name"]].present?
+            item["plugin_name"].blank? || Discourse.plugins_by_name[item["plugin_name"]].present?
 
           valid_version && valid_plugin_name
         rescue StandardError

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -291,6 +291,7 @@ RSpec.describe DiscourseUpdates do
           "created_at" => 2.days.ago,
           "plugin_name" => "discourse-ai",
         },
+        { "emoji" => "🙈", "title" => "Whistles", "created_at" => 3.days.ago, "plugin_name" => "" },
         {
           "emoji" => "🙈",
           "title" => "Confetti",
@@ -303,8 +304,9 @@ RSpec.describe DiscourseUpdates do
       DiscourseUpdates.last_installed_version = "2.7.0.beta2"
       result = DiscourseUpdates.new_features
 
-      expect(result.length).to eq(1)
+      expect(result.length).to eq(2)
       expect(result[0]["title"]).to eq("Bells")
+      expect(result[1]["title"]).to eq("Whistles")
     end
   end
 


### PR DESCRIPTION
Bug introduced in this PR https://github.com/discourse/discourse/pull/29244

When the experiment toggle button was introduced, new features did not look right when the toggle button was not available.

In addition, the plugin name can be an empty string. In that case, information about new features should be displayed.

Before
<img width="1427" alt="Screenshot 2024-10-23 at 3 44 37 pm" src="https://github.com/user-attachments/assets/dbe0209a-30b1-40b4-8565-66f832182f7c">

After
<img width="1077" alt="Screenshot 2024-10-23 at 4 06 00 pm" src="https://github.com/user-attachments/assets/632b7bb1-fb27-49e8-9134-ef72bad18294">

<img width="479" alt="Screenshot 2024-10-23 at 4 06 09 pm" src="https://github.com/user-attachments/assets/90b67845-3b7b-49a7-b7ad-9e350a44dd4d">
