### PR TITLE
UX: avoid triggering the autocomplete mid-word

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -560,6 +560,11 @@ export default function (options) {
     let cp = caretPosition(me[0]);
     const key = me[0].value[cp - 1];
 
+    // only continue if the caret is at the end of a word, like #line|<-
+    if (me[0].value[cp]?.match(/\S/)) {
+      return;
+    }
+
     if (options.key) {
       if (options.onKeyUp && key !== options.key) {
         let match = options.onKeyUp(me.val(), cp);


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->