### PR TITLE
DEV: Configure glint hbs checking

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -120,13 +120,13 @@
   ],
   "exclude": [
     "app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js",
-    "app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs",
+    "app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs"
   ],
   "glint": {
     "environment": [
       "ember-loose",
       "ember-template-imports"
-    ]
+    ],
     "checkStandaloneTemplates": false
   }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -119,7 +119,6 @@
     "./plugins/styleguide/test/javascripts"
   ],
   "exclude": [
-    "**/*.hbs",
     "app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js",
     "app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs",
   ],
@@ -128,5 +127,6 @@
       "ember-loose",
       "ember-template-imports"
     ]
+    "checkStandaloneTemplates": false
   }
 }

--- a/script/build_jsconfig.rb
+++ b/script/build_jsconfig.rb
@@ -40,12 +40,12 @@ def write_config(package_dir, extras: {})
     },
     "include" => namespaces.flat_map { |ns, paths| paths.map { |p| relative(package_dir, p) } },
     "exclude" => [
-      "**/*.hbs",
       "app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js", # Native class decorators - unsupported by ts/glint
       "app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs", # hbs`` tagged templates - https://github.com/typed-ember/glint/issues/705
     ],
     "glint" => {
       "environment" => %w[ember-loose ember-template-imports],
+      "checkStandaloneTemplates" => false,
     },
   }
 


### PR DESCRIPTION
Check *.hbs, but skip 'standalone' template. This gives us working glint in colocated templates, without a ton of errors from the standalone templates which Glint can't map to the relevant component/controller

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->