### PR TITLE
FIX: Add back the option to create invite without emailing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -193,7 +193,6 @@ export default class CreateInvite extends Component {
   }
 
   get inviteCreated() {
-    // use .get to track the id
     return !!this.invite.get("id");
   }
 

--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -329,7 +329,7 @@ export default class CreateInvite extends Component {
             @data={{this.data}}
             @onSubmit={{this.onFormSubmit}}
             @onRegisterApi={{this.registerApi}}
-            as |form transientData|
+            as |form|
           >
             <form.Field
               @name="restrictTo"

--- a/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
@@ -15,6 +15,23 @@ class Field {
     return this.element.dataset.controlType;
   }
 
+  value() {
+    switch (this.controlType) {
+      case "input-text":
+        const input = this.element.querySelector("input");
+        return parseInt(input.value, 10);
+    }
+  }
+
+  options() {
+    if (this.controlType !== "select") {
+      throw new Error(`Unsupported control type: ${this.controlType}`);
+    }
+    return [...this.element.querySelectorAll("select option")].map((node) =>
+      node.getAttribute("value")
+    );
+  }
+
   async fillIn(value) {
     let element;
 
@@ -131,15 +148,17 @@ class Form {
   }
 
   field(name) {
-    const field = new Field(
-      this.element.querySelector(`[data-name="${name}"]`)
-    );
+    const fieldElement = this.element.querySelector(`[data-name="${name}"]`);
 
-    if (!field) {
+    if (!fieldElement) {
       throw new Error(`Field with name ${name} not found`);
     }
 
-    return field;
+    return new Field(fieldElement);
+  }
+
+  hasField(name) {
+    return !!this.element.querySelector(`[data-name="${name}"]`);
   }
 }
 export default function form(selector = "form") {
@@ -154,6 +173,10 @@ export default function form(selector = "form") {
     },
     field(name) {
       return helper.field(name);
+    },
+
+    hasField(name) {
+      return helper.hasField(name);
     },
   };
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
@@ -1,5 +1,4 @@
-import { getOwner } from "@ember/owner";
-import { click, fillIn, render } from "@ember/test-helpers";
+import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import CreateInvite from "discourse/components/modal/create-invite";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";

--- a/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
@@ -1,0 +1,187 @@
+import { getOwner } from "@ember/owner";
+import { click, fillIn, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import CreateInvite from "discourse/components/modal/create-invite";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import formKit from "discourse/tests/helpers/form-kit-helper";
+
+module("Integration | Component | CreateInvite", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("typing an email address in the restrictTo field", async function (assert) {
+    const model = {};
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+
+    await click(".edit-link-options");
+
+    assert.false(
+      formKit().hasField("customMessage"),
+      "customMessage field is not shown before typing an email address in the restrictTo field"
+    );
+    assert.true(
+      formKit().hasField("maxRedemptions"),
+      "maxRedemptions field is shown before typing an email address in the restrictTo field"
+    );
+    assert
+      .dom(".save-invite-and-send-email")
+      .doesNotExist(
+        "'Create invite and send email' button is not shown before typting an email address in the restrictTo field"
+      );
+    assert
+      .dom(".save-invite")
+      .exists(
+        "'Create invite' button is shown before typting an email address in the restrictTo field"
+      );
+
+    await formKit().field("restrictTo").fillIn("discourse@example.com");
+
+    assert.true(
+      formKit().hasField("customMessage"),
+      "customMessage field is shown after typing an email address in the restrictTo field"
+    );
+    assert.false(
+      formKit().hasField("maxRedemptions"),
+      "maxRedemptions field is not shown after typing an email address in the restrictTo field"
+    );
+    assert
+      .dom(".save-invite-and-send-email")
+      .exists(
+        "'Create invite and send email' button is shown after typting an email address in the restrictTo field"
+      );
+    assert
+      .dom(".save-invite")
+      .exists(
+        "'Create invite' button is shown after typting an email address in the restrictTo field"
+      );
+  });
+
+  test("the inviteToTopic field", async function (assert) {
+    const model = {};
+    this.currentUser.admin = true;
+    this.siteSettings.must_approve_users = true;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.false(
+      formKit().hasField("inviteToTopic"),
+      "inviteToTopic field is not shown to admins if must_approve_users is true"
+    );
+
+    this.siteSettings.must_approve_users = false;
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.true(
+      formKit().hasField("inviteToTopic"),
+      "inviteToTopic field is shown to admins if must_approve_users is false"
+    );
+
+    this.currentUser.set("admin", false);
+    this.currentUser.set("moderator", false);
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.false(
+      formKit().hasField("inviteToTopic"),
+      "inviteToTopic field is not shown to regular users"
+    );
+  });
+
+  test("the maxRedemptions field for non-staff users", async function (assert) {
+    const model = {};
+    this.siteSettings.invite_link_max_redemptions_limit_users = 11;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.strictEqual(
+      formKit().field("maxRedemptions").value(),
+      10,
+      "uses 10 as the default value if invite_link_max_redemptions_limit_users is larger than 10"
+    );
+
+    this.siteSettings.invite_link_max_redemptions_limit_users = 9;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.strictEqual(
+      formKit().field("maxRedemptions").value(),
+      9,
+      "uses invite_link_max_redemptions_limit_users as the default value if it's smaller than 10"
+    );
+  });
+
+  test("the maxRedemptions field for staff users", async function (assert) {
+    const model = {};
+    this.currentUser.set("moderator", true);
+    this.siteSettings.invite_link_max_redemptions_limit = 111;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.strictEqual(
+      formKit().field("maxRedemptions").value(),
+      100,
+      "uses 100 as the default value if invite_link_max_redemptions_limit is larger than 100"
+    );
+
+    this.siteSettings.invite_link_max_redemptions_limit = 98;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.strictEqual(
+      formKit().field("maxRedemptions").value(),
+      98,
+      "uses invite_link_max_redemptions_limit as the default value if it's smaller than 10"
+    );
+  });
+
+  test("the expiresAfterDays field", async function (assert) {
+    const model = {};
+    this.siteSettings.invite_expiry_days = 3;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.deepEqual(
+      formKit().field("expiresAfterDays").options(),
+      ["1", "3", "7", "30", "90", "999999"],
+      "the value of invite_expiry_days is added to the dropdown"
+    );
+
+    this.siteSettings.invite_expiry_days = 90;
+
+    await render(<template>
+      <CreateInvite @inline={{true}} @model={{model}} />
+    </template>);
+    await click(".edit-link-options");
+
+    assert.deepEqual(
+      formKit().field("expiresAfterDays").options(),
+      ["1", "7", "30", "90", "999999"],
+      "the value of invite_expiry_days is not added to the dropdown if it's already one of the options"
+    );
+  });
+});

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1970,7 +1970,6 @@ en:
           new_title: "Invite members"
           edit_title: "Edit invite"
 
-          instructions: "Share this link to instantly grant access to this site:"
           expires_in_time: "Expires in %{time}"
           expired_at_time: "Expired at %{time}"
           create_link_to_invite: "Create a link that can be shared to instantly grant access to this site."
@@ -2006,11 +2005,14 @@ en:
 
           send_invite_email: "Save and Send Email"
           send_invite_email_instructions: "Restrict invite to email to send an invite email"
-          save_invite: "Save"
+          update_invite: "Update"
+          update_invite_and_send_email: "Update and send email"
           cancel: "Cancel"
           create_link: "Create link"
+          create_link_and_send_email: "Create link and send email"
 
-          invite_saved: "Invite saved."
+          invite_saved_without_sending_email: "Invite saved. Copy the link below and share it to instantly grant access to this site."
+          invite_saved_with_sending_email: "Invite email has been sent. You can also copy the link below and share it to instantly grant access to this site."
 
         bulk_invite:
           none: "No invitations to display on this page."

--- a/spec/system/page_objects/modals/create_invite.rb
+++ b/spec/system/page_objects/modals/create_invite.rb
@@ -15,12 +15,20 @@ module PageObjects
         within(modal) { find(".save-invite") }
       end
 
+      def save_and_email_button
+        within(modal) { find(".save-invite-and-send-email") }
+      end
+
       def copy_button
         within(modal) { find(".copy-button") }
       end
 
       def has_copy_button?
         within(modal) { has_css?(".copy-button") }
+      end
+
+      def has_alert_message?(message)
+        within(modal) { has_css?("#modal-alert .invite-link", text: message) }
       end
 
       def has_invite_link_input?


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/28974

In the linked PR, as part of simplifying the invite modal, we removed the option to skip sending an email when creating an invite restricted to a specific address. This has caused confusion about whether an email will be sent by Discourse or not, so we're adding back the option to create a restricted invite without emailing.

Screenshot:

<img src="https://github.com/user-attachments/assets/bfd46ae9-ae00-4363-98f3-c963f5073620" width=400>

Internal topic: t/134023/48.