### PR TITLE
UX: align PM icon when editing title, allow shrink-to-fit

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -324,10 +324,11 @@
   #topic-title {
     .edit-topic-title {
       position: relative;
+      min-width: 0;
       .private-message-glyph {
         position: absolute;
         left: 0.75em;
-        top: 7px;
+        top: 0.7em;
       }
       #edit-title {
         width: calc(100% - 50px);


### PR DESCRIPTION
This fixes the icon alignment, and shrinks the input to avoid overflow on narrow screens 

Before:
![image](https://github.com/user-attachments/assets/c547b5f0-4cdc-402b-b6d8-7129217bf826)

After: 
![image](https://github.com/user-attachments/assets/0b10503a-5fb4-491f-ba00-b7b87dee507d)

