### PR TITLE
FEATURE: Allow adding custom user fields for existing users only

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.hbs
@@ -85,6 +85,14 @@
                     "admin.user_fields.requirement.for_all_users.description"
                   }}</radio.Description>
               </radioGroup.Radio>
+              <radioGroup.Radio @value="for_existing_users" as |radio|>
+                {{i18n
+                  "admin.user_fields.requirement.for_existing_users.title"
+                }}
+                <radio.Description>{{i18n
+                    "admin.user_fields.requirement.for_existing_users.description"
+                  }}</radio.Description>
+              </radioGroup.Radio>
               <radioGroup.Radio @value="on_signup" as |radio|>
                 {{i18n "admin.user_fields.requirement.on_signup.title"}}
                 <radio.Description>{{i18n

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.js
@@ -17,7 +17,9 @@ export default class AdminUserFieldItem extends Component {
 
   @tracked isEditing = false;
   @tracked
-  editableDisabled = this.args.userField.requirement === "for_all_users";
+  editableDisabled = this._requiredForExistingUsers(
+    this.args.userField.requirement
+  );
 
   originalRequirement = this.args.userField.requirement;
 
@@ -75,7 +77,7 @@ export default class AdminUserFieldItem extends Component {
   setRequirement(value, { set }) {
     set("requirement", value);
 
-    if (value === "for_all_users") {
+    if (this._requiredForExistingUsers(value)) {
       this.editableDisabled = true;
       set("editable", true);
     } else {
@@ -88,8 +90,8 @@ export default class AdminUserFieldItem extends Component {
     let confirm = true;
 
     if (
-      data.requirement === "for_all_users" &&
-      this.originalRequirement !== "for_all_users"
+      this._requiredForExistingUsers(data.requirement) &&
+      this.originalRequirement !== data.requirement
     ) {
       confirm = await this._confirmChanges();
     }
@@ -139,5 +141,9 @@ export default class AdminUserFieldItem extends Component {
     schedule("afterRender", () =>
       document.querySelector(".user-field-name")?.focus()
     );
+  }
+
+  _requiredForExistingUsers(requirement) {
+    return ["for_all_users", "for_existing_users"].includes(requirement);
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -90,10 +90,14 @@ export default class ProfileController extends Controller {
     return siteFields
       .filter(
         (siteField) =>
-          siteField.requirement === "for_all_users" &&
+          this._requiredForAllUsers(siteField) &&
           isEmpty(userFields[siteField.id])
       )
       .map((field) => EmberObject.create({ field, value: "" }));
+  }
+
+  _requiredForAllUsers(field) {
+    return ["for_all_users", "for_existing_users"].includes(field.requirement);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/mixins/user-fields-validation.js
+++ b/app/assets/javascripts/discourse/app/mixins/user-fields-validation.js
@@ -18,6 +18,7 @@ export default Mixin.create({
     let userFields = this.site.get("user_fields");
     if (userFields) {
       userFields = userFields
+        .filter((uf) => uf.requirement !== "for_existing_users")
         .sortBy("position")
         .map((f) => EmberObject.create({ value: null, field: f }));
     }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -221,7 +221,7 @@ class UsersController < ApplicationController
 
         if value.blank? &&
              (
-               field.for_all_users? ||
+               field.required_for_existing_users? ||
                  field.on_signup? &&
                    user.custom_fields["#{User::USER_FIELD_PREFIX}#{field_id}"].present?
              )
@@ -703,7 +703,7 @@ class UsersController < ApplicationController
     end
 
     # Handle custom fields
-    user_fields = UserField.all
+    user_fields = UserField.for_new_users
     if user_fields.present?
       field_params = params[:user_fields] || {}
       fields = user.custom_fields

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1894,7 +1894,8 @@ class User < ActiveRecord::Base
 
   def populated_required_custom_fields?
     UserField
-      .for_all_users
+      .required_for_existing_users
+      .where("created_at > ?", self.created_at)
       .pluck(:id)
       .all? { |field_id| custom_fields["#{User::USER_FIELD_PREFIX}#{field_id}"].present? }
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6943,6 +6943,9 @@ en:
           for_all_users:
             title: "For all users"
             description: "When new users sign up, they must fill out this field. When existing users return to the site and this is a new required field for them, they will also be prompted to fill it out. To re-prompt all users, delete this custom field and re-create it."
+          for_existing_users:
+            title: "For existing users"
+            description: "When existing users return to the site and this is a new required field for them, they will also be prompted to fill it out. To re-prompt all existing users, delete this custom field and re-create it. New users will not be presented with this field."
           on_signup:
             title: "On signup"
             description: "When new users sign up, they must fill out this field. Existing users are unaffected."

--- a/spec/models/user_field_spec.rb
+++ b/spec/models/user_field_spec.rb
@@ -2,7 +2,9 @@
 
 RSpec.describe UserField do
   it do
-    is_expected.to define_enum_for(:requirement).with_values(%w[optional for_all_users on_signup])
+    is_expected.to define_enum_for(:requirement).with_values(
+      %w[optional for_all_users on_signup for_existing_users],
+    )
   end
 
   describe "doesn't validate presence of name if field type is 'confirm'" do

--- a/spec/system/create_account_spec.rb
+++ b/spec/system/create_account_spec.rb
@@ -20,4 +20,25 @@ describe "Create account", type: :system do
     expect(user.username).to eq("user1")
     expect(user.emails).to eq(["test@example.com"])
   end
+
+  context "when the site has custom user fields" do
+    before do
+      Fabricate(:user_field, name: "Favorite Avenger", requirement: "on_signup")
+      Fabricate(:user_field, name: "Favorite Power Ranger", requirement: "for_all_users")
+      Fabricate(:user_field, name: "Favorite Pokemon", requirement: "for_existing_users")
+      Fabricate(:user_field, name: "Favorite Jedi", requirement: "optional")
+    end
+
+    it "displays the correct user fields" do
+      visit "/"
+      click_button "Sign Up"
+
+      custom_fields = find("#login-form .user-fields")
+
+      expect(custom_fields).to have_css(".user-field-favorite-avenger")
+      expect(custom_fields).to have_css(".user-field-favorite-power-ranger")
+      expect(custom_fields).to have_no_css(".user-field-favorite-pokemon")
+      expect(custom_fields).to have_css(".user-field-favorite-jedi")
+    end
+  end
 end

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -96,7 +96,7 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
           .fill_code("pudding")
         expect(signup_form).to have_valid_fields
 
-        signup_form.click_create_account
+        signup_form.click_create_account(expect_success: false)
         expect(signup_form).to have_content(I18n.t("login.wrong_invite_code"))
         expect(signup_form).to have_no_css(".account-created")
       end


### PR DESCRIPTION
### What is this feature?

Product has requested that we add a "for existing" users option to custom user fields. This will require all existing users to fill this up the next time they visit the site by restricting (almost) all routing until they've done so.

Meanwhile, new signups won't need to fill this up.

The primary use case for this is for having existing users accept updated terms of service and privacy policy.

**Screenshot**

<img width="716" alt="Screenshot 2024-10-25 at 3 24 54 PM" src="https://github.com/user-attachments/assets/d973f8e1-f011-42e6-8758-d11b2608e917">
