### PR TITLE
DEV: Remove migrate_column_to_bigint spec helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -476,23 +476,19 @@ RSpec.configure do |config|
       Capybara::Selenium::Driver.new(app, **mobile_driver_options)
     end
 
-    migrate_column_to_bigint(PostAction, :post_action_type_id)
-    migrate_column_to_bigint(Reviewable, :target_id)
-    migrate_column_to_bigint(ReviewableHistory, :reviewable_id)
-    migrate_column_to_bigint(ReviewableScore, :reviewable_id)
-    migrate_column_to_bigint(ReviewableScore, :reviewable_score_type)
-    migrate_column_to_bigint(SidebarSectionLink, :linkable_id)
-    migrate_column_to_bigint(SidebarSectionLink, :sidebar_section_id)
-    migrate_column_to_bigint(User, :last_seen_reviewable_id)
-    migrate_column_to_bigint(User, :required_fields_version)
-
-    $columns_to_migrate_to_bigint.each do |model, column|
-      if model.is_a?(String)
-        DB.exec("ALTER TABLE #{model} ALTER #{column} TYPE bigint")
-      else
-        DB.exec("ALTER TABLE #{model.table_name} ALTER #{column} TYPE bigint")
-        model.reset_column_information
-      end
+    [
+      [PostAction, :post_action_type_id],
+      [Reviewable, :target_id],
+      [ReviewableHistory, :reviewable_id],
+      [ReviewableScore, :reviewable_id],
+      [ReviewableScore, :reviewable_score_type],
+      [SidebarSectionLink, :linkable_id],
+      [SidebarSectionLink, :sidebar_section_id],
+      [User, :last_seen_reviewable_id],
+      [User, :required_fields_version],
+    ].each do |model, column|
+      DB.exec("ALTER TABLE #{model.table_name} ALTER #{column} TYPE bigint")
+      model.reset_column_information
     end
 
     # Sets sequence's value to be greater than the max value that an INT column can hold. This is done to prevent
@@ -1048,10 +1044,6 @@ def apply_base_chrome_options(options)
   if ENV["CHROME_DISABLE_FORCE_DEVICE_SCALE_FACTOR"].blank?
     options.add_argument("--force-device-scale-factor=1")
   end
-end
-
-def migrate_column_to_bigint(model, column)
-  ($columns_to_migrate_to_bigint ||= []) << [model, column]
 end
 
 class SpecSecureRandom


### PR DESCRIPTION
This spec helper was introduced as a temporary solution to the problem of mismatched types between primary key and foreign key columns. All plugins have been migrated and the only remaining use of this helper is in core Discourse.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->