### PR TITLE
FIX: Don't include secret membership groups when serializing other users

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -90,7 +90,11 @@ class UserSerializer < UserCardSerializer
   end
 
   def groups
-    object.groups.order(:id).visible_groups(scope.user)
+    if scope.user == object
+      object.groups.order(:id).visible_groups(scope.user)
+    else
+      object.groups.order(:id).visible_groups(scope.user).members_visible_groups(scope.user)
+    end
   end
 
   def group_users


### PR DESCRIPTION
### What is this fix?

As part of [this fix](https://github.com/discourse/discourse/pull/27664) we changed which groups are serialized for a user, in order to fix a bug in the default group selector under user preferences.

However, we should only change this when serializing the current user. This change combines the old code-path and the new based on who is serializing.