### PR TITLE
DEV: Fix flaky spec related to Scheduler::Defer

### DIFF
--- a/lib/scheduler/defer.rb
+++ b/lib/scheduler/defer.rb
@@ -136,8 +136,9 @@ module Scheduler
     rescue => ex
       Discourse.handle_job_exception(ex, message: "Processing deferred code queue")
     ensure
-      ActiveRecord::Base.connection.verify!
-      ActiveRecord::Base.connection_handler.clear_active_connections!
+      if ActiveRecord::Base.connection
+        ActiveRecord::Base.connection_handler.clear_active_connections!
+      end
       if start
         @stats_mutex.synchronize do
           stats = @stats[desc]


### PR DESCRIPTION
In some cases in CI env, it seems the AR connection isn’t available and the `ensure` block is executed. It’s calling `#verify!` on the connection, so it can fail sometimes. This is probably why `#clear_active_connections!` was failing too sometimes.

Here, we just check the connection is present before clearing the connections.