### PR TITLE
FIX: Do not discard redirects containing "/login"

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -128,18 +128,19 @@ class StaticController < ApplicationController
     redirect_location = params[:redirect]
     if redirect_location.present? && !redirect_location.is_a?(String)
       raise Discourse::InvalidParameters.new(:redirect)
-    elsif redirect_location.present? && !redirect_location.match(login_path)
-      begin
-        forum_uri = URI(Discourse.base_url)
-        uri = URI(redirect_location)
+    elsif redirect_location.present? &&
+          begin
+            forum_uri = URI(Discourse.base_url)
+            uri = URI(redirect_location)
 
-        if uri.path.present? && (uri.host.blank? || uri.host == forum_uri.host) &&
-             uri.path =~ %r{\A\/{1}[^\.\s]*\z}
-          destination = "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
-        end
-      rescue URI::Error
-        # Do nothing if the URI is invalid
-      end
+            if uri.path.present? && !uri.path.starts_with?(login_path) &&
+                 (uri.host.blank? || uri.host == forum_uri.host) &&
+                 uri.path =~ %r{\A\/{1}[^\.\s]*\z}
+              destination = "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
+            end
+          rescue URI::Error
+            # Do nothing if the URI is invalid
+          end
     end
 
     redirect_to(destination, allow_other_host: false)

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -321,6 +321,12 @@ RSpec.describe StaticController do
       end
     end
 
+    context "when the redirect path contains the '/login' string" do
+      it "redirects to the requested path" do
+        post "/login.json", params: { redirect: "/page/login/1" }
+        expect(response).to redirect_to("/page/login/1")
+      end
+    end
     context "when the redirect path is invalid" do
       it "redirects to the root URL" do
         post "/login.json", params: { redirect: "test" }


### PR DESCRIPTION
Previously, we were doing a blank match validation here with: 

```
!redirect_location.match(login_path)
```

That means that any `redirect` parameter containing `/login` would be discarded. This causes a bug, for example `redirect=https://loginsite.test.com/about` would be discarded even though it is valid on a site with `base_url=https://loginsite.test.com`. 

The fix here moves the check a bit later and scopes it down to paths starting with `/login`. 