### PR TITLE
FIX: flaky system flags spec

### DIFF
--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -245,6 +245,7 @@ module PageObjects
       end
 
       def open_flag_topic_modal
+        expect(page).to have_css(".flag-topic", wait: Capybara.default_max_wait_time * 3)
         find(".flag-topic").click
       end
 


### PR DESCRIPTION
Wait for the flag button to arrive before clicking it.