### PR TITLE
FIX: correctly destroy menu/tooltip when removed from dom

### DIFF
--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -25,6 +25,10 @@ export default class DMenu extends Component {
   registerTrigger = modifier((element) => {
     this.menuInstance.trigger = element;
     this.options.onRegisterApi?.(this.menuInstance);
+
+    return () => {
+      this.menuInstance.destroy();
+    };
   });
 
   get menuId() {

--- a/app/assets/javascripts/float-kit/addon/components/d-tooltip.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-tooltip.gjs
@@ -23,6 +23,10 @@ export default class DTooltip extends Component {
   registerTrigger = modifier((element) => {
     this.tooltipInstance.trigger = element;
     this.options.onRegisterApi?.(this.tooltipInstance);
+
+    return () => {
+      this.tooltipInstance.destroy();
+    };
   });
 
   get options() {


### PR DESCRIPTION
This fix will ensure we correctly play the close/destroy sequence in this situation.