### PR TITLE
FIX: Prevent experimental badge from splitting onto new lines with long titles

### DIFF
--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -667,6 +667,7 @@
   margin-left: 0.5rem;
   font-weight: 400;
   border-radius: var(--d-border-radius);
+  display: inline-block;
 }
 
 .admin-new-feature-item__body {


### PR DESCRIPTION
This PR resolves an issue where the "Experimental" badge would break onto a new line when the title was too long, causing the badge text to separate from the icon. The fix ensures the badge text and icon remain aligned, even with longer titles.

### Before
<img width="548" alt="image" src="https://github.com/user-attachments/assets/85e9230d-7033-437f-86ff-e92d65338970">


### After
<img width="546" alt="image" src="https://github.com/user-attachments/assets/ab21168a-1208-456a-b00c-98ad9928afe5">

