### PR TITLE
DEV: Don’t replace Rails logger in specs

### DIFF
--- a/plugins/automation/spec/scripts/topic_spec.rb
+++ b/plugins/automation/spec/scripts/topic_spec.rb
@@ -167,12 +167,11 @@ describe "Topic" do
     end
 
     context "when creating the post fails" do
-      before do
-        @orig_logger = Rails.logger
-        Rails.logger = @fake_logger = FakeLogger.new
-      end
+      let(:fake_logger) { FakeLogger.new }
 
-      after { Rails.logger = @orig_logger }
+      before { Rails.logger.broadcast_to(fake_logger) }
+
+      after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
       it "logs a warning" do
         expect { UserUpdater.new(user, user).update(location: "Japan") }.to change {

--- a/plugins/automation/spec/scripts/user_group_membership_through_badge_spec.rb
+++ b/plugins/automation/spec/scripts/user_group_membership_through_badge_spec.rb
@@ -28,12 +28,11 @@ describe "UserGroupMembershipThroughBadge" do
   end
 
   context "with invalid field values" do
-    before do
-      @original_logger = Rails.logger
-      Rails.logger = @fake_logger = FakeLogger.new
-    end
+    let(:fake_logger) { FakeLogger.new }
 
-    after { Rails.logger = @original_logger }
+    before { Rails.logger.broadcast_to(fake_logger) }
+
+    after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
     context "with an unknown badge" do
       let(:unknown_badge_id) { -1 }
@@ -47,7 +46,7 @@ describe "UserGroupMembershipThroughBadge" do
       end
 
       it "logs warning message and does nothing" do
-        expect(@fake_logger.warnings).to include(
+        expect(fake_logger.warnings).to include(
           "[discourse-automation] Couldn’t find badge with id #{unknown_badge_id}",
         )
         expect(user.reload.groups).to be_empty
@@ -68,7 +67,7 @@ describe "UserGroupMembershipThroughBadge" do
           "user" => user,
         )
 
-        expect(@fake_logger.warnings).to include(
+        expect(fake_logger.warnings).to include(
           "[discourse-automation] Couldn’t find group with id #{target_group.id}",
         )
         expect(user.reload.groups).to be_empty

--- a/plugins/automation/spec/scripts/zapier_webhook_spec.rb
+++ b/plugins/automation/spec/scripts/zapier_webhook_spec.rb
@@ -22,12 +22,11 @@ describe "ZapierWebhook" do
   end
 
   context "with invalid webhook url" do
-    before do
-      @orig_logger = Rails.logger
-      Rails.logger = @fake_logger = FakeLogger.new
-    end
+    let(:fake_logger) { FakeLogger.new }
 
-    after { Rails.logger = @orig_logger }
+    before { Rails.logger.broadcast_to(fake_logger) }
+
+    after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
     it "logs an error and do nothing" do
       expect { automation.trigger! }.not_to change {

--- a/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_archive_service_spec.rb
@@ -413,7 +413,6 @@ describe Chat::ChannelArchiveService do
       end
 
       it "handles errors gracefully, sends a private message to the archiving user, and is idempotent on retry" do
-        Rails.logger = @fake_logger = FakeLogger.new
         create_messages(35) && start_archive
 
         Chat::ChannelArchiveService

--- a/spec/lib/discourse_hub_spec.rb
+++ b/spec/lib/discourse_hub_spec.rb
@@ -106,12 +106,11 @@ RSpec.describe DiscourseHub do
   end
 
   describe ".collection_action" do
-    before do
-      @orig_logger = Rails.logger
-      Rails.logger = @fake_logger = FakeLogger.new
-    end
+    let(:fake_logger) { FakeLogger.new }
 
-    after { Rails.logger = @orig_logger }
+    before { Rails.logger.broadcast_to(fake_logger) }
+
+    after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
     it "should log correctly on error" do
       stub_request(:get, (ENV["HUB_BASE_URL"] || "http://local.hub:3000/api") + "/test").to_return(
@@ -123,9 +122,9 @@ RSpec.describe DiscourseHub do
 
       DiscourseHub.collection_action(:get, "/test")
 
-      expect(@fake_logger.warnings).to eq([DiscourseHub.response_status_log_message("/test", 500)])
+      expect(fake_logger.warnings).to eq([DiscourseHub.response_status_log_message("/test", 500)])
 
-      expect(@fake_logger.errors).to eq([DiscourseHub.response_body_log_message("")])
+      expect(fake_logger.errors).to eq([DiscourseHub.response_body_log_message("")])
     end
   end
 end

--- a/spec/lib/discourse_ip_info_spec.rb
+++ b/spec/lib/discourse_ip_info_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe DiscourseIpInfo do
     end
 
     it "should not throw an error and instead log the exception when database file fails to download" do
-      original_logger = Rails.logger
-      Rails.logger = fake_logger = FakeLogger.new
+      fake_logger = FakeLogger.new
+      Rails.logger.broadcast_to(fake_logger)
 
       global_setting :maxmind_license_key, "license_key"
       global_setting :maxmind_account_id, "account_id"
@@ -81,7 +81,7 @@ RSpec.describe DiscourseIpInfo do
         "MaxMind database GeoLite2-City download failed. 500 Error",
       )
     ensure
-      Rails.logger = original_logger
+      Rails.logger.stop_broadcasting_to(fake_logger)
     end
   end
 end

--- a/spec/lib/middleware/discourse_public_exceptions_spec.rb
+++ b/spec/lib/middleware/discourse_public_exceptions_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Middleware::DiscoursePublicExceptions do
-  before do
-    @orig_logger = Rails.logger
-    Rails.logger = @fake_logger = FakeLogger.new
-  end
+  let(:fake_logger) { FakeLogger.new }
 
-  after { Rails.logger = @orig_logger }
+  before { Rails.logger.broadcast_to(fake_logger) }
+
+  after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
   def env(opts = {})
     {
@@ -27,6 +26,6 @@ RSpec.describe Middleware::DiscoursePublicExceptions do
       ),
     )
 
-    expect(@fake_logger.warnings.length).to eq(0)
+    expect(fake_logger.warnings.length).to eq(0)
   end
 end

--- a/spec/lib/mini_scheduler_long_running_job_logger_spec.rb
+++ b/spec/lib/mini_scheduler_long_running_job_logger_spec.rb
@@ -38,12 +38,11 @@ RSpec.describe MiniSchedulerLongRunningJobLogger do
     manager.stop!
   end
 
-  before do
-    @orig_logger = Rails.logger
-    Rails.logger = @fake_logger = FakeLogger.new
-  end
+  let(:fake_logger) { FakeLogger.new }
 
-  after { Rails.logger = @orig_logger }
+  before { Rails.logger.broadcast_to(fake_logger) }
+
+  after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
   it "logs long running jobs" do
     with_running_scheduled_job(Every10MinutesJob) do
@@ -58,28 +57,28 @@ RSpec.describe MiniSchedulerLongRunningJobLogger do
 
         wait_for { loops == 1 }
 
-        expect(@fake_logger.warnings.size).to eq(1)
+        expect(fake_logger.warnings.size).to eq(1)
 
-        expect(@fake_logger.warnings.first).to match(
+        expect(fake_logger.warnings.first).to match(
           "Sidekiq scheduled job `Every10MinutesJob` has been running for more than 30 minutes",
         )
 
         # Matches the backtrace
-        expect(@fake_logger.warnings.first).to match("sleep")
+        expect(fake_logger.warnings.first).to match("sleep")
 
         # Check that the logger doesn't log repeated warnings after 2 loops
         expect do
           checker.thread.wakeup # Force the thread to run the next loop
 
           wait_for { loops == 2 }
-        end.not_to change { @fake_logger.warnings.size }
+        end.not_to change { fake_logger.warnings.size }
 
         # Check that the logger doesn't log repeated warnings after 3 loops
         expect do
           checker.thread.wakeup # Force the thread to run the next loop
 
           wait_for { loops == 3 }
-        end.not_to change { @fake_logger.warnings.size }
+        end.not_to change { fake_logger.warnings.size }
       ensure
         checker.stop
         expect(checker.thread).to eq(nil)
@@ -100,9 +99,9 @@ RSpec.describe MiniSchedulerLongRunningJobLogger do
 
         wait_for { loops == 1 }
 
-        expect(@fake_logger.warnings.size).to eq(1)
+        expect(fake_logger.warnings.size).to eq(1)
 
-        expect(@fake_logger.warnings.first).to match(
+        expect(fake_logger.warnings.first).to match(
           "Sidekiq scheduled job `DailyJob` has been running for more than 120 minutes",
         )
       ensure

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1036,12 +1036,11 @@ RSpec.describe Report do
   end
 
   describe "unexpected error on report initialization" do
-    before do
-      @orig_logger = Rails.logger
-      Rails.logger = @fake_logger = FakeLogger.new
-    end
+    let(:fake_logger) { FakeLogger.new }
 
-    after { Rails.logger = @orig_logger }
+    before { Rails.logger.broadcast_to(fake_logger) }
+
+    after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
     it "returns no report" do
       class ReportInitError < StandardError
@@ -1053,7 +1052,7 @@ RSpec.describe Report do
 
       expect(report).to be_nil
 
-      expect(@fake_logger.errors).to eq(["Couldn’t create report `signups`: <ReportInitError x>"])
+      expect(fake_logger.errors).to eq(["Couldn’t create report `signups`: <ReportInitError x>"])
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -967,12 +967,12 @@ ensure
 end
 
 def track_log_messages
-  old_logger = Rails.logger
-  logger = Rails.logger = FakeLogger.new
+  logger = FakeLogger.new
+  Rails.logger.broadcast_to(logger)
   yield logger
   logger
 ensure
-  Rails.logger = old_logger
+  Rails.logger.stop_broadcasting_to(logger)
 end
 
 # this takes a string and returns a copy where 2 different

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -426,12 +426,11 @@ RSpec.describe ApplicationController do
       end
 
       describe "no logspam" do
-        before do
-          @orig_logger = Rails.logger
-          Rails.logger = @fake_logger = FakeLogger.new
-        end
+        let(:fake_logger) { FakeLogger.new }
 
-        after { Rails.logger = @orig_logger }
+        before { Rails.logger.broadcast_to(fake_logger) }
+
+        after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
         it "should handle 404 to a css file" do
           Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
@@ -453,9 +452,9 @@ RSpec.describe ApplicationController do
           expect(response.body).to include(topic1.title)
           expect(response.body).to_not include(topic2.title)
 
-          expect(@fake_logger.fatals.length).to eq(0)
-          expect(@fake_logger.errors.length).to eq(0)
-          expect(@fake_logger.warnings.length).to eq(0)
+          expect(fake_logger.fatals.length).to eq(0)
+          expect(fake_logger.errors.length).to eq(0)
+          expect(fake_logger.warnings.length).to eq(0)
         end
       end
 

--- a/spec/requests/csp_reports_controller_spec.rb
+++ b/spec/requests/csp_reports_controller_spec.rb
@@ -2,15 +2,16 @@
 
 RSpec.describe CspReportsController do
   describe "#create" do
+    let(:fake_logger) { FakeLogger.new }
+
     before do
       SiteSetting.content_security_policy = true
       SiteSetting.content_security_policy_collect_reports = true
 
-      @orig_logger = Rails.logger
-      Rails.logger = @fake_logger = FakeLogger.new
+      Rails.logger.broadcast_to(fake_logger)
     end
 
-    after { Rails.logger = @orig_logger }
+    after { Rails.logger.stop_broadcasting_to(fake_logger) }
 
     def send_report
       post "/csp_reports",
@@ -73,7 +74,7 @@ RSpec.describe CspReportsController do
 
     it "logs the violation report" do
       send_report
-      expect(@fake_logger.warnings).to include(
+      expect(fake_logger.warnings).to include(
         "CSP Violation: 'http://suspicio.us/assets.js' \n\nconsole.log('unsafe')",
       )
     end


### PR DESCRIPTION
Instead of replacing the Rails logger in specs, we can instead use `#broadcast_to` which has been introduced in Rails 7.
