### PR TITLE
DEV: Add --ignore-workspace immediately after 'pnpm' in arguments

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -31,14 +31,14 @@ if (
     "> pnpm was run inside a plugin directory. Re-executing with --ignore-workspace..."
   );
 
+  const indexOfPnpm = process.argv.findIndex((a) => a.endsWith("pnpm"));
+  const newArgs = [...process.argv];
+  newArgs.splice(indexOfPnpm + 1, 0, "--ignore-workspace");
+
   try {
-    execFileSync(
-      process.argv[0],
-      [...process.argv.slice(1), "--ignore-workspace"],
-      {
-        stdio: "inherit",
-      }
-    );
+    execFileSync(newArgs[0], newArgs.slice(1), {
+      stdio: "inherit",
+    });
   } catch (e) {
     if (e.status) {
       process.exit(e.status);


### PR DESCRIPTION
Adding it to the end means it may get passed to some other tool (e.g. `pnpm eslint` would end up as `pnpm eslint --ignore-workspace`, but we want `pnpm --ignore-workspace eslint`)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->