### PR TITLE
UX: remove extra margin from PM small actions

### DIFF
--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -60,10 +60,6 @@
     padding-right: var(--topic-body-width-padding);
   }
 
-  .small-action {
-    margin: 1em 0 0;
-  }
-
   .post-notice {
     box-sizing: border-box;
     border-radius: var(--pm-border-radius);


### PR DESCRIPTION
This margin no longer appears necessary... 


before:
![image](https://github.com/user-attachments/assets/75452530-6cfa-49c9-9492-72577c0acd58)


after: 
![image](https://github.com/user-attachments/assets/1c4a1643-bcd1-447b-b6a8-91e52e2e1377)
