### PR TITLE
UX: fix channel name style for unread threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -142,7 +142,7 @@ export default class ChatChannelRow extends Component {
   get channelHasUnread() {
     return (
       this.args.channel.tracking.unreadCount > 0 ||
-      this.args.channel.unreadThreadsCount > 0
+      this.args.channel.unreadThreadsCountSinceLastViewed > 0
     );
   }
 


### PR DESCRIPTION
Follow up to #30127.

Normally when viewing a channel with tracked threads, we dismiss the blue dot next to the channel name even though the thread has not been read yet.

This change applies the same criteria to determine if we should bold the channel name.

#### The issue:

When we have unread threads but haven't opened the channel yet (looks correct):

<img width="411" alt="Screenshot 2024-12-06 at 5 04 35 PM" src="https://github.com/user-attachments/assets/d10ab34b-7c56-4459-b175-830d3ce3d073">

We open the channel but don't open the thread:

<img width="411" alt="Screenshot 2024-12-06 at 5 04 49 PM" src="https://github.com/user-attachments/assets/f4d4eaef-51bc-45b1-a71f-f364638e786c">

After hitting the back button or channels tab the channel name is still bolded but blue dot removed:

<img width="411" alt="Screenshot 2024-12-06 at 5 05 21 PM" src="https://github.com/user-attachments/assets/cfb5c58a-4759-4acf-b28f-680d02c6f2fd">
