### PR TITLE
FIX: properly quote videos

### DIFF
--- a/app/assets/javascripts/discourse-markdown-it/src/engine.js
+++ b/app/assets/javascripts/discourse-markdown-it/src/engine.js
@@ -187,7 +187,7 @@ function renderImageOrPlayableMedia(tokens, idx, options, env, slf) {
       options.discourse.previewing &&
       !options.discourse.limitedSiteSettings.enableDiffhtmlPreview
     ) {
-      const origSrc = token.attrGet("data-orig-src");
+      const origSrc = token.attrGet("data-orig-src") || token.attrGet("src");
       const origSrcId = origSrc
         .substring(origSrc.lastIndexOf("/") + 1)
         .split(".")[0];

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -169,9 +169,7 @@ export function selectedText() {
   div
     .querySelectorAll("div.video-placeholder-container[data-video-src]")
     .forEach((element) => {
-      element.replaceWith(
-        `<div class="video-container"><video preload="metadata" controls><source src="${element.dataset.videoSrc}"></video></div>`
-      );
+      element.replaceWith(`![|video](${element.dataset.videoSrc})`);
     });
 
   return toMarkdown(div.outerHTML);


### PR DESCRIPTION
Follow up to f294f984cf64236a63e9ed21df3c8782e046c90f

All that was needed was a little fix to our markdown engine to use the "image src" as the "video src" when the "data video src" was not defined.

That way we can use the regular image markdown with the "|video" option (?).

