### PR TITLE
FIX: Preserve history when routing to `/filter` route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -7,6 +7,25 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
     q: { replace: true, refreshModel: true },
   };
 
+  comingFromDifferentRoute = true;
+
+  beforeModel(transition) {
+    if (transition.from && transition.from.name !== this.routeName) {
+      this.comingFromDifferentRoute = true;
+    } else {
+      this.comingFromDifferentRoute = false;
+    }
+
+    super.beforeModel(...arguments);
+  }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    const qParamConfig = this.queryParams.q;
+    qParamConfig.replace = !this.comingFromDifferentRoute;
+  }
+
   async model(data) {
     const list = await this.store.findFiltered("topicList", {
       filter: "filter",

--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -1,30 +1,12 @@
 import { setTopicList } from "discourse/lib/topic-list-tracker";
+import { escapeExpression } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
 export default class DiscoveryFilterRoute extends DiscourseRoute {
   queryParams = {
-    q: { replace: true, refreshModel: true },
+    q: { refreshModel: true },
   };
-
-  comingFromDifferentRoute = true;
-
-  beforeModel(transition) {
-    if (transition.from && transition.from.name !== this.routeName) {
-      this.comingFromDifferentRoute = true;
-    } else {
-      this.comingFromDifferentRoute = false;
-    }
-
-    super.beforeModel(...arguments);
-  }
-
-  setupController(controller, model) {
-    super.setupController(controller, model);
-
-    const qParamConfig = this.queryParams.q;
-    qParamConfig.replace = !this.comingFromDifferentRoute;
-  }
 
   async model(data) {
     const list = await this.store.findFiltered("topicList", {
@@ -38,7 +20,7 @@ export default class DiscoveryFilterRoute extends DiscourseRoute {
   }
 
   titleToken() {
-    const filterText = i18n("filters.filter.title");
-    return i18n("filters.with_topics", { filter: filterText });
+    const query = this.paramsFor(this.routeName).q;
+    return i18n("filters.filter.title", { filter: escapeExpression(query) });
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4352,7 +4352,7 @@ en:
       with_topics: "%{filter} topics"
       with_category: "%{filter} %{category} topics"
       filter:
-        title: "Filter"
+        title: "Filtered results for %{filter}"
         button:
           label: "Filter"
       latest:


### PR DESCRIPTION
## :mag: Overview
This PR removes the `replace: true` option in the query param for the `/filter` route. This allows for the history to be preserved with each subsequent search as well as when we link to the filter route from another page.

## ➕ More Info
Initially we had simply `replace: true` because on the `/filter` route we want to perform multiple filters without worrying about polluting the browser history. However, preserving the history is genuinely useful and we do so in other areas of the app with similar functionality such as the full page search.

No tests added as this is difficult to test browser back without having the browser refresh tests and make tests incomplete.

## 📹 Screen Captures

### Before
https://github.com/user-attachments/assets/a6765922-fc53-4b55-97a6-ad942e5cd4a5


### After
https://github.com/user-attachments/assets/79e1f4f2-1604-4509-a8a0-0b682234b9a6

