### PR TITLE
FIX: Dismiss unread posts in subcategories

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -207,7 +207,7 @@ export default class DiscoveryListController extends Controller {
     this.bulkSelectHelper.dismissRead(operationType, {
       categoryId: this.model.category?.id,
       tagName: this.model.tag?.id,
-      includeSubcategories: this.model.noSubcategories,
+      includeSubcategories: !this.model.noSubcategories,
     });
   }
 }

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -32,3 +32,24 @@ describe "Viewing top topics on categories page", type: :system do
     expect(category_list).to have_no_new_posts_badge
   end
 end
+
+describe "Viewing category topic list", type: :system do
+  let(:topic_list) { PageObjects::Components::TopicList.new }
+
+  context "when parent category has no_subcategories=true" do
+    fab!(:parent_category) { Fabricate(:category_with_definition, default_list_filter: "none") }
+    fab!(:subcategoryA) { Fabricate(:category_with_definition, parent_category: parent_category) }
+    fab!(:topic) { Fabricate(:topic, category: subcategoryA) }
+    fab!(:post) { create_post(topic: topic) }
+
+    it "shows the topic on the subcategory" do
+      visit "/c/#{parent_category.slug}/#{subcategoryA.slug}"
+      expect(topic_list).to have_topic(topic)
+    end
+
+    it "does not list the topic on the parent category" do
+      visit "/c/#{parent_category.slug}"
+      expect(topic_list).to have_no_topic(topic)
+    end
+  end
+end

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -36,13 +36,13 @@ end
 describe "Viewing category topic list", type: :system do
   let(:topic_list) { PageObjects::Components::TopicList.new }
 
-  context "when parent category has no_subcategories=true" do
+  context "when parent category has default_list_filter=none" do
     fab!(:parent_category) { Fabricate(:category_with_definition, default_list_filter: "none") }
     fab!(:subcategoryA) { Fabricate(:category_with_definition, parent_category: parent_category) }
     fab!(:topic) { Fabricate(:topic, category: subcategoryA) }
     fab!(:post) { create_post(topic: topic) }
 
-    it "shows the topic on the subcategory" do
+    it "lists the topic on the subcategory" do
       visit "/c/#{parent_category.slug}/#{subcategoryA.slug}"
       expect(topic_list).to have_topic(topic)
     end

--- a/spec/system/category_topics_spec.rb
+++ b/spec/system/category_topics_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Viewing top topics on categories page", type: :system do
+describe "Viewing categories page", type: :system do
   fab!(:user)
   fab!(:category)
   fab!(:topic) { Fabricate(:topic, category: category) }
@@ -8,48 +8,50 @@ describe "Viewing top topics on categories page", type: :system do
   let(:category_list) { PageObjects::Components::CategoryList.new }
   let(:topic_view) { PageObjects::Components::TopicView.new }
 
-  it "displays and updates new counter" do
-    skip(<<~TEXT)
+  context "when viewing top topics" do
+    it "displays and updates new counter" do
+      skip(<<~TEXT)
     Flaky at the following step:
 
     expect(category_list).to have_no_new_posts_badge
        expected `#<PageObjects::Components::CategoryList:0x00007fe27a3d2340>.has_no_new_posts_badge?` to be truthy, got false
     TEXT
 
-    sign_in(user)
+      sign_in(user)
 
-    visit("/categories")
+      visit("/categories")
 
-    category_list.click_new_posts_badge(count: 1)
-    category_list.click_topic(topic)
+      category_list.click_new_posts_badge(count: 1)
+      category_list.click_topic(topic)
 
-    expect(topic_view).to have_read_post(post)
+      expect(topic_view).to have_read_post(post)
 
-    category_list.click_logo
-    category_list.click_category_navigation
+      category_list.click_logo
+      category_list.click_category_navigation
 
-    expect(category_list).to have_category(category)
-    expect(category_list).to have_no_new_posts_badge
-  end
-end
-
-describe "Viewing category topic list", type: :system do
-  let(:topic_list) { PageObjects::Components::TopicList.new }
-
-  context "when parent category has default_list_filter=none" do
-    fab!(:parent_category) { Fabricate(:category_with_definition, default_list_filter: "none") }
-    fab!(:subcategoryA) { Fabricate(:category_with_definition, parent_category: parent_category) }
-    fab!(:topic) { Fabricate(:topic, category: subcategoryA) }
-    fab!(:post) { create_post(topic: topic) }
-
-    it "lists the topic on the subcategory" do
-      visit "/c/#{parent_category.slug}/#{subcategoryA.slug}"
-      expect(topic_list).to have_topic(topic)
+      expect(category_list).to have_category(category)
+      expect(category_list).to have_no_new_posts_badge
     end
