### PR TITLE
UX: reduce bottom topic map threshold, with protections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -28,7 +28,7 @@ const MIN_LIKES_COUNT = 5;
 const MIN_PARTICIPANTS_COUNT = 5;
 const MIN_USERS_COUNT_FOR_AVATARS = 2;
 
-export const MIN_POSTS_COUNT = 5;
+export const MIN_POSTS_COUNT = 3;
 
 export default class TopicMapSummary extends Component {
   @service site;

--- a/spec/system/topic_map_spec.rb
+++ b/spec/system/topic_map_spec.rb
@@ -21,7 +21,6 @@ describe "Topic Map", type: :system do
     topic_page.visit_topic(topic)
 
     expect(topic_page).to have_topic_map
-    2.times { Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1) }
     page.refresh
     expect(topic_page).to have_topic_map
     expect(topic_map).to have_no_users
@@ -32,6 +31,7 @@ describe "Topic Map", type: :system do
     # bottom map, avatars details with post counts
     expect(topic_map).to have_no_bottom_map
 
+    2.times { Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 1) }
     Fabricate(:post, topic: topic, created_at: 2.day.ago)
     Fabricate(:post, topic: topic, created_at: 1.day.ago, like_count: 3)
     page.refresh


### PR DESCRIPTION
This reduces the post count threshold for the bottom topic map to 3. 


![image](https://github.com/user-attachments/assets/10cd1ecb-d893-4b23-af4a-bad280ea5147)


Including a word count minimum and filtering out small posts will help ensure that in cases where there's not much content people won't be seeing two topic maps at the same time. 