### PR TITLE
FIX: supports escape sequence in chat

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -220,6 +220,7 @@ module Chat
       blockquote
       emphasis
       replacements
+      escape
     ]
 
     def self.cook(message, opts = {})

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -115,6 +115,12 @@ describe Chat::Message do
       expect(cooked).to eq("<p>—</p>")
     end
 
+    it "supports escape sequence" do
+      cooked = described_class.cook('\*test\*')
+
+      expect(cooked).to eq("<p>*test*</p>")
+    end
+
     it "supports backticks rule" do
       cooked = described_class.cook("`test`")
 


### PR DESCRIPTION
Writing `\*test\*` will now correctly cook `*test*`, and not `<em>test</em>`.
