### PR TITLE
FIX: Add specs to check sort on custom fields

### DIFF
--- a/spec/fabricators/user_field_fabricator.rb
+++ b/spec/fabricators/user_field_fabricator.rb
@@ -7,3 +7,5 @@ Fabricator(:user_field) do
   editable true
   requirement "on_signup"
 end
+
+Fabricator(:multiselect_user_field, from: :user_field) { field_type "multiselect" }


### PR DESCRIPTION
Sorting via a custom field on the non-admin user directory results in a few problems.

1.) The values do not appear to be sorted correctly in either direction.

2.) Multi-select values do not all show up -- only 1 value per user.

This PR adds specs and addresses this problem.

Before:

After: 