### PR TITLE
UX: Move "What's new?" link in admin sidebar to root section

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -11,14 +11,6 @@ export const ADMIN_NAV_MAP = [
         label: "admin.account.sidebar_link.backups",
         icon: "box-archive",
       },
-      {
-        name: "admin_whats_new",
-        route: "admin.whatsNew",
-        label: "admin.account.sidebar_link.whats_new.title",
-        icon: "gift",
-        keywords: "admin.account.sidebar_link.whats_new.keywords",
-        moderator: true,
-      },
     ],
   },
   {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -208,6 +208,14 @@ export function useAdminNavConfig(navMap) {
           label: "admin.advanced.sidebar_link.all_site_settings",
           icon: "gear",
         },
+        {
+          name: "admin_whats_new",
+          route: "admin.whatsNew",
+          label: "admin.account.sidebar_link.whats_new.title",
+          icon: "gift",
+          keywords: "admin.account.sidebar_link.whats_new.keywords",
+          moderator: true,
+        },
       ],
     },
   ];

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -50,8 +50,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "collapses sections by default" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(3)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
+    expect(links.count).to eq(4)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
   end
 
   context "when on mobile" do
@@ -173,8 +173,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "temporarily expands section when filter" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(3)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
+    expect(links.count).to eq(4)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
 
     filter.filter("ie")
     links = page.all(".sidebar-section-link-content-text")
@@ -183,8 +183,8 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
 
     filter.filter("")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(3)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings"])
+    expect(links.count).to eq(4)
+    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
   end
 
   it "allows further filtering of site settings or users if links do not show results" do
@@ -223,9 +223,9 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(page).to have_selector(".sidebar-section-link-content-text", minimum: 50)
 
     sidebar.toggle_all_sections
-    expect(page).to have_selector(".sidebar-section-link-content-text", count: 3)
+    expect(page).to have_selector(".sidebar-section-link-content-text", count: 4)
     expect(all(".sidebar-section-link-content-text").map(&:text)).to eq(
-      ["Dashboard", "Users", "All Site Settings"],
+      ["Dashboard", "Users", "All Site Settings", "What's New"],
     )
 
     sidebar.toggle_all_sections


### PR DESCRIPTION
This is so the link is more visible, instead of being
buried in the Account section.

![image](https://github.com/user-attachments/assets/13d69568-b0b8-42f4-9b54-086b118869f8)

