### PR TITLE
FIX: allow anon users to download calendar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/download-calendar.hbs
@@ -31,13 +31,15 @@
       </div>
     </div>
 
-    <div class="control-group remember">
-      <label class="checkbox-label">
-        <Input @type="checkbox" @checked={{this.remember}} />
-        <span>{{i18n "download_calendar.remember"}}</span>
-      </label>
-      <span>{{i18n "download_calendar.remember_explanation"}}</span>
-    </div>
+    {{#if this.currentUser}}
+      <div class="control-group remember">
+        <label class="checkbox-label">
+          <Input @type="checkbox" @checked={{this.remember}} />
+          <span>{{i18n "download_calendar.remember"}}</span>
+        </label>
+        <span>{{i18n "download_calendar.remember_explanation"}}</span>
+      </div>
+    {{/if}}
   </:body>
   <:footer>
     <DButton

--- a/app/assets/javascripts/discourse/app/lib/download-calendar.js
+++ b/app/assets/javascripts/discourse/app/lib/download-calendar.js
@@ -9,16 +9,16 @@ export function downloadCalendar(title, dates, options = {}) {
   const formattedDates = formatDates(dates);
   title = title.trim();
 
-  switch (currentUser.user_option.default_calendar) {
-    case "none_selected":
-      _displayModal(title, formattedDates, options);
-      break;
+  switch (currentUser?.user_option.default_calendar) {
     case "ics":
       downloadIcs(title, formattedDates, options);
       break;
     case "google":
       downloadGoogle(title, formattedDates, options);
       break;
+    case "none_selected":
+    default:
+      _displayModal(title, formattedDates, options);
   }
 }
 

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js
@@ -33,6 +33,40 @@ acceptance(
           I18n.t("download_calendar.title"),
           "it should display modal to select calendar"
         );
+
+      assert.dom(".control-group.remember").exists();
+    });
+  }
+);
+
+acceptance(
+  "Local Dates - Download calendar as an anonymous user",
+  function (needs) {
+    needs.settings({ discourse_local_dates_enabled: true });
+    needs.pretender((server, helper) => {
+      const response = cloneJSON(fixturesByUrl["/t/281.json"]);
+      const startDate = moment
+        .tz("America/Lima")
+        .add(1, "days")
+        .format("YYYY-MM-DD");
+      response.post_stream.posts[0].cooked = `<p><span data-date=\"${startDate}\" data-time=\"13:00:00\" class=\"discourse-local-date\" data-timezone=\"America/Lima\" data-email-preview=\"${startDate}T18:00:00Z UTC\">${startDate}T18:00:00Z</span></p>`;
+
+      server.get("/t/281.json", () => helper.response(response));
+    });
+
+    test("Display pick calendar modal", async function (assert) {
+      await visit("/t/local-dates/281");
+      await click(".discourse-local-date");
+      await click(".download-calendar");
+
+      assert
+        .dom("#discourse-modal-title")
+        .hasText(
+          I18n.t("download_calendar.title"),
+          "it should display modal to select calendar"
+        );
+
+      assert.dom(".control-group.remember").doesNotExist();
     });
   }
 );


### PR DESCRIPTION
Allows anonymous users to download the calendar file. Before, they were given the option, but it would fail silently with a `TypeError: Cannot read properties of null (reading 'user_option')`.