### PR TITLE
DEV: Add 'custom' WebHook event type group

### DIFF
--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -35,6 +35,7 @@ class WebHookEventType < ActiveRecord::Base
          user_promoted: 13,
          voting: 14,
          chat: 15,
+         custom: 16,
        },
        _scopes: false
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5494,6 +5494,8 @@ en:
           group_name: "Group User Events"
           user_added_to_group: "A user is added to a group"
           user_removed_from_group: "A user is removed from a group"
+        custom_event:
+          group_name: "Custom Events"
         user_promoted_event:
           group_name: "User Promoted Events"
           user_promoted: "A user is promoted"


### PR DESCRIPTION
This group will not show up unless a plugin registers a WebHookEventType under the `:custom` group, so this is an invisible change.