### PR TITLE
DEV: Clean up d-toggle-switch

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-toggle-switch.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-toggle-switch.gjs
@@ -3,18 +3,23 @@ import icon from "discourse-common/helpers/d-icon";
 import I18n from "discourse-i18n";
 
 export default class DToggleSwitch extends Component {
+  get computedLabel() {
+    if (this.args.label) {
+      return I18n.t(this.args.label);
+    }
+    return this.args.translatedLabel;
+  }
+
   <template>
     <div class="d-toggle-switch">
       <label class="d-toggle-switch__label">
-        {{! template-lint-disable no-redundant-role }}
         <button
           class="d-toggle-switch__checkbox"
           type="button"
           role="switch"
-          aria-checked={{this.checked}}
+          aria-checked={{if @state "true" "false"}}
           ...attributes
         ></button>
-        {{! template-lint-enable no-redundant-role }}
 
         <span class="d-toggle-switch__checkbox-slider">
           {{#if @state}}
@@ -30,15 +35,4 @@ export default class DToggleSwitch extends Component {
       {{/if}}
     </div>
   </template>
-
-  get computedLabel() {
-    if (this.args.label) {
-      return I18n.t(this.args.label);
-    }
-    return this.args.translatedLabel;
-  }
-
-  get checked() {
-    return this.args.state ? "true" : "false";
-  }
 }


### PR DESCRIPTION
move the template to the bottom, inline `checked`, remove unnecessary `template-lint-disable`

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->