### PR TITLE
DEV: Fix constant redefinition warnings when running specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -291,6 +291,7 @@ RSpec.configure do |config|
 
     DiscoursePluginRegistry.reset! if ENV["LOAD_PLUGINS"] != "1"
     Discourse.current_user_provider = TestCurrentUserProvider
+    Discourse::Application.load_tasks
 
     SiteSetting.refresh!
 

--- a/spec/services/site_settings_spec.rb
+++ b/spec/services/site_settings_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe SiteSettingsTask do
-  before { Discourse::Application.load_tasks }
-
   describe "export" do
     it "creates a hash of all site settings" do
       sso_url = "https://somewhere.over.com"

--- a/spec/services/themes_spec.rb
+++ b/spec/services/themes_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe ThemesInstallTask do
   fab!(:admin)
 
-  before { Discourse::Application.load_tasks }
-
   describe ".new" do
     THEME_NAME = "awesome theme"
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -251,6 +251,13 @@ module Helpers
     theme
   end
 
+  # Invokes a Rake task in a way that is safe for the test environment
+  def invoke_rake_task(task_name, *args)
+    Rake::Task[task_name].invoke(*args)
+  ensure
+    Rake::Task[task_name].reenable
+  end
+
   # Uploads a theme component from a directory.
   #
   # @param parent_theme_id [Integer] The ID of the theme to add the theme component to. Defaults to `SiteSetting.default_theme_id`.

--- a/spec/tasks/assets_precompile_spec.rb
+++ b/spec/tasks/assets_precompile_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "assets:precompile" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   describe "assets:precompile:theme_transpiler" do
     it "compiles the js processor" do
       path = Rake::Task["assets:precompile:theme_transpiler"].actions.first.call

--- a/spec/tasks/compatibility_spec.rb
+++ b/spec/tasks/compatibility_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "compatibility:validate" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   def invoke(content)
     file = Tempfile.new("discourse-compat-validate")
     file.write content
@@ -13,7 +8,7 @@ RSpec.describe "compatibility:validate" do
     error = nil
     stdout =
       capture_stdout do
-        Rake::Task["compatibility:validate"].invoke(file.path)
+        invoke_rake_task("compatibility:validate", file.path)
       rescue => e
         error = e
       end

--- a/spec/tasks/hashtags_spec.rb
+++ b/spec/tasks/hashtags_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "tasks/hashtags" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   describe "hashtag:mark_old_format_for_rebake" do
     fab!(:category) { Fabricate(:category, slug: "support") }
 
@@ -25,7 +20,7 @@ RSpec.describe "tasks/hashtags" do
         cooked: post_1.cooked.gsub(hashtag_html, "<span class=\"hashtag\"'>#support</span>"),
       )
 
-      capture_stdout { Rake::Task["hashtags:mark_old_format_for_rebake"].invoke }
+      capture_stdout { invoke_rake_task("hashtags:mark_old_format_for_rebake") }
 
       [post_1, post_2, post_3].each(&:reload)
 

--- a/spec/tasks/incoming_emails_spec.rb
+++ b/spec/tasks/incoming_emails_spec.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "incoming emails tasks" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   describe "email with attachment" do
     fab!(:incoming_email) { Fabricate(:incoming_email, raw: email(:attached_txt_file)) }
 
     it "updates record" do
