### PR TITLE
FIX: hide chat button in user card

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/fabricators.js
+++ b/app/assets/javascripts/discourse/app/lib/fabricators.js
@@ -82,6 +82,8 @@ export default class CoreFabricators {
       name: args.name,
       avatar_template: "/letter_avatar_proxy/v3/letter/t/41988e/{size}.png",
       suspended_till: args.suspended_till,
+      can_send_private_message_to_user:
+        args.can_send_private_message_to_user ?? true,
     });
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/direct-message-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/direct-message-button.gjs
@@ -10,7 +10,10 @@ export default class ChatDirectMessageButton extends Component {
   @service router;
 
   get shouldRender() {
-    return this.chat.userCanDirectMessage && !this.args.user.suspended;
+    return (
+      this.chat.userCanDirectMessage &&
+      this.args.user.can_send_private_message_to_user
+    );
   }
 
   @action

--- a/plugins/chat/test/javascripts/components/chat-user-card-button-test.js
+++ b/plugins/chat/test/javascripts/components/chat-user-card-button-test.js
@@ -39,13 +39,13 @@ module(
         .doesNotExist("it doesn’t show the chat button");
     });
 
-    test("when displayed user is suspended", async function (assert) {
+    test("when displayed user has disabled PMs / DMs", async function (assert) {
       sinon
         .stub(this.owner.lookup("service:chat"), "userCanDirectMessage")
         .value(true);
 
       this.user = new CoreFabricators(getOwner(this)).user({
-        suspended_till: moment().add(1, "year").toDate(),
+        can_send_private_message_to_user: false,
       });
 
       await render(


### PR DESCRIPTION
when the user isn't able to receive DMs (either because they've disabled it or because they're suspended for example).

Internal ref - t/142198

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->