### PR TITLE
FIX: Stick to then/finally in history-store

### DIFF
--- a/app/assets/javascripts/discourse/app/services/history-store.js
+++ b/app/assets/javascripts/discourse/app/services/history-store.js
@@ -111,7 +111,7 @@ export default class HistoryStore extends Service {
    * not available as an event on the router service.
    */
   @bind
-  async willResolveModel(transition) {
+  willResolveModel(transition) {
     if (HANDLED_TRANSITIONS.has(transition)) {
       return;
     }
@@ -141,16 +141,16 @@ export default class HistoryStore extends Service {
     }
 
     this.#pendingStore = pendingStoreForThisTransition;
-
-    try {
-      await transition;
-      this.#uuid = window.history.state?.uuid;
-      this.#routeData.set(this.#uuid, this.#pendingStore);
-      this.#pruneOldData();
-    } finally {
-      if (pendingStoreForThisTransition === this.#pendingStore) {
-        this.#pendingStore = null;
-      }
-    }
+    transition
+      .then(() => {
+        this.#uuid = window.history.state?.uuid;
+        this.#routeData.set(this.#uuid, this.#pendingStore);
+        this.#pruneOldData();
+      })
+      .finally(() => {
+        if (pendingStoreForThisTransition === this.#pendingStore) {
+          this.#pendingStore = null;
+        }
+      });
   }
 }


### PR DESCRIPTION
async/await doesn't play well with transitions (to be investigated… later)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->