### PR TITLE
FIX: flakey due to 0 width/height images

### DIFF
--- a/plugins/chat/test/javascripts/components/chat-message-collapser-test.js
+++ b/plugins/chat/test/javascripts/components/chat-message-collapser-test.js
@@ -13,9 +13,9 @@ const youtubeCooked =
 
 const animatedImageCooked =
   "<p>written text</p>" +
-  '<p><img src="/images/avatar.png" class="animated onebox"></img></p>' +
+  '<p><img src="/images/avatar.png" width="8" height="8" class="animated onebox"></img></p>' +
   "<p>more written text</p>" +
-  '<p><img src="/images/d-logo-sketch-small.png" class="animated onebox"></img></p>' +
+  '<p><img src="/images/d-logo-sketch-small.png" width="8" height="8" class="animated onebox"></img></p>' +
   "<p>and even more</p>";
 
 const externalImageCooked =


### PR DESCRIPTION
https://github.com/mainmatter/qunit-dom/blob/master/API.md#isvisible will return true if offsetWidth or offsetHeight are zero which could happen in this case as the test could run before the image has loaded. By forcing a minimum height in the test we ensure it will be consistent.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->