### PR TITLE
FIX: Extension-less secure uploads

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -160,7 +160,8 @@ class UploadsController < ApplicationController
     # do not serve uploads requested via XHR to prevent XSS
     return xhr_not_allowed if request.xhr?
 
-    path_with_ext = "#{params[:path]}.#{params[:extension]}"
+    path_with_ext =
+      params[:extension].nil? ? params[:path] : "#{params[:path]}.#{params[:extension]}"
     upload = upload_from_path_and_extension(path_with_ext)
 
     return render_404 if upload.blank?

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -605,6 +605,16 @@ RSpec.describe UploadsController do
         expect(response.redirect_url).to match("Amz-Expires")
       end
 
+      it "should return signed url for legitimate request with no extension" do
+        upload.update!(extension: nil, url: upload.url.sub(".png", ""))
+        sign_in(user)
+        get secure_url
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to match("Amz-Expires")
+        expect(response.location).not_to include(".?")
+      end
+
       it "should return secure uploads URL when looking up urls" do
         upload.update_column(:secure, true)
         sign_in(user)

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -605,7 +605,7 @@ RSpec.describe UploadsController do
         expect(response.redirect_url).to match("Amz-Expires")
       end
 
-      it "should return signed url for legitimate request with no extension" do
+      it "returns signed url for legitimate request with no extension" do
         upload.update!(extension: nil, url: upload.url.sub(".png", ""))
         sign_in(user)
         get secure_url


### PR DESCRIPTION
Previously, the secure-upload redirection logic would fail for extension-less files. This commit updates it to work, and adds a spec for the behavior.

Extension-less file uploads are not allowed by default, so this is a very niche situation.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->