### PR TITLE
DEV: Fix duplicated logging of unicorn worker backtraces

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -131,9 +131,12 @@ before_fork do |server, worker|
           tmp = @timeout - diff
 
           # START MONKEY PATCH
-          if tmp < 2
-            logger.error "worker=#{worker.nr} PID:#{wpid} running too long " \
-                           "(#{diff}s), sending USR2 to dump thread backtraces"
+          if tmp < 2 && !worker.instance_variable_get(:@timing_out_logged)
+            logger.error do
+              "worker=#{worker.nr} PID:#{wpid} running too long (#{diff}s), sending USR2 to dump thread backtraces"
+            end
+
+            worker.instance_variable_set(:@timing_out_logged, true)
             kill_worker(:USR2, wpid)
           end
           # END MONKEY PATCH


### PR DESCRIPTION
In 6cafe59c76fd2e1151f2b8483402a6984ccd901b, we added a monkey patch to
`Unicorn::HtppServer#murder_lazy_workers` to log a message and send a
`USR2` signal to the Unicorn worker process when the Unicorn worker
process is 2 seconds away from being timed out by the Unicorn master
process. However, we ended up logging multiple messages and sending
multiple USR2 signal during the 2 seconds before the Unicorn worker
process hits the time out.

To overcome this problem, we will now set an instance variable on the
`Unicorn::Worker` instance and use it to ensure that the log message is
only logged once and USR2 signal to the Unicorn worker process is only
sent one as well.

### Reviewer notes

This change has to be tested manually. To replicate the problem, follow the steps below:

1. Run `UNICORN_TIMEOUT=5 ENABLE_LOGSTASH_LOGGER=1 bin/rails s` in a terminal
2. Run `tail -f log/unicorn.stderr.log` in another terminal
3. Add `before_action { sleep 6 }` after `class ApplicationController < ActionController::Base` in `app/controllers/application_controller.rb`
4. Visit `localhost:4200` in your browser.
5. After 5 seconds, you should see the following printed in the logs.

    ```
    {"message":"worker=0 PID:4358 running too long (4s), sending USR2 to dump thread backtraces",
    {"message":"worker=0 PID:4358 running too long (5s), sending USR2 to dump thread backtraces",
    {"message":"worker=0 PID:4358 running too long (6s), sending USR2 to dump thread backtraces",
    {"message":"worker=0 PID:4358 timeout (6s \u003e 5s), killing","severity":3
    ```
    
 To test out this change after the setup above:
 
 1. Run `git fetch origin fix_logging_when_unicorn_times_out && git checkout fix_logging_when_unicorn_times_out`
 2. Unicorn should automatically reload.
 3. Visit `localhost:4200` in the browser again.
 4. You should only see a single log line `{"message":"worker=0 PID:10847 running too long (4s), sending USR2 to dump thread backtraces",`.