### PR TITLE
UX: Use correct case for "Add Flag" button

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5668,7 +5668,7 @@ en:
           subheader: "The flagging system in Discourse helps you and your moderator team manage content and user behavior, keeping your community respectful and healthy. The defaults are suitable for most communities and you don’t have to change them. However, if your site has particular requirements you can disable flags you don’t need and add your own custom flags."
           description: "Description"
           enabled: "Enabled?"
-          add: "Add Flag"
+          add: "Add flag"
           edit: "Edit"
           back: "Back to flags"
           delete: "Delete"


### PR DESCRIPTION
Per https://meta.discourse.org/t/formatting-text-in-discourse-documentation-and-uis/324637

![image](https://github.com/user-attachments/assets/4dda7ee4-e3df-4eb3-a4d9-56059d496d6f)
