### PR TITLE
DEV: make verbose localization work without mutating I18n.t

### DIFF
--- a/app/assets/javascripts/discourse-i18n/src/index.js
+++ b/app/assets/javascripts/discourse-i18n/src/index.js
@@ -21,10 +21,16 @@ export class I18n {
   extras = null;
   noFallbacks = false;
   testing = false;
+  verbose = false;
+  verboseIndicies = new Map();
 
   pluralizationRules = Cardinals;
 
-  translate = (scope, options) => this._translate(scope, options);
+  translate = (scope, options) => {
+    return this.verbose
+      ? this._verboseTranslate(scope, options)
+      : this._translate(scope, options);
+  };
 
   // shortcut
   t = this.translate;
@@ -45,25 +51,8 @@ export class I18n {
   }
 
   enableVerboseLocalization() {
-    let counter = 0;
-    let keys = {};
-
     this.noFallbacks = true;
-
-    this.t = this.translate = (scope, options) => {
-      let current = keys[scope];
-      if (!current) {
-        current = keys[scope] = ++counter;
-        let message = "Translation #" + current + ": " + scope;
-        if (options && Object.keys(options).length > 0) {
-          message += ", parameters: " + JSON.stringify(options);
-        }
-        // eslint-disable-next-line no-console
-        console.info(message);
-      }
-
-      return this._translate(scope, options) + " (#" + current + ")";
-    };
+    this.verbose = true;
   }
 
   enableVerboseLocalizationSession() {
@@ -396,6 +385,22 @@ export class I18n {
     } catch (err) {
       return err.message;
     }
+  }
+
+  verboseTranslate(scope, options) {
+    const result = this._translate(scope, options);
+    let i = this.verboseIndicies.get(scope);
+    if (!i) {
+      i = this.verboseIndicies.size + 1;
+      this.verboseIndicies.set(scope, i);
+    }
+    let message = `Translation #${i}: ${scope}`;
+    if (options && Object.keys(options).length > 0) {
+      message += `, parameters: ${JSON.stringify(options)}`;
+    }
+    // eslint-disable-next-line no-console
+    console.info(message);
+    return `${result} (#${i})`;
   }
 }
 


### PR DESCRIPTION
We now extensively reference the `{ i18n }` named export of the `discourse-i18n` package, instead of calling `I18n.t` directly. That means that mutations of `I18n.t` no longer have any impact on most of the app.

This commit updates the verbose localisation logic to be switched by a boolean instead of a method mutation.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->