### PR TITLE
FIX: S3 custom endpoint incompatible with dualstack

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -169,7 +169,7 @@ class SiteSetting < ActiveRecord::Base
     end
 
     def self.use_dualstack_endpoint
-      !SiteSetting.Upload.s3_region.start_with?("cn-")
+      SiteSetting.Upload.s3_endpoint.blank? && !SiteSetting.Upload.s3_region.start_with?("cn-")
     end
 
     def self.enable_s3_uploads

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -196,4 +196,25 @@ RSpec.describe SiteSetting do
       expect(SiteSetting.all_settings(filter_categories: ["required"]).count).to eq(12)
     end
   end
+
+  describe "Upload" do
+    before { setup_s3 }
+
+    describe "#use_dualstack_endpoint" do
+      it "returns false if s3_endpoint has been set" do
+        SiteSetting.s3_endpoint = "https://s3clone.test.com"
+        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+      end
+
+      it "returns false if the s3_region is in China" do
+        SiteSetting.s3_region = "cn-north-1"
+        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+      end
+
+      it "returns true if the s3_region is not in China" do
+        SiteSetting.s3_region = "us-west-1"
+        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -139,10 +139,6 @@ module SystemHelpers
     SiteSetting.s3_secret_access_key = MinioRunner.config.minio_root_password
     SiteSetting.s3_endpoint = MinioRunner.config.minio_server_url
 
-    # This is necessary for Minio because you cannot use dualstack
-    # at the same time as using a custom S3 endpoint.
-    SiteSetting.Upload.stubs(:use_dualstack_endpoint).returns(false)
-
     SiteSetting.enable_direct_s3_uploads = enable_direct_s3_uploads
     SiteSetting.secure_uploads = enable_secure_uploads
 


### PR DESCRIPTION
Followup 0568d36133081e52f25f05585c1a568c3b828d79

S3 itself and other S3-compatible providers do not
allow using an S3 custom endpoint and dualstack at
the same time, so this commit fixes that by not using
dualstack when the endpoint is present.

c.f. https://meta.discourse.org/t/rebuild-issue-cannot-set-dual-stack-in-combination-with-a-custom-endpoint/334902