### PR TITLE
DEV: Add new plugin outlets to edit topic area

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -52,33 +52,49 @@
           <div class="edit-topic-title">
             <PrivateMessageGlyph @shouldShow={{this.model.isPrivateMessage}} />
 
-            <TextField
-              @id="edit-title"
-              @value={{this.buffered.title}}
-              @maxlength={{this.siteSettings.max_topic_title_length}}
-              @autofocus="true"
-            />
+            <PluginOutlet
+              @name="edit-topic-title"
+              @outletArgs={{hash model=this.model buffered=this.buffered}}
+            >
+              <TextField
+                @id="edit-title"
+                @value={{this.buffered.title}}
+                @maxlength={{this.siteSettings.max_topic_title_length}}
+                @autofocus="true"
+              />
+            </PluginOutlet>
 
             {{#if this.showCategoryChooser}}
-              <CategoryChooser
-                @value={{this.buffered.category_id}}
-                @onChange={{action "topicCategoryChanged"}}
-                class="small"
-              />
+              <PluginOutlet
+                @name="edit-topic-category"
+                @outletArgs={{hash model=this.model buffered=this.buffered}}
+              >
+                <CategoryChooser
+                  @value={{this.buffered.category_id}}
+                  @onChange={{action "topicCategoryChanged"}}
+                  class="small"
+                />
+              </PluginOutlet>
             {{/if}}
 
             {{#if this.canEditTags}}
-              <MiniTagChooser
-                @value={{this.buffered.tags}}
-                @onChange={{action "topicTagsChanged"}}
-                @options={{hash
-                  filterable=true
-                  categoryId=this.buffered.category_id
-                  minimum=this.minimumRequiredTags
-                  filterPlaceholder="tagging.choose_for_topic"
-                  useHeaderFilter=true
-                }}
-              />
+              <PluginOutlet
+                @name="edit-topic-tags"
+                @outletArgs={{hash model=this.model buffered=this.buffered}}
+              >
+                <MiniTagChooser
+                  @value={{this.buffered.tags}}
+                  @onChange={{action "topicTagsChanged"}}
+                  @options={{hash
+                    filterable=true
+                    categoryId=this.buffered.category_id
+                    minimum=this.minimumRequiredTags
+                    filterPlaceholder="tagging.choose_for_topic"
+                    useHeaderFilter=true
+                  }}
+                />
+              </PluginOutlet>
+
             {{/if}}
 
             <span>


### PR DESCRIPTION
This PR adds new wrapper plugin outlets in the edit topic area. Adding these wrapper plugin outlets gives us easy access to `__before` and `__after`. Particularly for use in Discourse AI's Helper suggestion buttons.