### PR TITLE
DEV: Remove unnecessary thread in `Jobs::Base::JobInstrumenter` take 2

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1224,7 +1224,18 @@ module Discourse
     locale
   end
 
+  # For test environment only
+  def self.enable_sidekiq_logging
+    @@sidekiq_logging_enabled = true
+  end
+
+  # For test environment only
+  def self.disable_sidekiq_logging
+    @@sidekiq_logging_enabled = false
+  end
+
   def self.enable_sidekiq_logging?
-    ENV["DISCOURSE_LOG_SIDEKIQ"] == "1"
+    ENV["DISCOURSE_LOG_SIDEKIQ"] == "1" ||
+      (defined?(@@sidekiq_logging_enabled) && @@sidekiq_logging_enabled)
   end
 end


### PR DESCRIPTION
This reverts commit 766ff723f8c216b2bf59053dba302b82e1d34d4b and reintroduces 1670ffe82dbfa46f33df94312a8649ab8117d19b.

Ensure that we create the sidekiq log file first before opening it for
logging. This avoids any issue of the log file not being present when we
initialize an instance of the `Logger`.
