### PR TITLE
DEV: admin-login submit should be a button, not an input

### DIFF
--- a/app/views/users/admin_login.html.erb
+++ b/app/views/users/admin_login.html.erb
@@ -10,6 +10,6 @@
       <%= t 'admin_login.safe_mode' %>
     </label>
     <br/>
-    <%= submit_tag t('admin_login.submit_button'), class: "btn btn-primary" %>
+    <%= button_tag t('admin_login.submit_button'), class: "btn btn-primary", type: "submit" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The submit button here (/u/admin-login) is a weird case at the moment, it's an input with button classes added.

![image](https://github.com/user-attachments/assets/691744d2-ac57-44b9-b1f9-1f7d680a3d3d)

This can cause the button to pickup styles of both a button and an input in a theme, which is undesirable. Better to be a button. 

Tested to verify that it still submits properly and generates an email. 




