### PR TITLE
DEV: Remove hash-like access from service contracts

### DIFF
--- a/app/services/admin_notices/dismiss.rb
+++ b/app/services/admin_notices/dismiss.rb
@@ -4,6 +4,11 @@ class AdminNotices::Dismiss
   include Service::Base
 
   policy :invalid_access
+  params do
+    attribute :id, :integer
+
+    validates :id, presence: true
+  end
   model :admin_notice, optional: true
   transaction do
     step :destroy
@@ -17,7 +22,7 @@ class AdminNotices::Dismiss
   end
 
   def fetch_admin_notice(params:)
-    AdminNotice.find_by(id: params[:id])
+    AdminNotice.find_by(id: params.id)
   end
 
   def destroy(admin_notice:)

--- a/app/services/experiments/toggle.rb
+++ b/app/services/experiments/toggle.rb
@@ -18,13 +18,13 @@ class Experiments::Toggle
   end
 
   def setting_is_available(params:)
-    SiteSetting.respond_to?(params[:setting_name])
+    SiteSetting.respond_to?(params.setting_name)
   end
 
   def toggle(params:, guardian:)
     SiteSetting.set_and_log(
-      params[:setting_name],
-      !SiteSetting.public_send(params[:setting_name]),
+      params.setting_name,
+      !SiteSetting.public_send(params.setting_name),
       guardian.user,
     )
   end

--- a/app/services/flags/create_flag.rb
+++ b/app/services/flags/create_flag.rb
@@ -32,7 +32,7 @@ class Flags::CreateFlag
   end
 
   def unique_name(params:)
-    !Flag.custom.where(name: params[:name]).exists?
+    !Flag.custom.where(name: params.name).exists?
   end
 
   def instantiate_flag(params:)

--- a/app/services/flags/destroy_flag.rb
+++ b/app/services/flags/destroy_flag.rb
@@ -3,6 +3,11 @@
 class Flags::DestroyFlag
   include Service::Base
 
+  params do
+    attribute :id, :integer
+
+    validates :id, presence: true
+  end
   model :flag
   policy :not_system
   policy :not_used
@@ -15,7 +20,7 @@ class Flags::DestroyFlag
   private
 
   def fetch_flag(params:)
-    Flag.find_by(id: params[:id])
+    Flag.find_by(id: params.id)
   end
 
   def not_system(flag:)

--- a/app/services/flags/reorder_flag.rb
+++ b/app/services/flags/reorder_flag.rb
@@ -22,7 +22,7 @@ class Flags::ReorderFlag
   private
 
   def fetch_flag(params:)
-    Flag.find_by(id: params[:flag_id])
+    Flag.find_by(id: params.flag_id)
   end
 
   def invalid_access(guardian:, flag:)
@@ -34,15 +34,15 @@ class Flags::ReorderFlag
   end
 
   def invalid_move(flag:, params:, all_flags:)
-    return false if all_flags.first == flag && params[:direction] == "up"
-    return false if all_flags.last == flag && params[:direction] == "down"
+    return false if all_flags.first == flag && params.direction == "up"
+    return false if all_flags.last == flag && params.direction == "down"
     true
   end
 
   def move(flag:, params:, all_flags:)
     old_position = flag.position
     index = all_flags.index(flag)
-    target_flag = all_flags[params[:direction] == "up" ? index - 1 : index + 1]
+    target_flag = all_flags[params.direction == "up" ? index - 1 : index + 1]
 
     flag.update!(position: target_flag.position)
     target_flag.update!(position: old_position)
@@ -51,7 +51,7 @@ class Flags::ReorderFlag
   def log(guardian:, flag:, params:)
     StaffActionLogger.new(guardian.user).log_custom(
       "move_flag",
-      { flag: flag.name, direction: params[:direction] },
+      { flag: flag.name, direction: params.direction },
     )
   end
 end

--- a/app/services/flags/toggle_flag.rb
+++ b/app/services/flags/toggle_flag.rb
@@ -22,7 +22,7 @@ class Flags::ToggleFlag
   end
 
   def fetch_flag(params:)
-    Flag.find_by(id: params[:flag_id])
+    Flag.find_by(id: params.flag_id)
   end
 
   def toggle(flag:)

--- a/app/services/flags/update_flag.rb
+++ b/app/services/flags/update_flag.rb
@@ -32,7 +32,7 @@ class Flags::UpdateFlag
   private
 
   def fetch_flag(params:)
-    Flag.find_by(id: params[:id])
+    Flag.find_by(id: params.id)
   end
 
   def not_system(flag:)
@@ -48,7 +48,7 @@ class Flags::UpdateFlag
   end
 
   def unique_name(params:)
-    !Flag.custom.where(name: params[:name]).where.not(id: params[:id]).exists?
+    !Flag.custom.where(name: params.name).where.not(id: params.id).exists?
   end
 
   def update(flag:, params:)

--- a/app/services/site_setting/update.rb
+++ b/app/services/site_setting/update.rb
@@ -45,16 +45,16 @@ class SiteSetting::Update
   end
 
   def setting_is_visible(params:, options:)
-    options.allow_changing_hidden || !SiteSetting.hidden_settings.include?(params[:setting_name])
+    options.allow_changing_hidden || !SiteSetting.hidden_settings.include?(params.setting_name)
   end
 
   def setting_is_configurable(params:)
-    return true if !SiteSetting.plugins[params[:setting_name]]
+    return true if !SiteSetting.plugins[params.setting_name]
 
