### PR TITLE
FIX: resume editing when through /new-message

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1407,8 +1407,6 @@ export default class ComposerService extends Service {
         composerModel.setProperties({ unlistTopic: false, whisper: false });
       }
 
-      await this._setModel(composerModel, opts);
-
       // we need a draft sequence for the composer to work
       if (opts.draftSequence === undefined) {
         let data = await Draft.get(opts.draftKey);
@@ -1421,8 +1419,13 @@ export default class ComposerService extends Service {
 
         opts.draft ||= data.draft;
         opts.draftSequence = data.draft_sequence;
+
+        await this._setModel(composerModel, opts);
+
         return;
       }
+
+      await this._setModel(composerModel, opts);
 
       // otherwise, do the draft check async
       if (!opts.draft && !opts.skipDraftCheck) {

--- a/spec/system/composer/discard_draft_spec.rb
+++ b/spec/system/composer/discard_draft_spec.rb
@@ -94,5 +94,24 @@ describe "Composer - discard draft modal", type: :system do
 
       wait_for(timeout: 5) { Draft.find_by(draft_key: draft_key) == nil }
     end
+
+    it "resumes draft when using /new-message" do
+      visit "/new-message"
+
+      composer.fill_content("a b c d e f g")
+      composer.close
+
+      expect(discard_draft_modal).to be_open
+      discard_draft_modal.click_save
+
+      visit "/new-message"
+
+      expect(dialog).to be_open
+      expect(page).to have_content(I18n.t("js.drafts.abandon.confirm"))
+      dialog.click_button I18n.t("js.drafts.abandon.no_value")
+
+      expect(composer).to be_opened
+      expect(composer).to have_content("a b c d e f g")
+    end
   end
 end


### PR DESCRIPTION
"Resume editing" would do nothing when going through the `/new-message` flow.

This seems to be broken since [this commit](https://github.com/discourse/discourse/commit/b0f6d074be2be452092c3062dde703d969c97110). which moved `this._setModel` calls around – the same we're doing now, but to different places: the first one needs to happen after the `draft.data` has been set , while the second needs to happen before the `this.open` call.