### PR TITLE
FEATURE: add transformer to pass topic ID to simple invite generation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -251,24 +251,17 @@ export default class CreateInvite extends Component {
   async createLink() {
     this.sendEmail = false;
 
-    const data = {
+    const topicId = applyValueTransformer("invite-simple-mode-topic", null, {
+      invite: this.invite,
+    });
+
+    await this.save({
       max_redemptions_allowed: this.defaultRedemptionsAllowed,
       expires_at: moment()
         .add(this.siteSettings.invite_expiry_days, "days")
         .format(DATE_INPUT_FORMAT),
-    };
-
-    const optionalTopicId = applyValueTransformer(
-      "invite-simple-mode-topic",
-      null,
-      { invite: this.invite }
-    );
-
-    if (optionalTopicId) {
-      data.topic_id = optionalTopicId;
-    }
-
-    await this.save(data);
+      ...(topicId != null && { topic_id: topicId }),
+    });
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -14,6 +14,7 @@ import FutureDateInput from "discourse/components/future-date-input";
 import { extractError } from "discourse/lib/ajax-error";
 import { canNativeShare, nativeShare } from "discourse/lib/pwa-utils";
 import { sanitize } from "discourse/lib/text";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { emailValid, hostnameValid } from "discourse/lib/utilities";
 import Group from "discourse/models/group";
 import Invite from "discourse/models/invite";
@@ -249,12 +250,25 @@ export default class CreateInvite extends Component {
   @action
   async createLink() {
     this.sendEmail = false;
-    await this.save({
+
+    const data = {
       max_redemptions_allowed: this.defaultRedemptionsAllowed,
       expires_at: moment()
         .add(this.siteSettings.invite_expiry_days, "days")
         .format(DATE_INPUT_FORMAT),
-    });
+    };
+
+    const optionalTopicId = applyValueTransformer(
+      "invite-simple-mode-topic",
+      null,
+      { invite: this.invite }
+    );
+
+    if (optionalTopicId) {
+      data.topic_id = optionalTopicId;
+    }
+
+    await this.save(data);
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -10,6 +10,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "header-notifications-avatar-size",
   "home-logo-href",
   "home-logo-image-url",
+  "invite-simple-mode-topic",
   "mentions-class",
   "more-topics-tabs",
   "post-menu-buttons",


### PR DESCRIPTION
This allows a theme to do:

```js
withPluginApi("1.32.0", (api) => {
  api.registerValueTransformer(
    "invite-simple-mode-topic",
    ({ value, context }) => {
      if (context.invite.isCustomInvite) {
        return INVITE_LANDING_TOPIC_ID;
      }
    }
  );
});
```

which will populate a landing topic in the invite modal's "simple mode" (this mode below) 

![image](https://github.com/user-attachments/assets/ce9cb0d1-c3d1-4a3e-9968-0a5e6799762f)