-    Discourse.plugins_by_name[SiteSetting.plugins[params[:setting_name]]].configurable?
+    Discourse.plugins_by_name[SiteSetting.plugins[params.setting_name]].configurable?
   end
 
   def save(params:, guardian:)
-    SiteSetting.set_and_log(params[:setting_name], params[:new_value], guardian.user)
+    SiteSetting.set_and_log(params.setting_name, params.new_value, guardian.user)
   end
 end

--- a/app/services/user/silence.rb
+++ b/app/services/user/silence.rb
@@ -30,11 +30,11 @@ class User::Silence
   private
 
   def fetch_user(params:)
-    User.find_by(id: params[:user_id])
+    User.find_by(id: params.user_id)
   end
 
   def fetch_users(user:, params:)
-    [user, *User.where(id: params[:other_user_ids].to_a.uniq).to_a]
+    [user, *User.where(id: params.other_user_ids.to_a.uniq).to_a]
   end
 
   def can_silence_all_users(guardian:, users:)
@@ -46,7 +46,7 @@ class User::Silence
   end
 
   def fetch_post(params:)
-    Post.find_by(id: params[:post_id])
+    Post.find_by(id: params.post_id)
   end
 
   def perform_post_action(guardian:, post:, params:)

--- a/app/services/user/suspend.rb
+++ b/app/services/user/suspend.rb
@@ -30,11 +30,11 @@ class User::Suspend
   private
 
   def fetch_user(params:)
-    User.find_by(id: params[:user_id])
+    User.find_by(id: params.user_id)
   end
 
   def fetch_users(user:, params:)
-    [user, *User.where(id: params[:other_user_ids].to_a.uniq).to_a]
+    [user, *User.where(id: params.other_user_ids.to_a.uniq).to_a]
   end
 
   def can_suspend_all_users(guardian:, users:)
@@ -46,7 +46,7 @@ class User::Suspend
   end
 
   def fetch_post(params:)
-    Post.find_by(id: params[:post_id])
+    Post.find_by(id: params.post_id)
   end
 
   def perform_post_action(guardian:, post:, params:)

--- a/lib/service/contract_base.rb
+++ b/lib/service/contract_base.rb
@@ -17,10 +17,6 @@ class Service::ContractBase
     @__options__
   end
 
-  def [](key)
-    public_send(key)
-  end
-
   def to_hash
     attributes.symbolize_keys
   end

--- a/plugins/chat/app/services/chat/add_users_to_channel.rb
+++ b/plugins/chat/app/services/chat/add_users_to_channel.rb
@@ -50,7 +50,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::Channel.includes(:chatable).find_by(id: params[:channel_id])
+      ::Chat::Channel.includes(:chatable).find_by(id: params.channel_id)
     end
 
     def can_add_users_to_channel(guardian:, channel:)
@@ -60,8 +60,8 @@ module Chat
 
     def fetch_target_users(params:, channel:)
       ::Chat::UsersFromUsernamesAndGroupsQuery.call(
-        usernames: params[:usernames],
-        groups: params[:groups],
+        usernames: params.usernames,
+        groups: params.groups,
         excluded_user_ids: channel.chatable.direct_message_users.pluck(:user_id),
       )
     end

--- a/plugins/chat/app/services/chat/auto_join_channel_batch.rb
+++ b/plugins/chat/app/services/chat/auto_join_channel_batch.rb
@@ -45,7 +45,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::CategoryChannel.find_by(id: params[:channel_id], auto_join_users: true)
+      ::Chat::CategoryChannel.find_by(id: params.channel_id, auto_join_users: true)
     end
 
     def create_memberships(channel:, params:)

--- a/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_category_updated.rb
@@ -38,7 +38,7 @@ module Chat
       end
 
       def fetch_category(params:)
-        Category.find_by(id: params[:category_id])
+        Category.find_by(id: params.category_id)
       end
 
       def fetch_category_channel_ids(category:)

--- a/plugins/chat/app/services/chat/auto_remove/handle_chat_allowed_groups_change.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_chat_allowed_groups_change.rb
@@ -33,7 +33,7 @@ module Chat
       end
 
       def not_everyone_allowed(params:)
-        params[:new_allowed_groups].exclude?(Group::AUTO_GROUPS[:everyone])
+        params.new_allowed_groups.exclude?(Group::AUTO_GROUPS[:everyone])
       end
 
       def fetch_users(params:)
@@ -46,8 +46,8 @@ module Chat
           .joins(:user_chat_channel_memberships)
           .distinct
           .then do |users|
