### PR TITLE
DEV: Fetch settings by area name instead of individual settings

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-config-about.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-about.js
@@ -5,21 +5,7 @@ export default class AdminConfigAboutRoute extends Route {
   model() {
     return ajax("/admin/config/site_settings.json", {
       data: {
-        filter_names: [
-          "title",
-          "site_description",
-          "extended_site_description",
-          "short_site_description",
-          "about_banner_image",
-          "community_owner",
-          "contact_email",
-          "contact_url",
-          "site_contact_username",
-          "site_contact_group_name",
-          "company_name",
-          "governing_law",
-          "city_for_disputes",
-        ],
+        filter_area: "about",
       },
     });
   }

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteSetting < ActiveRecord::Base
-  VALID_AREAS = %w[flags]
+  VALID_AREAS = %w[flags about]
 
   extend GlobalPath
   extend SiteSettingExtension

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -42,25 +42,32 @@ required:
   title:
     client: true
     default: "Discourse"
+    area: "about"
   site_description:
     default: ""
+    area: "about"
   short_site_description:
     default: ""
     client: true
+    area: "about"
   contact_email:
     default: ""
     type: email
+    area: "about"
   contact_url:
     default: ""
+    area: "about"
   notification_email:
     default: "noreply@unconfigured.discourse.org"
     type: email
   site_contact_username:
     default: ""
     type: username
+    area: "about"
   site_contact_group_name:
     default: ""
     type: group
+    area: "about"
   exclude_rel_nofollow_domains:
     client: true
     default: ""
@@ -68,10 +75,13 @@ required:
     list_type: simple
   company_name:
     default: ""
+    area: "about"
   governing_law:
     default: ""
+    area: "about"
   city_for_disputes:
     default: ""
+    area: "about"
 
 branding:
   logo:
@@ -414,6 +424,7 @@ basic:
     default: ""
     max: 10_000
     hidden: true
+    area: "about"
   extended_site_description_cooked:
     default: ""
     hidden: true
@@ -422,10 +433,12 @@ basic:
     default: ""
     type: upload
     hidden: true
+    area: "about"
   community_owner:
     default: ""
     max: 300
     hidden: true
+    area: "about"
   use_legacy_pageviews:
     default: false
     hidden: true


### PR DESCRIPTION
This PR switches the route for the about config page to retrieve the list of site settings that control the /about page by their area instead of their individual names.

Internal topic: t/136384.