### PR TITLE
UX: Make 'About Your Site' link to the admin about config page

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -377,6 +377,17 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         });
     }
 
+    // TODO: update the route in ADMIN_NAV_MAP when removing the new /about
+    // feature flag
+    if (currentUser.render_experimental_about_page) {
+      const aboutYourSiteLink = navMap
+        .find((section) => section.name === "community")
+        .links.find((link) => link.name === "admin_about_your_site");
+      aboutYourSiteLink.route = "adminConfig.about";
+      delete aboutYourSiteLink.routeModels;
+      delete aboutYourSiteLink.query;
+    }
+
     navMap.forEach((section) =>
       section.links.forEach((link) => {
         if (link.keywords) {


### PR DESCRIPTION
This PR makes the "About Your Site" link in the admin sidebar navigate to the new admin config page for the /about page instead of the site settings page, if the admin has enabled the new /about page for themselves. In a later PR, when we remove the old /about page, we'll make the "About Your Site" sidebar link always navigate to the about config page.