-            break users if params[:new_allowed_groups].blank?
-            users.where(<<~SQL, params[:new_allowed_groups])
+            break users if params.new_allowed_groups.blank?
+            users.where(<<~SQL, params.new_allowed_groups)
                 users.id NOT IN (
                   SELECT DISTINCT group_users.user_id
                   FROM group_users

--- a/plugins/chat/app/services/chat/auto_remove/handle_destroyed_group.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_destroyed_group.rb
@@ -56,7 +56,7 @@ module Chat
           .not_staged
           .includes(:group_users)
           .where("NOT admin AND NOT moderator")
-          .where(id: params[:destroyed_group_user_ids])
+          .where(id: params.destroyed_group_user_ids)
           .joins(:user_chat_channel_memberships)
           .distinct
       end

--- a/plugins/chat/app/services/chat/auto_remove/handle_user_removed_from_group.rb
+++ b/plugins/chat/app/services/chat/auto_remove/handle_user_removed_from_group.rb
@@ -49,7 +49,7 @@ module Chat
       end
 
       def fetch_user(params:)
-        User.find_by(id: params[:user_id])
+        User.find_by(id: params.user_id)
       end
 
       def user_not_staff(user:)

--- a/plugins/chat/app/services/chat/create_category_channel.rb
+++ b/plugins/chat/app/services/chat/create_category_channel.rb
@@ -66,11 +66,11 @@ module Chat
     end
 
     def fetch_category(params:)
-      Category.find_by(id: params[:category_id])
+      Category.find_by(id: params.category_id)
     end
 
     def category_channel_does_not_exist(category:, params:)
-      !Chat::Channel.exists?(chatable: category, name: params[:name])
+      !Chat::Channel.exists?(chatable: category, name: params.name)
     end
 
     def create_channel(category:, params:)

--- a/plugins/chat/app/services/chat/create_direct_message_channel.rb
+++ b/plugins/chat/app/services/chat/create_direct_message_channel.rb
@@ -64,8 +64,8 @@ module Chat
 
     def fetch_target_users(guardian:, params:)
       ::Chat::UsersFromUsernamesAndGroupsQuery.call(
-        usernames: [*params[:target_usernames], guardian.user.username],
-        groups: params[:target_groups],
+        usernames: [*params.target_usernames, guardian.user.username],
+        groups: params.target_groups,
       )
     end
 
@@ -79,9 +79,9 @@ module Chat
 
     def fetch_or_create_direct_message(target_users:, params:)
       ids = target_users.map(&:id)
-      is_group = ids.size > 2 || params[:name].present?
+      is_group = ids.size > 2 || params.name.present?
 
-      if params[:upsert] || !is_group
+      if params.upsert || !is_group
         ::Chat::DirectMessage.for_user_ids(ids, group: is_group) ||
           ::Chat::DirectMessage.create(user_ids: ids, group: is_group)
       else
@@ -94,7 +94,7 @@ module Chat
     end
 
     def set_optional_name(channel:, params:)
-      channel.update!(params.slice(:name)) if params[:name]&.size&.positive?
+      channel.update!(params.slice(:name)) if params.name&.size&.positive?
     end
 
     def update_memberships(channel:, target_users:)

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -90,7 +90,7 @@ module Chat
     end
 
     def fetch_channel(params:)
-      Chat::Channel.find_by_id_or_slug(params[:chat_channel_id])
+      Chat::Channel.find_by_id_or_slug(params.chat_channel_id)
     end
 
     def enforce_membership(guardian:, channel:, options:)
@@ -108,16 +108,16 @@ module Chat
     end
 
     def fetch_reply(params:)
-      Chat::Message.find_by(id: params[:in_reply_to_id])
+      Chat::Message.find_by(id: params.in_reply_to_id)
     end
 
     def ensure_reply_consistency(channel:, params:, reply:)
-      return true if params[:in_reply_to_id].blank?
+      return true if params.in_reply_to_id.blank?
       reply&.chat_channel == channel
     end
 
     def fetch_thread(params:, reply:, channel:, options:)
-      return Chat::Thread.find_by(id: params[:thread_id]) if params[:thread_id].present?
+      return Chat::Thread.find_by(id: params.thread_id) if params.thread_id.present?
       return unless reply
       reply.thread ||
         reply.build_thread(
@@ -129,7 +129,7 @@ module Chat
     end
 
     def ensure_valid_thread_for_channel(thread:, params:, channel:)
-      return true if params[:thread_id].blank?
+      return true if params.thread_id.blank?
       thread&.channel == channel
     end
 
@@ -140,7 +140,7 @@ module Chat
 
     def fetch_uploads(params:, guardian:)
       return [] if !SiteSetting.chat_allow_uploads
-      guardian.user.uploads.where(id: params[:upload_ids])
+      guardian.user.uploads.where(id: params.upload_ids)
     end
 
     def instantiate_message(channel:, guardian:, params:, uploads:, thread:, reply:, options:)
@@ -148,10 +148,10 @@ module Chat
         user: guardian.user,
         last_editor: guardian.user,
         in_reply_to: reply,
-        message: params[:message],
+        message: params.message,
         uploads: uploads,
         thread: thread,
-        cooked: ::Chat::Message.cook(params[:message], user_id: guardian.user.id),
+        cooked: ::Chat::Message.cook(params.message, user_id: guardian.user.id),
         cooked_version: ::Chat::Message::BAKED_VERSION,
         streaming: options.streaming,
       )
@@ -206,7 +206,7 @@ module Chat
     end
 
     def process(channel:, message_instance:, params:, thread:, options:)
-      ::Chat::Publisher.publish_new!(channel, message_instance, params[:staged_id])
+      ::Chat::Publisher.publish_new!(channel, message_instance, params.staged_id)
 
       DiscourseEvent.trigger(
         :chat_message_created,
@@ -217,20 +217,20 @@ module Chat
           thread: thread,
           thread_replies_count: thread&.replies_count_cache || 0,
           context: {
-            post_ids: params[:context_post_ids],
-            topic_id: params[:context_topic_id],
+            post_ids: params.context_post_ids,
+            topic_id: params.context_topic_id,
           },
         },
       )
 
       if options.process_inline
         Jobs::Chat::ProcessMessage.new.execute(
-          { chat_message_id: message_instance.id, staged_id: params[:staged_id] },
+          { chat_message_id: message_instance.id, staged_id: params.staged_id },
         )
       else
         Jobs.enqueue(
           Jobs::Chat::ProcessMessage,
-          { chat_message_id: message_instance.id, staged_id: params[:staged_id] },
+          { chat_message_id: message_instance.id, staged_id: params.staged_id },
         )
       end
     end

