### PR TITLE
DEV: Combine S3 system spec helpers into one

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -127,7 +127,9 @@ module SystemHelpers
     page.execute_script(js, selector, start, offset)
   end
 
-  def setup_s3_system_test(enable_secure_uploads: false, enable_direct_s3_uploads: true)
+  def setup_or_skip_s3_system_test(enable_secure_uploads: false, enable_direct_s3_uploads: true)
+    skip_unless_s3_system_specs_enabled!
+
     SiteSetting.enable_s3_uploads = true
 
     SiteSetting.s3_upload_bucket = "discoursetest"

--- a/spec/system/s3_secure_uploads_spec.rb
+++ b/spec/system/s3_secure_uploads_spec.rb
@@ -23,9 +23,7 @@ describe "Uploading files in the composer to S3", type: :system do
     end
 
     it "marks uploads inside of private message posts as secure" do
-      skip_unless_s3_system_specs_enabled!
-
-      setup_s3_system_test(enable_secure_uploads: true)
+      setup_or_skip_s3_system_test(enable_secure_uploads: true)
       sign_in(current_user)
 
       topic_page.open_new_message
@@ -45,10 +43,8 @@ describe "Uploading files in the composer to S3", type: :system do
     end
 
     it "marks uploads inside of private category posts as secure" do
-      skip_unless_s3_system_specs_enabled!
-
       private_category = Fabricate(:private_category, group: Fabricate(:group))
-      setup_s3_system_test(enable_secure_uploads: true)
+      setup_or_skip_s3_system_test(enable_secure_uploads: true)
       sign_in(current_user)
 
       topic_page.open_new_topic
@@ -68,10 +64,8 @@ describe "Uploading files in the composer to S3", type: :system do
     end
 
     it "marks uploads for all posts as secure when login_required" do
-      skip_unless_s3_system_specs_enabled!
-
       SiteSetting.login_required = true
-      setup_s3_system_test(enable_secure_uploads: true)
+      setup_or_skip_s3_system_test(enable_secure_uploads: true)
       sign_in(current_user)
 
       topic_page.open_new_topic
@@ -90,9 +84,7 @@ describe "Uploading files in the composer to S3", type: :system do
     end
 
     it "doesn't mark uploads for public posts as secure" do
-      skip_unless_s3_system_specs_enabled!
-
-      setup_s3_system_test(enable_secure_uploads: true)
+      setup_or_skip_s3_system_test(enable_secure_uploads: true)
       sign_in(current_user)
 
       topic_page.open_new_topic

--- a/spec/system/s3_uploads_spec.rb
+++ b/spec/system/s3_uploads_spec.rb
@@ -10,9 +10,7 @@ describe "Uploading files in the composer to S3", type: :system do
   describe "direct S3 uploads" do
     describe "single part uploads" do
       it "uploads custom avatars to S3" do
-        skip_unless_s3_system_specs_enabled!
-
-        setup_s3_system_test
+        setup_or_skip_s3_system_test
         sign_in(current_user)
 
         visit "/my/preferences/account"
@@ -37,9 +35,7 @@ describe "Uploading files in the composer to S3", type: :system do
 
     describe "multipart uploads" do
       it "uploads a file in the post composer" do
-        skip_unless_s3_system_specs_enabled!
-
-        setup_s3_system_test
+        setup_or_skip_s3_system_test
         sign_in(current_user)
 
         topic.open_new_topic


### PR DESCRIPTION
It's annoying to have to do both of these every
time you write an S3 system spec, let's just do them
in one call instead.
