### PR TITLE
FIX: Recover user deleted post

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -171,7 +171,7 @@ export default class Post extends RestModel {
   @alias("can_edit") canEdit; // for compatibility with existing code
   @equal("trust_level", 0) new_user;
   @equal("post_number", 1) firstPost;
-  @or("deleted_at", "deletedViaTopic") deleted;
+  @or("deleted_at", "deletedViaTopic", "user_deleted") deleted;
   @not("deleted") notDeleted;
   @propertyEqual("topic.details.created_by.id", "user_id") topicOwner;
   @alias("topic.details.created_by.id") topicCreatedById;
@@ -314,20 +314,20 @@ export default class Post extends RestModel {
     return this.firstPost && !!this.topic.details.can_publish_page;
   }
 
-  get canRecover() {
-    return this.deleted && this.can_recover;
-  }
-
-  get isRecovering() {
-    return !this.deleted && this.can_recover;
-  }
-
   get canRecoverTopic() {
     return this.firstPost && this.deleted && this.topic.details.can_recover;
   }
 
   get isRecoveringTopic() {
     return this.firstPost && !this.deleted && this.topic.details.can_recover;
+  }
+
+  get canRecover() {
+    return !this.canRecoverTopic && this.deleted && this.can_recover;
+  }
+
+  get isRecovering() {
+    return !this.isRecoveringTopic && !this.deleted && this.can_recover;
   }
 
   get canToggleLike() {

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -171,14 +171,14 @@ export default class Post extends RestModel {
   @alias("can_edit") canEdit; // for compatibility with existing code
   @equal("trust_level", 0) new_user;
   @equal("post_number", 1) firstPost;
-  @or("deleted_at", "deletedViaTopic", "user_deleted") deleted;
+  @and("firstPost", "topic.deleted_at") deletedViaTopic; // topic was deleted
+  @or("deleted_at", "deletedViaTopic") deleted; // post is either highlighted is deleted or hidden/removed from the post stream
   @not("deleted") notDeleted;
+  @or("deleted_at", "user_deleted") recoverable; // post or content still can be recovered
   @propertyEqual("topic.details.created_by.id", "user_id") topicOwner;
   @alias("topic.details.created_by.id") topicCreatedById;
 
   // Posts can show up as deleted if the topic is deleted
-  @and("firstPost", "topic.deleted_at") deletedViaTopic;
-
   constructor() {
     super(...arguments);
 
@@ -323,11 +323,11 @@ export default class Post extends RestModel {
   }
 
   get canRecover() {
-    return !this.canRecoverTopic && this.deleted && this.can_recover;
+    return !this.canRecoverTopic && this.recoverable && this.can_recover;
   }
 
   get isRecovering() {
-    return !this.isRecoveringTopic && !this.deleted && this.can_recover;
+    return !this.isRecoveringTopic && !this.recoverable && this.can_recover;
   }
 
   get canToggleLike() {

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -171,14 +171,13 @@ export default class Post extends RestModel {
   @alias("can_edit") canEdit; // for compatibility with existing code
   @equal("trust_level", 0) new_user;
   @equal("post_number", 1) firstPost;
-  @and("firstPost", "topic.deleted_at") deletedViaTopic; // topic was deleted
-  @or("deleted_at", "deletedViaTopic") deleted; // post is either highlighted is deleted or hidden/removed from the post stream
+  @and("firstPost", "topic.deleted_at") deletedViaTopic; // mark fist post as deleted if topic was deleted
+  @or("deleted_at", "deletedViaTopic") deleted; // post is either highlighted as deleted or hidden/removed from the post stream
   @not("deleted") notDeleted;
   @or("deleted_at", "user_deleted") recoverable; // post or content still can be recovered
   @propertyEqual("topic.details.created_by.id", "user_id") topicOwner;
   @alias("topic.details.created_by.id") topicCreatedById;
 
-  // Posts can show up as deleted if the topic is deleted
   constructor() {
     super(...arguments);
 

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -213,16 +213,30 @@ describe "Post menu", type: :system do
           expect(topic_page).to have_no_post_action_button(post, :recover)
           expect(topic_page).to have_no_post_action_button(post2, :recover)
 
-          # do not display the recover button because when `user` deletes teh post. it's just marked for deletion
-          # `user` cannot recover it.
+          #  display the recover button when the POST was user deleted
+          # `post2` is marked for deletion and displays text (post deleted by author) but `user` as the author can
+          # recover it.
           sign_in(user)
 
           topic_page.visit_topic(post.topic)
 
           expect(topic_page).to have_no_post_action_button(post, :recover)
+          expect(topic_page).to have_post_action_button(post2, :recover)
+
+          # do not display the recover button for other users when the post was USER deleted
+          sign_in(Fabricate(:user))
+          topic_page.visit_topic(post.topic)
+          expect(topic_page).to have_no_post_action_button(post, :recover)
           expect(topic_page).to have_no_post_action_button(post2, :recover)
 
-          # display the recover button for the deleted post because an admin is logged
+          # do not display the recover button even for admins when the post was USER deleted, because the action
+          # displayed for the admin is deleting the post to remove it from the post stream
+          sign_in(admin)
+          topic_page.visit_topic(post.topic)
+          expect(topic_page).to have_no_post_action_button(post, :recover)
+          expect(topic_page).to have_no_post_action_button(post2, :recover)
+
+          # display the recover button for an admin when the post was deleted
           PostDestroyer.new(admin, post).destroy
 
           sign_in(admin)


### PR DESCRIPTION
This commit fixes an issue where the recover button would not be displayed for a user delete post.

