### PR TITLE
DEV: Consistent AdminConfigAreaEmptyList options

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-area-empty-list.gjs
@@ -1,23 +1,33 @@
+import Component from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
+import { i18n } from "discourse-i18n";
 
-const AdminConfigAreaEmptyList = <template>
-  <div class="admin-config-area-empty-list">
-    {{htmlSafe @emptyLabel}}
+export default class AdminConfigAreaEmptyList extends Component {
+  get emptyLabel() {
+    if (this.args.emptyLabelTranslated) {
+      return this.args.emptyLabelTranslated;
+    }
 
-    {{#if @ctaLabel}}
-      <DButton
-        @label={{@ctaLabel}}
-        class={{concatClass
-          "btn-default btn-small admin-config-area-empty-list__cta-button"
-          @ctaClass
-        }}
-        @action={{@ctaAction}}
-        @route={{@ctaRoute}}
-      />
-    {{/if}}
-  </div>
-</template>;
+    return i18n(this.args.emptyLabel);
+  }
 
-export default AdminConfigAreaEmptyList;
+  <template>
+    <div class="admin-config-area-empty-list">
+      {{htmlSafe this.emptyLabel}}
+
+      {{#if @ctaLabel}}
+        <DButton
+          @label={{@ctaLabel}}
+          class={{concatClass
+            "btn-default btn-small admin-config-area-empty-list__cta-button"
+            @ctaClass
+          }}
+          @action={{@ctaAction}}
+          @route={{@ctaRoute}}
+        />
+      {{/if}}
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
@@ -91,7 +91,7 @@ export default class AdminConfigAreasEmojisList extends Component {
         @ctaLabel="admin.emoji.add"
         @ctaRoute="adminEmojis.new"
         @ctaClass="admin-emojis__add-emoji"
-        @emptyLabel={{i18n "admin.emoji.no_emoji"}}
+        @emptyLabel="admin.emoji.no_emoji"
       />
     {{/if}}
   </template>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
@@ -97,7 +97,7 @@ export default class AdminConfigAreasUserFieldsList extends Component {
           @ctaLabel="admin.user_fields.add"
           @ctaRoute="adminUserFields.new"
           @ctaClass="admin-user_fields__add-emoji"
-          @emptyLabel={{i18n "admin.user_fields.no_user_fields"}}
+          @emptyLabel="admin.user_fields.no_user_fields"
         />
       {{/if}}
     </div>

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
@@ -72,7 +72,7 @@ export default class DashboardNewFeatures extends Component {
           </AdminConfigAreaCard>
         {{else}}
           <AdminConfigAreaEmptyList
-            @emptyLabel={{i18n
+            @emptyLabelTranslated={{i18n
               "admin.dashboard.new_features.previous_announcements"
               url="https://meta.discourse.org/tags/c/announcements/67/release-notes"
             }}

--- a/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
@@ -127,7 +127,7 @@
               @ctaLabel="admin.permalink.add"
               @ctaRoute="adminPermalinks.new"
               @ctaClass="admin-permalinks__add-permalink"
-              @emptyLabel={{i18n "admin.permalink.no_permalinks"}}
+              @emptyLabel="admin.permalink.no_permalinks"
             />
           {{/if}}
         {{/if}}


### PR DESCRIPTION
Followup ccc8e37dde6dd16de1f1103d60065c1b5afcbc6e

The fix above was good, but I would prefer to give
the option of untranslated vs translated label like
I have for other admin components for consistency.
