### PR TITLE
FIX: correctly render unicode in channel page title

### DIFF
--- a/plugins/chat/app/serializers/chat/channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_serializer.rb
@@ -11,6 +11,7 @@ module Chat
                :chatable_url,
                :description,
                :title,
+               :unicode_title,
                :slug,
                :status,
                :archive_failed,
@@ -51,6 +52,10 @@ module Chat
 
     def title
       object.name || object.title(scope.user)
+    end
+
+    def unicode_title
+      Emoji.gsub_emoji_to_unicode(title)
     end
 
     def chatable

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -87,6 +87,7 @@ export default class ChatChannel {
     this.membershipsCount = args.memberships_count;
     this.slug = args.slug;
     this.title = args.title;
+    this.unicodeTitle = args.unicode_title;
     this.status = args.status;
     this.description = args.description;
     this.threadingEnabled = args.threading_enabled;

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-decorator.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-decorator.js
@@ -15,10 +15,12 @@ export default function withChatChannel(extendedClass) {
         return;
       }
 
+      const title = this.currentModel.unicodeTitle || this.currentModel.title;
+
       if (this.currentModel.isDirectMessageChannel) {
-        return `${this.currentModel.title}`;
+        return `${title}`;
       } else {
-        return `#${this.currentModel.title}`;
+        return `#${title}`;
       }
     }
 

--- a/plugins/chat/spec/serializer/chat/channel_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/channel_serializer_spec.rb
@@ -113,4 +113,10 @@ describe Chat::ChannelSerializer do
       end
     end
   end
+
+  it "has a unicode_title" do
+    chat_channel.update!(name: ":cat: Cats")
+
+    expect(serializer.as_json[:unicode_title]).to eq("🐱 Cats")
+  end
 end

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -419,4 +419,11 @@ RSpec.describe "Chat channel", type: :system do
       )
     end
   end
+
+  it "renders emojis in page title" do
+    channel_1.update!(name: ":dog: Dogs")
+    chat_page.visit_channel(channel_1)
+
+    expect(page).to have_title("#🐶 Dogs - Chat - Discourse")
+  end
 end


### PR DESCRIPTION
Before this fix we would render the emoji as text, eg: `:cat:`

Example with the fix:
<img width="117" alt="Screenshot 2024-11-08 at 09 25 10" src="https://github.com/user-attachments/assets/bd10c3a5-628d-4d95-879d-17e7afb34b04">
