### PR TITLE
UX: fix topic map padding in low-content situations

### DIFF
--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -43,6 +43,7 @@ body:not(.archetype-private_message) {
     var(--topic-avatar-width) + var(--topic-body-width) +
       (var(--topic-body-width-padding) * 2)
   );
+  padding-block: 0.5em;
 
   @include breakpoint(mobile-large) {
     font-size: var(--font-down-1);
@@ -91,7 +92,6 @@ body:not(.archetype-private_message) {
   }
 
   &__contents {
-    padding-block: 0.5em;
     flex-grow: 1;
 
     .number {


### PR DESCRIPTION
this moves padding to the parent container to avoid a situation where padding can be missing when a child div isn't rendered

Before:
![image](https://github.com/user-attachments/assets/938ab330-bd76-4944-a548-a02958e13288)

After:
![image](https://github.com/user-attachments/assets/c256014f-4fbe-4ba8-a9b8-53de3bc01543)
