### PR TITLE
DEV: Add `disableDefaultKeyboardShortcuts` plugin API to disable default keyboard shortcuts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -13,6 +13,15 @@ import { INPUT_DELAY } from "discourse-common/config/environment";
 import discourseLater from "discourse-common/lib/later";
 import domUtils from "discourse-common/utils/dom-utils";
 
+let disabledBindings = [];
+export function disableDefaultKeyboardShortcuts(bindings) {
+  disabledBindings = disabledBindings.concat(bindings);
+}
+
+export function clearDisabledDefaultKeyboardBindings() {
+  disabledBindings = [];
+}
+
 let extraKeyboardShortcutsHelp = {};
 function addExtraKeyboardShortcutHelp(help) {
   const category = help.category;
@@ -156,6 +165,10 @@ export default {
     // Disable the shortcut if private messages are disabled
     if (!this.currentUser?.can_send_private_messages) {
       delete DEFAULT_BINDINGS["g m"];
+    }
+
+    if (disabledBindings.length) {
+      disabledBindings.forEach((binding) => delete DEFAULT_BINDINGS[binding]);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.37.2";
+export const PLUGIN_API_VERSION = "1.37.3";
 
 import $ from "jquery";
 import { h } from "virtual-dom";
@@ -73,7 +73,9 @@ import {
   registerHighlightJSLanguage,
   registerHighlightJSPlugin,
 } from "discourse/lib/highlight-syntax";
-import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
+import KeyboardShortcuts, {
+  disableDefaultKeyboardShortcuts,
+} from "discourse/lib/keyboard-shortcuts";
 import { registerModelTransformer } from "discourse/lib/model-transformers";
 import { registerNotificationTypeRenderer } from "discourse/lib/notification-types-manager";
 import { addGTMPageChangedCallback } from "discourse/lib/page-tracker";
@@ -588,6 +590,21 @@ class PluginApi {
    **/
   addKeyboardShortcut(shortcut, callback, opts = {}) {
     KeyboardShortcuts.addShortcut(shortcut, callback, opts);
+  }
+
+  /**
+   * This function is used to disable a "default" keyboard shortcut. You can pass
+   * an array of shortcut bindings as strings to disable them.
+   *
+   * Please note that this function must be called from a pre-initializer.
+   *
+   * Example:
+   * ```
+   * api.disableDefaultKeyboardShortcuts(['command+f', 'shift+c']);
+   * ```
+   **/
+  disableDefaultKeyboardShortcuts(bindings) {
+    disableDefaultKeyboardShortcuts(bindings);
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -41,6 +41,7 @@ import { clearPopupMenuOptions } from "discourse/lib/composer/custom-popup-menu-
 import { clearDesktopNotificationHandlers } from "discourse/lib/desktop-notifications";
 import { cleanUpHashtagTypeClasses } from "discourse/lib/hashtag-type-registry";
 import {
+  clearDisabledDefaultKeyboardBindings,
   clearExtraKeyboardShortcutHelp,
   PLATFORM_KEY_MODIFIER,
 } from "discourse/lib/keyboard-shortcuts";
@@ -208,6 +209,7 @@ export function testCleanup(container, app) {
   resetPostMenuExtraButtons();
   resetUserMenuProfileTabItems();
   clearExtraKeyboardShortcutHelp();
+  clearDisabledDefaultKeyboardBindings();
   clearNavItems();
   setTopicList(null);
   _clearSnapshots();

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,11 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.37.3] - 2024-10-24
+
+- Added `disableDefaultKeyboardShortcuts` which allows plugins/TCs to disable default keyboard shortcuts.
+
+
 ## [1.37.2] - 2024-10-02
 
 - Fixed comments and text references to Font Awesome 5 in favor of the more generic Font Awesome due to core now having the latest version and no longer needing to specify version 5.


### PR DESCRIPTION
# Context

Add `disableDefaultKeyboardShortcuts` function to the plugin API to allow for disabling [default bindings](https://github.com/discourse/discourse/blob/e4941278b2055285d0e83330732ffb63f285b86e/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js#L49). 

# Details
This function is used to disable a "default" keyboard shortcut. You can pass an array of shortcut bindings as strings to disable them.

**Please note that this function must be called from a pre-initializer.**

Example:
```js
api.disableDefaultKeyboardShortcuts(['command+f', 'shift+c']);
```

- Added system spec, displaying intended behavior 