### PR TITLE
DEV: update deprecated icon names in themes-grid-card

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -41,7 +41,7 @@ export default class ThemeCard extends Component {
   }
 
   get footerActionIcon() {
-    return this.args.theme.isPendingUpdates ? "sync" : "ellipsis-h";
+    return this.args.theme.isPendingUpdates ? "arrows-rotate" : "ellipsis";
   }
 
   // NOTE: inspired by -> https://github.com/discourse/discourse/blob/24caa36eef826bcdaed88aebfa7df154413fb349/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js#L366
@@ -116,7 +116,7 @@ export default class ThemeCard extends Component {
           <span
             title={{i18n "admin.customize.theme.updates_available_tooltip"}}
             class="theme-card__update-available"
-          >{{icon "info-circle"}}</span>
+          >{{icon "circle-info"}}</span>
         {{/if}}
         <div class="theme-card__image-wrapper">
           {{#if @theme.screenshot_url}}
@@ -179,7 +179,7 @@ export default class ThemeCard extends Component {
                       @preventFocus={{true}}
                       @icon={{if
                         @theme.default
-                        "far-check-square"
+                        "far-square-check"
                         "far-square"
                       }}
                       class="theme-card__button"

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -47,7 +47,7 @@
       }
     }
   }
-  &.--updating .d-icon-sync {
+  &.--updating .d-icon-arrows-rotate {
     animation: rotate 3s linear infinite;
     margin-right: 0.45em;
     @keyframes rotate {


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names in the ThemesGridCard component and associated styling. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.