### PR TITLE
DEV: Improve hbr topic list detection

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/raw-templates.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/raw-templates.js
@@ -48,10 +48,14 @@ export function addRawTemplate(name, template, opts = {}) {
     !opts.hasModernReplacement
   ) {
     const message = `[${name}] hbr topic-list template overrides and connectors are deprecated. Use the value transformer \`topic-list-columns\` and other new topic-list plugin APIs instead.`;
+
+    // NOTE: addRawTemplate is called too early for deprecation handlers to process this:
     deprecated(message, {
       since: "v3.4.0.beta3-dev",
       id: "discourse.hbr-topic-list-overrides",
     });
+
+    needsHbrTopicList(true);
 
     let prefix;
     if (opts.themeId) {

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -13,7 +13,6 @@ import { observes, on } from "@ember-decorators/object";
 import $ from "jquery";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
-import { consolePrefix } from "discourse/lib/source-identifier";
 import DiscourseURL, { groupPath } from "discourse/lib/url";
 import deprecated from "discourse-common/lib/deprecated";
 import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
@@ -53,27 +52,25 @@ export function navigateToTopic(topic, href) {
 @attributeBindings("dataTopicId:data-topic-id", "role", "ariaLevel:aria-level")
 export default class TopicListItem extends Component {
   static reopen() {
-    const message =
-      "Modifying topic-list-item with `reopen` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-    deprecated(message, {
-      since: "v3.4.0.beta3-dev",
-      id: "discourse.hbr-topic-list-overrides",
-    });
-    // eslint-disable-next-line no-console
-    console.debug(consolePrefix(), message);
+    deprecated(
+      "Modifying topic-list-item with `reopen` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
 
     return super.reopen(...arguments);
   }
 
   static reopenClass() {
-    const message =
-      "Modifying topic-list-item with `reopenClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-    deprecated(message, {
-      since: "v3.4.0.beta3-dev",
-      id: "discourse.hbr-topic-list-overrides",
-    });
-    // eslint-disable-next-line no-console
-    console.debug(consolePrefix(), message);
+    deprecated(
+      "Modifying topic-list-item with `reopenClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
 
     return super.reopenClass(...arguments);
   }

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -8,46 +8,34 @@ import {
   tagName,
 } from "@ember-decorators/component";
 import { observes, on } from "@ember-decorators/object";
-import { consolePrefix } from "discourse/lib/source-identifier";
 import LoadMore from "discourse/mixins/load-more";
-import deprecated, {
-  registerDeprecationHandler,
-} from "discourse-common/lib/deprecated";
-import { needsHbrTopicList } from "discourse-common/lib/raw-templates";
+import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
-
-registerDeprecationHandler((message, opts) => {
-  if (opts?.id === "discourse.hbr-topic-list-overrides") {
-    needsHbrTopicList(true);
-  }
-});
 
 @tagName("table")
 @classNames("topic-list")
 @classNameBindings("bulkSelectEnabled:sticky-header")
 export default class TopicList extends Component.extend(LoadMore) {
   static reopen() {
-    const message =
-      "Modifying topic-list with `reopen` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-    deprecated(message, {
-      since: "v3.4.0.beta3-dev",
-      id: "discourse.hbr-topic-list-overrides",
-    });
-    // eslint-disable-next-line no-console
-    console.debug(consolePrefix(), message);
+    deprecated(
+      "Modifying topic-list with `reopen` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
 
     return super.reopen(...arguments);
   }
 
   static reopenClass() {
-    const message =
-      "Modifying topic-list with `reopenClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-    deprecated(message, {
-      since: "v3.4.0.beta3-dev",
-      id: "discourse.hbr-topic-list-overrides",
-    });
-    // eslint-disable-next-line no-console
-    console.debug(consolePrefix(), message);
+    deprecated(
+      "Modifying topic-list with `reopenClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
 
     return super.reopenClass(...arguments);
   }

--- a/app/assets/javascripts/discourse/app/instance-initializers/hbr-topic-list-overrides.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/hbr-topic-list-overrides.js
@@ -1,0 +1,17 @@
+import { consolePrefix } from "discourse/lib/source-identifier";
+import { registerDeprecationHandler } from "discourse-common/lib/deprecated";
+import { needsHbrTopicList } from "discourse-common/lib/raw-templates";
+
+export default {
+  before: "inject-objects",
+
+  initialize() {
+    registerDeprecationHandler((message, opts) => {
+      if (opts?.id === "discourse.hbr-topic-list-overrides") {
+        needsHbrTopicList(true);
+        // eslint-disable-next-line no-console
+        console.debug(consolePrefix(), message);
+      }
+    });
+  },
+};

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -297,14 +297,13 @@ class PluginApi {
       resolverName === "component:topic-list" ||
       resolverName === "component:topic-list-item"
     ) {
-      const message =
-        "Modifying topic-list and topic-list-item with `modifyClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-      deprecated(message, {
-        since: "v3.4.0.beta3-dev",
-        id: "discourse.hbr-topic-list-overrides",
-      });
-      // eslint-disable-next-line no-console
-      console.debug(consolePrefix(), message);
+      deprecated(
+        "Modifying topic-list and topic-list-item with `modifyClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+        {
+          since: "v3.4.0.beta3-dev",
+          id: "discourse.hbr-topic-list-overrides",
+        }
+      );
     }
 
     const klass = this._resolveClass(resolverName, opts);
@@ -348,14 +347,13 @@ class PluginApi {
       resolverName === "component:topic-list" ||
       resolverName === "component:topic-list-item"
     ) {
-      const message =
-        "Modifying topic-list and topic-list-item with `modifyClassStatic` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.";
-      deprecated(message, {
-        since: "v3.4.0.beta3-dev",
-        id: "discourse.hbr-topic-list-overrides",
-      });
-      // eslint-disable-next-line no-console
-      console.debug(consolePrefix(), message);
+      deprecated(
+        "Modifying topic-list and topic-list-item with `modifyClassStatic` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+        {
+          since: "v3.4.0.beta3-dev",
+          id: "discourse.hbr-topic-list-overrides",
+        }
+      );
     }
 
     const klass = this._resolveClass(resolverName, opts);


### PR DESCRIPTION
1. `addRawTemplate` is called too early for deprecation handlers to process its deprecation call, so toggle the hbr flag directly
2. move the deprecation handler to an initializer so that other (non-template) calls are always handled
3. mvoe the debug logging to the handler

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->