### PR TITLE
REFACTOR: Simplify converter steps in migration tooling

### DIFF
--- a/migrations/bin/cli
+++ b/migrations/bin/cli
@@ -1,23 +1,49 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "thor"
 require_relative "../lib/migrations"
 
+require "colored2"
+require "thor"
+
 module Migrations
-  load_rails_environment
   configure_zeitwerk
   enable_i18n
 
-  class CommandLineInterface < Thor
-    include ::Migrations::CLI::ConvertCommand
-    include ::Migrations::CLI::ImportCommand
-    include ::Migrations::CLI::UploadCommand
+  module CLI
+    class Application < Thor
+      desc "convert [FROM]", "Convert a file"
+      option :settings, type: :string, desc: "Path of settings file", banner: "path"
+      option :reset, type: :boolean, desc: "Reset database before converting data"
+      def convert(converter_type)
+        ::Migrations::CLI::ConvertCommand.new(converter_type, options).execute
+      end
 
-    def self.exit_on_failure?
-      true
+      desc "import", "Import a file"
+      def import
+        ::Migrations::CLI::ImportCommand.new(options).execute
+      end
+
+      desc "upload", "Upload media uploads"
+      option :settings,
+             type: :string,
+             desc: "Uploads settings file path",
+             default: "./migrations/config/upload.yml",
+             aliases: "-s",
+             banner: "path"
+      option :fix_missing, type: :boolean, desc: "Fix missing uploads"
+      option :optimize, type: :boolean, desc: "Optimize uploads"
+      def upload
+        ::Migrations::CLI::UploadCommand.new(options).execute
+      end
+
+      def self.exit_on_failure?
+        true
+      end
     end
   end
-
-  Dir.chdir(Rails.root) { CommandLineInterface.start } # rubocop:disable Discourse/NoChdir
 end
+
+# rubocop:disable Discourse/NoChdir
+Dir.chdir(File.expand_path("../..", __dir__)) { ::Migrations::CLI::Application.start }
+# rubocop:enable Discourse/NoChdir

--- a/migrations/config/locales/migrations.en.yml
+++ b/migrations/config/locales/migrations.en.yml
@@ -9,7 +9,6 @@ en:
     estimated: "ETA: %{duration}"
     elapsed: "Time: %{duration}"
     processed:
-      percentage: "Processed: %{percentage}"
       progress: "Processed: %{current}"
       progress_with_max: "Processed: %{current} / %{max}"
 

--- a/migrations/db/intermediate_db_schema/002-log_entries.sql
+++ b/migrations/db/intermediate_db_schema/002-log_entries.sql
@@ -4,5 +4,5 @@ CREATE TABLE log_entries
     type       TEXT     NOT NULL,
     message    TEXT     NOT NULL,
     exception  TEXT,
-    details    TEXT
+    details    JSON_TEXT
 );

--- a/migrations/lib/cli/convert_command.rb
+++ b/migrations/lib/cli/convert_command.rb
@@ -1,52 +1,48 @@
 # frozen_string_literal: true
 
-module Migrations::CLI::ConvertCommand
-  def self.included(thor)
-    thor.class_eval do
-      desc "convert [FROM]", "Convert a file"
-      option :settings, type: :string, desc: "Path of settings file", banner: "path"
-      option :reset, type: :boolean, desc: "Reset database before converting data"
-      def convert(converter_type)
-        converter_type = converter_type.downcase
-        validate_converter_type!(converter_type)
+module Migrations::CLI
+  class ConvertCommand
+    def initialize(converter_type, options)
+      @converter_type = converter_type.downcase
+      @options = options
+    end
 
-        settings = load_settings(converter_type)
+    def execute
+      validate_converter_type!
+      settings = load_settings
 
-        ::Migrations::Database.reset!(settings[:intermediate_db][:path]) if options[:reset]
+      ::Migrations::Database.reset!(settings[:intermediate_db][:path]) if @options[:reset]
 
