### PR TITLE
FEATURE: Add modifier to delete after merge

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -686,7 +686,14 @@ class PostMover
 
     days_to_deleting = SiteSetting.delete_merged_stub_topics_after_days
     if days_to_deleting == 0
-      if Guardian.new(@user).can_delete?(@original_topic)
+      is_allowed_to_delete_after_merge =
+        DiscoursePluginRegistry.apply_modifier(
+          :is_allowed_to_delete_after_merge,
+          Guardian.new(@user).can_delete?(@original_topic),
+          @original_topic,
+          @user,
+        )
+      if is_allowed_to_delete_after_merge
         first_post = @original_topic.ordered_posts.first
 
         PostDestroyer.new(

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2579,5 +2579,63 @@ RSpec.describe PostMover do
         expect(event[:params][1]).to eq(topic_1.id)
       end
     end
+
+    context "with modifier" do
+      fab!(:topic_1) { Fabricate(:topic) }
+      fab!(:topic_2) { Fabricate(:topic) }
+      fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+      fab!(:user)
+
+      before { SiteSetting.delete_merged_stub_topics_after_days = 0 }
+      let(:modifier_block) do
+        Proc.new do |is_currently_allowed_to_delete, topic, who_is_merging|
+          expect(is_currently_allowed_to_delete).to eq(false)
+          expect(topic).to eq(topic_1)
+          user.id == who_is_merging.id
+        end
+      end
+      it "lets user merge topics immediately" do
+        plugin_instance = Plugin::Instance.new
+        plugin_instance.register_modifier(:is_allowed_to_delete_after_merge, &modifier_block)
+        topic_1.move_posts(user, topic_1.posts.map(&:id), destination_topic_id: topic_2.id)
+
+        expect(topic_1.deleted_at).not_to be_nil
+        expect(topic_2.posts.count).to eq(1)
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :is_allowed_to_delete_after_merge,
+          &modifier_block
+        )
+      end
+
+      it "allows specific user to merge topics" do
+        special_user = Fabricate(:user)
+        plugin_instance = Plugin::Instance.new
+
+        plugin_instance.register_modifier(:is_allowed_to_delete_after_merge, &modifier_block)
+        topic_1.move_posts(special_user, topic_1.posts.map(&:id), destination_topic_id: topic_2.id)
+
+        expect(topic_1.deleted_at).to be_nil
+        topic_1.move_posts(user, topic_1.posts.map(&:id), destination_topic_id: topic_2.id)
+        expect(topic_1.deleted_at).not_to be_nil
+      ensure
+        DiscoursePluginRegistry.unregister_modifier(
+          plugin_instance,
+          :is_allowed_to_delete_after_merge,
+          &modifier_block
+        )
+      end
+
+      it "works fine without modifier" do
+        topic_1.move_posts(user, topic_1.posts.map(&:id), destination_topic_id: topic_2.id)
+
+        expect(topic_1.deleted_at).to be_nil
+
+        topic_1.move_posts(admin, topic_1.posts.map(&:id), destination_topic_id: topic_2.id)
+
+        expect(topic_1.deleted_at).not_to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
While it is ok to have the check for if the person can delete a topic, for this feature some times you might want some more flexibility.

Instead of relying on patching this class and method, it would be better to have a modifier that can decide if the topic should be deleted after the merge.
