### PR TITLE
FIX: removes aria-hidden on category-status

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -289,7 +289,7 @@ export default class CategoryRow extends Component {
     >
 
       {{#if this.category}}
-        <div class="category-status" aria-hidden="true">
+        <div class="category-status">
           {{#if this.hasParentCategory}}
             {{#unless this.hideParentCategory}}
               {{this.badgeForParentCategory}}


### PR DESCRIPTION
Descendants can gain focus (category badge) and that makes aria-hidden incorrect as a result.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->