### PR TITLE
Switch the glimmer post menu to auto and unsilence deprecations

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse-common/addon/deprecation-workflow.js
@@ -8,10 +8,6 @@ const DEPRECATION_WORKFLOW = [
   },
   {
     handler: "silence",
-    matchId: "discourse.post-menu-widget-overrides",
-  },
-  {
-    handler: "silence",
     matchId: "discourse.hbr-topic-list-overrides",
   },
 ];

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -171,6 +171,12 @@ const DEPRECATED_POST_MENU_WIDGETS = [
   "small-user-list",
 ];
 
+const POST_MENU_DEPRECATION_OPTIONS = {
+  since: "v3.4.0.beta3-dev",
+  id: "discourse.post-menu-widget-overrides",
+  url: "https://meta.discourse.org/t/341014",
+};
+
 const appliedModificationIds = new WeakMap();
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
@@ -880,11 +886,7 @@ class PluginApi {
   addPostMenuButton(name, callback) {
     deprecated(
       "`api.addPostMenuButton` has been deprecated. Use the value transformer `post-menu-buttons` instead.",
-      {
-        since: "v3.4.0.beta3-dev",
-        id: "discourse.post-menu-widget-overrides",
-        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
-      }
+      POST_MENU_DEPRECATION_OPTIONS
     );
 
     apiExtraButtons[name] = callback;
@@ -959,11 +961,7 @@ class PluginApi {
   removePostMenuButton(name, callback) {
     deprecated(
       "`api.removePostMenuButton` has been deprecated. Use the value transformer `post-menu-buttons` instead.",
-      {
-        since: "v3.4.0.beta3-dev",
-        id: "discourse.post-menu-widget-overrides",
-        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
-      }
+      POST_MENU_DEPRECATION_OPTIONS
     );
 
     removeButton(name, callback);
@@ -988,11 +986,7 @@ class PluginApi {
   replacePostMenuButton(name, widget) {
     deprecated(
       "`api.replacePostMenuButton` has been deprecated. Use the value transformer `post-menu-buttons` instead.",
-      {
-        since: "v3.4.0.beta3-dev",
-        id: "discourse.post-menu-widget-overrides",
-        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
-      }
+      POST_MENU_DEPRECATION_OPTIONS
     );
 
     replaceButton(name, widget);
@@ -3421,11 +3415,7 @@ class PluginApi {
     if (DEPRECATED_POST_MENU_WIDGETS.includes(widgetName)) {
       deprecated(
         `The ${widgetName} widget has been deprecated and ${override} is no longer a supported override.`,
-        {
-          since: "v3.4.0.beta3-dev",
-          id: "discourse.post-menu-widget-overrides",
-          url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
-        }
+        POST_MENU_DEPRECATION_OPTIONS
       );
     }
   }

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -883,6 +883,7 @@ class PluginApi {
       {
         since: "v3.4.0.beta3-dev",
         id: "discourse.post-menu-widget-overrides",
+        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
       }
     );
 
@@ -961,6 +962,7 @@ class PluginApi {
       {
         since: "v3.4.0.beta3-dev",
         id: "discourse.post-menu-widget-overrides",
+        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
       }
     );
 
@@ -989,6 +991,7 @@ class PluginApi {
       {
         since: "v3.4.0.beta3-dev",
         id: "discourse.post-menu-widget-overrides",
+        url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
       }
     );
 
@@ -3421,6 +3424,7 @@ class PluginApi {
         {
           since: "v3.4.0.beta3-dev",
           id: "discourse.post-menu-widget-overrides",
+          url: "https://meta.discourse.org/t/upcoming-post-menu-changes-how-to-prepare-themes-and-plugins/341014",
         }
       );
     }

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -554,8 +554,10 @@ createWidget("post-contents", {
         !postMenuWidgetExtensionsAdded)
     ) {
       if (!postMenuConsoleWarningLogged) {
-        // eslint-disable-next-line no-console
-        console.log("✅  Using the new 'glimmer' post menu!");
+        if (!isTesting()) {
+          // eslint-disable-next-line no-console
+          console.log("✅  Using the new 'glimmer' post menu!");
+        }
 
         if (postMenuWidgetExtensionsAdded) {
           postMenuConsoleWarningLogged = true;

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -550,11 +550,13 @@ createWidget("post-contents", {
 
     if (
       this.siteSettings.glimmer_post_menu_mode === "enabled" ||
-      ((this.siteSettings.glimmer_post_menu_mode === "auto" ||
-        this.currentUser?.use_auto_glimmer_post_menu) &&
+      (this.siteSettings.glimmer_post_menu_mode === "auto" &&
         !postMenuWidgetExtensionsAdded)
     ) {
       if (!postMenuConsoleWarningLogged) {
+        // eslint-disable-next-line no-console
+        console.log("✅  Using the new 'glimmer' post menu!");
+
         if (postMenuWidgetExtensionsAdded) {
           postMenuConsoleWarningLogged = true;
 
@@ -567,12 +569,6 @@ createWidget("post-contents", {
               // TODO (glimmer-post-menu): add link to meta topic here when the roadmap for the update is announced
             ].join("\n- ")
           );
-        } else if (this.currentUser?.use_auto_glimmer_post_menu) {
-          // TODO (glimmer-post-menu): remove this else if block when removing the site setting glimmer_post_menu_groups
-          postMenuConsoleWarningLogged = true;
-
-          // eslint-disable-next-line no-console
-          console.log("✅  Using the new 'glimmer' post menu!");
         }
       }
 
@@ -617,8 +613,7 @@ createWidget("post-contents", {
       );
     } else {
       if (
-        (this.siteSettings.glimmer_post_menu_mode !== "disabled" ||
-          this.currentUser?.use_auto_glimmer_post_menu) &&
+        this.siteSettings.glimmer_post_menu_mode !== "disabled" &&
         postMenuWidgetExtensionsAdded &&
         !postMenuConsoleWarningLogged
       ) {
@@ -1019,15 +1014,16 @@ createWidget("post-article", {
     return new RenderGlimmer(
       this,
       "div.topic-map.--op",
-      hbs`<TopicMap
-        @model={{@data.model}}
-        @topicDetails={{@data.topicDetails}}
-        @postStream={{@data.postStream}}
-        @showPMMap={{@data.showPMMap}}
-        @showInvite={{@data.showInvite}}
-        @removeAllowedGroup={{@data.removeAllowedGroup}}
-        @removeAllowedUser={{@data.removeAllowedUser}}
-      />`,
+      hbs`
+        <TopicMap
+          @model={{@data.model}}
+          @topicDetails={{@data.topicDetails}}
+          @postStream={{@data.postStream}}
+          @showPMMap={{@data.showPMMap}}
+          @showInvite={{@data.showInvite}}
+          @removeAllowedGroup={{@data.removeAllowedGroup}}
+          @removeAllowedUser={{@data.removeAllowedUser}}
+        />`,
       {
         model: attrs.topic,
         topicDetails: attrs.topic.get("details"),

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -31,7 +31,7 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
     await visit("/t/this-is-a-test-topic/9");
     await triggerKeyEvent(document, "keypress", "G");
     await triggerKeyEvent(document, "keypress", "S");
-    assert.strictEqual(currentURL(), "/t/this-is-a-test-topic/9");
+    assert.true(currentURL().startsWith("/t/this-is-a-test-topic/9"));
 
     // Suggested topics elements exist.
     await visit("/t/internationalization-localization/280");

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -76,7 +76,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_admin_sidebar,
              :can_view_raw_email,
              :use_glimmer_topic_list?,
-             :use_auto_glimmer_post_menu?,
              :login_method,
              :has_unseen_features
 
@@ -325,10 +324,6 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def use_glimmer_topic_list?
     scope.user.in_any_groups?(SiteSetting.experimental_glimmer_topic_list_groups_map)
-  end
-
-  def use_auto_glimmer_post_menu?
-    scope.user.in_any_groups?(SiteSetting.glimmer_post_menu_groups_map)
   end
 
   def do_not_disturb_channel_position

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3344,20 +3344,12 @@ experimental:
     refresh: true
   glimmer_post_menu_mode:
     client: true
-    hidden: true
     type: enum
     choices:
       - disabled
       - auto
       - enabled
-    default: disabled
-  glimmer_post_menu_groups:
-    client: true
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true
+    default: auto
   enable_experimental_lightbox:
     default: false
     client: true

--- a/db/migrate/20241211030039_remove_glimmer_post_menu_groups_setting.rb
+++ b/db/migrate/20241211030039_remove_glimmer_post_menu_groups_setting.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class RemoveGlimmerPostMenuGroupsSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'glimmer_post_menu_groups'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This commit starts the rollout of the Glimmer post menu:

- default to `auto`: after the upgrade, it will be enabled on all discourse instances that do not have incompatible customizations

- unsilence the deprecation messages in the console

- removes the setting `glimmer_post_menu_groups` as it's no longer in the test phase