### PR TITLE
UX: Improve error when trying to edit globally shadowed setting

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -49,6 +49,10 @@ class Admin::SiteSettingsController < Admin::AdminController
       on_failed_policy(:setting_is_visible) do
         raise Discourse::InvalidParameters, I18n.t("errors.site_settings.site_setting_is_hidden")
       end
+      on_failed_policy(:setting_is_shadowed_globally) do
+        raise Discourse::InvalidParameters,
+              I18n.t("errors.site_settings.site_setting_is_shadowed_globally")
+      end
       on_failed_policy(:setting_is_configurable) do
         raise Discourse::InvalidParameters,
               I18n.t("errors.site_settings.site_setting_is_unconfigurable")

--- a/app/services/site_setting/update.rb
+++ b/app/services/site_setting/update.rb
@@ -36,6 +36,7 @@ class SiteSetting::Update
     end
   end
 
+  policy :setting_is_shadowed_globally
   policy :setting_is_visible
   policy :setting_is_configurable
   step :save
@@ -44,6 +45,10 @@ class SiteSetting::Update
 
   def current_user_is_admin(guardian:)
     guardian.is_admin?
+  end
+
+  def setting_is_shadowed_globally(params:)
+    !SiteSetting.shadowed_settings.include?(params.setting_name)
   end
 
   def setting_is_visible(params:, options:)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -340,6 +340,7 @@ en:
       invalid_site_setting: "No setting named '%{name}' exists"
       invalid_category_id: "You specified a category that does not exist"
       site_setting_is_hidden: "You are not allowed to change hidden settings"
+      site_setting_is_shadowed_globally: "You cannot change this setting because it is globally configured"
       site_setting_is_unconfigurable: "You are not allowed to change unconfigurable settings"
       invalid_choice:
         one: "'%{name}' is an invalid choice."

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -634,6 +634,22 @@ RSpec.describe Admin::SiteSettingsController do
 
         expect(SiteSetting.max_category_nesting).to eq(3)
         expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("errors.site_settings.site_setting_is_hidden"),
+        )
+      end
+
+      it "does not allow changing of globally shadowed settings" do
+        SiteSetting.max_category_nesting = 3
+        SiteSetting.stubs(:shadowed_settings).returns(Set.new([:max_category_nesting]))
+
+        put "/admin/site_settings/max_category_nesting.json", params: { max_category_nesting: 2 }
+
+        expect(SiteSetting.max_category_nesting).to eq(3)
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("errors.site_settings.site_setting_is_shadowed_globally"),
+        )
       end
 
       context "with an plugin" do

--- a/spec/services/site_setting/update_spec.rb
+++ b/spec/services/site_setting/update_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe SiteSetting::Update do
       end
     end
 
+    context "when a user changes a setting shadowed by a global variable" do
+      let(:setting_name) { :max_category_nesting }
+      let(:new_value) { 3 }
+
+      before { SiteSetting.stubs(:shadowed_settings).returns(Set.new([:max_category_nesting])) }
+
+      it { is_expected.to fail_a_policy(:setting_is_shadowed_globally) }
+    end
+
     context "when the user changes a visible setting" do
       let(:new_value) { "hello this is title" }
 


### PR DESCRIPTION
Previously when attempting to edit a globally shadowed setting, the
error message was not very helpful, it said "You are not allowed to
change hidden settings". This commit changes the error message to
reflect the actual problem, which is that the setting is shadowed by
a global setting via ENV var.
