### PR TITLE
DEV: Fix `uploads:fix_missing_s3` rake task when file is too big

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1122,6 +1122,7 @@ def fix_missing_s3
               tempfile,
               "temp.#{upload.extension}",
               skip_validations: true,
+              external_upload_too_big: true,
             ).create_for(Discourse.system_user.id)
         rescue => fix_error
           # invalid extension is the most common issue


### PR DESCRIPTION
If the upload has existed before, we should allow the upload to be
created even if the upload's size is too big.

### Reviewer notes

There are no tests for this rake task and it is quite complicated to write tests for a rake task like this. Please give me a pass 😉 