### PR TITLE
DEV: Update Gemfile.lock for MacOS 15 on x86

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,6 +591,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -591,6 +591,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-darwin-24
   x86_64-linux
 


### PR DESCRIPTION
Running a local dev environment on an Intel Mac with MacOS 15 causes `Gemfile.lock` to be updated with the latest Darwin kernel version number every time `bundle install` is run.

This PR adds `x86_64-darwin-23` and `x86_64-darwin-24` to the `PLATFORMS` section, to avoid this.