### PR TITLE
UX: Change "What's new in Discourse?" link

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
@@ -166,14 +166,9 @@
                   this.model.attributes.discourse_updated_at
                   leaveAgo="true"
                 }}</p>
-              <a
-                rel="noopener noreferrer"
-                target="_blank"
-                href={{this.model.attributes.release_notes_link}}
-                class="btn btn-default"
-              >
+              <LinkTo @route="admin.whatsNew">
                 {{i18n "admin.dashboard.whats_new_in_discourse"}}
-              </a>
+              </LinkTo>
             </div>
           {{/if}}
         </div>


### PR DESCRIPTION
We want to point to our dedicated /admin/whats-new
page which is more focused and has better screenshots
and so on.

![image](https://github.com/user-attachments/assets/988acf2c-785a-46bd-8027-ccab5088d0b0)

