### PR TITLE
FIX: font awesome remapping migration should not drop unmapped names from svg_icon_subset

### DIFF
--- a/db/migrate/20241127072350_remap_fa5_icon_names_to_fa6.rb
+++ b/db/migrate/20241127072350_remap_fa5_icon_names_to_fa6.rb
@@ -708,28 +708,27 @@ class RemapFa5IconNamesToFa6 < ActiveRecord::Migration[7.1]
           case icon_name
           when /^fab-/
             prefix = "fab"
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^fab-/, "")]
+            lookup_name = icon_name.sub(/^fab-/, "")
           when /^far-/
             prefix = "far"
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^far-/, "")]
+            lookup_name = icon_name.sub(/^far-/, "")
           when /^fab fa-/
             prefix = "fab"
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^fab fa-/, "")]
+            lookup_name = icon_name.sub(/^fab fa-/, "")
           when /^far fa-/
             prefix = "far"
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^far fa-/, "")]
+            lookup_name = icon_name.sub(/^far fa-/, "")
           when /^fas fa-/
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^fas fa-/, "")]
+            lookup_name = icon_name.sub(/^fas fa-/, "")
           when /^fa-/
-            found_icon_name = FA5_REMAPS[icon_name.sub(/^fa-/, "")]
+            lookup_name = icon_name.sub(/^fa-/, "")
           else
-            found_icon_name = FA5_REMAPS[icon_name]
+            lookup_name = icon_name
           end
 
-          return icon_name if found_icon_name.nil?
-          return "#{prefix}-#{found_icon_name}" if prefix
-
-          found_icon_name
+          new_icon_name = FA5_REMAPS[lookup_name] || lookup_name
+          new_icon_name = "#{prefix}-#{new_icon_name}" if prefix
+          new_icon_name
         end
         .join("|")
 

--- a/db/migrate/20241127072350_remap_fa5_icon_names_to_fa6.rb
+++ b/db/migrate/20241127072350_remap_fa5_icon_names_to_fa6.rb
@@ -703,25 +703,33 @@ class RemapFa5IconNamesToFa6 < ActiveRecord::Migration[7.1]
       original_setting_value
         .split("|")
         .map do |icon_name|
-          found_icon_name =
-            case icon_name
-            when /^fab-/
-              "fab-#{FA5_REMAPS[icon_name.sub(/^fab-/, "")]}"
-            when /^far-/
-              "far-#{FA5_REMAPS[icon_name.sub(/^far-/, "")]}"
-            when /^fab fa-/
-              "fab-#{FA5_REMAPS[icon_name.sub(/^fab fa-/, "")]}"
-            when /^far fa-/
-              "far-#{FA5_REMAPS[icon_name.sub(/^far fa-/, "")]}"
-            when /^fas fa-/
-              FA5_REMAPS[icon_name.sub(/^fas fa-/, "")]
-            when /^fa-/
-              FA5_REMAPS[icon_name.sub(/^fa-/, "")]
-            else
-              FA5_REMAPS[icon_name]
-            end
-          # if not converted, just return the original icon name
-          found_icon_name || icon_name
+          prefix = nil
+
+          case icon_name
+          when /^fab-/
+            prefix = "fab"
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^fab-/, "")]
+          when /^far-/
+            prefix = "far"
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^far-/, "")]
+          when /^fab fa-/
+            prefix = "fab"
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^fab fa-/, "")]
+          when /^far fa-/
+            prefix = "far"
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^far fa-/, "")]
+          when /^fas fa-/
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^fas fa-/, "")]
+          when /^fa-/
+            found_icon_name = FA5_REMAPS[icon_name.sub(/^fa-/, "")]
+          else
+            found_icon_name = FA5_REMAPS[icon_name]
+          end
+
+          return icon_name if found_icon_name.nil?
+          return "#{prefix}-#{found_icon_name}" if prefix
+
+          found_icon_name
         end
         .join("|")
 

--- a/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
+++ b/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
@@ -16,17 +16,32 @@ RSpec.describe RemapFa5IconNamesToFa6 do
   end
 
   context "when svg_icon_subset site setting has values to be remapped" do
+    let(:svg_icon_subset_icon_mapping) do
+      {
+        "fa-ambulance" => "truck-medical",
+        "far-ambulance" => "far-truck-medical",
+        "fab-ambulance" => "fab-truck-medical",
+        "far fa-ambulance" => "far-truck-medical",
+        "far fa-gear" => "far-gear",
+        "gear" => "gear",
+        "fab fa-ambulance" => "fab-truck-medical",
+        "fas fa-ambulance" => "truck-medical",
+      }
+    end
+
     let!(:site_setting) do
       SiteSetting.create!(
         name: "svg_icon_subset",
-        value: icon_mapping.keys.join("|"),
+        value: svg_icon_subset_icon_mapping.keys.join("|"),
         data_type: SiteSettings::TypeSupervisor.types[:list],
       )
     end
 
     it "remaps the values correctly" do
       silence_stdout { migrate }
-      expect(site_setting.reload.value.split("|")).to match_array(icon_mapping.values)
+      expect(site_setting.reload.value.split("|")).to match_array(
+        svg_icon_subset_icon_mapping.values,
+      )
     end
   end
 

--- a/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
+++ b/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe RemapFa5IconNamesToFa6 do
   end
 
   context "when no icon names can be remapped" do
-    let(:icon_names) { ["fal fa-adjust", "heart"] }
+    let(:icon_names) { ["fal fa-adjust", "heart", "far-heart"] }
     let(:site_setting) do
       SiteSetting.create!(
         name: "svg_icon_subset",

--- a/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
+++ b/spec/migrations/remap_fa5_icon_names_to_fa6_spec.rb
@@ -91,11 +91,18 @@ RSpec.describe RemapFa5IconNamesToFa6 do
       )
     end
     let(:group) { Fabricate(:group, flair_icon: icon_names.first) }
+    let(:group_2) { Fabricate(:group, flair_icon: icon_names.last) }
     let(:post_action_type) { PostActionType.create!(name_key: "foo", icon: icon_names.first) }
+    let(:post_action_type_2) { PostActionType.create!(name_key: "foo", icon: icon_names.last) }
     let(:badge) { Fabricate(:badge, icon: icon_names.first) }
+    let(:badge_2) { Fabricate(:badge, icon: icon_names.last) }
     let(:sidebar_url) { Fabricate(:sidebar_url, icon: icon_names.first) }
+    let(:sidebar_url_2) { Fabricate(:sidebar_url, icon: icon_names.last) }
     let(:directory_column) do
       DirectoryColumn.create!(enabled: true, position: 1, icon: icon_names.first)
+    end
+    let(:directory_column_2) do
+      DirectoryColumn.create!(enabled: true, position: 1, icon: icon_names.last)
     end
 
     it "does not change any icon column values" do
@@ -107,6 +114,11 @@ RSpec.describe RemapFa5IconNamesToFa6 do
           badge.reload.icon,
           sidebar_url.reload.icon,
           directory_column.reload.icon,
+          group_2.reload.flair_icon,
+          post_action_type_2.reload.icon,
+          badge_2.reload.icon,
+          sidebar_url_2.reload.icon,
+          directory_column_2.reload.icon,
         ]
       }
     end


### PR DESCRIPTION
The current migration would lead to us removing from the `svg_icon_subset` site setting any updated icon names with fab/far prefixes, leaving only the prefix. The migration for the other tables done directly in SQL is fine as we directly search for FA5 icon names before applying the remapping logic (I've added more example rows in the spec to verify this).