### PR TITLE
UX: attempt to reduce jumpy topic scroll in Firefox

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -617,6 +617,7 @@ blockquote {
   float: left;
   z-index: z("base") + 1;
   height: 100%;
+  overflow-anchor: none;
 }
 
 .gap {


### PR DESCRIPTION
Broadly reported here and reproduced internally as well: https://meta.discourse.org/t/scroll-jumping-in-this-meta-site-while-viewing-threads/324800

Firefox in some situations seems to have very jumpy scroll. This is most notable in long topics while scrolling with a Macbook touchpad (perhaps the smoothing exacerbates it)... it seems to be a Firefox-specific performance issue with `position: sticky;` avatars. 

Disabling overflow anchor on these elements seems to have some positive impact (and there are no downsides since these images don't impact page height), so let's give it a try. 