### PR TITLE
Update site_settings to include https://sbedit.net/embed/ iframe option

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2038,7 +2038,7 @@ security:
     allow_any: false
     choices: "['*'] + Onebox::Engine.all_iframe_origins"
   allowed_iframes:
-    default: "https://www.google.com/maps/embed?|https://www.openstreetmap.org/export/embed.html?|https://calendar.google.com/calendar/embed?|https://codepen.io/|https://www.instagram.com/|https://open.spotify.com/"
+    default: "https://www.google.com/maps/embed?|https://www.openstreetmap.org/export/embed.html?|https://calendar.google.com/calendar/embed?|https://codepen.io/|https://www.instagram.com/|https://open.spotify.com/|https://sbedit.net/embed/"
     type: list
     list_type: simple
     client: true


### PR DESCRIPTION
added option to allow https://sbedit.net/embed/ to iframe options.

sbedit is a lightweight online html/css/javascript code editor similar to jsfiddle, codesandbox, codepen, glitch, et.al.
It has an option to share edits as editable code, or as a view that can be displayed in an iframe on your own site.

mains site, 
https://sbedit.net/

some embed examples
https://sbedit.net/embed/34bd3e2dd86320713f9f38ffa1994ba8d4bdf049
https://sbedit.net/embed/7c1827ce7a13a6b161368a6f90d7006d96c3c1e5
https://sbedit.net/embed/5ec9d9edb8e62780c0a1745ec87aaa3f4e10072f
https://sbedit.net/embed/2f155fdea48d15b90f9230867a396a501dd24ec2

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->