### PR TITLE
FIX: `Permalink.create` didn't work as expected anymore

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-permalink-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-permalink-form.gjs
@@ -45,7 +45,7 @@ export default class AdminFlagsForm extends Component {
       } else if (!isEmpty(this.args.permalink.category_id)) {
         permalinkType = "category";
         permalinkValue = this.args.permalink.category_id;
-      } else if (!isEmpty(this.args.permalink.tag_name)) {
+      } else if (!isEmpty(this.args.permalink.tag_id)) {
         permalinkType = "tag";
         permalinkValue = this.args.permalink.tag_name;
       } else if (!isEmpty(this.args.permalink.external_url)) {

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -474,13 +474,13 @@ RSpec.describe Category do
     end
 
     it "deletes permalink when category slug is reused" do
-      Fabricate(:permalink, url: "/c/bikeshed-category")
+      Fabricate(:permalink, url: "/c/bikeshed-category", category_id: 42)
       Fabricate(:category_with_definition, slug: "bikeshed-category")
       expect(Permalink.count).to eq(0)
     end
 
     it "deletes permalink when sub category slug is reused" do
-      Fabricate(:permalink, url: "/c/main-category/sub-category")
+      Fabricate(:permalink, url: "/c/main-category/sub-category", category_id: 42)
       main_category = Fabricate(:category_with_definition, slug: "main-category")
       Fabricate(
         :category_with_definition,

--- a/spec/requests/admin/permalinks_controller_spec.rb
+++ b/spec/requests/admin/permalinks_controller_spec.rb
@@ -10,20 +10,10 @@ RSpec.describe Admin::PermalinksController do
       before { sign_in(admin) }
 
       it "filters url" do
-        Fabricate(:permalink, url: "/forum/23", permalink_type_value: "1", permalink_type: "topic")
-        Fabricate(:permalink, url: "/forum/98", permalink_type_value: "1", permalink_type: "topic")
-        Fabricate(
-          :permalink,
-          url: "/discuss/topic/45",
-          permalink_type_value: "1",
-          permalink_type: "topic",
-        )
-        Fabricate(
-          :permalink,
-          url: "/discuss/topic/76",
-          permalink_type_value: "1",
-          permalink_type: "topic",
-        )
+        Fabricate(:permalink, url: "/forum/23", topic_id: 1)
+        Fabricate(:permalink, url: "/forum/98", topic_id: 1)
+        Fabricate(:permalink, url: "/discuss/topic/45", topic_id: 1)
+        Fabricate(:permalink, url: "/discuss/topic/76", topic_id: 1)
 
         get "/admin/permalinks.json", params: { filter: "topic" }
 
@@ -33,26 +23,10 @@ RSpec.describe Admin::PermalinksController do
       end
 
       it "filters external url" do
-        Fabricate(
-          :permalink,
-          permalink_type_value: "http://google.com",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          permalink_type_value: "http://wikipedia.org",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          permalink_type_value: "http://www.discourse.org",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          permalink_type_value: "http://try.discourse.org",
-          permalink_type: "external_url",
-        )
+        Fabricate(:permalink, external_url: "http://google.com")
+        Fabricate(:permalink, external_url: "http://wikipedia.org")
+        Fabricate(:permalink, external_url: "http://www.discourse.org")
+        Fabricate(:permalink, external_url: "http://try.discourse.org")
 
         get "/admin/permalinks.json", params: { filter: "discourse" }
 
@@ -62,30 +36,10 @@ RSpec.describe Admin::PermalinksController do
       end
 
       it "filters url and external url both" do
-        Fabricate(
-          :permalink,
-          url: "/forum/23",
-          permalink_type_value: "http://google.com",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          url: "/discourse/98",
-          permalink_type_value: "http://wikipedia.org",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          url: "/discuss/topic/45",
-          permalink_type_value: "http://discourse.org",
-          permalink_type: "external_url",
-        )
-        Fabricate(
-          :permalink,
-          url: "/discuss/topic/76",
-          permalink_type_value: "http://try.discourse.org",
-          permalink_type: "external_url",
-        )
+        Fabricate(:permalink, url: "/forum/23", external_url: "http://google.com")
+        Fabricate(:permalink, url: "/discourse/98", external_url: "http://wikipedia.org")
+        Fabricate(:permalink, url: "/discuss/topic/45", external_url: "http://discourse.org")
+        Fabricate(:permalink, url: "/discuss/topic/76", external_url: "http://try.discourse.org")
 
         get "/admin/permalinks.json", params: { filter: "discourse" }
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -345,11 +345,7 @@ RSpec.describe ApplicationController do
     describe "topic not found" do
       it "should not redirect to permalink if topic/category does not exist" do
         topic = create_post.topic
-        Permalink.create!(
-          url: topic.relative_url,
-          permalink_type_value: topic.id + 1,
-          permalink_type: "topic",
-        )
+        Permalink.create!(url: topic.relative_url, topic_id: topic.id + 1)
         topic.trash!
 
         SiteSetting.detailed_404 = false
@@ -364,11 +360,7 @@ RSpec.describe ApplicationController do
       it "should return permalink for deleted topics" do
         topic = create_post.topic
         external_url = "https://somewhere.over.rainbow"
-        Permalink.create!(
-          url: topic.relative_url,
-          permalink_type_value: external_url,
-          permalink_type: "external_url",
-        )
+        Permalink.create!(url: topic.relative_url, external_url: external_url)
         topic.trash!
 
         get topic.relative_url
@@ -390,12 +382,7 @@ RSpec.describe ApplicationController do
         trashed_topic = create_post.topic
         trashed_topic.trash!
         new_topic = create_post.topic
-        permalink =
-          Permalink.create!(
-            url: trashed_topic.relative_url,
-            permalink_type_value: new_topic.id,
-            permalink_type: "topic",
-          )
+        permalink = Permalink.create!(url: trashed_topic.relative_url, topic_id: new_topic.id)
 
         # no subfolder because router doesn't know about subfolder in this test
         get "/t/#{trashed_topic.slug}/#{trashed_topic.id}"
@@ -404,23 +391,14 @@ RSpec.describe ApplicationController do
 
         permalink.destroy
         category = Fabricate(:category)
-        permalink =
-          Permalink.create!(
-            url: trashed_topic.relative_url,
-            permalink_type_value: category.id,
-            permalink_type: "category",
-          )
+        permalink = Permalink.create!(url: trashed_topic.relative_url, category_id: category.id)
         get "/t/#{trashed_topic.slug}/#{trashed_topic.id}"
         expect(response.status).to eq(301)
         expect(response).to redirect_to("/forum/c/#{category.slug}/#{category.id}")
 
         permalink.destroy
         permalink =
-          Permalink.create!(
-            url: trashed_topic.relative_url,
-            permalink_type_value: new_topic.posts.last.id,
-            permalink_type: "post",
-          )
+          Permalink.create!(url: trashed_topic.relative_url, post_id: new_topic.posts.last.id)
         get "/t/#{trashed_topic.slug}/#{trashed_topic.id}"
         expect(response.status).to eq(301)
         expect(response).to redirect_to(

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -44,12 +44,7 @@ RSpec.describe CategoriesController do
     end
 
     it "respects permalinks before redirecting /category paths to /c paths" do
-      _perm =
-        Permalink.create!(
-          url: "category/something",
-          permalink_type_value: category.id,
-          permalink_type: "category",
-        )
+      _perm = Permalink.create!(url: "category/something", category_id: category.id)
 
       get "/category/something"
       expect(response).to have_http_status(:moved_permanently)

--- a/spec/requests/permalinks_controller_spec.rb
+++ b/spec/requests/permalinks_controller_spec.rb
@@ -2,12 +2,10 @@
 
 RSpec.describe PermalinksController do
   fab!(:topic)
-  fab!(:permalink) { Fabricate(:permalink, url: "deadroute/topic/546") }
+  fab!(:permalink) { Fabricate(:permalink, url: "deadroute/topic/546", topic_id: topic.id) }
 
   describe "show" do
     it "should redirect to a permalink's target_url with status 301" do
-      permalink.update!(permalink_type_value: topic.id, permalink_type: "topic")
-
       get "/#{permalink.url}"
 
       expect(response).to redirect_to(topic.relative_url)
@@ -15,7 +13,6 @@ RSpec.describe PermalinksController do
     end
 
     it "should work for subfolder installs too" do
-      permalink.update!(permalink_type_value: topic.id, permalink_type: "topic")
       set_subfolder "/forum"
 
       get "/#{permalink.url}"
@@ -25,7 +22,7 @@ RSpec.describe PermalinksController do
     end
 
     it "should apply normalizations" do
-      permalink.update!(permalink_type_value: "/topic/100", permalink_type: "external_url")
+      permalink.update!(external_url: "/topic/100", topic_id: nil)
       SiteSetting.permalink_normalizations = "/(.*)\\?.*/\\1"
 
       get "/#{permalink.url}", params: { test: "hello" }
@@ -46,14 +43,9 @@ RSpec.describe PermalinksController do
     end
 
     context "when permalink's target_url is an external URL" do
-      before do
-        permalink.update!(
-          permalink_type_value: "https://github.com/discourse/discourse",
-          permalink_type: "external_url",
-        )
-      end
-
       it "redirects to it properly" do
+        permalink.update!(external_url: "https://github.com/discourse/discourse", topic_id: nil)
+
         get "/#{permalink.url}"
         expect(response).to redirect_to(permalink.external_url)
       end


### PR DESCRIPTION
This moves the logic of setting the correct permalink values back into the controller. And it replaces the validation with a simpler one, that always works, even when the model is loaded from the DB.

Follow-up to https://github.com/discourse/discourse/pull/29634 which broke import scripts and lots of documentation on Meta.