### PR TITLE
UX: Move BackButton outside admin-config-area to prevent unintended wrapping

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
@@ -125,11 +125,11 @@ export default class AdminFlagsForm extends Component {
   }
 
   <template>
+    <BackButton
+      @route="adminConfig.flags"
+      @label="admin.config_areas.flags.back"
+    />
     <div class="admin-config-area">
-      <BackButton
-        @route="adminConfig.flags"
-        @label="admin.config_areas.flags.back"
-      />
       <div class="admin-config-area__primary-content admin-flag-form">
         <AdminConfigAreaCard @heading={{this.header}}>
           <:content>


### PR DESCRIPTION
Moved the BackButton component outside the admin-config-area wrapper to address layout issues.

### Before
<img width="916" alt="image" src="https://github.com/user-attachments/assets/c4a644ed-b0d9-4f61-ac97-e5f529339e34">



### After
<img width="777" alt="image" src="https://github.com/user-attachments/assets/da8dbde2-7aef-45a8-baea-28a52186dcc9">
