### PR TITLE
UX: Change the authorize button color to primary

### DIFF
--- a/app/views/user_api_keys/new.html.erb
+++ b/app/views/user_api_keys/new.html.erb
@@ -28,7 +28,7 @@
   <%= hidden_field_tag 'push_url', @push_url %>
   <%= hidden_field_tag 'public_key', @public_key%>
   <%= hidden_field_tag 'scopes', @scopes%>
-  <%= submit_tag t('user_api_key.authorize'), class: 'btn btn-danger' %>
+  <%= submit_tag t('user_api_key.authorize'), class: 'btn btn-primary' %>
 <% end %>
 </div>
 <% end %>

--- a/app/views/user_api_keys/otp.html.erb
+++ b/app/views/user_api_keys/otp.html.erb
@@ -4,6 +4,6 @@
   <%= hidden_field_tag 'application_name', @application_name %>
   <%= hidden_field_tag 'public_key', @public_key%>
   <%= hidden_field_tag('auth_redirect', @auth_redirect) %>
-  <%= submit_tag t('user_api_key.authorize'), class: 'btn btn-danger' %>
+  <%= submit_tag t('user_api_key.authorize'), class: 'btn btn-primary' %>
 <% end %>
 </div>


### PR DESCRIPTION
Primary is a more appropriate color here than "danger". Authorizing is important, but we usually use "danger" for destructive actions and nothing is being destroyed here.