### PR TITLE
FIX: Allow `target` attribute in translation overrides

### DIFF
--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -69,7 +69,7 @@ class TranslationOverride < ActiveRecord::Base
 
     translation_override = find_or_initialize_by(params)
     sanitized_value =
-      translation_override.sanitize_field(value, additional_attributes: ["data-auto-route"])
+      translation_override.sanitize_field(value, additional_attributes: %w[data-auto-route target])
     original_translation =
       I18n.overrides_disabled { I18n.t(transform_pluralized_key(key), locale: :en) }
 

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -186,14 +186,14 @@ RSpec.describe TranslationOverride do
   end
 
   it "sanitizes values before upsert" do
-    xss = "<a target='blank' href='%{path}'>Click here</a> <script>alert('TEST');</script>"
+    xss = "<a target='_blank' href='%{path}'>Click here</a> <script>alert('TEST');</script>"
 
     TranslationOverride.upsert!("en", "js.themes.error_caused_by", xss)
 
     ovr =
       TranslationOverride.where(locale: "en", translation_key: "js.themes.error_caused_by").first
     expect(ovr).to be_present
-    expect(ovr.value).to eq("<a href=\"%{path}\">Click here</a> alert('TEST');")
+    expect(ovr.value).to eq("<a target=\"_blank\" href=\"%{path}\">Click here</a> alert('TEST');")
   end
 
   describe "site cache" do


### PR DESCRIPTION
Some of our translations are HTML and have `target='_blank'`
included, we should allow the same when sanitizing input for
translation overrides.
