### PR TITLE
FIX: adjust codeblock link styling

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -8,6 +8,13 @@ em > code {
   color: var(--primary);
 }
 
+a > code {
+  padding: 2px 4px;
+  background: var(--inline-code-bg);
+  white-space: pre-wrap;
+  color: var(--tertiary);
+}
+
 code {
   color: var(--primary-very-high);
   background: var(--hljs-bg);


### PR DESCRIPTION
This PR adjusts codeblocks nested in link tags to convey they are links.

**Before**
<img width="318" alt="image" src="https://github.com/user-attachments/assets/ea4be79b-bbc9-436a-95cd-bb25f86c8de7">


**After**
<img width="356" alt="image" src="https://github.com/user-attachments/assets/7768cb7c-e48d-42ef-a3c7-1348ea17a348">

<img width="324" alt="image" src="https://github.com/user-attachments/assets/ab61518b-048c-483e-a1fc-07095db915cc">

