### PR TITLE
 DEV: Delete plugin specific webhook event types

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -40,8 +40,6 @@ class WebHook < ActiveRecord::Base
         WebHookEventType::TYPES[:post_edited],
         WebHookEventType::TYPES[:post_destroyed],
         WebHookEventType::TYPES[:post_recovered],
-        WebHookEventType::TYPES[:category_experts_approved],
-        WebHookEventType::TYPES[:category_experts_unapproved],
       ],
     )
   end

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -40,6 +40,8 @@ class WebHook < ActiveRecord::Base
         WebHookEventType::TYPES[:post_edited],
         WebHookEventType::TYPES[:post_destroyed],
         WebHookEventType::TYPES[:post_recovered],
+        WebHookEventType::TYPES[:category_experts_approved],
+        WebHookEventType::TYPES[:category_experts_unapproved],
       ],
     )
   end

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -85,8 +85,6 @@ class WebHookEventType < ActiveRecord::Base
     chat_message_edited: 1802,
     chat_message_trashed: 1803,
     chat_message_restored: 1804,
-    category_experts_approved: 1901,
-    category_experts_unapproved: 1902,
   }
 
   has_and_belongs_to_many :web_hooks
@@ -116,11 +114,6 @@ class WebHookEventType < ActiveRecord::Base
           TYPES[:chat_message_trashed],
           TYPES[:chat_message_restored],
         ],
-      )
-    end
-    unless defined?(SiteSetting.enable_category_experts) && SiteSetting.enable_category_experts
-      ids_to_exclude.concat(
-        [TYPES[:category_experts_approved], TYPES[:category_experts_unapproved]],
       )
     end
     self.where.not(id: ids_to_exclude)

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -85,6 +85,8 @@ class WebHookEventType < ActiveRecord::Base
     chat_message_edited: 1802,
     chat_message_trashed: 1803,
     chat_message_restored: 1804,
+    category_experts_approved: 1901,
+    category_experts_unapproved: 1902,
   }
 
   has_and_belongs_to_many :web_hooks
@@ -114,6 +116,11 @@ class WebHookEventType < ActiveRecord::Base
           TYPES[:chat_message_trashed],
           TYPES[:chat_message_restored],
         ],
+      )
+    end
+    unless defined?(SiteSetting.enable_category_experts) && SiteSetting.enable_category_experts
+      ids_to_exclude.concat(
+        [TYPES[:category_experts_approved], TYPES[:category_experts_unapproved]],
       )
     end
     self.where.not(id: ids_to_exclude)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5441,6 +5441,8 @@ en:
           post_edited: "Post is updated"
           post_destroyed: "Post is deleted"
           post_recovered: "Post is recovered"
+          category_experts_approved: "Post marked as category experts post"
+          category_experts_unapproved: "Post unmarked as category experts post"
         group_event:
           group_name: "Group Events"
           group_created: "Group is created"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5441,8 +5441,6 @@ en:
           post_edited: "Post is updated"
           post_destroyed: "Post is deleted"
           post_recovered: "Post is recovered"
-          category_experts_approved: "Post marked as category experts post"
-          category_experts_unapproved: "Post unmarked as category experts post"
         group_event:
           group_name: "Group Events"
           group_created: "Group is created"

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -230,3 +230,13 @@ WebHookEventType.seed do |b|
   b.name = "chat_message_restored"
   b.group = WebHookEventType.groups[:chat]
 end
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::TYPES[:category_experts_approved]
+  b.name = "category_experts_approved"
+  b.group = WebHookEventType.groups[:post]
+end
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::TYPES[:category_experts_unapproved]
+  b.name = "category_experts_unapproved"
+  b.group = WebHookEventType.groups[:post]
+end

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -230,13 +230,3 @@ WebHookEventType.seed do |b|
   b.name = "chat_message_restored"
   b.group = WebHookEventType.groups[:chat]
 end
