### PR TITLE
A11Y: remove redundant alt text from github oneboxes

### DIFF
--- a/lib/onebox/templates/githubcommit.mustache
+++ b/lib/onebox/templates/githubcommit.mustache
@@ -15,7 +15,7 @@
 
       <div class="user">
         <a href="{{author.html_url}}" target="_blank" rel="noopener">
-          <img alt="{{author.login}}" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+          <img alt="" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
           {{author.login}}
         </a>
       </div>

--- a/lib/onebox/templates/githubissue.mustache
+++ b/lib/onebox/templates/githubissue.mustache
@@ -21,7 +21,7 @@
 
       <div class="user">
         <a href="{{user.html_url}}" target="_blank" rel="noopener">
-          <img alt="{{user.login}}" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+          <img alt="" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
           {{user.login}}
         </a>
       </div>

--- a/lib/onebox/templates/githubpullrequest.mustache
+++ b/lib/onebox/templates/githubpullrequest.mustache
@@ -33,7 +33,7 @@
         <span>
           {{i18n.commit_by}}
           <a href="{{author.html_url}}" target="_blank" rel="noopener">
-            <img alt="{{author.login}}" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+            <img alt="" src="{{author.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
             {{author.login}}
           </a> - <a href="{{link}}" target="_blank" rel="noopener">{{title}}</a>
         </span>
@@ -44,7 +44,7 @@
       <h4>
         {{i18n.comment_by}}
         <a href="{{user.html_url}}" target="_blank" rel="noopener">
-          <img alt="{{user.login}}" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+          <img alt="" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
           {{user.login}}
         </a> - <a href="{{link}}" target="_blank" rel="noopener">{{title}}</a>
       </h4>
@@ -54,7 +54,7 @@
       <h4>
         {{i18n.review_by}}
         <a href="{{user.html_url}}" target="_blank" rel="noopener">
-          <img alt="{{user.login}}" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+          <img alt="" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
           {{user.login}}
         </a> - <a href="{{link}}" target="_blank" rel="noopener">{{title}}</a>
       </h4>
@@ -78,7 +78,7 @@
 
         <div class="user">
           <a href="{{user.html_url}}" target="_blank" rel="noopener">
-            <img alt="{{user.login}}" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
+            <img alt="" src="{{user.avatar_url}}" class="onebox-avatar-inline" width="20" height="20">
             {{user.login}}
           </a>
         </div>


### PR DESCRIPTION
Github oneboxes have an avatar next to the username text, and the alt for the avatar is the username. For screenreaders this is redundant information. 

If we're not providing a description of the avatar content (which github doesn't provide), then setting the alt attribute as the username results in the username being read twice... once for the image, and again for the actual text. 

So in this case, since the username is already provided, the image is decorative. Setting a blank alt attribute means screenreaders can skip it. 

This also fixes a broken image state, where if the image fails to load the alt text breaks the layout:

![image](https://github.com/user-attachments/assets/237b7bc9-43c3-4f2b-909f-4bc0ca7f7184)

This conveniently fixes it 

![image](https://github.com/user-attachments/assets/17538c1d-fb35-47b2-9f7b-42ee4376a86f)



