### PR TITLE
FIX: whisper's presence channels

### DIFF
--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -118,15 +118,20 @@ RSpec.describe "discourse-presence" do
     it "handles permissions for whispers" do
       c = PresenceChannel.new("/discourse-presence/whisper/#{public_topic.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        *SiteSetting.whispers_allowed_groups_map,
+      )
       expect(c.config.allowed_user_ids).to eq(nil)
     end
 
-    it "only allows staff when editing whispers" do
+    it "correctly allows whisperers when editing whispers" do
       p = Fabricate(:whisper, topic: public_topic, user: admin)
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        Group::AUTO_GROUPS[:staff],
+        *SiteSetting.whispers_allowed_groups_map,
+      )
       expect(c.config.allowed_user_ids).to eq(nil)
     end
 


### PR DESCRIPTION
In 0993273 we introduced the `whisper_allowed_group_ids` to allow whispers to more users than "staff".

The presence plugin hadn't been updated to account for this change.

Extracted from #30067