### PR TITLE
FIX: ensures category row is not focusable

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -106,7 +106,7 @@ export default class CategoryRow extends Component {
   get badgeForCategory() {
     return htmlSafe(
       categoryBadgeHTML(this.category, {
-        link: this.categoryLink,
+        link: false,
         allowUncategorized:
           this.allowUncategorizedTopics || this.allowUncategorized,
         hideParent: !!this.parentCategory,
@@ -122,7 +122,7 @@ export default class CategoryRow extends Component {
   get badgeForParentCategory() {
     return htmlSafe(
       categoryBadgeHTML(this.parentCategory, {
-        link: this.categoryLink,
+        link: false,
         allowUncategorized:
           this.allowUncategorizedTopics || this.allowUncategorized,
         recursive: true,
@@ -285,7 +285,7 @@ export default class CategoryRow extends Component {
       {{on "click" this.handleClick}}
       {{on "keydown" this.handleKeyDown}}
       aria-checked={{this.isSelected}}
-      tabindex="0"
+      tabindex="-1"
     >
 
       {{#if this.category}}

--- a/app/assets/javascripts/select-kit/addon/components/none-category-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/none-category-row.js
@@ -10,7 +10,7 @@ export default class NoneCategoryRow extends CategoryRowComponent {
   badgeForCategory(category) {
     return htmlSafe(
       categoryBadgeHTML(category, {
-        link: this.categoryLink,
+        link: false,
         allowUncategorized: true,
         hideParent: true,
       })


### PR DESCRIPTION
There were two problems here:

- category link shouldn't output a link or we will get focus on it
- category row itself should not be focusable

The purpose of this dropdown is to navigate from one dropdown to another and to use arrow keys and enter to navigate inside.
