### PR TITLE
FIX: Missing glimmer topic list focus actions on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-cell.gjs
@@ -40,12 +40,12 @@ export default class TopicCell extends Component {
 
   @action
   onTitleFocus(event) {
-    event.target.classList.add("selected");
+    event.target.closest(".topic-list-item").classList.add("selected");
   }
 
   @action
   onTitleBlur(event) {
-    event.target.classList.remove("selected");
+    event.target.closest(".topic-list-item").classList.remove("selected");
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-list-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-list-item.gjs
@@ -94,6 +94,16 @@ export default class TopicListItem extends Component {
   }
 
   @action
+  onTitleFocus(event) {
+    event.target.closest(".topic-list-item").classList.add("selected");
+  }
+
+  @action
+  onTitleBlur(event) {
+    event.target.closest(".topic-list-item").classList.remove("selected");
+  }
+
+  @action
   applyTitleDecorators(element) {
     const rawTopicLink = element.querySelector(".raw-topic-link");
 


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->

## PR changes

- Fixes the topic focus style for Glimmer components.

### Motivation / Background

During work on [PR #29420](https://github.com/discourse/discourse/pull/29420), I noticed that the topic focus feature is broken for Glimmer components. This PR attempts to address this issue. 

My initial approach duplicates events to achieve the fix, I think the current approach can be polished further by reusing the `<TopicCell>` component for a more streamlined implementation.

## ScreenShots / Recording

BEFORE:

https://github.com/user-attachments/assets/d4b7a0f0-44de-41e1-960e-76489accbca1

AFTER:

https://github.com/user-attachments/assets/1689d5f8-0692-44ef-8a56-cbd66a91ce93
