### PR TITLE
FIX: Missing translations for empty config area

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
@@ -91,7 +91,7 @@ export default class AdminConfigAreasEmojisList extends Component {
         @ctaLabel="admin.emoji.add"
         @ctaRoute="adminEmojis.new"
         @ctaClass="admin-emojis__add-emoji"
-        @emptyLabel="admin.emoji.no_emoji"
+        @emptyLabel={{i18n "admin.emoji.no_emoji"}}
       />
     {{/if}}
   </template>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
@@ -97,7 +97,7 @@ export default class AdminConfigAreasUserFieldsList extends Component {
           @ctaLabel="admin.user_fields.add"
           @ctaRoute="adminUserFields.new"
           @ctaClass="admin-user_fields__add-emoji"
-          @emptyLabel="admin.user_fields.no_user_fields"
+          @emptyLabel={{i18n "admin.user_fields.no_user_fields"}}
         />
       {{/if}}
     </div>

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -73,11 +72,9 @@ export default class DashboardNewFeatures extends Component {
           </AdminConfigAreaCard>
         {{else}}
           <AdminConfigAreaEmptyList
-            @emptyLabel={{htmlSafe
-              (i18n
-                "admin.dashboard.new_features.previous_announcements"
-                url="https://meta.discourse.org/tags/c/announcements/67/release-notes"
-              )
+            @emptyLabel={{i18n
+              "admin.dashboard.new_features.previous_announcements"
+              url="https://meta.discourse.org/tags/c/announcements/67/release-notes"
             }}
           />
         {{/each}}

--- a/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
@@ -127,7 +127,7 @@
               @ctaLabel="admin.permalink.add"
               @ctaRoute="adminPermalinks.new"
               @ctaClass="admin-permalinks__add-permalink"
-              @emptyLabel="admin.permalink.no_permalinks"
+              @emptyLabel={{i18n "admin.permalink.no_permalinks"}}
             />
           {{/if}}
         {{/if}}


### PR DESCRIPTION
Fixes these: 

<img width="527" alt="image" src="https://github.com/user-attachments/assets/c4f7e966-8ea0-4fbc-a076-a5f322261dd1">

<img width="527" alt="image" src="https://github.com/user-attachments/assets/4bde01fa-02d0-4ca4-823c-0d371c4cbac1">