-        converter = "migrations/converters/#{converter_type}/converter".camelize.constantize
-        converter.new(settings).run
-      end
+      converter = "migrations/converters/#{@converter_type}/converter".camelize.constantize
+      converter.new(settings).run
+    end
 
-      private
+    private
 
-      def validate_converter_type!(type)
-        converter_names = ::Migrations::Converters.names
+    def validate_converter_type!
+      converter_names = ::Migrations::Converters.names
 
-        raise Thor::Error, <<~MSG if !converter_names.include?(type)
-            Unknown converter name: #{type}
-            Valid names are: #{converter_names.join(", ")}
-          MSG
-      end
+      raise Thor::Error, <<~MSG if !converter_names.include?(@converter_type)
+        Unknown converter name: #{@converter_type}
+        Valid names are: #{converter_names.join(", ")}
+      MSG
+    end
 
-      def validate_settings_path!(settings_path)
-        if !File.exist?(settings_path)
-          raise Thor::Error, "Settings file not found: #{settings_path}"
-        end
-      end
+    def validate_settings_path!(settings_path)
+      raise Thor::Error, "Settings file not found: #{settings_path}" if !File.exist?(settings_path)
+    end
 
-      def load_settings(converter_type)
-        settings_path = calculate_settings_path(converter_type)
-        validate_settings_path!(settings_path)
+    def load_settings
+      settings_path = calculate_settings_path
+      validate_settings_path!(settings_path)
 
-        YAML.safe_load(File.read(settings_path), symbolize_names: true)
-      end
+      YAML.safe_load(File.read(settings_path), symbolize_names: true)
+    end
 
-      def calculate_settings_path(converter_type)
-        settings_path =
-          options[:settings] || ::Migrations::Converters.default_settings_path(converter_type)
-        File.expand_path(settings_path, Dir.pwd)
-      end
+    def calculate_settings_path
+      settings_path =
+        @options[:settings] || ::Migrations::Converters.default_settings_path(@converter_type)
+      File.expand_path(settings_path, Dir.pwd)
     end
   end
 end

--- a/migrations/lib/cli/import_command.rb
+++ b/migrations/lib/cli/import_command.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
-module Migrations::CLI::ImportCommand
-  def self.included(thor)
-    thor.class_eval do
-      desc "import", "Import a file"
-      def import
-        require "extralite"
+require "extralite"
 
-        puts "Importing into Discourse #{Discourse::VERSION::STRING}"
-        puts "Extralite SQLite version: #{Extralite.sqlite3_version}"
-      end
+module Migrations::CLI
+  class ImportCommand
+    def initialize(options)
+      @options = options
+    end
+
+    def execute
+      ::Migrations.load_rails_environment
+
+      puts "Importing into Discourse #{Discourse::VERSION::STRING}"
+      puts "Extralite SQLite version: #{Extralite.sqlite3_version}"
     end
   end
 end

--- a/migrations/lib/common/extended_progress_bar.rb
+++ b/migrations/lib/common/extended_progress_bar.rb
@@ -4,14 +4,8 @@ require "ruby-progressbar"
 
 module Migrations
   class ExtendedProgressBar
-    def initialize(
-      max_progress: nil,
-      report_progress_in_percent: false,
-      use_custom_progress_increment: false
-    )
+    def initialize(max_progress: nil)
       @max_progress = max_progress
-      @report_progress_in_percent = report_progress_in_percent
-      @use_custom_progress_increment = use_custom_progress_increment
 
       @warning_count = 0
       @error_count = 0
@@ -31,16 +25,16 @@ module Migrations
       nil
     end
 
-    def update(stats)
+    def update(progress, warning_count, error_count)
       extra_information_changed = false
 
-      if stats.warning_count > 0
-        @warning_count += stats.warning_count
+      if warning_count > 0
+        @warning_count += warning_count
         extra_information_changed = true
       end
 
-      if stats.error_count > 0
-        @error_count += stats.error_count
+      if error_count > 0
+        @error_count += error_count
         extra_information_changed = true
       end
 