--- a/plugins/chat/app/services/chat/create_thread.rb
+++ b/plugins/chat/app/services/chat/create_thread.rb
@@ -40,14 +40,11 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::Channel.find_by(id: params[:channel_id])
+      ::Chat::Channel.find_by(id: params.channel_id)
     end
 
     def fetch_original_message(channel:, params:)
-      ::Chat::Message.find_by(
-        id: params[:original_message_id],
-        chat_channel_id: params[:channel_id],
-      )
+      ::Chat::Message.find_by(id: params.original_message_id, chat_channel_id: params.channel_id)
     end
 
     def can_view_channel(guardian:, channel:)
@@ -64,7 +61,7 @@ module Chat
       end
 
       context[:thread] = channel.threads.create(
-        title: params[:title],
+        title: params.title,
         original_message: original_message,
         original_message_user: original_message.user,
       )

--- a/plugins/chat/app/services/chat/flag_message.rb
+++ b/plugins/chat/app/services/chat/flag_message.rb
@@ -48,8 +48,8 @@ module Chat
 
     def fetch_message(params:)
       Chat::Message.includes(:chat_channel, :revisions).find_by(
-        id: params[:message_id],
-        chat_channel_id: params[:channel_id],
+        id: params.message_id,
+        chat_channel_id: params.channel_id,
       )
     end
 
@@ -58,7 +58,7 @@ module Chat
         guardian.can_flag_chat_message?(message) &&
         guardian.can_flag_message_as?(
           message,
-          params[:flag_type_id],
+          params.flag_type_id,
           params.slice(:queue_for_review, :take_action, :is_warning),
         )
     end
@@ -67,7 +67,7 @@ module Chat
       Chat::ReviewQueue.new.flag_message(
         message,
         guardian,
-        params[:flag_type_id],
+        params.flag_type_id,
         **params.slice(:message, :is_warning, :take_action, :queue_for_review),
       )
     end

--- a/plugins/chat/app/services/chat/invite_users_to_channel.rb
+++ b/plugins/chat/app/services/chat/invite_users_to_channel.rb
@@ -33,7 +33,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::Channel.find_by(id: params[:channel_id])
+      ::Chat::Channel.find_by(id: params.channel_id)
     end
 
     def can_view_channel(guardian:, channel:)
@@ -45,7 +45,7 @@ module Chat
         .joins(:user_option)
         .where(user_options: { chat_enabled: true })
         .not_suspended
-        .where(id: params[:user_ids])
+        .where(id: params.user_ids)
         .limit(50)
     end
 
@@ -59,7 +59,7 @@ module Chat
           chat_channel_title: channel.title(invited_user),
           chat_channel_slug: channel.slug,
           invited_by_username: guardian.user.username,
-          chat_message_id: params[:message_id],
+          chat_message_id: params.message_id,
         }.compact
 
         invited_user.notifications.create(

--- a/plugins/chat/app/services/chat/leave_channel.rb
+++ b/plugins/chat/app/services/chat/leave_channel.rb
@@ -32,7 +32,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      Chat::Channel.find_by(id: params[:channel_id])
+      Chat::Channel.find_by(id: params.channel_id)
     end
 
     def leave(channel:, guardian:)

--- a/plugins/chat/app/services/chat/list_channel_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_messages.rb
@@ -57,7 +57,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::Channel.includes(:chatable).find_by(id: params[:channel_id])
+      ::Chat::Channel.includes(:chatable).find_by(id: params.channel_id)
     end
 
     def fetch_membership(channel:, guardian:)
@@ -73,10 +73,10 @@ module Chat
     end
 
     def determine_target_message_id(params:, membership:)
-      if params[:fetch_from_last_read]
+      if params.fetch_from_last_read
         context[:target_message_id] = membership&.last_read_message_id
       else
-        context[:target_message_id] = params[:target_message_id]
+        context[:target_message_id] = params.target_message_id
       end
     end
 
@@ -103,9 +103,9 @@ module Chat
           guardian:,
           target_message_id:,
           include_thread_messages: !enabled_threads,
-          page_size: params[:page_size] || Chat::MessagesQuery::MAX_PAGE_SIZE,
-          direction: params[:direction],
-          target_date: params[:target_date],
+          page_size: params.page_size || Chat::MessagesQuery::MAX_PAGE_SIZE,
+          direction: params.direction,
+          target_date: params.target_date,
         )
 
       context[:can_load_more_past] = messages_data[:can_load_more_past]

--- a/plugins/chat/app/services/chat/list_channel_thread_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_thread_messages.rb
@@ -51,7 +51,7 @@ module Chat
     private
 
     def fetch_thread(params:)
-      ::Chat::Thread.strict_loading.includes(channel: :chatable).find_by(id: params[:thread_id])
+      ::Chat::Thread.strict_loading.includes(channel: :chatable).find_by(id: params.thread_id)
     end
 
     def can_view_thread(guardian:, thread:)
@@ -63,14 +63,14 @@ module Chat
     end
 
     def determine_target_message_id(params:, membership:, guardian:, thread:)
-      if params[:fetch_from_last_message]
+      if params.fetch_from_last_message
         context[:target_message_id] = thread.last_message_id
-      elsif params[:fetch_from_first_message]
+      elsif params.fetch_from_first_message
         context[:target_message_id] = thread.original_message_id
-      elsif params[:fetch_from_last_read] || !params[:target_message_id]
+      elsif params.fetch_from_last_read || !params.target_message_id
         context[:target_message_id] = membership&.last_read_message_id