-WebHookEventType.seed do |b|
-  b.id = WebHookEventType::TYPES[:category_experts_approved]
-  b.name = "category_experts_approved"
-  b.group = WebHookEventType.groups[:post]
-end
-WebHookEventType.seed do |b|
-  b.id = WebHookEventType::TYPES[:category_experts_unapproved]
-  b.name = "category_experts_unapproved"
-  b.group = WebHookEventType.groups[:post]
-end

--- a/db/migrate/20241024093027_remove_category_experts_web_hook_event_types.rb
+++ b/db/migrate/20241024093027_remove_category_experts_web_hook_event_types.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RemoveCategoryExpertsWebHookEventTypes < ActiveRecord::Migration[7.1]
+  def up
+    if !defined?(DiscourseCategoryExperts)
+      execute "DELETE FROM web_hook_event_types WHERE (name = 'category_experts_approved' AND id = 1901) OR (name = 'category_experts_unapproved' AND id = 1902)"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20241024093027_remove_category_experts_web_hook_event_types.rb
+++ b/db/migrate/20241024093027_remove_category_experts_web_hook_event_types.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 class RemoveCategoryExpertsWebHookEventTypes < ActiveRecord::Migration[7.1]
   def up
-    if !defined?(DiscourseCategoryExperts)
-      execute "DELETE FROM web_hook_event_types WHERE (name = 'category_experts_approved' AND id = 1901) OR (name = 'category_experts_unapproved' AND id = 1902)"
-    end
+    execute "DELETE FROM web_hook_event_types WHERE (name, id) IN (('category_experts_approved', 1901), ('category_experts_unapproved', 1902))"
   end
 
   def down

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe WebHookEventType do
       SiteSetting.stubs(:assign_enabled).returns(true)
       SiteSetting.stubs(:topic_voting_enabled).returns(true)
       SiteSetting.stubs(:chat_enabled).returns(true)
+      SiteSetting.stubs(:enable_category_experts).returns(true)
       plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
       expect(plugins_event_types).to match_array(
         %w[
@@ -62,6 +63,8 @@ RSpec.describe WebHookEventType do
           chat_message_edited
           chat_message_trashed
           chat_message_restored
+          category_experts_approved
+          category_experts_unapproved
         ],
       )
     end

--- a/spec/models/web_hook_event_type_spec.rb
+++ b/spec/models/web_hook_event_type_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe WebHookEventType do
       SiteSetting.stubs(:assign_enabled).returns(true)
       SiteSetting.stubs(:topic_voting_enabled).returns(true)
       SiteSetting.stubs(:chat_enabled).returns(true)
-      SiteSetting.stubs(:enable_category_experts).returns(true)
       plugins_event_types = WebHookEventType.active.map(&:name) - core_event_types
       expect(plugins_event_types).to match_array(
         %w[
@@ -63,8 +62,6 @@ RSpec.describe WebHookEventType do
           chat_message_edited
           chat_message_trashed
           chat_message_restored
-          category_experts_approved
-          category_experts_unapproved
         ],
       )
     end


### PR DESCRIPTION
### Background

When creating webhooks on a site without the Discourse Category Experts plugin installed, the `category_experts_unapproved_event` and `category_experts_approved_event` webhook events are getting automatically added to webhooks without a way to disable them.

The `category_experts_unapproved_event` and `category_experts_approved_event` webhook events are associated with the Discourse Category Experts plugin so I am moving these webhook events into the Category Experts plugin.

[Here is the PR](https://github.com/discourse/discourse-category-experts/pull/167) that adds the webhook events into the Category Experts plugin.

### Changes

This PR deletes Category Experts plugin specific webhook event types added into core:
* [Added Category Experts approved WebHook Event](https://github.com/discourse/discourse/pull/28525)
* [Added Category Experts unapproved post WebHook Event](https://github.com/discourse/discourse/pull/28802)
