### PR TITLE
Fix the import votes for posts table to the new 'post_voting_votes' table

### DIFF
--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -1960,7 +1960,7 @@ class BulkImport::Generic < BulkImport::Base
 
     votes = query(<<~SQL)
       SELECT *
-        FROM votes
+        FROM post_voting_votes
        WHERE votable_type = 'Post'
     SQL
 


### PR DESCRIPTION
Forgot to update the table during these changes - https://github.com/discourse/discourse/pull/29442
