### PR TITLE
Revert "DEV: Enable the normalize_emails site setting by default (#29587)"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -611,7 +611,7 @@ login:
     type: host_list
     list_type: simple
   normalize_emails:
-    default: true
+    default: false
   auto_approve_email_domains:
     default: ""
     type: host_list

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -804,11 +804,11 @@ RSpec.describe Search do
     end
 
     context "with all topics" do
-      let!(:u1) { Fabricate(:user, username: "fred", name: "bob jones", email: "fred@bar.baz") }
-      let!(:u2) { Fabricate(:user, username: "bob", name: "fred jones", email: "bob@bar.baz") }
-      let!(:u3) { Fabricate(:user, username: "jones", name: "bob fred", email: "jones@bar.baz") }
+      let!(:u1) { Fabricate(:user, username: "fred", name: "bob jones", email: "foo+1@bar.baz") }
+      let!(:u2) { Fabricate(:user, username: "bob", name: "fred jones", email: "foo+2@bar.baz") }
+      let!(:u3) { Fabricate(:user, username: "jones", name: "bob fred", email: "foo+3@bar.baz") }
       let!(:u4) do
-        Fabricate(:user, username: "alice", name: "bob fred", email: "alice@bar.baz", admin: true)
+        Fabricate(:user, username: "alice", name: "bob fred", email: "foo+4@bar.baz", admin: true)
       end
 
       let!(:public_topic) { Fabricate(:topic, user: u1) }

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -904,7 +904,7 @@ RSpec.describe DiscourseConnect do
       user = sso.lookup_or_create_user(ip_address)
       expect(user.active).to eq(true)
 
-      user.primary_email.update(email: "xXx@themovie.com")
+      user.primary_email.update_columns(email: "xXx@themovie.com")
 
       user = sso.lookup_or_create_user(ip_address)
       expect(user.email).to eq(old_email)


### PR DESCRIPTION
This reverts commit 7d9d98422c8c68db5b6f64e08428ea5a2b30f4f2.

Reverting for now because this can cause issues on SSO setups