### PR TITLE
DEV: Improve pnpmfile workspace workaround

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -31,7 +31,9 @@ if (
     "> pnpm was run inside a plugin directory. Re-executing with --ignore-workspace..."
   );
 
-  const indexOfPnpm = process.argv.findIndex((a) => a.endsWith("pnpm"));
+  const indexOfPnpm = process.argv.findIndex(
+    (a) => a.includes("/pnpm") || a.endsWith("pnpm")
+  );
   const newArgs = [...process.argv];
   newArgs.splice(indexOfPnpm + 1, 0, "--ignore-workspace");
 


### PR DESCRIPTION
Some setups have pnpm installed as `pnpm.cjs`, so the `endsWith` check wasn't working

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->