### PR TITLE
DEV: restore AutoJoinChannelBatch job as a no-op to clear queue

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/auto_join_channel_batch.rb
+++ b/plugins/chat/app/jobs/regular/chat/auto_join_channel_batch.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# TODO: delete this unused job after 2025-01-01
+
+module Jobs
+  module Chat
+    class AutoJoinChannelBatch < ::Jobs::Base
+      def execute(args)
+        # no-op
+      end
+    end
+  end
+end


### PR DESCRIPTION
The job was removed in 6dfe2fbe16a4096ff342ec8b626ac62a19eaa180 as part of a performance-related refactor.

The issue was that job was already enqueued in sidekiq and now that the file has been deleted, it's generating a lot of `uninitialized constant Jobs::Chat::AutoJoinChannelBatch` errors.

Restoring this file will help clear the sidekiq queue. We'll remove the job in a few months.

Internal ref - t/141563

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->