### PR TITLE
FEATURE: Add bulk destroy to admin users list

### DIFF
--- a/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
+++ b/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
@@ -65,11 +65,7 @@ export default class BulkUserDeleteConfirmation extends Component {
       this.#logSuccess(
         i18n(
           "admin.users.bulk_actions.delete.confirmation_modal.user_delete_succeeded",
-          {
-            position: data.position,
-            total: data.total,
-            username: data.username,
-          }
+          data
         )
       );
     } else if (data.failed) {
@@ -77,12 +73,7 @@ export default class BulkUserDeleteConfirmation extends Component {
       this.#logError(
         i18n(
           "admin.users.bulk_actions.delete.confirmation_modal.user_delete_failed",
-          {
-            position: data.position,
-            total: data.total,
-            username: data.username,
-            error: data.error,
-          }
+          data
         )
       );
     }

--- a/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
+++ b/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
@@ -1,0 +1,199 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import { TrackedArray } from "@ember-compat/tracked-built-ins";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import { ajax } from "discourse/lib/ajax";
+import { extractError } from "discourse/lib/ajax-error";
+import { bind } from "discourse-common/utils/decorators";
+import { i18n } from "discourse-i18n";
+
+const BULK_DELETE_CHANNEL = "/bulk-user-delete";
+
+export default class BulkUserDeleteConfirmation extends Component {
+  @service messageBus;
+
+  @tracked confirmButtonDisabled = true;
+  @tracked deleteStarted = false;
+  @tracked logs = new TrackedArray();
+  failedUsernames = [];
+
+  callAfterBulkDelete = false;
+
+  constructor() {
+    super(...arguments);
+    this.messageBus.subscribe(BULK_DELETE_CHANNEL, this.onDeleteProgress);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.messageBus.unsubscribe(BULK_DELETE_CHANNEL, this.onDeleteProgress);
+  }
+
+  get confirmDeletePhrase() {
+    return i18n(
+      "admin.users.bulk_actions.delete.confirmation_modal.confirmation_phrase",
+      { count: this.args.model.userIds.length }
+    );
+  }
+
+  #logError(line) {
+    this.#log(line, "error");
+  }
+
+  #logSuccess(line) {
+    this.#log(line, "success");
+  }
+
+  #logNeutral(line) {
+    this.#log(line, "neutral");
+  }
+
+  #log(line, type) {
+    this.logs.push({
+      line,
+      type,
+    });
+  }
+
+  @bind
+  onDeleteProgress(data) {
+    if (data.success) {
+      this.#logSuccess(
+        i18n(
+          "admin.users.bulk_actions.delete.confirmation_modal.user_delete_succeeded",
+          {
+            position: data.position,
+            total: data.total,
+            username: data.username,
+          }
+        )
+      );
+    } else if (data.failed) {
+      this.failedUsernames.push(data.username);
+      this.#logError(
+        i18n(
+          "admin.users.bulk_actions.delete.confirmation_modal.user_delete_failed",
+          {
+            position: data.position,
+            total: data.total,
+            username: data.username,
+            error: data.error,
+          }
+        )
+      );
+    }
+
+    if (data.position === data.total) {
+      this.callAfterBulkDelete = true;
+      this.#logNeutral(
+        i18n(
+          "admin.users.bulk_actions.delete.confirmation_modal.bulk_delete_finished"
+        )
+      );
+      if (this.failedUsernames.length > 0) {
+        this.#logNeutral(
+          i18n(
+            "admin.users.bulk_actions.delete.confirmation_modal.failed_to_delete_users"
+          )
+        );
+        for (const username of this.failedUsernames) {
+          this.#logNeutral(`* ${username}`);
+        }
+      }
+    }
+  }
+
+  @action
+  onPromptInput(event) {
+    this.confirmButtonDisabled =
+      event.target.value.toLowerCase() !== this.confirmDeletePhrase;
+  }
+
+  @action
+  async startDelete() {
+    this.deleteStarted = true;
+    this.confirmButtonDisabled = true;
+    this.#logNeutral(
+      i18n(
+        "admin.users.bulk_actions.delete.confirmation_modal.bulk_delete_starting"
+      )
+    );
+
+    try {
+      await ajax("/admin/users/destroy-bulk.json", {
+        type: "DELETE",
+        data: { user_ids: this.args.model.userIds },
+      });
+      this.callAfterBulkDelete = true;
+    } catch (err) {
+      this.#logError(extractError(err));
+      this.confirmButtonDisabled = false;
+    }
+  }
+
+  @action
+  closeModal() {
+    this.args.closeModal();
+    if (this.callAfterBulkDelete) {
+      this.args.model?.afterBulkDelete();
+    }
+  }
+
+  <template>
+    <DModal
+      class="bulk-user-delete-confirmation"
+      @closeModal={{this.closeModal}}
+      @title={{i18n
+        "admin.users.bulk_actions.delete.confirmation_modal.title"
+        count=@model.userIds.length
+      }}
+    >
+      <:body>
+        {{#if this.deleteStarted}}
+          <div class="bulk-user-delete-confirmation__progress">
+            {{#each this.logs as |entry|}}
+              <div
+                class="bulk-user-delete-confirmation__progress-line -{{entry.type}}"
+              >
+                {{entry.line}}
+              </div>
+            {{/each}}
+            <div class="bulk-user-delete-confirmation__progress-anchor">
+            </div>
+          </div>
+        {{else}}
+          <p>{{i18n
+              "admin.users.bulk_actions.delete.confirmation_modal.prompt_text"
+              count=@model.userIds.length
+              confirmation_phrase=this.confirmDeletePhrase
+            }}
+          </p>
+          <input
+            class="confirmation-phrase"
+            type="text"
+            placeholder={{this.confirmDeletePhrase}}
+            {{on "input" this.onPromptInput}}
+          />
+        {{/if}}
+      </:body>
+      <:footer>
+        <DButton
+          class="confirm-delete btn-danger"
+          @icon="trash-can"
+          @label="admin.users.bulk_actions.delete.confirmation_modal.confirm"
+          @disabled={{this.confirmButtonDisabled}}
+          @action={{this.startDelete}}
+        />
+        <DButton
+          class="btn-default"
+          @label="admin.users.bulk_actions.delete.confirmation_modal.close"
+          @action={{this.closeModal}}
+        />
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -65,7 +65,7 @@ export default class AdminUsersListShowController extends Controller.extend(
     this._page = 1;
     this._results = [];
     this._canLoadMore = true;
-    this._refreshUsers();
+    return this._refreshUsers();
   }
 
   _refreshUsers() {
@@ -76,7 +76,7 @@ export default class AdminUsersListShowController extends Controller.extend(
     const page = this._page;
     this.set("refreshing", true);
 
-    AdminUser.findAll(this.query, {
+    return AdminUser.findAll(this.query, {
       filter: this.listFilter,
       show_emails: this.showEmails,
       order: this.order,
@@ -156,9 +156,9 @@ export default class AdminUsersListShowController extends Controller.extend(
             type: "DELETE",
             data: { user_ids: userIds },
           });
+          await this.resetFilters();
           this.bulkSelectedUsers = null;
           this.displayBulkActions = false;
-          this.resetFilters();
         } catch (err) {
           this.dialog.alert(extractError(err));
         }

--- a/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
@@ -24,7 +24,8 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
           listFilter: transition.to.queryParams.username,
           query: params.filter,
           refreshing: false,
-          bulkSelectedUsers: null,
+          bulkSelectedUsersMap: {},
+          bulkSelectedUserIdsSet: new Set(),
           displayBulkActions: false,
         });
 

--- a/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list-show.js
@@ -24,6 +24,8 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
           listFilter: transition.to.queryParams.username,
           query: params.filter,
           refreshing: false,
+          bulkSelectedUsers: null,
+          displayBulkActions: false,
         });
 
         controller.resetFilters();

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -19,19 +19,46 @@
   {{/if}}
 </div>
 
-<div class="username controls">
-  <TextField
-    @value={{this.listFilter}}
-    @placeholder={{this.searchHint}}
-    @title={{this.searchHint}}
-  />
+<div class="admin-users-list__controls">
+  <div class="username">
+    <TextField
+      @value={{this.listFilter}}
+      @placeholder={{this.searchHint}}
+      @title={{this.searchHint}}
+    />
+  </div>
+  {{#if this.displayBulkActions}}
+    <div class="bulk-actions-dropdown">
+      <DMenu @autofocus={{true}} @identifier="bulk-select-admin-users-dropdown">
+        <:trigger>
+          <span class="d-button-label">
+            {{i18n "admin.users.bulk_actions.title"}}
+          </span>
+          {{dIcon "angle-down"}}
+        </:trigger>
+
+        <:content>
+          <DropdownMenu as |dropdown|>
+            <dropdown.item>
+              <DButton
+                @translatedLabel={{i18n "admin.users.bulk_actions.delete"}}
+                @icon="trash-can"
+                @action={{this.performBulkDelete}}
+                class="bulk-delete btn-danger"
+              />
+            </dropdown.item>
+          </DropdownMenu>
+        </:content>
+      </DMenu>
+    </div>
+  {{/if}}
 </div>
 <LoadMore
   @selector=".directory-table .directory-table__cell"
   @action={{action "loadMore"}}
   class="users-list-container"
 >
-  {{#if this.model}}
+  {{#if this.users}}
     <ResponsiveTable
       @className="users-list"
       @aria-label={{this.title}}
@@ -42,18 +69,24 @@
           ", minmax(min-content, 1fr))"
         )
       }}
-      @updates={{this.model.email}}
     >
       <:header>
-        <TableHeaderToggle
-          @onToggle={{this.updateOrder}}
-          @field="username"
-          @labelKey="username"
-          @order={{this.order}}
-          @asc={{this.asc}}
-          @automatic={{true}}
-          class="directory-table__column-header--username"
-        />
+        <div class="directory-table__column-header-wrapper">
+          <DButton
+            class="btn-flat bulk-select"
+            @icon="list-check"
+            @action={{this.toggleBulkSelect}}
+          />
+          <TableHeaderToggle
+            @onToggle={{this.updateOrder}}
+            @field="username"
+            @labelKey="username"
+            @order={{this.order}}
+            @asc={{this.asc}}
+            @automatic={{true}}
+            class="directory-table__column-header--username"
+          />
+        </div>
         <TableHeaderToggle
           @onToggle={{this.updateOrder}}
           @field="email"
@@ -130,14 +163,23 @@
       </:header>
 
       <:body>
-        {{#each this.model as |user|}}
+        {{#each this.users as |user|}}
           <div
             class="user
               {{user.selected}}
               {{unless user.active 'not-activated'}}
               directory-table__row"
+            data-user-id={{user.id}}
           >
             <div class="directory-table__cell username">
+              {{#if this.bulkSelect}}
+                <input
+                  type="checkbox"
+                  class="directory-table__cell-bulk-select"
+                  checked={{eq (get this.bulkSelectedUsers user.id) 1}}
+                  {{on "click" (fn this.bulkSelectItemToggle user.id)}}
+                />
+              {{/if}}
               <a
                 class="avatar"
                 href={{user.path}}

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -21,10 +21,12 @@
 
 <div class="admin-users-list__controls">
   <div class="username">
-    <TextField
-      @value={{this.listFilter}}
-      @placeholder={{this.searchHint}}
-      @title={{this.searchHint}}
+    <input
+      type="text"
+      dir="auto"
+      placeholder={{this.searchHint}}
+      title={{this.searchHint}}
+      {{on "input" this.onListFilterChange}}
     />
   </div>
   {{#if this.displayBulkActions}}
@@ -41,9 +43,11 @@
           <DropdownMenu as |dropdown|>
             <dropdown.item>
               <DButton
-                @translatedLabel={{i18n "admin.users.bulk_actions.delete"}}
+                @translatedLabel={{i18n
+                  "admin.users.bulk_actions.delete.label"
+                }}
                 @icon="trash-can"
-                @action={{this.performBulkDelete}}
+                @action={{this.openBulkDeleteConfirmation}}
                 class="bulk-delete btn-danger"
               />
             </dropdown.item>
@@ -173,12 +177,38 @@
           >
             <div class="directory-table__cell username">
               {{#if this.bulkSelect}}
-                <input
-                  type="checkbox"
-                  class="directory-table__cell-bulk-select"
-                  checked={{eq (get this.bulkSelectedUsers user.id) 1}}
-                  {{on "click" (fn this.bulkSelectItemToggle user.id)}}
-                />
+                {{#if user.can_be_deleted}}
+                  <input
+                    type="checkbox"
+                    class="directory-table__cell-bulk-select"
+                    checked={{eq (get this.bulkSelectedUsersMap user.id) 1}}
+                    {{on "click" (fn this.bulkSelectItemToggle user.id)}}
+                  />
+                {{else}}
+                  <DTooltip
+                    @identifier="bulk-delete-unavailable-reason"
+                    @placement="bottom-start"
+                  >
+                    <:trigger>
+                      <input
+                        type="checkbox"
+                        class="directory-table__cell-bulk-select"
+                        disabled={{true}}
+                      />
+                    </:trigger>
+                    <:content>
+                      {{#if user.admin}}
+                        {{i18n
+                          "admin.users.bulk_actions.admin_cant_be_deleted"
+                        }}
+                      {{else}}
+                        {{i18n
+                          "admin.users.bulk_actions.too_many_or_old_posts"
+                        }}
+                      {{/if}}
+                    </:content>
+                  </DTooltip>
+                {{/if}}
               {{/if}}
               <a
                 class="avatar"
@@ -325,9 +355,8 @@
         {{/each}}
       </:body>
     </ResponsiveTable>
-
-    <ConditionalLoadingSpinner @condition={{this.refreshing}} />
-  {{else}}
+  {{else if (not this.refreshing)}}
     <p>{{i18n "search.no_results"}}</p>
   {{/if}}
+  <ConditionalLoadingSpinner @condition={{this.refreshing}} />
 </LoadMore>

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -182,6 +182,7 @@
                     type="checkbox"
                     class="directory-table__cell-bulk-select"
                     checked={{eq (get this.bulkSelectedUsersMap user.id) 1}}
+                    data-user-id={{user.id}}
                     {{on "click" (fn this.bulkSelectItemToggle user.id)}}
                   />
                 {{else}}

--- a/app/assets/javascripts/discourse/app/components/responsive-table.hbs
+++ b/app/assets/javascripts/discourse/app/components/responsive-table.hbs
@@ -8,7 +8,7 @@
     aria-label={{@ariaLabel}}
     style={{@style}}
     {{did-insert this.checkScroll}}
-    {{did-update this.checkScroll @updates}}
+    {{did-update this.checkScroll}}
     {{on-resize this.checkScroll}}
     {{on "scroll" this.onBottomScroll}}
   >

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -18,7 +18,7 @@ acceptance("Admin - Users List", function (needs) {
   test("searching users with no matches", async function (assert) {
     await visit("/admin/users/list/active");
 
-    await fillIn(".controls.username input", "doesntexist");
+    await fillIn(".admin-users-list__controls .username input", "doesntexist");
 
     assert.dom(".users-list-container").hasText(i18n("search.no_results"));
   });
@@ -28,7 +28,9 @@ acceptance("Admin - Users List", function (needs) {
 
     assert.dom(".users-list .user").exists();
 
-    await click(".users-list .sortable:nth-child(1)");
+    await click(
+      ".users-list .directory-table__column-header--username.sortable"
+    );
 
     assert.ok(
       query(".users-list .user:nth-child(1) .username").innerText.includes(
@@ -37,7 +39,9 @@ acceptance("Admin - Users List", function (needs) {
       "list should be sorted by username"
     );
 
-    await click(".users-list .sortable:nth-child(1)");
+    await click(
+      ".users-list .directory-table__column-header--username.sortable"
+    );
 
     assert.ok(
       query(".users-list .user:nth-child(1) .username").innerText.includes(

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -1105,3 +1105,4 @@ a.inline-editable-field {
 @import "common/admin/mini_profiler";
 @import "common/admin/schema_theme_setting_editor";
 @import "common/admin/customize_themes_show_schema";
+@import "common/admin/admin_bulk_users_delete_modal";

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -473,7 +473,7 @@ $mobile-breakpoint: 700px;
   }
 
   .username {
-    input {
+    input[type="text"] {
       min-width: 15em;
       @media screen and (max-width: 500px) {
         box-sizing: border-box;

--- a/app/assets/stylesheets/common/admin/admin_bulk_users_delete_modal.scss
+++ b/app/assets/stylesheets/common/admin/admin_bulk_users_delete_modal.scss
@@ -1,0 +1,23 @@
+.bulk-user-delete-confirmation {
+  &__progress {
+    font-family: var(--d-font-family--monospace);
+    max-height: 400px;
+    background: var(--blend-primary-secondary-5);
+    padding: 1em;
+    overflow-y: auto;
+  }
+  &__progress-line {
+    overflow-anchor: none;
+
+    &.-success {
+      color: var(--success);
+    }
+    &.-error {
+      color: var(--danger);
+    }
+  }
+  &__progress-anchor {
+    overflow-anchor: auto;
+    height: 1px;
+  }
+}

--- a/app/assets/stylesheets/common/admin/users.scss
+++ b/app/assets/stylesheets/common/admin/users.scss
@@ -115,11 +115,25 @@
 
   .directory-table {
     margin-top: 1em;
-    &__column-header--username,
-    &__column-header--email {
-      .header-contents {
-        text-align: left;
+    &__column-header {
+      &--username,
+      &---email {
+        .header-contents {
+          text-align: left;
+        }
       }
+
+      &--username {
+        flex-grow: 1;
+      }
+    }
+
+    &__column-header-wrapper {
+      display: flex;
+    }
+
+    &__cell-bulk-select {
+      margin-right: 1em;
     }
 
     &__cell.username {
@@ -147,6 +161,11 @@
 
   .avatar {
     margin-right: 0.25em;
+  }
+
+  &__controls {
+    display: flex;
+    gap: 1em;
   }
 }
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -414,6 +414,8 @@ class Admin::UsersController < Admin::StaffController
         on_failed_policy(:can_delete_users) do
           render json: failed_json.merge(errors: [I18n.t("user.cannot_bulk_delete")]), status: 403
         end
+
+        on_model_not_found(:users) { render json: failed_json, status: 404 }
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,7 +32,7 @@ class Admin::UsersController < Admin::StaffController
   def index
     users = ::AdminUserIndexQuery.new(params).find_users
 
-    opts = {}
+    opts = { include_can_be_deleted: true }
     if params[:show_emails] == "true"
       StaffActionLogger.new(current_user).log_show_emails(users, context: request.path)
       opts[:emails_desired] = true

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -402,6 +402,22 @@ class Admin::UsersController < Admin::StaffController
     end
   end
 
+  def destroy_bulk
+    hijack do
+      User::BulkDestroy.call(service_params) do
+        on_success { render json: { deleted: true } }
+
+        on_failed_contract do |contract|
+          render json: failed_json.merge(errors: contract.errors.full_messages), status: 400
+        end
+
+        on_failed_policy(:can_delete_users) do
+          render json: failed_json.merge(errors: [I18n.t("user.cannot_bulk_delete")]), status: 403
+        end
+      end
+    end
+  end
+
   def badges
   end
 

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -116,4 +116,8 @@ class AdminUserListSerializer < BasicUserSerializer
   def can_be_deleted
     scope.can_delete_user?(object)
   end
+
+  def include_can_be_deleted?
+    @options[:include_can_be_deleted]
+  end
 end

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -24,7 +24,8 @@ class AdminUserListSerializer < BasicUserSerializer
              :silenced_till,
              :time_read,
              :staged,
-             :second_factor_enabled
+             :second_factor_enabled,
+             :can_be_deleted
 
   %i[days_visited posts_read_count topics_entered post_count].each do |sym|
     attributes sym
@@ -110,5 +111,9 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def second_factor_enabled
     true
+  end
+
+  def can_be_deleted
+    scope.can_delete_user?(object)
   end
 end

--- a/app/serializers/admin_user_serializer.rb
+++ b/app/serializers/admin_user_serializer.rb
@@ -39,4 +39,8 @@ class AdminUserSerializer < AdminUserListSerializer
   def registration_ip_address
     object.registration_ip_address.try(:to_s)
   end
+
+  def include_can_be_deleted?
+    true
+  end
 end

--- a/app/services/user/bulk_destroy.rb
+++ b/app/services/user/bulk_destroy.rb
@@ -28,11 +28,11 @@ class User::BulkDestroy
   end
 
   def delete(users:, guardian:)
-    users.each.with_index do |u, index|
+    users.find_each.with_index do |user, index|
       position = index + 1
       success =
         UserDestroyer.new(guardian.user).destroy(
-          u,
+          user,
           delete_posts: true,
           prepare_for_destroy: true,
           context: I18n.t("staff_action_logs.bulk_user_delete", users: users.map(&:id).inspect),
@@ -41,24 +41,24 @@ class User::BulkDestroy
       if success
         publish_progress(
           guardian.user,
-          { position:, username: u.username, total: users.size, success: true },
+          { position:, username: user.username, total: users.size, success: true },
         )
       else
         publish_progress(
           guardian.user,
           {
             position:,
-            username: u.username,
+            username: user.username,
             total: users.size,
             failed: true,
-            error: u.errors.full_messages.join(", "),
+            error: user.errors.full_messages.join(", "),
           },
         )
       end
     rescue => err
       publish_progress(
         guardian.user,
-        { position:, username: u.username, total: users.size, failed: true, error: err.message },
+        { position:, username: user.username, total: users.size, failed: true, error: err.message },
       )
     end
   end

--- a/app/services/user/bulk_destroy.rb
+++ b/app/services/user/bulk_destroy.rb
@@ -35,7 +35,7 @@ class User::BulkDestroy
           user,
           delete_posts: true,
           prepare_for_destroy: true,
-          context: I18n.t("staff_action_logs.bulk_user_delete", users: users.map(&:id).inspect),
+          context: I18n.t("staff_action_logs.bulk_user_delete"),
         )
 
       if success

--- a/app/services/user/bulk_destroy.rb
+++ b/app/services/user/bulk_destroy.rb
@@ -16,7 +16,7 @@ class User::BulkDestroy
   private
 
   def fetch_users(params:)
-    ids = params.user_ids.to_a
+    ids = params.user_ids
     # this order cluase ensures we retrieve the users in the same order as the
     # IDs in the param. we do this to ensure the users are deleted in the same
     # order as they're selected in the UI

--- a/app/services/user/bulk_destroy.rb
+++ b/app/services/user/bulk_destroy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class User::BulkDestroy
+  include Service::Base
+
+  params do
+    attribute :user_ids, :array
+
+    validates :user_ids, length: { maximum: 100 }
+  end
+
+  model :users
+  policy :can_delete_users
+  step :delete
+
+  private
+
+  def fetch_users(params:)
+    User.where(id: params.user_ids.to_a)
+  end
+
+  def can_delete_users(guardian:, users:)
+    users.all? { |u| guardian.can_delete_user?(u) }
+  end
+
+  def delete(users:, guardian:)
+    users.each do |u|
+      UserDestroyer.new(guardian.user).destroy(
+        u,
+        delete_posts: true,
+        context: I18n.t("staff_action_logs.bulk_user_delete", users: users.map(&:id).inspect),
+      )
+    end
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6643,12 +6643,15 @@ en:
           title: "Bulk actions"
           admin_cant_be_deleted: "This user can't be deleted because they're an admin"
           too_many_or_old_posts: "This user can't be deleted they have too many posts or a very old post"
+          too_many_selected_users:
+            one: "You've reached the %{count} user limit for bulk deletion"
+            other: "You've reached the %{count} users limit for bulk deletion"
           delete:
             label: "Delete users…"
             confirmation_modal:
               prompt_text:
-                one: "You're about to delete %{count} user permanently. Type \"%{confirmation_phrase}\" below to proceed:"
-                other: "You're about to delete %{count} users permanently. Type \"%{confirmation_phrase}\" below to proceed:"
+                one: 'You''re about to delete %{count} user permanently. Type "%{confirmation_phrase}" below to proceed:'
+                other: 'You''re about to delete %{count} users permanently. Type "%{confirmation_phrase}" below to proceed:'
               confirmation_phrase:
                 one: "delete %{count} user"
                 other: "delete %{count} users"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6639,6 +6639,15 @@ en:
         status: "Status"
         show_emails: "Show Emails"
         hide_emails: "Hide Emails"
+        bulk_actions:
+          title: "Bulk actions"
+          delete: "Delete users…"
+          confirm_delete_title:
+            one: "Delete %{count} user?"
+            other: "Delete %{count} users?"
+          confirm_delete_body:
+            one: "Are you sure you want to delete %{count} user? This action is permanent and cannot be reversed."
+            other: "Are you sure you want to delete %{count} users? This action is permanent and cannot be reversed."
         nav:
           new: "New"
           active: "Active"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6641,13 +6641,27 @@ en:
         hide_emails: "Hide Emails"
         bulk_actions:
           title: "Bulk actions"
-          delete: "Delete users…"
-          confirm_delete_title:
-            one: "Delete %{count} user?"
-            other: "Delete %{count} users?"
-          confirm_delete_body:
-            one: "Are you sure you want to delete %{count} user? This action is permanent and cannot be reversed."
-            other: "Are you sure you want to delete %{count} users? This action is permanent and cannot be reversed."
+          admin_cant_be_deleted: "This user can't be deleted because they're an admin"
+          too_many_or_old_posts: "This user can't be deleted they have too many posts or a very old post"
+          delete:
+            label: "Delete users…"
+            confirmation_modal:
+              prompt_text:
+                one: "You're about to delete %{count} user permanently. Type \"%{confirmation_phrase}\" below to proceed:"
+                other: "You're about to delete %{count} users permanently. Type \"%{confirmation_phrase}\" below to proceed:"
+              confirmation_phrase:
+                one: "delete %{count} user"
+                other: "delete %{count} users"
+              close: "Close"
+              confirm: "Delete"
+              title:
+                one: "Delete %{count} user"
+                other: "Delete %{count} users"
+              bulk_delete_starting: "Starting bulk delete…"
+              user_delete_succeeded: "[%{position}/%{total}] Successfully deleted @%{username}"
+              user_delete_failed: "[%{position}/%{total}] Failed to delete @%{username} - %{error}"
+              bulk_delete_finished: "Bulk delete operation completed."
+              failed_to_delete_users: "The following users failed to be deleted:"
         nav:
           new: "New"
           active: "Active"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5535,7 +5535,7 @@ en:
         other: "Automatically revoked, created at more than %{count} days ago"
       revoked: Revoked
       restored: Restored
-    bulk_user_delete: "bulk deletion of users: %{users}"
+    bulk_user_delete: "deleted in a bulk delete operation"
 
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3062,6 +3062,7 @@ en:
     cannot_delete_has_posts:
       one: "User %{username} has %{count} post in a public topic or personal message, so they can't be deleted."
       other: "User %{username} has %{count} posts in public topics or personal messages, so they can't be deleted."
+    cannot_bulk_delete: "One or more users cannot be deleted either because they're an admin, have too many posts or have a very old post."
 
   unsubscribe_mailer:
     title: "Unsubscribe Mailer"
@@ -5534,6 +5535,7 @@ en:
         other: "Automatically revoked, created at more than %{count} days ago"
       revoked: Revoked
       restored: Restored
+    bulk_user_delete: "bulk deletion of users: %{users}"
 
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Discourse::Application.routes.draw do
           delete "delete-others-with-same-ip" => "users#delete_other_accounts_with_same_ip"
           get "total-others-with-same-ip" => "users#total_other_accounts_with_same_ip"
           put "approve-bulk" => "users#approve_bulk"
+          delete "destroy-bulk" => "users#destroy_bulk"
         end
         delete "penalty_history", constraints: AdminConstraint.new
         put "suspend"

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1445,6 +1445,12 @@ RSpec.describe Admin::UsersController do
         expect(User.where(id: deleted_users.map(&:id)).count).to eq(0)
       end
 
+      it "responds with 404 when sending an empty user_ids list" do
+        delete "/admin/users/destroy-bulk.json", params: { user_ids: [] }
+
+        expect(response.status).to eq(404)
+      end
+
       it "doesn't allow deleting a user that can't be deleted" do
         deleted_users[0].update!(admin: true)
 

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -89,4 +89,24 @@ RSpec.describe AdminUserListSerializer do
       expect(json[:secondary_emails]).to contain_exactly("first@email.com", "second@email.com")
     end
   end
+
+  describe "#can_be_deleted" do
+    it "is not included if the include_can_be_deleted option is not present" do
+      json = AdminUserListSerializer.new(user, scope: guardian, root: false).as_json
+
+      expect(json.key?(:can_be_deleted)).to eq(false)
+    end
+
+    it "is included if the include_can_be_deleted option is true" do
+      json =
+        AdminUserListSerializer.new(
+          user,
+          scope: guardian,
+          root: false,
+          include_can_be_deleted: true,
+        ).as_json
+
+      expect(json[:can_be_deleted]).to eq(true)
+    end
+  end
 end

--- a/spec/system/admin_users_list_spec.rb
+++ b/spec/system/admin_users_list_spec.rb
@@ -2,70 +2,141 @@
 
 describe "Admin Users Page", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
+  fab!(:another_admin) { Fabricate(:admin) }
   fab!(:users) { Fabricate.times(3, :user) }
 
   let(:admin_users_page) { PageObjects::Pages::AdminUsers.new }
-  let(:dialog) { PageObjects::Components::Dialog.new }
 
   before { sign_in(current_user) }
 
-  it "has a button that toggles the bulk select checkboxes" do
-    admin_users_page.visit
+  describe "bulk user delete" do
+    let(:confirmation_modal) { PageObjects::Modals::BulkUserDeleteConfirmation.new }
 
-    expect(admin_users_page).to have_users(users.map(&:id))
+    it "disables checkboxes for users that can't be deleted" do
+      admin_users_page.visit
 
-    expect(admin_users_page.user_row(users[0].id)).to have_no_bulk_select_checkbox
-    expect(admin_users_page.user_row(users[1].id)).to have_no_bulk_select_checkbox
-    expect(admin_users_page.user_row(users[2].id)).to have_no_bulk_select_checkbox
+      admin_users_page.bulk_select_button.click
 
-    admin_users_page.bulk_select_button.click
+      expect(admin_users_page.user_row(current_user.id).bulk_select_checkbox.disabled?).to eq(true)
+      expect(admin_users_page.user_row(another_admin.id).bulk_select_checkbox.disabled?).to eq(true)
+      expect(admin_users_page.user_row(users[0].id).bulk_select_checkbox.disabled?).to eq(false)
 
-    expect(admin_users_page.user_row(users[0].id)).to have_bulk_select_checkbox
-    expect(admin_users_page.user_row(users[1].id)).to have_bulk_select_checkbox
-    expect(admin_users_page.user_row(users[2].id)).to have_bulk_select_checkbox
+      admin_users_page.user_row(another_admin.id).bulk_select_checkbox.hover
+      expect(PageObjects::Components::Tooltips.new("bulk-delete-unavailable-reason")).to be_present(
+        text: I18n.t("admin_js.admin.users.bulk_actions.admin_cant_be_deleted"),
+      )
+    end
 
-    expect(admin_users_page).to have_no_bulk_actions_dropdown
+    it "has a button that toggles the bulk select checkboxes" do
+      admin_users_page.visit
 
-    admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+      expect(admin_users_page).to have_users(users.map(&:id))
 
-    expect(admin_users_page).to have_bulk_actions_dropdown
+      expect(admin_users_page.user_row(users[0].id)).to have_no_bulk_select_checkbox
+      expect(admin_users_page.user_row(users[1].id)).to have_no_bulk_select_checkbox
+      expect(admin_users_page.user_row(users[2].id)).to have_no_bulk_select_checkbox
 
-    admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
-    admin_users_page.bulk_actions_dropdown.expand
-    admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+      admin_users_page.bulk_select_button.click
 
-    expect(dialog).to be_open
-    dialog.click_danger
+      expect(admin_users_page.user_row(users[0].id)).to have_bulk_select_checkbox
+      expect(admin_users_page.user_row(users[1].id)).to have_bulk_select_checkbox
+      expect(admin_users_page.user_row(users[2].id)).to have_bulk_select_checkbox
 
-    deleted_ids = users[0..1].map(&:id)
-    expect(admin_users_page).to have_no_users(deleted_ids)
-    expect(User.where(id: deleted_ids).count).to eq(0)
-  end
+      expect(admin_users_page).to have_no_bulk_actions_dropdown
 
-  it "remembers selected users when the user list refreshes due to search" do
-    admin_users_page.visit
-    admin_users_page.bulk_select_button.click
-    admin_users_page.search_input.fill_in(with: users[0].username)
-    admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+      admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
 
-    admin_users_page.search_input.fill_in(with: users[1].username)
-    admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
+      expect(admin_users_page).to have_bulk_actions_dropdown
 
-    admin_users_page.search_input.fill_in(with: "")
+      admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
+      admin_users_page.bulk_actions_dropdown.expand
+      admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
 
-    expect(admin_users_page).to have_users(users.map(&:id))
-    expect(admin_users_page.user_row(users[0].id).bulk_select_checkbox).to be_checked
-    expect(admin_users_page.user_row(users[1].id).bulk_select_checkbox).to be_checked
-    expect(admin_users_page.user_row(users[2].id).bulk_select_checkbox).not_to be_checked
+      expect(confirmation_modal).to be_open
+      expect(confirmation_modal).to have_confirm_button_disabled
 
-    admin_users_page.bulk_actions_dropdown.expand
-    admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+      confirmation_modal.fill_in_confirmation_phase(user_count: 3)
+      expect(confirmation_modal).to have_confirm_button_disabled
 
-    expect(dialog).to be_open
-    dialog.click_danger
+      confirmation_modal.fill_in_confirmation_phase(user_count: 2)
+      expect(confirmation_modal).to have_confirm_button_enabled
 
-    deleted_ids = users[0..1].map(&:id)
-    expect(admin_users_page).to have_no_users(deleted_ids)
-    expect(User.where(id: deleted_ids).count).to eq(0)
+      confirmation_modal.confirm_button.click
+
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: users[0],
+        position: 1,
+        total: 2,
+      )
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: users[1],
+        position: 2,
+        total: 2,
+      )
+      expect(confirmation_modal).to have_no_error_log_entries
+
+      confirmation_modal.close
+      deleted_ids = users[0..1].map(&:id)
+      expect(admin_users_page).to have_no_users(deleted_ids)
+      expect(User.where(id: deleted_ids).count).to eq(0)
+    end
+
+    it "remembers selected users when the user list refreshes due to search" do
+      admin_users_page.visit
+      admin_users_page.bulk_select_button.click
+      admin_users_page.search_input.fill_in(with: users[0].username)
+      admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+
+      admin_users_page.search_input.fill_in(with: users[1].username)
+      admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
+
+      admin_users_page.search_input.fill_in(with: "")
+
+      expect(admin_users_page).to have_users(users.map(&:id))
+      expect(admin_users_page.user_row(users[0].id).bulk_select_checkbox).to be_checked
+      expect(admin_users_page.user_row(users[1].id).bulk_select_checkbox).to be_checked
+      expect(admin_users_page.user_row(users[2].id).bulk_select_checkbox).not_to be_checked
+
+      admin_users_page.bulk_actions_dropdown.expand
+      admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+
+      expect(confirmation_modal).to be_open
+      confirmation_modal.fill_in_confirmation_phase(user_count: 2)
+      confirmation_modal.confirm_button.click
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: users[0],
+        position: 1,
+        total: 2,
+      )
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: users[1],
+        position: 2,
+        total: 2,
+      )
+      confirmation_modal.close
+
+      deleted_ids = users[0..1].map(&:id)
+      expect(admin_users_page).to have_no_users(deleted_ids)
+      expect(User.where(id: deleted_ids).count).to eq(0)
+    end
+
+    it "displays an error message if bulk delete fails" do
+      admin_users_page.visit
+      admin_users_page.bulk_select_button.click
+
+      admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+      admin_users_page.bulk_actions_dropdown.expand
+      admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+      confirmation_modal.fill_in_confirmation_phase(user_count: 1)
+
+      users[0].update!(admin: true)
+
+      confirmation_modal.confirm_button.click
+      expect(confirmation_modal).to have_error_log_entry(
+        I18n.t("js.generic_error_with_reason", error: I18n.t("user.cannot_bulk_delete")),
+      )
+      confirmation_modal.close
+      expect(admin_users_page).to have_users([users[0].id])
+    end
   end
 end

--- a/spec/system/admin_users_list_spec.rb
+++ b/spec/system/admin_users_list_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe "Admin Users Page", type: :system do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:users) { Fabricate.times(3, :user) }
+
+  let(:admin_users_page) { PageObjects::Pages::AdminUsers.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
+
+  before { sign_in(current_user) }
+
+  it "has a button that toggles the bulk select checkboxes" do
+    admin_users_page.visit
+
+    expect(admin_users_page).to have_users(users.map(&:id))
+
+    expect(admin_users_page.user_row(users[0].id)).to have_no_bulk_select_checkbox
+    expect(admin_users_page.user_row(users[1].id)).to have_no_bulk_select_checkbox
+    expect(admin_users_page.user_row(users[2].id)).to have_no_bulk_select_checkbox
+
+    admin_users_page.bulk_select_button.click
+
+    expect(admin_users_page.user_row(users[0].id)).to have_bulk_select_checkbox
+    expect(admin_users_page.user_row(users[1].id)).to have_bulk_select_checkbox
+    expect(admin_users_page.user_row(users[2].id)).to have_bulk_select_checkbox
+
+    expect(admin_users_page).to have_no_bulk_actions_dropdown
+
+    admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+
+    expect(admin_users_page).to have_bulk_actions_dropdown
+
+    admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
+    admin_users_page.bulk_actions_dropdown.expand
+    admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+
+    expect(dialog).to be_open
+    dialog.click_danger
+
+    deleted_ids = users[0..1].map(&:id)
+    expect(admin_users_page).to have_no_users(deleted_ids)
+    expect(User.where(id: deleted_ids).count).to eq(0)
+  end
+
+  it "remembers selected users when the user list refreshes due to search" do
+    admin_users_page.visit
+    admin_users_page.bulk_select_button.click
+    admin_users_page.search_input.fill_in(with: users[0].username)
+    admin_users_page.user_row(users[0].id).bulk_select_checkbox.click
+
+    admin_users_page.search_input.fill_in(with: users[1].username)
+    admin_users_page.user_row(users[1].id).bulk_select_checkbox.click
+
+    admin_users_page.search_input.fill_in(with: "")
+
+    expect(admin_users_page).to have_users(users.map(&:id))
+    expect(admin_users_page.user_row(users[0].id).bulk_select_checkbox).to be_checked
+    expect(admin_users_page.user_row(users[1].id).bulk_select_checkbox).to be_checked
+    expect(admin_users_page.user_row(users[2].id).bulk_select_checkbox).not_to be_checked
+
+    admin_users_page.bulk_actions_dropdown.expand
+    admin_users_page.bulk_actions_dropdown.option(".bulk-delete").click
+
+    expect(dialog).to be_open
+    dialog.click_danger
+
+    deleted_ids = users[0..1].map(&:id)
+    expect(admin_users_page).to have_no_users(deleted_ids)
+    expect(User.where(id: deleted_ids).count).to eq(0)
+  end
+end

--- a/spec/system/page_objects/components/d_menu.rb
+++ b/spec/system/page_objects/components/d_menu.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class DMenu < PageObjects::Components::Base
+      attr_reader :component
+
+      def initialize(input)
+        if input.is_a?(Capybara::Node::Element)
+          @component = input
+        else
+          @component = find(input)
+        end
+      end
+
+      def expand
+        raise "DMenu is already expanded" if is_expanded?
+        component.click
+      end
+
+      def collapse
+        raise "DMenu is already collapsed" if is_collapsed?
+        component.click
+      end
+
+      def is_expanded?
+        component["aria-expanded"] == "true"
+      end
+
+      def is_collapsed?
+        !is_expanded?
+      end
+
+      def option(selector)
+        within("#d-menu-portals") { find(selector) }
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/bulk_user_delete_confirmation.rb
+++ b/spec/system/page_objects/modals/bulk_user_delete_confirmation.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class BulkUserDeleteConfirmation < Base
+      MODAL_SELECTOR = ".bulk-user-delete-confirmation"
+
+      def confirm_button
+        within(modal) { find(".btn.confirm-delete") }
+      end
+
+      def has_confirm_button_disabled?
+        within(modal) { has_css?(".btn.confirm-delete[disabled]") }
+      end
+
+      def has_confirm_button_enabled?
+        within(modal) do
+          has_no_css?(".btn.confirm-delete[disabled]") && has_css?(".btn.confirm-delete")
+        end
+      end
+
+      def fill_in_confirmation_phase(user_count:)
+        within(modal) do
+          find("input.confirmation-phrase").fill_in(
+            with:
+              I18n.t(
+                "admin_js.admin.users.bulk_actions.delete.confirmation_modal.confirmation_phrase",
+                count: user_count,
+              ),
+          )
+        end
+      end
+
+      def has_successful_log_entry_for_user?(user:, position:, total:)
+        within(modal) do
+          has_css?(
+            ".bulk-user-delete-confirmation__progress-line.-success",
+            text:
+              I18n.t(
+                "admin_js.admin.users.bulk_actions.delete.confirmation_modal.user_delete_succeeded",
+                position:,
+                total:,
+                username: user.username,
+              ),
+          )
+        end
+      end
+
+      def has_no_error_log_entries?
+        within(modal) { has_no_css?(".bulk-user-delete-confirmation__progress-line.-error") }
+      end
+
+      def has_error_log_entry?(message)
+        within(modal) do
+          has_css?(".bulk-user-delete-confirmation__progress-line.-error", text: message)
+        end
+      end
+
+      private
+
+      def modal
+        find(MODAL_SELECTOR)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_users.rb
+++ b/spec/system/page_objects/pages/admin_users.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminUsers < PageObjects::Pages::Base
+      class UserRow
+        attr_reader :element
+
+        def initialize(element)
+          @element = element
+        end
+
+        def bulk_select_checkbox
+          element.find(".directory-table__cell-bulk-select")
+        end
+
+        def has_bulk_select_checkbox?
+          element.has_css?(".directory-table__cell-bulk-select")
+        end
+
+        def has_no_bulk_select_checkbox?
+          element.has_no_css?(".directory-table__cell-bulk-select")
+        end
+      end
+
+      def visit
+        page.visit("/admin/users/list/active")
+      end
+
+      def bulk_select_button
+        find(".btn.bulk-select")
+      end
+
+      def search_input
+        find(".admin-users-list__controls .username input")
+      end
+
+      def user_row(id)
+        UserRow.new(find(".directory-table__row[data-user-id=\"#{id}\"]"))
+      end
+
+      def users_count
+        all(".directory-table__row").size
+      end
+
+      def has_users?(user_ids)
+        user_ids.all? { |id| has_css?(".directory-table__row[data-user-id=\"#{id}\"]") }
+      end
+
+      def has_no_users?(user_ids)
+        user_ids.all? { |id| has_no_css?(".directory-table__row[data-user-id=\"#{id}\"]") }
+      end
+
+      def bulk_actions_dropdown
+        PageObjects::Components::DMenu.new(find(".bulk-select-admin-users-dropdown-trigger"))
+      end
+
+      def has_bulk_actions_dropdown?
+        has_css?(".bulk-select-admin-users-dropdown-trigger")
+      end
+
+      def has_no_bulk_actions_dropdown?
+        has_no_css?(".bulk-select-admin-users-dropdown-trigger")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a new feature that allows staff to bulk select and delete users directly from the users list at `/admin/users/list`. The main use-case for this feature is make deleting spammers easier when a site is under a large spam attack.

Screenshot:

<img src="https://github.com/user-attachments/assets/a66dfc8d-fd2a-4d90-b8df-7809f57e9bfe" width=600>

<img src="https://github.com/user-attachments/assets/2fdf25dc-efa6-48f6-9cd7-43ebda226a55" width=600>

<img src="https://github.com/user-attachments/assets/591213ca-16d6-4fd3-b666-ba85aa919623" width=500>

Internal topic: t/140321.