### PR TITLE
UX: Make cells middle aligned; apply overview class directly to td elements

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_table.scss
+++ b/app/assets/stylesheets/common/admin/admin_table.scss
@@ -26,7 +26,7 @@
   }
 
   td {
-    vertical-align: top;
+    vertical-align: middle;
     padding-top: var(--space-3);
     padding-bottom: var(--space-3);
 
@@ -37,6 +37,15 @@
 
     &:first-child {
       @include breakpoint("tablet") {
+        border-top: 0;
+      }
+    }
+
+    &.d-admin-row__overview {
+      width: 55%;
+
+      @include breakpoint("tablet") {
+        width: auto;
         border-top: 0;
       }
     }
@@ -62,13 +71,6 @@
 }
 
 .d-admin-row__overview {
-  width: 55%;
-
-  @include breakpoint("tablet") {
-    width: auto;
-    border-top: 0;
-  }
-
   &-name {
     font-weight: 700;
     max-width: 80%;


### PR DESCRIPTION
This PR: 
* Vertically align the content within each table cell to the center
* Updated the `.overview` class to be applied specifically to `td` elements, giving better control over cell-specific styling and preventing any unintended styling on entire rows