### PR TITLE
FEATURE: allow disable local logins when 2fa enforced for staff

### DIFF
--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -221,12 +221,14 @@ module SiteSettings::Validations
     end
     return if SiteSetting.enable_local_logins
     return if new_val == "no"
+    return if new_val == "staff"
     validate_error :second_factor_cannot_be_enforced_with_disabled_local_login
   end
 
   def validate_enable_local_logins(new_val)
     return if new_val == "t"
     return if SiteSetting.enforce_second_factor == "no"
+    return if SiteSetting.enforce_second_factor == "staff"
     validate_error :local_login_cannot_be_disabled_if_second_factor_enforced
   end
 

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -149,6 +149,10 @@ RSpec.describe SiteSettings::Validations do
             error_message,
           )
         end
+
+        it "should be ok when the new value is 'staff'" do
+          expect { validations.validate_enforce_second_factor("staff") }.not_to raise_error
+        end
       end
 
       context "when local logins are enabled" do
@@ -198,6 +202,14 @@ RSpec.describe SiteSettings::Validations do
 
         context "when enforce second factor is disabled" do
           before { SiteSetting.enforce_second_factor = "no" }
+
+          it "should be ok" do
+            expect { validations.validate_enable_local_logins("f") }.not_to raise_error
+          end
+        end
+
+        context "when enforce second factor is staff" do
+          before { SiteSetting.enforce_second_factor = "staff" }
 
           it "should be ok" do
             expect { validations.validate_enable_local_logins("f") }.not_to raise_error


### PR DESCRIPTION
Admin should be able to disable local logins even when 2FA is enabled for staff users.

