### PR TITLE
DEV: Drop `experimental_topics_filter` site setting take 2

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2729,7 +2729,6 @@ en:
     default_navigation_menu_categories: "Selected categories will be displayed under Navigation Menu's Categories section by default."
     default_navigation_menu_tags: "Selected tags will be displayed under Navigation Menu's Tags section by default."
     experimental_new_new_view_groups: 'Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
-    experimental_topics_filter: "Enables the experimental topics filter route at /filter"
     enable_experimental_lightbox: "Replace the default image lightbox with the revamped design."
     experimental_glimmer_topic_list_groups: "Enable the new 'glimmer' topic list implementation. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced."
     glimmer_post_menu_mode: "Control whether the new 'glimmer' post menu implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3362,9 +3362,6 @@ experimental:
     default: false
     client: true
     hidden: true
-  experimental_topics_filter:
-    client: true
-    default: true
   enable_rich_text_paste:
     client: true
     default: true

--- a/db/migrate/20241206002425_drop_experimental_topics_filter_site_setting.rb
+++ b/db/migrate/20241206002425_drop_experimental_topics_filter_site_setting.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DropExperimentalTopicsFilterSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'experimental_topics_filter'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This is a follow-up to e6fdfcdcd25d4bf7f009079cace41d0e9ffe4791 which
did not remove the site setting from `config/site_settings.yml` and drop
the site setting value from the database.
