### PR TITLE
FIX: Simplify max-height calculation for chat composer 

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -85,12 +85,7 @@
     outline: none;
     border: 0;
     resize: none;
-    max-height: calc(
-      (
-          var(--100dvh) - var(--main-outlet-offset, 0px) -
-            var(--chat-header-offset, 0px)
-        ) / 100 * 25
-    );
+    max-height: calc(var(--100dvh) / 100 * 25);
     background: none;
     padding: 0;
     margin: 5px 0;

--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -85,7 +85,7 @@
     outline: none;
     border: 0;
     resize: none;
-    max-height: calc(var(--100dvh) / 100 * 25);
+    max-height: calc(var(--100dvh) / 4);
     background: none;
     padding: 0;
     margin: 5px 0;


### PR DESCRIPTION
In some rare cases, this was causing the input to be invisible, for example when `--main-outlet-offset` was a high number. The change here means the input will have a slightly different max height, but since here we are limiting this to 25% of the viewport height, it should be fine.

It's also not necessary to include the `chat-header-offset`, it ends up being only a few pixels' difference (since, again, the value is divided by 4).

Before / after desktop

<img width="500" alt="image" src="https://github.com/user-attachments/assets/920e403f-6943-46ed-8373-85412874c130">

<img width="500" alt="image" src="https://github.com/user-attachments/assets/98d1dfc9-1dc6-4b4f-a8dd-654af8e33406">

Before / after mobile with keyboard visible

![image](https://github.com/user-attachments/assets/7fbe3ff1-6bc0-43e0-8b31-08d3595aaa37)
![image](https://github.com/user-attachments/assets/a8266919-3126-4398-bb5e-d41c08086656)
