### PR TITLE
FIX: chat channel sort order consistency in sidebar

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -34,9 +34,7 @@ export default class ChannelsListPublic extends Component {
   }
 
   get channelList() {
-    return this.args.sortByActivity === true
-      ? this.chatChannelsManager.publicMessageChannelsByActivity
-      : this.chatChannelsManager.publicMessageChannels;
+    return this.chatChannelsManager.publicMessageChannelsByActivity;
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channels.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channels.gjs
@@ -22,7 +22,7 @@ export default class ChatDrawerRoutesChannels extends Component {
 
       {{#if this.chatStateManager.isDrawerExpanded}}
         <div class="chat-drawer-content">
-          <ChannelsListPublic @sortByActivity={{true}} />
+          <ChannelsListPublic />
         </div>
 
         <ChatFooter />

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channels.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channels.gjs
@@ -17,7 +17,7 @@ export default class ChatRoutesChannels extends Component {
         </navbar.Actions>
       </Navbar>
 
-      <ChannelsListPublic @sortByActivity={{true}} />
+      <ChannelsListPublic />
     </div>
   </template>
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -136,7 +136,7 @@ export default class ChatChannelsManager extends Service {
   }
 
   get publicMessageChannelsByActivity() {
-    return this.#sortChannelsByActivity(this.publicMessageChannels);
+    return this.#sortChannelsByActivity([...this.publicMessageChannels]);
   }
 
   @cached

--- a/plugins/chat/spec/system/list_channels/sidebar_spec.rb
+++ b/plugins/chat/spec/system/list_channels/sidebar_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "List channels | sidebar", type: :system do
   fab!(:current_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }
+  let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
 
   before do
     chat_system_bootstrap
@@ -70,6 +71,24 @@ RSpec.describe "List channels | sidebar", type: :system do
         )
         expect(page.find("#sidebar-section-content-chat-channels li:nth-child(2)")).to have_css(
           ".channel-#{channel_1.id}",
+        )
+      end
+
+      it "does not change sorting order when using drawer" do
+        Fabricate(:chat_message, chat_channel: channel_1)
+        visit("/")
+
+        expect(page.find("#sidebar-section-content-chat-channels li:nth-child(1)")).to have_css(
+          ".channel-#{channel_2.id}",
+        )
+
+        drawer_page.visit_index
+        drawer_page.click_channels
+
+        expect(drawer_page).to have_channel_at_position(channel_1, 1)
+
+        expect(page.find("#sidebar-section-content-chat-channels li:nth-child(1)")).to have_css(
+          ".channel-#{channel_2.id}",
         )
       end
     end


### PR DESCRIPTION
This change creates a shallow copy of the public message channels so we don't change the original array while sorting.

Without this change the `publicMessageChannels` getter cache gets invalidated and cached again with the sorted channels array instead, which causes a bug where the sidebar channel list sorting order is updated by activity when user interacts with the chat drawer.

Note: sidebar is the only place that we don't sort chat channels by activity, and it directly loads the channels by calling `chatChannelsManager.publicMessageChannels`.

Internal ref: /t/-/143486