### PR TITLE
UX: Increase admin section header contrast

### DIFF
--- a/app/assets/stylesheets/common/admin/sidebar.scss
+++ b/app/assets/stylesheets/common/admin/sidebar.scss
@@ -2,6 +2,7 @@
   background-color: var(--d-sidebar-admin-background);
   .sidebar-section-header-text {
     font-weight: bold;
+    color: var(--primary-very-high);
   }
 }
 


### PR DESCRIPTION
The section header text does not stand out enough with the background color. This PR improves the text color for better visibility.

### Before
<img width="201" alt="image" src="https://github.com/user-attachments/assets/1247f14a-a252-48d5-a486-0083b4659f97">


### After
<img width="201" alt="image" src="https://github.com/user-attachments/assets/3ed3992b-7663-49a1-b1db-33da44e01954">
