### PR TITLE
UX: disable scrolling when modal is open on desktop

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -12,6 +12,7 @@ import DButton from "discourse/components/d-button";
 import FlashMessage from "discourse/components/flash-message";
 import concatClass from "discourse/helpers/concat-class";
 import element from "discourse/helpers/element";
+import htmlClass from "discourse/helpers/html-class";
 import {
   disableBodyScroll,
   enableBodyScroll,
@@ -261,6 +262,7 @@ export default class DModal extends Component {
       @inline={{@inline}}
       @append={{true}}
     >
+      {{htmlClass "modal-open"}}
       <this.dynamicElement
         class={{concatClass
           "modal"

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -1,3 +1,7 @@
+html.modal-open {
+  overflow: hidden;
+}
+
 .d-modal {
   --modal-max-width: 600px;
   --modal-width: 30em; // set in ems to scale with user font-size


### PR DESCRIPTION
Uses the `htmlClass` to automagically set the `modal-open` class to `<html>` so that we can do `overflow: hidden` and prevent the "background" behind the modal from scrolling while the modal is open.

Internal ref - t/142760

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->