### PR TITLE
UX: Give ranked choice polls distinctive bullets in preview

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -452,9 +452,43 @@ div.poll-outer {
       content: "";
     }
 
+    &[data-poll-type="multiple"],
+    &[data-poll-type="ranked_choice"] {
+      [data-poll-option-id] {
+        display: flex;
+        align-items: center;
+      }
+    }
+
     &[data-poll-type="multiple"] {
       li[data-poll-option-id]:before {
         border-radius: 3px;
+      }
+    }
+
+    &[data-poll-type="ranked_choice"] {
+      li[data-poll-option-id] {
+        position: relative;
+        &:before {
+          mask-image: svg-uri(
+            '<svg width="0.75em" height="0.75em" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M201.4 374.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 306.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"/></svg>'
+          );
+          z-index: 1;
+          width: 0.75em;
+          margin-right: 0.75em;
+          left: 0.2em;
+          background: var(--primary-high);
+          border-radius: var(--d-button-border-radius);
+          border: none;
+        }
+        &:after {
+          content: "";
+          position: absolute;
+          height: 1.125em;
+          width: 1.125em;
+          background: var(--primary-low);
+          border-radius: var(--d-button-border-radius);
+        }
       }
     }
   }


### PR DESCRIPTION
Extending @merefield's PR a bit (https://github.com/discourse/discourse/pull/28593) 

This gives the ranked choice polls a distinctive preview style, rather than the default radio buttons. This more closely mimics the button styles in the live post: 

The live poll: 

![image](https://github.com/user-attachments/assets/672c0b2d-c79f-43d6-a355-71a1e7ae1d2b)



Preview before: 

![image](https://github.com/user-attachments/assets/876ef249-be1f-4dd7-90f8-c7b10cc90121)


Preview after:

![image](https://github.com/user-attachments/assets/3223f06e-e9c6-4acb-af20-805f4c720273)

![image](https://github.com/user-attachments/assets/d6acaa36-79c5-4384-8e96-d3f449393a16)
