### PR TITLE
UX: make chat drawer element more minimalistic when minimised

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.hbs
@@ -12,7 +12,7 @@
     data-chat-thread-id={{this.chat.activeChannel.activeThread.id}}
     class={{concat-class
       "chat-drawer"
-      (if this.chatStateManager.isDrawerExpanded "is-expanded")
+      (if this.chatStateManager.isDrawerExpanded "is-expanded" "is-collapsed")
     }}
     {{chat/resizable-node ".chat-drawer-resizer" this.didResize}}
     style={{this.drawerStyle}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
@@ -1,16 +1,24 @@
 import { LinkTo } from "@ember/routing";
 import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-title";
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
 
-const ChatNavbarChannelTitle = <template>
-  {{#if @channel}}
-    <LinkTo
-      @route="chat.channel.info.settings"
-      @models={{@channel.routeModels}}
-      class="c-navbar__channel-title"
-    >
-      <ChannelTitle @channel={{@channel}} />
-    </LinkTo>
-  {{/if}}
-</template>;
+export default class ChatNavbarChannelTitle extends Component {
+  @service chatStateManager;
 
-export default ChatNavbarChannelTitle;
+  <template>
+    {{#if @channel}}
+      {{#if this.chatStateManager.isDrawerExpanded}}
+        <LinkTo
+          @route="chat.channel.info.settings"
+          @models={{@channel.routeModels}}
+          class="c-navbar__channel-title"
+        >
+          <ChannelTitle @channel={{@channel}} />
+        </LinkTo>
+      {{else}}
+        <ChannelTitle @channel={{@channel}} />
+      {{/if}}
+    {{/if}}
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
@@ -17,7 +17,9 @@ export default class ChatNavbarChannelTitle extends Component {
           <ChannelTitle @channel={{@channel}} />
         </LinkTo>
       {{else}}
-        <ChannelTitle @channel={{@channel}} />
+        <div class="c-navbar__channel-title">
+          <ChannelTitle @channel={{@channel}} />
+        </div>
       {{/if}}
     {{/if}}
   </template>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/navbar/channel-title.gjs
@@ -1,7 +1,7 @@
-import { LinkTo } from "@ember/routing";
-import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-title";
 import Component from "@glimmer/component";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
+import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-title";
 
 export default class ChatNavbarChannelTitle extends Component {
   @service chatStateManager;

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -55,6 +55,8 @@ html.rtl {
   min-width: 250px !important; // important to override inline styles
   max-width: calc(100% - var(--composer-right));
   min-height: 300px !important; // important to override inline styles
+  height: 0;
+  transition: height 2s ease-out;
 
   .chat-drawer-container {
     background: var(--secondary);
@@ -79,7 +81,7 @@ html.rtl {
   &.is-collapsed {
     min-height: 0 !important;
     height: auto !important;
-    max-width: 350px !important;
+    max-width: 25vw;
   }
 
   .chat-channel,

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -76,9 +76,10 @@ html.rtl {
     }
   }
 
-  &:not(.is-expanded) {
+  &.is-collapsed {
     min-height: 0 !important;
     height: auto !important;
+    max-width: 350px !important;
   }
 
   .chat-channel,

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -104,6 +104,10 @@
 .c-navbar__threads-list-button {
   gap: 0.25rem;
 
+  .is-collapsed & {
+    display: none;
+  }
+
   &.has-unreads {
     .d-icon-discourse-threads {
       color: var(--tertiary-med-or-tertiary);

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -33,6 +33,20 @@
   gap: 0.25rem;
   position: relative;
 
+  .is-collapsed & {
+    padding-left: 1rem;
+
+    &:hover {
+      .c-navbar__toggle-drawer-button {
+        color: var(--tertiary-hover);
+
+        .d-icon {
+          color: inherit;
+        }
+      }
+    }
+  }
+
   .single-select-header {
     padding: 0.3675rem 0.584rem;
   }
@@ -44,6 +58,10 @@
 
 .c-navbar__back-button {
   height: var(--chat-header-offset);
+
+  .is-collapsed & {
+    display: none;
+  }
 }
 
 .c-navbar__channel-title {

--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -32,16 +32,29 @@
   width: 100%;
   gap: 0.25rem;
   position: relative;
+  container-type: inline-size;
 
   .is-collapsed & {
-    padding-left: 1rem;
+    &__channel-title:not(:first-child) {
+      margin-left: 1rem;
+    }
 
-    &:hover {
-      .c-navbar__toggle-drawer-button {
-        color: var(--tertiary-hover);
+    &__toggle-drawer-button {
+      &:after {
+        @container (inline-size) {
+          content: "";
+          position: absolute;
+          height: 100%;
+          left: 0;
+          width: calc(100cqw - 2.3em + 1rem);
+        }
 
-        .d-icon {
-          color: inherit;
+        &:hover {
+          color: var(--tertiary-hover);
+
+          .d-icon {
+            color: inherit;
+          }
         }
       }
     }


### PR DESCRIPTION
This commit removes the unnecessary elements when the drawer is minimised, so the focus remains on either re-opening or closing the drawer.

* remove thread button
* remove back button
* apply max width when minimised
* avoid drawer re-opening on settings page
* apply hover to correctly indicate targeted action: hovering anywhere but the x-button will highlight the maximise toggle

https://github.com/user-attachments/assets/6b021513-a638-4777-97a2-6d2f5470027f




