### PR TITLE
DEV: Add remote debugging URLs to system spec helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1030,6 +1030,7 @@ def apply_base_chrome_options(options)
   options.add_argument("--no-sandbox")
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--mute-audio")
+  options.add_argument("--remote-allow-origins=*")
 
   # A file that contains just a list of paths like so:
   #


### PR DESCRIPTION
These URLs allow the state of a headless browser to be viewed and debugged using any other browser, without needing to restart the test with `SELENIUM_HEADLESS=0`.

Also adds a 'resuming test...' indicator when you end the pause.

New output of pause_test:

<img width="1158" alt="SCR-20241112-qwfq" src="https://github.com/user-attachments/assets/e00fb91e-e6fb-4cc9-818f-19640a966f46">

When visiting those URLs, this is what the inspector looks like:
<img width="1342" alt="SCR-20241112-qwny" src="https://github.com/user-attachments/assets/ddaf9780-500e-46f5-a5cc-a795c4df350d">


<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->