### PR TITLE
FIX: Filter out secured categories first

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -304,7 +304,12 @@ class CategoriesController < ApplicationController
     page = [1, params[:page].to_i].max
     offset = params[:offset].to_i
     parent_category_id = params[:parent_category_id].to_i if params[:parent_category_id].present?
-    only = Category.where(id: params[:only].to_a.map(&:to_i)) if params[:only].present?
+    only =
+      if params[:only].present?
+        Category.secured(guardian).where(id: params[:only].to_a.map(&:to_i))
+      else
+        Category.secured(guardian)
+      end
     except_ids = params[:except].to_a.map(&:to_i)
     include_uncategorized =
       (

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1533,6 +1533,25 @@ RSpec.describe CategoriesController do
       expect(response.parsed_body["categories"].length).not_to eq(0)
     end
 
+    it "produces exactly 5 subcategories" do
+      subcategories = Fabricate.times(6, :category, parent_category: category)
+      subcategories[3].update!(read_restricted: true)
+
+      get "/categories/hierarchical_search.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["categories"].length).to eq(7)
+      expect(response.parsed_body["categories"].map { |c| c["id"] }).to contain_exactly(
+        category.id,
+        subcategories[0].id,
+        subcategories[1].id,
+        subcategories[2].id,
+        subcategories[4].id,
+        subcategories[5].id,
+        SiteSetting.uncategorized_category_id,
+      )
+    end
+
     it "doesn't produce categories with a very specific term" do
       get "/categories/hierarchical_search.json", params: { term: "acategorythatdoesnotexist" }
 


### PR DESCRIPTION
The hierarchical search for categories is composed of several complex nested queries. This change ensures that the secured categories are filtered out as soon as possible to ensure that the default limit of 5 categories is reached.

Without this fix, the search can return less than 5 categories if any of the first 5 categories cannot be displayed due to permissions.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->