### PR TITLE
UX: Migrate to `btn-flat`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/codeblock-buttons.js
+++ b/app/assets/javascripts/discourse/app/lib/codeblock-buttons.js
@@ -110,7 +110,7 @@ export default class CodeblockButtons {
 
       if (this.showCopy) {
         const copyButton = document.createElement("button");
-        copyButton.classList.add("btn", "nohighlight", "copy-cmd");
+        copyButton.classList.add("btn", "nohighlight", "copy-cmd", "btn-flat");
         copyButton.ariaLabel = I18n.t("copy_codeblock.copy");
         copyButton.innerHTML = iconHTML("copy");
         wrapperEl.appendChild(copyButton);
@@ -121,7 +121,12 @@ export default class CodeblockButtons {
 
       if (this.showFullscreen && !Mobile.isMobileDevice) {
         const fullscreenButton = document.createElement("button");
-        fullscreenButton.classList.add("btn", "nohighlight", "fullscreen-cmd");
+        fullscreenButton.classList.add(
+          "btn",
+          "nohighlight",
+          "fullscreen-cmd",
+          "btn-flat"
+        );
         fullscreenButton.ariaLabel = I18n.t("copy_codeblock.fullscreen");
         fullscreenButton.innerHTML = iconHTML("discourse-expand");
         wrapperEl.appendChild(fullscreenButton);


### PR DESCRIPTION
This PR changes the buttons inside of code blocks to use the `btn-flat` class.

**After**
<img width="291" alt="image" src="https://github.com/user-attachments/assets/fb33dae8-f1c7-4f88-b0a4-b8744e642d0a">

**Before**
<img width="241" alt="image" src="https://github.com/user-attachments/assets/35be4a12-bae2-4a90-9c89-44163e855525">
