### PR TITLE
DEV: Add user_id and post_user_id to MovedPost records

### DIFF
--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -6,6 +6,12 @@ class MovedPost < ActiveRecord::Base
 
   belongs_to :new_topic, class_name: "Topic", foreign_key: :new_topic_id
   belongs_to :new_post, class_name: "Post", foreign_key: :new_post_id
+
+  # The author of the moved post
+  belongs_to :posting_user, class_name: "User", foreign_key: :post_user_id
+
+  # The user who moved the post
+  belongs_to :user
 end
 
 # == Schema Information
@@ -23,12 +29,15 @@ end
 #  created_new_topic :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  post_user_id      :integer
+#  user_id           :integer
 #
 # Indexes
 #
-#  index_moved_posts_on_new_post_id      (new_post_id)
-#  index_moved_posts_on_new_topic_id     (new_topic_id)
-#  index_moved_posts_on_old_post_id      (old_post_id)
-#  index_moved_posts_on_old_post_number  (old_post_number)
-#  index_moved_posts_on_old_topic_id     (old_topic_id)
+#  index_moved_posts_on_new_post_id                    (new_post_id)
+#  index_moved_posts_on_new_topic_id                   (new_topic_id)
+#  index_moved_posts_on_new_topic_id_and_post_user_id  (new_topic_id,post_user_id)
+#  index_moved_posts_on_old_post_id                    (old_post_id)
+#  index_moved_posts_on_old_post_number                (old_post_number)
+#  index_moved_posts_on_old_topic_id                   (old_topic_id)
 #

--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -29,6 +29,7 @@ end
 #  created_new_topic :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  old_topic_title   :string
 #  post_user_id      :integer
 #  user_id           :integer
 #

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -335,6 +335,7 @@ class PostMover
   def movement_metadata(post, new_post_number: nil)
     {
       old_topic_id: post.topic_id,
+      old_topic_title: post.topic.title,
       old_post_id: post.id,
       old_post_number: post.post_number,
       post_user_id: post.user_id,
@@ -351,8 +352,8 @@ class PostMover
     metadata[:user_id] = @user.id
 
     DB.exec(<<~SQL, metadata)
-      INSERT INTO moved_posts(old_topic_id, old_post_id, old_post_number, post_user_id, user_id, new_topic_id, new_topic_title, new_post_id, new_post_number, created_new_topic, created_at, updated_at)
-      VALUES (:old_topic_id, :old_post_id, :old_post_number, :post_user_id, :user_id, :new_topic_id, :new_topic_title, :new_post_id, :new_post_number, :created_new_topic, :now, :now)
+      INSERT INTO moved_posts(old_topic_id, old_topic_title, old_post_id, old_post_number, post_user_id, user_id, new_topic_id, new_topic_title, new_post_id, new_post_number, created_new_topic, created_at, updated_at)
+      VALUES (:old_topic_id, :old_topic_title, :old_post_id, :old_post_number, :post_user_id, :user_id, :new_topic_id, :new_topic_title, :new_post_id, :new_post_number, :created_new_topic, :now, :now)
     SQL
   end
 

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -337,6 +337,7 @@ class PostMover
       old_topic_id: post.topic_id,
       old_post_id: post.id,
       old_post_number: post.post_number,
+      post_user_id: post.user_id,
       new_topic_id: destination_topic.id,
       new_post_number: new_post_number,
       new_topic_title: destination_topic.title,
@@ -347,10 +348,11 @@ class PostMover
     metadata[:new_post_id] = new_post.id
     metadata[:now] = Time.zone.now
     metadata[:created_new_topic] = @creating_new_topic
+    metadata[:user_id] = @user.id
 
     DB.exec(<<~SQL, metadata)
-      INSERT INTO moved_posts(old_topic_id, old_post_id, old_post_number, new_topic_id, new_topic_title, new_post_id, new_post_number, created_new_topic, created_at, updated_at)
-      VALUES (:old_topic_id, :old_post_id, :old_post_number, :new_topic_id, :new_topic_title, :new_post_id, :new_post_number, :created_new_topic, :now, :now)
+      INSERT INTO moved_posts(old_topic_id, old_post_id, old_post_number, post_user_id, user_id, new_topic_id, new_topic_title, new_post_id, new_post_number, created_new_topic, created_at, updated_at)
+      VALUES (:old_topic_id, :old_post_id, :old_post_number, :post_user_id, :user_id, :new_topic_id, :new_topic_title, :new_post_id, :new_post_number, :created_new_topic, :now, :now)
     SQL
   end
 

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -11,6 +11,7 @@ class PostMover
   # freeze_original: :boolean  - if true, the original topic will be frozen but not deleted and posts will be "copied" to topic
   def initialize(original_topic, user, post_ids, move_to_pm: false, options: {})
     @original_topic = original_topic
+    @original_topic_title = original_topic.title
     @user = user
     @post_ids = post_ids
     @move_to_pm = move_to_pm
@@ -335,7 +336,6 @@ class PostMover
   def movement_metadata(post, new_post_number: nil)
     {
       old_topic_id: post.topic_id,
-      old_topic_title: post.topic.title,
       old_post_id: post.id,
       old_post_number: post.post_number,
       post_user_id: post.user_id,
@@ -349,6 +349,7 @@ class PostMover
     metadata[:new_post_id] = new_post.id
     metadata[:now] = Time.zone.now
     metadata[:created_new_topic] = @creating_new_topic
+    metadata[:old_topic_title] = @original_topic_title
     metadata[:user_id] = @user.id
 
     DB.exec(<<~SQL, metadata)

--- a/db/migrate/20241205162117_add_columns_to_moved_posts.rb
+++ b/db/migrate/20241205162117_add_columns_to_moved_posts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class AddColumnsToMovedPosts < ActiveRecord::Migration[7.2]
   def change
+    add_column :moved_posts, :old_topic_title, :string
     add_column :moved_posts, :post_user_id, :integer
     add_column :moved_posts, :user_id, :integer
 

--- a/db/migrate/20241205162117_add_columns_to_moved_posts.rb
+++ b/db/migrate/20241205162117_add_columns_to_moved_posts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class AddColumnsToMovedPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :moved_posts, :post_user_id, :integer
+    add_column :moved_posts, :user_id, :integer
+
+    # Index for querying moved_posts for post author given a new topic ID
+    add_index :moved_posts, %i[new_topic_id post_user_id]
+  end
+end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -316,6 +316,8 @@ RSpec.describe PostMover do
                 new_post_id: p2.id,
                 old_topic: topic,
                 old_post_id: p2.id,
+                post_user_id: p2.user_id,
+                user_id: user.id,
                 created_new_topic: true,
               ),
             ).to eq(true)
