### PR TITLE
DEV: Fix benchmark script

### DIFF
--- a/lib/tasks/profile.rake
+++ b/lib/tasks/profile.rake
@@ -13,15 +13,15 @@ task "user_api_key:create", [:username] => :environment do |task, args|
 
   application_name = "perf test application"
 
-  user_api_key = UserApiKey.where(application_name: application_name).destroy_all
+  UserApiKeyClient.where(application_name: application_name).destroy_all
 
-  user_api_key =
-    UserApiKey.create!(
-      application_name: application_name,
-      client_id: "1234",
-      scopes: ["read"].map { |name| UserApiKeyScope.new(name: name) },
-      user_id: user.id,
-    )
-
-  puts user_api_key.key
+  UserApiKeyClient
+    .create!(client_id: "1234", application_name:)
+    .then do |client|
+      client.keys.create!(
+        scopes: ["read"].map { |name| UserApiKeyScope.new(name:) },
+        user_id: user.id,
+      )
+    end
+    .then { |user_api_key| puts user_api_key.key }
 end

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -168,7 +168,7 @@ puts `bundle exec rake db:create`
 `bundle exec rake db:migrate`
 
 puts "Timing loading Rails"
-measure("load_rails") { `bundle exec rake middleware` }
+measure("load_rails") { `bundle exec rails middleware` }
 
 puts "Populating Profile DB"
 run("bundle exec ruby script/profile_db_generator.rb")
@@ -320,6 +320,7 @@ begin
     results.merge(
       "timings" => @timings,
       "ruby-version" => "#{RUBY_DESCRIPTION}",
+      "yjit" => RubyVM::YJIT.enabled?,
       "rss_kb" => mem["rss_kb"],
       "pss_kb" => mem["pss_kb"],
     ).merge(facts)


### PR DESCRIPTION
Following a recent commit (cb4b8146a30cd94b04db1b662fbebdb8021a7771), the benchmark script wasn’t working anymore (and the related rake task).

This PR fixes it. It also adds some information about Ruby YJIT being enabled or not.