### PR TITLE
DEV: Ensure `post.updateFromPost` syncs tracked properties

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -2147,16 +2147,13 @@ class PluginApi {
    *
    * ```
    * const IconWithDropdown = <template>
-    *
-    <DMenu @icon="foo" title={{i18n "title"}}>
-      *
-      <:content as |args|>
-        *       dropdown content here
-        *
-        <DButton @action={{args.close}} @icon="bar" />
-        *     </:content>
-      *   </DMenu>
-    * </template>;
+   *   <DMenu @icon="foo" title={{i18n "title"}}>
+   *     <:content as |args|>
+   *       dropdown content here
+   *       <DButton @action={{args.close}} @icon="bar" />
+   *     </:content>
+   *   </DMenu>
+   * </template>;
    *
    * api.headerIcons.add("icon-name", IconWithDropdown, { before: "search" })
    * ```

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -820,8 +820,15 @@ class PluginApi {
     includeAttributes(...attributes);
   }
 
-  addTrackedPostProperty(name, value) {
-    _addTrackedPostProperty(name, value);
+  /**
+   * Adds a tracked property to the post model.
+   *
+   * This method is used to mark a property as tracked for post updates.
+   *
+   * @param {string} name - The name of the property to track.
+   */
+  addTrackedPostProperty(name) {
+    _addTrackedPostProperty(name);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.38.0";
+export const PLUGIN_API_VERSION = "1.39.0";
 
 import $ from "jquery";
 import { h } from "virtual-dom";
@@ -119,6 +119,7 @@ import Composer, {
   registerCustomizationCallback,
 } from "discourse/models/composer";
 import { addNavItem } from "discourse/models/nav-item";
+import { _addTrackedPostProperty } from "discourse/models/post";
 import { registerCustomLastUnreadUrlCallback } from "discourse/models/topic";
 import {
   addSaveableUserField,
@@ -817,6 +818,10 @@ class PluginApi {
    **/
   includePostAttributes(...attributes) {
     includeAttributes(...attributes);
+  }
+
+  addTrackedPostProperty(name, value) {
+    _addTrackedPostProperty(name, value);
   }
 
   /**
@@ -2135,13 +2140,16 @@ class PluginApi {
    *
    * ```
    * const IconWithDropdown = <template>
-   *   <DMenu @icon="foo" title={{i18n "title"}}>
-   *     <:content as |args|>
-   *       dropdown content here
-   *       <DButton @action={{args.close}} @icon="bar" />
-   *     </:content>
-   *   </DMenu>
-   * </template>;
+    *
+    <DMenu @icon="foo" title={{i18n "title"}}>
+      *
+      <:content as |args|>
+        *       dropdown content here
+        *
+        <DButton @action={{args.close}} @icon="bar" />
+        *     </:content>
+      *   </DMenu>
+    * </template>;
    *
    * api.headerIcons.add("icon-name", IconWithDropdown, { before: "search" })
    * ```

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -10,6 +10,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { propertyEqual } from "discourse/lib/computed";
 import { cook } from "discourse/lib/text";
 import { fancyTitle } from "discourse/lib/topic-fancy-title";
+import { defineTrackedProperty } from "discourse/lib/tracked-tools";
 import { userPath } from "discourse/lib/url";
 import { postUrl } from "discourse/lib/utilities";
 import ActionSummary from "discourse/models/action-summary";
@@ -19,6 +20,39 @@ import Site from "discourse/models/site";
 import User from "discourse/models/user";
 import discourseComputed from "discourse-common/utils/decorators";
 import { i18n } from "discourse-i18n";
+
+const pluginTrackedProperties = new Map();
+const trackedPropertiesForPostUpdate = new Set();
+
+/**
+ * @internal
+ * Adds a tracked property to the post model.
+ *
+ * Intended to be used only in the plugin API.
+ *
+ * @param {string} propertyKey - The key of the property to track.
+ * @param {*} value - The initial value of the property.
+ */
+export function _addTrackedPostProperty(propertyKey, value) {
+  pluginTrackedProperties.set(propertyKey, value);
+  trackedPropertiesForPostUpdate.add(propertyKey);
+}
+
+/**
+ * Decorator to mark a property as post property as tracked.
+ *
+ * It extends the standard Ember @tracked behavior to also keep track of the fields
+ * that need to be copied when using `post.updateFromPost`.
+ *
+ * @param {Object} target - The target object.
+ * @param {string} propertyKey - The key of the property to track.
+ * @param {PropertyDescriptor} descriptor - The property descriptor.
+ * @returns {PropertyDescriptor} The updated property descriptor.
+ */
+function trackedPostProperty(target, propertyKey, descriptor) {
+  trackedPropertiesForPostUpdate.add(propertyKey);
+  return tracked(target, propertyKey, descriptor);
+}
 
 export default class Post extends RestModel {
   static munge(json) {
@@ -107,17 +141,22 @@ export default class Post extends RestModel {
   @service currentUser;
   @service site;
 
-  @tracked bookmarked;
-  @tracked can_delete;
-  @tracked can_edit;
-  @tracked can_permanently_delete;
-  @tracked can_recover;
-  @tracked deleted_at;
-  @tracked likeAction;
-  @tracked post_type;
-  @tracked user_deleted;
-  @tracked user_id;
-  @tracked yours;
+  // Use @trackedPostProperty here instead of Glimmer's @tracked because we need to know which properties are tracked
+  // in order to correctly update the post in the updateFromPost method. Currently this is not possible using only
+  // the standard tracked method because these properties are added to the class prototype and are not enumarated by
+  // object.keys().
+  // See https://github.com/emberjs/ember.js/issues/18220
+  @trackedPostProperty bookmarked;
+  @trackedPostProperty can_delete;
+  @trackedPostProperty can_edit;
+  @trackedPostProperty can_permanently_delete;
+  @trackedPostProperty can_recover;
+  @trackedPostProperty deleted_at;
+  @trackedPostProperty likeAction;
+  @trackedPostProperty post_type;
+  @trackedPostProperty user_deleted;
+  @trackedPostProperty user_id;
+  @trackedPostProperty yours;
 
   customShare = null;
 
@@ -131,6 +170,15 @@ export default class Post extends RestModel {
 
   // Posts can show up as deleted if the topic is deleted
   @and("firstPost", "topic.deleted_at") deletedViaTopic;
+
+  constructor() {
+    super(...arguments);
+
+    // adds tracked properties defined by plugin to the instance
+    pluginTrackedProperties.forEach((value, key) => {
+      defineTrackedProperty(this, key, value);
+    });
+  }
 
   @discourseComputed("url", "customShare")
   shareUrl(url) {
@@ -466,35 +514,37 @@ export default class Post extends RestModel {
   }
 
   /**
-   Updates a post from another's attributes. This will normally happen when a post is loading but
-   is already found in an identity map.
+   * Updates a post from another's attributes. This will normally happen when a post is loading but
+   * is already found in an identity map.
    **/
   updateFromPost(otherPost) {
-    Object.keys(otherPost).forEach((key) => {
-      let value = otherPost[key],
-        oldValue = this[key];
+    [...Object.keys(otherPost), ...trackedPropertiesForPostUpdate].forEach(
+      (key) => {
+        let value = otherPost[key],
+          oldValue = this[key];
 
-      if (!value) {
-        value = null;
-      }
-      if (!oldValue) {
-        oldValue = null;
-      }
-
-      let skip = false;
-      if (typeof value !== "function" && oldValue !== value) {
-        // wishing for an identity map
-        if (key === "reply_to_user" && value && oldValue) {
-          skip =
-            value.username === oldValue.username ||
-            get(value, "username") === get(oldValue, "username");
+        if (!value) {
+          value = null;
+        }
+        if (!oldValue) {
+          oldValue = null;
         }
 
-        if (!skip) {
-          this.set(key, value);
+        let skip = false;
+        if (typeof value !== "function" && oldValue !== value) {
+          // wishing for an identity map
+          if (key === "reply_to_user" && value && oldValue) {
+            skip =
+              value.username === oldValue.username ||
+              get(value, "username") === get(oldValue, "username");
+          }
+
+          if (!skip) {
+            this.set(key, value);
+          }
         }
       }
-    });
+    );
   }
 
   expandHidden() {

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -82,6 +82,7 @@ import { resetUserSearchCache } from "discourse/lib/user-search";
 import { resetComposerCustomizations } from "discourse/models/composer";
 import { clearAuthMethods } from "discourse/models/login-method";
 import { clearNavItems } from "discourse/models/nav-item";
+import { clearAddedTrackedPostProperties } from "discourse/models/post";
 import { resetLastEditNotificationClick } from "discourse/models/post-stream";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
@@ -257,6 +258,7 @@ export function testCleanup(container, app) {
   clearPluginHeaderActionComponents();
   clearRegisteredTabs();
   resetNeedsHbrTopicList();
+  clearAddedTrackedPostProperties();
 }
 
 function cleanupCssGeneratorTags() {

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.38.0] - 2024-10-30
 
-- Added `registerMoreTopicsTab` and "more-topics-tabs" value transformer that allows to add or remove new tabs to the "
-  more topics" (suggested/related) area.
+- Added `registerMoreTopicsTab` and "more-topics-tabs" value transformer that allows to add or remove new tabs to the "more topics" (suggested/related) area.
 
 ## [1.37.3] - 2024-10-24
 
@@ -22,42 +21,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.37.2] - 2024-10-02
 
-- Fixed comments and text references to Font Awesome 5 in favor of the more generic Font Awesome due to core now having
-  the latest version and no longer needing to specify version 5.
+- Fixed comments and text references to Font Awesome 5 in favor of the more generic Font Awesome due to core now having the latest version and no longer needing to specify version 5.
 
 ## [1.37.1] - 2024-08-21
 
-- Added support for `shortcut` in `addComposerToolbarPopupMenuOption` which allows to add a keyboard shortcut to the
-  popup menu option.
+- Added support for `shortcut` in `addComposerToolbarPopupMenuOption` which allows to add a keyboard shortcut to the popup menu option.
 
 ## [1.37.0] - 2024-08-19
 
-- Added `addAboutPageActivity` which allows plugins/TCs to register a custom site activity item in the new /about page.
-  Requires the server-side `register_stat` plugin API.
+- Added `addAboutPageActivity` which allows plugins/TCs to register a custom site activity item in the new /about page. Requires the server-side `register_stat` plugin API.
 
 ## [1.36.0] - 2024-08-06
 
-- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked
-  and before a search log is created
+- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked and before a search log is created
 
 ## [1.35.0] - 2024-07-30
 
-- Added `registerBehaviorTransformer` which allows registering a transformer callback to override behavior defined in
-  Discourse modules
-- Added `addBehaviorTransformerName` which allows plugins/TCs to register a new transformer to override behavior defined
-  in their modules
+- Added `registerBehaviorTransformer` which allows registering a transformer callback to override behavior defined in Discourse modules
+- Added `addBehaviorTransformerName` which allows plugins/TCs to register a new transformer to override behavior defined in their modules
 
 ## [1.34.0] - 2024-06-06
 
-- Added `registerValueTransformer` which allows registering a transformer callback to override values defined in
-  Discourse modules
-- Added `addValueTransformerName` which allows plugins/TCs to register a new transformer to override values defined in
-  their modules
+- Added `registerValueTransformer` which allows registering a transformer callback to override values defined in Discourse modules
+- Added `addValueTransformerName` which allows plugins/TCs to register a new transformer to override values defined in their modules
 
 ## [1.33.0] - 2024-06-06
 
-- Added `addCustomUserFieldValidationCallback` which allows to set a callback to change the validation and user facing
-  message when attempting to save the signup form.
+- Added `addCustomUserFieldValidationCallback` which allows to set a callback to change the validation and user facing message when attempting to save the signup form.
 
 ## [1.32.0] - 2024-05-16
 
@@ -69,18 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.30.0] - 2024-03-20
 
-- Added `addAdminPluginConfigurationNav`, which defines a list of links used in the adminPlugins.show page for a
-  specific plugin, and displays them either in an inner sidebar or in a top horizontal nav.
+- Added `addAdminPluginConfigurationNav`, which defines a list of links used in the adminPlugins.show page for a specific plugin, and displays them either in an inner sidebar or in a top horizontal nav.
 
 ## [1.29.0] - 2024-03-05
 
-- Added `headerButtons` which allows for manipulation of the header buttons. This includes, adding, removing, or
-  modifying the order of buttons.
+- Added `headerButtons` which allows for manipulation of the header buttons. This includes, adding, removing, or modifying the order of buttons.
 
 ## [1.28.0] - 2024-02-21
 
-- Added `headerIcons` which allows for manipulation of the header icons. This includes, adding, removing, or modifying
-  the order of icons.
+- Added `headerIcons` which allows for manipulation of the header icons. This includes, adding, removing, or modifying the order of icons.
 
 ## [1.27.0] - 2024-02-21
 
@@ -93,78 +80,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.25.0] - 2024-02-05
 
-- Added `addComposerImageWrapperButton` which is used to add a custom button to the composer preview's image wrapper
-  that appears on hover of an uploaded image.
+- Added `addComposerImageWrapperButton` which is used to add a custom button to the composer preview's image wrapper that appears on hover of an uploaded image.
 
 ## [1.24.0] - 2024-01-08
 
-- Added `addAdminSidebarSectionLink` which is used to add a link to a specific admin sidebar section, as a replacement
-  for the `admin-menu` plugin outlet. This only has an effect if the `admin_sidebar_enabled_groups` site setting is in
-  use, which enables the new admin nav sidebar.
+- Added `addAdminSidebarSectionLink` which is used to add a link to a specific admin sidebar section, as a replacement for the `admin-menu` plugin outlet. This only has an effect if the `admin_sidebar_enabled_groups` site setting is in use, which enables the new admin nav sidebar.
 
 ## [1.23.0] - 2024-01-03
 
 ### Added
 
-- Added `setUserMenuNotificationsLimit` function which is used to specify a new limit for the notifications query when
-  the user menu is opened.
+- Added `setUserMenuNotificationsLimit` function which is used to specify a new limit for the notifications query when the user menu is opened.
 
 ## [1.21.0] - 2023-12-22
 
 ### Added
 
-- Added `includeUserFieldPropertiesOnSave` function, which includes the passed user field properties in the user field
-  save request. This is useful for plugins that are adding additional columns to the user field model and want to save
-  the new property values alongside the default user field properties (all under the same save call).
+- Added `includeUserFieldPropertiesOnSave` function, which includes the passed user field properties in the user field save request. This is useful for plugins that are adding additional columns to the user field model and want to save the new property values alongside the default user field properties (all under the same save call).
+
 
 ## [1.20.0] - 2023-12-20
 
 ### Added
 
-- Added `addSearchMenuAssistantSelectCallback` function, which is used to override the behavior of clicking a search
-  menu assistant item. If any callback returns false, the core behavior will not be executed.
+- Added `addSearchMenuAssistantSelectCallback` function, which is used to override the behavior of clicking a search menu assistant item. If any callback returns false, the core behavior will not be executed.
 
 ## [1.19.0] - 2023-12-13
 
 ### Added
 
-- Added `setNotificationsLimit` function, which sets a new limit for how many notifications are loaded for the user
-  notifications route
+- Added `setNotificationsLimit` function, which sets a new limit for how many notifications are loaded for the user notifications route
 
-- Added `addBeforeLoadMoreNotificationsCallback` function, which takes a function as the argument. All added callbacks
-  are evaluated before `loadMore` is triggered for user notifications. If any callback returns false, notifications will
-  not be loaded.
+- Added `addBeforeLoadMoreNotificationsCallback` function, which takes a function as the argument. All added callbacks are evaluated before `loadMore` is triggered for user notifications. If any callback returns false, notifications will not be loaded.
 
 ## [1.18.0] - 2023-12-1
 
 ### Added
 
-- Added `setDesktopTopicTimelineScrollAreaHeight` function, which takes an object with min/max key value pairs as an
-  argument. This is used to adjust the height of the topic timeline on desktop without CSS hacks that break the
-  functionality of the topic timeline.
+- Added `setDesktopTopicTimelineScrollAreaHeight` function, which takes an object with min/max key value pairs as an argument. This is used to adjust the height of the topic timeline on desktop without CSS hacks that break the functionality of the topic timeline.
 
 ## [1.17.0] - 2023-11-30
 
 ### Added
 
-- Introduces `forceDropdownAnimationForMenuPanels` API for forcing one or many Menu Panels (search-menu, user-menu, etc)
-  to be rendered as a dropdown. This can be useful for plugins as the default behavior is to add a 'slide-in' behavior
-  to a menu panel if you are viewing on a small screen. eg. mobile.
+- Introduces `forceDropdownAnimationForMenuPanels` API for forcing one or many Menu Panels (search-menu, user-menu, etc) to be rendered as a dropdown. This can be useful for plugins as the default behavior is to add a 'slide-in' behavior to a menu panel if you are viewing on a small screen. eg. mobile.
 
 ## [1.16.0] - 2023-11-17
 
 ### Added
 
-- Added `recurrenceRule` option to `downloadCalendar`, this can be used to set recurring events in the calendar. Rule
-  syntax can be found at https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10.
+- Added `recurrenceRule` option to `downloadCalendar`, this can be used to set recurring events in the calendar. Rule syntax can be found at https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10.
 
 ## [1.15.0] - 2023-10-18
 
 ### Added
 
-- Added `hidden` option to `addSidebarPanel`, this can be used to remove the panel from combined sidebar mode as well as
-  hiding its switch button. Useful for cases where only one sidebar should be shown at a time regardless of other
-  panels.
+- Added `hidden` option to `addSidebarPanel`, this can be used to remove the panel from combined sidebar mode as well as hiding its switch button. Useful for cases where only one sidebar should be shown at a time regardless of other panels.
 - Added `getSidebarPanel` function, which returns the current sidebar panel object for comparison.
 
 ## [1.14.0] - 2023-10-06
@@ -209,11 +180,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds `showSidebarSwitchPanelButtons` which is experimental, and allows plugins to show sidebar switch panel buttons in
-  separated mode
+- Adds `showSidebarSwitchPanelButtons` which is experimental, and allows plugins to show sidebar switch panel buttons in separated mode
 
-- Adds `hideSidebarSwitchPanelButtons` which is experimental, and allows plugins to hide sidebar switch panel buttons in
-  separated mode
+- Adds `hideSidebarSwitchPanelButtons` which is experimental, and allows plugins to hide sidebar switch panel buttons in separated mode
 
 ## [1.8.1] - 2023-08-08
 
@@ -224,7 +193,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.0] - 2023-07-18
 
 ### Added
-
 - Adds `addSidebarPanel` which is experimental, and adds a Sidebar panel by returning a class which extends from the
   BaseCustomSidebarPanel class.
 

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,9 +7,14 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.39.0] - 2024-11-27
+
+- Added `addTrackedPostProperty` which allows plugins/TCs to add a new tracked property to the post model.
+
 ## [1.38.0] - 2024-10-30
 
-- Added `registerMoreTopicsTab` and "more-topics-tabs" value transformer that allows to add or remove new tabs to the "more topics" (suggested/related) area.
+- Added `registerMoreTopicsTab` and "more-topics-tabs" value transformer that allows to add or remove new tabs to the "
+  more topics" (suggested/related) area.
 
 ## [1.37.3] - 2024-10-24
 
@@ -17,33 +22,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.37.2] - 2024-10-02
 
-- Fixed comments and text references to Font Awesome 5 in favor of the more generic Font Awesome due to core now having the latest version and no longer needing to specify version 5.
+- Fixed comments and text references to Font Awesome 5 in favor of the more generic Font Awesome due to core now having
+  the latest version and no longer needing to specify version 5.
 
 ## [1.37.1] - 2024-08-21
 
-- Added support for `shortcut` in `addComposerToolbarPopupMenuOption` which allows to add a keyboard shortcut to the popup menu option.
+- Added support for `shortcut` in `addComposerToolbarPopupMenuOption` which allows to add a keyboard shortcut to the
+  popup menu option.
 
 ## [1.37.0] - 2024-08-19
 
-- Added `addAboutPageActivity` which allows plugins/TCs to register a custom site activity item in the new /about page. Requires the server-side `register_stat` plugin API.
+- Added `addAboutPageActivity` which allows plugins/TCs to register a custom site activity item in the new /about page.
+  Requires the server-side `register_stat` plugin API.
 
 ## [1.36.0] - 2024-08-06
 
-- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked and before a search log is created
+- Added `addLogSearchLinkClickedCallbacks` which allows plugins/TCs to register a callback when a search link is clicked
+  and before a search log is created
 
 ## [1.35.0] - 2024-07-30
 
-- Added `registerBehaviorTransformer` which allows registering a transformer callback to override behavior defined in Discourse modules
-- Added `addBehaviorTransformerName` which allows plugins/TCs to register a new transformer to override behavior defined in their modules
+- Added `registerBehaviorTransformer` which allows registering a transformer callback to override behavior defined in
+  Discourse modules
+- Added `addBehaviorTransformerName` which allows plugins/TCs to register a new transformer to override behavior defined
+  in their modules
 
 ## [1.34.0] - 2024-06-06
 
-- Added `registerValueTransformer` which allows registering a transformer callback to override values defined in Discourse modules
-- Added `addValueTransformerName` which allows plugins/TCs to register a new transformer to override values defined in their modules
+- Added `registerValueTransformer` which allows registering a transformer callback to override values defined in
+  Discourse modules
+- Added `addValueTransformerName` which allows plugins/TCs to register a new transformer to override values defined in
+  their modules
 
 ## [1.33.0] - 2024-06-06
 
-- Added `addCustomUserFieldValidationCallback` which allows to set a callback to change the validation and user facing message when attempting to save the signup form.
+- Added `addCustomUserFieldValidationCallback` which allows to set a callback to change the validation and user facing
+  message when attempting to save the signup form.
 
 ## [1.32.0] - 2024-05-16
 
@@ -55,15 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.30.0] - 2024-03-20
 
-- Added `addAdminPluginConfigurationNav`, which defines a list of links used in the adminPlugins.show page for a specific plugin, and displays them either in an inner sidebar or in a top horizontal nav.
+- Added `addAdminPluginConfigurationNav`, which defines a list of links used in the adminPlugins.show page for a
+  specific plugin, and displays them either in an inner sidebar or in a top horizontal nav.
 
 ## [1.29.0] - 2024-03-05
 
-- Added `headerButtons` which allows for manipulation of the header buttons. This includes, adding, removing, or modifying the order of buttons.
+- Added `headerButtons` which allows for manipulation of the header buttons. This includes, adding, removing, or
+  modifying the order of buttons.
 
 ## [1.28.0] - 2024-02-21
 
-- Added `headerIcons` which allows for manipulation of the header icons. This includes, adding, removing, or modifying the order of icons.
+- Added `headerIcons` which allows for manipulation of the header icons. This includes, adding, removing, or modifying
+  the order of icons.
 
 ## [1.27.0] - 2024-02-21
 
@@ -76,62 +93,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.25.0] - 2024-02-05
 
-- Added `addComposerImageWrapperButton` which is used to add a custom button to the composer preview's image wrapper that appears on hover of an uploaded image.
+- Added `addComposerImageWrapperButton` which is used to add a custom button to the composer preview's image wrapper
+  that appears on hover of an uploaded image.
 
 ## [1.24.0] - 2024-01-08
 
-- Added `addAdminSidebarSectionLink` which is used to add a link to a specific admin sidebar section, as a replacement for the `admin-menu` plugin outlet. This only has an effect if the `admin_sidebar_enabled_groups` site setting is in use, which enables the new admin nav sidebar.
+- Added `addAdminSidebarSectionLink` which is used to add a link to a specific admin sidebar section, as a replacement
+  for the `admin-menu` plugin outlet. This only has an effect if the `admin_sidebar_enabled_groups` site setting is in
+  use, which enables the new admin nav sidebar.
 
 ## [1.23.0] - 2024-01-03
 
 ### Added
 
-- Added `setUserMenuNotificationsLimit` function which is used to specify a new limit for the notifications query when the user menu is opened.
+- Added `setUserMenuNotificationsLimit` function which is used to specify a new limit for the notifications query when
+  the user menu is opened.
 
 ## [1.21.0] - 2023-12-22
 
 ### Added
 
-- Added `includeUserFieldPropertiesOnSave` function, which includes the passed user field properties in the user field save request. This is useful for plugins that are adding additional columns to the user field model and want to save the new property values alongside the default user field properties (all under the same save call).
-
+- Added `includeUserFieldPropertiesOnSave` function, which includes the passed user field properties in the user field
+  save request. This is useful for plugins that are adding additional columns to the user field model and want to save
+  the new property values alongside the default user field properties (all under the same save call).
 
 ## [1.20.0] - 2023-12-20
 
 ### Added
 
-- Added `addSearchMenuAssistantSelectCallback` function, which is used to override the behavior of clicking a search menu assistant item. If any callback returns false, the core behavior will not be executed.
+- Added `addSearchMenuAssistantSelectCallback` function, which is used to override the behavior of clicking a search
+  menu assistant item. If any callback returns false, the core behavior will not be executed.
 
 ## [1.19.0] - 2023-12-13
 
 ### Added
 
-- Added `setNotificationsLimit` function, which sets a new limit for how many notifications are loaded for the user notifications route
+- Added `setNotificationsLimit` function, which sets a new limit for how many notifications are loaded for the user
+  notifications route
 
-- Added `addBeforeLoadMoreNotificationsCallback` function, which takes a function as the argument. All added callbacks are evaluated before `loadMore` is triggered for user notifications. If any callback returns false, notifications will not be loaded.
+- Added `addBeforeLoadMoreNotificationsCallback` function, which takes a function as the argument. All added callbacks
+  are evaluated before `loadMore` is triggered for user notifications. If any callback returns false, notifications will
+  not be loaded.
 
 ## [1.18.0] - 2023-12-1
 
 ### Added
 
-- Added `setDesktopTopicTimelineScrollAreaHeight` function, which takes an object with min/max key value pairs as an argument. This is used to adjust the height of the topic timeline on desktop without CSS hacks that break the functionality of the topic timeline.
+- Added `setDesktopTopicTimelineScrollAreaHeight` function, which takes an object with min/max key value pairs as an
+  argument. This is used to adjust the height of the topic timeline on desktop without CSS hacks that break the
+  functionality of the topic timeline.
 
 ## [1.17.0] - 2023-11-30
 
 ### Added
 
-- Introduces `forceDropdownAnimationForMenuPanels` API for forcing one or many Menu Panels (search-menu, user-menu, etc) to be rendered as a dropdown. This can be useful for plugins as the default behavior is to add a 'slide-in' behavior to a menu panel if you are viewing on a small screen. eg. mobile.
+- Introduces `forceDropdownAnimationForMenuPanels` API for forcing one or many Menu Panels (search-menu, user-menu, etc)
+  to be rendered as a dropdown. This can be useful for plugins as the default behavior is to add a 'slide-in' behavior
+  to a menu panel if you are viewing on a small screen. eg. mobile.
 
 ## [1.16.0] - 2023-11-17
 
 ### Added
 
-- Added `recurrenceRule` option to `downloadCalendar`, this can be used to set recurring events in the calendar. Rule syntax can be found at https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10.
+- Added `recurrenceRule` option to `downloadCalendar`, this can be used to set recurring events in the calendar. Rule
+  syntax can be found at https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10.
 
 ## [1.15.0] - 2023-10-18
 
 ### Added
 
-- Added `hidden` option to `addSidebarPanel`, this can be used to remove the panel from combined sidebar mode as well as hiding its switch button. Useful for cases where only one sidebar should be shown at a time regardless of other panels.
+- Added `hidden` option to `addSidebarPanel`, this can be used to remove the panel from combined sidebar mode as well as
+  hiding its switch button. Useful for cases where only one sidebar should be shown at a time regardless of other
+  panels.
 - Added `getSidebarPanel` function, which returns the current sidebar panel object for comparison.
 
 ## [1.14.0] - 2023-10-06
@@ -176,9 +209,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds `showSidebarSwitchPanelButtons` which is experimental, and allows plugins to show sidebar switch panel buttons in separated mode
+- Adds `showSidebarSwitchPanelButtons` which is experimental, and allows plugins to show sidebar switch panel buttons in
+  separated mode
 
-- Adds `hideSidebarSwitchPanelButtons` which is experimental, and allows plugins to hide sidebar switch panel buttons in separated mode
+- Adds `hideSidebarSwitchPanelButtons` which is experimental, and allows plugins to hide sidebar switch panel buttons in
+  separated mode
 
 ## [1.8.1] - 2023-08-08
 
@@ -189,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.8.0] - 2023-07-18
 
 ### Added
+
 - Adds `addSidebarPanel` which is experimental, and adds a Sidebar panel by returning a class which extends from the
   BaseCustomSidebarPanel class.
 


### PR DESCRIPTION
This PR ensures that tracked properties added to the post model are correctly synced when using `post.updateFromPost`.

It also introduces a plugin API to allow plugins to register new tracked properties in the post model without needing to modify the class