### PR TITLE
DEV: Add plugin outlets to create invite modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -11,6 +11,7 @@ import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import Form from "discourse/components/form";
 import FutureDateInput from "discourse/components/future-date-input";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import { extractError } from "discourse/lib/ajax-error";
 import { canNativeShare, nativeShare } from "discourse/lib/pwa-utils";
 import { sanitize } from "discourse/lib/text";
@@ -306,6 +307,14 @@ export default class CreateInvite extends Component {
         {{/if}}
       </:belowHeader>
       <:body>
+        <PluginOutlet
+          @name="create-invite-before-modal-body"
+          @outletArgs={{hash
+            invite=@invite
+            simpleMode=this.simpleMode
+            inviteCreated=this.inviteCreated
+          }}
+        />
         {{#if this.simpleMode}}
           {{#if this.inviteCreated}}
             {{#unless this.site.mobileView}}
@@ -455,6 +464,14 @@ export default class CreateInvite extends Component {
             {{/if}}
           </Form>
         {{/if}}
+        <PluginOutlet
+          @name="create-invite-after-modal-body"
+          @outletArgs={{hash
+            invite=@invite
+            simpleMode=this.simpleMode
+            inviteCreated=this.inviteCreated
+          }}
+        />
       </:body>
       <:footer>
         {{#if this.simpleMode}}
@@ -543,5 +560,9 @@ class ShareOrCopyInviteLink extends Component {
         @translatedLabelAfterCopy={{i18n "user.invited.invite.link_copied"}}
       />
     {{/if}}
+    <PluginOutlet
+      @name="create-invite-after-copy-link"
+      @outletArgs={{hash invite=@invite}}
+    />
   </template>
 }


### PR DESCRIPTION
Added three plugin outlets:
* `create-invite-before-modal-body`
* `create-invite-after-modal-body`
* `create-invite-after-copy-link`