### PR TITLE
Revert "FIX: deduplicate css in mails (#30003)"

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -374,31 +374,12 @@ module Email
       end
     end
 
-    def deduplicate_style(style)
-      styles = {}
-
-      style
-        .split(";")
-        .select(&:present?)
-        .map { _1.split(":", 2).map(&:strip) }
-        .each { |k, v| styles[k] = v if k.present? && v.present? }
-
-      styles.map { |k, v| "#{k}:#{v}" }.join(";")
-    end
-
-    def deduplicate_styles
-      @fragment
-        .css("[style]")
-        .each { |element| element["style"] = deduplicate_style element["style"] }
-    end
-
     def to_html
       # needs to be before class + id strip because we need to style redacted
       # media and also not double-redact already redacted from lower levels
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
       strip_classes_and_ids
       replace_relative_urls
-      deduplicate_styles
 
       @fragment.to_html
     end

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -168,24 +168,6 @@ RSpec.describe Email::Styles do
     end
   end
 
-  describe "deduplicate styles" do
-    it "removes double definitions" do
-      frag = "<test style='color:green;color:red'>hello</test>"
-      styler = Email::Styles.new(frag)
-      styled = styler.to_html
-      styled = Nokogiri::HTML5.fragment(styled)
-      expect(styled.at("test")["style"]).to eq("color:red")
-    end
-    it "handles whitespace correctly" do
-      frag =
-        "<test style=' color :  green ; ; ;   color :    red; background:white;  background:yellow '>hello</test>"
-      styler = Email::Styles.new(frag)
-      styled = styler.to_html
-      styled = Nokogiri::HTML5.fragment(styled)
-      expect(styled.at("test")["style"]).to eq("color:red;background:yellow")
-    end
-  end
-
   describe "dark mode emails" do
     it "adds dark_mode_styles when site setting active" do
       frag = html_fragment('<div class="body">test</div>')


### PR DESCRIPTION
This reverts commit 6e726d436f51924083829bfe14ffa0a8f7f44985.

The specs were failing in the original PR but the CI didn't run.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->