### PR TITLE
FIX: increase chat thread title limit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/thread-settings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/thread-settings.gjs
@@ -66,13 +66,13 @@ export default class ChatModalThreadSettings extends Component {
         <Input
           name="thread-title"
           class="chat-modal-thread-settings__title-input"
-          maxlength="50"
+          maxlength="100"
           placeholder={{i18n "chat.thread_title_modal.input_placeholder"}}
           @type="text"
           @value={{this.editedTitle}}
         />
         <div class="thread-title-length">
-          <span>{{this.threadTitleLength}}</span>/50
+          <span>{{this.threadTitleLength}}</span>/100
         </div>
 
         {{#if this.currentUser.admin}}


### PR DESCRIPTION
This will ensure AI generated titles don't appear as out of range in the UI and also allow users to set longer titles. The limit in DB was already 100 so it's just a simple frontend change.
