### PR TITLE
FIX: serializes interaction for direct messages

### DIFF
--- a/plugins/chat/app/serializers/chat/message_interaction_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_interaction_serializer.rb
@@ -9,7 +9,7 @@ module Chat
     end
 
     def channel
-      { id: object.message.chat_channel.id, title: object.message.chat_channel.title }
+      { id: object.message.chat_channel.id, title: object.message.chat_channel.title(scope.user) }
     end
 
     def message

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -173,6 +173,11 @@ Fabricator(:chat_reviewable_message, class_name: "Chat::ReviewableMessage") do
   reviewable_scores { |p| [Fabricate.build(:reviewable_score, reviewable_id: p[:id])] }
 end
 
+Fabricator(:chat_message_interaction, class_name: "Chat::MessageInteraction") do
+  message { Fabricate(:chat_message) }
+  user { Fabricate(:user) }
+end
+
 Fabricator(:direct_message, class_name: "Chat::DirectMessage") do
   users { [Fabricate(:user), Fabricate(:user)] }
 end

--- a/plugins/chat/spec/serializer/chat/message_interaction_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/message_interaction_serializer_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 RSpec.describe Chat::MessageInteractionSerializer do
   subject(:serializer) do
-    interaction = Chat::CreateMessageInteraction.call(params:, guardian: user.guardian).interaction
+    interaction =
+      Fabricate(
+        :chat_message_interaction,
+        message:,
+        user:,
+        action: message.blocks.first["elements"].first,
+      )
     described_class.new(interaction, scope: Guardian.new(user), root: false)
   end
 

--- a/plugins/chat/spec/serializer/chat/message_interaction_spec.rb
+++ b/plugins/chat/spec/serializer/chat/message_interaction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Chat::MessageInteractionSerializer do
     )
   end
   let(:message_id) { message.id }
-  let(:params) { { message_id: message_id, action_id: "like" } }
+  let(:params) { { message_id:, action_id: "like" } }
 
   before do
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]

--- a/plugins/chat/spec/serializer/chat/message_interaction_spec.rb
+++ b/plugins/chat/spec/serializer/chat/message_interaction_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+RSpec.describe Chat::MessageInteractionSerializer do
+  subject(:serializer) do
+    interaction = Chat::CreateMessageInteraction.call(params:, guardian: user.guardian).interaction
+    described_class.new(interaction, scope: Guardian.new(user), root: false)
+  end
+
+  fab!(:user)
+
+  let(:message) do
+    Fabricate(
+      :chat_message,
+      chat_channel: channel,
+      user: Discourse.system_user,
+      blocks: [
+        {
+          type: "actions",
+          elements: [
+            { type: "button", text: { type: "plain_text", text: "Like" }, action_id: "like" },
+          ],
+        },
+      ],
+    )
+  end
+  let(:message_id) { message.id }
+  let(:params) { { message_id: message_id, action_id: "like" } }
+
+  before do
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
+  end
+
+  context "when interaction's channel is private" do
+    let(:channel) { Fabricate(:direct_message_channel, users: [user, Fabricate(:user)]) }
+
+    it "serializes the interaction" do
+      expect(serializer.as_json).to match_response_schema("message_interaction")
+    end
+  end
+
+  context "when interaction's channel is public" do
+    let(:channel) { Fabricate(:chat_channel) }
+
+    it "serializes the interaction" do
+      expect(serializer.as_json).to match_response_schema("message_interaction")
+    end
+  end
+end

--- a/plugins/chat/spec/support/api/schemas/message_interaction.json
+++ b/plugins/chat/spec/support/api/schemas/message_interaction.json
@@ -1,0 +1,101 @@
+{
+  "type": "object",
+  "required": [
+    "action",
+    "channel",
+    "message",
+    "user"
+  ],
+  "properties": {
+    "action": {
+      "type": "object",
+      "required": [
+        "action_id",
+        "schema_version",
+        "text",
+        "type"
+      ],
+      "properties": {
+        "action_id": {
+          "type": "string"
+        },
+        "schema_version": {
+          "type": "integer"
+        },
+        "text": {
+          "type": "object",
+          "required": [
+            "text",
+            "type"
+          ],
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "plain_text"
+              ]
+            }
+          }
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "button"
+          ]
+        }
+      }
+    },
+    "channel": {
+      "type": "object",
+      "required": [
+        "id",
+        "title"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "required": [
+        "id",
+        "text",
+        "user_id"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "text": {
+          "type": "string"
+        },
+        "user_id": {
+          "type": "integer"
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "required": [
+        "id",
+        "username"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prior to this fix it would cause an error as we need to pass the user to get the title of the channel.

This commit also adds a test for message interaction serializer.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->