### PR TITLE
UX: fix visibility of grant badge modal dropdowns

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -524,12 +524,13 @@
 .d-modal.grant-badge-modal {
   .d-modal {
     &__body {
-      @include breakpoint(mobile-extra-large) {
-        flex-grow: 1;
-      }
-
       @include breakpoint(medium) {
         overflow: visible;
+      }
+
+      @include breakpoint(mobile-extra-large) {
+        overflow: auto;
+        flex-grow: 1;
       }
     }
   }

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -520,3 +520,17 @@
     margin-top: 1em;
   }
 }
+
+.d-modal.grant-badge-modal {
+  .d-modal {
+    &__body {
+      @include breakpoint(mobile-extra-large) {
+        flex-grow: 1;
+      }
+
+      @include breakpoint(medium) {
+        overflow: visible;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commits adds breakpoints for mobile & tablet to stretch the content and show visible overflow respectively

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/40eef2bc-a1c8-440c-a39d-d392e651275d) | ![DiscoToc test topic - General - Yes](https://github.com/user-attachments/assets/e9180bf9-3051-4444-9d46-6db0745b093a) |
| ![Open Discourse Meta](https://github.com/user-attachments/assets/3b65bda9-8dc4-44b3-a648-d8184fb90134) | ![CleanShot 2024-11-06 at 11 35 34@2x](https://github.com/user-attachments/assets/20c128bc-ccac-4e2c-86d5-d69327bcb849) |




