### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20120427154330_create_vestal_versions.rb
+++ b/db/migrate/20120427154330_create_vestal_versions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CreateVestalVersions < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     create_table :versions do |t|
       t.belongs_to :versioned, polymorphic: true
       t.belongs_to :user, polymorphic: true
@@ -24,7 +24,7 @@ class CreateVestalVersions < ActiveRecord::Migration[4.2]
     end
   end
 
-  def self.down
+  def down
     drop_table :versions
   end
 end

--- a/db/migrate/20120924182000_add_hstore_extension.rb
+++ b/db/migrate/20120924182000_add_hstore_extension.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class AddHstoreExtension < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     execute "CREATE EXTENSION IF NOT EXISTS hstore"
   end
 
-  def self.down
+  def down
     execute "DROP EXTENSION hstore"
   end
 end

--- a/db/migrate/20130127213646_remove_trust_levels.rb
+++ b/db/migrate/20130127213646_remove_trust_levels.rb
@@ -11,4 +11,8 @@ class RemoveTrustLevels < ActiveRecord::Migration[4.2]
     remove_column :users, :moderator
     add_column :users, :flag_level, :integer, null: false, default: 0
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20131014203951_backfill_post_upload_reverse_index.rb
+++ b/db/migrate/20131014203951_backfill_post_upload_reverse_index.rb
@@ -17,6 +17,10 @@ class BackfillPostUploadReverseIndex < ActiveRecord::Migration[4.2]
       end
   end
 
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
   def add_to_reverse_index(url, post_id)
     # make sure we have a url to insert
     return if url.blank?

--- a/db/migrate/20131210181901_migrate_word_counts.rb
+++ b/db/migrate/20131210181901_migrate_word_counts.rb
@@ -34,4 +34,8 @@ class MigrateWordCounts < ActiveRecord::Migration[4.2]
         execute("SELECT id FROM topics WHERE word_count IS NULL LIMIT 500").map { |r| r["id"].to_i }
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20140929204155_migrate_tos_setting.rb
+++ b/db/migrate/20140929204155_migrate_tos_setting.rb
@@ -15,4 +15,8 @@ class MigrateTosSetting < ActiveRecord::Migration[4.2]
       )
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20141014191645_fix_tos_name.rb
+++ b/db/migrate/20141014191645_fix_tos_name.rb
@@ -8,4 +8,8 @@ class FixTosName < ActiveRecord::Migration[4.2]
       WHERE name = 'I have read and accept the <a href="/tos" target="_blank">Terms of Service</a>.'
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20150709021818_add_like_count_to_post_menu.rb
+++ b/db/migrate/20150709021818_add_like_count_to_post_menu.rb
@@ -9,4 +9,8 @@ WHERE name = 'post_menu'
 AND value NOT LIKE '%like-count%'
 SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20150728210202_migrate_old_moderator_posts.rb
+++ b/db/migrate/20150728210202_migrate_old_moderator_posts.rb
@@ -21,4 +21,8 @@ class MigrateOldModeratorPosts < ActiveRecord::Migration[4.2]
     migrate_key("pinned_globally.disabled")
     Rails.application.config.i18n.raise_on_missing_translations = true
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20150729150523_migrate_auto_close_posts.rb
+++ b/db/migrate/20150729150523_migrate_auto_close_posts.rb
@@ -21,4 +21,8 @@ class MigrateAutoClosePosts < ActiveRecord::Migration[4.2]
       SQL
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20150731225331_migrate_old_moved_posts.rb
+++ b/db/migrate/20150731225331_migrate_old_moved_posts.rb
@@ -5,4 +5,8 @@ class MigrateOldMovedPosts < ActiveRecord::Migration[4.2]
     execute "UPDATE posts SET post_type = 3, action_code = 'split_topic' WHERE post_type = 2 AND raw ~* '^I moved [a\\d]+ posts? to a new topic:'"
     execute "UPDATE posts SET post_type = 3, action_code = 'split_topic' WHERE post_type = 2 AND raw ~* '^I moved [a\\d]+ posts? to an existing topic:'"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20150822141540_fix_migrated_hosts.rb
+++ b/db/migrate/20150822141540_fix_migrated_hosts.rb
@@ -4,4 +4,8 @@ class FixMigratedHosts < ActiveRecord::Migration[4.2]
   def up
     execute "UPDATE embeddable_hosts SET host = regexp_replace(host, '^https?:\/\/', '', 'i')"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20160407160756_remove_user_firsts.rb
+++ b/db/migrate/20160407160756_remove_user_firsts.rb
@@ -7,4 +7,8 @@ class RemoveUserFirsts < ActiveRecord::Migration[4.2]
     # continues with other migrations if we can't delete that table
     nil
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20160627104436_use_https_name_change_in_site_settings.rb
+++ b/db/migrate/20160627104436_use_https_name_change_in_site_settings.rb
@@ -4,4 +4,8 @@ class UseHttpsNameChangeInSiteSettings < ActiveRecord::Migration[4.2]
   def up
     execute "UPDATE site_settings SET name = 'force_https' WHERE name = 'use_https'"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20161202034856_add_uploads_to_categories.rb
