### PR TITLE
DEV: adds default option to form-kit select

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { NO_VALUE_OPTION } from "discourse/form-kit/lib/constants";
+import { i18n } from "discourse-i18n";
 import FKControlSelectOption from "./select/option";
 
 export default class FKControlSelect extends Component {
@@ -17,6 +18,10 @@ export default class FKControlSelect extends Component {
     );
   }
 
+  get hasSelectedValue() {
+    return this.args.field.value && this.args.field.value !== NO_VALUE_OPTION;
+  }
+
   <template>
     <select
       value={{@field.value}}
@@ -25,6 +30,14 @@ export default class FKControlSelect extends Component {
       class="form-kit__control-select"
       {{on "input" this.handleInput}}
     >
+      <FKControlSelectOption @value={{NO_VALUE_OPTION}}>
+        {{#if this.hasSelectedValue}}
+          {{i18n "form_kit.select.unselect_placeholder"}}
+        {{else}}
+          {{i18n "form_kit.select.select_placeholder"}}
+        {{/if}}
+      </FKControlSelectOption>
+
       {{yield
         (hash Option=(component FKControlSelectOption selected=@field.value))
       }}

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
@@ -32,7 +32,7 @@ export default class FKControlSelect extends Component {
     >
       <FKControlSelectOption @value={{NO_VALUE_OPTION}}>
         {{#if this.hasSelectedValue}}
-          {{i18n "form_kit.select.unselect_placeholder"}}
+          {{i18n "form_kit.select.none_placeholder"}}
         {{else}}
           {{i18n "form_kit.select.select_placeholder"}}
         {{/if}}

--- a/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/create-invite-test.gjs
@@ -166,7 +166,7 @@ module("Integration | Component | CreateInvite", function (hooks) {
 
     assert.deepEqual(
       formKit().field("expiresAfterDays").options(),
-      ["1", "3", "7", "30", "90", "999999"],
+      ["__NONE__", "1", "3", "7", "30", "90", "999999"],
       "the value of invite_expiry_days is added to the dropdown"
     );
 
@@ -179,7 +179,7 @@ module("Integration | Component | CreateInvite", function (hooks) {
 
     assert.deepEqual(
       formKit().field("expiresAfterDays").options(),
-      ["1", "7", "30", "90", "999999"],
+      ["__NONE__", "1", "7", "30", "90", "999999"],
       "the value of invite_expiry_days is not added to the dropdown if it's already one of the options"
     );
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
@@ -3,6 +3,7 @@ import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+import { i18n } from "discourse-i18n";
 
 module(
   "Integration | Component | FormKit | Controls | Select",
@@ -49,6 +50,34 @@ module(
       </template>);
 
       assert.dom(".form-kit__control-select").hasAttribute("disabled");
+    });
+
+    test("no selection", async function (assert) {
+      await render(<template>
+        <Form as |form|>
+          <form.Field @name="foo" @title="Foo" as |field|>
+            <field.Select as |select|>
+              <select.Option @value="option-1">Option 1</select.Option>
+            </field.Select>
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert
+        .dom(".form-kit__control-select option:nth-child(1)")
+        .hasText(
+          i18n("form_kit.select.select_placeholder"),
+          "it shows a placeholder for selection"
+        );
+
+      await formKit().field("foo").select("option-1");
+
+      assert
+        .dom(".form-kit__control-select option:nth-child(1)")
+        .hasText(
+          i18n("form_kit.select.unselect_placeholder"),
+          "it shows a placeholder for unselection"
+        );
     });
   }
 );

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
@@ -75,7 +75,7 @@ module(
       assert
         .dom(".form-kit__control-select option:nth-child(1)")
         .hasText(
-          i18n("form_kit.select.unselect_placeholder"),
+          i18n("form_kit.select.none_placeholder"),
           "it shows a placeholder for unselection"
         );
     });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2205,7 +2205,7 @@ en:
       dirty_form: "You didn't submit your changes! Are you sure you want to leave?"
       select:
         select_placeholder: "Select…"
-        unselect_placeholder: "Unselect…"
+        none_placeholder: "None"
       errors:
         required: "Required"
         invalid_url: "Must be a valid URL"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2203,6 +2203,9 @@ en:
       optional: optional
       errors_summary_title: "This form contains errors:"
       dirty_form: "You didn't submit your changes! Are you sure you want to leave?"
+      select:
+        select_placeholder: "Select…"
+        unselect_placeholder: "Unselect…"
       errors:
         required: "Required"
         invalid_url: "Must be a valid URL"


### PR DESCRIPTION
This commit will now show a "Select..." option when no value selected and a "Unselect" option when a value is selected, as the first row. It ensures that people don't think a value is selected when it's actually just the html select showing the first available option.

<img width="378" alt="Screenshot 2024-12-05 at 10 41 56" src="https://github.com/user-attachments/assets/782abf35-1c3e-435a-abc1-b79264f81f9d">
<img width="368" alt="Screenshot 2024-12-05 at 10 42 00" src="https://github.com/user-attachments/assets/e408e274-4a4f-4946-8280-ed9e4a8620ec">
