### PR TITLE
FIX: deduplicate css in mails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -374,18 +374,22 @@ module Email
       end
     end
 
-    def dedup_style(style)
-      style_instructions =
-        style.split(";").map(&:strip).select(&:present?).map { |s| s.split(":", 2).map(&:strip) }
+    def deduplicate_style(style)
       styles = {}
-      style_instructions.each { |key, value| styles[key] = value }
-      styles.map { |k, v| "#{k}:#{v}" }.join(";")
-    rescue StandardError
+
       style
+        .split(";")
+        .select(&:present?)
+        .map { _1.split(":", 2).map(&:strip) }
+        .each { |k, v| styles[k] = v if k.present? && v.present? }
+
+      styles.map { |k, v| "#{k}:#{v}" }.join(";")
     end
 
-    def dedup_styles
-      @fragment.css("[style]").each { |element| element["style"] = dedup_style element["style"] }
+    def deduplicate_styles
+      @fragment
+        .css("[style]")
+        .each { |element| element["style"] = deduplicate_style element["style"] }
     end
 
     def to_html
@@ -394,7 +398,7 @@ module Email
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
       strip_classes_and_ids
       replace_relative_urls
-      dedup_styles
+      deduplicate_styles
 
       @fragment.to_html
     end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -374,12 +374,27 @@ module Email
       end
     end
 
+    def dedup_style(style)
+      style_instructions =
+        style.split(";").map(&:strip).select(&:present?).map { |s| s.split(":", 2).map(&:strip) }
+      styles = {}
+      style_instructions.each { |key, value| styles[key] = value }
+      styles.map { |k, v| "#{k}:#{v}" }.join(";")
+    rescue StandardError
+      style
+    end
+
+    def dedup_styles
+      @fragment.css("[style]").each { |element| element["style"] = dedup_style element["style"] }
+    end
+
     def to_html
       # needs to be before class + id strip because we need to style redacted
       # media and also not double-redact already redacted from lower levels
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
       strip_classes_and_ids
       replace_relative_urls
+      dedup_styles
 
       @fragment.to_html
     end

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Email::Styles do
     end
   end
 
-  describe "dedup_css" do
+  describe "deduplicate styles" do
     it "removes double definitions" do
       frag = "<test style='color:green;color:red'>hello</test>"
       styler = Email::Styles.new(frag)

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -168,6 +168,24 @@ RSpec.describe Email::Styles do
     end
   end
 
+  describe "dedup_css" do
+    it "removes double definitions" do
+      frag = "<test style='color:green;color:red'>hello</test>"
+      styler = Email::Styles.new(frag)
+      styled = styler.to_html
+      styled = Nokogiri::HTML5.fragment(styled)
+      expect(styled.at("test")["style"]).to eq("color:red")
+    end
+    it "handles whitespace correctly" do
+      frag =
+        "<test style=' color :  green ; ; ;   color :    red; background:white;  background:yellow '>hello</test>"
+      styler = Email::Styles.new(frag)
+      styled = styler.to_html
+      styled = Nokogiri::HTML5.fragment(styled)
+      expect(styled.at("test")["style"]).to eq("color:red;background:yellow")
+    end
+  end
+
   describe "dark mode emails" do
     it "adds dark_mode_styles when site setting active" do
       frag = html_fragment('<div class="body">test</div>')


### PR DESCRIPTION
Shortens multiple CSS style definitions in emails to the last given one.

https://meta.discourse.org/t/resolve-final-styles-in-email-notifications/310219

