### PR TITLE
DEV: Refactor header offset calculations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -126,7 +126,10 @@ export default class GlimmerSiteHeader extends Component {
     this._headerWrap = document.querySelector(".d-header-wrap");
     this._mainOutletWrapper = document.querySelector("#main-outlet-wrapper");
     if (this._headerWrap) {
-      this._recalculateHeaderOffset();
+      schedule("afterRender", () => {
+        this.headerElement = this._headerWrap.querySelector("header.d-header");
+        this.updateOffsets();
+      });
 
       window.addEventListener("scroll", this._recalculateHeaderOffset, {
         passive: true,

--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -71,6 +71,7 @@ export default class GlimmerSiteHeader extends Component {
 
   @bind
   updateOffsets() {
+    // clamping to 0 to prevent negative values (hello, Safari)
     const headerWrapBottom = Math.max(
       0,
       Math.floor(this._headerWrap.getBoundingClientRect().bottom)

--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -36,6 +36,7 @@ export default class GlimmerSiteHeader extends Component {
   @tracked _dockedHeader = false;
   _animate = false;
   _headerWrap;
+  _mainOutletWrapper;
   _swipeMenuOrigin;
   _applicationElement;
   _resizeObserver;
@@ -74,29 +75,35 @@ export default class GlimmerSiteHeader extends Component {
     // This shows up as a negative value in window.scrollY.
     // We can use this to offset the headerWrap's top offset to avoid
     // jitteriness and bad positioning.
-    const windowOverscroll = Math.min(0, window.scrollY);
+    // const windowOverscroll = Math.min(0, window.scrollY);
+    let mainOutletOffsetTop = Math.max(
+      0,
+      Math.floor(this._mainOutletWrapper.getBoundingClientRect().top) -
+        this._headerWrap.offsetHeight
+    );
 
+    console.log(mainOutletOffsetTop);
     // The headerWrap's top offset can also be a negative value on Safari,
     // because of the changing height of the viewport (due to the URL bar).
     // For our use case, it's best to ensure this is clamped to 0.
-    const headerWrapTop = Math.max(
-      0,
-      Math.floor(this._headerWrap.getBoundingClientRect().top)
-    );
-    let offsetTop = headerWrapTop + windowOverscroll;
+    // const headerWrapTop = Math.max(
+    //   0,
+    //   Math.floor(this._headerWrap.getBoundingClientRect().top)
+    // );
+    // let offsetTop = headerWrapTop + windowOverscroll;
 
     if (DEBUG && isTesting()) {
-      offsetTop -= document
+      mainOutletOffsetTop -= document
         .getElementById("ember-testing-container")
         .getBoundingClientRect().top;
 
-      offsetTop -= 1; // For 1px border on testing container
+      mainOutletOffsetTop -= 1; // For 1px border on testing container
     }
 
     const documentStyle = document.documentElement.style;
     const currentValue =
       parseInt(documentStyle.getPropertyValue("--header-offset"), 10) || 0;
-    const newValue = this._headerWrap.offsetHeight + offsetTop;
+    const newValue = this._headerWrap.offsetHeight + mainOutletOffsetTop;
     if (currentValue !== newValue) {
       documentStyle.setProperty("--header-offset", `${newValue}px`);
     }
@@ -119,6 +126,7 @@ export default class GlimmerSiteHeader extends Component {
     }
 
     this._headerWrap = document.querySelector(".d-header-wrap");
+    this._mainOutletWrapper = document.querySelector("#main-outlet-wrapper");
     if (this._headerWrap) {
       schedule("afterRender", () => {
         this.headerElement = this._headerWrap.querySelector("header.d-header");

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -16,7 +16,7 @@
   // positions are relative to the .d-header .panel div
   top: 100%; // directly underneath .panel
   right: -10px; // 10px to the right of .panel - adjust as needed
-  max-height: 80vh;
+  max-height: calc(100vh - var(--header-offset) - 1em);
   border-radius: var(--d-border-radius-large);
 }
 
@@ -660,14 +660,14 @@
   width: 100%;
   position: fixed;
   background-color: rgba(0, 0, 0, 0.3);
-  top: var(--header-top);
+  top: 0;
   left: 0;
   display: none;
   touch-action: pan-y pinch-zoom;
 }
 
 .menu-panel.slide-in {
-  top: var(--header-top);
+  top: 0;
   box-sizing: border-box;
   // ensure there's always space to click outside on tiny devices
   max-width: 90vw;
@@ -678,11 +678,5 @@
   }
   box-shadow: 0px 0 30px -2px rgba(0, 0, 0, 0.5);
 
-  --base-height: calc(var(--100dvh) - var(--header-top));
-
-  height: var(--base-height);
-
-  html.footer-nav-ipad & {
-    height: calc(var(--base-height) - var(--footer-nav-height));
-  }
+  height: var(--100dvh);
 }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -16,7 +16,7 @@
   // positions are relative to the .d-header .panel div
   top: 100%; // directly underneath .panel
   right: -10px; // 10px to the right of .panel - adjust as needed
-  max-height: calc(100vh - var(--header-offset) - 1em);
+  max-height: calc(100dvh - var(--header-offset) - 1em);
   border-radius: var(--d-border-radius-large);
 }
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -45,7 +45,7 @@
   display: flex;
   grid-area: sidebar;
   position: sticky;
-  top: var(--header-offset);
+  top: var(--main-outlet-offset);
   background: var(--d-sidebar-background);
 
   @include unselectable;
@@ -57,7 +57,7 @@
   }
 
   height: calc(
-    var(--composer-vh, var(--1dvh)) * 100 - var(--header-offset, 0px)
+    var(--composer-vh, var(--1dvh)) * 100 - var(--main-outlet-offset, 0px)
   );
 
   align-self: start;

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -5,7 +5,6 @@
 
   &.drop-down {
     .panel-body {
-      max-height: calc(100vh - var(--header-offset));
       max-width: calc(100vw - 2em);
     }
   }

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -190,7 +190,7 @@ body.has-full-page-chat {
 
   .c-navbar-container {
     position: sticky;
-    top: var(--header-offset);
+    top: var(--main-outlet-offset);
   }
 
   .chat-messages-scroller {

--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -87,7 +87,7 @@
     resize: none;
     max-height: calc(
       (
-          var(--100dvh) - var(--header-offset, 0px) -
+          var(--100dvh) - var(--main-outlet-offset, 0px) -
             var(--chat-header-offset, 0px)
         ) / 100 * 25
     );

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -2,7 +2,8 @@
   // desktop and mobile
   // -1px is for the bottom border of the chat navbar
   $base-height: calc(
-    var(--composer-vh, 1vh) * 100 - var(--header-offset, 0px) - 1px - $inset
+    var(--composer-vh, 1vh) * 100 - var(--main-outlet-offset, 0px) - 1px -
+      $inset
   );
 
   height: calc($base-height - var(--composer-height, 0px));

--- a/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-index-full-page.scss
@@ -1,7 +1,7 @@
 .has-full-page-chat:not(.discourse-sidebar) {
   .full-page-chat {
     .channels-list {
-      height: calc(100vh - var(--header-offset));
+      height: calc(100vh - var(--main-outlet-offset));
       border-right: 1px solid var(--primary-low);
       background: var(--secondary);
       overflow-y: auto;


### PR DESCRIPTION
This introduces a new CSS var, `--main-outlet-offset` alongside the existing `--header-offset`. 

- `--header-offset` remains as before, giving in CSS the header's offset from the top of the viewpoint
- `--main-outlet-offset` includes `--header-offset` plus any elements that are above the main outlet and below the header, for example, elements in the `below-header` outlet

This fixes issues with the sidebar overflowing on sites with some theme components. And incompatibilities between said theme components and chat. 

Before/After (notice the missing bottom of chat and sidebar in the before screenshot)

![image](https://github.com/user-attachments/assets/31d75026-39b6-40d1-a1a1-cc51446ec702)

![image](https://github.com/user-attachments/assets/e82a1307-9b52-4fdf-9457-eb37f667c17d)
