### PR TITLE
FEATURE: Adds personal messages to SMF2 importer

### DIFF
--- a/script/import_scripts/smf2.rb
+++ b/script/import_scripts/smf2.rb
@@ -11,7 +11,7 @@ require "etc"
 require "open3"
 
 class ImportScripts::Smf2 < ImportScripts::Base
-  BATCH_SIZE ||= 5000
+  BATCH_SIZE = 5000
 
   def self.run
     options = Options.new


### PR DESCRIPTION
This commits ports the personal messages conversion step from `smf1.rb` into `smf2.rb`.
No tests are included (but I can't see tests for the original importer either) but a manual test with ~600k personal messages worked flawlessly with reasonably adequate throughput (around 1500 records per minute on my machine).

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->