### PR TITLE
FIX: Remove duplicate id

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -559,9 +559,7 @@
             @replyToPost={{action "replyToPost"}}
           />
         {{else}}
-          <div id="topic-footer-buttons">
-            <AnonymousTopicFooterButtons @topic={{this.model}} />
-          </div>
+          <AnonymousTopicFooterButtons @topic={{this.model}} />
         {{/if}}
       {{/if}}
 


### PR DESCRIPTION
This PR removes the duplicate html ID inserted on the anonymous footer button container as `the anonymous-topic-footer-buttons.js` file defines this ID already.

https://github.com/discourse/discourse/blob/c91dcd0447d4e5bda8be6e9fcfb9c37aae3ea1d0/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.js#L8