-      elsif params[:target_message_id]
-        context[:target_message_id] = params[:target_message_id]
+      elsif params.target_message_id
+        context[:target_message_id] = params.target_message_id
       end
     end
 
@@ -79,7 +79,7 @@ module Chat
       target_message =
         ::Chat::Message.with_deleted.find_by(
           id: context.target_message_id,
-          thread_id: params[:thread_id],
+          thread_id: params.thread_id,
         )
       return false if target_message.blank?
       return true if !target_message.trashed?
@@ -93,11 +93,11 @@ module Chat
           guardian: guardian,
           target_message_id: context.target_message_id,
           thread_id: thread.id,
-          page_size: params[:page_size] || Chat::MessagesQuery::MAX_PAGE_SIZE,
-          direction: params[:direction],
-          target_date: params[:target_date],
+          page_size: params.page_size || Chat::MessagesQuery::MAX_PAGE_SIZE,
+          direction: params.direction,
+          target_date: params.target_date,
           include_target_message_id:
-            params[:fetch_from_first_message] || params[:fetch_from_last_message],
+            params.fetch_from_first_message || params.fetch_from_last_message,
         )
 
       context[:can_load_more_past] = messages_data[:can_load_more_past]

--- a/plugins/chat/app/services/chat/lookup_thread.rb
+++ b/plugins/chat/app/services/chat/lookup_thread.rb
@@ -36,7 +36,7 @@ module Chat
         :channel,
         original_message_user: :user_status,
         original_message: :chat_webhook_event,
-      ).find_by(id: params[:thread_id], channel_id: params[:channel_id])
+      ).find_by(id: params.thread_id, channel_id: params.channel_id)
     end
 
     def invalid_access(guardian:, thread:)

--- a/plugins/chat/app/services/chat/mark_thread_title_prompt_seen.rb
+++ b/plugins/chat/app/services/chat/mark_thread_title_prompt_seen.rb
@@ -38,7 +38,7 @@ module Chat
     private
 
     def fetch_thread(params:)
-      Chat::Thread.find_by(id: params[:thread_id], channel_id: params[:channel_id])
+      Chat::Thread.find_by(id: params.thread_id, channel_id: params.channel_id)
     end
 
     def can_view_channel(guardian:, thread:)

--- a/plugins/chat/app/services/chat/restore_message.rb
+++ b/plugins/chat/app/services/chat/restore_message.rb
@@ -40,7 +40,7 @@ module Chat
       Chat::Message
         .with_deleted
         .includes(chat_channel: :chatable)
-        .find_by(id: params[:message_id], chat_channel_id: params[:channel_id])
+        .find_by(id: params.message_id, chat_channel_id: params.channel_id)
     end
 
     def invalid_access(guardian:, message:)

--- a/plugins/chat/app/services/chat/stop_message_streaming.rb
+++ b/plugins/chat/app/services/chat/stop_message_streaming.rb
@@ -29,7 +29,7 @@ module Chat
     private
 
     def fetch_message(params:)
-      ::Chat::Message.find_by(id: params[:message_id])
+      ::Chat::Message.find_by(id: params.message_id)
     end
 
     def enforce_membership(guardian:, message:)

--- a/plugins/chat/app/services/chat/trash_channel.rb
+++ b/plugins/chat/app/services/chat/trash_channel.rb
@@ -18,7 +18,12 @@ module Chat
 
     DELETE_CHANNEL_LOG_KEY = "chat_channel_delete"
 
-    model :channel, :fetch_channel
+    params do
+      attribute :channel_id, :integer
+
+      validates :channel_id, presence: true
+    end
+    model :channel
     policy :invalid_access
     transaction do
       step :prevents_slug_collision
@@ -30,7 +35,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      Chat::Channel.find_by(id: params[:channel_id])
+      Chat::Channel.find_by(id: params.channel_id)
     end
 
     def invalid_access(guardian:, channel:)

--- a/plugins/chat/app/services/chat/trash_message.rb
+++ b/plugins/chat/app/services/chat/trash_message.rb
@@ -40,8 +40,8 @@ module Chat
 
     def fetch_message(params:)
       Chat::Message.includes(chat_channel: :chatable).find_by(
-        id: params[:message_id],
-        chat_channel_id: params[:channel_id],
+        id: params.message_id,
+        chat_channel_id: params.channel_id,
       )
     end
 

--- a/plugins/chat/app/services/chat/trash_messages.rb
+++ b/plugins/chat/app/services/chat/trash_messages.rb
@@ -40,8 +40,8 @@ module Chat
 
     def fetch_messages(params:)
       Chat::Message.includes(chat_channel: :chatable).where(
-        id: params[:message_ids],
-        chat_channel_id: params[:channel_id],
+        id: params.message_ids,
+        chat_channel_id: params.channel_id,
       )
     end
 
@@ -90,7 +90,7 @@ module Chat
       messages.each do |message|
         DiscourseEvent.trigger(:chat_message_trashed, message, message.chat_channel, guardian.user)
       end
-      Chat::Publisher.publish_bulk_delete!(messages.first.chat_channel, params[:message_ids])
+      Chat::Publisher.publish_bulk_delete!(messages.first.chat_channel, params.message_ids)
     end
   end
 end

--- a/plugins/chat/app/services/chat/unfollow_channel.rb
+++ b/plugins/chat/app/services/chat/unfollow_channel.rb
@@ -31,7 +31,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      Chat::Channel.find_by(id: params[:channel_id])
+      Chat::Channel.find_by(id: params.channel_id)
     end
 
     def unfollow(channel:, guardian:)

