### PR TITLE
DEV: Add index to users.ip_address

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2295,6 +2295,7 @@ end
 # Indexes
 #
 #  idx_users_admin                    (id) WHERE admin
+#  idx_users_ip_address               (ip_address)
 #  idx_users_moderator                (id) WHERE moderator
 #  index_users_on_last_posted_at      (last_posted_at)
 #  index_users_on_last_seen_at        (last_seen_at)

--- a/db/migrate/20241115143259_add_index_to_users_ip_address.rb
+++ b/db/migrate/20241115143259_add_index_to_users_ip_address.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToUsersIpAddress < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :ip_address, algorithm: :concurrently, name: "idx_users_ip_address"
+  end
+end


### PR DESCRIPTION
We have at least one query that looks up users based on their recorded IP address:

https://github.com/discourse/discourse/blob/8325465dea94faf4ded27bcc24fcf983f75d5170/app/models/user.rb#L1910-L1915

Without an index on the `ip_address` column, this kind of queries takes up a lot of time to execute on sites with millions of users and can cause performance degradation. 

Internal topic: t/141792.