@@ -59,10 +53,10 @@ module Migrations
         @progressbar.format = "#{@base_format}#{@extra_information}"
       end
 
-      if @use_custom_progress_increment
-        @progressbar.progress += stats.progress
-      else
+      if progress == 1
         @progressbar.increment
+      else
+        @progressbar.progress += progress
       end
     end
 
@@ -70,9 +64,7 @@ module Migrations
 
     def setup_progressbar
       format =
-        if @report_progress_in_percent
-          I18n.t("progressbar.processed.percentage", percentage: "%J%")
-        elsif @max_progress
+        if @max_progress
           I18n.t("progressbar.processed.progress_with_max", current: "%c", max: "%C")
         else
           I18n.t("progressbar.processed.progress", current: "%c")

--- a/migrations/lib/converters/base/converter.rb
+++ b/migrations/lib/converters/base/converter.rb
@@ -73,7 +73,7 @@ module Migrations::Converters::Base
       default_args = { settings: settings }
 
       args = default_args.merge(step_args(step_class))
-      step_class.new(args)
+      step_class.new(StepTracker.new, args)
     end
   end
 end

--- a/migrations/lib/converters/base/progress_step.rb
+++ b/migrations/lib/converters/base/progress_step.rb
@@ -10,7 +10,7 @@ module Migrations::Converters::Base
       raise NotImplementedError
     end
 
-    def process_item(item, stats)
+    def process_item(item)
       raise NotImplementedError
     end
 
@@ -21,22 +21,6 @@ module Migrations::Converters::Base
 
       def run_in_parallel?
         @run_in_parallel == true
-      end
-
-      def report_progress_in_percent(value)
-        @report_progress_in_percent = !!value
-      end
-
-      def report_progress_in_percent?
-        @report_progress_in_percent == true
-      end
-
-      def use_custom_progress_increment(value)
-        @use_custom_progress_increment = !!value
-      end
-
-      def use_custom_progress_increment?
-        @use_custom_progress_increment == true
       end
     end
   end

--- a/migrations/lib/converters/base/progress_step_executor.rb
+++ b/migrations/lib/converters/base/progress_step_executor.rb
@@ -39,7 +39,7 @@ module Migrations::Converters::Base
       with_progressbar do |progressbar|
         @step.items.each do |item|
           stats = job.run(item)
-          progressbar.update(stats)
+          progressbar.update(stats.progress, stats.warning_count, stats.error_count)
         end
       end
     end
@@ -76,11 +76,7 @@ module Migrations::Converters::Base
 
     def with_progressbar
       ::Migrations::ExtendedProgressBar
-        .new(
-          max_progress: @max_progress,
-          report_progress_in_percent: @step.class.report_progress_in_percent?,
-          use_custom_progress_increment: @step.class.use_custom_progress_increment?,
-        )
+        .new(max_progress: @max_progress)
         .run { |progressbar| yield progressbar }
     end
 
@@ -94,7 +90,7 @@ module Migrations::Converters::Base
               ::Migrations::Database::IntermediateDB.insert(sql, *parameters)
             end
 
-            progressbar.update(stats)
+            progressbar.update(stats.progress, stats.warning_count, stats.error_count)
           end
         end
       end

--- a/migrations/lib/converters/base/serial_job.rb
+++ b/migrations/lib/converters/base/serial_job.rb
@@ -4,19 +4,19 @@ module Migrations::Converters::Base
   class SerialJob
     def initialize(step)
       @step = step
-      @stats = ProgressStats.new
+      @tracker = step.tracker
     end
 
     def run(item)
-      @stats.reset!
+      @tracker.reset_stats!
 
       begin
-        @step.process_item(item, @stats)
+        @step.process_item(item)
       rescue StandardError => e
-        @stats.log_error("Failed to process item", exception: e, details: item)
+        @tracker.log_error("Failed to process item", exception: e, details: item)
       end
 
-      @stats
+      @tracker.stats
     end
 
     def cleanup

