### PR TITLE
DEV: allow non focused tab to be primary tab in service worker

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -132,9 +132,11 @@ self.addEventListener('message', function(event) {
 
   event.waitUntil(
     self.clients.matchAll().then(function(clients) {
+      const activeClient = clients.find(client => client.focused) || clients.find(client => client.visibilityState === "visible");
+
       clients.forEach(function(client) {
         client.postMessage({
-          primaryTab: client.focused
+          primaryTab: client.id === activeClient?.id
         });
       });
     })


### PR DESCRIPTION
Follow up to #29388 - when there are no clients in focus, we should take the first visible client as the primary tab.

Example with chat desktop sounds:

You have 2 Discourse tabs open, but then switch to another app (ie. <kbd>cmd</kbd> + <kbd>tab</kbd>). Now the Discourse tab is still visible but not in focus, therefore if a chat message is received it won't play the sound despite being recently active.

With this change the user can switch between apps and we still attempt to play the sound in the visible tab, even when the browser is not in focus.
