### PR TITLE
Update client.en.yml to improve link text on invite popup

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1985,7 +1985,7 @@ en:
                 one {# day}
               other {# days}
             }.
-          edit_link_options: "Edit link options."
+          edit_link_options: "Edit link options or send by email."
           show_advanced: "Show Advanced Options"
           hide_advanced: "Hide Advanced Options"
 


### PR DESCRIPTION
Updated "Edit link options" link on the invite popup so it now reads "Edit link options or send by email". This will help folks find the legacy send invite by email UI. We are still wanting to move away from that and encourage site members to grab an invite link and send it themselves using email, chat app, social media etc.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->