--- a/plugins/chat/app/services/chat/update_channel_status.rb
+++ b/plugins/chat/app/services/chat/update_channel_status.rb
@@ -16,28 +16,30 @@ module Chat
     #   @option params [String] :status
     #   @return [Service::Base::Context]
 
-    model :channel
     params do
+      attribute :channel_id, :integer
       attribute :status, :string
 
+      validates :channel_id, presence: true
       validates :status, inclusion: { in: Chat::Channel.editable_statuses.keys }
     end
+    model :channel
     policy :check_channel_permission
     step :change_status
 
     private
 
     def fetch_channel(params:)
-      Chat::Channel.find_by(id: params[:channel_id])
+      Chat::Channel.find_by(id: params.channel_id)
     end
 
     def check_channel_permission(guardian:, channel:, params:)
       guardian.can_preview_chat_channel?(channel) &&
-        guardian.can_change_channel_status?(channel, params[:status].to_sym)
+        guardian.can_change_channel_status?(channel, params.status.to_sym)
     end
 
     def change_status(channel:, params:, guardian:)
-      channel.public_send("#{params[:status]}!", guardian.user)
+      channel.public_send("#{params.status}!", guardian.user)
     end
   end
 end

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -79,7 +79,7 @@ module Chat
           chatable: [:topic_only_relative_url, direct_message_users: [user: :user_option]],
         ],
         user: :user_status,
-      ).find_by(id: params[:message_id])
+      ).find_by(id: params.message_id)
     end
 
     def fetch_membership(guardian:, message:)
@@ -88,7 +88,7 @@ module Chat
 
     def fetch_uploads(params:, guardian:)
       return if !SiteSetting.chat_allow_uploads
-      guardian.user.uploads.where(id: params[:upload_ids])
+      guardian.user.uploads.where(id: params.upload_ids)
     end
 
     def can_modify_channel_message(guardian:, message:)
@@ -100,11 +100,11 @@ module Chat
     end
 
     def modify_message(params:, message:, guardian:, uploads:)
-      message.message = params[:message]
+      message.message = params.message
       message.last_editor_id = guardian.user.id
       message.cook
 
-      return if uploads&.size != params[:upload_ids].to_a.size
+      return if uploads&.size != params.upload_ids.to_a.size
 
       new_upload_ids = uploads.map(&:id)
       existing_upload_ids = message.upload_ids

--- a/plugins/chat/app/services/chat/update_thread.rb
+++ b/plugins/chat/app/services/chat/update_thread.rb
@@ -36,7 +36,7 @@ module Chat
     private
 
     def fetch_thread(params:)
-      Chat::Thread.find_by(id: params[:thread_id])
+      Chat::Thread.find_by(id: params.thread_id)
     end
 
     def can_view_channel(guardian:, thread:)

--- a/plugins/chat/app/services/chat/update_thread_notification_settings.rb
+++ b/plugins/chat/app/services/chat/update_thread_notification_settings.rb
@@ -45,7 +45,7 @@ module Chat
     private
 
     def fetch_thread(params:)
-      Chat::Thread.find_by(id: params[:thread_id], channel_id: params[:channel_id])
+      Chat::Thread.find_by(id: params.thread_id, channel_id: params.channel_id)
     end
 
     def can_view_channel(guardian:, thread:)
@@ -62,7 +62,7 @@ module Chat
         membership = thread.add(guardian.user)
         membership.update!(last_read_message_id: thread.last_message_id)
       end
-      membership.update!(notification_level: params[:notification_level])
+      membership.update!(notification_level: params.notification_level)
       context[:membership] = membership
     end
   end

--- a/plugins/chat/app/services/chat/update_user_channel_last_read.rb
+++ b/plugins/chat/app/services/chat/update_user_channel_last_read.rb
@@ -36,7 +36,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      ::Chat::Channel.find_by(id: params[:channel_id])
+      ::Chat::Channel.find_by(id: params.channel_id)
     end
 
     def fetch_membership(guardian:, channel:)
@@ -48,7 +48,7 @@ module Chat
     end
 
     def fetch_message(channel:, params:)
-      ::Chat::Message.with_deleted.find_by(chat_channel_id: channel.id, id: params[:message_id])
+      ::Chat::Message.with_deleted.find_by(chat_channel_id: channel.id, id: params.message_id)
     end
 
     def ensure_message_id_recency(message:, membership:)

--- a/plugins/chat/app/services/chat/update_user_thread_last_read.rb
+++ b/plugins/chat/app/services/chat/update_user_thread_last_read.rb
@@ -37,7 +37,7 @@ module Chat
     private
 
     def fetch_thread(params:)
-      ::Chat::Thread.find_by(id: params[:thread_id], channel_id: params[:channel_id])
+      ::Chat::Thread.find_by(id: params.thread_id, channel_id: params.channel_id)
     end
 
     def invalid_access(guardian:, thread:)
@@ -50,7 +50,7 @@ module Chat
 
     def fetch_message(params:, thread:)
       ::Chat::Message.with_deleted.find_by(
-        id: params[:message_id] || thread.last_message_id,
+        id: params.message_id || thread.last_message_id,
         thread: thread,
         chat_channel: thread.channel,
       )

--- a/plugins/chat/app/services/chat/upsert_draft.rb
+++ b/plugins/chat/app/services/chat/upsert_draft.rb
@@ -39,7 +39,7 @@ module Chat
     private
 
     def fetch_channel(params:)
-      Chat::Channel.find_by(id: params[:channel_id])
+      Chat::Channel.find_by(id: params.channel_id)
     end
 
     def can_upsert_draft(guardian:, channel:)
