### PR TITLE
UX: prevent shrinking unread badge for long DM channel names

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-name.scss
@@ -29,6 +29,7 @@
     justify-content: center;
     width: 8px;
     height: 8px;
+    flex-shrink: 0;
 
     &.-urgent {
       width: auto;


### PR DESCRIPTION
Fixes a small UX issue where the unread badge gets squashed in long DM channel names.

Before:

<img width="394" alt="Screenshot 2024-11-14 at 3 04 08 PM" src="https://github.com/user-attachments/assets/15e25bce-54bc-47c4-8b62-8fc70439fa62">

After:

<img width="393" alt="Screenshot 2024-11-14 at 3 12 31 PM" src="https://github.com/user-attachments/assets/08fded1f-e455-4eac-aabc-d7bd79451764">
