### PR TITLE
FIX: Empty post reviewable ignore bundle causing client errors

### DIFF
--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         expect(reviewable.actions_for(guardian).has?(:agree_and_suspend)).to eq(false)
       end
 
+      it "doesn't end up with an empty ignore bundle when the post is already hidden and deleted" do
+        post.update!(hidden: true)
+        post.topic.trash!
+        post.trash!
+        expect(reviewable.actions_for(guardian).has?(:ignore_and_do_nothing)).to eq(false)
+        expect(reviewable.actions_for(guardian).has?(:delete_and_ignore)).to eq(false)
+        expect(
+          reviewable.actions_for(guardian).bundles.find { |bundle| bundle.id.include?("-ignore") },
+        ).to be_blank
+      end
+
       context "when flagged as potential_spam" do
         before { reviewable.update!(potential_spam: true) }
 


### PR DESCRIPTION
We ran into an edge case where it was possible for a
ReviewableFlaggedPost to end up in a state where it was hidden
and the topic was already deleted. This meant that the Ignore
action bundle for the reviewable ended up empty, with no associated
actions.

This commit fixes the server-side issue where this was ending up
empty. A further commit will aim to make the client more resilient
to these issues by gracefully failing if a reviewable action bundle
is detected with no associated actions.