--- a/migrations/lib/converters/base/step.rb
+++ b/migrations/lib/converters/base/step.rb
@@ -5,9 +5,18 @@ module Migrations::Converters::Base
     IntermediateDB = ::Migrations::Database::IntermediateDB
 
     attr_accessor :settings
+    attr_reader :tracker
 
-    def initialize(args = {})
-      args.each { |arg, value| instance_variable_set("@#{arg}", value) if respond_to?(arg, true) }
+    # inside of Step it might make more sense to access it as `step` instead of `tracker`
+    alias step tracker
+
+    def initialize(tracker, args = {})
+      @tracker = tracker
+
+      args.each do |arg, value|
+        setter = "#{arg}=".to_sym
+        public_send(setter, value) if respond_to?(setter, true)
+      end
     end
 
     def execute

--- a/migrations/lib/converters/base/step_stats.rb
+++ b/migrations/lib/converters/base/step_stats.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Migrations::Converters::Base
+  StepStats = Struct.new(:progress, :warning_count, :error_count)
+end

--- a/migrations/lib/converters/base/step_tracker.rb
+++ b/migrations/lib/converters/base/step_tracker.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 module Migrations::Converters::Base
-  class ProgressStats
-    attr_accessor :progress, :warning_count, :error_count
+  class StepTracker
+    attr_reader :stats
 
     def initialize
-      reset!
+      @stats = StepStats.new
+      reset_stats!
     end
 
-    def reset!
-      @progress = 1
-      @warning_count = 0
-      @error_count = 0
+    def reset_stats!
+      @stats.progress = 1
+      @stats.warning_count = 0
+      @stats.error_count = 0
+    end
+
+    def progress=(value)
+      @stats.progress = value
     end
 
     def log_info(message, details: nil)
@@ -19,18 +24,13 @@ module Migrations::Converters::Base
     end
 
     def log_warning(message, exception: nil, details: nil)
-      @warning_count += 1
+      @stats.warning_count += 1
       log(::Migrations::Database::IntermediateDB::LogEntry::WARNING, message, exception:, details:)
     end
 
     def log_error(message, exception: nil, details: nil)
-      @error_count += 1
+      @stats.error_count += 1
       log(::Migrations::Database::IntermediateDB::LogEntry::ERROR, message, exception:, details:)
-    end
-
-    def ==(other)
-      other.is_a?(ProgressStats) && progress == other.progress &&
-        warning_count == other.warning_count && error_count == other.error_count
     end
 
     private

--- a/migrations/lib/converters/base/worker.rb
+++ b/migrations/lib/converters/base/worker.rb
@@ -4,14 +4,7 @@ require "oj"
 
 module Migrations::Converters::Base
   class Worker
-    OJ_SETTINGS = {
-      mode: :custom,
-      create_id: "^o",
-      create_additions: true,
-      cache_keys: true,
-      class_cache: true,
-      symbol_keys: true,
-    }
+    OJ_SETTINGS = { mode: :object, class_cache: true, symbol_keys: true }
 
     def initialize(index, input_queue, output_queue, job)
       @index = index

--- a/migrations/lib/converters/example/steps/step2.rb
+++ b/migrations/lib/converters/example/steps/step2.rb
@@ -8,11 +8,11 @@ module Migrations::Converters::Example
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     end
 
-    def process_item(item, stats)
+    def process_item(item)
       sleep(0.5)
 
-      stats.warning_count += 1 if item.in?([3, 7, 9])
-      stats.error_count += 1 if item.in?([6, 10])
+      step.log_warning("Test", details: item) if item.in?([3, 7, 9])
+      step.log_error("Test", details: item) if item.in?([6, 10])
 
       IntermediateDB::LogEntry.create!(type: "info", message: "Step2 - #{item}")
     end

--- a/migrations/lib/converters/example/steps/step3.rb
+++ b/migrations/lib/converters/example/steps/step3.rb
@@ -12,8 +12,10 @@ module Migrations::Converters::Example
       (1..1000).map { |i| { counter: i } }
     end
 
-    def process_item(item, stats)
+    def process_item(item)
       sleep(0.5)