+  end
 
-    it "does not list the topic on the parent category" do
-      visit "/c/#{parent_category.slug}"
-      expect(topic_list).to have_no_topic(topic)
+  context "when viewing the category's topic list" do
+    let(:topic_list) { PageObjects::Components::TopicList.new }
+
+    context "when parent category has default_list_filter=none" do
+      fab!(:parent_category) { Fabricate(:category_with_definition, default_list_filter: "none") }
+      fab!(:subcategoryA) { Fabricate(:category_with_definition, parent_category: parent_category) }
+      fab!(:topic) { Fabricate(:topic, category: subcategoryA) }
+      fab!(:post) { create_post(topic: topic) }
+
+      it "lists the topic on the subcategory" do
+        visit "/c/#{parent_category.slug}/#{subcategoryA.slug}"
+        expect(topic_list).to have_topic(topic)
+      end
+
+      it "does not list the topic on the parent category" do
+        visit "/c/#{parent_category.slug}"
+        expect(topic_list).to have_no_topic(topic)
+      end
     end
   end
 end

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe "Dismissing New", type: :system do
       using_session(:tab_1) { expect(topic_view).to have_tracking_status("regular") }
     end
 
-    context "with subcategories" do
+    context "when dismissing new on a category's topic list" do
       fab!(:category) { Fabricate(:category_with_definition) }
       fab!(:subcategory) { Fabricate(:category_with_definition, parent_category: category) }
       fab!(:subcategory_topic) { Fabricate(:topic, category: subcategory, user: user) }
       fab!(:subcategory_post1) { create_post(user: user, topic: subcategory_topic) }
       fab!(:subcategory_post2) { create_post(topic: subcategory_topic) }
 
-      it "should dismiss unread posts in subcategories when they are included in the parent category topic list" do
+      it "should dismiss unread posts for the category and its subcategories" do
         sign_in(user)
 
         visit("/c/#{category.id}/l/unread")

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe "Dismissing New", type: :system do
     context "when dismissing new on a category's topic list" do
       fab!(:category) { Fabricate(:category_with_definition) }
       fab!(:subcategory) { Fabricate(:category_with_definition, parent_category: category) }
+      fab!(:category_topic) { Fabricate(:topic, category: category, user: user) }
+      fab!(:category_post1) { create_post(user: user, topic: category_topic) }
+      fab!(:category_post2) { create_post(topic: category_topic) }
       fab!(:subcategory_topic) { Fabricate(:topic, category: subcategory, user: user) }
       fab!(:subcategory_post1) { create_post(user: user, topic: subcategory_topic) }
       fab!(:subcategory_post2) { create_post(topic: subcategory_topic) }
@@ -66,7 +69,7 @@ RSpec.describe "Dismissing New", type: :system do
 
         visit("/c/#{category.id}/l/unread")
 
-        expect(topic_list_controls).to have_unread(count: 1)
+        expect(topic_list_controls).to have_unread(count: 2)
 
         topic_list_controls.dismiss_unread
 

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe "Dismissing New", type: :system do
 
       using_session(:tab_1) { expect(topic_view).to have_tracking_status("regular") }
     end
+
+    context "with subcategories" do
+      fab!(:category) { Fabricate(:category_with_definition) }
+      fab!(:subcategory) { Fabricate(:category_with_definition, parent_category: category) }
+      fab!(:subcategory_topic) { Fabricate(:topic, category: subcategory, user: user) }
+      fab!(:subcategory_post1) { create_post(user: user, topic: subcategory_topic) }
+      fab!(:subcategory_post2) { create_post(topic: subcategory_topic) }
+
+      it "should dismiss unread posts in subcategories when they are included in the parent category topic list" do
+        sign_in(user)
+
+        visit("/c/#{category.id}/l/unread")
+
+        expect(topic_list_controls).to have_unread(count: 1)
+
+        topic_list_controls.dismiss_unread
+
+        expect(topic_list_controls).to have_unread(count: 0)
+      end
+    end
   end
 
   describe "when a user has a new topic" do


### PR DESCRIPTION
When a parent category shows topics from subcategories, dismissing should dismiss posts in both parent and subcategories.

See meta t/335195 for the original report. 