### PR TITLE
2FA Backup Code Download: Use CRLF for Windows-compatibility

### DIFF
--- a/app/assets/javascripts/discourse/app/components/backup-codes.gjs
+++ b/app/assets/javascripts/discourse/app/components/backup-codes.gjs
@@ -38,7 +38,7 @@ export default class BackupCodes extends Component {
       return null;
     }
 
-    return this.args.backupCodes.join("\n").trim();
+    return this.args.backupCodes.join("\r\n").trim();
   }
 
   @action


### PR DESCRIPTION
Currently LF is used, making the backup codes indistinguishable for Windows users. Instead, use CRLF which is compatible for Windows as well as Linux and macOS fixes https://meta.discourse.org/t/downloaded-two-factor-backup-codes-are-not-separated-on-windows-only-lf-newline/331940

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->