### PR TITLE
DEV: Apply modifier for topic_view link_counts

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -692,7 +692,6 @@ class TopicView
       DiscoursePluginRegistry.apply_modifier(
         :topic_view_link_counts,
         TopicLink.counts_for(@guardian, @topic, posts),
-        self,
       )
   end
 

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -684,7 +684,16 @@ class TopicView
   end
 
   def link_counts
-    @link_counts ||= TopicLink.counts_for(@guardian, @topic, posts)
+    # Normal memoizations doesn't work in nil cases, so using the ol' `defined?` trick
+    # to memoize more safely, as a modifier could nil this out.
+    return @link_counts if defined?(@link_counts)
+
+    @link_counts =
+      DiscoursePluginRegistry.apply_modifier(
+        :topic_view_link_counts,
+        TopicLink.counts_for(@guardian, @topic, posts),
+        self,
+      )
   end
 
   def pm_params


### PR DESCRIPTION
I also refactored some existing modifier tests for TopicView that I didn't like. Now they're grouped together and follow a very similar pattern.