### PR TITLE
FIX: Blank "Legacy Pageviews" report showed no data

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -311,7 +311,7 @@ class Report
         # This is a separate report because if people have switched over
         # to _not_ use legacy pageviews, we want to show both a Pageviews
         # and Legacy Pageviews report.
-      elsif filter == :page_view_legacy_total_reqs
+      elsif filter == :page_view_legacy_total
         legacy_page_view_requests
       else
         ApplicationRequest.where(req_type: ApplicationRequest.req_types[filter])


### PR DESCRIPTION
Followup bd4e8422fe46f5eff63fdc073f480ec948b0e1f8

In the previous commit, we introduced the `page_view_legacy_total_reqs`
report. However this was not tested properly, and due to a typo
the report returned no data.

This commit fixes the issue and adds a spec to catch this.
