### PR TITLE
FIX: filterable staff logs for flags

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-flags.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-flags.js
@@ -1,7 +1,7 @@
 import Controller from "@ember/controller";
 import { service } from "@ember/service";
 
-export default class AdminConfigFlagsSettingsController extends Controller {
+export default class AdminConfigFlagsController extends Controller {
   @service router;
 
   get hideTabs() {

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -274,6 +274,10 @@ class UserHistory < ActiveRecord::Base
       tag_group_destroy
       tag_group_change
       delete_associated_accounts
+      toggle_flag
+      delete_flag
+      update_flag
+      create_flag
     ]
   end
 

--- a/spec/system/admin_staff_action_logs_spec.rb
+++ b/spec/system/admin_staff_action_logs_spec.rb
@@ -11,6 +11,14 @@ describe "Admin staff action logs", type: :system do
     )
   end
   fab!(:history_2) { Fabricate(:topic_closed_change_history) }
+  fab!(:history_3) do
+    Fabricate(
+      :user_history,
+      action: UserHistory.actions[:custom_staff],
+      details: "flag updated",
+      custom_type: "update_flag",
+    )
+  end
   let(:staff_action_logs_page) { PageObjects::Pages::AdminStaffActionLogs.new }
 
   before { sign_in(current_user) }
@@ -34,6 +42,7 @@ describe "Admin staff action logs", type: :system do
 
     expect(staff_action_logs_page).to have_log_row(history_1)
     expect(staff_action_logs_page).to have_log_row(history_2)
+    expect(staff_action_logs_page).to have_log_row(history_3)
 
     staff_action_logs_page.filter_by_action(:change_site_setting)
 
@@ -44,6 +53,21 @@ describe "Admin staff action logs", type: :system do
 
     expect(staff_action_logs_page).to have_log_row(history_1)
     expect(staff_action_logs_page).to have_no_log_row(history_2)
+    expect(staff_action_logs_page).to have_no_log_row(history_3)
+
+    staff_action_logs_page.clear_filter
+
+    staff_action_logs_page.filter_by_action(:update_flag)
+
+    expect(staff_action_logs_page).to have_no_log_row(history_1)
+    expect(staff_action_logs_page).to have_no_log_row(history_2)
+    expect(staff_action_logs_page).to have_log_row(history_3)
+  end
+
+  it "displays no result" do
+    visit "/admin/logs/staff_action_logs"
+    staff_action_logs_page.filter_by_action(:toggle_flag)
+    expect(page).to have_text(I18n.t("js.search.no_results"))
   end
 
   it "can show details for an action" do

--- a/spec/system/page_objects/pages/admin_staff_action_logs.rb
+++ b/spec/system/page_objects/pages/admin_staff_action_logs.rb
@@ -26,8 +26,12 @@ module PageObjects
 
       def filter_by_action(action)
         filter = PageObjects::Components::SelectKit.new("#staff-action-logs-action-filter")
-        filter.search(I18n.t("admin_js.admin.logs.staff_actions.actions.change_site_setting"))
-        filter.select_row_by_value(UserHistory.actions.key(UserHistory.actions[action.to_sym]).to_s)
+        filter.search(I18n.t("admin_js.admin.logs.staff_actions.actions.#{action}"))
+        filter.select_row_by_value(action.to_s)
+      end
+
+      def clear_filter
+        find(".clear-filters").click
       end
     end
   end


### PR DESCRIPTION
Flag actions must be added to `staff_actions` method to be filterable.

<img width="1414" alt="Screenshot 2024-11-11 at 4 05 13 PM" src="https://github.com/user-attachments/assets/6c37e8fe-dfc6-4693-8859-b358f5b141f9">
