### PR TITLE
FIX: word break long continuous thread titles

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-thread-heading.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-heading.scss
@@ -16,4 +16,5 @@
   padding-left: 0.5em;
   color: var(--secondary-low);
   margin-bottom: 0;
+  word-break: break-word;
 }


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->