@@ -47,26 +47,26 @@ module Chat
     end
 
     def check_thread_exists(params:, channel:)
-      return if params[:thread_id].blank?
-      fail!("Thread not found") if !channel.threads.exists?(id: params[:thread_id])
+      return if params.thread_id.blank?
+      fail!("Thread not found") if !channel.threads.exists?(id: params.thread_id)
     end
 
     def upsert_draft(params:, guardian:)
-      if params[:data].present?
+      if params.data.present?
         draft =
           Chat::Draft.find_or_initialize_by(
             user_id: guardian.user.id,
-            chat_channel_id: params[:channel_id],
-            thread_id: params[:thread_id],
+            chat_channel_id: params.channel_id,
+            thread_id: params.thread_id,
           )
-        draft.data = params[:data]
+        draft.data = params.data
         draft.save!
       else
         # when data is empty, we destroy the draft
         Chat::Draft.where(
           user: guardian.user,
-          chat_channel_id: params[:channel_id],
-          thread_id: params[:thread_id],
+          chat_channel_id: params.channel_id,
+          thread_id: params.thread_id,
         ).destroy_all
       end
     end

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
       let(:limit) { nil }
 
       it "defaults to a max value" do
-        expect(result.limit).to eq(described_class::THREADS_LIMIT)
+        expect(result.params.limit).to eq(described_class::THREADS_LIMIT)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
       let(:limit) { 0 }
 
       it "defaults to a max value" do
-        expect(result.limit).to eq(1)
+        expect(result.params.limit).to eq(1)
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
       let(:offset) { nil }
 
       it "defaults to zero" do
-        expect(result.offset).to eq(0)
+        expect(result.params.offset).to eq(0)
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe ::Chat::LookupChannelThreads do
       let(:offset) { -99 }
 
       it "defaults to a min value" do
-        expect(result.offset).to eq(0)
+        expect(result.params.offset).to eq(0)
       end
     end
   end

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Chat::SearchChatable do
 
       it "cleans the term" do
         params[:term] = "#bob"
-        expect(result.params[:term]).to eq("bob")
+        expect(result.params.term).to eq("bob")
 
         params[:term] = "@bob"
-        expect(result.params[:term]).to eq("bob")
+        expect(result.params.term).to eq("bob")
       end
 
       it "fetches user memberships" do

--- a/plugins/chat/spec/services/chat/trash_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_channel_spec.rb
@@ -1,30 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe Chat::TrashChannel do
-  subject(:result) { described_class.call(params:, **dependencies) }
-
-  fab!(:current_user) { Fabricate(:admin) }
-  fab!(:channel) { Fabricate(:chat_channel) }
-
-  let(:params) { { channel_id: } }
-  let(:dependencies) { { guardian: } }
-  let(:guardian) { Guardian.new(current_user) }
-  let(:channel_id) { channel.id }
-
-  context "when channel_id is not provided" do
-    let(:channel_id) { nil }
-
-    it { is_expected.to fail_to_find_a_model(:channel) }
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:channel_id) }
   end
 
-  context "when channel_id is provided" do
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:current_user) { Fabricate(:admin) }
+    fab!(:channel) { Fabricate(:chat_channel) }
+
+    let(:params) { { channel_id: } }
+    let(:dependencies) { { guardian: } }
+    let(:guardian) { Guardian.new(current_user) }
+    let(:channel_id) { channel.id }
+
+    context "when data is invalid" do
+      let(:channel_id) { nil }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when model is not found" do
+      let(:channel_id) { 0 }
+
+      it { is_expected.to fail_to_find_a_model(:channel) }
+    end
+
     context "when user is not allowed to perform the action" do
       let!(:current_user) { Fabricate(:user) }
 
       it { is_expected.to fail_a_policy(:invalid_access) }
     end
 
-    context "when user is allowed to perform the action" do
+    context "when everything’s ok" do
       it { is_expected.to run_successfully }
 
       it "trashes the channel" do

--- a/plugins/chat/spec/services/chat/update_channel_status_spec.rb
+++ b/plugins/chat/spec/services/chat/update_channel_status_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe(Chat::UpdateChannelStatus) do
   describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:channel_id) }
     it do
       is_expected.to validate_inclusion_of(:status).in_array(Chat::Channel.editable_statuses.keys)
     end
@@ -19,8 +20,8 @@ RSpec.describe(Chat::UpdateChannelStatus) do
     let(:status) { "open" }
     let(:channel_id) { channel.id }
 
-    context "when no channel_id is given" do
-      let(:channel_id) { nil }
+    context "when model is not found" do
+      let(:channel_id) { 0 }
 
       it { is_expected.to fail_to_find_a_model(:channel) }
     end

--- a/spec/services/admin_notices/dismiss_spec.rb
+++ b/spec/services/admin_notices/dismiss_spec.rb
@@ -1,36 +1,49 @@
 # frozen_string_literal: true
 
 RSpec.describe(AdminNotices::Dismiss) do
-  subject(:result) { described_class.call(params:, **dependencies) }
-
-  fab!(:current_user) { Fabricate(:admin) }
-  fab!(:admin_notice) { Fabricate(:admin_notice, identifier: "problem.test") }
-  fab!(:problem_check) { Fabricate(:problem_check_tracker, identifier: "problem.test", blips: 3) }
-
-  let(:params) { { id: admin_notice.id } }
-  let(:dependencies) { { guardian: current_user.guardian } }
-
-  context "when user is not allowed to perform the action" do
-    fab!(:current_user) { Fabricate(:user) }
-
-    it { is_expected.to fail_a_policy(:invalid_access) }
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:id) }
   end
 
