### PR TITLE
FIX: Virtual keyboard for fullpage login/signup

### DIFF
--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -7,6 +7,11 @@ html.keyboard-visible.mobile-view
   overflow-y: scroll;
   overflow-x: hidden;
   padding-top: 0;
+  .login-fullpage,
+  .signup-fullpage,
+  .invites-show {
+    padding-top: var(--header-offset);
+  }
 }
 
 .login-fullpage,

--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -1,26 +1,24 @@
 // Shared styles
 
-html.keyboard-visible.mobile-view {
-  body.login-page,
-  body.signup-page,
-  body.invite-page {
-    height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
-    max-height: calc(00dvh - var(--header-offset) - env(keyboard-inset-height));
-    overflow-y: scroll;
-    overflow-x: hidden;
-    padding-top: 0;
-
-    .login-fullpage,
-    .signup-fullpage,
-    .invites-show {
-      padding-top: var(--header-offset);
-    }
+.login-page,
+.signup-page,
+.invite-page {
+  #main-outlet,
+  #main-outlet-wrapper {
+    padding: 0;
   }
 }
 
 .login-fullpage,
 .signup-fullpage,
 .invites-show {
+  justify-content: flex-start;
+
+  html.keyboard-visible:not(.ios-device) & {
+    height: calc((var(--composer-vh, 1vh) * 100) - var(--header-offset));
+    overflow-y: scroll;
+  }
+
   .signup-body,
   .login-body {
     flex-direction: column;
@@ -85,7 +83,6 @@ html.keyboard-visible.mobile-view {
       .user-field.text label.control-label {
         top: 11px;
       }
-
       div.user-field:not(.dropdown)
         .controls
         input:focus
@@ -95,7 +92,6 @@ html.keyboard-visible.mobile-view {
         label.alt-placeholder.control-label {
         top: -10px;
       }
-
       .user-field.dropdown label.control-label,
       .user-field.multiselect label.control-label {
         top: -10px;
@@ -161,7 +157,6 @@ html.keyboard-visible.mobile-view {
   .login-welcome-header {
     padding-inline: 0;
   }
-
   .signup-progress-bar {
     margin-inline: 0;
   }
@@ -177,13 +172,11 @@ html.keyboard-visible.mobile-view {
         margin-bottom: 0.5rem;
       }
     }
-
     &__signup {
       background: none !important;
       font-size: var(--font-up-1);
       padding: 0;
     }
-
     &__no-account-yet {
       font-size: var(--font-up-1);
     }
@@ -200,13 +193,11 @@ html.keyboard-visible.mobile-view {
         margin-bottom: 0.5rem;
       }
     }
-
     &__login {
       background: none !important;
       font-size: var(--font-up-1);
       padding: 0;
     }
-
     &__existing-account {
       font-size: var(--font-up-1);
     }

--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -1,16 +1,20 @@
 // Shared styles
 
-html.keyboard-visible.mobile-view
-  #main-outlet:has(.login-fullpage, .signup-fullpage, .invites-show) {
-  height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
-  max-height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
-  overflow-y: scroll;
-  overflow-x: hidden;
-  padding-top: 0;
-  .login-fullpage,
-  .signup-fullpage,
-  .invites-show {
-    padding-top: var(--header-offset);
+html.keyboard-visible.mobile-view {
+  body.login-page,
+  body.signup-page,
+  body.invite-page {
+    height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
+    max-height: calc(00dvh - var(--header-offset) - env(keyboard-inset-height));
+    overflow-y: scroll;
+    overflow-x: hidden;
+    padding-top: 0;
+
+    .login-fullpage,
+    .signup-fullpage,
+    .invites-show {
+      padding-top: var(--header-offset);
+    }
   }
 }
 
@@ -81,6 +85,7 @@ html.keyboard-visible.mobile-view
       .user-field.text label.control-label {
         top: 11px;
       }
+
       div.user-field:not(.dropdown)
         .controls
         input:focus
@@ -90,6 +95,7 @@ html.keyboard-visible.mobile-view
         label.alt-placeholder.control-label {
         top: -10px;
       }
+
       .user-field.dropdown label.control-label,
       .user-field.multiselect label.control-label {
         top: -10px;
@@ -155,6 +161,7 @@ html.keyboard-visible.mobile-view
   .login-welcome-header {
     padding-inline: 0;
   }
+
   .signup-progress-bar {
     margin-inline: 0;
   }
@@ -170,11 +177,13 @@ html.keyboard-visible.mobile-view
         margin-bottom: 0.5rem;
       }
     }
+
     &__signup {
       background: none !important;
       font-size: var(--font-up-1);
       padding: 0;
     }
+
     &__no-account-yet {
       font-size: var(--font-up-1);
     }
@@ -191,11 +200,13 @@ html.keyboard-visible.mobile-view
         margin-bottom: 0.5rem;
       }
     }
+
     &__login {
       background: none !important;
       font-size: var(--font-up-1);
       padding: 0;
     }
+
     &__existing-account {
       font-size: var(--font-up-1);
     }

--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -1,5 +1,13 @@
 // Shared styles
 
+html.keyboard-visible.mobile-view
+  #main-outlet:has(.login-fullpage, .signup-fullpage, .invites-show) {
+  height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
+  max-height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
+  overflow-y: scroll;
+  padding-top: 0;
+}
+
 .login-fullpage,
 .signup-fullpage,
 .invites-show {

--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -5,6 +5,7 @@ html.keyboard-visible.mobile-view
   height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
   max-height: calc(100dvh - var(--header-offset) - env(keyboard-inset-height));
   overflow-y: scroll;
+  overflow-x: hidden;
   padding-top: 0;
 }
 


### PR DESCRIPTION
This change allows the form to resize when the virtual keyboard is shown on mobile devices.
Otherwise, the keyboard would appear on top of the inputs. I was only able to reproduce the issue on a production site, on Android, in Chromium-based browsers.