### PR TITLE
FIX: WIP User directory custom field limit issue

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -63,6 +63,7 @@ class DirectoryItemsController < ApplicationController
     user_ids = nil
     if params[:name].present?
       user_ids = UserSearch.new(params[:name], include_staged_users: true).search.pluck(:id)
+      # binding.pry
       if user_ids.present?
         # Add the current user if we have at least one other match
         user_ids << current_user.id if current_user && result.dup.where(user_id: user_ids).exists?

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -47,6 +47,7 @@ class UserSearch
   end
 
   def filtered_by_term_users
+    # binding.pry
     if @term.blank?
       scoped_users
     elsif SiteSetting.enable_names? && @term !~ /[_\.-]/

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DirectoryItemsController do
   fab!(:user)
-  fab!(:evil_trout)
+  fab!(:evil_trout) { Fabricate(:evil_trout, name: "Bobby") }
   fab!(:walter_white)
   fab!(:stage_user) { Fabricate(:staged, username: "stage_user") }
   fab!(:group) { Fabricate(:group, users: [evil_trout, stage_user]) }
@@ -157,7 +157,7 @@ RSpec.describe DirectoryItemsController do
     end
 
     it "finds user by name" do
-      get "/directory_items.json", params: { period: "all", name: "eviltrout" }
+      get "/directory_items.json", params: { period: "all", name: "Bobby" }
       expect(response.status).to eq(200)
 
       json = response.parsed_body
@@ -255,30 +255,25 @@ RSpec.describe DirectoryItemsController do
     end
 
     it "limits as expected when filtering with custom fields" do
-      field1 = Fabricate(:user_field, searchable: true)
-      users = Array.new(DirectoryItemsController::PAGE_SIZE + 10) { Fabricate(:user) }
+      # field1 = Fabricate(:user_field, searchable: true)
+      # users = Array.new(DirectoryItemsController::PAGE_SIZE + 10) { Fabricate(:user) }
+      # puts users.count
 
-      DirectoryItem.refresh!
+      # u1 = users.first
+      # u1.set_user_field(field1.id, "red")
+      # u1.save_custom_fields
 
-      22.times do |i|
-        users.each do |user|
-          group.add(user)
-          user.set_user_field(field1.id, "red")
-          user.save_custom_fields
-        end
-      end
+      # u2 = users.second
+      # u2.set_user_field(field1.id, "red")
+      # u2.save_custom_fields
 
-      get "/directory_items.json",
-          params: {
-            period: "all",
-            group: group.name,
-            order: field1.name,
-            user_field_ids: "#{field1.id}",
-            asc: true,
-          }
-      json = response.parsed_body
+      # get "/directory_items.json", params: { period: "all", name: "bruce" }
+      # json = response.parsed_body
 
-      expect(json["directory_items"].length).to eq(25)
+      # expect(json["directory_items"].length).to eq(3)
+
+      ## search gives back results first by name
+      ## then somehow the serializer cuts that result down further, causing the problem as reported
     end
 
     it "checks group permissions" do

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -254,6 +254,23 @@ RSpec.describe DirectoryItemsController do
       end
     end
 
+    it "limits as expected with custom fields" do
+      field1 = Fabricate(:user_field, searchable: true)
+      users = Array.new(DirectoryItemsController::PAGE_SIZE + 10) { Fabricate(:user) }
+
+      DirectoryItem.refresh!
+
+      users.each do |user|
+        group.add(user)
+        user.set_user_field(field1.id, "red")
+      end
+
+      get "/directory_items.json", params: { period: "all", name: "red" }
+      json = response.parsed_body
+
+      expect(json["directory_items"].length).to eq(22)
+    end
+
     it "checks group permissions" do
       group.update!(visibility_level: Group.visibility_levels[:members])
 

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -254,21 +254,31 @@ RSpec.describe DirectoryItemsController do
       end
     end
 
-    it "limits as expected with custom fields" do
+    it "limits as expected when filtering with custom fields" do
       field1 = Fabricate(:user_field, searchable: true)
       users = Array.new(DirectoryItemsController::PAGE_SIZE + 10) { Fabricate(:user) }
 
       DirectoryItem.refresh!
 
-      users.each do |user|
-        group.add(user)
-        user.set_user_field(field1.id, "red")
+      22.times do |i|
+        users.each do |user|
+          group.add(user)
+          user.set_user_field(field1.id, "red")
+          user.save_custom_fields
+        end
       end
 
-      get "/directory_items.json", params: { period: "all", name: "red" }
+      get "/directory_items.json",
+          params: {
+            period: "all",
+            group: group.name,
+            order: field1.name,
+            user_field_ids: "#{field1.id}",
+            asc: true,
+          }
       json = response.parsed_body
 
-      expect(json["directory_items"].length).to eq(22)
+      expect(json["directory_items"].length).to eq(25)
     end
 
     it "checks group permissions" do


### PR DESCRIPTION
Customer reported a bug in which clicking on a searchable user field value in the user directory limits unnaturally. It doesn't show all results and also does not paginate or indicate that there are more results.