### PR TITLE
FEATURE: Automatically fix upload URLs with inventory

### DIFF
--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -80,6 +80,15 @@ class S3Inventory
                 #{table_name}.url = #{tmp_table_name}.url",
             )
 
+            # fix urls
+            connection.async_exec(
+              "UPDATE #{table_name}
+              SET url = #{tmp_table_name}.url
+              FROM #{tmp_table_name}
+              WHERE #{table_name}.url != #{tmp_table_name}.url AND
+                #{table_name}.etag = #{tmp_table_name}.etag",
+            )
+
             uploads = @scope.where("updated_at < ?", inventory_date)
 
             missing_uploads =

--- a/spec/lib/s3_inventory_spec.rb
+++ b/spec/lib/s3_inventory_spec.rb
@@ -143,6 +143,26 @@ RSpec.describe S3Inventory do
     expect(Upload.by_users.order(:url).pluck(:url, :etag)).to eq(files)
   end
 
+  it "should fix the url in uploads table correctly" do
+    files = [
+      [
+        "#{Discourse.store.absolute_base_url}/uploads/default/original/1X/0184537a4f419224404d013414e913a4f56018f2.jpg",
+        "defcaac0b4aca535c284e95f30d608d0",
+      ],
+      [
+        "#{Discourse.store.absolute_base_url}/uploads/default/original/1X/0789fbf5490babc68326b9cec90eeb0d6590db05.png",
+        "25c02eaceef4cb779fc17030d33f7f06",
+      ],
+    ]
+    files.each { |file| Fabricate(:upload, etag: file[1], url: "") }
+
+    inventory.expects(:files).returns([{ key: "Key", filename: "#{csv_filename}.gz" }]).times(3)
+
+    inventory.backfill_etags_and_list_missing
+
+    expect(Upload.by_users.order(:url).pluck(:url, :etag)).to eq(files)
+  end
+
   context "when site was restored from a backup" do
     before do
       freeze_time


### PR DESCRIPTION
The URLs from the uploads table can be automatically fixed using the inventory from S3. This may be necessary if a site is moved.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->