+
+      step.log_warning("Test", details: item) if item[:counter] > 10 && item[:counter] < 20
 
       IntermediateDB::LogEntry.create!(type: "info", message: "Step3 - #{item[:counter]}")
     end

--- a/migrations/lib/database.rb
+++ b/migrations/lib/database.rb
@@ -3,23 +3,22 @@
 require "date"
 require "extralite"
 require "ipaddr"
+require "oj"
 
 module Migrations
   module Database
     INTERMEDIATE_DB_SCHEMA_PATH = File.join(::Migrations.root_path, "db", "intermediate_db_schema")
     UPLOADS_DB_SCHEMA_PATH = File.join(::Migrations.root_path, "db", "uploads_db_schema")
 
-    module_function
-
-    def migrate(db_path, migrations_path:)
+    def self.migrate(db_path, migrations_path:)
       Migrator.new(db_path).migrate(migrations_path)
     end
 
-    def reset!(db_path)
+    def self.reset!(db_path)
       Migrator.new(db_path).reset!
     end
 
-    def connect(path)
+    def self.connect(path)
       connection = Connection.new(path:)
       return connection unless block_given?
 
@@ -31,29 +30,34 @@ module Migrations
       nil
     end
 
-    def format_datetime(value)
+    def self.format_datetime(value)
       value&.utc&.iso8601
     end
 
-    def format_date(value)
+    def self.format_date(value)
       value&.to_date&.iso8601
     end
 
-    def format_boolean(value)
+    def self.format_boolean(value)
       return nil if value.nil?
       value ? 1 : 0
     end
 
-    def format_ip_address(value)
+    def self.format_ip_address(value)
       return nil if value.blank?
       IPAddr.new(value).to_s
     rescue ArgumentError
       nil
     end
 
-    def to_blob(value)
+    def self.to_blob(value)
       return nil if value.blank?
-      Extralite::Blob.new(value)
+      ::Extralite::Blob.new(value)
+    end
+
+    def self.to_json(value)
+      return nil if value.nil?
+      ::Oj.dump(value, mode: :compat)
     end
   end
 end

--- a/migrations/lib/database/intermediate_db.rb
+++ b/migrations/lib/database/intermediate_db.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "singleton"
-
 module Migrations::Database
   module IntermediateDB
     def self.setup(db_connection)

--- a/migrations/lib/database/intermediate_db/log_entry.rb
+++ b/migrations/lib/database/intermediate_db/log_entry.rb
@@ -18,7 +18,7 @@ module Migrations::Database::IntermediateDB
         type,
         message,
         exception&.full_message(highlight: false),
-        details,
+        ::Migrations::Database.to_json(details),
       )
     end
   end

--- a/migrations/lib/database/migrator.rb
+++ b/migrations/lib/database/migrator.rb
@@ -21,12 +21,14 @@ module Migrations::Database
       migrate_from_path(@migrations_path, performed_migrations)
 
       @db.close
+      nil
     end
 
     def reset!
       [@db_path, "#{@db_path}-wal", "#{@db_path}-shm"].each do |path|
         FileUtils.remove_file(path, force: true) if File.exist?(path)
       end
+      nil
     end
 
     private

--- a/migrations/lib/database/prepared_statement_cache.rb
+++ b/migrations/lib/database/prepared_statement_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "lru_redux"
+
 module Migrations::Database
   class PreparedStatementCache < LruRedux::Cache
     class PreparedStatementHash < Hash

--- a/migrations/lib/migrations.rb
+++ b/migrations/lib/migrations.rb
@@ -19,7 +19,7 @@ module Migrations
 
   def self.load_rails_environment(quiet: false)
     message = "Loading Rails environment ..."
-    print message unless quiet
+    print message if !quiet
 
     rails_root = File.expand_path("../..", __dir__)
     # rubocop:disable Discourse/NoChdir
@@ -33,9 +33,11 @@ module Migrations
     end
     # rubocop:enable Discourse/NoChdir
 
