### PR TITLE
UX: lower min_post_count to show bottom topic map

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -28,7 +28,7 @@ const MIN_LIKES_COUNT = 5;
 const MIN_PARTICIPANTS_COUNT = 5;
 const MIN_USERS_COUNT_FOR_AVATARS = 2;
 
-export const MIN_POSTS_COUNT = 10;
+export const MIN_POSTS_COUNT = 5;
 
 export default class TopicMapSummary extends Component {
   @service site;

--- a/spec/system/topic_map_spec.rb
+++ b/spec/system/topic_map_spec.rb
@@ -22,7 +22,7 @@ describe "Topic Map", type: :system do
 
     expect(topic_page).to have_topic_map
     Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 3)
-    2.times { Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1) }
+    Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1)
     page.refresh
     expect(topic_page).to have_topic_map
     expect(topic_map).to have_no_users

--- a/spec/system/topic_map_spec.rb
+++ b/spec/system/topic_map_spec.rb
@@ -21,7 +21,6 @@ describe "Topic Map", type: :system do
     topic_page.visit_topic(topic)
 
     expect(topic_page).to have_topic_map
-    Fabricate(:post, topic: topic, created_at: 2.day.ago)
     Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 3)
     2.times { Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1) }
     page.refresh

--- a/spec/system/topic_map_spec.rb
+++ b/spec/system/topic_map_spec.rb
@@ -21,14 +21,21 @@ describe "Topic Map", type: :system do
     topic_page.visit_topic(topic)
 
     expect(topic_page).to have_topic_map
-    Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 3)
-    Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1)
+    2.times { Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1) }
     page.refresh
     expect(topic_page).to have_topic_map
     expect(topic_map).to have_no_users
 
     Fabricate(:post, topic: topic, created_at: 1.day.ago)
     page.refresh
+
+    # bottom map, avatars details with post counts
+    expect(topic_map).to have_no_bottom_map
+
+    Fabricate(:post, topic: topic, created_at: 2.day.ago)
+    Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 3)
+    page.refresh
+
     expect(topic_map.users_count).to eq 6
 
     # user count
@@ -39,9 +46,6 @@ describe "Topic Map", type: :system do
       topic_page.send_reply("this is a cool-cat post") # fabricating posts doesn't update the last post details
       topic_page.visit_topic(topic)
     }.to change(topic_map, :users_count).by(1)
-
-    # bottom map, avatars details with post counts
-    expect(topic_map).to have_no_bottom_map
 
     Fabricate(:post, topic: topic)
     Fabricate(:post, user: user, topic: topic)


### PR DESCRIPTION
We want to make summaries shown through the AI plugin a little easier to reach at the bottom of the topic, so lowering the threshold on the topic map's appearance should help initially. 