### PR TITLE
REVERT:  "A11Y: topic list links should not be headings (#27700)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
@@ -13,6 +13,8 @@ export default class TopicLink extends Component {
     <a
       href={{this.url}}
       data-topic-id={{@topic.id}}
+      role="heading"
+      aria-level="2"
       class="title"
       ...attributes
     >{{htmlSafe @topic.fancyTitle}}</a>

--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -17,6 +17,8 @@ export default function topicLink(topic, args = {}) {
 
   return htmlSafe(
     `<a href='${url}'
+        role='heading'
+        aria-level='2'
         class='${classes.join(" ")}'
         data-topic-id='${topic.id}'>${title}</a>`
   );


### PR DESCRIPTION
This reverts commit 72a53894592cf07bb206a949f703193a486b654c.

Despite advice from a customer's accessibility team, we've had a couple users mention that labeling these as headings is actually helpful. 

https://meta.discourse.org/t/a11y-topic-lists-do-not-have-headings-for-each-topic/332050

Maybe this can be an optional feature at some point, but until we have better accessibility controls and options this seems like the best path to take. 