### PR TITLE
DEV: Gracefully handle `regex_replace` max column length violations

### DIFF
--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -223,7 +223,7 @@ class DbHelper
 
     skipped = DB.query_hash(<<~SQL, params).first
       SELECT #{query_parts[:skipped_sums].join(", ")}
-      FROM \"#{table}\"
+      FROM "#{table}"
     SQL
 
     skipped.select { |_, count| count.to_i > 0 }
@@ -248,7 +248,7 @@ class DbHelper
 
   def self.execute_transform(table, query_parts, params)
     DB.exec(<<~SQL, params)
-      UPDATE \"#{table}\"
+      UPDATE "#{table}"
         SET #{query_parts[:updates].join(", ")}
       WHERE #{query_parts[:conditions].join(" OR ")}
     SQL

--- a/spec/lib/db_helper_spec.rb
+++ b/spec/lib/db_helper_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe DbHelper do
-  describe ".remap" do
-    fab!(:bookmark1) { Fabricate(:bookmark, name: "short-bookmark") }
-    fab!(:bookmark2) { Fabricate(:bookmark, name: "another-bookmark") }
-    let(:bookmark_name_limit) { Bookmark.columns_hash["name"].limit }
-    let(:long_bookmark_name) { "a" * (bookmark_name_limit + 1) }
+  fab!(:bookmark1) { Fabricate(:bookmark, name: "short-bookmark") }
+  fab!(:bookmark2) { Fabricate(:bookmark, name: "another-bookmark") }
+  let(:bookmark_name_limit) { Bookmark.columns_hash["name"].limit }
+  let(:long_bookmark_name) { "a" * (bookmark_name_limit + 1) }
 
+  describe ".remap" do
     it "should remap columns properly" do
       post = Fabricate(:post, cooked: "this is a specialcode that I included")
       post_attributes = post.reload.attributes
@@ -96,6 +96,44 @@ RSpec.describe DbHelper do
       DbHelper.regexp_replace("\\[img\\]test\\[/img\\]", "[img]something[/img]")
 
       expect(post.reload.raw).to include("[img]something[/img]")
+    end
+
+    context "when skip_max_length_violations is false" do
+      it "raises an exception if regexp_replace exceeds column length constraint by default" do
+        expect { DbHelper.regexp_replace("bookmark", long_bookmark_name) }.to raise_error(
+          PG::StringDataRightTruncation,
+          /value too long.*table: bookmarks,.*name/,
+        )
+      end
+    end
+
+    context "when skip_max_length_violations is true" do
+      it "skips regexp_replace eligible rows if new value exceeds column length constraint" do
+        DbHelper.regexp_replace("bookmark", long_bookmark_name, skip_max_length_violations: true)
+
+        bookmark1.reload
+        bookmark2.reload
+
+        expect(bookmark1.name).to eq("short-bookmark")
+        expect(bookmark2.name).to eq("another-bookmark")
+      end
+
+      it "logs skipped regexp_replace due to max length constraints when verbose is true" do
+        expect {
+          DbHelper.regexp_replace(
+            "bookmark",
+            long_bookmark_name,
+            verbose: true,
+            skip_max_length_violations: true,
+          )
+        }.to output(/SKIPPED:/).to_stdout
+
+        bookmark1.reload
+        bookmark2.reload
+
+        expect(bookmark1.name).to eq("short-bookmark")
+        expect(bookmark2.name).to eq("another-bookmark")
+      end
     end
   end
 end


### PR DESCRIPTION
This is a follow-up to the `remap` [refactor](https://github.com/discourse/discourse/commit/9b0cfa99c5277daccef24ef6e3b79597de1470a1). Similar to `remap`, the entire `regex_replace` operation fails if the new content exceeds the column’s max length.

This change introduces an optional mode, controlled by the new `skip_max_length_violations` param to skip records eligible for `regex_replace`  where the new content violates the max column length constraint.

It also includes updates to the exception message raised when `regex_replace` fails to include more details

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->