### PR TITLE
PERF: Don't execute a `git` command each time we log a log line

### DIFF
--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -67,7 +67,7 @@ class DiscourseLogstashLogger < Logger
       "pid" => PROCESS_PID,
       "type" => @type.to_s,
       "host" => HOST,
-      "git_version" => GitUtils.git_version,
+      "git_version" => GIT_VERSION,
     }
 
     # Only log backtrace and env for Logger::WARN and above.


### PR DESCRIPTION
We already have a `GIT_VERSION` constant in `DiscourseLogstashLogger` so
we can just use that.
