### PR TITLE
DEV: Fix theme name in `this` deprecation notices

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/deprecation-this-property-fallback-handler.js
+++ b/app/assets/javascripts/discourse/app/initializers/deprecation-this-property-fallback-handler.js
@@ -23,7 +23,7 @@ export default {
       if (pluginMatch || themeIdMatch) {
         const source = {
           type: pluginMatch ? "plugin" : "theme",
-          name: pluginMatch || getThemeInfo(parseInt(themeIdMatch, 10)),
+          name: pluginMatch || getThemeInfo(parseInt(themeIdMatch, 10)).name,
           id: themeIdMatch,
         };
         options.source = source;


### PR DESCRIPTION
A followup to 019ba099c84f2e2e4fa0053588707acd2e728376

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->