### PR TITLE
DEV: Update dynamic component hbs syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
@@ -59,12 +59,12 @@
         (component
           this.reviewableComponent reviewable=this.reviewable tagName=""
         )
-        as |reviewableComponent|
+        as |ReviewableComponent|
       }}
         {{! template-lint-disable no-shadowed-elements }}{{! (seems to be a false positive) }}
-        <reviewableComponent>
+        <ReviewableComponent>
           <ReviewableScores @reviewable={{this.reviewable}} @tagName="" />
-        </reviewableComponent>
+        </ReviewableComponent>
       {{/let}}
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
@@ -55,11 +55,17 @@
         {{/each}}
       </div>
     {{else}}
-      {{#component
-        this.reviewableComponent reviewable=this.reviewable tagName=""
+      {{#let
+        (component
+          this.reviewableComponent reviewable=this.reviewable tagName=""
+        )
+        as |reviewableComponent|
       }}
-        <ReviewableScores @reviewable={{this.reviewable}} @tagName="" />
-      {{/component}}
+        {{! template-lint-disable no-shadowed-elements }}{{! (seems to be a false positive) }}
+        <reviewableComponent>
+          <ReviewableScores @reviewable={{this.reviewable}} @tagName="" />
+        </reviewableComponent>
+      {{/let}}
     {{/if}}
   </div>
 


### PR DESCRIPTION
The block form of `{{#component` is not supported by Glint tooling. They recommend using this `{{#let`-based syntax to achieve the same result

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->