### PR TITLE
UX: Improve loading-slider behavior

### DIFF
--- a/app/assets/javascripts/discourse/app/services/loading-slider.js
+++ b/app/assets/javascripts/discourse/app/services/loading-slider.js
@@ -7,7 +7,7 @@ import { bind } from "discourse-common/utils/decorators";
 
 const STORE_LOADING_TIMES = 5;
 const DEFAULT_LOADING_TIME = 0.3;
-const MIN_LOADING_TIME = 0.1;
+const MIN_LOADING_TIME = 0.2;
 
 const STILL_LOADING_DURATION = 2;
 


### PR DESCRIPTION
- Use `requestAnimationFrame` when transitioning from `ready` -> `loading`. The previous `next()` implementation was unreliable, particularly in Safari, and would cause the loading slider to jump backwards instead of forwards

- Double the minimum transition time to 200ms. This avoids the rolling average being skewed too much by routes which load quickly without network access.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->