-      expect { Rake::Task["incoming_emails:truncate_long"].invoke }.to change {
+      expect { invoke_rake_task("incoming_emails:truncate_long") }.to change {
         incoming_email.reload.raw
       }
     end
@@ -18,8 +13,9 @@ RSpec.describe "incoming emails tasks" do
 
   describe "short email without attachment" do
     fab!(:incoming_email) { Fabricate(:incoming_email, raw: email(:html_reply)) }
+
     it "does not update record" do
-      expect { Rake::Task["incoming_emails:truncate_long"].invoke }.not_to change {
+      expect { invoke_rake_task("incoming_emails:truncate_long") }.not_to change {
         incoming_email.reload.raw
       }
     end

--- a/spec/tasks/redis_spec.rb
+++ b/spec/tasks/redis_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe "Redis rake tasks", type: :multisite do
   let(:redis) { Discourse.redis.without_namespace }
 
-  before { Discourse::Application.load_tasks }
-
   describe "clean up" do
     it "should clean up orphan Redis keys" do
       active_keys = %w[
@@ -18,7 +16,7 @@ RSpec.describe "Redis rake tasks", type: :multisite do
 
       (active_keys | orphan_keys).each { |key| redis.set(key, 1) }
 
-      Rake::Task["redis:clean_up"].invoke
+      invoke_rake_task("redis:clean_up")
 
       active_keys.each { |key| expect(redis.get(key)).to eq("1") }
 

--- a/spec/tasks/themes_spec.rb
+++ b/spec/tasks/themes_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "tasks/themes" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   describe "themes:update" do
     let(:initial_repo) do
       about_json = <<~JSON
@@ -77,7 +72,7 @@ RSpec.describe "tasks/themes" do
       original_remote_version = theme.remote_theme.remote_version
       original_local_version = theme.remote_theme.local_version
 
-      stderr = capture_stderr { capture_stdout { Rake::Task["themes:update"].invoke } }
+      stderr = capture_stderr { capture_stdout { invoke_rake_task("themes:update") } }
 
       expect(stderr.chomp).to eq(
         "[default] Failed to update 'awesome theme' (#{theme.id}): The property at JSON Pointer '/0/title' must be present.",
@@ -111,7 +106,7 @@ RSpec.describe "tasks/themes" do
       original_remote_version = theme.remote_theme.remote_version
       original_local_version = theme.remote_theme.local_version
 
-      capture_stderr { capture_stdout { Rake::Task["themes:update"].invoke } }
+      capture_stderr { capture_stdout { invoke_rake_task("themes:update") } }
 
       theme.reload
 

--- a/spec/tasks/topics_spec.rb
+++ b/spec/tasks/topics_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe "Post rake tasks" do
   let(:topic) { post.topic }
   let(:category) { topic.category }
 
-  before do
-    Rake::Task.clear if defined?(Rake::Task)
-    Discourse::Application.load_tasks
-    STDOUT.stubs(:write)
-  end
+  before { STDOUT.stubs(:write) }
 
   describe "topics:apply_autoclose" do
     it "should close topics silently" do
@@ -20,7 +16,7 @@ RSpec.describe "Post rake tasks" do
 
       freeze_time 2.hours.from_now
 
-      Rake::Task["topics:apply_autoclose"].invoke
+      invoke_rake_task("topics:apply_autoclose")
 
       topic.reload
 

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe "tasks/uploads" do
   before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
     SiteSetting.authorized_extensions += "|pdf"
     STDIN.stubs(:gets).returns("y\n")
   end
@@ -28,7 +26,7 @@ RSpec.describe "tasks/uploads" do
     end
 
     def invoke_task
-      capture_stdout { Rake::Task["uploads:secure_upload_analyse_and_update"].invoke }
+      capture_stdout { invoke_rake_task("uploads:secure_upload_analyse_and_update") }
     end
 
     context "when the store is internal" do
@@ -188,7 +186,7 @@ RSpec.describe "tasks/uploads" do
 
   describe "uploads:disable_secure_uploads" do
     def invoke_task
-      capture_stdout { Rake::Task["uploads:disable_secure_uploads"].invoke }
+      capture_stdout { invoke_rake_task("uploads:disable_secure_uploads") }
     end
 
     before do
@@ -253,7 +251,7 @@ RSpec.describe "tasks/uploads" do
 
   describe "uploads:downsize" do
     def invoke_task
-      capture_stdout { Rake::Task["uploads:downsize"].invoke }
+      capture_stdout { invoke_rake_task("uploads:downsize") }
     end
 
     before { STDIN.stubs(:beep) }

--- a/spec/tasks/users_spec.rb
+++ b/spec/tasks/users_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "tasks/users" do
-  before do
-    Rake::Task.clear
-    Discourse::Application.load_tasks
-  end
-
   describe "users:disable_2fa" do
     let(:user) { Fabricate(:user) }
 
@@ -27,7 +22,7 @@ RSpec.describe "tasks/users" do
       expect(user.user_second_factors.totps.count).to eq(2)
       expect(user.second_factor_security_keys.count).to eq(1)
 
-      stdout = capture_stdout { Rake::Task["users:disable_2fa"].invoke(user.username) }
+      stdout = capture_stdout { invoke_rake_task("users:disable_2fa", user.username) }
       user.reload
 
       expect(stdout.chomp).to eq("2FA disabled for #{user.username}")

--- a/spec/tasks/version_bump_spec.rb
+++ b/spec/tasks/version_bump_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "tasks/version_bump" do
   end
 
   it "can bump the beta version with version_bump:beta" do
-    Dir.chdir(local_path) { capture_stdout { Rake::Task["version_bump:beta"].invoke } }
+    Dir.chdir(local_path) { capture_stdout { invoke_rake_task("version_bump:beta") } }
 
     Dir.chdir(origin_path) do
       # Commits are present with correct messages
@@ -83,7 +83,7 @@ RSpec.describe "tasks/version_bump" do
   end
 
   it "can perform a minor stable bump with version_bump:minor_stable" do
-    Dir.chdir(local_path) { capture_stdout { Rake::Task["version_bump:minor_stable"].invoke } }
+    Dir.chdir(local_path) { capture_stdout { invoke_rake_task("version_bump:minor_stable") } }
 
     Dir.chdir(origin_path) do
       # No commits on main branch
@@ -110,7 +110,7 @@ RSpec.describe "tasks/version_bump" do
 
   it "can prepare a major stable bump with version_bump:major_stable_prepare" do
     Dir.chdir(local_path) do
-      capture_stdout { Rake::Task["version_bump:major_stable_prepare"].invoke("3.3.0") }
+      capture_stdout { invoke_rake_task("version_bump:major_stable_prepare", "3.3.0") }
     end
 
     Dir.chdir(origin_path) do
@@ -148,9 +148,9 @@ RSpec.describe "tasks/version_bump" do
   it "can merge a stable release commit into the stable branch with version_bump:major_stable_merge" do
     Dir.chdir(local_path) do
       # Prepare first, and find sha1 in output
-      output = capture_stdout { Rake::Task["version_bump:major_stable_prepare"].invoke("3.3.0") }
+      output = capture_stdout { invoke_rake_task("version_bump:major_stable_prepare", "3.3.0") }
       stable_bump_commit = output[/major_stable_merge\[(.*)\]/, 1]
-      capture_stdout { Rake::Task["version_bump:major_stable_merge"].invoke(stable_bump_commit) }
+      capture_stdout { invoke_rake_task("version_bump:major_stable_merge", stable_bump_commit) }
     end
 
     Dir.chdir(origin_path) do
@@ -204,7 +204,7 @@ RSpec.describe "tasks/version_bump" do
       output =
         capture_stdout do
           ENV["SECURITY_FIX_REFS"] = "origin/security-fix-one,origin/security-fix-two"
-          Rake::Task["version_bump:stage_security_fixes"].invoke("main")
+          invoke_rake_task("version_bump:stage_security_fixes", "main")
         ensure
           ENV.delete("SECURITY_FIX_REFS")
         end


### PR DESCRIPTION
Don't load rake files over and over again when running specs.
