### PR TITLE
UX: fix emoji spacing in chat members user status

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -43,6 +43,10 @@
           }
         }
 
+        .fk-d-tooltip__trigger-container {
+          gap: 0.5rem;
+        }
+
         .user-status-message {
           color: var(--primary-medium);
           font-size: var(--font-down-2);


### PR DESCRIPTION
Improves layout of channel members list with user status emojis.

Before:

<img width="306" alt="Screenshot 2024-10-29 at 4 49 03 PM" src="https://github.com/user-attachments/assets/3b453a23-445f-4cc4-b8f0-c0b9a3b446d0">


After:

<img width="308" alt="Screenshot 2024-10-29 at 4 57 28 PM" src="https://github.com/user-attachments/assets/5b822d04-25c7-4d51-b65e-4be3907db36f">
