### PR TITLE
FEATURE: Add plugin outlets to parent category row for desktop

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/category-list-item.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { tagName } from "@ember-decorators/component";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import discourseComputed from "discourse-common/utils/decorators";
 
 const LIST_TYPE = {
@@ -39,5 +40,9 @@ export default class CategoryListItem extends Component {
   @discourseComputed("category.path")
   slugPath(categoryPath) {
     return categoryPath.substring("/c/".length);
+  }
+
+  applyValueTransformer(name, value, context) {
+    return applyValueTransformer(name, value, context);
   }
 }

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
@@ -5,6 +5,14 @@
   />
 
   {{#if this.site.mobileView}}
+    <PluginOutlet
+      @name="category-list-before-category-mobile"
+      @outletArgs={{hash
+        category=this.category
+        listType=this.listType
+        isMuted=this.isMuted
+      }}
+    />
     <div
       data-category-id={{this.category.id}}
       data-notification-level={{this.category.notificationLevelString}}
@@ -80,11 +88,16 @@
           'has-description'
           'no-description'
         }}
+        {{this.applyValueTransformer
+          'parent-category-row-class'
+          (array)
+          (hash category=this.category)
+        }}
         {{if this.category.uploaded_logo.url 'has-logo' 'no-logo'}}"
     >
 
       <PluginOutlet
-        @name="category-list-above-category-section"
+        @name="category-list-before-category-section"
         @outletArgs={{hash category=this.category listType=this.listType}}
       />
 
@@ -148,7 +161,7 @@
       </td>
 
       <PluginOutlet
-        @name="category-list-above-topics-section"
+        @name="category-list-before-topics-section"
         @outletArgs={{hash category=this.category}}
       />
 
@@ -166,7 +179,7 @@
       </td>
 
       <PluginOutlet
-        @name="category-list-below-topics-section"
+        @name="category-list-after-topics-section"
         @outletArgs={{hash category=this.category}}
       />
 
@@ -182,7 +195,7 @@
             {{/each}}
           </td>
           <PluginOutlet
-            @name="category-list-below-latest-section"
+            @name="category-list-after-latest-section"
             @outletArgs={{hash category=this.category}}
           />
         {{/if}}

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.hbs
@@ -82,6 +82,12 @@
         }}
         {{if this.category.uploaded_logo.url 'has-logo' 'no-logo'}}"
     >
+
+      <PluginOutlet
+        @name="category-list-above-category-section"
+        @outletArgs={{hash category=this.category listType=this.listType}}
+      />
+
       <td
         class="category {{if this.isMuted 'muted'}}"
         style={{category-color-variable this.category.color}}
@@ -141,6 +147,11 @@
         {{/if}}
       </td>
 
+      <PluginOutlet
+        @name="category-list-above-topics-section"
+        @outletArgs={{hash category=this.category}}
+      />
+
       <td class="topics">
         <div title={{this.category.statTitle}}>{{html-safe
             this.category.stat
@@ -154,6 +165,11 @@
         />
       </td>
 
+      <PluginOutlet
+        @name="category-list-below-topics-section"
+        @outletArgs={{hash category=this.category}}
+      />
+
       {{#unless this.isMuted}}
         {{#if this.showTopics}}
           <td class="latest">
@@ -165,6 +181,10 @@
               {{/if}}
             {{/each}}
           </td>
+          <PluginOutlet
+            @name="category-list-below-latest-section"
+            @outletArgs={{hash category=this.category}}
+          />
         {{/if}}
       {{/unless}}
     </tr>

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -16,4 +16,6 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "post-menu-buttons",
   "small-user-attrs",
   "topic-list-columns",
+  "parent-category-row-class",
+  "parent-category-row-class-mobile",
 ]);

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -13,9 +13,9 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "invite-simple-mode-topic",
   "mentions-class",
   "more-topics-tabs",
+  "parent-category-row-class-mobile",
+  "parent-category-row-class",
   "post-menu-buttons",
   "small-user-attrs",
   "topic-list-columns",
-  "parent-category-row-class",
-  "parent-category-row-class-mobile",
 ]);


### PR DESCRIPTION
Added 3 plugin outlets:

- `category-list-above-category-section` (above `td.category`)
- `category-list-above-topics-section` (above `td.topics`)
- `category-list-below-topics-section` (below `td.topics`)
