### PR TITLE
FEATURE: Add 'Community title' field to about config page

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-cards/about/general-settings.gjs
@@ -23,6 +23,7 @@ export default class AdminConfigAreasAboutGeneralSettings extends Component {
       summary: this.args.generalSettings.siteDescription.value,
       extendedDescription:
         this.args.generalSettings.extendedSiteDescription.value,
+      communityTitle: this.args.generalSettings.communityTitle.value,
       aboutBannerImage: this.args.generalSettings.aboutBannerImage.value,
     };
   }
@@ -38,6 +39,7 @@ export default class AdminConfigAreasAboutGeneralSettings extends Component {
             name: data.name,
             summary: data.summary,
             extended_description: data.extendedDescription,
+            community_title: data.communityTitle,
             about_banner_image: data.aboutBannerImage,
           },
         },
@@ -93,6 +95,16 @@ export default class AdminConfigAreasAboutGeneralSettings extends Component {
         as |field|
       >
         <field.Composer />
+      </form.Field>
+
+      <form.Field
+        @name="communityTitle"
+        @title={{i18n "admin.config_areas.about.community_title"}}
+        @description={{i18n "admin.config_areas.about.community_title_help"}}
+        @format="large"
+        as |field|
+      >
+        <field.Input />
       </form.Field>
 
       <form.Field

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
@@ -16,6 +16,7 @@ export default class AdminConfigAreasAbout extends Component {
       extendedSiteDescription: this.#lookupSettingFromData(
         "extended_site_description"
       ),
+      communityTitle: this.#lookupSettingFromData("short_site_description"),
       aboutBannerImage: this.#lookupSettingFromData("about_banner_image"),
     };
   }

--- a/app/assets/javascripts/admin/addon/routes/admin-config-about.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-about.js
@@ -9,6 +9,7 @@ export default class AdminConfigAboutRoute extends Route {
           "title",
           "site_description",
           "extended_site_description",
+          "short_site_description",
           "about_banner_image",
           "community_owner",
           "contact_email",

--- a/app/controllers/admin/config/about_controller.rb
+++ b/app/controllers/admin/config/about_controller.rb
@@ -12,6 +12,7 @@ class Admin::Config::AboutController < Admin::AdminController
       settings_map[:about_banner_image] = general_settings[:about_banner_image]
 
       settings_map[:extended_site_description] = general_settings[:extended_description]
+      settings_map[:short_site_description] = general_settings[:community_title]
       if settings_map[:extended_site_description].present?
         settings_map[:extended_site_description_cooked] = PrettyText.markdown(
           settings_map[:extended_site_description],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5619,6 +5619,8 @@ en:
           community_name_placeholder: "Example Community"
           community_summary: "Community summary"
           community_description: "Community description"
+          community_title: "Community title"
+          community_title_help: "Short description, shown in the browser tab, for key pages such as categories and topic lists."
           banner_image: "Banner image"
           banner_image_help: |
             This will be used on your About page. Recommended size: 1100x300px. Accepted types: JPG, PNG, and SVG up to 10MB.

--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -14,6 +14,7 @@ describe "Admin About Config Area Page", type: :system do
       SiteSetting.site_description = "this is a description for my forums"
       SiteSetting.about_banner_image = image_upload
       SiteSetting.extended_site_description = "this is an extended description for my forums"
+      SiteSetting.short_site_description = "short description for browser tab"
 
       SiteSetting.community_owner = "kitty"
       SiteSetting.contact_email = "kitty@litterbox.com"
@@ -37,6 +38,9 @@ describe "Admin About Config Area Page", type: :system do
       )
       expect(config_area.general_settings_section.community_description_editor.value).to eq(
         "this is an extended description for my forums",
+      )
+      expect(config_area.general_settings_section.community_title_input.value).to eq(
+        "short description for browser tab",
       )
       expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
@@ -78,6 +82,9 @@ describe "Admin About Config Area Page", type: :system do
       config_area.general_settings_section.community_description_editor.fill_in(
         "here's an extended description for the **community**",
       )
+      config_area.general_settings_section.community_title_input.fill_in(
+        "here's a title for my site",
+      )
       config_area.general_settings_section.banner_image_uploader.select_image(image_file.path)
       expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
@@ -93,6 +100,7 @@ describe "Admin About Config Area Page", type: :system do
       expect(SiteSetting.extended_site_description_cooked).to eq(
         "<p>here’s an extended description for the <strong>community</strong></p>",
       )
+      expect(SiteSetting.short_site_description).to eq("here's a title for my site")
       expect(SiteSetting.about_banner_image.sha1).to eq(Upload.generate_digest(image_file))
     end
 

--- a/spec/system/page_objects/components/admin_about_config_area_general_settings_card.rb
+++ b/spec/system/page_objects/components/admin_about_config_area_general_settings_card.rb
@@ -15,6 +15,10 @@ module PageObjects
         form.field("extendedDescription")
       end
 
+      def community_title_input
+        form.field("communityTitle")
+      end
+
       def banner_image_uploader
         PageObjects::Components::UppyImageUploader.new(card.find(".image-uploader"))
       end


### PR DESCRIPTION
This PR adds a new "Community title" field to the about config page. This field controls the `short_site_description` setting, which is shown in the browser tab for key pages such categories pages and topic lists.

Screenshot:

<img src="https://github.com/user-attachments/assets/5df7ed30-8615-4130-a925-756711e3442d" width=500>

Internal topic: t/140812.