### PR TITLE
DEV: Add a `try` step to services

### DIFF
--- a/lib/service/base.rb
+++ b/lib/service/base.rb
@@ -121,6 +121,10 @@ module Service
         const_set("Options", klass)
         steps << OptionsStep.new(:default, class_name: klass)
       end
+
+      def try(*exceptions, &block)
+        steps << TryStep.new(exceptions, &block)
+      end
     end
 
     # @!visibility private
@@ -140,18 +144,18 @@ module Service
           raise "In #{type} '#{name}': default values in step implementations are not allowed. Maybe they could be defined in a params or options block?"
         end
         args = context.slice(*method.parameters.select { _1[0] == :keyreq }.map(&:last))
-        context[result_key] = Context.build(object: object)
+        context[result_key] = Context.build({ object: }.compact)
         instance.instance_exec(**args, &method)
+      end
+
+      def result_key
+        "result.#{type}.#{name}"
       end
 
       private
 
       def type
         self.class.name.split("::").last.downcase.sub(/^(\w+)step$/, "\\1")
-      end
-
-      def result_key
-        "result.#{type}.#{name}"
       end
     end
 
@@ -241,6 +245,33 @@ module Service
 
       def call(instance, context)
         ActiveRecord::Base.transaction { steps.each { |step| step.call(instance, context) } }
+      end
+    end
+
+    # @!visibility private
+    class TryStep < Step
+      include StepsHelpers
+
+      attr_reader :steps, :exceptions
+
+      def initialize(exceptions, &block)
+        @name = "default"
+        @steps = []
+        @exceptions = exceptions.presence || [StandardError]
+        instance_exec(&block)
+      end
+
+      def call(instance, context)
+        context[result_key] = Context.build
+        steps.each do |step|
+          @current_step = step
+          step.call(instance, context)
+        end
+      rescue *exceptions => e
+        raise e if e.is_a?(Failure)
+        context[@current_step.result_key].fail(raised_exception?: true, exception: e)
+        context[result_key].fail(exception: e)
+        context.fail!
       end
     end
 

--- a/spec/lib/service/runner_spec.rb
+++ b/spec/lib/service/runner_spec.rb
@@ -147,6 +147,26 @@ RSpec.describe Service::Runner do
     end
   end
 
+  class FailureTryService
+    include Service::Base
+
+    try { step :raising_step }
+
+    def raising_step
+      raise "BOOM"
+    end
+  end
+
+  class SuccessTryService
+    include Service::Base
+
+    try { step :non_raising_step }
+
+    def non_raising_step
+      true
+    end
+  end
+
   describe ".call" do
     subject(:runner) { described_class.call(service, dependencies, &actions_block) }
 
@@ -425,6 +445,30 @@ RSpec.describe Service::Runner do
 
         it "does not run the provided block" do
           expect(runner).not_to eq :model_errors
+        end
+      end
+    end
+
+    context "when using the on_exceptions action" do
+      let(:actions) { <<-BLOCK }
+        proc do |result|
+          on_exceptions { |exception| exception.message == "BOOM" }
+        end
+      BLOCK
+
+      context "when the service fails" do
+        let(:service) { FailureTryService }
+
+        it "runs the provided block" do
+          expect(runner).to be true
+        end
+      end
+
+      context "when the service does not fail" do
+        let(:service) { SuccessTryService }
+
+        it "does not run the provided block" do
+          expect(runner).not_to eq true
         end
       end
     end

--- a/spec/lib/service/steps_inspector_spec.rb
+++ b/spec/lib/service/steps_inspector_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Service::StepsInspector do
       step :in_transaction_step_1
       step :in_transaction_step_2
     end
+    try { step :might_raise }
     step :final_step
   end
 
@@ -30,9 +31,14 @@ RSpec.describe Service::StepsInspector do
 
   before do
     class DummyService
-      %i[fetch_model policy in_transaction_step_1 in_transaction_step_2 final_step].each do |name|
-        define_method(name) { true }
-      end
+      %i[
+        fetch_model
+        policy
+        in_transaction_step_1
+        in_transaction_step_2
+        might_raise
+        final_step
+      ].each { |name| define_method(name) { true } }
     end
   end
 
@@ -42,14 +48,16 @@ RSpec.describe Service::StepsInspector do
     context "when service runs without error" do
       it "outputs all the steps of the service" do
         expect(output).to eq <<~OUTPUT.chomp
