### PR TITLE
FIX: Remove some mandatory_values for reserved_usernames

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -675,7 +675,7 @@ users:
     type: list
     list_type: compact
     default: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support|all|here"
-    mandatory_values: "admin|moderator|administrator|mod|sys|system|community|info|you|name|username|user|nickname|discourse|discourseorg|discourseforum|support|all|here"
+    mandatory_values: "admin|moderator|administrator|mod|sys|system|you|name|username|user|nickname|discourse|discourseorg|discourseforum|all|here"
   min_password_length:
     client: true
     default: 10


### PR DESCRIPTION
Followup 56df077931e42749ea254a9df32154a8aa13bddc

This removes info, support, and community as mandatory values for the reserved_usernames site setting. These could arguably be useful for admins generally. The rest can stay as-is as they are much more likely to be
confusing to members.

c.f. https://meta.discourse.org/t/default-reserved-usernames-can-not-be-deleted/336020
