### PR TITLE
FIX: Account for sidebars with no primary links when adding invite link

### DIFF
--- a/db/migrate/20241025045928_add_invites_link_to_sidebar.rb
+++ b/db/migrate/20241025045928_add_invites_link_to_sidebar.rb
@@ -19,6 +19,15 @@ class AddInvitesLinkToSidebar < ActiveRecord::Migration[7.1]
          AND su.segment = 0
     SQL
 
+    max_position ||= (DB.query_single(<<~SQL, section_id: community_section_id).first || 0) - 1
+      SELECT MIN(ssl.position)
+        FROM sidebar_urls su
+             JOIN sidebar_section_links ssl ON su.id = ssl.linkable_id
+       WHERE ssl.linkable_type = 'SidebarUrl'
+         AND ssl.sidebar_section_id = :section_id
+         AND su.segment = 1
+    SQL
+
     updated_rows = DB.query_hash(<<~SQL, position: max_position, section_id: community_section_id)
       DELETE FROM sidebar_section_links
        WHERE position > :position


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/stumped-about-launcher-rebuild-app-error-process-pid-2096/333876?u=osama.

Follow up to https://github.com/discourse/discourse/pull/29448.

The migration that adds the invite link to the sidebar determines the position of the link by looking up the max position that a primary link has and inserts the invite link at the max position plus 1. This approach works fine for most sites, however, sites that have deleted all primary links from the sidebar will fail because the max position will be `nil` which blows up the migration.

This PR addresses this edge case by falling back to looking up the min position of secondary links,    or to zero if there're also no secondary links, and then inserts the invite link at the min position minus 1.