### PR TITLE
DEV: Create permanent version of `moved_posts` table from PostMover class

### DIFF
--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MovedPost < ActiveRecord::Base
+  belongs_to :old_topic, class_name: "Topic", foreign_key: :old_topic_id
+  belongs_to :old_post, class_name: "Post", foreign_key: :old_post_id
+
+  belongs_to :new_topic, class_name: "Topic", foreign_key: :new_topic_id
+  belongs_to :new_post, class_name: "Post", foreign_key: :new_post_id
+end

--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -7,3 +7,28 @@ class MovedPost < ActiveRecord::Base
   belongs_to :new_topic, class_name: "Topic", foreign_key: :new_topic_id
   belongs_to :new_post, class_name: "Post", foreign_key: :new_post_id
 end
+
+# == Schema Information
+#
+# Table name: moved_posts
+#
+#  id                :bigint           not null, primary key
+#  old_topic_id      :bigint
+#  old_post_id       :bigint
+#  old_post_number   :bigint
+#  new_topic_id      :bigint           not null
+#  new_topic_title   :string           not null
+#  new_post_id       :bigint           not null
+#  new_post_number   :bigint           not null
+#  created_new_topic :boolean          default(FALSE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_moved_posts_on_new_post_id      (new_post_id)
+#  index_moved_posts_on_new_topic_id     (new_topic_id)
+#  index_moved_posts_on_old_post_id      (old_post_id)
+#  index_moved_posts_on_old_post_number  (old_post_number)
+#  index_moved_posts_on_old_topic_id     (old_topic_id)
+#

--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -13,9 +13,9 @@ end
 # Table name: moved_posts
 #
 #  id                :bigint           not null, primary key
-#  old_topic_id      :bigint
-#  old_post_id       :bigint
-#  old_post_number   :bigint
+#  old_topic_id      :bigint           not null
+#  old_post_id       :bigint           not null
+#  old_post_number   :bigint           not null
 #  new_topic_id      :bigint           not null
 #  new_topic_title   :string           not null
 #  new_post_id       :bigint           not null

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -56,6 +56,15 @@ class Post < ActiveRecord::Base
   has_many :post_revisions
   has_many :revisions, -> { order(:number) }, foreign_key: :post_id, class_name: "PostRevision"
 
+  has_many :moved_posts_as_old_post,
+           class_name: "MovedPost",
+           foreign_key: :old_post_id,
+           dependent: :destroy
+  has_many :moved_posts_as_new_post,
+           class_name: "MovedPost",
+           foreign_key: :new_post_id,
+           dependent: :destroy
+
   has_many :user_actions, foreign_key: :target_post_id
 
   belongs_to :image_upload, class_name: "Upload"

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -276,6 +276,15 @@ class Topic < ActiveRecord::Base
   has_many :tags, through: :topic_tags, dependent: :destroy # dependent destroy applies to the topic_tags records
   has_many :tag_users, through: :tags
 
+  has_many :moved_posts_as_old_topic,
+           class_name: "MovedPost",
+           foreign_key: :old_topic_id,
+           dependent: :destroy
+  has_many :moved_posts_as_new_topic,
+           class_name: "MovedPost",
+           foreign_key: :new_topic_id,
+           dependent: :destroy
+
   has_one :top_topic
   has_one :shared_draft, dependent: :destroy
   has_one :published_page
@@ -927,7 +936,7 @@ class Topic < ActiveRecord::Base
       WHERE
         topics.archetype = 'private_message' AND
         X.topic_id = topics.id AND