-        [1/8] [options] 'default' ✅
-        [2/8] [model] 'model' ✅
-        [3/8] [policy] 'policy' ✅
-        [4/8] [params] 'default' ✅
-        [5/8] [transaction]
-        [6/8]   [step] 'in_transaction_step_1' ✅
-        [7/8]   [step] 'in_transaction_step_2' ✅
-        [8/8] [step] 'final_step' ✅
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ✅
+        [ 3/10] [policy] 'policy' ✅
+        [ 4/10] [params] 'default' ✅
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1' ✅
+        [ 7/10]   [step] 'in_transaction_step_2' ✅
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise' ✅
+        [10/10] [step] 'final_step' ✅
         OUTPUT
       end
     end
@@ -65,14 +73,16 @@ RSpec.describe Service::StepsInspector do
 
       it "shows the failing step" do
         expect(output).to eq <<~OUTPUT.chomp
-        [1/8] [options] 'default' ✅
-        [2/8] [model] 'model' ❌
-        [3/8] [policy] 'policy'
-        [4/8] [params] 'default'
-        [5/8] [transaction]
-        [6/8]   [step] 'in_transaction_step_1'
-        [7/8]   [step] 'in_transaction_step_2'
-        [8/8] [step] 'final_step'
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ❌
+        [ 3/10] [policy] 'policy'
+        [ 4/10] [params] 'default'
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1'
+        [ 7/10]   [step] 'in_transaction_step_2'
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise'
+        [10/10] [step] 'final_step'
         OUTPUT
       end
     end
@@ -88,14 +98,16 @@ RSpec.describe Service::StepsInspector do
 
       it "shows the failing step" do
         expect(output).to eq <<~OUTPUT.chomp
-        [1/8] [options] 'default' ✅
-        [2/8] [model] 'model' ✅
-        [3/8] [policy] 'policy' ❌
-        [4/8] [params] 'default'
-        [5/8] [transaction]
-        [6/8]   [step] 'in_transaction_step_1'
-        [7/8]   [step] 'in_transaction_step_2'
-        [8/8] [step] 'final_step'
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ✅
+        [ 3/10] [policy] 'policy' ❌
+        [ 4/10] [params] 'default'
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1'
+        [ 7/10]   [step] 'in_transaction_step_2'
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise'
+        [10/10] [step] 'final_step'
         OUTPUT
       end
     end
@@ -105,14 +117,16 @@ RSpec.describe Service::StepsInspector do
 
       it "shows the failing step" do
         expect(output).to eq <<~OUTPUT.chomp
-        [1/8] [options] 'default' ✅
-        [2/8] [model] 'model' ✅
-        [3/8] [policy] 'policy' ✅
-        [4/8] [params] 'default' ❌
-        [5/8] [transaction]
-        [6/8]   [step] 'in_transaction_step_1'
-        [7/8]   [step] 'in_transaction_step_2'
-        [8/8] [step] 'final_step'
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ✅
+        [ 3/10] [policy] 'policy' ✅
+        [ 4/10] [params] 'default' ❌
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1'
+        [ 7/10]   [step] 'in_transaction_step_2'
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise'
+        [10/10] [step] 'final_step'
         OUTPUT
       end
     end
@@ -128,14 +142,41 @@ RSpec.describe Service::StepsInspector do
 
       it "shows the failing step" do
         expect(output).to eq <<~OUTPUT.chomp
-        [1/8] [options] 'default' ✅
-        [2/8] [model] 'model' ✅
-        [3/8] [policy] 'policy' ✅
-        [4/8] [params] 'default' ✅
-        [5/8] [transaction]
-        [6/8]   [step] 'in_transaction_step_1' ✅
-        [7/8]   [step] 'in_transaction_step_2' ❌
-        [8/8] [step] 'final_step'
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ✅
+        [ 3/10] [policy] 'policy' ✅
+        [ 4/10] [params] 'default' ✅
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1' ✅
+        [ 7/10]   [step] 'in_transaction_step_2' ❌
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise'
+        [10/10] [step] 'final_step'
+        OUTPUT
+      end
+    end
+
+    context "when a step raises an exception inside the 'try' block" do
+      before do
+        class DummyService
+          def might_raise
+            raise "BOOM"
+          end
+        end
+      end
+
+      it "shows the failing step" do
+        expect(output).to eq <<~OUTPUT.chomp
+        [ 1/10] [options] 'default' ✅
+        [ 2/10] [model] 'model' ✅
+        [ 3/10] [policy] 'policy' ✅
+        [ 4/10] [params] 'default' ✅
+        [ 5/10] [transaction]
+        [ 6/10]   [step] 'in_transaction_step_1' ✅
+        [ 7/10]   [step] 'in_transaction_step_2' ✅
+        [ 8/10] [try]
+        [ 9/10]   [step] 'might_raise' 💥
+        [10/10] [step] 'final_step'
         OUTPUT
       end
     end
