### PR TITLE
DEV: Update vscode config to use ruby-lsp for syntax_tree formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
         "Shopify.ruby-lsp",
         "esbenp.prettier-vscode",
         "dbaeumer.vscode-eslint",
-        "ruby-syntax-tree.vscode-syntax-tree",
         "lifeart.vscode-glimmer-syntax",
         "typed-ember.glint-vscode"
       ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "Shopify.ruby-lsp",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "ruby-syntax-tree.vscode-syntax-tree",
     "lifeart.vscode-glimmer-syntax",
     "typed-ember.glint-vscode"
   ]

--- a/.vscode/settings.json.sample
+++ b/.vscode/settings.json.sample
@@ -19,7 +19,7 @@
   },
   "[ruby]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "ruby-syntax-tree.vscode-syntax-tree"
+    "editor.defaultFormatter": "Shopify.ruby-lsp"
   },
   "[handlebars]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -33,4 +33,5 @@
 
   "task.autoDetect": "off",
   "eslint.debug": false,
+  "rubyLsp.formatter": "syntax_tree",
 }


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->