### PR TITLE
FIX: correctly handle hidden tags when checking for edit conflicts

### DIFF
--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -164,6 +164,39 @@ RSpec.describe DraftsController do
       expect(response.parsed_body["conflict_user"]["id"]).to eq(post.last_editor.id)
     end
 
+    it "handles hidden tags when checking for tag conflict" do
+      sign_in(user)
+
+      regular_tag = Fabricate(:tag)
+      admin_only_tag_one = Fabricate(:tag)
+      admin_only_tag_two = Fabricate(:tag)
+
+      admin_only_tag_group = Fabricate(:tag_group)
+      admin_only_tag_group.tags = [admin_only_tag_one, admin_only_tag_two]
+      admin_only_tag_group.permissions = [
+        [Group::AUTO_GROUPS[:admins], TagGroupPermission.permission_types[:full]],
+      ]
+      admin_only_tag_group.save!
+
+      post = Fabricate(:post, user:)
+      post.topic.tags = [regular_tag, admin_only_tag_one]
+
+      post "/drafts.json",
+           params: {
+             draft_key: "topic",
+             sequence: 0,
+             data: {
+               postId: post.id,
+               original_text: post.raw,
+               original_tags: [regular_tag.name],
+               action: "edit",
+             }.to_json,
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["conflict_user"]).to eq(nil)
+    end
+
     it "cant trivially resolve conflicts without interaction" do
       sign_in(user)
 

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe DraftsController do
       Draft.set(user, "xxx", 0, "{}")
       get "/drafts.json"
       expect(response.status).to eq(200)
-      parsed = response.parsed_body
       expect(response.parsed_body["drafts"].length).to eq(1)
     end
 


### PR DESCRIPTION
In 806e37aaec549069a599fd31edc16c5cdcd0774e, I improved the conflict handling when editing a post to account for title and tags.

This fixes an edge cases when a topic has a hidden tag the current editor can't see. When they submit their edit, we automatically add the hidden tags before checking with the tags stored in the database.

Reported in https://meta.discourse.org/t/341375