### PR TITLE
UX: replace broken link SVG with new Font Awesome 6 name

### DIFF
--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -260,7 +260,7 @@ module CookedProcessorMixin
     img.name = "span"
     img.set_attribute("class", "broken-image")
     img.set_attribute("title", I18n.t("post.image_placeholder.broken"))
-    img << "<svg class=\"fa d-icon d-icon-unlink svg-icon\" aria-hidden=\"true\"><use href=\"#unlink\"></use></svg>"
+    img << "<svg class=\"fa d-icon d-icon-link-slash svg-icon\" aria-hidden=\"true\"><use href=\"#link-slash\"></use></svg>"
     img.remove_attribute("src")
     img.remove_attribute("width")
     img.remove_attribute("height")


### PR DESCRIPTION
Follow-up to 7d8974d

This icon was renamed, and won't auto-remap when referenced like this