-        Y.topic_id = topics.id AND 
+        Y.topic_id = topics.id AND
         Z.topic_id = topics.id AND (
           topics.highest_staff_post_number <> X.highest_post_number OR
           topics.highest_post_number <> Y.highest_post_number OR

--- a/db/migrate/20241108154026_create_moved_posts.rb
+++ b/db/migrate/20241108154026_create_moved_posts.rb
@@ -3,13 +3,13 @@
 class CreateMovedPosts < ActiveRecord::Migration[7.1]
   def change
     create_table :moved_posts do |t|
-      t.bigint :old_topic_id, null: true, index: true
-      t.bigint :old_post_id, null: true, index: true
-      t.bigint :old_post_number, null: true, index: true
+      t.bigint :old_topic_id, null: false, index: true
+      t.bigint :old_post_id, null: false, index: true
+      t.bigint :old_post_number, null: false, index: true
       t.bigint :new_topic_id, null: false, index: true
-      t.string :new_topic_title, null: false, index: false
+      t.string :new_topic_title, null: false
       t.bigint :new_post_id, null: false, index: true
-      t.bigint :new_post_number, null: false, index: false
+      t.bigint :new_post_number, null: false
       t.boolean :created_new_topic, null: false, default: false
       t.timestamps
     end

--- a/db/migrate/20241108154026_create_moved_posts.rb
+++ b/db/migrate/20241108154026_create_moved_posts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateMovedPosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :moved_posts do |t|
+      t.bigint :old_topic_id, null: true, index: true
+      t.bigint :old_post_id, null: true, index: true
+      t.bigint :old_post_number, null: true, index: true
+      t.bigint :new_topic_id, null: false, index: true
+      t.string :new_topic_title, null: false, index: false
+      t.bigint :new_post_id, null: false, index: true
+      t.bigint :new_post_number, null: false, index: false
+      t.boolean :created_new_topic, null: false, default: false
+      t.timestamps
+    end
+  end
+end

--- a/spec/fabricators/moved_post_fabricator.rb
+++ b/spec/fabricators/moved_post_fabricator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Fabricator(:moved_post) do
+  created_new_topic false
+  new_topic { Fabricate(:topic) }
+  new_post { Fabricate(:post) }
+  old_topic { Fabricate(:topic) }
+  old_post { Fabricate(:post) }
+
+  after_build do |moved_post, transients|
+    moved_post.new_topic_title = moved_post.new_topic.title
+    moved_post.new_post_number = moved_post.new_post.post_number
+    moved_post.old_post_number = moved_post.old_post.post_number
+  end
+end

--- a/spec/models/moved_post_spec.rb
+++ b/spec/models/moved_post_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe MovedPost do
+  fab!(:new_topic) { Fabricate(:topic) }
+  fab!(:new_post) { Fabricate(:post, topic: new_topic) }
+
+  fab!(:old_topic) { Fabricate(:topic) }
+  fab!(:old_post) { Fabricate(:post, topic: old_topic) }
+
+  fab!(:moved_post) do
+    Fabricate(
+      :moved_post,
+      new_topic: new_topic,
+      new_post: new_post,
+      old_topic: old_topic,
+      old_post: old_post,
+    )
+  end
+
+  describe "Topic & Post associations" do
+    it "deletes the MovePost record when new_topic is deleted" do
+      new_topic.destroy
+      expect { moved_post.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes the MovePost record when old_topic is deleted" do
+      old_topic.destroy
+      expect { moved_post.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes the MovePost record when new_post is deleted" do
+      new_post.destroy
+      expect { moved_post.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes the MovePost record when old_post is deleted" do
+      old_post.destroy
+      expect { moved_post.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -249,6 +249,8 @@ RSpec.describe PostMover do
         context "when moved to a new topic" do
           it "works correctly" do
             topic.expects(:add_moderator_post).once
+            p2_id = p2.id
+            p4_id = p4.id
             new_topic =
               topic.move_posts(
                 user,
@@ -308,6 +310,26 @@ RSpec.describe PostMover do
               ),
             ).to eq(true)
             expect(TopicUser.exists?(user_id: user, topic_id: new_topic.id)).to eq(true)
+
+            # moved_post records are created correctly
+            expect(
+              MovedPost.exists?(
+                new_topic: new_topic,
+                new_post_id: p2.id,
+                old_topic: topic,
+                old_post_id: p2.id,
+                created_new_topic: true,
+              ),
+            ).to eq(true)
+            expect(
+              MovedPost.exists?(
+                new_topic: new_topic,
+                new_post_id: p4.id,
+                old_topic: topic,
+                old_post_id: p4.id,
+                created_new_topic: true,
+              ),
+            ).to eq(true)
           end
 
           it "moving all posts will close the topic" do
@@ -670,6 +692,25 @@ RSpec.describe PostMover do
             expect(
               TopicUser.find_by(user_id: user.id, topic_id: topic.id).last_read_post_number,
             ).to eq(p3.post_number)
+
+            expect(
+              MovedPost.exists?(
+                new_topic: destination_topic,
+                new_post_id: p2.id,
+                old_topic: topic,
+                old_post_id: p2.id,
+                created_new_topic: false,
+              ),
+            ).to eq(true)
+            expect(
+              MovedPost.exists?(
+                new_topic: destination_topic,
+                new_post_id: p4.id,
+                old_topic: topic,
+                old_post_id: p4.id,
+                created_new_topic: false,
+              ),
+            ).to eq(true)
           end
 
           it "moving all posts will close the topic" do

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -249,8 +249,6 @@ RSpec.describe PostMover do
         context "when moved to a new topic" do
           it "works correctly" do
             topic.expects(:add_moderator_post).once
-            p2_id = p2.id
-            p4_id = p4.id
             new_topic =
               topic.move_posts(
                 user,


### PR DESCRIPTION
This is a very simple change, which creates a permanent table in the DB, rather than generating a temporary table when moving posts. This change is about capturing data and any usage will appear in a follow-up.

I did include a new column `created_new_topic` in the new table, so that it can be easily audited without having to compare destination topic created_at with moved_post records.