### PR TITLE
UX: Multiple codeblocks fixes

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -113,6 +113,7 @@
   --hljs-attribute: #{$hljs-attribute};
   --hljs-addition: #{$hljs-addition};
   --hljs-bg: #{$hljs-bg};
+  --inline-code-bg: #{$inline-code-bg};
   --hljs-comment: #{$hljs-comment};
   --hljs-deletion: #{$hljs-deletion};
   --hljs-keyword: #{$hljs-keyword};

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -3,15 +3,21 @@ li > code,
 pre > code,
 strong > code,
 em > code {
-  font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono",
-    Menlo, Monaco, Consolas, monospace;
+  padding: 0.5em;
+}
+
+code {
   color: var(--primary-very-high);
   background: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
   font-size: 14px;
   line-height: calc((13 + 4) / 13);
-  padding: 12px;
+  padding: 0.5em;
+}
+
+pre > code {
   display: block;
+  padding: 12px;
   max-height: 500px;
 }
 

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -1,5 +1,3 @@
-/* originally based on github.com style (c) Vasily Polovnyov <vast@whiteants.net> */
-
 p > code,
 li > code,
 pre > code,
@@ -8,12 +6,13 @@ em > code {
   font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono",
     Menlo, Monaco, Consolas, monospace;
   color: var(--primary-very-high);
-  background-color: var(--hljs-bg);
+  background: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
   font-size: 14px;
   line-height: calc((13 + 4) / 13);
   padding: 12px;
   display: block;
+  max-height: 500px;
 }
 
 .hljs-comment,

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -5,9 +5,11 @@ em > code {
   padding: 2px 4px;
   background: var(--inline-code-bg);
   white-space: pre-wrap;
+  color: var(--primary);
 }
 
 code {
+  color: var(--primary-very-high);
   background: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
   font-size: 14px;

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -1,18 +1,17 @@
 p > code,
 li > code,
-pre > code,
 strong > code,
 em > code {
-  padding: 0.5em;
+  padding: 2px 4px;
+  background: var(--inline-code-bg);
+  white-space: pre-wrap;
 }
 
 code {
-  color: var(--primary-very-high);
   background: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
   font-size: 14px;
   line-height: calc((13 + 4) / 13);
-  padding: 0.5em;
 }
 
 pre > code {

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -8,17 +8,12 @@ em > code {
   font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono",
     Menlo, Monaco, Consolas, monospace;
   color: var(--primary-very-high);
-  background: var(--hljs-bg);
+  background-color: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
   font-size: 14px;
   line-height: calc((13 + 4) / 13);
-}
-
-.hljs {
-  display: block;
   padding: 12px;
-  color: var(--primary-very-high);
-  background-color: var(--hljs-bg);
+  display: block;
 }
 
 .hljs-comment,

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -920,15 +920,6 @@ aside.quote {
 pre {
   max-height: 2000px;
 
-  code {
-    word-wrap: normal;
-    display: block;
-    padding: 0.5em;
-    color: var(--primary);
-    background: var(--blend-primary-secondary-5);
-    max-height: 500px;
-  }
-
   .bidi-warning,
   .bidi-warning span {
     font-style: normal;

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -12,9 +12,8 @@
   --d-button-border-radius: 2px;
   --d-input-border-radius: 2px;
   --d-content-background: initial;
-  --d-font-family--monospace: Consolas, Menlo, Monaco, "Lucida Console",
-    "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono",
-    "Courier New", monospace;
+  --d-font-family--monospace: ui-monospace, "Cascadia Mono", "Segoe UI Mono",
+    "Liberation Mono", Menlo, Monaco, Consolas, monospace;
   --d-button-transition: none;
 }
 

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -166,7 +166,7 @@ $hljs-attr: dark-light-choose(#015692, #88aece) !default;
 $hljs-attribute: dark-light-choose(#803378, #c59bc1) !default;
 $hljs-addition: dark-light-choose(#2f6f44, #76c490) !default;
 $hljs-bg: dark-light-choose($primary-50, rgba(0, 0, 0, 0.25)) !default;
-$inline-code-bg: dark-light-choose($primary-200, rgba(0, 0, 0, 0.35)) !default;
+$inline-code-bg: dark-light-choose($primary-100, rgba(0, 0, 0, 0.35)) !default;
 $hljs-comment: $primary-500 !default;
 $hljs-deletion: dark-light-choose(#c02d2e, #de7176) !default;
 $hljs-keyword: dark-light-choose(#015692, #88aece) !default;

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -166,6 +166,7 @@ $hljs-attr: dark-light-choose(#015692, #88aece) !default;
 $hljs-attribute: dark-light-choose(#803378, #c59bc1) !default;
 $hljs-addition: dark-light-choose(#2f6f44, #76c490) !default;
 $hljs-bg: dark-light-choose($primary-50, rgba(0, 0, 0, 0.25)) !default;
+$inline-code-bg: dark-light-choose($primary-200, rgba(0, 0, 0, 0.35)) !default;
 $hljs-comment: $primary-500 !default;
 $hljs-deletion: dark-light-choose(#c02d2e, #de7176) !default;
 $hljs-keyword: dark-light-choose(#015692, #88aece) !default;


### PR DESCRIPTION
This PR addresses a couple issues:

- lines up inline codeblocks with web standard styling
- adds a darker bg for inline codeblock for better readability

### After
<img width="793" alt="image" src="https://github.com/user-attachments/assets/b981a360-29aa-49ad-b343-139c113f3453">

### Before
<img width="790" alt="image" src="https://github.com/user-attachments/assets/20d9065d-b6ef-4c90-81bb-ae63892192c2">
