### PR TITLE
DEV: Fix open composer without post topic loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -952,6 +952,7 @@ export default class Composer extends RestModel {
         } else {
           const topicData = await Topic.find(this.post.topic_id, {});
           const topic = this.store.createRecord("topic", topicData);
+          this.post.set("topic", topic);
           this.set("topic", topic);
         }
 

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -2,6 +2,7 @@ import { cached } from "@glimmer/tracking";
 import EmberObject, { computed } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { alias, and, equal, notEmpty, or } from "@ember/object/computed";
+import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { Promise } from "rsvp";
 import { resolveShareUrl } from "discourse/helpers/share-url";
@@ -461,7 +462,15 @@ export default class Topic extends RestModel {
   }
 
   set details(value) {
-    this._details = value;
+    const TopicDetails = getOwner(this).factoryFor("model:topic-details").class;
+
+    if (value instanceof TopicDetails) {
+      this._details = value;
+      return;
+    }
+
+    // we need to ensure that details is an instance of TopicDetails
+    this._details = this.store.createRecord("topicDetails", value);
   }
 
   @discourseComputed("visible")

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -2,7 +2,6 @@ import { cached } from "@glimmer/tracking";
 import EmberObject, { computed } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { alias, and, equal, notEmpty, or } from "@ember/object/computed";
-import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { Promise } from "rsvp";
 import { resolveShareUrl } from "discourse/helpers/share-url";
@@ -20,6 +19,7 @@ import ActionSummary from "discourse/models/action-summary";
 import Bookmark from "discourse/models/bookmark";
 import RestModel from "discourse/models/rest";
 import Site from "discourse/models/site";
+import TopicDetails from "discourse/models/topic-details";
 import { flushMap } from "discourse/services/store";
 import deprecated from "discourse-common/lib/deprecated";
 import getURL from "discourse-common/lib/get-url";
@@ -462,8 +462,6 @@ export default class Topic extends RestModel {
   }
 
   set details(value) {
-    const TopicDetails = getOwner(this).factoryFor("model:topic-details").class;
-
     if (value instanceof TopicDetails) {
       this._details = value;
       return;

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -4,6 +4,7 @@ import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
+import TopicDetails from "discourse/models/topic-details";
 
 module("Unit | Model | topic", function (hooks) {
   setupTest(hooks);
@@ -108,6 +109,10 @@ module("Unit | Model | topic", function (hooks) {
     const topic = this.store.createRecord("topic", { id: 1234 });
     const topicDetails = topic.details;
 
+    assert.true(
+      topicDetails instanceof TopicDetails,
+      "topicDetails is an instance of TopicDetails"
+    );
     assert.present(topicDetails, "a topic has topicDetails after we create it");
     assert.strictEqual(
       topicDetails.topic,
@@ -165,6 +170,10 @@ module("Unit | Model | topic", function (hooks) {
     });
 
     assert.blank(topic.post_stream, "it does not update post_stream");
+    assert.true(
+      topic.details instanceof TopicDetails,
+      "topicDetails is an instance of TopicDetails"
+    );
     assert.strictEqual(topic.details.hello, "world", "it updates the details");
     assert.strictEqual(topic.cool, "property", "it updates other properties");
     assert.strictEqual(topic.category, category);


### PR DESCRIPTION
This PR fixes an error that would be thrown in some edge cases where the composer is opened for a post instance without an associated topic model already loaded.

An example of such edge cases would be, a plugin trying to edit a post outside of the topic view.

This was causing an error that would prevent the composer from being opened.