### PR TITLE
DEV: Ignore normalize_emails when using SSO

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -252,7 +252,10 @@ class DiscourseConnect < DiscourseConnectBase
 
       if !user
         user_params = {
-          primary_email: UserEmail.new(email: email, primary: true),
+          primary_email:
+            UserEmail.new(email: email, primary: true) do |user_email|
+              user_email.skip_normalize_email = true
+            end,
           name: resolve_name,
           username: resolve_username,
           ip_address: ip_address,

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -5,6 +5,7 @@ class UserEmail < ActiveRecord::Base
 
   attr_accessor :skip_validate_email
   attr_accessor :skip_validate_unique_email
+  attr_accessor :skip_normalize_email
 
   before_validation :strip_downcase_email
   before_validation :normalize_email
@@ -50,9 +51,15 @@ class UserEmail < ActiveRecord::Base
     will_save_change_to_email?
   end
 
+  def normalize_emails?
+    return false if self.skip_normalize_email
+
+    SiteSetting.normalize_emails?
+  end
+
   def unique_email
     email_exists =
-      if SiteSetting.normalize_emails?
+      if self.normalize_emails?
         self
           .class
           .where("lower(email) = ? OR lower(normalized_email) = ?", email, normalized_email)

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -119,6 +119,22 @@ RSpec.describe DiscourseConnect do
     expect(user.persisted?).to eq(true)
   end
 
+  it "always creates new users when using plus addressing" do
+    SiteSetting.stubs(:normalize_emails).returns(true)
+
+    existing_user = Fabricate(:user, email: "bob+1@user.com")
+
+    sso = new_discourse_sso
+    sso.username = "test"
+    sso.name = ""
+    sso.email = "bob+2@user.com"
+    sso.external_id = "A"
+    sso.suppress_welcome_message = true
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.id).not_to eq(existing_user.id)
+  end
+
   it "unstaged users" do
     SiteSetting.auth_overrides_name = true
 


### PR DESCRIPTION
### What is this change?

We recently tried to default the `normalize_emails` site setting to `true` to avoid spam. What this does is it considers e-mails the same regardless of plus addressing, e.g. `bob+1@mail.com == bob+2@mail.com`. This caused some problems for SSO users.

This PR makes it so that DiscourseConnect never normalizes e-mails.