### PR TITLE
PERF: Update `maybeContinueList` to avoid replacing the entire post

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
@@ -620,6 +620,7 @@ export default class TextareaTextManipulation {
       // Clear the new autocompleted list item if there is no other text.
       const offsetWithoutPrefix = offset - `\n${listPrefix}`.length;
       this._insertAt(offsetWithoutPrefix, offset, "");
+      this.selectText(offsetWithoutPrefix, 0);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
@@ -619,12 +619,7 @@ export default class TextareaTextManipulation {
     } else {
       // Clear the new autocompleted list item if there is no other text.
       const offsetWithoutPrefix = offset - `\n${listPrefix}`.length;
-      this.replaceText(
-        text,
-        text.substring(0, offsetWithoutPrefix) + text.substring(offset),
-        { skipNewSelection: true }
-      );
-      this.selectText(offsetWithoutPrefix, 0);
+      this._insertAt(offsetWithoutPrefix, offset, "");
     }
   }
 


### PR DESCRIPTION
Using execCommand to replace the entire contents of the textarea is very slow for larger posts (it seems the browser does a reflow after every 'virtual keypress').

This commit updates the `maybeContinueList()` function to be more surgical when removing the bullet. Now it only selects & removes the characters which actually need to be deleted

Similar to a7cd2207048bfac3e76fafdf47e259cd1b391352

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->