### PR TITLE
UX: Only add `user-badge-buttons` wrapper when badges exist

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -141,7 +141,7 @@ export default createWidget("poster-name", {
       }
     }
 
-    if (attrs.badgesGranted) {
+    if (attrs.badgesGranted?.length) {
       const badges = [];
       attrs.badgesGranted.forEach((badge) => {
         // Alter the badge description to show that the badge was granted for this post.


### PR DESCRIPTION
Followup to 2513339955ebdfa457a5d6126716091110045e37

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->