### PR TITLE
DEV: Fix passing translatedTitle as argument to flat-button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flat-button.js
+++ b/app/assets/javascripts/discourse/app/components/flat-button.js
@@ -9,12 +9,14 @@ import I18n from "discourse-i18n";
 
 @tagName("button")
 @classNames("btn-flat")
-@attributeBindings("disabled", "translatedTitle:title")
+@attributeBindings("disabled", "resolvedTitle:title")
 export default class FlatButton extends Component {
-  @discourseComputed("title")
-  translatedTitle(title) {
+  @discourseComputed("title", "translatedTitle")
+  resolvedTitle(title, translatedTitle) {
     if (title) {
       return I18n.t(title);
+    } else if (translatedTitle) {
+      return translatedTitle;
     }
   }
 


### PR DESCRIPTION
Overriding computed properties with arguments is no longer supported by Ember, so we need to rename this computed property and add fallback logic manually.

This fixes the styleguide 'buttons' page. Ref https://meta.discourse.org/t/styleguide-bugs/335211?u=david

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->