### PR TITLE
DEV: add transformers to navigation bar for theme dev

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
@@ -7,6 +7,7 @@ import DropdownMenu from "discourse/components/dropdown-menu";
 import NavigationItem from "discourse/components/navigation-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import icon from "discourse-common/helpers/d-icon";
 import DMenu from "float-kit/components/d-menu";
 
@@ -26,6 +27,20 @@ export default class NavigationBarComponent extends Component {
     return item || navItems[0];
   }
 
+  get showDropdown() {
+    return applyValueTransformer(
+      "navigation-bar-dropdown-mode",
+      this.site.mobileView
+    );
+  }
+
+  get navigationBarIcon() {
+    return applyValueTransformer(
+      "navigation-bar-dropdown-icon",
+      "discourse-chevron-expand"
+    );
+  }
+
   @action
   onRegisterApi(api) {
     this.dMenu = api;
@@ -33,7 +48,7 @@ export default class NavigationBarComponent extends Component {
 
   <template>
     <ul id="navigation-bar" class="nav nav-pills">
-      {{#if this.site.mobileView}}
+      {{#if this.showDropdown}}
         <li>
           <DMenu
             @modalForMobile={{true}}
@@ -45,7 +60,7 @@ export default class NavigationBarComponent extends Component {
               <span
                 class="list-control-toggle-link__text"
               >{{this.selectedNavItem.displayName}}</span>
-              {{icon "discourse-chevron-expand"}}
+              {{icon this.navigationBarIcon}}
             </:trigger>
 
             <:content>

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -15,6 +15,8 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "more-topics-tabs",
   "move-to-topic-merge-options",
   "move-to-topic-move-options",
+  "navigation-bar-dropdown-mode",
+  "navigation-bar-dropdown-icon",
   "parent-category-row-class-mobile",
   "parent-category-row-class",
   "post-menu-buttons",


### PR DESCRIPTION
Adds `navigation-bar-dropdown-mode` and `navigation-bar-dropdown-icon` value transformer for use here: https://github.com/discourse/discourse-compact-nav/pull/19