### PR TITLE
DEV: Fix specs for directory items controller

### DIFF
--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -5,6 +5,7 @@ Fabricator(:user_stat) {}
 Fabricator(:user, class_name: :user) do
   transient refresh_auto_groups: false
   transient trust_level: nil
+  transient search_index: false
 
   name "Bruce Wayne"
   username { sequence(:username) { |i| "bruce#{i}" } }
@@ -19,7 +20,10 @@ Fabricator(:user, class_name: :user) do
     if transients[:refresh_auto_groups] || transients[:trust_level]
       Group.user_trust_level_change!(user.id, user.trust_level)
     end
+    SearchIndexer.disable if transients[:search_index]
   end
+
+  before_create { |user, transients| SearchIndexer.enable if transients[:search_index] }
 end
 
 Fabricator(:user_with_secondary_email, from: :user) do


### PR DESCRIPTION
The directory items controller specs that have a search param were not
matching how things worked in production. In a non-test environment the
UserSearch class depends on the `user_search_data` table being
populated, so the tests I corrected now use this table as well to match
reality.

Also added a new test to match the 20 user limit for search results that
currently exists. This 20 user limit is on the line between a bug and a
feature but it is how it is currently working so we should document
that. We have plans to increase this limit and it has been documented
here: https://meta.discourse.org/t/296485

This PR is a no-op and only changes the tests.

Co-authored-by: brrusselburg <25828824+brrusselburg@users.noreply.github.com>
