### PR TITLE
FIX: Improve name validation in the signup form

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/password-validation.js
+++ b/app/assets/javascripts/discourse/app/mixins/password-validation.js
@@ -30,6 +30,7 @@ export default Mixin.create({
     "passwordRequired",
     "rejectedPasswords.[]",
     "accountUsername",
+    "accountName",
     "accountEmail",
     "passwordMinLength",
     "forceValidationReason",
@@ -84,6 +85,17 @@ export default Mixin.create({
         return EmberObject.create(
           Object.assign(failedAttrs, {
             reason: i18n("user.password.same_as_username"),
+          })
+        );
+      }
+
+      if (
+        !isEmpty(this.accountName) &&
+        this.accountPassword === this.accountName
+      ) {
+        return EmberObject.create(
+          Object.assign(failedAttrs, {
+            reason: i18n("user.password.same_as_name"),
           })
         );
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2044,6 +2044,7 @@ en:
           other: "Your password is too short (minimum is %{count} characters)."
         common: "That password is too common."
         same_as_username: "Your password is the same as your username."
+        same_as_name: "Your password is the same as your name."
         same_as_email: "Your password is the same as your email."
         ok: "Your password looks good."
         instructions:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -749,6 +749,8 @@ en:
       user:
         ip_address: ""
         password: "Password"
+      user_password:
+        password: "Password"
     errors:
       <<: *errors
       models:


### PR DESCRIPTION
This PR fixes the Rails validation error messages for user passwords, changing redundant phrasing from `User password password` to `Password`.

E.g. `User password password is the same as your name.` is now `Password is the same as your name.`

It also adds client-side validation for passwords and names, similar to the validation already implemented for usernames.
