### PR TITLE
DEV: Auto grid images no longer experimental

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -352,10 +352,7 @@ export default class UppyComposerUpload {
         });
 
         const MIN_IMAGES_TO_AUTO_GRID = 3;
-        if (
-          this.siteSettings.experimental_auto_grid_images &&
-          this.#consecutiveImages?.length >= MIN_IMAGES_TO_AUTO_GRID
-        ) {
+        if (this.#consecutiveImages?.length >= MIN_IMAGES_TO_AUTO_GRID) {
           this.#autoGridImages();
         }
       });

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2728,7 +2728,6 @@ en:
     experimental_form_templates: "EXPERIMENTAL: Enable the form templates feature. <b>After enabled,</b> manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     admin_sidebar_enabled_groups: "Enable sidebar navigation for the admin UI for the specified groups, which replaces the top-level admin navigation buttons."
     lazy_load_categories_groups: "EXPERIMENTAL: Lazy load category information only for users of these groups. This improves performance on sites with many categories."
-    experimental_auto_grid_images: "EXPERIMENTAL: Automatically wraps images in [grid] tags when 3 or more images are uploaded in the composer."
 
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2471,9 +2471,6 @@ developer:
     default: 50
     hidden: true
     client: true
-  experimental_auto_grid_images:
-    default: false
-    client: true
 
 navigation:
   navigation_menu:

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -160,8 +160,6 @@ describe "Uploading files in the composer", type: :system do
   end
 
   context "when multiple images are uploaded" do
-    before { SiteSetting.experimental_auto_grid_images = true }
-
     it "automatically wraps images in [grid] tags on 3 or more images" do
       visit "/new-topic"
       expect(composer).to be_opened
@@ -227,8 +225,6 @@ describe "Uploading files in the composer", type: :system do
     end
 
     it "does not automatically wrap images in [grid] tags when setting is disabled" do
-      SiteSetting.experimental_auto_grid_images = false
-
       visit "/new-topic"
       expect(composer).to be_opened
 


### PR DESCRIPTION
Recently we added a new feature for automatically gridding images in the composer (https://github.com/discourse/discourse/pull/29260). After testing this feature under a setting for a short period of time, the feature is no longer experimental anymore.

This PR removes the site setting `experimental_auto_grid_images`.