### PR TITLE
DEV: Make service contracts immutable

### DIFF
--- a/lib/service/base.rb
+++ b/lib/service/base.rb
@@ -202,13 +202,18 @@ module Service
         attributes = class_name.attribute_names.map(&:to_sym)
         default_values = {}
         default_values = context[default_values_from].slice(*attributes) if default_values_from
-        contract = class_name.new(default_values.merge(context[:params].slice(*attributes)))
+        contract =
+          class_name.new(
+            **default_values.merge(context[:params].slice(*attributes)),
+            options: context[:options],
+          )
         context[contract_name] = contract
         context[result_key] = Context.build
         if contract.invalid?
           context[result_key].fail(errors: contract.errors, parameters: contract.raw_attributes)
           context.fail!
         end
+        contract.freeze
       end
 
       private

--- a/lib/service/contract_base.rb
+++ b/lib/service/contract_base.rb
@@ -8,12 +8,17 @@ class Service::ContractBase
 
   delegate :slice, :merge, to: :to_hash
 
-  def [](key)
-    public_send(key)
+  def initialize(*args, options: nil, **kwargs)
+    @__options__ = options
+    super(*args, **kwargs)
   end
 
-  def []=(key, value)
-    public_send("#{key}=", value)
+  def options
+    @__options__
+  end
+
+  def [](key)
+    public_send(key)
   end
 
   def to_hash

--- a/plugins/chat/app/services/chat/search_chatable.rb
+++ b/plugins/chat/app/services/chat/search_chatable.rb
@@ -24,8 +24,9 @@ module Chat
       attribute :include_category_channels, :boolean, default: true
       attribute :include_direct_message_channels, :boolean, default: true
       attribute :excluded_memberships_channel_id, :integer
+
+      after_validation { self.term = term&.downcase&.strip&.gsub(/^[@#]+/, "") }
     end
-    step :clean_term
     model :memberships, optional: true
     model :users, optional: true
     model :groups, optional: true
@@ -33,10 +34,6 @@ module Chat
     model :direct_message_channels, optional: true
 
     private
-
-    def clean_term(params:)
-      params[:term] = params[:term]&.downcase&.strip&.gsub(/^[@#]+/, "")
-    end
 
     def fetch_memberships(guardian:)
       ::Chat::ChannelMembershipManager.all_for_user(guardian.user)


### PR DESCRIPTION
We decided to make contracts immutable once their validations have run. Indeed, it doesn’t make a lot of sense to modify a contract value outside the contract itself.

If processing is needed, then it should happen inside the contract itself.