### PR TITLE
DEV: adds is-disabled modifier to form field container

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
@@ -44,6 +44,7 @@ export default class FKControlWrapper extends Component {
         "form-kit__field"
         (concat "form-kit__field-" this.controlType)
         (if this.error "has-error")
+        (if @field.disabled "is-disabled")
         (if (eq @format "full") "--full")
       }}
       data-disabled={{@field.disabled}}

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -35,6 +35,20 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     assert.dom(".form-kit__row .form-kit__col.--col-8").hasText("Test");
   });
 
+  test("@disabled", async function (assert) {
+    await render(<template>
+      <Form as |form|>
+        <form.Field @name="foo" @title="Foo" @disabled={{true}} as |field|>
+          <field.Input />
+        </form.Field>
+      </Form>
+    </template>);
+
+    assert
+      .dom("#control-foo.is-disabled[data-disabled]")
+      .exists("it sets the disabled class and data attribute");
+  });
+
   test("@description", async function (assert) {
     await render(<template>
       <Form as |form|>


### PR DESCRIPTION
We already had a data-attribute, but a class feels more natural in this case.