### PR TITLE
FIX: improve chat channel sorting for DMs

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
@@ -3,12 +3,23 @@ import { i18n } from "discourse-i18n";
 
 export default class ChatChannelMetadata extends Component {
   get lastMessageFormattedDate() {
-    return moment(this.args.channel.lastMessage.createdAt).calendar(null, {
+    const lastMessageDate = this.showThreadUnreadDate
+      ? this.args.channel.lastUnreadThreadDate
+      : this.args.channel.lastMessage.createdAt;
+
+    return moment(lastMessageDate).calendar(null, {
       sameDay: "LT",
       lastDay: `[${i18n("chat.dates.yesterday")}]`,
       lastWeek: "dddd",
       sameElse: "l",
     });
+  }
+
+  get showThreadUnreadDate() {
+    return (
+      this.args.channel.lastUnreadThreadDate >
+      this.args.channel.lastMessage.createdAt
+    );
   }
 
   <template>

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -120,6 +120,10 @@ export default class ChatChannel {
   }
 
   get lastUnreadThreadDate() {
+    if (this.unreadThreadsCount === 0) {
+      return this.lastMessage.createdAt;
+    }
+
     return Array.from(this.threadsManager.unreadThreadOverview.values())
       .sort((a, b) => b - a)
       .pop();

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -119,6 +119,12 @@ export default class ChatChannel {
     return this.threadsManager.unreadThreadCount;
   }
 
+  get lastUnreadThreadDate() {
+    return Array.from(this.threadsManager.unreadThreadOverview.values())
+      .sort((a, b) => b - a)
+      .pop();
+  }
+
   get watchedThreadsUnreadCount() {
     return this.threadsManager.threads.reduce((unreadCount, thread) => {
       return unreadCount + thread.tracking.watchedThreadsUnreadCount;

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -263,20 +263,33 @@ export default class ChatChannelsManager extends Service {
         b.tracking.mentionCount +
         b.tracking.watchedThreadsUnreadCount;
 
-      if (aUrgent > 0 || bUrgent > 0) {
-        return aUrgent > bUrgent ? -1 : 1;
-      }
+      const aUnread = a.unreadThreadsCountSinceLastViewed;
+      const bUnread = b.unreadThreadsCountSinceLastViewed;
 
-      if (
-        a.unreadThreadsCountSinceLastViewed > 0 ||
-        b.unreadThreadsCountSinceLastViewed > 0
-      ) {
-        return a.unreadThreadsCountSinceLastViewed >
-          b.unreadThreadsCountSinceLastViewed
+      // if both channels have urgent count, sort by last message date
+      if (aUrgent > 0 && bUrgent > 0) {
+        return new Date(a.lastMessage.createdAt) >
+          new Date(b.lastMessage.createdAt)
           ? -1
           : 1;
       }
 
+      // otherwise prioritize channel with urgent count
+      if (aUrgent > 0 || bUrgent > 0) {
+        return aUrgent > bUrgent ? -1 : 1;
+      }
+
+      // if both channels have unread threads, sort by last thread reply date
+      if (aUnread > 0 && bUnread > 0) {
+        return a.lastUnreadThreadDate > b.lastUnreadThreadDate ? -1 : 1;
+      }
+
+      // otherwise prioritize channel with unread thread count
+      if (aUnread > 0 || bUnread > 0) {
+        return aUnread > bUnread ? -1 : 1;
+      }
+
+      // read channels are sorted by last message date
       return new Date(a.lastMessage.createdAt) >
         new Date(b.lastMessage.createdAt)
         ? -1


### PR DESCRIPTION
This change sorts unread channels in descending order based on last message date, so channels with the latest activity will always appear at the top. It also adds some improvements for sorting channels with unread threads, now when multiple channels have unread threads, they will be sorted by last thread reply date to ensure more active channels rise to the top.

For DM channels, the order is now:
- Urgent (green badge) - unread messages, mentions and unread watched threads (most recent activity at top)
- Unread (blue badge) - unread tracked threads (most recent thread reply at top)
- Everything else (most recent message at top)

### How it looks:

<img width="411" alt="Screenshot 2024-12-05 at 12 10 22 PM" src="https://github.com/user-attachments/assets/7f9c504f-b32c-4047-93c9-03c97572b522">

