### PR TITLE
FIX: correctly display category name in replace text modal

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/reseed.hbs
+++ b/app/assets/javascripts/admin/addon/components/modal/reseed.hbs
@@ -19,7 +19,7 @@
                 @type="checkbox"
                 @checked={{category.selected}}
               />
-              <span>{{category.displayName}}</span>
+              <span>{{category.name}}</span>
             </label>
           {{/each}}
         </fieldset>

--- a/spec/system/admin_site_texts_spec.rb
+++ b/spec/system/admin_site_texts_spec.rb
@@ -121,4 +121,11 @@ describe "Admin Site Texts Page", type: :system do
     expect(site_texts_page).to have_translation_value("Some overridden value")
     expect(TranslationOverride.exists?(translation_key: "js.skip_to_main_content")).to eq(true)
   end
+
+  it "properly display category names in replace text modal" do
+    site_texts_page.visit
+    site_texts_page.click_replace_text_button
+
+    expect(page.all(".modal label span").map(&:text)).to eq(["Uncategorized"])
+  end
 end

--- a/spec/system/page_objects/pages/admin_site_texts.rb
+++ b/spec/system/page_objects/pages/admin_site_texts.rb
@@ -48,6 +48,10 @@ module PageObjects
         find(".site-text-value").fill_in(with: value)
         find(".save-changes").click
       end
+
+      def click_replace_text_button
+        find(".reseed button").click
+      end
     end
   end
 end


### PR DESCRIPTION
Bug introduced in this PR https://github.com/discourse/discourse/pull/23232

The previous modal was using `category.name`

https://github.com/discourse/discourse/pull/23232/files#diff-bfae353a2f3457780e5c281b6a165261cfe552dd9dd791f3859e52d60e22be7fL20

Demo
<img width="643" alt="Screenshot 2024-11-06 at 1 26 28 PM" src="https://github.com/user-attachments/assets/a1e56965-fea7-4951-9e28-e680fb3cc714">