+++ b/db/migrate/20161202034856_add_uploads_to_categories.rb
@@ -21,4 +21,8 @@ class AddUploadsToCategories < ActiveRecord::Migration[4.2]
     WHERE c1.id = c2.id
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20180521190040_allow_null_ip_topic_link_click.rb
+++ b/db/migrate/20180521190040_allow_null_ip_topic_link_click.rb
@@ -9,4 +9,8 @@ class AllowNullIpTopicLinkClick < ActiveRecord::Migration[5.1]
       Migration::SafeMigrate.enable!
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20190123171817_drop_queued_posts.rb
+++ b/db/migrate/20190123171817_drop_queued_posts.rb
@@ -4,4 +4,8 @@ class DropQueuedPosts < ActiveRecord::Migration[5.2]
   def up
     drop_table :queued_posts
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20190402142223_disable_invite_only_sso.rb
+++ b/db/migrate/20190402142223_disable_invite_only_sso.rb
@@ -8,4 +8,8 @@ class DisableInviteOnlySso < ActiveRecord::Migration[5.2]
         AND EXISTS(SELECT 1 FROM site_settings WHERE name = 'enable_sso' AND value = 't')
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20190503180839_remove_like_count_from_post_menu.rb
+++ b/db/migrate/20190503180839_remove_like_count_from_post_menu.rb
@@ -8,4 +8,8 @@ class RemoveLikeCountFromPostMenu < ActiveRecord::Migration[5.2]
       WHERE name = 'post_menu'
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20190508141824_drop_claimed_by_id.rb
+++ b/db/migrate/20190508141824_drop_claimed_by_id.rb
@@ -4,4 +4,8 @@ class DropClaimedById < ActiveRecord::Migration[5.2]
   def up
     remove_column :reviewables, :claimed_by_id
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
+++ b/db/migrate/20190908234054_migrate_post_edit_time_limit.rb
@@ -23,4 +23,8 @@ class MigratePostEditTimeLimit < ActiveRecord::Migration[5.2]
     DO NOTHING
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20191025005204_amend_oauth2_user_info_index.rb
+++ b/db/migrate/20191025005204_amend_oauth2_user_info_index.rb
@@ -6,4 +6,8 @@ class AmendOauth2UserInfoIndex < ActiveRecord::Migration[6.0]
     execute "DROP INDEX index_oauth2_user_infos_on_user_id_and_provider"
     add_index :oauth2_user_infos, %i[user_id provider]
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20200429095035_migrate_image_url_to_image_upload_id.rb
+++ b/db/migrate/20200429095035_migrate_image_url_to_image_upload_id.rb
@@ -98,6 +98,10 @@ class MigrateImageUrlToImageUploadId < ActiveRecord::Migration[6.0]
     drop_temporary_table!
   end
 
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
   def drop_temporary_table!
     Migration::SafeMigrate.disable!
     execute <<~SQL

--- a/db/migrate/20210127140730_undo_add_processed_to_notifications.rb
+++ b/db/migrate/20210127140730_undo_add_processed_to_notifications.rb
@@ -3,4 +3,8 @@ class UndoAddProcessedToNotifications < ActiveRecord::Migration[6.0]
   def up
     execute "ALTER TABLE notifications DROP COLUMN IF EXISTS processed"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20230224225129_backfill_svg_sprites.rb
+++ b/db/migrate/20230224225129_backfill_svg_sprites.rb
@@ -6,4 +6,8 @@ class BackfillSvgSprites < ActiveRecord::Migration[7.0]
   def up
     ThemeSvgSprite.refetch!
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/migrate/20230308042434_backfill_auto_bump_cooldown_days_category_setting.rb
+++ b/db/migrate/20230308042434_backfill_auto_bump_cooldown_days_category_setting.rb
@@ -23,4 +23,8 @@ class BackfillAutoBumpCooldownDaysCategorySetting < ActiveRecord::Migration[7.0]
           updated_at = NOW();
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end

--- a/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
+++ b/db/post_migrate/20240612073116_swap_field_type_with_field_type_enum_on_user_fields.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SwapFieldTypeWithFieldTypeEnumOnUserFields < ActiveRecord::Migration[7.0]
+  def change
+  end
   # DROPPED_COLUMNS = { user_fields: %i[field_type] }
 
   # def up

--- a/db/post_migrate/20240912210450_delete_anonymous_users_from_directory_items.rb
+++ b/db/post_migrate/20240912210450_delete_anonymous_users_from_directory_items.rb
@@ -8,4 +8,7 @@ class DeleteAnonymousUsersFromDirectoryItems < ActiveRecord::Migration[7.1]
       WHERE directory_items.user_id = anonymous_users.user_id
     SQL
   end
+
+  def down
+  end
 end

--- a/db/post_migrate/20241023041126_clear_duplicate_admin_notices.rb
+++ b/db/post_migrate/20241023041126_clear_duplicate_admin_notices.rb
@@ -8,4 +8,7 @@ class ClearDuplicateAdminNotices < ActiveRecord::Migration[7.1]
       WHERE subject = #{problem_subject_id}
     SQL
   end
+
+  def down
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to `rubocop-discourse`, this change resolves existing errors under this rule.

All migrations before the last irreversible migration will now raise irreversible migration error as well on `down`.