### PR TITLE
FIX: broken post in styleguide

### DIFF
--- a/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js
+++ b/plugins/styleguide/assets/javascripts/discourse/lib/dummy-data.js
@@ -169,11 +169,11 @@ export function createData(store) {
     canManage: true,
     canDelete: true,
     post_number: 1,
+    topic: createTopic(),
   };
 
   const postModel = store.createRecord("post", {
     ...transformedPost,
-    topic: createTopic(),
   });
 
   _data = {


### PR DESCRIPTION
The base `transformedPost` in dummy-data was missing the topic object.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->