@@ -697,6 +699,8 @@ RSpec.describe PostMover do
                 new_post_id: p2.id,
                 old_topic: topic,
                 old_post_id: p2.id,
+                post_user_id: p2.user_id,
+                user_id: user.id,
                 created_new_topic: false,
               ),
             ).to eq(true)
@@ -706,6 +710,8 @@ RSpec.describe PostMover do
                 new_post_id: p4.id,
                 old_topic: topic,
                 old_post_id: p4.id,
+                post_user_id: p4.user_id,
+                user_id: user.id,
                 created_new_topic: false,
               ),
             ).to eq(true)
@@ -2703,8 +2709,10 @@ RSpec.describe PostMover do
         expect(
           MovedPost.exists?(
             old_topic_id: original_topic.id,
-            new_topic_id: destination_topic.id,
             old_post_id: first_post.id,
+            post_user_id: first_post.user_id,
+            user_id: Discourse.system_user.id,
+            new_topic_id: destination_topic.id,
           ),
         ).to eq(true)
       end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2823,7 +2823,7 @@ RSpec.describe PostMover do
       describe "moved_post notifications" do
         before { Jobs.run_immediately! }
 
-        it "Notifications point to the new post and topic" do
+        it "Generates notifications pointing to the newly created post and topic" do
           PostMover.new(
             original_topic,
             Discourse.system_user,

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -314,7 +314,8 @@ RSpec.describe PostMover do
               MovedPost.exists?(
                 new_topic: new_topic,
                 new_post_id: p2.id,
-                old_topic: topic,
+                old_topic_id: topic.id,
+                old_topic_title: topic.title,
                 old_post_id: p2.id,
                 post_user_id: p2.user_id,
                 user_id: user.id,
@@ -325,8 +326,11 @@ RSpec.describe PostMover do
               MovedPost.exists?(
                 new_topic: new_topic,
                 new_post_id: p4.id,
-                old_topic: topic,
+                old_topic_id: topic.id,
+                old_topic_title: topic.title,
                 old_post_id: p4.id,
+                post_user_id: p4.user_id,
+                user_id: user.id,
                 created_new_topic: true,
               ),
             ).to eq(true)
@@ -697,7 +701,8 @@ RSpec.describe PostMover do
               MovedPost.exists?(
                 new_topic: destination_topic,
                 new_post_id: p2.id,
-                old_topic: topic,
+                old_topic_id: topic.id,
+                old_topic_title: topic.title,
                 old_post_id: p2.id,
                 post_user_id: p2.user_id,
                 user_id: user.id,
@@ -708,7 +713,8 @@ RSpec.describe PostMover do
               MovedPost.exists?(
                 new_topic: destination_topic,
                 new_post_id: p4.id,
-                old_topic: topic,
+                old_topic_id: topic.id,
+                old_topic_title: topic.title,
                 old_post_id: p4.id,
                 post_user_id: p4.user_id,
                 user_id: user.id,
@@ -2709,6 +2715,7 @@ RSpec.describe PostMover do
         expect(
           MovedPost.exists?(
             old_topic_id: original_topic.id,
+            old_topic_title: original_topic.title,
             old_post_id: first_post.id,
             post_user_id: first_post.user_id,
             user_id: Discourse.system_user.id,


### PR DESCRIPTION
Follow-up from this PR - https://github.com/discourse/discourse/commit/9b8af0ea9fdd8e82e8c1dc4fedcc754bff8830c9

Adds helpful data into `MovedPost` records for later lookup. ALSO fixes notifications for `freeze_original` to point to the newly created post, not the moved post.