### PR TITLE
FIX: reword auto action type field for flags

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
@@ -202,11 +202,7 @@ export default class AdminFlagsForm extends Component {
                   }}
                   as |field|
                 >
-                  <field.Checkbox>
-                    {{i18n
-                      "admin.config_areas.flags.form.auto_action_type_description"
-                    }}
-                  </field.Checkbox>
+                  <field.Checkbox />
                 </checkboxGroup.Field>
               </form.CheckboxGroup>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5688,8 +5688,7 @@ en:
             non_deletable: "You cannot delete this flag because it is a system flag or has already been used in the review system, however you can still disable it."
             require_message: "Prompt users to provide additional reasons"
             require_message_description: "When this flag is selected, a text field will be displayed for the user to provide additional detail about why they are flagging the content"
-            auto_action_type: "Auto action type"
-            auto_action_type_description: "When a post is flagged by a staff member it is automatically hidden"
+            auto_action_type: "Auto hide flagged content"
           more_options:
             title: "More options"
             move_up: "Move up"


### PR DESCRIPTION
Simplified wording for `auto_action_type` flags.

