### PR TITLE
DEV: Untangle award badge admin CSS

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/award.hbs
@@ -1,4 +1,4 @@
-<section class="award-badge">
+<section class="current-badge content-body">
   <h2>{{i18n "admin.badges.mass_award.title"}}</h2>
   <p>{{i18n "admin.badges.mass_award.description"}}</p>
 

--- a/app/assets/stylesheets/common/admin/badges.scss
+++ b/app/assets/stylesheets/common/admin/badges.scss
@@ -87,6 +87,30 @@
     .readonly-field {
       color: var(--primary-high);
     }
+
+    .badge-preview {
+      min-height: 110px;
+      max-width: 300px;
+      display: flex;
+      align-items: center;
+      background-color: var(--primary-very-low);
+      border: 1px solid var(--primary-low);
+      padding: 0 10px 0 10px;
+
+      img,
+      svg {
+        width: 60px;
+        height: 60px;
+      }
+
+      .badge-display-name {
+        margin-left: 5px;
+      }
+    }
+
+    .badge-required {
+      font-weight: bold;
+    }
   }
 
   .current-badge-actions {
@@ -117,29 +141,6 @@
     &.failure {
       color: var(--danger);
     }
-  }
-
-  .badge-preview {
-    min-height: 110px;
-    max-width: 300px;
-    display: flex;
-    align-items: center;
-    background-color: var(--primary-very-low);
-    border: 1px solid var(--primary-low);
-    padding: 0 10px 0 10px;
-
-    img,
-    svg {
-      width: 60px;
-      height: 60px;
-    }
-
-    .badge-display-name {
-      margin-left: 5px;
-    }
-  }
-  .badge-required {
-    font-weight: bold;
   }
 }
 


### PR DESCRIPTION
### What is this change?

I was skimming through existing pages to get a feel for the admin UI guidelines. I noticed that this part was missing its margin. On some further investigation, it seems that a single CSS selector, `.award-badge` was being used both for the section and for the button in the header, so I decided to 1) separate the two and 2) add in the missing margin.

**Before:**

<img width="463" alt="Screenshot 2024-11-06 at 11 52 25 AM" src="https://github.com/user-attachments/assets/50d0fc38-f345-4fa7-9422-411c8242becd">

**After:**

<img width="464" alt="Screenshot 2024-11-06 at 11 52 17 AM" src="https://github.com/user-attachments/assets/7089982e-60b3-4d99-941f-a95124915478">
