### PR TITLE
FEATURE: add mention count to threads

### DIFF
--- a/plugins/chat/app/queries/chat/channel_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/channel_unreads_query.rb
@@ -46,7 +46,6 @@ module Chat
           AND notifications.notification_type = :notification_type_mention
           AND (data::json->>'chat_message_id')::bigint > COALESCE(user_chat_channel_memberships.last_read_message_id, 0)
           AND (data::json->>'chat_channel_id')::bigint = memberships.chat_channel_id
-          AND (chat_messages.thread_id IS NULL OR chat_messages.id = chat_threads.original_message_id)
         ) AS mention_count,
         (
           SELECT COUNT(*) AS watched_threads_unread_count

--- a/plugins/chat/app/queries/chat/thread_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/thread_unreads_query.rb
@@ -59,7 +59,21 @@ module Chat
           AND user_chat_channel_memberships.muted = false
           AND user_chat_channel_memberships.user_id = :user_id
         ) AS unread_count,
-        0 as mention_count,
+        (
+          SELECT COUNT(*) AS mention_count
+          FROM notifications
+          INNER JOIN chat_messages ON chat_messages.id = (data::json->>'chat_message_id')::bigint
+          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
+          INNER JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_messages.chat_channel_id
+          LEFT JOIN chat_threads ON chat_threads.id = chat_messages.thread_id
+          WHERE NOT read
+          AND notifications.user_id = :user_id
+          AND notifications.notification_type = :notification_type_mention
+          AND user_chat_channel_memberships.user_id = :user_id
+          AND chat_channels.threading_enabled
+          AND chat_messages.deleted_at IS NULL
+          AND NOT user_chat_channel_memberships.muted
+        ) AS mention_count,
         (
           SELECT COUNT(*) AS watched_threads_unread_count
           FROM chat_messages
@@ -122,6 +136,7 @@ module Chat
         limit: MAX_THREADS,
         tracking_level: ::Chat::UserChatThreadMembership.notification_levels[:tracking],
         watching_level: ::Chat::UserChatThreadMembership.notification_levels[:watching],
+        notification_type_mention: ::Notification.types[:chat_mention],
       )
     end
   end

--- a/plugins/chat/app/queries/chat/thread_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/thread_unreads_query.rb
@@ -72,6 +72,7 @@ module Chat
           AND user_chat_channel_memberships.user_id = :user_id
           AND chat_channels.threading_enabled
           AND chat_messages.deleted_at IS NULL
+          AND chat_messages.thread_id = memberships.thread_id
           AND NOT user_chat_channel_memberships.muted
         ) AS mention_count,
         (

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-unread-indicator.gjs
@@ -11,6 +11,7 @@ export default class ChatChannelUnreadIndicator extends Component {
   get showUnreadIndicator() {
     return (
       this.args.channel.tracking.unreadCount > 0 ||
+      this.args.channel.tracking.mentionCount > 0 ||
       this.args.channel.unreadThreadsCountSinceLastViewed > 0
     );
   }

--- a/plugins/chat/assets/javascripts/discourse/components/thread-unread-indicator/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/thread-unread-indicator/index.gjs
@@ -8,7 +8,10 @@ export default class ChatThreadUnreadIndicator extends Component {
   }
 
   get urgentCount() {
-    return this.args.thread.tracking.watchedThreadsUnreadCount;
+    return (
+      this.args.thread.tracking.mentionCount +
+      this.args.thread.tracking.watchedThreadsUnreadCount
+    );
   }
 
   get showUnreadIndicator() {

--- a/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
@@ -225,14 +225,14 @@ describe Chat::ChannelUnreadsQuery do
         )
       end
 
-      it "does not include other thread messages in the mention count" do
+      it "includes thread messages with mentions in the channel mention count" do
         thread_message_1 = Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
         thread_message_2 = Fabricate(:chat_message, chat_channel: channel_1, thread: thread)
         create_mention(thread_message_1, channel_1)
         create_mention(thread_message_2, channel_1)
         expect(query.first).to eq(
           {
-            mention_count: 0,
+            mention_count: 2,
             unread_count: 1,
             watched_threads_unread_count: 0,
             channel_id: channel_1.id,

--- a/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
@@ -211,14 +211,37 @@ describe Chat::ThreadUnreadsQuery do
         let!(:message) { create_mention(message_1, channel_1, thread_1) }
 
         it "counts both unread messages and mentions separately" do
-          expect(query.map(&:to_h).find { |tracking| tracking[:thread_id] == thread_1.id }).to eq(
-            {
-              thread_id: thread_1.id,
-              channel_id: channel_1.id,
-              unread_count: 1,
-              mention_count: 1,
-              watched_threads_unread_count: 0,
-            },
+          expect(query.map(&:to_h)).to eq(
+            [
+              {
+                channel_id: channel_1.id,
+                thread_id: thread_1.id,
+                mention_count: 1,
+                unread_count: 1,
+                watched_threads_unread_count: 0,
+              },
+              {
+                channel_id: channel_1.id,
+                thread_id: thread_2.id,
+                mention_count: 0,
+                unread_count: 0,
+                watched_threads_unread_count: 0,
+              },
+              {
+                channel_id: channel_2.id,
+                thread_id: thread_3.id,
+                mention_count: 0,
+                unread_count: 1,
+                watched_threads_unread_count: 0,
+              },
+              {
+                channel_id: channel_2.id,
+                thread_id: thread_4.id,
+                mention_count: 0,
+                unread_count: 1,
+                watched_threads_unread_count: 0,
+              },
+            ],
           )
         end
 


### PR DESCRIPTION
### What is this change?

Previously we only counted mentions that were made within channels, however for threads this was never implemented. 

This change adds a thread count to the `ThreadUnreadsQuery`, which is used for channel thread lists and the user thread list. We are also expanding channel mentions count to include mentions within threads.

This means that we can have a more consistent urgent badge across chat, in places such as channel lists and the chat header.

### How does this change look

Chat mention within a public channel thread on mobile:

<img width="355" alt="Screenshot 2024-11-14 at 12 09 27 PM" src="https://github.com/user-attachments/assets/6cdb6717-c5b5-4dae-bdc2-8e8d898e6036">
<img width="352" alt="Screenshot 2024-11-14 at 12 09 48 PM" src="https://github.com/user-attachments/assets/05026003-cd00-416b-a40e-f94e67519951">
<img width="355" alt="Screenshot 2024-11-14 at 12 40 38 PM" src="https://github.com/user-attachments/assets/7e1da625-b6dc-4ee7-836b-9a6aaff23081">
<img width="358" alt="Screenshot 2024-11-14 at 12 43 09 PM" src="https://github.com/user-attachments/assets/f1c1999a-de09-4992-b8a2-3ee865e8fdfe">


