### PR TITLE
DEV: attempt to fix some system spec flakes

### DIFF
--- a/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.gjs
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.gjs
@@ -33,6 +33,12 @@ export default class ComposerPresenceDisplay extends Component {
   });
 
   setupWhisperChannel = helperFn((_, on) => {
+    // NOTE: this is here to prevent some flakes in tests
+    // For some random reasons, this component is being rendered even though `currentUser` is `null`
+    if (!this.currentUser) {
+      return;
+    }
+
     const { topic } = this.args.model;
     const { whisperer } = this.currentUser;
 

--- a/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.gjs
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.gjs
@@ -30,6 +30,12 @@ export default class TopicPresenceDisplay extends Component {
   });
 
   setupWhisperChannel = helperFn((_, on) => {
+    // NOTE: this is here to prevent some flakes in tests
+    // For some random reasons, this component is being rendered even though `currentUser` is `null`
+    if (!this.currentUser) {
+      return;
+    }
+
     const { topic } = this.args;
     const { whisperer } = this.currentUser;
 


### PR DESCRIPTION
Since 3e7f0867ea044ffd3e957946e1996736d4a19df8, I started seeing some specs fail due to the following error

```plain
Error occurred while rendering: top-level application > discourse-root > topic > discourse-topic > topic-navigation > plugin-outlet > plugin-connector > topic-presence-display

/assets/plugins/discourse-presence.js - Uncaught TypeError: Cannot destructure property 'whisperer' of 'this.currentUser' as it is null.
```

For some reasons I can't fanthom, the presence components seem to be rendered even though they're using outlets that are only rendered when a user is signed in... 🤷‍♂️

Lost too much time trying to reproduce so I ended up adding this `if (!this.currentUser) { return; }` condition to both "presence display" component to (hopefully) fix these flakes.