### PR TITLE
FIX: Signup fields tab order and descriptions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/fullname-input.gjs
+++ b/app/assets/javascripts/discourse/app/components/fullname-input.gjs
@@ -1,0 +1,33 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import InputTip from "discourse/components/input-tip";
+import TextField from "discourse/components/text-field";
+import valueEntered from "discourse/helpers/value-entered";
+
+export default class SidebarEditNavigationMenuTagsModal extends Component {
+  get showFullname() {
+    return (
+      this.siteSettings.full_name_required || this.siteSettings.enable_names
+    );
+  }
+
+  <template>
+    <div ...attributes>
+      <TextField
+        {{on "focusin" @onFocusIn}}
+        @disabled={{@nameDisabled}}
+        @value={{@accountName}}
+        @id="new-account-name"
+        aria-describedby="fullname-validation fullname-validation-more-info"
+        aria-invalid={{@nameValidation.failed}}
+        class={{valueEntered @accountName}}
+        name="name"
+      />
+      <label class="alt-placeholder" for="new-account-name">
+        {{@nameTitle}}
+      </label>
+
+      <InputTip @validation={{@nameValidation}} id="fullname-validation" />
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -95,18 +95,14 @@
             />
           </div>
 
-          {{#if (and this.showFullname this.fullnameRequired)}}
+          {{#if this.fullnameRequired}}
             <FullnameInput
               @nameValidation={{this.nameValidation}}
               @nameTitle={{this.nameTitle}}
               @accountName={{this.accountName}}
               @nameDisabled={{this.nameDisabled}}
               @onFocusIn={{this.scrollInputIntoView}}
-              class={{concat-class
-                "input-group"
-                "create-account__fullname"
-                (if this.siteSettings.full_name_required "required")
-              }}
+              class="input-group create-account__fullname required"
             />
           {{/if}}
 
@@ -222,11 +218,7 @@
               @accountName={{this.accountName}}
               @nameDisabled={{this.nameDisabled}}
               @onFocusIn={{this.scrollInputIntoView}}
-              class={{concat-class
-                "input-group"
-                "create-account__fullname"
-                (if this.siteSettings.full_name_required "required")
-              }}
+              class="input-group create-account__fullname"
             />
           {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -95,6 +95,21 @@
             />
           </div>
 
+          {{#if (and this.showFullname this.fullnameRequired)}}
+            <FullnameInput
+              @nameValidation={{this.nameValidation}}
+              @nameTitle={{this.nameTitle}}
+              @accountName={{this.accountName}}
+              @nameDisabled={{this.nameDisabled}}
+              @onFocusIn={{this.scrollInputIntoView}}
+              class={{concat-class
+                "input-group"
+                "create-account__fullname"
+                (if this.siteSettings.full_name_required "required")
+              }}
+            />
+          {{/if}}
+
           <PluginOutlet
             @name="create-account-before-password"
             @outletArgs={{hash
@@ -200,33 +215,20 @@
             }}
           />
 
-          <div
-            class={{concat-class
-              "input-group"
-              "create-account__fullname"
-              (if this.siteSettings.full_name_required "required")
-            }}
-          >
-            {{#if this.fullnameRequired}}
-              <TextField
-                {{on "focusin" this.scrollInputIntoView}}
-                @disabled={{this.nameDisabled}}
-                @value={{this.model.accountName}}
-                @id="new-account-name"
-                aria-describedby="fullname-validation fullname-validation-more-info"
-                aria-invalid={{this.nameValidation.failed}}
-                class={{value-entered this.model.accountName}}
-              />
-              <label class="alt-placeholder" for="new-account-name">
-                {{this.nameTitle}}
-              </label>
-
-              <InputTip
-                @validation={{this.nameValidation}}
-                id="fullname-validation"
-              />
-            {{/if}}
-          </div>
+          {{#if (and this.showFullname (not this.fullnameRequired))}}
+            <FullnameInput
+              @nameValidation={{this.nameValidation}}
+              @nameTitle={{this.nameTitle}}
+              @accountName={{this.accountName}}
+              @nameDisabled={{this.nameDisabled}}
+              @onFocusIn={{this.scrollInputIntoView}}
+              class={{concat-class
+                "input-group"
+                "create-account__fullname"
+                (if this.siteSettings.full_name_required "required")
+              }}
+            />
+          {{/if}}
 
           {{#if this.userFields}}
             <div class="user-fields">

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.js
@@ -133,10 +133,13 @@ export default class CreateAccount extends Component.extend(
   }
 
   @discourseComputed
+  showFullname() {
+    return this.siteSettings.enable_names;
+  }
+
+  @discourseComputed
   fullnameRequired() {
-    return (
-      this.siteSettings.full_name_required || this.siteSettings.enable_names
-    );
+    return this.siteSettings.full_name_required;
   }
 
   @discourseComputed("model.authOptions.auth_provider")

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -156,10 +156,13 @@ export default class InvitesShowController extends Controller.extend(
   }
 
   @discourseComputed
+  showFullname() {
+    return this.siteSettings.enable_names;
+  }
+
+  @discourseComputed
   fullnameRequired() {
-    return (
-      this.siteSettings.full_name_required || this.siteSettings.enable_names
-    );
+    return this.siteSettings.full_name_required;
   }
 
   @discourseComputed(
@@ -279,6 +282,14 @@ export default class InvitesShowController extends Controller.extend(
   @action
   togglePasswordMask() {
     this.toggleProperty("maskPassword");
+  }
+
+  @action
+  scrollInputIntoView(event) {
+    event.target.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -122,10 +122,13 @@ export default class SignupPageController extends Controller.extend(
   }
 
   @discourseComputed
+  showFullname() {
+    return this.siteSettings.enable_names;
+  }
+
+  @discourseComputed
   fullnameRequired() {
-    return (
-      this.siteSettings.full_name_required || this.siteSettings.enable_names
-    );
+    return this.siteSettings.full_name_required;
   }
 
   @discourseComputed("authOptions.auth_provider")

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -66,6 +66,7 @@
               {{#if this.isInviteLink}}
                 <div class="input email-input input-group">
                   <Input
+                    {{on "focusin" this.scrollInputIntoView}}
                     @type="email"
                     @value={{this.email}}
                     id="new-account-email"
@@ -91,6 +92,7 @@
 
               <div class="input username-input input-group">
                 <Input
+                  {{on "focusin" this.scrollInputIntoView}}
                   @value={{this.accountUsername}}
                   class={{value-entered this.accountUsername}}
                   id="new-account-username"
@@ -107,9 +109,26 @@
                 />
               </div>
 
+              {{#if this.fullnameRequired}}
+                <FullnameInput
+                  @nameValidation={{this.nameValidation}}
+                  @nameTitle={{this.nameTitle}}
+                  @accountName={{this.accountName}}
+                  @nameDisabled={{this.nameDisabled}}
+                  @onFocusIn={{this.scrollInputIntoView}}
+                  class={{concat-class
+                    "input"
+                    "name-input"
+                    "input-group"
+                    (if this.siteSettings.full_name_required "name-required")
+                  }}
+                />
+              {{/if}}
+
               {{#unless this.externalAuthsOnly}}
                 <div class="input password-input input-group">
                   <PasswordField
+                    {{on "focusin" this.scrollInputIntoView}}
                     @value={{this.accountPassword}}
                     @capsLockOn={{this.capsLockOn}}
                     type={{if this.maskPassword "password" "text"}}
@@ -143,29 +162,20 @@
                 </div>
               {{/unless}}
 
-              {{#if this.fullnameRequired}}
-                <div
+              {{#if (and this.showFullname (not this.fullnameRequired))}}
+                <FullnameInput
+                  @nameValidation={{this.nameValidation}}
+                  @nameTitle={{this.nameTitle}}
+                  @accountName={{this.accountName}}
+                  @nameDisabled={{this.nameDisabled}}
+                  @onFocusIn={{this.scrollInputIntoView}}
                   class={{concat-class
                     "input"
                     "name-input"
                     "input-group"
                     (if this.siteSettings.full_name_required "name-required")
                   }}
-                >
-                  <Input
-                    @value={{this.accountName}}
-                    class={{value-entered this.accountName}}
-                    id="new-account-name"
-                    name="name"
-                  />
-                  <label class="alt-placeholder" for="new-account-name">
-                    {{i18n "invites.name_label"}}
-                  </label>
-                  <InputTip
-                    @validation={{this.nameValidation}}
-                    id="fullname-validation"
-                  />
-                </div>
+                />
               {{/if}}
 
               {{#if this.userFields}}
@@ -173,6 +183,7 @@
                   {{#each this.userFields as |f|}}
                     <div class="input-group">
                       <UserField
+                        {{on "focusin" this.scrollInputIntoView}}
                         @field={{f.field}}
                         @value={{f.value}}
                         class={{value-entered f.value}}

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -116,12 +116,7 @@
                   @accountName={{this.accountName}}
                   @nameDisabled={{this.nameDisabled}}
                   @onFocusIn={{this.scrollInputIntoView}}
-                  class={{concat-class
-                    "input"
-                    "name-input"
-                    "input-group"
-                    (if this.siteSettings.full_name_required "name-required")
-                  }}
+                  class="input name-input input-group name-required"
                 />
               {{/if}}
 
@@ -169,12 +164,7 @@
                   @accountName={{this.accountName}}
                   @nameDisabled={{this.nameDisabled}}
                   @onFocusIn={{this.scrollInputIntoView}}
-                  class={{concat-class
-                    "input"
-                    "name-input"
-                    "input-group"
-                    (if this.siteSettings.full_name_required "name-required")
-                  }}
+                  class="input name-input input-group"
                 />
               {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/signup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/signup.hbs
@@ -91,18 +91,14 @@
             />
           </div>
 
-          {{#if (and this.showFullname this.fullnameRequired)}}
+          {{#if this.fullnameRequired}}
             <FullnameInput
               @nameValidation={{this.nameValidation}}
               @nameTitle={{this.nameTitle}}
               @accountName={{this.accountName}}
               @nameDisabled={{this.nameDisabled}}
               @onFocusIn={{this.scrollInputIntoView}}
-              class={{concat-class
-                "input-group"
-                "create-account__fullname"
-                (if this.siteSettings.full_name_required "required")
-              }}
+              class="input-group create-account__fullname required"
             />
           {{/if}}
 
@@ -218,11 +214,7 @@
               @accountName={{this.accountName}}
               @nameDisabled={{this.nameDisabled}}
               @onFocusIn={{this.scrollInputIntoView}}
-              class={{concat-class
-                "input-group"
-                "create-account__fullname"
-                (if this.siteSettings.full_name_required "required")
-              }}
+              class="input-group create-account__fullname"
             />
           {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/signup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/signup.hbs
@@ -91,6 +91,21 @@
             />
           </div>
 
+          {{#if (and this.showFullname this.fullnameRequired)}}
+            <FullnameInput
+              @nameValidation={{this.nameValidation}}
+              @nameTitle={{this.nameTitle}}
+              @accountName={{this.accountName}}
+              @nameDisabled={{this.nameDisabled}}
+              @onFocusIn={{this.scrollInputIntoView}}
+              class={{concat-class
+                "input-group"
+                "create-account__fullname"
+                (if this.siteSettings.full_name_required "required")
+              }}
+            />
+          {{/if}}
+
           <PluginOutlet
             @name="create-account-before-password"
             @outletArgs={{hash
@@ -196,33 +211,20 @@
             }}
           />
 
-          <div
-            class={{concat-class
-              "input-group"
-              "create-account__fullname"
-              (if this.siteSettings.full_name_required "required")
-            }}
-          >
-            {{#if this.fullnameRequired}}
-              <TextField
-                {{on "focusin" this.scrollInputIntoView}}
-                @disabled={{this.nameDisabled}}
-                @value={{this.accountName}}
-                @id="new-account-name"
-                aria-describedby="fullname-validation fullname-validation-more-info"
-                aria-invalid={{this.nameValidation.failed}}
-                class={{value-entered this.accountName}}
-              />
-              <label class="alt-placeholder" for="new-account-name">
-                {{this.nameTitle}}
-              </label>
-
-              <InputTip
-                @validation={{this.nameValidation}}
-                id="fullname-validation"
-              />
-            {{/if}}
-          </div>
+          {{#if (and this.showFullname (not this.fullnameRequired))}}
+            <FullnameInput
+              @nameValidation={{this.nameValidation}}
+              @nameTitle={{this.nameTitle}}
+              @accountName={{this.accountName}}
+              @nameDisabled={{this.nameDisabled}}
+              @onFocusIn={{this.scrollInputIntoView}}
+              class={{concat-class
+                "input-group"
+                "create-account__fullname"
+                (if this.siteSettings.full_name_required "required")
+              }}
+            />
+          {{/if}}
 
           {{#if this.userFields}}
             <div class="user-fields">

--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -193,14 +193,6 @@ body.signup-page {
     display: flex;
     flex-direction: column;
 
-    .input-group {
-      &.create-account-email,
-      &.create-account__username,
-      &.create-account__fullname.required {
-        order: -1;
-      }
-    }
-
     .create-account-associate-link {
       order: 1;
     }
@@ -244,15 +236,6 @@ body.signup-page {
     font-size: var(--font-down-1);
     color: var(--primary-medium);
     overflow-wrap: anywhere;
-    transition: opacity 0.2s ease;
-    opacity: 0;
-  }
-
-  .input-group input:focus {
-    & ~ .more-info,
-    & ~ .instructions {
-      opacity: 1;
-    }
   }
 
   .caps-lock-warning {

--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -68,13 +68,6 @@
     display: flex;
     flex-direction: column;
 
-    .input-group {
-      &.create-account-email,
-      &.create-account__username,
-      &.create-account__fullname.required {
-        order: -1;
-      }
-    }
     .create-account-associate-link {
       order: 1;
     }
@@ -98,15 +91,6 @@
     font-size: var(--font-down-1);
     color: var(--primary-medium);
     overflow-wrap: anywhere;
-    transition: opacity 0.2s ease;
-    opacity: 0;
-  }
-
-  .input-group input:focus {
-    & ~ .more-info,
-    & ~ .instructions {
-      opacity: 1;
-    }
   }
 
   .caps-lock-warning {


### PR DESCRIPTION
Using the site setting `full_name_required` changes the order of the fields in the signup form. Previously, this was done with CSS, which caused issues with tab navigation. This PR fixes that by rearranging the elements in the template. 
It also makes the field descriptions always visible, instead of only when the input was focused, and adds the auto-scroll feature for the invites page as well