### PR TITLE
UX: Add title & adjust dnd image

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
@@ -78,7 +78,7 @@ export default class Notifications extends Component {
     {{#if this.isInDoNotDisturb}}
       <div
         class="do-not-disturb-background"
-        title={{i18n "notifications.do_not_disturb"}}
+        title={{i18n "notifications.paused"}}
       >{{icon "discourse-dnd"}}</div>
     {{else}}
       {{#if this.currentUser.new_personal_messages_notifications_count}}

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
@@ -76,7 +76,10 @@ export default class Notifications extends Component {
     {{/if}}
 
     {{#if this.isInDoNotDisturb}}
-      <div class="do-not-disturb-background">{{icon "discourse-dnd"}}</div>
+      <div
+        class="do-not-disturb-background"
+        title={{i18n "notifications.do_not_disturb"}}
+      >{{icon "discourse-dnd"}}</div>
     {{else}}
       {{#if this.currentUser.new_personal_messages_notifications_count}}
         <a

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -400,10 +400,11 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.25em;
+  width: 1em;
   background-color: var(--secondary);
   border-radius: 50%;
-  height: 1.25em;
+  height: 1em;
+  box-shadow: 0px 0px 0px 2px var(--secondary);
 
   .d-icon.d-icon-discourse-dnd {
     color: var(--header_primary-medium) !important;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2810,6 +2810,7 @@ en:
         new_reviewable:
           one: "%{count} new reviewable"
           other: "%{count} new reviewables"
+      do_not_disturb: "Do Not Disturb"
       title: "notifications of @name mentions, replies to your posts and topics, messages, etc"
       none: "Unable to load notifications at this time."
       empty: "No notifications found."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2810,7 +2810,7 @@ en:
         new_reviewable:
           one: "%{count} new reviewable"
           other: "%{count} new reviewables"
-      do_not_disturb: "Do Not Disturb"
+      paused: "Notifications paused"
       title: "notifications of @name mentions, replies to your posts and topics, messages, etc"
       none: "Unable to load notifications at this time."
       empty: "No notifications found."


### PR DESCRIPTION
This PR:
 
- changes the way we show a border around the dnd icon, preventing alignment at different zoom amounts.
- adds a localized string on hover to show what the icon means