### PR TITLE
FIX: Remove scroll events for mobile modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -60,11 +60,6 @@ export default class DModal extends Component {
       this.handleDocumentKeydown
     );
 
-    this.appEvents.on(
-      "keyboard-visibility-change",
-      this.handleKeyboardVisibilityChange
-    );
-
     if (this.site.mobileView) {
       this.animating = true;
 
@@ -88,11 +83,6 @@ export default class DModal extends Component {
     document.documentElement.removeEventListener(
       "keydown",
       this.handleDocumentKeydown
-    );
-
-    this.appEvents.off(
-      "keyboard-visibility-change",
-      this.handleKeyboardVisibilityChange
     );
   }
 
@@ -218,13 +208,6 @@ export default class DModal extends Component {
     }
 
     return element(tagName);
-  }
-
-  @bind
-  handleKeyboardVisibilityChange(visible) {
-    if (visible) {
-      window.scrollTo(0, 0);
-    }
   }
 
   #animateBackdropOpacity(position) {

--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -19,7 +19,6 @@ import {
 import { getMaxAnimationTimeMs } from "discourse/lib/swipe-events";
 import swipe from "discourse/modifiers/swipe";
 import trapTab from "discourse/modifiers/trap-tab";
-import { bind } from "discourse-common/utils/decorators";
 
 export const CLOSE_INITIATED_BY_BUTTON = "initiatedByCloseButton";
 export const CLOSE_INITIATED_BY_ESC = "initiatedByESC";


### PR DESCRIPTION
This causes some issues with different devices. We want to test the side effects of removing this.