### PR TITLE
PERF: Allow `assets:precompile:compress_js` to skip assets already on S3

### DIFF
--- a/lib/s3_assets_helper.rb
+++ b/lib/s3_assets_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class S3AssetsHelper
+  attr_reader :helper
+
+  def initialize(use_db_s3_config: false)
+    @helper = S3Helper.build_from_config(use_db_s3_config:)
+  end
+
+  def asset_on_s3?(path)
+    existing_assets.include?(prefix_s3_path(path))
+  end
+
+  def prefix_s3_path(path)
+    path = File.join(helper.s3_bucket_folder_path, path) if helper.s3_bucket_folder_path
+    path
+  end
+
+  private
+
+  def existing_assets
+    return @existing_assets if defined?(@existing_assets)
+    @existing_assets = Set.new(@helper.list("assets/").map(&:key))
+  end
+end


### PR DESCRIPTION
In a production setup where assets are uploaded to S3, we noticed that
we were spending CPU cycles compressing assets to only throw them away
because the asset has not changed and a copy is already on S3.

Therefore, we are adding an `PRECOMPILE_SKIP_COMPRESSING_JS_ALREADY_ON_S3` env
which allows us to skip compressing JS assets when the asset is already
present on the S3 bucket.

### Reviewer notes

These rake tasks are hard to test automatically so we usually have to test in production. I've tested this in production and have a site working with this change. 