### PR TITLE
Update customer image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To learn more, visit [**discourse.org**](https://www.discourse.org) and join our
 
 <a href="https://twittercommunity.com/"><img alt="X Community" src="https://github.com/discourse/discourse/assets/2790986/ebb63eee-1927-4060-ada1-cf1bc774084c.png" width="720px"></a>
 
-<img src="https://user-images.githubusercontent.com/1681963/52239118-b304f800-289b-11e9-9904-16450680d9ec.jpg" alt="Mobile" width="414">
+<img width="414" alt="Mobile Preview" src="https://github.com/user-attachments/assets/6e209258-258a-48f9-8a31-1b7d9eee4b77">
 
 Browse [lots more notable Discourse instances](https://www.discourse.org/customers).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To learn more, visit [**discourse.org**](https://www.discourse.org) and join our
 
 <a href="https://blog.discourse.org/2023/08/discourse-3-1-is-here/"><img alt="Discourse 3.1" src="https://github-production-user-asset-6210df.s3.amazonaws.com/5862206/261215898-ae95f963-5ab4-4509-b87a-f9f6e9a109bf.png" width="720px"></a>
 
-<a href="https://bbs.boingboing.net"><img alt="Boing Boing" src="https://github-production-user-asset-6210df.s3.amazonaws.com/5862206/261580781-1413ac96-5d08-40b2-bc8e-27c3f2d3bfe6.png" width="720px"></a>
+<a href="https://forum.homeexchange.com"><img alt="HomeExchange" src="https://github.com/user-attachments/assets/42fbbd25-502f-4047-a348-c93fb99d7986" width="720px"></a>
 
 <a href="https://twittercommunity.com/"><img alt="X Community" src="https://github.com/discourse/discourse/assets/2790986/ebb63eee-1927-4060-ada1-cf1bc774084c.png" width="720px"></a>
 


### PR DESCRIPTION
Replace Boing Boing with HomeExchange forum. Also updated mobile preview image to replace Codecademy with OpenAI.

Before:

<img width="414" alt="Screenshot 2024-11-28 at 3 48 31 PM" src="https://github.com/user-attachments/assets/29da6fe6-fd60-4b6a-ad46-065f3b0afcc0">

After:

<img width="414" alt="Mobile Preview" src="https://github.com/user-attachments/assets/d0124602-15ad-434a-9ef0-148631361186">
