### PR TITLE
FIX: lower thread panel min-width

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-side-panel.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   border-left: 1px solid var(--primary-low);
   position: relative;
-  min-width: clamp(350px, 33vw, 33vw);
+  min-width: 150px;
 
   &__list {
     flex-grow: 1;


### PR DESCRIPTION
It's been set to this value as a workaround for long thread titles, but we now have standalone thread titles in the thread body which makes this not needed. People had troubles understanding why they couldn't resize more the thread panel.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->