### PR TITLE
FIX: correct breadcrumb for admin users page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list.hbs
@@ -7,7 +7,7 @@
     <:breadcrumbs>
       <DBreadcrumbsItem
         @path="/admin/users/list"
-        @label={{i18n "admin.permalink.title"}}
+        @label={{i18n "admin.users.title"}}
       />
     </:breadcrumbs>
     <:actions as |actions|>

--- a/spec/system/admin_users_list_spec.rb
+++ b/spec/system/admin_users_list_spec.rb
@@ -11,6 +11,11 @@ describe "Admin Users Page", type: :system do
 
   before { sign_in(current_user) }
 
+  it "show correct breadcrumbs" do
+    admin_users_page.visit
+    expect(admin_users_page).to have_correct_breadcrumbs
+  end
+
   describe "bulk user delete" do
     let(:confirmation_modal) { PageObjects::Modals::BulkUserDeleteConfirmation.new }
 

--- a/spec/system/page_objects/pages/admin_users.rb
+++ b/spec/system/page_objects/pages/admin_users.rb
@@ -43,6 +43,12 @@ module PageObjects
         all(".directory-table__row").size
       end
 
+      def has_correct_breadcrumbs?
+        expect(all(".d-breadcrumbs__item").map(&:text)).to eq(
+          [I18n.t("js.admin_title"), I18n.t("admin_js.admin.users.title")],
+        )
+      end
+
       def has_users?(user_ids)
         user_ids.all? { |id| has_css?(".directory-table__row[data-user-id=\"#{id}\"]") }
       end


### PR DESCRIPTION
Omission and instead of `permlinks`, `users` title should be used.

Screenshot

<img width="1401" alt="Screenshot 2024-12-09 at 10 33 18 AM" src="https://github.com/user-attachments/assets/bb3ff606-a8a8-4c1d-97b4-3dcfef9c535e">
