### PR TITLE
FIX: remove redundant body scroll lock

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.hbs
@@ -1,11 +1,5 @@
 {{#if this.collection.content.length}}
-  <ul
-    class="select-kit-collection"
-    aria-live="polite"
-    role="menu"
-    {{did-insert this.lock}}
-    {{will-destroy this.unlock}}
-  >
+  <ul class="select-kit-collection" aria-live="polite" role="menu">
     {{#each this.collection.content as |item index|}}
       {{component
         (component-for-row this.collection.identifier item this.selectKit)

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-collection.js
@@ -1,31 +1,5 @@
-import { cached } from "@glimmer/tracking";
 import Component from "@ember/component";
-import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
-import {
-  disableBodyScroll,
-  enableBodyScroll,
-} from "discourse/lib/body-scroll-lock";
 
 @tagName("")
-export default class SelectKitCollection extends Component {
-  @cached
-  get inModal() {
-    const element = this.selectKit.mainElement();
-    return element.closest(".d-modal");
-  }
-
-  @action
-  lock(element) {
-    if (!this.inModal) {
-      return;
-    }
-
-    disableBodyScroll(element);
-  }
-
-  @action
-  unlock(element) {
-    enableBodyScroll(element);
-  }
-}
+export default class SelectKitCollection extends Component {}

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -66,6 +66,7 @@
   }
 
   &__body {
+    overflow-y: auto;
     padding: 1rem 1.5rem;
     box-sizing: border-box;
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -66,7 +66,6 @@
   }
 
   &__body {
-    overflow-y: auto;
     padding: 1rem 1.5rem;
     box-sizing: border-box;
 

--- a/app/assets/stylesheets/common/components/add-pm-participants.scss
+++ b/app/assets/stylesheets/common/components/add-pm-participants.scss
@@ -1,3 +1,9 @@
+.d-modal.add-pm-participants {
+  .d-modal__body {
+    overflow-y: visible;
+  }
+}
+
 .add-pm-participants.modal .share.modal-panel {
   .header {
     display: flex;

--- a/app/assets/stylesheets/mobile/modal-overrides.scss
+++ b/app/assets/stylesheets/mobile/modal-overrides.scss
@@ -19,12 +19,6 @@
   }
 }
 
-.d-modal.add-pm-participants {
-  .d-modal__body {
-    overflow: visible;
-  }
-}
-
 .d-modal.bookmark-reminder-modal {
   .d-modal__container {
     min-height: calc(var(--composer-vh, var(--1dvh)) * 85);


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/26784 adds the scroll lock in the modal which renders this second scroll lock for SK component redundant. Having it there in fact causes issues on iPads, where it isn't necessary. The modal scroll lock is limited to mobile devices only: 

https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/d-modal.gjs#L46-L49

