### PR TITLE
FIX: Sanitization issue when replacing default emoji with custom emojis that contains `+` or `-` symbols

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -327,6 +327,6 @@ class Emoji
   end
 
   def self.sanitize_emoji_name(name)
-    name.gsub(/[^a-z0-9]+/i, "_").gsub(/_{2,}/, "_").downcase
+    name.gsub(/[^a-z0-9\+\-]+/i, "_").gsub(/_{2,}/, "_").downcase
   end
 end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -706,9 +706,13 @@ TEXT
     it "sanitizes emojis' names" do
       Plugin::Instance.new.register_emoji("?", "/baz/bar.png", "baz")
       Plugin::Instance.new.register_emoji("?test?!!", "/foo/bar.png", "baz")
+      Plugin::Instance.new.register_emoji("+1", "/foo/bar.png", "baz")
+      Plugin::Instance.new.register_emoji("test!-1", "/foo/bar.png", "baz")
 
       expect(Emoji.custom.first.name).to eq("_")
       expect(Emoji.custom.second.name).to eq("_test_")
+      expect(Emoji.custom.third.name).to eq("+1")
+      expect(Emoji.custom.fourth.name).to eq("test_-1")
     end
   end
 


### PR DESCRIPTION
**Description**

Recent problems with custom emojis having `+` and `-` symbols in their names have surfaced, this addresses the issue.