### PR TITLE
UX: remove icons indicating time in userstatus, bookmarks, topic timer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/time-shortcut-picker.hbs
+++ b/app/assets/javascripts/discourse/app/components/time-shortcut-picker.hbs
@@ -2,11 +2,11 @@
   {{#each this.options key="id" as |option|}}
     {{#unless option.hidden}}
       <TapTile
-        @icon={{option.icon}}
         @tileId={{option.id}}
         @activeTile={{grid.activeTile}}
         @onChange={{action "selectShortcut"}}
       >
+
         <div class="tap-tile-title">{{i18n option.label}}</div>
         <div class="tap-tile-date">{{option.timeFormatted}}</div>
       </TapTile>


### PR DESCRIPTION
These icons are not contributing to any clarity or user understanding, and instead can even cause confusion by the chevron being a usual indicator of a toggle, which is not the case here. Tomorrow is also not traditionally a cog, and some icons are being used double. In general, when an icon doesn't contribute to clarity, it's just noise.

This commit removes them from the tiles used for these duration or time indicators.
 
| Before | After |
|--------|--------|
| ![CleanShot 2024-11-07 at 14 40 11@2x](https://github.com/user-attachments/assets/74318bf9-0c93-4193-84b0-844ccc5e09ad) | ![CleanShot 2024-11-07 at 14 34 45@2x](https://github.com/user-attachments/assets/570b7ec3-2309-4e05-bcdf-ca78d61f6da2) |
| ![CleanShot 2024-11-07 at 14 39 43@2x](https://github.com/user-attachments/assets/cf594dc6-c6c4-4f18-80b6-978b91f2dbe5) | ![CleanShot 2024-11-07 at 14 36 51@2x](https://github.com/user-attachments/assets/66e3d9c9-6a96-48ba-95d2-ac045b1bf534) |
| ![CleanShot 2024-11-07 at 14 39 13@2x](https://github.com/user-attachments/assets/d363462e-7d57-4a6c-8ee9-7f80223563b7) | ![CleanShot 2024-11-07 at 14 42 48@2x](https://github.com/user-attachments/assets/0a18061b-c4d1-4d89-aef2-5e9bf98026d1) | 