### PR TITLE
DEV: Hide experimental lightbox setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2438,6 +2438,7 @@ developer:
   enable_experimental_lightbox:
     default: false
     client: true
+    hidden: true
   experimental_topics_filter:
     client: true
     default: false


### PR DESCRIPTION
This setting is not ready for use, we should hide it from the UI.
