### PR TITLE
FIX: ensures thread panel closes on escape

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane.js
@@ -10,7 +10,10 @@ export default class ChatThreadPane extends ChatChannelPane {
   }
 
   get isOpened() {
-    return this.router.currentRoute.name === "chat.channel.thread";
+    return (
+      this.router.currentRoute.name === "chat.channel.thread" ||
+      this.router.currentRoute.name === "chat.channel.thread.index"
+    );
   }
 
   get selectedMessageIds() {

--- a/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
         expect(side_panel_page).to have_open_thread
       end
     end
+
+    it "closes the thread panel" do
+      chat_page.visit_thread(thread_1)
+      thread_page.composer.cancel_shortcut # ensures we are not focused in the composer
+      page.send_keys(:escape)
+
+      expect(side_panel_page).to have_no_open_thread
+    end
   end
 
   describe "ArrowUp" do


### PR DESCRIPTION
`chatThreadPane.isOpened` was returning `false` when it should return `true` due to an incorrect matching on the route.

Note that visiting a thread will focus the composer and the first escape will blur the input, only the second will close the panel.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->