-    print "\r"
-    print " " * message.length
-    print "\r"
+    if !quiet
+      print "\r"
+      print " " * message.length
+      print "\r"
+    end
   end
 
   def self.configure_zeitwerk
@@ -49,7 +51,7 @@ module Migrations
     loader.push_dir(File.join(::Migrations.root_path, "lib"), namespace: ::Migrations)
     loader.push_dir(File.join(::Migrations.root_path, "lib", "common"), namespace: ::Migrations)
 
-    # All sub-directories of a converter should have the same namespace.
+    # All subdirectories of a converter should have the same namespace.
     # Unfortunately `loader.collapse` doesn't work recursively.
     Converters.all.each do |name, converter_path|
       module_name = name.camelize.to_sym

--- a/migrations/spec/lib/converters/base/step_spec.rb
+++ b/migrations/spec/lib/converters/base/step_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe ::Migrations::Converters::Base::Step do
+  let(:tracker) { instance_double(::Migrations::Converters::Base::StepTracker) }
+
   before do
     Object.const_set(
       "TemporaryModule",
@@ -32,13 +34,13 @@ RSpec.describe ::Migrations::Converters::Base::Step do
   describe "#initialize" do
     it "works when no arguments are supplied" do
       step = nil
-      expect { step = TemporaryModule::Users.new }.not_to raise_error
+      expect { step = TemporaryModule::Users.new(tracker) }.not_to raise_error
       expect(step.settings).to be_nil
     end
 
     it "initializes the `settings` attribute if given" do
       settings = { a: 1, b: 2 }
-      step = TemporaryModule::Users.new(settings:)
+      step = TemporaryModule::Users.new(tracker, settings:)
       expect(step.settings).to eq(settings)
     end
 
@@ -49,7 +51,7 @@ RSpec.describe ::Migrations::Converters::Base::Step do
       foo = "a string"
       bar = false
 
-      step = TemporaryModule::Users.new(settings:, foo:, bar:, non_existent: 123)
+      step = TemporaryModule::Users.new(tracker, settings:, foo:, bar:, non_existent: 123)
       expect(step.settings).to eq(settings)
       expect(step.foo).to eq(foo)
       expect(step.bar).to eq(bar)

--- a/migrations/spec/lib/converters/base/worker_spec.rb
+++ b/migrations/spec/lib/converters/base/worker_spec.rb
@@ -49,11 +49,7 @@ RSpec.describe ::Migrations::Converters::Base::Worker do
     end
 
     def create_progress_stats(progress: 1, warning_count: 0, error_count: 0)
-      stats = ::Migrations::Converters::Base::ProgressStats.new
-      stats.progress = progress
-      stats.warning_count = warning_count
-      stats.error_count = error_count
-      stats
+      ::Migrations::Converters::Base::StepStats.new(progress:, warning_count:, error_count:)
     end
 
     it "writes objects to the `output_queue`" do

--- a/migrations/spec/lib/database_spec.rb
+++ b/migrations/spec/lib/database_spec.rb
@@ -140,4 +140,22 @@ RSpec.describe ::Migrations::Database do
       expect(described_class.to_blob(nil)).to be_nil
     end
   end
+
+  describe ".to_json" do
+    it "returns a JSON string for objects" do
+      expect(described_class.to_json(123)).to eq("123")
+      expect(described_class.to_json("hello world")).to eq(%q|"hello world"|)
+      expect(
+        described_class.to_json(
+          text: "foo",
+          number: 123,
+          date: DateTime.new(2023, 10, 5, 17, 30, 0),
+        ),
+      ).to eq(%q|{"text":"foo","number":123,"date":"2023-10-05T17:30:00.000+00:00"}|)
+    end
+
+    it "returns nil for nil input" do
+      expect(described_class.to_json(nil)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
* Remove unused `report_progress_in_percent` option from step
* Remove `use_custom_progress_increment` option from step because we can figure it out by looking at the progress
* Introduce `StepTracker` to for logging warnings and errors and tracking step progress
* Make it easier to log warnings and errors in all methods of `Step` without the need to pass around a `stats` object