### PR TITLE
DEV: refactor `composer` references on composer-container/-editor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -102,36 +102,7 @@
           />
         </div>
 
-        <ComposerEditor
-          @topic={{this.composer.topic}}
-          @composer={{this.composer.model}}
-          @lastValidatedAt={{this.composer.lastValidatedAt}}
-          @canWhisper={{this.composer.canWhisper}}
-          @storeToolbarState={{this.composer.storeToolbarState}}
-          @onPopupMenuAction={{this.composer.onPopupMenuAction}}
-          @showUploadModal={{route-action "showUploadSelector"}}
-          @popupMenuOptions={{this.composer.popupMenuOptions}}
-          @draftStatus={{this.composer.model.draftStatus}}
-          @isUploading={{this.composer.isUploading}}
-          @isProcessingUpload={{this.composer.isProcessingUpload}}
-          @allowUpload={{this.composer.allowUpload}}
-          @uploadIcon={{this.composer.uploadIcon}}
-          @isCancellable={{this.composer.isCancellable}}
-          @uploadProgress={{this.composer.uploadProgress}}
-          @groupsMentioned={{this.composer.groupsMentioned}}
-          @cannotSeeMention={{this.composer.cannotSeeMention}}
-          @hereMention={{this.composer.hereMention}}
-          @importQuote={{this.composer.importQuote}}
-          @togglePreview={{this.composer.togglePreview}}
-          @processPreview={{this.composer.showPreview}}
-          @showToolbar={{this.composer.showToolbar}}
-          @afterRefresh={{this.composer.afterRefresh}}
-          @focusTarget={{this.composer.focusTarget}}
-          @disableTextarea={{this.composer.disableTextarea}}
-          @formTemplateIds={{this.composer.formTemplateIds}}
-          @formTemplateInitialValues={{this.composer.formTemplateInitialValues}}
-          @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
-        >
+        <ComposerEditor @showUploadModal={{route-action "showUploadSelector"}}>
           <div class="composer-fields">
             <PluginOutlet
               @name="before-composer-fields"

--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -102,7 +102,7 @@
           />
         </div>
 
