### PR TITLE
UX: Fix modal header background color in webview

### DIFF
--- a/app/assets/javascripts/discourse/app/components/footer-nav.gjs
+++ b/app/assets/javascripts/discourse/app/components/footer-nav.gjs
@@ -21,10 +21,13 @@ export default class FooterNav extends Component {
   }
 
   _modalOff() {
-    postRNWebviewMessage(
-      "headerBg",
-      document.documentElement.style.getPropertyValue("--header_background")
-    );
+    const header = document.querySelector(".d-header-wrap .d-header");
+    if (header) {
+      postRNWebviewMessage(
+        "headerBg",
+        window.getComputedStyle(header).backgroundColor
+      );
+    }
   }
 
   @action


### PR DESCRIPTION
This regressed at some point during a refactor. 

`document.documentElement.style.getPropertyValue` will only get inline CSS custom properties, and `--header_background` isn't inline, so this always returns nothing. 

Before 

![image](https://github.com/user-attachments/assets/6f4a277c-2a3d-4e37-8613-ae65c03c41e1)

After

![image](https://github.com/user-attachments/assets/0ba12c89-db5b-41b2-b79d-adb9352f7892)

The fix here is consistent with how we calculate the same background in `glimmer-site-header.gjs`. We could have also used: 

```
        getComputedStyle(document.documentElement).getPropertyValue(
          "--header_background"
        )
```

But the header element check is better because it is consistent with how we set the original webview background and it also works correctly with themes that don't use the `--header_background` and override the header in other ways. 

No tests, we can't easily simulate the webview context. 