### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/plugins/chat/db/migrate/20241029192512_alter_chat_ids_to_bigint.rb
+++ b/plugins/chat/db/migrate/20241029192512_alter_chat_ids_to_bigint.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AlterChatIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :chat_channel_archives, :chat_channel_id, :bigint
+    change_column :chat_channels, :chatable_id, :bigint
+    change_column :chat_drafts, :chat_channel_id, :bigint
+    change_column :chat_mention_notifications, :chat_mention_id, :bigint
+    change_column :chat_mention_notifications, :notification_id, :bigint
+    change_column :chat_mentions, :chat_message_id, :bigint
+    change_column :chat_message_reactions, :chat_message_id, :bigint
+    change_column :chat_message_revisions, :chat_message_id, :bigint
+    change_column :chat_messages, :chat_channel_id, :bigint
+    change_column :chat_messages, :in_reply_to_id, :bigint
+    change_column :chat_webhook_events, :chat_message_id, :bigint
+    change_column :chat_webhook_events, :incoming_chat_webhook_id, :bigint
+    change_column :direct_message_users, :direct_message_channel_id, :bigint
+    change_column :incoming_chat_webhooks, :chat_channel_id, :bigint
+    change_column :user_chat_channel_memberships, :chat_channel_id, :bigint
+    change_column :user_chat_channel_memberships, :last_read_message_id, :bigint
+    change_column :user_chat_channel_memberships, :last_unread_mention_when_emailed_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/spec/plugin_helper.rb
+++ b/plugins/chat/spec/plugin_helper.rb
@@ -153,24 +153,4 @@ RSpec.configure do |config|
     # Or a very large value, if you do want to truncate at some point
     c.max_formatted_output_length = nil
   end
-
-  config.before(:suite) do
-    migrate_column_to_bigint(Chat::Channel, :chatable_id)
-    migrate_column_to_bigint(Chat::ChannelArchive, :chat_channel_id)
-    migrate_column_to_bigint(Chat::DirectMessageUser, :direct_message_channel_id)
-    migrate_column_to_bigint(Chat::Draft, :chat_channel_id)
-    migrate_column_to_bigint(Chat::IncomingWebhook, :chat_channel_id)
-    migrate_column_to_bigint(Chat::Mention, :chat_message_id)
-    migrate_column_to_bigint(Chat::MentionNotification, :chat_mention_id)
-    migrate_column_to_bigint(Chat::MentionNotification, :notification_id)
-    migrate_column_to_bigint(Chat::Message, :chat_channel_id)
-    migrate_column_to_bigint(Chat::Message, :in_reply_to_id)
-    migrate_column_to_bigint(Chat::MessageReaction, :chat_message_id)
-    migrate_column_to_bigint(Chat::MessageRevision, :chat_message_id)
-    migrate_column_to_bigint(Chat::UserChatChannelMembership, :chat_channel_id)
-    migrate_column_to_bigint(Chat::UserChatChannelMembership, :last_read_message_id)
-    migrate_column_to_bigint(Chat::UserChatChannelMembership, :last_unread_mention_when_emailed_id)
-    migrate_column_to_bigint(Chat::WebhookEvent, :chat_message_id)
-    migrate_column_to_bigint(Chat::WebhookEvent, :incoming_chat_webhook_id)
-  end
 end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.

This was using a temporary plugin / test API to make tests pass. After more careful consideration, we concluded that it is safe to alter the tables directly.

Even for larger communities, with more than 1M chat messages, the slowest `ALTER` query runs in about 15 seconds, which well under the 30 seconds query timeout limit. As a result, chat messages will be delayed for a few seconds, but the system will remain operational.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->