-        <ComposerEditor @showUploadModal={{route-action "showUploadSelector"}}>
+        <ComposerEditor>
           <div class="composer-fields">
             <PluginOutlet
               @name="before-composer-fields"

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -1,36 +1,57 @@
-<DEditor
-  @value={{this.composer.reply}}
-  @placeholder={{this.replyPlaceholder}}
-  @previewUpdated={{action "previewUpdated"}}
-  @markdownOptions={{this.markdownOptions}}
-  @extraButtons={{action "extraButtons"}}
-  @importQuote={{this.importQuote}}
-  @showUploadModal={{this.showUploadModal}}
-  @togglePreview={{this.togglePreview}}
-  @processPreview={{this.processPreview}}
-  @validation={{this.validation}}
-  @loading={{this.composer.loading}}
-  @forcePreview={{this.forcePreview}}
-  @showLink={{this.showLink}}
-  @composerEvents={{true}}
-  @onExpandPopupMenuOptions={{action "onExpandPopupMenuOptions"}}
-  @onPopupMenuAction={{this.onPopupMenuAction}}
-  @popupMenuOptions={{this.popupMenuOptions}}
-  @formTemplateId={{this.composer.formTemplateId}}
-  @formTemplateIds={{this.formTemplateIds}}
-  @formTemplateInitialValues={{@formTemplateInitialValues}}
-  @onSelectFormTemplate={{@onSelectFormTemplate}}
-  @replyingToTopic={{this.composer.replyingToTopic}}
-  @editingPost={{this.composer.editingPost}}
-  @disabled={{this.disableTextarea}}
-  @outletArgs={{hash composer=this.composer editorType="composer"}}
-  @topicId={{this.composer.topic.id}}
-  @categoryId={{this.composer.category.id}}
->
-  {{yield}}
-</DEditor>
+{{#if this.showFormTemplateForm}}
+  <div class="d-editor">
+    <div class="d-editor-container">
+      <div class="d-editor-textarea-column">
+        {{yield}}
 
-{{#if this.allowUpload}}
+        {{#if (gt this.composer.formTemplateIds.length 1)}}
+          <FormTemplateChooser
+            @filteredIds={{this.composer.formTemplateIds}}
+            @value={{this.selectedFormTemplateId}}
+            @onChange={{this.updateSelectedFormTemplateId}}
+            @options={{hash maximum=1}}
+            class="composer-select-form-template"
+          />
+        {{/if}}
+        <form id="form-template-form">
+          <FormTemplateField::Wrapper
+            @id={{this.selectedFormTemplateId}}
+            @initialValues={{this.composer.formTemplateInitialValues}}
+            @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
+          />
+        </form>
+      </div>
+    </div>
+  </div>
+{{else}}
+  <DEditor
+    @value={{this.composer.model.reply}}
+    @placeholder={{this.replyPlaceholder}}
+    @previewUpdated={{action "previewUpdated"}}
+    @markdownOptions={{this.markdownOptions}}
+    @extraButtons={{action "extraButtons"}}
+    @importQuote={{this.composer.importQuote}}
+    @processPreview={{this.composer.showPreview}}
+    @validation={{this.validation}}
+    @loading={{this.composer.loading}}
+    @forcePreview={{this.forcePreview}}
+    @showLink={{this.showLink}}
+    @composerEvents={{true}}
+    @onPopupMenuAction={{this.composer.onPopupMenuAction}}
+    @popupMenuOptions={{this.composer.popupMenuOptions}}
+    @formTemplateId={{this.composer.model.formTemplateId}}
+    @formTemplateInitialValues={{this.composer.formTemplateInitialValues}}
+    @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
+    @disabled={{this.composer.disableTextarea}}
+    @outletArgs={{hash composer=this.composer.model editorType="composer"}}
+    @topicId={{this.composer.model.topic.id}}
+    @categoryId={{this.composer.model.category.id}}
+  >
+    {{yield}}
+  </DEditor>
+{{/if}}
+
+{{#if this.composer.allowUpload}}
   <PickFilesButton
     @fileInputId="file-uploader"
     @allowMultiple={{true}}

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -50,7 +50,7 @@
 
 {{#if this.composer.allowUpload}}
   <PickFilesButton
-    @fileInputId={{this.uppyComposerUpload.fileUploadElementId}}
+    @fileInputId={{this.fileUploadElementId}}
     @allowMultiple={{true}}
     name="file-uploader"
   />

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -39,9 +39,6 @@
     @composerEvents={{true}}
     @onPopupMenuAction={{this.composer.onPopupMenuAction}}
     @popupMenuOptions={{this.composer.popupMenuOptions}}
-    @formTemplateId={{this.composer.model.formTemplateId}}
-    @formTemplateInitialValues={{this.composer.formTemplateInitialValues}}
-    @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
     @disabled={{this.composer.disableTextarea}}
     @outletArgs={{hash composer=this.composer.model editorType="composer"}}
     @topicId={{this.composer.model.topic.id}}

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -50,7 +50,7 @@
 
 {{#if this.composer.allowUpload}}
   <PickFilesButton
-    @fileInputId="file-uploader"
+    @fileInputId={{this.uppyComposerUpload.fileUploadElementId}}
     @allowMultiple={{true}}
     name="file-uploader"
   />

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -933,7 +933,8 @@ export default class ComposerEditor extends Component {
     return formTemplateIds?.length > 0 && !replyingToTopic && !editingPost;
   }
 
+  @action
   showUploadModal() {
-    document.querySelector(this.fileUploadElementId).click();
+    document.getElementById(this.fileUploadElementId).click();
   }
 }

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -95,6 +95,8 @@ export default class ComposerEditor extends Component {
   shouldBuildScrollMap = true;
   scrollMap = null;
 
+  fileUploadElementId = "file-uploader";
+
   get topic() {
     return this.composer.get("model.topic");
   }
@@ -110,6 +112,7 @@ export default class ComposerEditor extends Component {
       uploadMarkdownResolvers,
       uploadPreProcessors,
       uploadHandlers,
+      fileUploadElementId: this.fileUploadElementId,
     });
   }
 
@@ -931,6 +934,6 @@ export default class ComposerEditor extends Component {
   }
 
   showUploadModal() {
-    document.querySelector(this.uppyComposerUpload.fileUploadElementId).click();
+    document.querySelector(this.fileUploadElementId).click();
   }
 }

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -929,4 +929,8 @@ export default class ComposerEditor extends Component {
   showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
     return formTemplateIds?.length > 0 && !replyingToTopic && !editingPost;
   }
+
+  showUploadModal() {
+    document.querySelector(this.uppyComposerUpload.fileUploadElementId).click();
+  }
 }

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -97,10 +97,6 @@ export default class ComposerEditor extends Component {
 
   fileUploadElementId = "file-uploader";
 
-  get topic() {
-    return this.composer.get("model.topic");
-  }
-
   init() {
     super.init(...arguments);
     this.warnedCannotSeeMentions = [];
@@ -114,6 +110,10 @@ export default class ComposerEditor extends Component {
       uploadHandlers,
       fileUploadElementId: this.fileUploadElementId,
     });
+  }
+
+  get topic() {
+    return this.composer.get("model.topic");
   }
 
   @discourseComputed("composer.model.requiredCategoryMissing")

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -927,7 +927,6 @@ export default class ComposerEditor extends Component {
     "composer.model.editingPost"
   )
   showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
-    // TODO(@keegan): Remove !editingPost once we add edit/draft support for form templates
     return formTemplateIds?.length > 0 && !replyingToTopic && !editingPost;
   }
 }

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -526,7 +526,7 @@ export default class ComposerEditor extends Component {
   // previously we would warn after @bob even if you were about to mention @bob2
   @debounce(DEBOUNCE_JIT_MS)
   _warnCannotSeeMention(preview) {
-    if (this.composer.model.draftKey === Composer.NEW_PRIVATE_MESSAGE_KEY) {
+    if (this.composer.model?.draftKey === Composer.NEW_PRIVATE_MESSAGE_KEY) {
       return;
     }
 
@@ -907,7 +907,9 @@ export default class ComposerEditor extends Component {
       return this._selectedFormTemplateId;
     }
 
-    return this.composer.formTemplateId || this.composer.formTemplateIds?.[0];
+    return (
+      this.composer.model.formTemplateId || this.composer.formTemplateIds?.[0]
+    );
   }
 
   set selectedFormTemplateId(value) {

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -1,81 +1,63 @@
 <div class="d-editor-container">
   <div class="d-editor-textarea-column">
     {{yield}}
-    {{#if this.showFormTemplateForm}}
-      {{#if (gt @formTemplateIds.length 1)}}
-        <FormTemplateChooser
-          @filteredIds={{@formTemplateIds}}
-          @value={{this.selectedFormTemplateId}}
-          @onChange={{this.updateSelectedFormTemplateId}}
-          @options={{hash maximum=1}}
-          class="composer-select-form-template"
-        />
-      {{/if}}
-      <form id="form-template-form">
-        <FormTemplateField::Wrapper
-          @id={{this.selectedFormTemplateId}}
-          @initialValues={{@formTemplateInitialValues}}
-          @onSelectFormTemplate={{@onSelectFormTemplate}}
-        />
-      </form>
-    {{else}}
-      <div
-        class="d-editor-textarea-wrapper
-          {{if this.disabled 'disabled'}}
-          {{if this.isEditorFocused 'in-focus'}}"
-      >
-        <div class="d-editor-button-bar" role="toolbar">
-          {{#each this.toolbar.groups as |group|}}
-            {{#each group.buttons as |b|}}
-              {{#if (b.condition this)}}
-                {{#if b.popupMenu}}
-                  <ToolbarPopupMenuOptions
-                    @content={{this.popupMenuOptions}}
-                    @onChange={{this.onPopupMenuAction}}
-                    @onOpen={{action b.action b}}
-                    @tabindex={{-1}}
-                    @onKeydown={{this.rovingButtonBar}}
-                    @options={{hash icon=b.icon focusAfterOnChange=false}}
-                    class={{b.className}}
-                  />
-                {{else}}
-                  <DButton
-                    @action={{fn (action b.action) b}}
-                    @translatedTitle={{b.title}}
-                    @label={{b.label}}
-                    @icon={{b.icon}}
-                    @preventFocus={{b.preventFocus}}
-                    @onKeyDown={{this.rovingButtonBar}}
-                    tabindex={{b.tabindex}}
-                    class={{b.className}}
-                  />
-                {{/if}}
-              {{/if}}
-            {{/each}}
-          {{/each}}
-        </div>
 
-        <ConditionalLoadingSpinner @condition={{this.loading}} />
-        <this.editorComponent
-          @onSetup={{this.setupEditor}}
-          @markdownOptions={{this.markdownOptions}}
-          @keymap={{this.keymap}}
-          @value={{this.value}}
-          @placeholder={{this.placeholderTranslated}}
-          @disabled={{this.disabled}}
-          @change={{this.change}}
-          @focusIn={{this.handleFocusIn}}
-          @focusOut={{this.handleFocusOut}}
-          @id={{this.textAreaId}}
-        />
-        <PopupInputTip @validation={{this.validation}} />
-        <PluginOutlet
-          @name="after-d-editor"
-          @connectorTagName="div"
-          @outletArgs={{this.outletArgs}}
-        />
+    <div
+      class="d-editor-textarea-wrapper
+        {{if this.disabled 'disabled'}}
+        {{if this.isEditorFocused 'in-focus'}}"
+    >
+      <div class="d-editor-button-bar" role="toolbar">
+        {{#each this.toolbar.groups as |group|}}
+          {{#each group.buttons as |b|}}
+            {{#if (b.condition this)}}
+              {{#if b.popupMenu}}
+                <ToolbarPopupMenuOptions
+                  @content={{this.popupMenuOptions}}
+                  @onChange={{this.onPopupMenuAction}}
+                  @onOpen={{action b.action b}}
+                  @tabindex={{-1}}
+                  @onKeydown={{this.rovingButtonBar}}
+                  @options={{hash icon=b.icon focusAfterOnChange=false}}
+                  class={{b.className}}
+                />
+              {{else}}
+                <DButton
+                  @action={{fn (action b.action) b}}
+                  @translatedTitle={{b.title}}
+                  @label={{b.label}}
+                  @icon={{b.icon}}
+                  @preventFocus={{b.preventFocus}}
+                  @onKeyDown={{this.rovingButtonBar}}
+                  tabindex={{b.tabindex}}
+                  class={{b.className}}
+                />
+              {{/if}}
+            {{/if}}
+          {{/each}}
+        {{/each}}
       </div>
-    {{/if}}
+
+      <ConditionalLoadingSpinner @condition={{this.loading}} />
+      <this.editorComponent
+        @onSetup={{this.setupEditor}}
+        @markdownOptions={{this.markdownOptions}}
+        @keymap={{this.keymap}}
+        @value={{this.value}}
+        @placeholder={{this.placeholderTranslated}}
+        @disabled={{this.disabled}}
+        @change={{this.change}}
+        @focusIn={{this.handleFocusIn}}
+        @focusOut={{this.handleFocusOut}}
+        @id={{this.textAreaId}}
+      />
+      <PopupInputTip @validation={{this.validation}} />
+      <PluginOutlet
+        @name="after-d-editor"
+        @connectorTagName="div"
+        @outletArgs={{this.outletArgs}}
+      />
+    </div>
   </div>
 
   <div

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { action, computed } from "@ember/object";
+import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { schedule, scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
@@ -80,30 +80,6 @@ export default class DEditor extends Component {
     super.init(...arguments);
 
     this.register = getRegister(this);
-  }
-
-  @computed("formTemplateIds")
-  get selectedFormTemplateId() {
-    if (this._selectedFormTemplateId) {
-      return this._selectedFormTemplateId;
-    }
-
-    return this.formTemplateId || this.formTemplateIds?.[0];
-  }
-
-  set selectedFormTemplateId(value) {
-    this._selectedFormTemplateId = value;
-  }
-
-  @action
-  updateSelectedFormTemplateId(formTemplateId) {
-    this.selectedFormTemplateId = formTemplateId;
-  }
-
-  @discourseComputed("formTemplateIds", "replyingToTopic", "editingPost")
-  showFormTemplateForm(formTemplateIds, replyingToTopic, editingPost) {
-    // TODO(@keegan): Remove !editingPost once we add edit/draft support for form templates
-    return formTemplateIds?.length > 0 && !replyingToTopic && !editingPost;
   }
 
   @discourseComputed("placeholder")

--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -44,7 +44,7 @@ export default class UppyComposerUpload {
   uploadType = "composer";
   editorInputClass = ".d-editor-input";
   mobileFileUploaderId = "mobile-file-upload";
-  fileUploadElementId = "file-uploader";
+  fileUploadElementId;
   editorClass = ".d-editor";
 
   composerEventPrefix;
@@ -73,6 +73,7 @@ export default class UppyComposerUpload {
       uploadMarkdownResolvers,
       uploadPreProcessors,
       uploadHandlers,
+      fileUploadElementId,
     }
   ) {
     setOwner(this, owner);
@@ -82,6 +83,7 @@ export default class UppyComposerUpload {
     this.uploadMarkdownResolvers = uploadMarkdownResolvers;
     this.uploadPreProcessors = uploadPreProcessors;
     this.uploadHandlers = uploadHandlers;
+    this.fileUploadElementId = fileUploadElementId;
   }
 
   @bind

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -421,10 +421,6 @@ html.composer-open {
     }
   }
 
-  #file-uploader {
-    display: none;
-  }
-
   .composer-select-form-template {
     margin-bottom: 8px;
     width: 100%;


### PR DESCRIPTION
Most of it is removing the `ComposerContainer > ComposerEditor` indirect references to the `composer` service, so `ComposerEditor` now deals with the service directly.

There are still some monkey patches in customizations to adjust before considering merging this.