### PR TITLE
DEV: Enable `experimental_topics_filter` by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3345,7 +3345,7 @@ experimental:
     hidden: true
   experimental_topics_filter:
     client: true
-    default: false
+    default: true
   enable_rich_text_paste:
     client: true
     default: true


### PR DESCRIPTION
The `/filter` route is now default available, no other UI changes are included.
