### PR TITLE
FIX: respect "hide presence" when displaying "is typing/replying..."

### DIFF
--- a/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.gjs
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.gjs
@@ -63,7 +63,7 @@ export default class ComposerPresenceDisplay extends Component {
     on.cleanup(() => editChannel.unsubscribe());
   });
 
-  notifyState = helperFn((_, on) => {
+  notifyState = () => {
     const { topic, post, replyDirty } = this.args.model;
     const entity = this.isEdit ? post : topic;
 
@@ -71,9 +71,7 @@ export default class ComposerPresenceDisplay extends Component {
       const name = `/discourse-presence/${this.state}/${entity.id}`;
       this.composerPresenceManager.notifyState(name, replyDirty);
     }
-
-    on.cleanup(() => this.composerPresenceManager.leave());
-  });
+  };
 
   get isReply() {
     return this.state === "reply" || this.state === "whisper";


### PR DESCRIPTION
While trying to reproduce an issue reported internally where a user saw the "is replying..." from another user who had disabled presence (aka. was "offline"), I noticed something odd about the way we "notify" presence via `notifyState`. The way it is setup up, it's being called on every "input" event in the composer/editor, due to it tracking the "reply" property of the composer model. That's fine, but the way the `helperFn` helper works, make it so we're calling the `on.cleanup` callback also on **every** "input" events in the composer/editor. For every character we enter in the composer, we're "entering" the presence channel and immediatelly "leaving" it...

If I remove the checks on `reply` (and thus the auto-tracking), then the `notifyState` function is called much less frequently. But we have some specs that expects us not to "publish" our presence when we open the composer and the reply is "empty".

Note: I switched to using `replyDirty` instead to re-use the checks the composer model is already doing to ensure we actually have changed something in the reply.

The best I came up with was not to rely on the `helperFn` but now, there's no way (that I could find) to call `composerPresenceManager.leave()` when the composer is closed. I tried a lot of different ways, but none worked. I'm sure it's something stupid easy, but I can't figure it out just now.


Internal ref - t/127490/74

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->