### PR TITLE
Corrected UI text for notifications in client.en.yml

### DIFF
--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -693,8 +693,8 @@ en:
       titles:
         chat_mention: "Chat mention"
         chat_invitation: "Chat invitation"
-        chat_quoted: "Chat quoted"
-        chat_watched_thread: "Chat watched thread"
+        chat_quoted: "Quoted in chat"
+        chat_watched_thread: "Watched chat thread"
     action_codes:
       chat:
         enabled: '%{who} enabled <button class="btn-link open-chat">chat</button> %{when}'


### PR DESCRIPTION
Two notifications did not read well and I corrected them

Chat quoted -> Quoted in chat 
Chat watched thread -> Watched chat thread

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->