### PR TITLE
FIX: Discard empty bundles for reviewables

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -270,8 +270,15 @@ class Reviewable < ActiveRecord::Base
 
   def actions_for(guardian, args = nil)
     args ||= {}
+    built_actions =
+      Actions.new(self, guardian).tap { |actions| build_actions(actions, guardian, args) }
 
-    Actions.new(self, guardian).tap { |actions| build_actions(actions, guardian, args) }
+    # Empty bundles can cause big issues on the client side, so we remove them
+    # here. It's not valid anyway to have a bundle with no actions, but you can
+    # add a bundle via actions.add_bundle and then not add any actions to it.
+    built_actions.bundles.reject! { |bundle| bundle.actions.empty? }
+
+    built_actions
   end
 
   def editable_for(guardian, args = nil)

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -276,7 +276,7 @@ class Reviewable < ActiveRecord::Base
     # Empty bundles can cause big issues on the client side, so we remove them
     # here. It's not valid anyway to have a bundle with no actions, but you can
     # add a bundle via actions.add_bundle and then not add any actions to it.
-    built_actions.bundles.reject! { |bundle| bundle.actions.empty? }
+    built_actions.bundles.reject!(&:empty?)
 
     built_actions
   end

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -30,6 +30,10 @@ class Reviewable < ActiveRecord::Base
         @label = label
         @actions = []
       end
+
+      def empty?
+        @actions.empty?
+      end
     end
 
     class Action < Item


### PR DESCRIPTION
Followup c7e471d35a0d394899eda5af26de64511e199cc6

It is currently possible to add a bundle (which is a collection
of actions used for a dropdown on the client) for a reviewable
via actions.add_bundle and then never add any actions to it.

This causes the client to explode, as seen in the referenced
commit, because of the way our store expects to resolve objects
referenced by ID that are passed down by the serializer, which
then causes Ember to have an unrecoverable render error.

Fixing this on the serializer level is not really possible because
of all the ActiveModel::Serializer magic that serializes
objects by ID reference when doing things like has_many.
`Reviewable#actions_for` is a better place to do this anyway,
because this is the main location where the bundles and actions
are built for every action via the serializer.
