### PR TITLE
DEV: Use query param for login-required welcome screen

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -35,7 +35,6 @@ export default class LoginPageController extends Controller {
   @tracked loggingIn = false;
   @tracked loggedIn = false;
   @tracked showLoginButtons = true;
-  @tracked showLogin = true;
   @tracked showSecondFactor = false;
   @tracked loginPassword = "";
   @tracked loginName = "";
@@ -54,6 +53,7 @@ export default class LoginPageController extends Controller {
   @tracked secondFactorToken;
   @tracked flash;
   @tracked flashType;
+  queryParams = ["welcome"];
 
   get isAwaitingApproval() {
     return (
@@ -118,7 +118,7 @@ export default class LoginPageController extends Controller {
 
   @action
   showLoginPage() {
-    this.showLogin = true;
+    this.router.transitionTo("login", { queryParams: { welcome: undefined } });
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -8,6 +8,10 @@ export default class LoginRoute extends DiscourseRoute {
   @service siteSettings;
   @service router;
 
+  queryParams = {
+    welcome: { refreshModel: true },
+  };
+
   beforeModel() {
     if (
       !this.siteSettings.login_required &&
@@ -33,9 +37,5 @@ export default class LoginRoute extends DiscourseRoute {
     controller.set("canSignUp", canSignUp);
     controller.set("flashType", "");
     controller.set("flash", "");
-
-    if (this.siteSettings.login_required) {
-      controller.set("showLogin", false);
-    }
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/login.hbs
@@ -1,9 +1,4 @@
-{{#if
-  (and
-    this.siteSettings.experimental_full_page_login
-    (or this.showLogin (not this.siteSettings.login_required))
-  )
-}}
+{{#if (and this.siteSettings.experimental_full_page_login (not this.welcome))}}
   {{hide-application-header-buttons "search" "login" "signup" "menu"}}
   {{hide-application-sidebar}}
   {{body-class "login-page"}}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -850,7 +850,7 @@ class ApplicationController < ActionController::Base
     else
       # save original URL in a cookie (javascript redirects after login in this case)
       cookies[:destination_url] = destination_url
-      redirect_to path("/login")
+      redirect_to path("/login?welcome")
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -850,7 +850,9 @@ class ApplicationController < ActionController::Base
     else
       # save original URL in a cookie (javascript redirects after login in this case)
       cookies[:destination_url] = destination_url
-      redirect_to path("/login?welcome")
+
+      redirect_path = request.path_info == "/" ? "/login?welcome" : "/login"
+      redirect_to path(redirect_path)
     end
   end
 

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -123,6 +123,15 @@ shared_examples "login scenarios" do |login_page_object|
       login_form.fill(username: "john", password: "supersecurepassword").click_login
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
+
+    it "shows login form when visiting /login route directly" do
+      skip "Only applies on full page login" if !SiteSetting.experimental_full_page_login
+
+      visit "/login"
+
+      expect(page).to have_css("#login-account-name")
+      expect(page).to have_css("#login-form")
+    end
   end
 
   context "with two-factor authentication" do

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -132,6 +132,21 @@ shared_examples "login scenarios" do |login_page_object|
       expect(page).to have_css("#login-account-name")
       expect(page).to have_css("#login-form")
     end
+
+    it "shows login form when visiting non-root route" do
+      skip "Only applies on full page login" if !SiteSetting.experimental_full_page_login
+      visit "/about"
+
+      expect(page).to have_css("#login-account-name")
+      expect(page).to have_css("#login-form")
+      expect(page).to have_current_path("/login")
+
+      EmailToken.confirm(Fabricate(:email_token, user: user).token)
+      login_form.fill(username: "john", password: "supersecurepassword").click_login
+      expect(page).to have_css(".header-dropdown-toggle.current-user")
+
+      expect(page).to have_current_path("/about")
+    end
   end
 
   context "with two-factor authentication" do


### PR DESCRIPTION
With the full screen login page, on login required sites we want to show a welcome page. However, we should be able to also link directly to the login form. This commit adds a `welcome` query param to the login route, and shows the login form when this param is not present.

This means links to "/login" will show the login form directly. And it also means routing between the welcome screen and the login form works as expected.
