### PR TITLE
DEV: Simplify livereload configuration for better proxy compatibility

### DIFF
--- a/app/assets/javascripts/custom-proxy/index.js
+++ b/app/assets/javascripts/custom-proxy/index.js
@@ -95,8 +95,10 @@ function updateScriptReferences({
           );
         }
 
+        // We use _lr/livereload.js directly instead of ember-cli-live-reload so that the protocol/port is configured automatically
+        // (important for cloud development environments like GitHub CodeSpaces)
         newElements.unshift(
-          `<script async src="${baseURL}ember-cli-live-reload.js" nonce="${nonce}"></script>`
+          `<script async src="/_lr/livereload.js?path=_lr/livereload" nonce="${nonce}"></script>`
         );
       }
 


### PR DESCRIPTION
When running a development environment behind a proxy (e.g. when using a cloud development environment, or a service like ngrok), the ember-cli port & protocol may not match the one in the browser. `livereload.js` knows how to auto-configure itself based on the current browser environment... but Ember CLI overrides that autoconfiguration with some hard-coded values.

The intention there is to allow running the livereload server on a different port to the ember-cli web proxy. We don't need that functionality.

This commit stops loading `ember-cli-live-reload.js`, and instead loads `_lr/livereload.js` directly.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->