### PR TITLE
FEATURE: Allow add group member endpoint to skip invite emails

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -413,7 +413,12 @@ class GroupsController < ApplicationController
 
       emails.each do |email|
         begin
-          Invite.generate(current_user, email: email, group_ids: [group.id])
+          Invite.generate(
+            current_user,
+            email: email,
+            group_ids: [group.id],
+            skip_email: params[:skip_email].to_s == "true",
+          )
         rescue RateLimiter::LimitExceeded => e
           return(
             render_json_error(

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1707,6 +1707,23 @@ RSpec.describe GroupsController do
           end
         end
 
+        it "sends emails with invitations when `skip_emails` param isn't present" do
+          expect_enqueued_with(job: :invite_email) do
+            put "/groups/#{group.id}/members.json", params: { emails: "something@gmail.com" }
+            expect(response.status).to eq(200)
+          end
+        end
+
+        it "sends emails with invitations when `skip_emails` is present" do
+          expect_not_enqueued_with(job: :invite_email) do
+            put "/groups/#{group.id}/members.json?skip_email=true",
+                params: {
+                  emails: "something@gmail.com",
+                }
+            expect(response.status).to eq(200)
+          end
+        end
+
         it "displays warning when all members already exists" do
           user1.update!(username: "john")
           user2.update!(username: "alice")


### PR DESCRIPTION
This adds a `skip_email` param for inviting users to the forum by email, when you don't want the actual email to be sent. 