### PR TITLE
FIX: topic post counts for webhook post_destroyed event

### DIFF
--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -32,12 +32,16 @@ class WebHookPostSerializer < PostSerializer
     mentioned_users
   ].each { |attr| define_method("include_#{attr}?") { false } }
 
+  def topic_posts
+    @topic_posts ||= object.topic.posts.where(user_deleted: false)
+  end
+
   def topic_posts_count
-    object.topic ? object.topic.posts_count : 0
+    object.topic ? topic_posts.count : 0
   end
 
   def topic_filtered_posts_count
-    object.topic ? object.topic.posts.where(post_type: Post.types[:regular]).count : 0
+    object.topic ? topic_posts.where(post_type: Post.types[:regular]).count : 0
   end
 
   def topic_archetype

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -84,8 +84,7 @@ class PostDestroyer
       UserProfile.remove_featured_topic_from_all_profiles(@topic)
       UserActionManager.topic_destroyed(@topic)
       DiscourseEvent.trigger(:topic_destroyed, @topic, @user)
-      has_topic_web_hooks = is_first_post && WebHook.active_web_hooks(:topic_destroyed).exists?
-      if has_topic_web_hooks
+      if WebHook.active_web_hooks(:topic_destroyed).exists?
         topic_view = TopicView.new(@topic.id, Discourse.system_user, skip_staff_action: true)
         topic_payload = WebHook.generate_payload(:topic, topic_view, WebHookTopicViewSerializer)
         WebHook.enqueue_topic_hooks(:topic_destroyed, @topic, topic_payload)

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -60,17 +60,6 @@ class PostDestroyer
   end
 
   def destroy
-    payload = WebHook.generate_payload(:post, @post) if WebHook.active_web_hooks(
-      :post_destroyed,
-    ).exists?
-    is_first_post = @post.is_first_post? && @topic
-    has_topic_web_hooks = is_first_post && WebHook.active_web_hooks(:topic_destroyed).exists?
-
-    if has_topic_web_hooks
-      topic_view = TopicView.new(@topic.id, Discourse.system_user, skip_staff_action: true)
-      topic_payload = WebHook.generate_payload(:topic, topic_view, WebHookTopicViewSerializer)
-    end
-
     delete_removed_posts_after =
       @opts[:delete_removed_posts_after] || SiteSetting.delete_removed_posts_after
 
@@ -84,14 +73,23 @@ class PostDestroyer
     UserActionManager.post_destroyed(@post)
 
     DiscourseEvent.trigger(:post_destroyed, @post, @opts, @user)
-    WebHook.enqueue_post_hooks(:post_destroyed, @post, payload)
+    if WebHook.active_web_hooks(:post_destroyed).exists?
+      payload = WebHook.generate_payload(:post, @post)
+      WebHook.enqueue_post_hooks(:post_destroyed, @post, payload)
+    end
     Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: @topic.id) if @topic
 
+    is_first_post = @post.is_first_post? && @topic
     if is_first_post
       UserProfile.remove_featured_topic_from_all_profiles(@topic)
       UserActionManager.topic_destroyed(@topic)
       DiscourseEvent.trigger(:topic_destroyed, @topic, @user)
-      WebHook.enqueue_topic_hooks(:topic_destroyed, @topic, topic_payload) if has_topic_web_hooks
+      has_topic_web_hooks = is_first_post && WebHook.active_web_hooks(:topic_destroyed).exists?
+      if has_topic_web_hooks
+        topic_view = TopicView.new(@topic.id, Discourse.system_user, skip_staff_action: true)
+        topic_payload = WebHook.generate_payload(:topic, topic_view, WebHookTopicViewSerializer)
+        WebHook.enqueue_topic_hooks(:topic_destroyed, @topic, topic_payload)
+      end
       if SiteSetting.tos_topic_id == @topic.id || SiteSetting.privacy_topic_id == @topic.id
         Discourse.clear_urls!
       end


### PR DESCRIPTION
- Generate webhook data after posts are destroyed
- Don't count user_deleted posts

See further:
- https://meta.discourse.org/t/discrepancies-in-webhook-topic-posts-count/292741
- https://meta.discourse.org/t/should-comments-webhook-update-count-after-deleting-posts-comments/336621/