### PR TITLE
DEV: Avoid creating system message when system user initiates restore

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -144,6 +144,8 @@ module BackupRestore
     end
 
     def notify_user
+      return if @success && @user_id == Discourse::SYSTEM_USER_ID
+
       if user = User.find_by_email(@user_info[:email])
         log "Notifying '#{user.username}' of the end of the restore..."
         status = @success ? :restore_succeeded : :restore_failed


### PR DESCRIPTION
There is no point creating a message for the system user since it is a
non-human user.

### Reviewer notes

There are no existing tests for the `BackupRestore::Restorer` class since it is hard to write an automated test for the whole restore process. Therefore, there are no tests for this change and I think it is fine since the impact of this change regressing is low.