### PR TITLE
UX: update minwidth to chat sidepanel + better title word-break fn

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -22,6 +22,7 @@
       overflow: visible;
       white-space: normal;
       text-overflow: unset;
+      overflow-wrap: anywhere;
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   border-left: 1px solid var(--primary-low);
   position: relative;
-  min-width: 150px;
+  min-width: clamp(350px, 33vw, 33vw);
 
   &__list {
     flex-grow: 1;


### PR DESCRIPTION
The min-width on the thread side panel was a bit too lenient at 150px. This commit implements a more graceful approach by setting it to a min-width of 33vw if possible, with a fallback to 350px minimum. This ensures better usability and decreases the risk of the title wrapping oddly. Additionally, the title is now working with `overflow-wrap: anywhere` to accommodate too long words where needed.