### PR TITLE
FIX: Pass upload type correctly to uploads#create

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
@@ -73,7 +73,7 @@ function lazyMergeConfig(config) {
   return mergedConfig;
 }
 
-const REQUIRED_CONFIG_KEYS = ["id", "uploadDone"];
+const REQUIRED_CONFIG_KEYS = ["id", "uploadDone", "type"];
 function validateConfig(config) {
   for (const key of REQUIRED_CONFIG_KEYS) {
     if (!config[key]) {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/image-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/image-test.gjs
@@ -36,7 +36,7 @@ module(
       await render(<template>
         <Form @mutable={{true}} @data={{data}} as |form|>
           <form.Field @name="image_url" @title="Foo" as |field|>
-            <field.Image />
+            <field.Image @type="site_setting" />
           </form.Field>
         </Form>
       </template>);

--- a/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
@@ -9,7 +9,7 @@ module("Integration | Component | uppy-image-uploader", function (hooks) {
 
   test("with image", async function (assert) {
     await render(hbs`
-      <UppyImageUploader @id="test-uppy-image-uploader" @imageUrl="/images/avatar.png" @placeholderUrl="/not/used.png" />
+      <UppyImageUploader @type="avatar" @id="test-uppy-image-uploader" @imageUrl="/images/avatar.png" @placeholderUrl="/not/used.png" />
     `);
 
     assert.strictEqual(
@@ -38,7 +38,9 @@ module("Integration | Component | uppy-image-uploader", function (hooks) {
   });
 
   test("without image", async function (assert) {
-    await render(hbs`<UppyImageUploader @id="test-uppy-image-uploader" />`);
+    await render(
+      hbs`<UppyImageUploader @type="site_setting" @id="test-uppy-image-uploader" />`
+    );
 
     assert.strictEqual(
       count(".d-icon-far-image"),
@@ -55,7 +57,7 @@ module("Integration | Component | uppy-image-uploader", function (hooks) {
 
   test("with placeholder", async function (assert) {
     await render(
-      hbs`<UppyImageUploader @id="test-uppy-image-uploader" @placeholderUrl="/images/avatar.png" />`
+      hbs`<UppyImageUploader @type="composer" @id="test-uppy-image-uploader" @placeholderUrl="/images/avatar.png" />`
     );
 
     assert.strictEqual(

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -32,11 +32,9 @@ class UploadsController < ApplicationController
       1.minute.to_i,
     ).performed!
 
-    params.permit(:type, :upload_type)
-    raise Discourse::InvalidParameters if params[:type].blank? && params[:upload_type].blank?
+    params.require(:upload_type)
     # 50 characters ought to be enough for the upload type
-    type =
-      (params[:upload_type].presence || params[:type].presence).parameterize(separator: "_")[0..50]
+    type = params[:upload_type].parameterize(separator: "_")[0..50]
 
     if type == "avatar" &&
          (


### PR DESCRIPTION
Prior to Uppy, the `uploads#create` endpoint used to receive a `type` param that indicated the purpose/target of the upload, such as `avatar`, `site_setting` and so on. With the introduction of Uppy, the `type` param became the MIME type of the file being uploaded, and the purpose/target of the upload became a new param called `upload_type`, however the backend could still use the `type` param (which now contains MIME type) as the purpose/target of the upload if `upload_type` is absent.

We technically don't need to send the MIME type over the network, but it seems like it's done by Uppy and we have no control over the `type` param that Uppy includes:

https://github.com/discourse/discourse/blob/758de8167bb79712fda01af0b35c2699c147b09e/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js#L146-L151

This PR does a couple of things:

1. It amends the `uploads#create` endpoint so it always requires the `upload_type` param and doesn't fallback to `type` if `upload_type` is absent
2. It forces consumers of the `UppyUpload` class (and by extension `UppyImageUploader`) to specify `type` of the upload

Internal topic: t/140945.