### PR TITLE
FEATURE: Add `freeze_original` option to `PostMover`

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -71,7 +71,6 @@ class PostMover
   def move_posts_to(topic)
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
-
     # when a topic contains some posts after moving posts to another topic we shouldn't close it
     # two types of posts should prevent a topic from closing:
     #   1. regular posts

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -92,6 +92,14 @@ class PostMover
     @first_post_number_moved =
       posts.first.is_first_post? ? posts[1]&.post_number : posts.first.post_number
 
+    if @options[:freeze_original] # in this case we need to add the moderator post after the last copied post
+      from_posts = @original_topic.posts.where("post_number > ?", posts.last.post_number)
+
+      shift_post_numbers(from_posts) if !moving_all_posts
+
+      @first_post_number_moved = posts.last.post_number + 1
+    end
+
     move_each_post
     handle_moved_references
 
@@ -283,15 +291,22 @@ class PostMover
 
     update[:reply_to_user_id] = nil unless @move_map[post.reply_to_post_number]
 
-    post.attributes = update
-    post.save(validate: false)
+    moved_post =
+      if @options[:freeze_original]
+        post.dup
+      else
+        post
+      end
 
-    DiscourseEvent.trigger(:post_moved, post, original_topic.id)
+    moved_post.attributes = update
+    moved_post.save(validate: false)
+
+    DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id)
 
     # Move any links from the post to the new topic
-    post.topic_links.update_all(topic_id: destination_topic.id)
+    moved_post.topic_links.update_all(topic_id: destination_topic.id)
 
-    post
+    moved_post
   end
 
   def move_same_topic(post)
@@ -331,6 +346,10 @@ class PostMover
       INSERT INTO moved_posts(old_topic_id, old_post_id, old_post_number, new_topic_id, new_topic_title, new_post_id, new_post_number, created_new_topic, created_at, updated_at)
       VALUES (:old_topic_id, :old_post_id, :old_post_number, :new_topic_id, :new_topic_title, :new_post_id, :new_post_number, :created_new_topic, :now, :now)
     SQL
+  end
+
+  def shift_post_numbers(from_posts)
+    from_posts.each { |post| post.update_columns(post_number: post.post_number + 1) }
   end
 
   def move_incoming_emails
@@ -685,6 +704,7 @@ class PostMover
 
   def close_topic_and_schedule_deletion
     @original_topic.update_status("closed", true, @user)
+    return if @options[:freeze_original] # we only close the topic when freezing it
 
     days_to_deleting = SiteSetting.delete_merged_stub_topics_after_days
     if days_to_deleting == 0

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -7,11 +7,14 @@ class PostMover
     @move_types ||= Enum.new(:new_topic, :existing_topic)
   end
 
-  def initialize(original_topic, user, post_ids, move_to_pm: false)
+  # options:
+  # freeze_original: :boolean  - if true, the original topic will be frozen but not deleted and posts will be "copied" to topic
+  def initialize(original_topic, user, post_ids, move_to_pm: false, options: {})
     @original_topic = original_topic
     @user = user
     @post_ids = post_ids
     @move_to_pm = move_to_pm
+    @options = options
   end
 
   def to_topic(id, participants: nil, chronological_order: false)

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -71,6 +71,7 @@ class PostMover
   def move_posts_to(topic)
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
+
     # when a topic contains some posts after moving posts to another topic we shouldn't close it
     # two types of posts should prevent a topic from closing:
     #   1. regular posts

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2685,7 +2685,13 @@ RSpec.describe PostMover do
             freeze_original: true,
           },
         ).to_topic(destination_topic.id)
-        expect(MovedPost.count).to eq(1)
+        expect(
+          MovedPost.exists?(
+            old_topic_id: original_topic.id,
+            new_topic_id: destination_topic.id,
+            old_post_id: first_post.id,
+          ),
+        ).to eq(true)
       end
 
       it "creates the moderator message in the correct position" do

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2676,6 +2676,18 @@ RSpec.describe PostMover do
         expect(original_topic.posts.map(&:raw)).to include(first_post.raw)
       end
 
+      it "creates a MovedPost record when moving to an existing topic" do
+        PostMover.new(
+          original_topic,
+          Discourse.system_user,
+          [first_post.id],
+          options: {
+            freeze_original: true,
+          },
+        ).to_topic(destination_topic.id)
+        expect(MovedPost.count).to eq(1)
+      end
+
       it "creates the moderator message in the correct position" do
         PostMover.new(
           original_topic,


### PR DESCRIPTION
This option will allow the api user to specify if the original topic should be `frozen`(locked and posts not deleted neither moved)

With this option when moving topic posts your posts will be `copied` to the new topic and the original topic will be kept there.
