### PR TITLE
PERF: optimize chat user membership cleanup when removing a single user

### DIFF
--- a/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
+++ b/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
@@ -2,8 +2,9 @@
 
 describe "Automatic user removal from channels" do
   fab!(:user_1) { Fabricate(:user, trust_level: 1) }
-  let(:user_1_guardian) { Guardian.new(user_1) }
   fab!(:user_2) { Fabricate(:user, trust_level: 3) }
+
+  fab!(:user_1_guardian) { Guardian.new(user_1) }
 
   fab!(:secret_group) { Fabricate(:group) }
   fab!(:private_category) { Fabricate(:private_category, group: secret_group) }
@@ -145,6 +146,7 @@ describe "Automatic user removal from channels" do
     context "when a user is removed from a private category group" do
       context "when the user is in another group that can interact with the channel" do
         fab!(:stealth_group) { Fabricate(:group) }
+
         before do
           CategoryGroup.create!(
             category: private_category,


### PR DESCRIPTION
This optimizes a hot path when users are being removed from one or more groups since we use the `on(:user_removed_from_group)` event to call the `Chat::AutoLeaveChannels` with a `user_id` parameter. In such case, we don't need to clear the membership of all users, just that one user.

DEBUG: Also added a "-- event = <event>" comment on top of the SQL queries used by the "AutoLeaveChannels" so they show up in the logs and hopefully facilitate any performance issues that might arise in the future.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->