### PR TITLE
FIX: Admin backups erroring because of S3 dualstack

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -169,7 +169,9 @@ class SiteSetting < ActiveRecord::Base
     end
 
     def self.use_dualstack_endpoint
-      SiteSetting.Upload.s3_endpoint.blank? && !SiteSetting.Upload.s3_region.start_with?("cn-")
+      return false if !SiteSetting.Upload.enable_s3_uploads
+      return false if SiteSetting.Upload.s3_endpoint.present?
+      !SiteSetting.Upload.s3_region.start_with?("cn-")
     end
 
     def self.enable_s3_uploads

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -201,19 +201,37 @@ RSpec.describe SiteSetting do
     before { setup_s3 }
 
     describe "#use_dualstack_endpoint" do
-      it "returns false if s3_endpoint has been set" do
-        SiteSetting.s3_endpoint = "https://s3clone.test.com"
-        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+      context "when the s3 endpoint has been set" do
+        before { SiteSetting.s3_endpoint = "https://s3clone.test.com" }
+
+        it "returns false " do
+          expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+        end
       end
 
-      it "returns false if the s3_region is in China" do
-        SiteSetting.s3_region = "cn-north-1"
-        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+      context "when enable_s3_uploads is false" do
+        before { SiteSetting.enable_s3_uploads = false }
+
+        it "returns false" do
+          expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+        end
       end
 
-      it "returns true if the s3_region is not in China" do
-        SiteSetting.s3_region = "us-west-1"
-        expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(true)
+      context "when enable_s3_uploads is true" do
+        before do
+          SiteSetting.enable_s3_uploads = true
+          SiteSetting.s3_endpoint = ""
+        end
+
+        it "returns false if the s3_region is in China" do
+          SiteSetting.s3_region = "cn-north-1"
+          expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(false)
+        end
+
+        it "returns true if the s3_region is not in China" do
+          SiteSetting.s3_region = "us-west-1"
+          expect(SiteSetting.Upload.use_dualstack_endpoint).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
Followup 0568d36133081e52f25f05585c1a568c3b828d79
Followup 97cf069a061e350edfc5310266e80e58532a39a4

Due to the S3 dualstack endpoint change, sites with
S3 backups configured but _not_ S3 uploads were erroring,
with admins unable to access the backups page. This
commit fixes the error by not enabling S3 dualstack
endpoints if S3 uploads have not been enabled, backups
don't need to use them.

c.f. https://meta.discourse.org/t/unable-to-backup-or-navigate-to-backups/335899