### PR TITLE
UX: Move flag CTA button from subheader to header

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/flags.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/flags.gjs
@@ -69,18 +69,6 @@ export default class AdminConfigAreasFlags extends Component {
   }
 
   <template>
-    <AdminPageSubheader @titleLabel="admin.config_areas.flags.flags_tab">
-      <:actions as |actions|>
-        <actions.Primary
-          @route="adminConfig.flags.new"
-          @title="admin.config_areas.flags.add"
-          @label="admin.config_areas.flags.add"
-          @icon="plus"
-          @disabled={{this.addFlagButtonDisabled}}
-          class="admin-flags__header-add-flag"
-        />
-      </:actions>
-    </AdminPageSubheader>
     <div class="container admin-flags">
       <table class="d-admin-table admin-flags__items">
         <thead>

--- a/app/assets/javascripts/admin/addon/templates/config-flags.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-flags.hbs
@@ -10,6 +10,15 @@
       @label={{i18n "admin.config_areas.flags.header"}}
     />
   </:breadcrumbs>
+  <:actions as |actions|>
+    <actions.Primary
+      @route="adminConfig.flags.new"
+      @title="admin.config_areas.flags.add"
+      @label="admin.config_areas.flags.add"
+      @disabled={{this.addFlagButtonDisabled}}
+      class="admin-flags__header-add-flag"
+    />
+  </:actions>
   <:tabs>
     <NavItem
       @route="adminConfig.flags.settings"


### PR DESCRIPTION
Make the CTA button placement consistent with the other admin pages, like in Permalinks and Emoji.

### Before
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/34ca34d1-c2d0-469b-bd04-bd98419ec7b0">


### After
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/972ac9f3-7495-487d-9bd5-9407088f1ffa">
