### PR TITLE
UX: Remove the admin menu button from expanded mobile timeline

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -179,10 +179,8 @@
         @appendReason={{false}}
         @showCaret={{false}}
       />
-      {{#if @mobileView}}
-        <TopicAdminMenu @topic={{@model}} />
-      {{/if}}
     {{/if}}
+
     <PluginOutlet
       @name="timeline-footer-controls-after"
       @outletArgs={{hash model=@model fullscreen=@fullscreen}}


### PR DESCRIPTION
Extracted from #29204