### PR TITLE
DEV: adds a page object for automation page

### DIFF
--- a/plugins/automation/spec/system/error_spec.rb
+++ b/plugins/automation/spec/system/error_spec.rb
@@ -3,6 +3,9 @@
 describe "DiscourseAutomation | error", type: :system do
   fab!(:admin)
 
+  let(:new_automation_page) { PageObjects::Pages::NewAutomation.new }
+  let(:automation_page) { PageObjects::Pages::Automation.new }
+
   before do
     SiteSetting.discourse_automation_enabled = true
     sign_in(admin)
@@ -10,26 +13,19 @@ describe "DiscourseAutomation | error", type: :system do
 
   context "when saving the form with an error" do
     it "shows the error correctly" do
-      visit("/admin/plugins/discourse-automation/new")
+      new_automation_page.visit
       find(".admin-section-landing__header-filter").set("create a post")
       find(".admin-section-landing-item", match: :first).click
 
-      expect(page).to have_selector("input[name='automation-name']")
+      automation_page.set_name("aaaaa").set_triggerables("recurring").update
 
-      find('input[name="automation-name"]').set("aaaaa")
-      select_kit = PageObjects::Components::SelectKit.new(".triggerables")
-      select_kit.expand
-      select_kit.select_row_by_value("recurring")
-      find(".update-automation").click
-
-      expect(page).to have_content(
+      expect(automation_page).to have_error(
         I18n.t(
           "discourse_automation.models.fields.required_field",
           { name: "topic", target: "script", target_name: "post" },
         ),
       )
-
-      expect(find('input[name="automation-name"]').value).to eq("aaaaa")
+      expect(automation_page).to have_name("aaaaa")
     end
   end
 end

--- a/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
+++ b/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
@@ -18,7 +18,7 @@ module PageObjects
       end
 
       def has_name?(name)
-        form.find_field("automation-name").value == name
+        form.find_field("automation-name", with: name)
       end
 
       def set_triggerables(triggerable)

--- a/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
+++ b/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Automation < PageObjects::Pages::Base
+      def visit(automation)
+        super("/admin/plugins/discourse-automation/#{automation.id}")
+        self
+      end
+
+      def set_name(name)
+        form.find('input[name="automation-name"]').set("aaaaa")
+        self
+      end
+
+      def has_error?(message)
+        form.has_content?(message)
+      end
+
+      def has_name?(name)
+        form.find_field("automation-name").value == name
+      end
+
+      def set_triggerables(triggerable)
+        select_kit = PageObjects::Components::SelectKit.new(".triggerables")
+        select_kit.expand
+        select_kit.select_row_by_value(triggerable)
+        self
+      end
+
+      def update
+        form.find(".update-automation").click
+        form.has_selector?(".update-automation.is-loading")
+        form.has_no_selector?(".update-automation.is-loading")
+        self
+      end
+
+      def form
+        @form ||= find(".discourse-automation-form.edit")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This page object also attempts to make the update automation more resilient as we are seeing flakey specs on this codepath. The solution for now is to ensure we have the sequence: click button/button is loading/ button has finished loading.