### PR TITLE
DEV: Refactor user-tip to avoid unneeded wrapper element

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -15,7 +15,7 @@ export default class UserTip extends Component {
   @service userTips;
   @service tooltip;
 
-  registerTip = helperFn((args, on) => {
+  registerTip = helperFn((_, on) => {
     const tip = {
       id: this.args.id,
       priority: this.args.priority ?? 0,

--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -16,21 +16,6 @@ export default class UserTip extends Component {
   @service userTips;
   @service tooltip;
 
-  registerTip = class extends Helper {
-    @service userTips;
-
-    compute(args, { id, priority }) {
-      const tip = {
-        id,
-        priority: priority ?? 0,
-      };
-
-      this.userTips.addAvailableTip(tip);
-
-      registerDestructor(this, () => this.userTips.removeAvailableTip(tip));
-    }
-  };
-
   tip = modifier((element) => {
     let instance;
     schedule("afterRender", () => {
@@ -86,9 +71,24 @@ export default class UserTip extends Component {
   }
 
   <template>
-    {{this.registerTip id=@id priority=@priority}}
+    {{registerTip id=@id priority=@priority}}
     {{#if this.shouldRenderTip}}
       <span {{this.tip}}></span>
     {{/if}}
   </template>
+}
+
+class registerTip extends Helper {
+  @service userTips;
+
+  compute(args, { id, priority }) {
+    const tip = {
+      id,
+      priority: priority ?? 0,
+    };
+
+    this.userTips.addAvailableTip(tip);
+
+    registerDestructor(this, () => this.userTips.removeAvailableTip(tip));
+  }
 }

--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -15,7 +15,7 @@ export default class UserTip extends Component {
   @service userTips;
   @service tooltip;
 
-  registerTip = helperFn(({ on }) => {
+  registerTip = helperFn((args, on) => {
     const tip = {
       id: this.args.id,
       priority: this.args.priority ?? 0,

--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -11,6 +11,21 @@ import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "discourse-i18n";
 import DTooltipInstance from "float-kit/lib/d-tooltip-instance";
 
+const registerTip = class extends Helper {
+  @service userTips;
+
+  compute(args, { id, priority }) {
+    const tip = {
+      id,
+      priority: priority ?? 0,
+    };
+
+    this.userTips.addAvailableTip(tip);
+
+    registerDestructor(this, () => this.userTips.removeAvailableTip(tip));
+  }
+};
+
 export default class UserTip extends Component {
   @service currentUser;
   @service userTips;
@@ -76,19 +91,4 @@ export default class UserTip extends Component {
       <span {{this.tip}}></span>
     {{/if}}
   </template>
-}
-
-class registerTip extends Helper {
-  @service userTips;
-
-  compute(args, { id, priority }) {
-    const tip = {
-      id,
-      priority: priority ?? 0,
-    };
-
-    this.userTips.addAvailableTip(tip);
-
-    registerDestructor(this, () => this.userTips.removeAvailableTip(tip));
-  }
 }

--- a/app/assets/javascripts/discourse/app/components/user-tip.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-tip.gjs
@@ -86,7 +86,7 @@ export default class UserTip extends Component {
   }
 
   <template>
-    {{this.registerTip id=this.args.id priority=this.args.priority}}
+    {{this.registerTip id=@id priority=@priority}}
     {{#if this.shouldRenderTip}}
       <span {{this.tip}}></span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/helpers/helper-fn.js
+++ b/app/assets/javascripts/discourse/app/helpers/helper-fn.js
@@ -1,5 +1,6 @@
 import Helper from "@ember/component/helper";
 import { registerDestructor } from "@ember/destroyable";
+import { bind } from "discourse-common/utils/decorators";
 
 /**
  * Build an Ember helper with cleanup logic. The passed function will be called with the named argument,
@@ -40,6 +41,7 @@ export default function helperFn(callback) {
       return callback(named, on);
     }
 
+    @bind
     cleanup() {
       this.cleanupFn?.();
       this.cleanupFn = null;

--- a/app/assets/javascripts/discourse/app/helpers/helper-fn.js
+++ b/app/assets/javascripts/discourse/app/helpers/helper-fn.js
@@ -1,0 +1,18 @@
+import Helper from "@ember/component/helper";
+import { registerDestructor } from "@ember/destroyable";
+
+export default function helperFn(callback) {
+  return class extends Helper {
+    compute(positional, named) {
+      const cleanup = (fn) => registerDestructor(this, fn);
+
+      return callback({
+        positional,
+        named,
+        on: {
+          cleanup,
+        },
+      });
+    }
+  };
+}

--- a/app/assets/javascripts/discourse/app/helpers/helper-fn.js
+++ b/app/assets/javascripts/discourse/app/helpers/helper-fn.js
@@ -1,19 +1,48 @@
 import Helper from "@ember/component/helper";
 import { registerDestructor } from "@ember/destroyable";
 
+/**
+ * Build an Ember helper with cleanup logic. The passed function will be called with the named argument,
+ * and an 'on' utility object which allows you to register a cleanup function via `on.cleanup(...)`.
+ *
+ * Whenever any autotracked state is changed, the cleanup function will be run, and your function
+ * will be re-evaluated.
+ *
+ * @param {(args: object, on: { cleanup: () => void } ) => any} fn - The helper function.
+ */
 export default function helperFn(callback) {
   return class extends Helper {
+    cleanupFn = null;
+
+    constructor() {
+      super(...arguments);
+      registerDestructor(this, this.cleanup);
+    }
+
     compute(positional, named) {
       if (positional.length) {
         throw new Error(
           "Positional arguments are not permitted for helperFn-defined helpers. Use named arguments instead."
         );
       }
+
+      this.cleanup();
+
       const on = {
-        cleanup: (fn) => registerDestructor(this, fn),
+        cleanup: (fn) => {
+          if (this.cleanupFn) {
+            throw new Error("on.cleanup can only be called once");
+          }
+          this.cleanupFn = fn;
+        },
       };
 
       return callback(named, on);
+    }
+
+    cleanup() {
+      this.cleanupFn?.();
+      this.cleanupFn = null;
     }
   };
 }

--- a/app/assets/javascripts/discourse/app/helpers/helper-fn.js
+++ b/app/assets/javascripts/discourse/app/helpers/helper-fn.js
@@ -4,15 +4,16 @@ import { registerDestructor } from "@ember/destroyable";
 export default function helperFn(callback) {
   return class extends Helper {
     compute(positional, named) {
-      const cleanup = (fn) => registerDestructor(this, fn);
+      if (positional.length) {
+        throw new Error(
+          "Positional arguments are not permitted for helperFn-defined helpers. Use named arguments instead."
+        );
+      }
+      const on = {
+        cleanup: (fn) => registerDestructor(this, fn),
+      };
 
-      return callback({
-        positional,
-        named,
-        on: {
-          cleanup,
-        },
-      });
+      return callback(named, on);
     }
   };
 }


### PR DESCRIPTION
We were using a modifier purely for its lifecycle hooks - not to modify an element. This commit switches to using a helper, which provides a similar lifecycle, but without needing to be attached to an element.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->