### PR TITLE
UI: hides channel with visible panel on narrow screen

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-channel.scss
@@ -1,0 +1,16 @@
+@media screen and (max-width: 1000px) {
+  .main-chat-outlet.has-side-panel-expanded {
+    .c-routes.--channel {
+      display: none;
+    }
+
+    .chat-side-panel {
+      width: 100% !important; // overrides the inline auto width
+      border: none;
+
+      .chat-side-panel-resizer {
+        display: none;
+      }
+    }
+  }
+}

--- a/plugins/chat/assets/stylesheets/desktop/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-channel.scss
@@ -1,4 +1,4 @@
-@media screen and (max-width: 1000px) {
+@include breakpoint(large) {
   .main-chat-outlet.has-side-panel-expanded {
     .c-routes.--channel {
       display: none;

--- a/plugins/chat/assets/stylesheets/desktop/index.scss
+++ b/plugins/chat/assets/stylesheets/desktop/index.scss
@@ -3,6 +3,7 @@
 @import "chat-composer-uploads";
 @import "chat-index-drawer";
 @import "chat-index-full-page";
+@import "chat-channel";
 @import "chat-message-actions";
 @import "chat-message";
 @import "chat-channel-info";


### PR DESCRIPTION
This commit will hide the channel when the side panel is present and the width of the viewport is less than 1000px. This is especially useful when you want to focus reading a thread on a small screen.

This change only impacts desktops.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->