### PR TITLE
DEV: remove !important from btn-transparent background

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -420,7 +420,7 @@
 .btn-transparent {
   &,
   &.btn-default {
-    background: transparent !important;
+    background: transparent;
     border: 0;
     color: var(--primary);
     .d-icon {
@@ -428,6 +428,7 @@
     }
     &:focus,
     &:focus-visible {
+      background: transparent;
       color: var(--tertiary-hover);
       .d-icon {
         color: inherit;
@@ -435,6 +436,7 @@
     }
     .discourse-no-touch & {
       &:hover {
+        background: transparent;
         color: var(--tertiary-hover);
         .d-icon {
           color: inherit;


### PR DESCRIPTION
Ideally we shouldn't use `!important` here, it's more succinct but it makes theming more difficult 