### PR TITLE
FIX: Use correct styles on category pages

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -83,7 +83,7 @@ export default class CategoriesDisplay extends Component {
   get categoriesComponent() {
     if (
       this.args.parentCategory &&
-      this.router.currentRouteName === "discovery.category"
+      this.router.currentRouteName !== "discovery.subcategories"
     ) {
       return this.#componentForSubcategories;
     } else {


### PR DESCRIPTION
Multiple category styles can be used on the same site. The category and subcategories page will use the "desktop_category_page_style" setting and individual category pages will use the style selected in settings, if any.

Commit c1f078ca tried to use the same style for both the category and subcategories page, but the route matching did not take into account the "discovery.categoryAll" and "discovery.categoryNone" variants of the "discovery.category" route.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->