### PR TITLE
FIX: ensures tabbing from trigger focus content

### DIFF
--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import { and } from "truth-helpers";
@@ -30,6 +33,28 @@ export default class DMenu extends Component {
       this.menuInstance.destroy();
     };
   });
+
+  @action
+  registerFloatBody(element) {
+    this.body = element;
+  }
+
+  @action
+  forwardTabToContent(event) {
+    if (!this.body) {
+      return;
+    }
+
+    if (event.key === "Tab") {
+      event.preventDefault();
+
+      const firstFocusable = this.body.querySelector(
+        'button, a, input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+
+      firstFocusable?.focus() || this.body.focus();
+    }
+  }
 
   get menuId() {
     return `d-menu-${this.menuInstance.id}`;
@@ -73,6 +98,7 @@ export default class DMenu extends Component {
       @translatedTitle={{@title}}
       @disabled={{@disabled}}
       aria-expanded={{if this.menuInstance.expanded "true" "false"}}
+      {{on "keydown" this.forwardTabToContent}}
       ...attributes
     >
       {{#if (has-block "trigger")}}
@@ -122,6 +148,7 @@ export default class DMenu extends Component {
           @innerClass="fk-d-menu__inner-content"
           @role="dialog"
           @inline={{this.options.inline}}
+          {{didInsert this.registerFloatBody}}
         >
           {{#if (has-block)}}
             {{yield this.componentArgs}}


### PR DESCRIPTION
`DMenu` is using in-element, which means the content is detached from the trigger, and pressing tab from the trigger is not going to jump into the content. This commit catches the tab event and attempts to focus the first focusable element of the content.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->