### PR TITLE
FIX: setup with db:create db:migrate

### DIFF
--- a/config/initializers/100-flags.rb
+++ b/config/initializers/100-flags.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# On initialize, reset flags cache
+Rails.application.config.to_prepare do
+  if Discourse.cache.is_a?(Cache) && ActiveRecord::Base.connection.table_exists?(:flags)
+    Flag.reset_flag_settings!
+  end
+end

--- a/db/fixtures/003_flags.rb
+++ b/db/fixtures/003_flags.rb
@@ -74,5 +74,3 @@ Flag.unscoped.seed do |s|
   s.applies_to = %w[Post]
   s.skip_reset_flag_callback = true
 end
-
-Flag.reset_flag_settings!


### PR DESCRIPTION
After data seed, we should reset Redis cache to ensure that the correct flags are cached.

However, `db:create` is skipping Redis 

https://github.com/discourse/discourse/blob/main/lib/tasks/db.rake#L39

And uses `ActiveSupport::Cache::MemoryStore.new`

https://github.com/discourse/discourse/blob/e2292d4c5914875ad0e303770c56db7cc96847e3/lib/discourse.rb#L523

Therefore, the reset flags cache was moved to initializers and evaluated only when the cache is Redis and Flags table already exists.

Meta: https://meta.discourse.org/t/development-install-fails-when-running-bin-rails-db-migrate/332754