-  context "when the admin notice has already been dismissed" do
-    before { admin_notice.destroy! }
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
 
-    it { is_expected.to run_successfully }
-  end
+    fab!(:current_user) { Fabricate(:admin) }
+    fab!(:admin_notice) { Fabricate(:admin_notice, identifier: "problem.test") }
+    fab!(:problem_check) { Fabricate(:problem_check_tracker, identifier: "problem.test", blips: 3) }
 
-  context "when everything's ok" do
-    it { is_expected.to run_successfully }
+    let(:params) { { id: notice_id } }
+    let(:notice_id) { admin_notice.id }
+    let(:dependencies) { { guardian: current_user.guardian } }
 
-    it "destroys the admin notice" do
-      expect { result }.to change { AdminNotice.count }.from(1).to(0)
+    context "when user is not allowed to perform the action" do
+      fab!(:current_user) { Fabricate(:user) }
+
+      it { is_expected.to fail_a_policy(:invalid_access) }
     end
 
-    it "resets any associated problem check" do
-      expect { result }.to change { problem_check.reload.blips }.from(3).to(0)
+    context "when data is invalid" do
+      let(:notice_id) { nil }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when the admin notice has already been dismissed" do
+      before { admin_notice.destroy! }
+
+      it { is_expected.to run_successfully }
+    end
+
+    context "when everything's ok" do
+      it { is_expected.to run_successfully }
+
+      it "destroys the admin notice" do
+        expect { result }.to change { AdminNotice.count }.from(1).to(0)
+      end
+
+      it "resets any associated problem check" do
+        expect { result }.to change { problem_check.reload.blips }.from(3).to(0)
+      end
     end
   end
 end

--- a/spec/services/flags/destroy_flag_spec.rb
+++ b/spec/services/flags/destroy_flag_spec.rb
@@ -1,57 +1,69 @@
 # frozen_string_literal: true
 
 RSpec.describe(Flags::DestroyFlag) do
-  subject(:result) { described_class.call(params:, **dependencies) }
-
-  fab!(:current_user) { Fabricate(:admin) }
-  fab!(:flag)
-
-  let(:params) { { id: flag_id } }
-  let(:dependencies) { { guardian: current_user.guardian } }
-  let(:flag_id) { flag.id }
-
-  # DO NOT REMOVE: flags have side effects and their state will leak to
-  # other examples otherwise.
-  after { flag.destroy! }
-
-  context "when model is not found" do
-    let(:flag_id) { 0 }
-
-    it { is_expected.to fail_to_find_a_model(:flag) }
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:id) }
   end
 
-  context "when the flag is a system one" do
-    let(:flag) { Flag.first }
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
 
-    it { is_expected.to fail_a_policy(:not_system) }
-  end
+    fab!(:current_user) { Fabricate(:admin) }
+    fab!(:flag)
 
-  context "when the flag has been used" do
-    let!(:post_action) { Fabricate(:post_action, post_action_type_id: flag.id) }
+    let(:params) { { id: flag_id } }
+    let(:dependencies) { { guardian: current_user.guardian } }
+    let(:flag_id) { flag.id }
 
-    it { is_expected.to fail_a_policy(:not_used) }
-  end
+    # DO NOT REMOVE: flags have side effects and their state will leak to
+    # other examples otherwise.
+    after { flag.destroy! }
 
-  context "when user is not allowed to perform the action" do
-    fab!(:current_user) { Fabricate(:user) }
+    context "when data is invalid" do
+      let(:flag_id) { nil }
 
-    it { is_expected.to fail_a_policy(:invalid_access) }
-  end
-
-  context "when everything's ok" do
-    it { is_expected.to run_successfully }
-
-    it "destroys the flag" do
-      expect { result }.to change { Flag.where(id: flag).count }.by(-1)
+      it { is_expected.to fail_a_contract }
     end
 
-    it "logs the action" do
-      expect { result }.to change { UserHistory.count }.by(1)
-      expect(UserHistory.last).to have_attributes(
-        custom_type: "delete_flag",
-        details:
-          "name: offtopic\ndescription: \napplies_to: [\"Post\", \"Chat::Message\"]\nenabled: true",
-      )
+    context "when model is not found" do
+      let(:flag_id) { 0 }
+
+      it { is_expected.to fail_to_find_a_model(:flag) }
+    end
+
+    context "when the flag is a system one" do
+      let(:flag) { Flag.first }
+
+      it { is_expected.to fail_a_policy(:not_system) }
+    end
+
+    context "when the flag has been used" do
+      let!(:post_action) { Fabricate(:post_action, post_action_type_id: flag.id) }
+
+      it { is_expected.to fail_a_policy(:not_used) }
+    end
+
+    context "when user is not allowed to perform the action" do
+      fab!(:current_user) { Fabricate(:user) }
+
+      it { is_expected.to fail_a_policy(:invalid_access) }
+    end
+
+    context "when everything's ok" do
+      it { is_expected.to run_successfully }
+
+      it "destroys the flag" do
+        expect { result }.to change { Flag.where(id: flag).count }.by(-1)
+      end
+
+      it "logs the action" do
+        expect { result }.to change { UserHistory.count }.by(1)
+        expect(UserHistory.last).to have_attributes(
+          custom_type: "delete_flag",
+          details:
+            "name: offtopic\ndescription: \napplies_to: [\"Post\", \"Chat::Message\"]\nenabled: true",
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
We decided to keep only one way to access values from a contract. This PR thus removes the hash-like access from contracts.
