### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flags-form.gjs
@@ -205,7 +205,7 @@ export default class AdminFlagsForm extends Component {
                 </checkboxGroup.Field>
               </form.CheckboxGroup>
 
-              <form.Alert @icon="info-circle">
+              <form.Alert @icon="circle-info">
                 {{i18n "admin.config_areas.flags.form.alert"}}
               </form.Alert>
 

--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -116,7 +116,7 @@ export default class ThemeCard extends Component {
           <span
             title={{i18n "admin.customize.theme.updates_available_tooltip"}}
             class="theme-card__update-available"
-          >{{icon "info-circle"}}</span>
+          >{{icon "circle-info"}}</span>
         {{/if}}
         <div class="theme-card__image-wrapper">
           {{#if @theme.screenshot_url}}

--- a/app/assets/javascripts/admin/addon/components/version-checks.hbs
+++ b/app/assets/javascripts/admin/addon/components/version-checks.hbs
@@ -108,7 +108,7 @@
               }}"
           >
             {{#if this.versionCheck.behindByOneVersion}}
-              {{d-icon "far-meh"}}
+              {{d-icon "far-face-meh"}}
             {{else}}
               {{d-icon "far-face-frown"}}
             {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -10,7 +10,7 @@
     {{#if this.model.can_view_action_logs}}
       <DButton
         @action={{fn this.viewActionLogs this.model.username}}
-        @icon="far-list-alt"
+        @icon="far-rectangle-list"
         @label="admin.user.action_logs"
         class="btn-default"
       />
@@ -850,7 +850,7 @@
           {{else}}
             <DButton
               @action={{fn this.checkSsoPayload this.model}}
-              @icon="far-list-alt"
+              @icon="far-rectangle-list"
               @label="admin.users.check_sso.text"
               @title="admin.users.check_sso.title"
               class="btn-default"

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/read.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/read.gjs
@@ -25,7 +25,7 @@ export default class PostMenuReadButton extends Component {
       <DButton
         ...attributes
         @action={{@buttonActions.toggleWhoRead}}
-        @icon="book-reader"
+        @icon="book-open-reader"
         @title="post.controls.read_indicator"
       />
     </div>

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/show-more.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/show-more.gjs
@@ -11,7 +11,7 @@ export default class PostMenuShowMoreButton extends Component {
       class="post-action-menu__show-more show-more-actions"
       ...attributes
       @action={{@buttonActions.showMoreActions}}
-      @icon="ellipsis-h"
+      @icon="ellipsis"
       @title="show_more"
     />
   </template>

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -49,14 +49,14 @@ module("Unit | Utility | icon-library", function (hooks) {
 
   test("fa5 remaps", function (assert) {
     withSilencedDeprecations("discourse.fontawesome-6-upgrade", () => {
-      const adjustIcon = iconHTML("adjust");
+      const adjustIcon = iconHTML("circle-half-stroke");
       assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
       assert.true(
         adjustIcon.includes('href="#circle-half-stroke"'),
         "has remapped icon"
       );
 
-      const farIcon = iconHTML("far-dot-circle");
+      const farIcon = iconHTML("far-circle-dot");
       assert.true(
         farIcon.includes("d-icon-far-dot-circle"),
         "class is maintained"

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -49,14 +49,14 @@ module("Unit | Utility | icon-library", function (hooks) {
 
   test("fa5 remaps", function (assert) {
     withSilencedDeprecations("discourse.fontawesome-6-upgrade", () => {
-      const adjustIcon = iconHTML("circle-half-stroke");
+      const adjustIcon = iconHTML("adjust");
       assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
       assert.true(
         adjustIcon.includes('href="#circle-half-stroke"'),
         "has remapped icon"
       );
 
-      const farIcon = iconHTML("far-circle-dot");
+      const farIcon = iconHTML("far-dot-circle");
       assert.true(
         farIcon.includes("d-icon-far-dot-circle"),
         "class is maintained"

--- a/plugins/chat/admin/assets/javascripts/admin/components/admin-chat-incoming-webhooks-list.gjs
+++ b/plugins/chat/admin/assets/javascripts/admin/components/admin-chat-incoming-webhooks-list.gjs
@@ -94,7 +94,7 @@ export default class AdminChatIncomingWebhooksList extends Component {
                 >{{i18n "chat.incoming_webhooks.edit"}}</LinkTo>
 
                 <DButton
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   @title="chat.incoming_webhooks.delete"
                   @action={{fn this.destroyWebhook webhook}}
                   class="btn-danger btn-small admin-chat-incoming-webhooks-delete"

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -11,7 +11,7 @@ register_asset "stylesheets/common/poll-ui-builder.scss"
 register_asset "stylesheets/desktop/poll-ui-builder.scss", :desktop
 register_asset "stylesheets/common/poll-breakdown.scss"
 
-register_svg_icon "far fa-square-check"
+register_svg_icon "far-square-check"
 
 enabled_site_setting :poll_enabled
 hide_plugin


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.