### PR TITLE
DEV: Increase pool connections to 2 in test environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -36,7 +36,7 @@ test:
   adapter: postgresql
   database: <%= test_db %>
   min_messages: warning
-  pool: 1
+  pool: 2
   reaping_frequency: 0
   checkout_timeout: <%= ENV["CHECKOUT_TIMEOUT"] || 5 %>
   host_names:


### PR DESCRIPTION
In our CI env, sometimes, we see problems regarding getting a connection from the pool. As it’s currently set to 1, increasing it a bit should fix that kind of issues.