### PR TITLE
FIX: Restore and deprecate the `:type` param of `uploads#create`

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -32,9 +32,21 @@ class UploadsController < ApplicationController
       1.minute.to_i,
     ).performed!
 
-    params.require(:upload_type)
+    type =
+      if params[:upload_type].presence
+        params[:upload_type]
+      elsif params[:type].presence
+        Discourse.deprecate(
+          "the :type param of `POST /uploads` is deprecated, use the :upload_type param instead",
+          since: "3.4",
+          drop_from: "3.5",
+        )
+        params[:type]
+      else
+        params.require(:upload_type)
+      end
     # 50 characters ought to be enough for the upload type
-    type = params[:upload_type].parameterize(separator: "_")[0..50]
+    type = type.parameterize(separator: "_")[0..50]
 
     if type == "avatar" &&
          (

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe UploadsController do
         expect(response.status).to eq 200
       end
 
+      it "accepts the type param but logs a deprecation message when used" do
+        allow(Discourse).to receive(:deprecate)
+        post "/uploads.json",
+             params: {
+               file: Rack::Test::UploadedFile.new(logo_file),
+               type: "avatar",
+             }
+        expect(response.status).to eq 200
+        expect(Discourse).to have_received(:deprecate).with(
+          "the :type param of `POST /uploads` is deprecated, use the :upload_type param instead",
+          since: "3.4",
+          drop_from: "3.5",
+        )
+      end
+
       it "is successful with an image" do
         post "/uploads.json", params: { file: logo, upload_type: "avatar" }
         expect(response.status).to eq 200


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/29600

Prior to the linked PR, the `uploads#create` endpoint had a `upload_type` and `type` param that acted as aliases for each other and raised an error if both of them were missing. In the linked PR, we removed the `type` param and always required the `upload_type` param which break API consumers that only included `type` in their requests.

This PR adds back the `type` param temporarily and introduces a deprecation message for it so that API consumers are made aware of the eventual removal of the `type` param.