### PR TITLE
DEV: clear asset cache when plugins add/remove client.*.yml files

### DIFF
--- a/bin/unicorn
+++ b/bin/unicorn
@@ -23,7 +23,11 @@ def ensure_cache_clean!
   _all_plugin_directories = Pathname.new(RAILS_ROOT + '/plugins').children.select(&:directory?)
   core_git_sha = `git rev-parse HEAD`.strip
   plugins_combined_git_sha = `git ls-files -s plugins | git hash-object --stdin`.strip
-  super_sha = Digest::SHA1.hexdigest(core_git_sha + plugins_combined_git_sha)
+  client_locale_paths_digest =
+    Digest::SHA1.hexdigest(Dir.glob("#{RAILS_ROOT}/plugins/*/config/locales/client.*.yml").join)
+  super_sha =
+    Digest::SHA1.hexdigest(core_git_sha + plugins_combined_git_sha + client_locale_paths_digest)
+  hash_file = "#{RAILS_ROOT}/tmp/plugin-hash"
   hash_file = "#{RAILS_ROOT}/tmp/plugin-hash"
 
   old_hash = File.exist?(hash_file) ? File.read(hash_file) : nil

--- a/bin/unicorn
+++ b/bin/unicorn
@@ -28,7 +28,6 @@ def ensure_cache_clean!
   super_sha =
     Digest::SHA1.hexdigest(core_git_sha + plugins_combined_git_sha + client_locale_paths_digest)
   hash_file = "#{RAILS_ROOT}/tmp/plugin-hash"
-  hash_file = "#{RAILS_ROOT}/tmp/plugin-hash"
 
   old_hash = File.exist?(hash_file) ? File.read(hash_file) : nil
 


### PR DESCRIPTION
Our sprockets-based locale pipeline correctly `depends_on` client.*.yml files which already exist. But sprockets does not provide a way to watch for the creation of new files matching a certain path. This commit works around that limitation by adding the set of client.*.yml files to our global cache-clearing logic

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->