### PR TITLE
DEV: cook grid bbcode in chat

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -223,8 +223,13 @@ module Chat
     ]
 
     def self.cook(message, opts = {})
+      bot = opts[:user_id] && opts[:user_id].negative?
+
+      features = MARKDOWN_FEATURES.dup
+      features << "image-grid" if bot
+
       rules = MARKDOWN_IT_RULES.dup
-      rules << "heading" if opts[:user_id] && opts[:user_id].negative?
+      rules << "heading" if bot
 
       # A rule in our Markdown pipeline may have Guardian checks that require a
       # user to be present. The last editing user of the message will be more
@@ -235,8 +240,7 @@ module Chat
       cooked =
         PrettyText.cook(
           message,
-          features_override:
-            MARKDOWN_FEATURES + DiscoursePluginRegistry.chat_markdown_features.to_a,
+          features_override: features + DiscoursePluginRegistry.chat_markdown_features.to_a,
           markdown_it_rules: rules,
           force_quote_link: true,
           user_id: opts[:user_id],

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -99,6 +99,16 @@ describe Chat::Message do
         <h6><a name="h6-6" class="anchor" href="#h6-6"></a>h6</h6>
         HTML
       end
+
+      it "cooks the grid bbcode" do
+        cooked = described_class.cook("[grid]\ntest\n[/grid]", user_id: -1)
+
+        expect(cooked).to match_html <<~HTML
+        <div class="d-image-grid">
+        <p>test</p>
+        </div>
+        HTML
+      end
     end
 
     it "doesn't support headings" do
@@ -106,6 +116,14 @@ describe Chat::Message do
 
       expect(cooked).to match_html <<~HTML
       <p># test</p>
+      HTML
+    end
+
+    it "doesn't support grid" do
+      cooked = described_class.cook("[grid]\ntest\n[/grid]")
+
+      expect(cooked).to match_html <<~HTML
+      <p>[grid]<br>test<br>[/grid]</p>
       HTML
     end
 


### PR DESCRIPTION
This change will only prevent a cooked message with `[grid]` to show `[grid]`, instead the content will be wrapped in `div class="d-image-grid"`. This is only enabled on messages made by bot, as regular users could use grid but have no reason to use it ATM, so it's ok to consider it as non supported markup for now. It will also not apply the decoration which shouldn't change the behavior more than just removing grid markup from the message.