### PR TITLE
FIX: update flag reason message with default value

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -658,6 +658,7 @@ class Post < ActiveRecord::Base
             "flag_reasons.#{post_action_type_view.types[post_action_type_id]}",
             locale: SiteSetting.default_locale,
             base_path: Discourse.base_path,
+            default: PostActionType.names[post_action_type_id],
           ),
       }
 

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -413,6 +413,7 @@ class PostDestroyer
             "flag_reasons#{".responder" if notify_responders}.#{flag_type}",
             locale: SiteSetting.default_locale,
             base_path: Discourse.base_path,
+            default: PostActionType.flags.find { |flag| flag[:name_key] == flag_type.to_s }[:name],
           ),
       },
     )

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1498,6 +1498,19 @@ RSpec.describe Post do
       ).to(true)
     end
 
+    it "should inform the user when custom flag" do
+      custom_flag = Fabricate(:flag, name: "custom flag")
+      post.hide!(PostActionType.types[:custom_custom_flag])
+
+      jobs = Jobs::SendSystemMessage.jobs
+      expect(jobs.size).to eq(1)
+
+      Jobs::SendSystemMessage.new.execute(jobs[0]["args"][0].with_indifferent_access)
+      expect(Post.last.raw).to match("custom flag")
+
+      custom_flag.destroy!
+    end
+
     it "should decrease user_stat topic_count for first post" do
       expect do post.hide!(PostActionType.types[:off_topic]) end.to change {
         post.user.user_stat.reload.topic_count


### PR DESCRIPTION
Currently, only system flags are translated. When we send a message to the user that their post was deleted because of a custom flag, we should default to the custom flag name.

Before: 
<img width="856" alt="Screenshot 2024-12-03 at 11 15 41 AM" src="https://github.com/user-attachments/assets/3783ff07-5336-4f80-bbef-712edba45677">

After:
<img width="1382" alt="Screenshot 2024-12-03 at 11 13 54 AM" src="https://github.com/user-attachments/assets/0e83e6f4-6ca4-4c1e-b0b1-6fa00918d343">

Meta: https://meta.discourse.org/t/modify-add-site-text-associated-with-custom-moderation-flags/335942
