### PR TITLE
FIX: chat bookmarks in drawer mode

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -34,11 +34,8 @@ export default class ChatRoute extends DiscourseRoute {
     ) {
       transition.abort();
 
-      if (this.chatDrawerRouter.currentRouteName === transition.targetName) {
-        return;
-      }
-
       let url = transition.intent.url;
+
       if (transition.targetName.startsWith("chat.channel")) {
         url ??= this.router.urlFor(
           transition.targetName,
@@ -49,6 +46,7 @@ export default class ChatRoute extends DiscourseRoute {
       }
 
       this.appEvents.trigger("chat:open-url", url);
+
       return;
     }
 

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Bookmark message", type: :system do
   let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:thread_page) { PageObjects::Pages::ChatThread.new }
   let(:bookmark_modal) { PageObjects::Modals::Bookmark.new }
+  let(:user_menu) { PageObjects::Components::UserMenu.new }
 
   fab!(:category_channel_1) { Fabricate(:category_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: category_channel_1) }
@@ -46,6 +47,36 @@ RSpec.describe "Bookmark message", type: :system do
       visit bookmark.bookmarkable.url
 
       expect(thread_page).to have_bookmarked_message(first_message)
+    end
+
+    context "in drawer mode" do
+      fab!(:category_channel_2) { Fabricate(:category_channel) }
+      fab!(:message_2) { Fabricate(:chat_message, chat_channel: category_channel_2) }
+
+      fab!(:bookmark_1) { Bookmark.create!(bookmarkable: message_1, user: current_user) }
+      fab!(:bookmark_2) { Bookmark.create!(bookmarkable: message_2, user: current_user) }
+
+      before do
+        chat_page.prefers_drawer
+        category_channel_2.add(current_user)
+      end
+
+      it "supports visiting multiple chat bookmarks from the user menu" do
+        visit("/")
+
+        user_menu.open
+        user_menu.click_bookmarks_tab
+
+        expect(user_menu).to have_bookmark_count_of(2)
+
+        user_menu.click_bookmark(bookmark_1)
+
+        expect(channel_page).to have_bookmarked_message(message_1)
+
+        user_menu.click_bookmark(bookmark_2)
+
+        expect(channel_page).to have_bookmarked_message(message_2)
+      end
     end
 
     context "when the user has a bookmark auto_delete_preference" do

--- a/spec/system/page_objects/components/user_menu.rb
+++ b/spec/system/page_objects/components/user_menu.rb
@@ -15,6 +15,12 @@ module PageObjects
         self
       end
 
+      def click_bookmarks_tab
+        click_link("user-menu-button-bookmarks")
+        has_css?("#quick-access-bookmarks")
+        self
+      end
+
       def click_profile_tab
         click_link("user-menu-button-profile")
         has_css?("#quick-access-profile")
@@ -24,6 +30,11 @@ module PageObjects
       def click_logout_button
         find("#quick-access-profile .logout .btn").click
         has_css?(".d-header .login-button")
+        self
+      end
+
+      def click_bookmark(bookmark)
+        find("#quick-access-bookmarks .bookmark a[href='#{bookmark.bookmarkable.url}']").click
         self
       end
 
@@ -46,6 +57,10 @@ module PageObjects
 
       def has_notification_count_of?(count)
         page.has_css?(".user-menu li.notification", count: count)
+      end
+
+      def has_bookmark_count_of?(count)
+        page.has_css?(".user-menu #quick-access-bookmarks li.bookmark", count: count)
       end
     end
   end


### PR DESCRIPTION
When using chat in drawer mode, after you've clicked on a chat bookmark in the user menu, clicking any other chat bookmark would "do nothing".

In 8b18fd155679fa9b9d6e660ac74130cb79daabdc we added an optimization to prevent the same route from being reloaded, but it ended up breaking the bookmarks.

This commit reverts the changed made the above commit and adds a system specs that ensure we can click two chat bookmarks in the user menu when using chat in drawer mode.

Internal ref - t/134362

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->