### PR TITLE
DEV: Make breadcrumb separators unclickable icons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-breadcrumbs-item.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import icon from "discourse-common/helpers/d-icon";
 import getURL from "discourse-common/lib/get-url";
 
 export default class DBreadcrumbsItem extends Component {
@@ -26,6 +27,9 @@ export default class DBreadcrumbsItem extends Component {
         <a href={{getURL path}} class={{@linkClass}}>
           {{label}}
         </a>
+        <span class="separator">
+          {{~icon "angle-right"~}}
+        </span>
       </li>
     </template>;
   }

--- a/app/assets/stylesheets/common/components/d-breadcrumbs.scss
+++ b/app/assets/stylesheets/common/components/d-breadcrumbs.scss
@@ -11,11 +11,20 @@
     color: var(--primary-medium);
   }
 
-  li:not(:last-child) a::after {
-    display: inline;
-    padding: 0 var(--space-1);
-    margin-right: var(--space-1);
-    font-size: var(--font-down-1);
-    content: ">";
+  li {
+    .separator {
+      margin-right: var(--space-1);
+
+      .d-icon {
+        color: var(--primary-medium);
+        font-size: var(--font-down-1);
+      }
+    }
+  }
+
+  li:last-child {
+    .separator {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
### What is this change?

The current breadcrumb separators are ">" characters that are added as pseudo-elements. These become part of the clickable area for the links:

<img width="268" alt="Screenshot 2024-11-19 at 3 30 00 PM" src="https://github.com/user-attachments/assets/035a6342-c9ce-4428-9817-21770df6228e">

which causes mis-clicks.

This PR does two things:

- Replace the pseudo-element with a DIcon.
- Make sure the separator is not clickable.

**Before:**

<img width="214" alt="Screenshot 2024-11-19 at 4 08 54 PM" src="https://github.com/user-attachments/assets/0cb92475-24e2-453c-b5c0-6a519beb2921">

**After:**

<img width="210" alt="Screenshot 2024-11-19 at 4 10 10 PM" src="https://github.com/user-attachments/assets/b9d7b05f-6b5d-4b38-ae0e-c7346f1383d3">