### PR TITLE
A11Y: Allow dismissing the discard drafts modal via keyboard

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/discard-draft.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/discard-draft.gjs
@@ -21,7 +21,7 @@ export default class DiscardDraftModal extends Component {
     <DModal
       @closeModal={{@closeModal}}
       class="discard-draft-modal"
-      @dismissable={{false}}
+      @hideHeader={{true}}
     >
       <:body>
         <div class="instructions" role="heading" aria-level="1">

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1012,11 +1012,12 @@ acceptance("Composer", function (needs) {
 
     assert.dom(".discard-draft-modal").doesNotExist();
 
-    assert.strictEqual(
-      query(".d-editor-input").value,
-      "[quote]some quote[/quote]",
-      "composer textarea is not cleared"
-    );
+    assert
+      .dom(".d-editor-input")
+      .hasValue(
+        "[quote]some quote[/quote]",
+        "composer textarea is not cleared"
+      );
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -994,6 +994,30 @@ acceptance("Composer", function (needs) {
     await click(".save-or-cancel .cancel");
     assert.dom(".discard-draft-modal .save-draft").exists();
   });
+
+  test("Discard drafts modal can be dismissed via keyboard", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-buttons .create");
+
+    await fillIn(".d-editor-input", "[quote]some quote[/quote]");
+
+    await click(".save-or-cancel .cancel");
+    assert.dom(".discard-draft-modal .save-draft").exists();
+
+    await triggerKeyEvent(
+      ".discard-draft-modal .save-draft",
+      "keydown",
+      "Escape"
+    );
+
+    assert.dom(".discard-draft-modal").doesNotExist();
+
+    assert.strictEqual(
+      query(".d-editor-input").value,
+      "[quote]some quote[/quote]",
+      "composer textarea is not cleared"
+    );
+  });
 });
 
 acceptance("Composer - Customizations", function (needs) {


### PR DESCRIPTION
Reference: https://meta.discourse.org/t/bug-unable-to-close-modal-using-keyboard-esc-or-clicking-modal-overlay/335849