### PR TITLE
DEV: Allow parent method to be called using `super.` in `modifyClass`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/class-prepend.js
+++ b/app/assets/javascripts/discourse/app/lib/class-prepend.js
@@ -42,7 +42,9 @@ export default function classPrepend(klass, callback) {
 
   // Make a fake class which is a copy of the klass at this point in time. This provides the 'super'
   // implementation.
-  const FakeSuperclass = class {};
+  const klassProto = Object.getPrototypeOf(klass);
+  const FakeSuperclass =
+    klassProto !== Function.prototype ? class extends klassProto {} : class {};
   Object.defineProperties(FakeSuperclass, originalKlassDescs);
   Object.defineProperties(FakeSuperclass.prototype, originalProtoDescs);
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/class-prepend-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/class-prepend-test.js
@@ -275,4 +275,26 @@ module("Unit | class-prepend", function () {
 
     assert.strictEqual(new Topic().someFunction(), 1, "change is rolled back");
   });
+
+  test("can override method from parent, with super support", function (assert) {
+    class Parent {
+      someFunction() {
+        return 1;
+      }
+    }
+
+    class Child extends Parent {}
+
+    classPrepend(
+      Child,
+      (Superclass) =>
+        class extends Superclass {
+          someFunction() {
+            return super.someFunction() + 1;
+          }
+        }
+    );
+
+    assert.strictEqual(new Child().someFunction(), 2, "it works");
+  });
 });


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->