### PR TITLE
FIX: weird slow auto scrolling on iOS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-virtual-height.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-virtual-height.gjs
@@ -75,13 +75,16 @@ export default class DVirtualHeight extends Component {
       height = activeWindow?.height || window.innerHeight;
     }
 
-    const newVh = height * 0.01;
-    if (this.lastVh === newVh) {
+    if (this.previousHeight && Math.abs(this.previousHeight - height) <= 1) {
       return;
     }
 
-    document.documentElement.style.setProperty("--composer-vh", `${newVh}px`);
-    this.lastVh = newVh;
+    this.previousHeight = height;
+
+    document.documentElement.style.setProperty(
+      "--composer-vh",
+      `${height / 100}px`
+    );
   }
 
   @bind


### PR DESCRIPTION
In some cases, on Safari iOS, we would recompute the "--composer-vh" variable due to a minimal change in the viewport. This ends up triggering a loop where setting this variable triggers another viewport resize event, which triggers another change of the variable...

In order to fix (patch?) this issue, we now have a 1px leeway when checking the difference between the previous and new viewport.

This is unfortunately very hard to test.

Internal ref - t/141088

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->