### PR TITLE
UX: adjust mobile chat text title alignment

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -8,4 +8,8 @@
   &__back-button {
     align-self: stretch;
   }
+
+  &__title {
+    padding-left: 0.25em;
+  }
 }

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -10,6 +10,6 @@
   }
 
   &__title {
-    padding-left: 0.25em;
+    padding-left: 0.3rem;
   }
 }


### PR DESCRIPTION
Minor alignment adjustment for text titles (this doesn't impact channel titles which are aligned correctly)

Before:
![image](https://github.com/user-attachments/assets/f72a18ec-b914-4c73-b177-4584fd375e37)


After:
![image](https://github.com/user-attachments/assets/69f1845e-6da5-473d-a8ba-3c00facaf178)
