### PR TITLE
FIX: pass topic+category to @-mention user search

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -484,8 +484,8 @@ export default class DEditor extends Component {
         destroyUserStatuses();
         return userSearch({
           term,
-          topicId: this.topic?.id,
-          categoryId: this.topic?.category_id || this.composer?.categoryId,
+          topicId: this.topicId,
+          categoryId: this.categoryId,
           includeGroups: true,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -160,7 +160,9 @@ acceptance("Composer - editor mentions", function (needs) {
     await simulateKeys(".d-editor-input", "abc @");
 
     assert.deepEqual(
-      [...document.querySelectorAll(".ac-user .username")].map((e) => e.innerText),
+      [...document.querySelectorAll(".ac-user .username")].map(
+        (e) => e.innerText
+      ),
       ["user_group", "user", "user2", "foo"]
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -160,7 +160,7 @@ acceptance("Composer - editor mentions", function (needs) {
     await simulateKeys(".d-editor-input", "abc @");
 
     assert.deepEqual(
-      [...queryAll(".ac-user .username")].map((e) => e.innerText),
+      [...document.querySelectorAll(".ac-user .username")].map((e) => e.innerText),
       ["user_group", "user", "user2", "foo"]
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -157,9 +157,7 @@ acceptance("Composer - editor mentions", function (needs) {
     await click(".topic-list-item .title");
     await click(".btn-primary.create");
 
-    const editor = query(".d-editor-input");
-
-    await simulateKeys(editor, "abc @");
+    await simulateKeys(".d-editor-input", "abc @");
 
     assert.deepEqual(
       [...queryAll(".ac-user .username")].map((e) => e.innerText),


### PR DESCRIPTION
When replying to a topic, the @-mention `userSearch` needs the `topicId` and the `categoryId` so they can trigger immediately, with sane suggestions.

This was broken when the mentions were [moved](https://github.com/discourse/discourse/pull/29411) from `ComposerEditor` to `DEditor`.