### PR TITLE
Update client.en.yml to change "locale" to "language" in a setting de…

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7009,7 +7009,7 @@ en:
         show_overriden: "Only show overridden"
         show_outdated: "Only show outdated/invalid"
         show_untranslated: "Only show untranslated"
-        only_show_selected_locale: "Only show results in selected locale"
+        only_show_selected_locale: "Only show results in selected language"
         locale: "Language:"
         more_than_50_results: "There are more than 50 results. Please refine your search."
         no_results: "No matching site texts found"


### PR DESCRIPTION
…scription

the only_show_selected_locale setting refers to "selected locale" when the rest of the UI on the page refers to "language", so I changed it to "Only show results in selected language".

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->