### PR TITLE
UX: do not hide topic composer in mobile chat

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-footer.scss
@@ -30,7 +30,3 @@
     }
   }
 }
-
-.has-full-page-chat div#reply-control {
-  display: none;
-}


### PR DESCRIPTION
This commit is a revert of https://github.com/discourse/discourse/commit/c91bd3ca07ebcb99a379861f9f17f948cc8ab491
