### PR TITLE
UX: hide automatic group admin tooltip from users

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -41,16 +41,18 @@
           </div>
         {{/if}}
 
-        {{#if this.model.automatic}}
-          <DTooltip class="admin-group-automatic-tooltip">
-            <:trigger>
-              {{d-icon "gear"}}
-              {{i18n "admin.groups.manage.membership.automatic"}}
-            </:trigger>
-            <:content>
-              {{i18n "admin.groups.manage.membership.automatic_tooltip"}}
-            </:content>
-          </DTooltip>
+        {{#if this.canManageGroup}}
+          {{#if this.model.automatic}}
+            <DTooltip class="admin-group-automatic-tooltip">
+              <:trigger>
+                {{d-icon "gear"}}
+                {{i18n "admin.groups.manage.membership.automatic"}}
+              </:trigger>
+              <:content>
+                {{i18n "admin.groups.manage.membership.automatic_tooltip"}}
+              </:content>
+            </DTooltip>
+          {{/if}}
         {{/if}}
       </div>
 


### PR DESCRIPTION
The tooltip introduced in [#28630](https://github.com/discourse/discourse/pull/28630) was displayed to all users, but it relied on text only available to staff. This resulted in a broken tooltip being shown to non-staff users.

See the report for more details: [Meta Topic](https://meta.discourse.org/t/admin-groups-manage-membership-automatic-not-replaced/324215).

Fix Details:
* I think automatic groups do not have group owners, so users who can manage the group are always staff.
* The tooltip is now hidden for users, who cannot manage the group.
* Staff users, who can manage the group, still see the tooltip as expected.


Before:
Non-staff users saw a broken tooltip:
![broken tooltip for user](https://github.com/user-attachments/assets/03e0e800-2a02-4758-a1e1-db1422a40163)

After:
Tooltip is hidden for non-staff users:
![hidden tooltip for user](https://github.com/user-attachments/assets/9a2494b2-cc25-45ba-b175-ef4486b64ee9)
Tooltip is still visible for admin:
![tooltip still visible for staff](https://github.com/user-attachments/assets/ffa43eeb-f679-4911-a8d3-502400e01b7a)


