### PR TITLE
DEV: Update sidebar invite button to use correct title attribute text

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/invite-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/invite-section-link.js
@@ -11,7 +11,7 @@ export default class InviteSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return i18n("sidebar.sections.community.links.invite.content");
+    return i18n("sidebar.sections.community.links.invite.title");
   }
 
   get text() {


### PR DESCRIPTION
This PR updates the sidebar's Invite button to use the intended text for its title attribute.

### Before
<img width="259" alt="image" src="https://github.com/user-attachments/assets/b64e8fc3-23ea-414d-a39b-a4649cc2a3ff">


### After
<img width="261" alt="image" src="https://github.com/user-attachments/assets/1720173c-0a4e-4bde-9900-67b4dce356d8">
