### PR TITLE
DEV: Allow async calls to finish before removing uploads

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -365,13 +365,14 @@ export default class UppyComposerUpload {
         if (!this.uppyWrapper.uppyInstance) {
           return;
         }
-        this.#removeInProgressUpload(file.id);
         let upload = response.body;
         const markdown = await this.uploadMarkdownResolvers.reduce(
           (md, resolver) => resolver(upload) || md,
           getUploadMarkdown(upload)
         );
 
+        // Only remove in progress after async resolvers finish:
+        this.#removeInProgressUpload(file.id);
         cacheShortUploadUrl(upload.short_url, upload);
 
         new ComposerVideoThumbnailUppy(getOwner(this)).generateVideoThumbnail(


### PR DESCRIPTION
## :mag: Overview
This PR simply moves the call to remove in progress uploads **after** the async markdown resolvers finish resolving. This is specifically for the case when markdown resolvers are async functions, such as in the case of Discourse AI's image caption feature. This ensures that the in progress upload doesn't get removed causing replace text having nothing to replace once the async call is finished.

No tests as there currently are no tests for this plugin API function, and it's a little tricky to test, especially with in progress uploads being a private property.