### PR TITLE
UX: limit user-card username focus ring to desktop

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -85,11 +85,7 @@
       .user-profile-link {
         display: flex;
         align-items: center;
-
-        &:focus-visible {
-          border: 1px solid;
-          @include default-focus;
-        }
+        outline: none;
       }
 
       .d-icon {

--- a/app/assets/stylesheets/desktop/components/user-card.scss
+++ b/app/assets/stylesheets/desktop/components/user-card.scss
@@ -12,6 +12,12 @@
         min-width: 150px;
       }
     }
+    .user-profile-link {
+      &:focus-visible {
+        border: 1px solid;
+        @include default-focus;
+      }
+    }
   }
   .names__primary {
     .d-icon {


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse/commit/74bb520877161bc04cd11a338949c85c5ab9db80

that commit applies focus on usercards in more situations, but sometimes this can create an undesirable focus ring on mobile 

this PR removes the ring from mobile, where typically other assistive technologies are used instead of keyboard nav

before:
![image](https://github.com/user-attachments/assets/c357ebbb-7875-47c7-b749-c737c9dc14f6)


after:
![image](https://github.com/user-attachments/assets/4282f140-e5a3-478f-938b-b5ffeae00191)
