### PR TITLE
FIX: `TopicTagsChanged` trigger not working with multiple tags

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -239,12 +239,9 @@ module DiscourseAutomation
           watching_tags = automation.trigger_field("watching_tags")
 
           if watching_tags["value"]
-            should_skip = false
-            watching_tags["value"].each do |tag|
-              should_skip = true if !removed_tags.empty? && !removed_tags.include?(tag)
-              should_skip = true if !added_tags.empty? && !added_tags.include?(tag)
-            end
-            next if should_skip
+            changed_tags = removed_tags + added_tags
+            is_ok = watching_tags["value"].any? { |tag| changed_tags.include?(tag) }
+            next if !is_ok
           end
 
           automation.trigger!(

--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -239,9 +239,8 @@ module DiscourseAutomation
           watching_tags = automation.trigger_field("watching_tags")
 
           if watching_tags["value"]
-            changed_tags = removed_tags + added_tags
-            is_ok = watching_tags["value"].any? { |tag| changed_tags.include?(tag) }
-            next if !is_ok
+            changed_tags = (removed_tags | added_tags)
+            next if (changed_tags & watching_tags["value"]).empty?
           end
 
           automation.trigger!(

--- a/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
+++ b/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
@@ -82,6 +82,54 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
     end
   end
 
+  context "when watching a few cool tags" do
+    fab!(:cool_tag_2) { Fabricate(:tag) }
+    fab!(:cool_tag_3) { Fabricate(:tag) }
+
+    before do
+      automation.upsert_field!(
+        "watching_tags",
+        "tags",
+        { value: [cool_tag.name, cool_tag_2.name, cool_tag_3.name] },
+        target: "trigger",
+      )
+      automation.reload
+    end
+
+    it "should fire the trigger if any tag is added" do
+      topic_0 = Fabricate(:topic, user: user, tags: [], category: category)
+
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(topic_0, Guardian.new(user), [cool_tag.name])
+        end
+
+      expect(list.length).to eq(1)
+      expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED)
+    end
+
+    it "should fire the trigger if any tag is removed" do
+      topic_0 = Fabricate(:topic, user: user, tags: [cool_tag], category: category)
+
+      list =
+        capture_contexts { DiscourseTagging.tag_topic_by_names(topic_0, Guardian.new(user), []) }
+
+      expect(list.length).to eq(1)
+      expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED)
+    end
+
+    it "should not fire if the tag is not present" do
+      topic_0 = Fabricate(:topic, user: user, tags: [], category: category)
+
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(topic_0, Guardian.new(user), [bad_tag.name])
+        end
+
+      expect(list.length).to eq(0)
+    end
+  end
+
   context "when watching a category" do
     before do
       automation.upsert_field!(

--- a/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
+++ b/plugins/automation/spec/triggers/topic_tags_changed_spec.rb
@@ -128,6 +128,18 @@ describe DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED do
 
       expect(list.length).to eq(0)
     end
+
+    it "should fire the trigger if a tag is add and one is removed" do
+      topic_0 = Fabricate(:topic, user: user, tags: [cool_tag], category: category)
+
+      list =
+        capture_contexts do
+          DiscourseTagging.tag_topic_by_names(topic_0, Guardian.new(user), [cool_tag_2.name])
+        end
+
+      expect(list.length).to eq(1)
+      expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED)
+    end
   end
 
   context "when watching a category" do


### PR DESCRIPTION
The check for when a rule had multiple tags was exclusive; you had to have all the tags to trigger the automation. Now, it's inclusive; you can trigger the automation if you have any of the tags.

