### PR TITLE
FIX: migrations must be finished to reset flags cache

### DIFF
--- a/config/initializers/100-flags.rb
+++ b/config/initializers/100-flags.rb
@@ -2,7 +2,8 @@
 
 # On initialize, reset flags cache
 Rails.application.config.to_prepare do
-  if Discourse.cache.is_a?(Cache) && ActiveRecord::Base.connection.table_exists?(:flags)
+  if Discourse.cache.is_a?(Cache) &&
+       !ActiveRecord::Base.connection.migration_context.needs_migration?
     Flag.reset_flag_settings!
   end
 end


### PR DESCRIPTION
Bug introduced here: https://github.com/discourse/discourse/pull/29609

It was checking if `flags` table existed before resetting the cache. However, `require_message` flag was added in further migration:

https://github.com/discourse/discourse/blob/main/db/migrate/20240714231226_duplicate_flags_custom_type_to_require_message.rb#L5

When the admin tried to update Discourse which already has `flags` table but no `require_message` column, it was causing the error.

Therefore, we should ensure that all migrations are finished before resetting flags cache.

Meta: https://meta.discourse.org/t/update-failing-column-require-message-does-not-exist/335030