### PR TITLE
DEV: Deprecate `discourseModule`

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -268,10 +268,10 @@ function cleanupCssGeneratorTags() {
 }
 
 export function discourseModule(name, options) {
-  // deprecated(
-  //   `${name}: \`discourseModule\` is deprecated. Use QUnit's \`module\` instead.`,
-  //   { since: "2.6.0" }
-  // );
+  deprecated(
+    `${name}: \`discourseModule\` is deprecated. Use QUnit's \`module\` instead.`,
+    { id: "discourse.discourse-module", since: "3.4.0.beta3-dev" }
+  );
 
   if (typeof options === "function") {
     module(name, function (hooks) {


### PR DESCRIPTION
We're now using QUnit's `module` directly in core and all plugins/themes.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->