### PR TITLE
FIX: correctly account for composer height in PWA

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -20,6 +20,8 @@
 
   // PWA/HUB without keyboard
   html.footer-nav-visible:not(.keyboard-visible) & {
-    height: calc($base-height - var(--footer-nav-height, 0px));
+    height: calc(
+      $base-height - var(--composer-height, 0px) - var(--footer-nav-height, 0px)
+    );
   }
 }


### PR DESCRIPTION
Prior to this fix a collapsed composer (40px height) would appear above the chat channel as the height of the channel would be too high.
