### PR TITLE
DEV: Additional outletArgs to full-page-search-below-search-info

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -151,7 +151,13 @@
       <PluginOutlet
         @name="full-page-search-below-search-info"
         @connectorTagName="div"
-        @outletArgs={{hash search=this.searchTerm}}
+        @outletArgs={{hash
+          search=this.searchTerm
+          type=this.search_type
+          model=this.model
+          addSearchResults=this.addSearchResults
+          sortOrder=this.sortOrder
+        }}
       />
     </span>
 


### PR DESCRIPTION
This passes more args to another outlet for plugin customization of the full-page search UI.