### PR TITLE
DEV: Add workaround for chrome crash

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -327,6 +327,13 @@ export default class ChatMessageInteractor {
 
   @action
   toggleBookmark() {
+    // somehow, this works around a low-level chrome rendering issue which
+    // causes a complete browser crash when saving/deleting bookmarks in chat.
+    // Error message: "Check failed: !NeedsToUpdateCachedValues()."
+    // Internal topic: t/143485
+    // Hopefully, this can be dropped in future chrome versions
+    document.activeElement?.blur();
+
     this.modal.show(BookmarkModal, {
       model: {
         bookmark: new BookmarkFormData(


### PR DESCRIPTION
Some users are seeing consistent "Error 5" crashes in chrome when saving/deleting bookmarks on chat messages.

When crash logging is enabled, the message is:

`[33466:259:1206/122312.195048:ERROR:ax_object.cc(3400)] Check failed: !NeedsToUpdateCachedValues(). Stale values: "Group" axid#7543 <svg#discourse-emojis> needsToUpdateCachedValues/disallowed isIgnored inUserAgentShadowRoot:<use> isInert needsToUpdateChildren hasDirtyDescendants`

This seems to be influenced by a few factors, including the re-render of the bookmarks button, the adjacent 'reactions' button, and also the opening/closing of the modal.

Adding this `activeElement.blur` seems to avoid the issue in my manual testing. Hopefully, this can be dropped after future chrome releases.

Internal topic: t/143485

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->