### PR TITLE
FIX: attempt to simplify chat navbar spacing

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-navbar.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   display: flex;
   z-index: z("composer", "content") - 1;
-  padding: 0 1rem;
+  padding: 0 0.67em;
 
   &.-clickable {
     cursor: pointer;
@@ -21,7 +21,6 @@
   container-type: inline-size;
 
   .is-collapsed & {
-    margin-left: 1rem;
     &__title {
       margin-left: 0 !important;
     }
@@ -50,16 +49,11 @@
   .single-select-header {
     padding: 0.3675rem 0.584rem;
   }
-
-  > .c-navbar__title:first-child {
-    .chat-drawer & {
-      margin-left: 1rem;
-    }
-  }
 }
 
 .c-navbar__back-button {
   height: var(--chat-header-offset);
+  padding: 0.5rem 0.8rem 0.5rem 0.25rem;
 }
 
 .c-navbar__channel-title {

--- a/plugins/chat/assets/stylesheets/desktop/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-navbar.scss
@@ -1,7 +1,0 @@
-.c-navbar-container {
-  .chat-drawer &,
-  .c-routes-channel.--thread &,
-  .c-routes-channel.--info & {
-    padding-inline: 0;
-  }
-}

--- a/plugins/chat/assets/stylesheets/desktop/index.scss
+++ b/plugins/chat/assets/stylesheets/desktop/index.scss
@@ -1,5 +1,4 @@
 @import "base-desktop";
-@import "chat-navbar";
 @import "chat-composer-uploads";
 @import "chat-index-drawer";
 @import "chat-index-full-page";

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -1,12 +1,10 @@
 .c-navbar {
-  gap: 0.75rem;
+  gap: 0.5rem;
+
   &-container {
     max-width: 100vw;
-    padding-inline: 0.25rem;
   }
-  &__actions {
-    margin-right: 0.5rem;
-  }
+
   &__back-button {
     align-self: stretch;
   }


### PR DESCRIPTION
The main bug this commit is fixing is lack of spacing on the title "channels" when visiting the chat homepage on mobile.
