### PR TITLE
FIX: `Tooltip` styleguide triggers not rendering options

### DIFF
--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/tooltips.js
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/tooltips.js
@@ -8,10 +8,11 @@ import DummyComponent from "discourse/plugins/styleguide/discourse/components/du
 
 export default class Tooltips extends Component {
   @service tooltip;
+  @service site;
 
   @tracked label = "What is this?";
-  @tracked triggers = TOOLTIP.options.triggers;
-  @tracked untriggers = TOOLTIP.options.untriggers;
+  @tracked triggers = TOOLTIP.options.triggers[this.triggersByDevice];
+  @tracked untriggers = TOOLTIP.options.untriggers[this.triggersByDevice];
   @tracked arrow = TOOLTIP.options.arrow;
   @tracked inline = TOOLTIP.options.inline;
   @tracked interactive = TOOLTIP.options.interactive;
@@ -19,6 +20,10 @@ export default class Tooltips extends Component {
   @tracked identifier;
   @tracked offset = TOOLTIP.options.offset;
   @tracked _content = "Hello World!";
+
+  get triggersByDevice() {
+    return this.site.mobileView ? "mobile" : "desktop";
+  }
 
   get content() {
     return this._content;


### PR DESCRIPTION
Tooltips have different triggers / untriggers by device type (mobile / desktop) and this PR provides the correct options in the styleguide based on device type. 

# Before
<img width="787" alt="Screenshot 2024-11-25 at 3 31 56 PM" src="https://github.com/user-attachments/assets/f18f3003-e887-42c5-8f42-24af87cadf56">

# After
<img width="800" alt="Screenshot 2024-11-25 at 3 30 48 PM" src="https://github.com/user-attachments/assets/6113eff3-7b1f-4782-aea3-c8bee5e9842a">
