### PR TITLE
DEV: Add "delete user" options to illegal flag review

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -103,6 +103,7 @@ class Reviewable < ActiveRecord::Base
     payload: nil,
     reviewable_by_moderator: false,
     potential_spam: true,
+    potentially_illegal: false,
     target_created_by: nil
   )
     reviewable =
@@ -113,6 +114,7 @@ class Reviewable < ActiveRecord::Base
         reviewable_by_moderator: reviewable_by_moderator,
         payload: payload,
         potential_spam: potential_spam,
+        potentially_illegal: potentially_illegal,
         target_created_by: target_created_by,
       )
     reviewable.created_new!
@@ -136,12 +138,14 @@ class Reviewable < ActiveRecord::Base
         id: target.id,
         type: target.class.polymorphic_name,
         potential_spam: potential_spam == true ? true : nil,
+        potentially_illegal: potentially_illegal == true ? true : nil,
       }
 
       row = DB.query_single(<<~SQL, update_args)
         UPDATE reviewables
         SET status = :status,
-          potential_spam = COALESCE(:potential_spam, reviewables.potential_spam)
+          potential_spam = COALESCE(:potential_spam, reviewables.potential_spam),
+          potentially_illegal = COALESCE(:potentially_illegal, reviewables.potentially_illegal)
         FROM reviewables AS old_reviewables
         WHERE reviewables.target_id = :id
           AND reviewables.target_type = :type
@@ -776,6 +780,7 @@ end
 #  updated_at              :datetime         not null
 #  force_review            :boolean          default(FALSE), not null
 #  reject_reason           :text
+#  potentially_illegal     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -48,7 +48,7 @@ class ReviewableFlaggedPost < Reviewable
     agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
-    if potential_spam? && guardian.can_delete_user?(target_created_by)
+    if (potential_spam? || potentially_illegal?) && guardian.can_delete_user?(target_created_by)
       delete_user_actions(actions, agree_bundle)
     end
 
@@ -390,6 +390,10 @@ class ReviewableFlaggedPost < Reviewable
         url: post.url,
       },
     )
+  end
+
+  def potentially_illegal?
+    reviewable_scores.exists?(reviewable_score_type: ReviewableScore.types[:illegal])
   end
 end
 

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -48,10 +48,6 @@ class ReviewableFlaggedPost < Reviewable
     agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
-    if (potential_spam? || potentially_illegal?) && guardian.can_delete_user?(target_created_by)
-      delete_user_actions(actions, agree_bundle)
-    end
-
     if !post.user_deleted? && !post.hidden?
       build_action(actions, :agree_and_hide, icon: "far-eye-slash", bundle: agree_bundle)
     end
@@ -81,6 +77,10 @@ class ReviewableFlaggedPost < Reviewable
           confirm: true,
         )
       end
+    end
+
+    if (potential_spam? || potentially_illegal?) && guardian.can_delete_user?(target_created_by)
+      delete_user_actions(actions, agree_bundle)
     end
 
     if guardian.can_suspend?(target_created_by)

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -391,10 +391,6 @@ class ReviewableFlaggedPost < Reviewable
       },
     )
   end
-
-  def potentially_illegal?
-    reviewable_scores.exists?(reviewable_score_type: ReviewableScore.types[:illegal])
-  end
 end
 
 # == Schema Information
@@ -420,6 +416,7 @@ end
 #  updated_at              :datetime         not null
 #  force_review            :boolean          default(FALSE), not null
 #  reject_reason           :text
+#  potentially_illegal     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -155,6 +155,7 @@ end
 #  updated_at              :datetime         not null
 #  force_review            :boolean          default(FALSE), not null
 #  reject_reason           :text
+#  potentially_illegal     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -257,6 +257,7 @@ end
 #  updated_at              :datetime         not null
 #  force_review            :boolean          default(FALSE), not null
 #  reject_reason           :text
+#  potentially_illegal     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -119,6 +119,7 @@ end
 #  updated_at              :datetime         not null
 #  force_review            :boolean          default(FALSE), not null
 #  reject_reason           :text
+#  potentially_illegal     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/db/migrate/20241127034553_add_potentially_illegal_to_reviewables.rb
+++ b/db/migrate/20241127034553_add_potentially_illegal_to_reviewables.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+#
+class AddPotentiallyIllegalToReviewables < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reviewables, :potentially_illegal, :boolean
+
+    up_only do
+      # NOTE: Only for records created after this migration. Trying to
+      # apply this as part of adding the column will attempt to backfill
+      # `false` into all existing reviewables. This is dangerous (locks
+      # a potentially huge table) and will create some false negatives.
+      #
+      change_column_default :reviewables, :potentially_illegal, false
+    end
+  end
+end

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -388,6 +388,7 @@ class PostActionCreator
         topic: @post.topic,
         reviewable_by_moderator: true,
         potential_spam: @post_action_type_id == @post_action_type_view.types[:spam],
+        potentially_illegal: @post_action_type_id == @post_action_type_view.types[:illegal],
         payload: {
           targets_topic: @targets_topic,
         },


### PR DESCRIPTION
### What is this change?

We already add the "delete user" and "delete and block user" options to the drop-down for potential spam, but we should do this for potentially illegal posts as well.

### Implementation details

This is entirely based on the implementation for the potential spam one, including caching the status on the reviewable record.

Also note that just as for potential spam, the user must be "deletable" for the option to appear.

I also took the liberty to move the options in the drop-down to what I think is a more intuitive place. (Between delete post and suspend/silence user.)

<img width="305" alt="Screenshot 2024-11-27 at 2 01 26 PM" src="https://github.com/user-attachments/assets/03bcfc53-579b-47dd-83a4-96be29641a78">

### No backfill?

I have decided not to back-fill existing reviewables for now, for a couple reasons: 1) the potentially huge number of reviewables (high risk) and the ephemeral nature of reviewables (low reward), but we can reconsider if we think this is important enough.