### PR TITLE
UX: Fix No button on review queue on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/reviewables.scss
+++ b/app/assets/stylesheets/mobile/reviewables.scss
@@ -82,11 +82,15 @@
 
 .reviewable-actions {
   margin-right: -0.5em;
+  margin-bottom: 0.5em;
 
   > div,
   > button {
     margin-right: 0.25em;
-    margin-bottom: 0.5em;
+  }
+
+  .btn.reviewable-action {
+    margin-bottom: 0;
   }
 
   .reviewable-action,


### PR DESCRIPTION
The "No" button for flagged posts was a different
size on mobile

Before:

![image](https://github.com/user-attachments/assets/15a653c3-f357-4932-9af3-b228675d98e8)

After:

![image](https://github.com/user-attachments/assets/ca0d030d-1658-4544-8f5f-c73911aa49f6)
