### PR TITLE
FEATURE: Add Bulk actions to /filter page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.hbs
@@ -1,12 +1,13 @@
 {{body-class "navigation-filter"}}
 
 <section class="navigation-container">
-  {{#if (and this.site.mobileView @canBulkSelect)}}
-    <div class="navigation-controls">
-      <BulkSelectToggle @bulkSelectHelper={{@bulkSelectHelper}} />
-    </div>
-  {{/if}}
   <div class="topic-query-filter">
+    {{#if (and this.site.mobileView @canBulkSelect)}}
+      <div class="topic-query-filter__bulk-action-btn">
+        <BulkSelectToggle @bulkSelectHelper={{@bulkSelectHelper}} />
+      </div>
+    {{/if}}
+
     <div class="topic-query-filter__input">
       {{d-icon "filter" class="topic-query-filter__icon"}}
       <Input

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.hbs
@@ -1,6 +1,11 @@
 {{body-class "navigation-filter"}}
 
 <section class="navigation-container">
+  {{#if (and this.site.mobileView @canBulkSelect)}}
+    <div class="navigation-controls">
+      <BulkSelectToggle @bulkSelectHelper={{@bulkSelectHelper}} />
+    </div>
+  {{/if}}
   <div class="topic-query-filter">
     <div class="topic-query-filter__input">
       {{d-icon "filter" class="topic-query-filter__icon"}}

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.js
@@ -1,11 +1,14 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { resettableTracked } from "discourse/lib/tracked-tools";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
 
 export default class DiscoveryFilterNavigation extends Component {
+  @service site;
+
   @tracked copyIcon = "link";
   @tracked copyClass = "btn-default";
   @resettableTracked newQueryString = this.args.queryString;

--- a/app/assets/javascripts/discourse/app/controllers/discovery/filter.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/filter.js
@@ -1,11 +1,17 @@
 import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 
 export default class extends Controller {
   @tracked q = "";
 
   queryParams = ["q"];
+  bulkSelectHelper = new BulkSelectHelper(this);
+
+  get canBulkSelect() {
+    return this.currentUser?.canManageTopic;
+  }
 
   @action
   updateTopicsListQueryParams(queryString) {

--- a/app/assets/javascripts/discourse/app/templates/discovery/filter.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/filter.hbs
@@ -3,6 +3,8 @@
     <Discovery::FilterNavigation
       @queryString={{this.q}}
       @updateTopicsListQueryParams={{this.updateTopicsListQueryParams}}
+      @canBulkSelect={{this.canBulkSelect}}
+      @bulkSelectHelper={{this.bulkSelectHelper}}
     />
   </:navigation>
   <:list>

--- a/app/assets/stylesheets/common/components/topic-query-filter.scss
+++ b/app/assets/stylesheets/common/components/topic-query-filter.scss
@@ -26,6 +26,10 @@
     color: var(--primary-low-mid);
   }
 
+  &__bulk-action-btn {
+    margin-right: 0.5em;
+  }
+
   input.topic-query-filter__filter-term {
     margin: 0 0.5em 0 0;
     border-color: var(--primary-low-mid);

--- a/spec/system/filtering_topics_spec.rb
+++ b/spec/system/filtering_topics_spec.rb
@@ -115,4 +115,36 @@ describe "Filtering topics", type: :system do
       expect(topic_list).to have_topic(topic_with_tag_and_tag2)
     end
   end
+
+  describe "bulk topic selection" do
+    fab!(:user) { Fabricate(:moderator) }
+
+    it "shows the buttons and checkboxes" do
+      topics = Fabricate.times(2, :topic)
+      sign_in(user)
+      visit("/filter")
+
+      find("button.bulk-select").click
+      expect(topic_list).to have_topic_checkbox(topics.first)
+      expect(page).to have_no_css("button.bulk-select-topics-dropdown-trigger")
+
+      topic_list.click_topic_checkbox(topics.first)
+      expect(page).to have_css("button.bulk-select-topics-dropdown-trigger")
+    end
+
+    context "when on mobile", mobile: true do
+      it "shows the buttons and checkboxes" do
+        topics = Fabricate.times(2, :topic)
+        sign_in(user)
+        visit("/filter")
+
+        find("button.bulk-select").click
+        expect(topic_list).to have_topic_checkbox(topics.first)
+        expect(page).to have_no_css("button.bulk-select-topics-dropdown-trigger")
+
+        topic_list.click_topic_checkbox(topics.first)
+        expect(page).to have_css("button.bulk-select-topics-dropdown-trigger")
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->

## PR Changes

- Add bulk actions component on /filter page for both desktop & mobile view.
- Add system specs to assert bulk actions to be available on /filter page.

### Assumption

- Only users with `canManageTopic` set as true can use bulk action.

## Screenshot / Recording

Desktop:

https://github.com/user-attachments/assets/3bb5e7b2-3b81-47e2-8189-5d6ce5faca50

Mobile:

https://github.com/user-attachments/assets/aff6e23e-d528-4f2c-a13b-4ccb08f28653

## Additional Information

- Manually tested with both ember & experimental glimmer components.
- With Glimmer components there was an issue with missing focus action on topic-link component. Attempted fix in PR 