### PR TITLE
FIX: Amend broken settings link in emoji admin breadcrumbs

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-settings.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-settings.gjs
@@ -34,7 +34,7 @@ export default class AdminConfigAreasEmojisSettings extends Component {
 
   <template>
     <DBreadcrumbsItem
-      @path="/admin/config/emojis/settings"
+      @path="/admin/customize/emojis/settings"
       @label={{i18n "settings"}}
     />
 


### PR DESCRIPTION
### What is this fix?

Because of an oversight in a previous PR, the breadcrumb link when visiting Admin > Emoji > Settings was broken. The correct path is `customize`, not `config`.