### PR TITLE
DEV: Include controller namespace in X-Discourse-Route

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -365,7 +365,7 @@ class ApplicationController < ActionController::Base
       Logster.add_to_env(request.env, "username", current_user.username)
       response.headers["X-Discourse-Username"] = current_user.username
     end
-    response.headers["X-Discourse-Route"] = "#{controller_name}/#{action_name}"
+    response.headers["X-Discourse-Route"] = "#{controller_path.gsub("/", "::")}/#{action_name}"
   end
 
   def set_mp_snapshot_fields

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -365,7 +365,7 @@ class ApplicationController < ActionController::Base
       Logster.add_to_env(request.env, "username", current_user.username)
       response.headers["X-Discourse-Username"] = current_user.username
     end
-    response.headers["X-Discourse-Route"] = "#{controller_path.gsub("/", "::")}/#{action_name}"
+    response.headers["X-Discourse-Route"] = "#{controller_path}/#{action_name}"
   end
 
   def set_mp_snapshot_fields

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1520,4 +1520,20 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe "#set_current_user_for_logs" do
+    fab!(:admin)
+
+    it "sets the X-Discourse-Route header to the controller name and action including namespace" do
+      sign_in(admin)
+
+      get "/admin/users/#{admin.id}.json"
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Route"]).to eq("admin::users/show")
+
+      get "/u/#{admin.username}.json"
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Route"]).to eq("users/show")
+    end
+  end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1529,7 +1529,7 @@ RSpec.describe ApplicationController do
 
       get "/admin/users/#{admin.id}.json"
       expect(response.status).to eq(200)
-      expect(response.headers["X-Discourse-Route"]).to eq("admin::users/show")
+      expect(response.headers["X-Discourse-Route"]).to eq("admin/users/show")
 
       get "/u/#{admin.username}.json"
       expect(response.status).to eq(200)


### PR DESCRIPTION
This prevents requests that are routed to controllers that share the same name under different namespaces from getting identical value for the `X-Discourse-Route` response header.