### PR TITLE
DEV: Hide admin_sidebar_enabled_groups

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2457,6 +2457,7 @@ developer:
     default: "1|2"
     allow_any: false
     refresh: true
+    hidden: true
   warn_critical_js_deprecations:
     default: true
     client: true


### PR DESCRIPTION
We are hiding this site setting because we no longer
support the old horizontal admin nav, and this setting
will be going away soon.
