### PR TITLE
DEV: fix flakey by duplicating constant

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -223,7 +223,7 @@ module Chat
     ]
 
     def self.cook(message, opts = {})
-      rules = MARKDOWN_IT_RULES
+      rules = MARKDOWN_IT_RULES.dup
       rules << "heading" if opts[:user_id] && opts[:user_id].negative?
 
       # A rule in our Markdown pipeline may have Guardian checks that require a


### PR DESCRIPTION
This is because rules is pointing to the same array MARKDOWN_IT_RULES, which is modified directly. Modifying rules with << changes the original MARKDOWN_IT_RULES array, so every call to something works with the altered array state from previous calls.
