### PR TITLE
FIX: duplicate topics in digests / summaries

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2341,26 +2341,38 @@ RSpec.describe Topic do
         expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
       end
 
-      it "doesn't return topics from suppressed tags" do
-        category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)
-        topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
-        topic2 = Fabricate(:topic, category: category, created_at: 1.minute.ago)
-        tag = Fabricate(:tag)
-        tag2 = Fabricate(:tag)
-        Fabricate(:topic_tag, topic: topic, tag: tag)
+      it "doesn't return topics with a suppressed tag" do
+        topic_with_tags = Fabricate(:topic, created_at: 1.minute.ago)
+        topic_without_tags = Fabricate(:topic, created_at: 1.minute.ago)
+        topic_with_other_tags = Fabricate(:topic, created_at: 1.minute.ago)
 
-        SiteSetting.digest_suppress_tags = "#{tag.name}|#{tag2.name}"
+        tag_1 = Fabricate(:tag)
+        tag_2 = Fabricate(:tag)
+        tag_3 = Fabricate(:tag)
+
+        Fabricate(:topic_tag, topic: topic_with_tags, tag: tag_1)
+        Fabricate(:topic_tag, topic: topic_with_tags, tag: tag_2)
+
+        Fabricate(:topic_tag, topic: topic_with_other_tags, tag: tag_2)
+        Fabricate(:topic_tag, topic: topic_with_other_tags, tag: tag_3)
+
+        SiteSetting.digest_suppress_tags = "#{tag_1.name}"
+
         topics = Topic.for_digest(user, 1.year.ago, top_order: true)
-        expect(topics).to eq([topic2])
+
+        expect(topics).to contain_exactly(topic_without_tags, topic_with_other_tags)
 
         Fabricate(
           :topic_user,
           user: user,
-          topic: topic,
+          topic: topic_with_tags,
           notification_level: TopicUser.notification_levels[:regular],
         )
 
-        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to eq([topic2])
+        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to contain_exactly(
+          topic_without_tags,
+          topic_with_other_tags,
+        )
       end
 
       it "doesn't return topics from TL0 users" do


### PR DESCRIPTION
When using the `digest_suppress_tags` site setting to list some tags that should be removed from the digests, if there was a topic that had one suppressed tag and other regular tag(s), it would be duplicated in the summaries.

https://meta.discourse.org/t/multiple-repeated-summary-mail-entries/296539

Thanks to @scossar for [figuring it out](https://meta.discourse.org/t/multiple-repeated-summary-mail-entries/296539/30).

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->