@@ -146,14 +187,16 @@ RSpec.describe Service::StepsInspector do
 
         it "adapts its output accordingly" do
           expect(output).to eq <<~OUTPUT.chomp
-          [1/8] [options] 'default' ✅
-          [2/8] [model] 'model' ✅
-          [3/8] [policy] 'policy' ✅ ⚠️  <= expected to return false but got true instead
-          [4/8] [params] 'default' ✅
-          [5/8] [transaction]
-          [6/8]   [step] 'in_transaction_step_1' ✅
-          [7/8]   [step] 'in_transaction_step_2' ✅
-          [8/8] [step] 'final_step' ✅
+          [ 1/10] [options] 'default' ✅
+          [ 2/10] [model] 'model' ✅
+          [ 3/10] [policy] 'policy' ✅ ⚠️  <= expected to return false but got true instead
+          [ 4/10] [params] 'default' ✅
+          [ 5/10] [transaction]
+          [ 6/10]   [step] 'in_transaction_step_1' ✅
+          [ 7/10]   [step] 'in_transaction_step_2' ✅
+          [ 8/10] [try]
+          [ 9/10]   [step] 'might_raise' ✅
+          [10/10] [step] 'final_step' ✅
           OUTPUT
         end
       end
@@ -170,14 +213,16 @@ RSpec.describe Service::StepsInspector do
 
         it "adapts its output accordingly" do
           expect(output).to eq <<~OUTPUT.chomp
-          [1/8] [options] 'default' ✅
-          [2/8] [model] 'model' ✅
-          [3/8] [policy] 'policy' ❌ ⚠️  <= expected to return true but got false instead
-          [4/8] [params] 'default'
-          [5/8] [transaction]
-          [6/8]   [step] 'in_transaction_step_1'
-          [7/8]   [step] 'in_transaction_step_2'
-          [8/8] [step] 'final_step'
+          [ 1/10] [options] 'default' ✅
+          [ 2/10] [model] 'model' ✅
+          [ 3/10] [policy] 'policy' ❌ ⚠️  <= expected to return true but got false instead
+          [ 4/10] [params] 'default'
+          [ 5/10] [transaction]
+          [ 6/10]   [step] 'in_transaction_step_1'
+          [ 7/10]   [step] 'in_transaction_step_2'
+          [ 8/10] [try]
+          [ 9/10]   [step] 'might_raise'
+          [10/10] [step] 'final_step'
           OUTPUT
         end
       end
@@ -264,6 +309,20 @@ RSpec.describe Service::StepsInspector do
 
       it "returns an error related to the step" do
         expect(error).to eq("my error")
+      end
+    end
+
+    context "when an exception occurred inside the 'try' block" do
+      before do
+        class DummyService
+          def might_raise
+            raise "BOOM"
+          end
+        end
+      end
+
+      it "returns an error related to the exception" do
+        expect(error).to match(/RuntimeError: BOOM/)
       end
     end
   end


### PR DESCRIPTION
This PR adds a new step to services named `try`.

It’s useful to rescue exceptions that some steps could raise. That way, if an exception is caught, the service will stop its execution and can be inspected like with any other steps.

Just wrap the steps that can raise with a `try` block:
```ruby
try do
  step :step_that_can_raise
  step :another_step_that_can_raise
end
```
By default, `try` will catch any exception inheriting from `StandardError`, but we can specify what exceptions to catch:
```ruby
try(ArgumentError, RuntimeError) do
  step :will_raise
end
```

An outcome matcher has been added: `on_exceptions`. By default, it will be executed for any exception caught by the `try` step. Here also, we can specify what exceptions to catch:
```ruby
on_exceptions(ArgumentError, RuntimeError) do |exception|
  …
end
```

Finally, an RSpec matcher has been added:
```ruby
  it { is_expected.to fail_with_exception }
  # or
  it { is_expected.to fail_with_exception(ArgumentError) }
```