### PR TITLE
UX: Copy for feature feed toggle

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import { and, not } from "truth-helpers";
 import CookText from "discourse/components/cook-text";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
@@ -127,12 +128,22 @@ export default class DiscourseNewFeatureItem extends Component {
                   <div class="admin-new-feature-item__tooltip">
                     <div class="admin-new-feature-item__tooltip-header">
                       {{i18n
-                        "admin.dashboard.new_features.experiment_tooltip.title"
+                        (if
+                          this.experimentEnabled
+                          "admin.dashboard.new_features.experiment_tooltip.title_enabled"
+                          "admin.dashboard.new_features.experiment_tooltip.title_disabled"
+                        )
                       }}
                     </div>
                     <div class="admin-new-feature-item__tooltip-content">
-                      {{i18n
-                        "admin.dashboard.new_features.experiment_tooltip.content"
+                      {{htmlSafe
+                        (i18n
+                          (if
+                            this.experimentEnabled
+                            "admin.dashboard.new_features.experiment_tooltip.content_enabled"
+                            "admin.dashboard.new_features.experiment_tooltip.content_disabled"
+                          )
+                        )
                       }}
                     </div>
                   </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5148,8 +5148,10 @@ en:
           experiment_disabled: "You have disabled the experimental feature."
           experiment_toggled_too_fast: "You have toggled the experimental feature too fast. Please wait a few seconds before trying again."
           experiment_tooltip:
-            title: "Try our experimental feature"
-            content: "Give our newest feature in development a spin! It's still in the experimental stage, so we might remove it at any time. You can opt-out whenever you like."
+            title_disabled: "Try our experimental feature"
+            title_enabled: "Turn off experimental feature"
+            content_disabled: "Give our newest feature in development a spin! It's still in the experimental stage, so we might remove it at any time. You can opt-out whenever you like.<br/><br/>Changing this will enable the feature for all users."
+            content_enabled: "Changing this will disable the feature for all users."
 
         last_checked: "Last checked"
         refresh_problems: "Refresh"
@@ -7101,7 +7103,7 @@ en:
         selectable_avatars:
           title: "List of avatars users can choose from"
         table_column_heading:
-          status: "Status" 
+          status: "Status"
         categories:
           all_results: "All"
           required: "Required"


### PR DESCRIPTION
Makes it so the result of toggling a new feature
feed item is clearer.

![image](https://github.com/user-attachments/assets/537edbc1-64f3-4750-bcfb-433b55f1d1d1)
![image](https://github.com/user-attachments/assets/e3826cf8-e8a5-4360-93cf-ff9dae5d2d5d)


