### PR TITLE
UX: make channel name bold for unread threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -140,7 +140,10 @@ export default class ChatChannelRow extends Component {
   }
 
   get channelHasUnread() {
-    return this.args.channel.tracking.unreadCount > 0;
+    return (
+      this.args.channel.tracking.unreadCount > 0 ||
+      this.args.channel.unreadThreadsCount > 0
+    );
   }
 
   get shouldRenderLastMessage() {


### PR DESCRIPTION
Channels with unread threads should have a font weight of bold to match unread channels.

Before:
<img width="410" alt="Screenshot 2024-12-05 at 1 43 07 PM" src="https://github.com/user-attachments/assets/4ed389b2-2b03-47b0-a576-03629ffa037b">


After:
<img width="409" alt="Screenshot 2024-12-05 at 1 43 20 PM" src="https://github.com/user-attachments/assets/3c7a0284-12ad-4109-8983-2b19d9fad6f7">
