### PR TITLE
UX: Strip multiline comments in github oneboxes

### DIFF
--- a/lib/onebox/engine/github_pull_request_onebox.rb
+++ b/lib/onebox/engine/github_pull_request_onebox.rb
@@ -12,8 +12,6 @@ module Onebox
       include Onebox::Mixins::GithubBody
       include Onebox::Mixins::GithubAuthHeader
 
-      GITHUB_COMMENT_REGEX = /(<!--.*?-->\r\n)/
-
       matches_regexp(%r{^https?://(?:www\.)?(?:(?:\w)+\.)?(github)\.com(?:/)?(?:.)*/pull})
       always_https
 

--- a/lib/onebox/engine/github_repo_onebox.rb
+++ b/lib/onebox/engine/github_repo_onebox.rb
@@ -11,7 +11,7 @@ module Onebox
       include JSON
       include Onebox::Mixins::GithubAuthHeader
 
-      GITHUB_COMMENT_REGEX = /(<!--.*?-->\r\n)/
+      GITHUB_COMMENT_REGEX = /(<!--.*?-->\r\n)/m
 
       matches_regexp(%r{^https?:\/\/(?:www\.)?(?!gist\.)[^\/]*github\.com\/[^\/]+\/[^\/]+\/?$})
       always_https

--- a/lib/onebox/mixins/github_body.rb
+++ b/lib/onebox/mixins/github_body.rb
@@ -9,7 +9,7 @@ module Onebox
       end
 
       module InstanceMethods
-        GITHUB_COMMENT_REGEX = /<!--.*?-->/
+        GITHUB_COMMENT_REGEX = /<!--.*?-->/m
         MAX_BODY_LENGTH = 80
 
         def compute_body(body)


### PR DESCRIPTION
We were already stripping comments from GitHub issue/PR oneboxes, but the regex was not correctly matching multiline comments.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->