### PR TITLE
DEV: Notify plugins when experimental plugin features are toggled

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -50,6 +50,9 @@ export default class DiscourseNewFeatureItem extends Component {
         type: "POST",
         data: {
           setting_name: this.args.item.experiment_setting,
+          plugin_name: this.args.item.plugin_name
+            ? this.args.item.plugin_name
+            : null,
         },
       });
       this.toasts.success({

--- a/app/services/experiments/toggle.rb
+++ b/app/services/experiments/toggle.rb
@@ -6,6 +6,8 @@ class Experiments::Toggle
   policy :current_user_is_admin
   params do
     attribute :setting_name, :string
+    attribute :plugin_name, :string
+
     validates :setting_name, presence: true
   end
   policy :setting_is_available
@@ -27,5 +29,17 @@ class Experiments::Toggle
       !SiteSetting.public_send(params[:setting_name]),
       guardian.user,
     )
+
+    if params[:plugin_name]
+      notify_plugin(
+        params[:setting_name],
+        !SiteSetting.public_send(params[:setting_name]),
+        params[:plugin_name],
+      )
+    end
+  end
+
+  def notify_plugin(setting_name, value, plugin_name = nil)
+    DiscourseEvent.trigger(:plugin_feature_toggled, setting_name, value, plugin_name)
   end
 end


### PR DESCRIPTION
## 🔎 Overview
This PR adds a Discourse Event trigger to notify plugins when experimental features are toggled on the `/whats-new` page. When an experimental feature is plugin specific and it is toggled by an admin, plugins will be notified through a Discourse Event trigger. Plugins can then tap into that by doing something like this in their `plugin.rb` file:
```ruby
  on(:plugin_feature_toggled) do |setting_name, value, plugin_name|
    next unless plugin_name == DiscourseExamplePlugin::PLUGIN_NAME

    # handle some complex config for experimental feature
  end
  ```

This allows for plugins to handle any complex configuration when experimental features are toggled.