### PR TITLE
FEATURE: Allow admins to force refresh "What's new?"

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
@@ -1,20 +1,33 @@
+import Component from "@glimmer/component";
+import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
 import { i18n } from "discourse-i18n";
 
-const AdminConfigAreaEmptyList = <template>
-  <div class="admin-config-area-empty-list">
-    {{i18n @emptyLabel}}
-    <DButton
-      @label={{@ctaLabel}}
-      class={{concatClass
-        "btn-default btn-small admin-config-area-empty-list__cta-button"
-        @ctaClass
-      }}
-      @action={{@ctaAction}}
-      @route={{@ctaRoute}}
-    />
-  </div>
-</template>;
+export default class AdminConfigAreaEmptyList extends Component {
+  get emptyLabel() {
+    if (this.args.emptyLabelArgs) {
+      return i18n(this.args.emptyLabel, this.args.emptyLabelArgs);
+    }
 
-export default AdminConfigAreaEmptyList;
+    return i18n(this.args.emptyLabel);
+  }
+
+  <template>
+    <div class="admin-config-area-empty-list">
+      {{htmlSafe this.emptyLabel}}
+
+      {{#if this.args.ctaLabel}}
+        <DButton
+          @label={{@ctaLabel}}
+          class={{concatClass
+            "btn-default btn-small admin-config-area-empty-list__cta-button"
+            @ctaClass
+          }}
+          @action={{@ctaAction}}
+          @route={{@ctaRoute}}
+        />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
@@ -1,33 +1,23 @@
-import Component from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
-import { i18n } from "discourse-i18n";
 
-export default class AdminConfigAreaEmptyList extends Component {
-  get emptyLabel() {
-    if (this.args.emptyLabelArgs) {
-      return i18n(this.args.emptyLabel, this.args.emptyLabelArgs);
-    }
+const AdminConfigAreaEmptyList = <template>
+  <div class="admin-config-area-empty-list">
+    {{htmlSafe @emptyLabel}}
 
-    return i18n(this.args.emptyLabel);
-  }
+    {{#if @ctaLabel}}
+      <DButton
+        @label={{@ctaLabel}}
+        class={{concatClass
+          "btn-default btn-small admin-config-area-empty-list__cta-button"
+          @ctaClass
+        }}
+        @action={{@ctaAction}}
+        @route={{@ctaRoute}}
+      />
+    {{/if}}
+  </div>
+</template>;
 
-  <template>
-    <div class="admin-config-area-empty-list">
-      {{htmlSafe this.emptyLabel}}
-
-      {{#if this.args.ctaLabel}}
-        <DButton
-          @label={{@ctaLabel}}
-          class={{concatClass
-            "btn-default btn-small admin-config-area-empty-list__cta-button"
-            @ctaClass
-          }}
-          @action={{@ctaAction}}
-          @route={{@ctaRoute}}
-        />
-      {{/if}}
-    </div>
-  </template>
-}
+export default AdminConfigAreaEmptyList;

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
@@ -1,12 +1,13 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse-common/utils/decorators";
+import { i18n } from "discourse-i18n";
 import AdminConfigAreaCard from "admin/components/admin-config-area-card";
 import AdminConfigAreaEmptyList from "admin/components/admin-config-area-empty-list";
 import DashboardNewFeatureItem from "admin/components/dashboard-new-feature-item";
@@ -24,36 +25,36 @@ export default class DashboardNewFeatures extends Component {
   }
 
   @bind
-  loadNewFeatures(opts = {}) {
+  async loadNewFeatures(opts = {}) {
     opts.forceRefresh ||= false;
     this.isLoading = true;
 
-    return ajax("/admin/whats-new.json?force_refresh=" + opts.forceRefresh)
-      .then((json) => {
-        const items = json.new_features.reduce((acc, feature) => {
-          const key = moment(feature.released_at || feature.created_at).format(
-            "YYYY-MM"
-          );
-          acc[key] = acc[key] || [];
-          acc[key].push(feature);
-          return acc;
-        }, {});
+    try {
+      const json = await ajax(
+        "/admin/whats-new.json?force_refresh=" + opts.forceRefresh
+      );
+      const items = json.new_features.reduce((acc, feature) => {
+        const key = moment(feature.released_at || feature.created_at).format(
+          "YYYY-MM"
+        );
+        acc[key] = acc[key] || [];
+        acc[key].push(feature);
+        return acc;
+      }, {});
 
-        this.groupedNewFeatures = Object.keys(items).map((date) => {
-          return {
-            date: moment
-              .tz(date, this.currentUser.user_option.timezone)
-              .format("MMMM YYYY"),
-            features: items[date],
-          };
-        });
-      })
-      .catch((err) => {
-        popupAjaxError(err);
-      })
-      .finally(() => {
-        this.isLoading = false;
+      this.groupedNewFeatures = Object.keys(items).map((date) => {
+        return {
+          date: moment
+            .tz(date, this.currentUser.user_option.timezone)
+            .format("MMMM YYYY"),
+          features: items[date],
+        };
       });
+    } catch (err) {
+      popupAjaxError(err);
+    } finally {
+      this.isLoading = false;
+    }
   }
 
   <template>
@@ -62,24 +63,24 @@ export default class DashboardNewFeatures extends Component {
       {{didInsert this.loadNewFeatures}}
     >
       <ConditionalLoadingSpinner @condition={{this.isLoading}}>
-        {{#if this.groupedNewFeatures}}
-          {{#each this.groupedNewFeatures as |groupedFeatures|}}
-            <AdminConfigAreaCard @translatedHeading={{groupedFeatures.date}}>
-              <:content>
-                {{#each groupedFeatures.features as |feature|}}
-                  <DashboardNewFeatureItem @item={{feature}} />
-                {{/each}}
-              </:content>
-            </AdminConfigAreaCard>
-          {{/each}}
+        {{#each this.groupedNewFeatures as |groupedFeatures|}}
+          <AdminConfigAreaCard @translatedHeading={{groupedFeatures.date}}>
+            <:content>
+              {{#each groupedFeatures.features as |feature|}}
+                <DashboardNewFeatureItem @item={{feature}} />
+              {{/each}}
+            </:content>
+          </AdminConfigAreaCard>
         {{else}}
           <AdminConfigAreaEmptyList
-            @emptyLabelArgs={{hash
-              url="https://meta.discourse.org/tags/c/announcements/67/release-notes"
+            @emptyLabel={{htmlSafe
+              (i18n
+                "admin.dashboard.new_features.previous_announcements"
+                url="https://meta.discourse.org/tags/c/announcements/67/release-notes"
+              )
             }}
-            @emptyLabel="admin.dashboard.new_features.previous_announcements"
           />
-        {{/if}}
+        {{/each}}
       </ConditionalLoadingSpinner>
     </div>
   </template>

--- a/app/assets/javascripts/admin/addon/controllers/admin-whats-new.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-whats-new.js
@@ -1,0 +1,16 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+
+export default class AdminWhatsNewController extends Controller {
+  @action
+  checkForUpdates() {
+    if (this.checkFeaturesCallback) {
+      this.checkFeaturesCallback({ forceRefresh: true });
+    }
+  }
+
+  @action
+  bindCheckFeatures(checkFeaturesCallback) {
+    this.checkFeaturesCallback = checkFeaturesCallback;
+  }
+}

--- a/app/assets/javascripts/admin/addon/controllers/admin-whats-new.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-whats-new.js
@@ -4,9 +4,7 @@ import { action } from "@ember/object";
 export default class AdminWhatsNewController extends Controller {
   @action
   checkForUpdates() {
-    if (this.checkFeaturesCallback) {
-      this.checkFeaturesCallback({ forceRefresh: true });
-    }
+    this.checkFeaturesCallback?.({ forceRefresh: true });
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/templates/whats-new.hbs
+++ b/app/assets/javascripts/admin/addon/templates/whats-new.hbs
@@ -10,10 +10,16 @@
       @label={{i18n "admin.dashboard.new_features.title"}}
     />
   </:breadcrumbs>
+  <:actions as |actions|>
+    <actions.Primary
+      @label="admin.new_features.check_for_updates"
+      @action={{this.checkForUpdates}}
+    />
+  </:actions>
 </AdminPageHeader>
 
 <div class="admin-container admin-config-page__main-area">
   <div class="admin-config-area">
-    <DashboardNewFeatures />
+    <DashboardNewFeatures @onCheckForFeatures={{this.bindCheckFeatures}} />
   </div>
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2861,7 +2861,6 @@ en:
       reaction_2: "<span>%{username}, %{username2}</span> %{description}"
       votes_released: "%{description} - completed"
       new_features: "New features available!"
-      check_for_updates: "Check for updates"
       admin_problems: "New advice on your site dashboard"
       dismiss_confirmation:
         body:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2861,6 +2861,7 @@ en:
       reaction_2: "<span>%{username}, %{username2}</span> %{description}"
       votes_released: "%{description} - completed"
       new_features: "New features available!"
+      check_for_updates: "Check for updates"
       admin_problems: "New advice on your site dashboard"
       dismiss_confirmation:
         body:
@@ -5115,6 +5116,7 @@ en:
 
       new_features:
         title: "What's new"
+        check_for_updates: "Check for updates"
       dashboard:
         title: "Dashboard"
         last_updated: "Dashboard updated:"

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -132,7 +132,8 @@ module DiscourseUpdates
     end
 
     def new_features_payload
-      response = Excon.new(new_features_endpoint).request(expects: [200], method: :Get)
+      response =
+        Excon.new(new_features_endpoint).request(expects: [200], method: :Get, read_timeout: 5)
       response.body
     end
 

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -141,7 +141,9 @@ module DiscourseUpdates
       Discourse.redis.set(new_features_key, payload)
     end
 
-    def new_features
+    def new_features(force_refresh: false)
+      update_new_features if force_refresh
+
       entries =
         begin
           JSON.parse(Discourse.redis.get(new_features_key))

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -308,6 +308,14 @@ RSpec.describe DiscourseUpdates do
       expect(result[0]["title"]).to eq("Bells")
       expect(result[1]["title"]).to eq("Whistles")
     end
+
+    it "correctly refetches features if force_refresh is used" do
+      DiscourseUpdates.expects(:update_new_features).once
+      result = DiscourseUpdates.new_features
+      expect(result.length).to eq(3)
+      result = DiscourseUpdates.new_features(force_refresh: true)
+      expect(result.length).to eq(3)
+    end
   end
 
   describe "#get_last_viewed_feature_date" do

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Admin::DashboardController do
               "emoji" => "🚀",
               "title" => "Space platform launched!",
               "description" => "Now to make it to the next planet unscathed...",
-              "created_at" => (Time.zone.now - 1.minutes),
+              "created_at" => 1.minute.ago,
             },
           ].to_json,
         )

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -191,6 +191,38 @@ RSpec.describe Admin::DashboardController do
         expect(json["has_unseen_features"]).to eq(true)
       end
 
+      it "allows for forcing a refresh of new features, busting the cache" do
+        populate_new_features
+
+        get "/admin/whats-new.json"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["new_features"].length).to eq(2)
+
+        get "/admin/whats-new.json"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["new_features"].length).to eq(2)
+
+        DiscourseUpdates.stubs(:new_features_payload).returns(
+          [
+            {
+              "id" => "3",
+              "emoji" => "🚀",
+              "title" => "Space platform launched!",
+              "description" => "Now to make it to the next planet unscathed...",
+              "created_at" => (Time.zone.now - 1.minutes),
+            },
+          ].to_json,
+        )
+
+        get "/admin/whats-new.json?force_refresh=true"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["new_features"].length).to eq(1)
+        expect(json["new_features"][0]["id"]).to eq("3")
+      end
+
       it "passes unseen feature state" do
         populate_new_features
         DiscourseUpdates.mark_new_features_as_seen(admin.id)


### PR DESCRIPTION
Sometimes changes to "What's new?" feed items are made or the feed items are
removed altogether, and the polling interval to check for new features is 1 day.

This is quite long, so this commit introduces a "Check for updates"
button for admins to click on the "What's new?" page which will bust
the cache for the feed and check again at the new features endpoint.
This is limited to 5 times per minute to avoid rapid sending of
requests.

![image](https://github.com/user-attachments/assets/b76ef84c-1759-4199-82d0-479d3e9d2c0d)
