### PR TITLE
UX: Add description config area card

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-card.gjs
@@ -16,6 +16,17 @@ export default class AdminConfigAreaCard extends Component {
     return this.args.heading || this.args.translatedHeading;
   }
 
+  get computedDescription() {
+    if (this.args.description) {
+      return I18n.t(this.args.description);
+    }
+    return this.args.translatedDescription;
+  }
+
+  get hasDescription() {
+    return this.args.description || this.args.translatedDescription;
+  }
+
   <template>
     <section class="admin-config-area-card" ...attributes>
       <div class="admin-config-area-card__header-wrapper">
@@ -35,6 +46,11 @@ export default class AdminConfigAreaCard extends Component {
         {{/if}}
       </div>
       <div class="admin-config-area-card__content">
+        {{#if this.hasDescription}}
+          <p class="admin-config-area-card__description">
+            {{this.computedDescription}}
+          </p>
+        {{/if}}
         {{yield to="content"}}
       </div>
     </section>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
@@ -76,6 +76,7 @@ export default class AdminConfigAreasAbout extends Component {
         </AdminConfigAreaCard>
         <AdminConfigAreaCard
           @heading="admin.config_areas.about.your_organization"
+          @description="admin.config_areas.about.your_organization_description"
           class="admin-config-area-about__your-organization-section"
         >
           <:content>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5634,19 +5634,20 @@ en:
           site_contact_group: "Site contact group"
           site_contact_group_help: |
             The group that gets invited to all automatically sent private messages.
-          your_organization: "Organization name"
-          company_name: "Company name"
-          company_name_placeholder: "Sample Company Inc."
+          your_organization: "Your organization"
+          your_organization_description: "We'll use this information in the Terms of Service and Privacy Notice to show who operates the site and under which jurisdiction."
+          company_name: "Name"
+          company_name_placeholder: "Acme Organization"
           company_name_warning: |
             If left blank, no boilerplate Terms of Service or Privacy Notice will be provided.
           governing_law: "Governing law"
-          governing_law_placeholder: "State of New York"
+          governing_law_placeholder: "Province, State, or Country"
           governing_law_help: |
-            Specify the jurisdiction that governs the legal aspects of the site, including Terms of Service and Privacy Notice. This is typically the country or state where the company operating the site is registered or conducts business.
+            Specify the jurisdiction for the site's legal terms, typically where the company is registered or operates.
           city_for_disputes: "City for disputes"
-          city_for_disputes_placeholder: "New York City"
+          city_for_disputes_placeholder: "City"
           city_for_disputes_help: |
-            Specify the city that will be used as the jurisdiction for resolving any disputes related to the use of this forum. This information is typically included in legal documents such as the forum's Terms of Service.
+            Specify the city for resolving legal disputes related to this forum.
           optional: "(optional)"
           update: "Update"
           toasts:


### PR DESCRIPTION
Follow up to #29387. 

Changes:
* added a `description` to the config area card component
* updated strings

### Before
<img width="770" alt="image" src="https://github.com/user-attachments/assets/f2adc7e9-df52-49fd-8dd5-9f8a2ac02aab">


### After
<img width="761" alt="image" src="https://github.com/user-attachments/assets/18d86220-d717-4eb6-b95c-03dd2f770695">
