### PR TITLE
DEV: add `i18n` named export to "discourse-i18n"

### DIFF
--- a/app/assets/javascripts/discourse-i18n/src/index.js
+++ b/app/assets/javascripts/discourse-i18n/src/index.js
@@ -408,3 +408,5 @@ export class I18nMissingInterpolationArgument extends Error {
 
 // Export a default/global instance
 export default globalThis.I18n = new I18n();
+
+export const i18n = globalThis.I18n.t;


### PR DESCRIPTION
Soon, we intend to consolidate all js/gjs translation calls to this new function. See https://github.com/discourse/lint-configs/pull/67 and https://github.com/discourse/discourse/pull/29804

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->