### PR TITLE
FIX: Reset likeAction when updating a cached post from JSON data

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -22,6 +22,7 @@ import { i18n } from "discourse-i18n";
 
 export default class Post extends RestModel {
   static munge(json) {
+    json.likeAction = null;
     if (json.actions_summary) {
       const lookup = EmberObject.create();
 

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -102,8 +102,8 @@ module("Unit | Model | post", function (hooks) {
     post.likeAction = { count: 1 };
     assert.deepEqual(post.likeAction, { count: 1 }, "likeAction set");
 
-    // creating a new post with the same id should reset the likeAction because the information required to properly
-    // generate the field is not available
+    // creating a new record with the same id should reset the likeAction in the original post because instance
+    // is cached and the information required to properly generate the field is not available in the new JSON data
     this.store.createRecord("post", {
       id: 1173,
     });

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -93,4 +93,21 @@ module("Unit | Model | post", function (hooks) {
     assert.ok(post.cooked !== originalCooked, "the cooked content changed");
     assert.strictEqual(post.version, 2, "the version number increased");
   });
+
+  test("likeAction", function (assert) {
+    const post = this.store.createRecord("post", {
+      id: 1173,
+    });
+
+    post.likeAction = { count: 1 };
+    assert.deepEqual(post.likeAction, { count: 1 }, "likeAction set");
+
+    // creating a new post with the same id should reset the likeAction because the information required to properly
+    // generate the field is not available
+    this.store.createRecord("post", {
+      id: 1173,
+    });
+
+    assert.ok(post.likeAction === null, "likeAction was reset to null");
+  });
 });


### PR DESCRIPTION
This PR addresses an issue where the `like button` would not be updated properly when reloading a post that lost the only like it had received.