### PR TITLE
A11Y: update clickable search dropdown tips to be buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/random-quick-tip.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/random-quick-tip.hbs
@@ -1,16 +1,16 @@
 <li class="search-random-quick-tip">
-  <span
+  <button
     class={{concat-class
       "tip-label"
       (if this.randomTip.clickable "tip-clickable")
     }}
-    role="button"
     {{on "click" this.tipSelected}}
+    aria-describedby="tip-description"
   >
     {{this.randomTip.label}}
-  </span>
+  </button>
 
-  <span class="tip-description">
+  <span id="tip-description">
     {{this.randomTip.description}}
   </span>
 </li>

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -326,6 +326,7 @@ $search-pad-horizontal: 0.5em;
       margin-right: 4px;
       padding: 2px 4px;
       display: inline-block;
+      border: none;
       &.tip-clickable {
         cursor: pointer;
       }


### PR DESCRIPTION
This updates these clickable search tips to buttons, rather than interactive spans — this allows them to be tabbable and more accessible by default. I've also added the description as a `aria-describedby` so they get read as well.  

![image](https://github.com/user-attachments/assets/235d082b-c6ca-40c9-a280-c1fd141076c0)

Appearance and functionality otherwise hasn't changed. 
