### PR TITLE
FIX: Move granted badges to the end of the post header.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -141,8 +141,8 @@ export default createWidget("poster-name", {
       }
     }
 
+    const badges = [];
     if (attrs.badgesGranted?.length) {
-      const badges = [];
       attrs.badgesGranted.forEach((badge) => {
         // Alter the badge description to show that the badge was granted for this post.
         badge.description = i18n("post.badge_granted_tooltip", {
@@ -161,7 +161,6 @@ export default createWidget("poster-name", {
         );
         badges.push(badgeIcon);
       });
-      nameContents.push(h("span.user-badge-buttons", badges));
     }
 
     const afterNameContents =
@@ -173,29 +172,31 @@ export default createWidget("poster-name", {
       h("span", { className: classNames.join(" ") }, nameContents),
     ];
 
-    if (!this.settings.showNameAndGroup) {
-      return contents;
-    }
-
-    if (
-      name &&
-      this.siteSettings.display_name_on_posts &&
-      sanitizeName(name) !== sanitizeName(username)
-    ) {
-      contents.push(
-        h(
-          "span.second." + (nameFirst ? "username" : "full-name"),
-          [this.userLink(attrs, nameFirst ? username : name)].concat(
-            afterNameContents
+    if (this.settings.showNameAndGroup) {
+      if (
+        name &&
+        this.siteSettings.display_name_on_posts &&
+        sanitizeName(name) !== sanitizeName(username)
+      ) {
+        contents.push(
+          h(
+            "span.second." + (nameFirst ? "username" : "full-name"),
+            [this.userLink(attrs, nameFirst ? username : name)].concat(
+              afterNameContents
+            )
           )
-        )
-      );
+        );
+      }
+
+      this.buildTitleObject(attrs, contents);
+
+      if (this.siteSettings.enable_user_status) {
+        this.addUserStatus(contents, attrs);
+      }
     }
 
-    this.buildTitleObject(attrs, contents);
-
-    if (this.siteSettings.enable_user_status) {
-      this.addUserStatus(contents, attrs);
+    if (badges.length) {
+      contents.push(h("span.user-badge-buttons", badges));
     }
 
     return contents;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -257,10 +257,15 @@
 
   .names {
     margin-right: auto;
+
+    .first {
+      flex-shrink: 0;
+    }
   }
 
   .user-badge-buttons {
-    margin-left: 15px;
+    display: flex;
+    flex-shrink: 0;
 
     a {
       background: none;
@@ -278,8 +283,9 @@
     align-items: center;
   }
 
-  .user-status-message {
+  .user-status-message-wrap {
     display: flex;
+    flex-shrink: 0;
 
     img.emoji {
       width: 1em;


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #29696.

Based on feedback, the badges look a little odd when the user's full name is shown in the post header.

This PR moves them to the end of the post header, and makes some improvements to how elements of the post header behave when it's getting a little squishy due to all the stuff in the header.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/96eb3a6c-ec78-4605-ade8-8eca2d03a5da)
![](https://github.com/user-attachments/assets/5640b60e-4253-4830-8382-acef57e857d2)
![](https://github.com/user-attachments/assets/4643fac2-94a9-4a9a-9aec-65a1bf56181c)
![](https://github.com/user-attachments/assets/9d4ae355-253a-4213-8d84-f81b4f133fc5)

## 👑 Testing

Try switching on different options that alter the post header, see how it looks.