### PR TITLE
DEV: Re-apply chat index migration

### DIFF
--- a/db/migrate/20241120182858_add_index_to_chat_messages_on_chat_channel_id.rb
+++ b/db/migrate/20241120182858_add_index_to_chat_messages_on_chat_channel_id.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexToChatMessages < ActiveRecord::Migration[7.0]
+class AddIndexToChatMessagesOnChatChannelId < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def up


### PR DESCRIPTION
Commit c2a733a95a422837d517a991de04f8462119cc5e was applied to an
existing migration that possibly had already run. Due to this some
discourse instances might not have the correct index.

This change removes the original migration and creates a new one so that
it will actually be applied.

This is the missing index that some sites might not have:
```
Missing Index | CREATE INDEX
index_chat_messages_on_chat_channel_id_and_id ON public.chat_messages
USING btree (chat_channel_id, id) WHERE (deleted_at IS NOT NULL)
```
