### PR TITLE
FIX: Rate limiting when moving posts with `freeze_original` option

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -299,6 +299,7 @@ class PostMover
       end
 
     moved_post.attributes = update
+    moved_post.disable_rate_limits! if @options[:freeze_original]
     moved_post.save(validate: false)
 
     DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id)


### PR DESCRIPTION
Before this commit, the rate limit was applied when moving posts with the `freeze_original` option, leading to errors. This commit fixes that.

And also adds tests for moving post scenarios with the `freeze_original` option.

