### PR TITLE
FIX: do not show as clickable the thread header

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/thread/header.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { service } from "@ember/service";
+import { or } from "truth-helpers";
 import noop from "discourse/helpers/noop";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import icon from "discourse-common/helpers/d-icon";
@@ -70,8 +71,6 @@ export default class ChatThreadHeader extends Component {
     ) {
       return () =>
         this.modal.show(ThreadSettingsModal, { model: this.args.thread });
-    } else {
-      return noop;
     }
   }
 
@@ -92,9 +91,9 @@ export default class ChatThreadHeader extends Component {
 
       <navbar.Title
         @title={{replaceEmoji this.headerTitle}}
-        {{on "click" this.openThreadTitleModal}}
+        {{on "click" (or this.openThreadTitleModal noop)}}
         role={{if this.openThreadTitleModal "button"}}
-        class="clickable"
+        class={{if this.openThreadTitleModal "clickable"}}
       />
       <navbar.Actions as |action|>
         <action.ThreadTrackingDropdown @thread={{@thread}} />


### PR DESCRIPTION
When the current user can't modify the thread title we shouldn't show it as a clickable area.
