### PR TITLE
DEV: supports blocks in chat message sdk

### DIFF
--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -116,6 +116,7 @@ module ChatSDK
       enforce_membership: false,
       force_thread: false,
       strip_whitespaces: true,
+      blocks: nil,
       **params,
       &block
     )
@@ -127,6 +128,7 @@ module ChatSDK
             in_reply_to_id:,
             thread_id:,
             upload_ids:,
+            blocks:,
             **params,
           },
           options: {
@@ -145,6 +147,7 @@ module ChatSDK
           on_failed_policy(:ensure_valid_thread_for_channel) do
             raise "Couldn't find thread with id: `#{thread_id}`"
           end
+          on_failed_policy(:accept_blocks) { raise "Only bots can create messages with blocks" }
           on_failed_policy(:allowed_to_join_channel) do
             raise "User with id: `#{guardian.user.id}` can't join this channel"
           end

--- a/plugins/chat/spec/lib/chat_sdk/message_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/message_spec.rb
@@ -56,9 +56,13 @@ describe ChatSDK::Message do
       end
 
       context "when user is not a bot" do
-        it "fails" do
-          params[:guardian] = Fabricate(:user).guardian
+        fab!(:user)
 
+        let(:guardian) { user.guardian }
+
+        before { channel_1.add(user) }
+
+        it "fails" do
           expect { described_class.create(**params) }.to raise_error(
             "Only bots can create messages with blocks",
           )

--- a/plugins/chat/spec/lib/chat_sdk/message_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/message_spec.rb
@@ -6,13 +6,64 @@ describe ChatSDK::Message do
 
     let(:guardian) { Discourse.system_user.guardian }
     let(:params) do
-      { enforce_membership: false, raw: "something", channel_id: channel_1.id, guardian: guardian }
+      {
+        blocks: nil,
+        enforce_membership: false,
+        raw: "something",
+        channel_id: channel_1.id,
+        guardian: guardian,
+      }
     end
 
     it "creates the message" do
       message = described_class.create(**params)
 
       expect(message.message).to eq("something")
+    end
+
+    context "when providing blocks" do
+      before do
+        params[:blocks] = [
+          {
+            type: "actions",
+            elements: [{ type: "button", value: "foo", text: { type: "plain_text", text: "Foo" } }],
+          },
+        ]
+      end
+
+      context "when user is a bot" do
+        it "saves the blocks" do
+          message = described_class.create(**params)
+
+          expect(message.blocks[0]).to include(
+            "type" => "actions",
+            "schema_version" => 1,
+            "block_id" => an_instance_of(String),
+            "elements" => [
+              {
+                "schema_version" => 1,
+                "type" => "button",
+                "value" => "foo",
+                "action_id" => an_instance_of(String),
+                "text" => {
+                  "type" => "plain_text",
+                  "text" => "Foo",
+                },
+              },
+            ],
+          )
+        end
+      end
+
+      context "when user is not a bot" do
+        it "fails" do
+          params[:guardian] = Fabricate(:user).guardian
+
+          expect { described_class.create(**params) }.to raise_error(
+            "Only bots can create messages with blocks",
+          )
+        end
+      end
     end
 
     it "sets created_by_sdk to true" do


### PR DESCRIPTION
Blocks have been added in https://github.com/discourse/discourse/commit/582de0ffe3a892db6db74b3d73ef105966534f13 but were not yet supported in the SDK.

Usage:

```ruby
ChatSDK::Message.create(
  raw: "hello world",
  blocks: [
    {
      type: "actions",
      elements: [
        { value: "foo", type: "button", text: { text: "How can I install themes?", type: "plain_text" } }
      ]
    }
  ],
  guardian: guardian,
  channel_id: channel.id,
)
```