### PR TITLE
DEV: Add support for image fields in FormKit PageObject

### DIFF
--- a/spec/system/page_objects/components/form_kit.rb
+++ b/spec/system/page_objects/components/form_kit.rb
@@ -44,6 +44,10 @@ module PageObjects
           component.find("select").value
         when "composer"
           component.find("textarea").value
+        when "image"
+          url = component.find(".uploaded-image-preview a.lightbox", wait: 10)[:href]
+          sha1 = url.match(/(\h{40})/).captures.first
+          Upload.find_by(sha1:)
         end
       end
 
@@ -152,7 +156,17 @@ module PageObjects
         if control_type == "question"
           component.find(".form-kit__control-radio[value='false']").click
         else
-          raise "'accept' is not supported for control type: #{control_type}"
+          raise "'refuse' is not supported for control type: #{control_type}"
+        end
+      end
+
+      def upload_image(image_path)
+        if control_type == "image"
+          attach_file(image_path) do
+            component.find(".image-upload-controls .btn.btn-default").click
+          end
+        else
+          raise "'upload_image' is not supported for control type: #{control_type}"
         end
       end
 


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->