### PR TITLE
FIX: Bug with edit reason on iOS

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -49,6 +49,7 @@ function positioningWorkaround(fixedElement) {
     // - invoking emoji dropdown via : and hitting return
     // - invoking a button in the editor toolbar
     // - tapping on emoji in the emoji modal
+    // - tapping on the edit reason icon/input
 
     if (
       lastTouchedElement &&

--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -59,7 +59,8 @@ function positioningWorkaround(fixedElement) {
         (lastTouchedElement.nodeName === "TEXTAREA" &&
           document.activeElement === lastTouchedElement) ||
         lastTouchedElement.closest(".d-editor-button-bar") ||
-        lastTouchedElement.classList.contains("emoji"))
+        lastTouchedElement.classList.contains("emoji") ||
+        lastTouchedElement.closest(".display-edit-reason"))
     ) {
       return;
     }


### PR DESCRIPTION
See report https://meta.discourse.org/t/cant-focus-and-type-in-reason-for-editing-text-box-ios/271082

No tests because behaviour is only on iOS Safari and that isn't a test target. 