### PR TITLE
DEV: unsilence server-side deprecation warning for old Font Awesome icons

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -523,8 +523,7 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     new_name = remap_from_fa5(new_name)
 
     if icon_name != new_name
-      # TODO: Enable message once core and official themes/plugins are updated
-      # Discourse.deprecate("The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.")
+      Discourse.deprecate("The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.")
       return new_name
     end
 


### PR DESCRIPTION
Following up on previous changes made for the Font Awesome 6 upgrade ( https://github.com/discourse/discourse/pull/28715 and https://github.com/discourse/discourse/pull/28778);

This deprecation warning is already present on the client side, we are now enabling it on server side too since the db migrations updating deprecated icon names were merged from https://github.com/discourse/discourse/pull/29958.