### PR TITLE
DEV: add order to posters column so it gets a classname

### DIFF
--- a/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
+++ b/app/assets/javascripts/discourse/app/raw-templates/topic-list-header.hbr
@@ -11,7 +11,7 @@
 {{raw-plugin-outlet name="topic-list-header-after-main-link"}}
 {{plugin-outlet name="topic-list-header-after-main-link"}}
 {{#if showPosters}}
-  {{raw "topic-list-header-column" name='posters' screenreaderOnly='true'}}
+  {{raw "topic-list-header-column" order='posters' name='posters' screenreaderOnly='true'}}
 {{/if}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
 {{#if showLikes}}


### PR DESCRIPTION
Adding an order value here ensures the column header gets the `posters` class — currently it has no unique class to target with CSS.

This has already been done in the glimmer topic list, because @CvX is wonderful and smart. 

https://github.com/discourse/discourse/blob/a914d3230bd53950677324ecc328d6c7a98167aa/app/assets/javascripts/discourse/app/components/topic-list/topic-list-header.gjs#L48