### PR TITLE
DEV: fix flaky spec

### DIFF
--- a/spec/lib/scheduler/defer_spec.rb
+++ b/spec/lib/scheduler/defer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Scheduler::Defer do
     @defer.later("second") {}
     @defer.later("bad") { raise "boom" }
 
-    wait_for(200) { @defer.length == 0 }
+    @defer.stop!(finish_work: true)
 
     stats = Hash[@defer.stats]
 
@@ -105,11 +105,8 @@ RSpec.describe Scheduler::Defer do
 
   it "can queue jobs properly" do
     s = nil
-
     @defer.later { s = "good" }
-
-    wait_for(1000) { s == "good" }
-
+    @defer.stop!(finish_work: true)
     expect(s).to eq("good")
   end
 


### PR DESCRIPTION
Spec was flaky cause work could still be in pipeline after the defer
length is 0. Our length denotes the backlog, not the in progress
count.

This adds a mechanism for gracefully stopping the queue and avoids
wait_for callse
