### PR TITLE
DEV: Try fixing flaky spec related to Scheduler::Defer

### DIFF
--- a/lib/scheduler/defer.rb
+++ b/lib/scheduler/defer.rb
@@ -136,7 +136,7 @@ module Scheduler
     rescue => ex
       Discourse.handle_job_exception(ex, message: "Processing deferred code queue")
     ensure
-      if ActiveRecord::Base.connection
+      if ActiveRecord::Base.connection&.verify!
         ActiveRecord::Base.connection_handler.clear_active_connections!
       end
       if start


### PR DESCRIPTION
Checking if a connection is available is probably not enough, when the connection is available, we should still verify it’s not stale.