### PR TITLE
DEV: Added value transformers that mutate the value instead of returning it

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transformer.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer.js
@@ -337,10 +337,10 @@ export function applyValueTransformer(
 
     try {
       const value = valueCallback({ value: newValue, context });
-      if (DEBUG && mutable && typeof value !== "undefined") {
+      if (mutable && typeof value !== "undefined") {
         // eslint-disable-next-line no-console
-        console.warn(
-          `${prefix}: transformer "${transformerName}" expects the value to be mutated instead of returned.`
+        throw new Error(
+          `${prefix}: transformer "${transformerName}" expects the value to be mutated instead of returned.\nRemove the return value in your transformer.`
         );
       }
 

--- a/app/assets/javascripts/discourse/app/lib/transformer.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer.js
@@ -340,7 +340,7 @@ export function applyValueTransformer(
       if (mutable && typeof value !== "undefined") {
         // eslint-disable-next-line no-console
         throw new Error(
-          `${prefix}: transformer "${transformerName}" expects the value to be mutated instead of returned.\nRemove the return value in your transformer.`
+          `${prefix}: transformer "${transformerName}" expects the value to be mutated instead of returned. Remove the return value in your transformer.`
         );
       }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/transformer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/transformer-test.js
@@ -7,6 +7,7 @@ import {
   acceptNewTransformerNames,
   acceptTransformerRegistrations,
   applyBehaviorTransformer,
+  applyMutableValueTransformer,
   applyValueTransformer,
   disableThrowingApplyExceptionOnTests,
   transformerTypes,
@@ -292,6 +293,7 @@ module("Unit | Utility | transformers", function (hooks) {
       );
 
       class Testable {}
+
       assert.throws(
         () =>
           applyValueTransformer(
@@ -496,6 +498,60 @@ module("Unit | Utility | transformers", function (hooks) {
         testObject.sequence.join(""),
         "correct",
         `the transformers applied in the expected sequence will produce the word "correct"`
+      );
+    });
+  });
+
+  module("applyMutableValueTransformer", function (innerHooks) {
+    innerHooks.beforeEach(function () {
+      this.consoleWarnStub = sinon.stub(console, "warn");
+      acceptNewTransformerNames();
+      withPluginApi("1.34.0", (api) => {
+        api.addValueTransformerName("test-mutable-transformer");
+      });
+      acceptTransformerRegistrations();
+    });
+
+    innerHooks.afterEach(function () {
+      this.consoleWarnStub.restore();
+    });
+
+    test("mutates the value as expected", function (assert) {
+      withPluginApi("1.34.0", (api) => {
+        api.registerValueTransformer(
+          "test-mutable-transformer",
+          ({ value }) => {
+            value.mutate();
+          }
+        );
+      });
+
+      let mutated = false;
+      const value = {
+        mutate() {
+          mutated = true;
+        },
+      };
+
+      applyMutableValueTransformer("test-mutable-transformer", value);
+      assert.strictEqual(mutated, true, "the value was mutated");
+    });
+
+    test("logs a warning if the transformer returns a value different from undefined", function (assert) {
+      withPluginApi("1.34.0", (api) => {
+        api.registerValueTransformer(
+          "test-mutable-transformer",
+          () => "unexpected value"
+        );
+      });
+
+      applyMutableValueTransformer("test-mutable-transformer", "default value");
+
+      assert.ok(
+        this.consoleWarnStub.calledWith(
+          sinon.match(/expects the value to be mutated instead of returned/)
+        ),
+        "logs warning to the console when the transformer returns a value different from undefined"
       );
     });
   });
@@ -816,6 +872,7 @@ module("Unit | Utility | transformers", function (hooks) {
       );
 
       class Testable {}
+
       assert.throws(
         () =>
           applyBehaviorTransformer(


### PR DESCRIPTION
This PR introduces a new method to apply value transformers, which mutate the value instead of returning it.

This is useful when we need to apply a transformer over an object that has internal state that is mutated using methods.

Using the new `applyMutableValueTranformer` it is not necessary that the registered transformers return the value at the end of the transformer in order for the transformer chain to be processed.

This improves the readability of the code of these transformers and prevent subtle bugs on more complex logics with multiple returns.

Example:

- before:

```js
  const transformerRegistered = api.registerValueTransformer(
    "post-menu-buttons",
    ({ value: dag }) => {
      dag.replace(POST_MENU_LIKE_BUTTON_KEY, ReactionsActionButton);

      return dag;
    }
  );
```

- after:

```js
  const transformerRegistered = api.registerValueTransformer(
    "post-menu-buttons",
    ({ value: dag }) => {
      dag.replace(POST_MENU_LIKE_BUTTON_KEY, ReactionsActionButton);
    }
  );
```