### PR TITLE
UX: lower copy link z-index

### DIFF
--- a/app/assets/stylesheets/desktop/post-action-feedback.scss
+++ b/app/assets/stylesheets/desktop/post-action-feedback.scss
@@ -9,7 +9,7 @@
   font-size: var(--font-down-2);
   opacity: 1;
   transition: opacity 0.5s ease-in-out;
-  z-index: z("modal", "popover");
+  z-index: calc(z("timeline") + 1);
   &.-success {
     color: var(--success);
   }


### PR DESCRIPTION
The z-index of the copy link effect on desktop was too high, making it appear from behind composer and drawer in certain screen layouts. It only needs to be higher than the timelime.