### PR TITLE
UX: only show automatic group tooltip to admins

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -41,7 +41,7 @@
           </div>
         {{/if}}
 
-        {{#if this.model.automatic}}
+        {{#if (and this.currentUser.admin this.model.automatic)}}
           <DTooltip class="admin-group-automatic-tooltip">
             <:trigger>
               {{d-icon "gear"}}

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -24,6 +24,24 @@ acceptance("Managing Group Membership", function (needs) {
     );
   });
 
+  test("As an admin on an automatic group", async function (assert) {
+    await visit("/g/moderators");
+
+    assert
+      .dom(".admin-group-automatic-tooltip")
+      .exists("displays automatic tooltip");
+  });
+
+  test("As a non-admin user on an automatic group", async function (assert) {
+    updateCurrentUser({ admin: false });
+
+    await visit("/g/moderators");
+
+    assert
+      .dom(".admin-group-automatic-tooltip")
+      .doesNotExist("does not display automatic tooltip");
+  });
+
   test("As an admin", async function (assert) {
     updateCurrentUser({ can_create_group: true });
 


### PR DESCRIPTION
Follow up to #28630 which added the tooltip on automatic group.

It was missing a check to ensure the current user is an admin, since only admins can manage automatic groups.

Reported in https://meta.discourse.org/t/324215 by @moin-Jana

Closes #30154