### PR TITLE
FIX: When moving first posts between topics, ensure only relevant timings are moved

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -472,7 +472,6 @@ class PostMover
             ON mp.old_topic_id = pt.topic_id
               AND mp.old_post_number = pt.post_number
               AND mp.old_topic_id = mp.new_topic_id
-              AND mp.new_post_number IN (:post_ids)
         )
     SQL
   end
@@ -480,7 +479,7 @@ class PostMover
   def copy_shifted_post_timings_from_temp
     DB.exec <<~SQL
       INSERT INTO post_timings (topic_id, user_id, post_number, msecs)
-      SELECT topic_id, user_id, post_number, msecs FROM temp_post_timings
+      SELECT DISTINCT topic_id, user_id, post_number, msecs FROM temp_post_timings
     SQL
   end
 
@@ -493,7 +492,7 @@ class PostMover
       FROM post_timings pt
       JOIN moved_posts mp ON (pt.topic_id = mp.old_topic_id AND pt.post_number = mp.old_post_number)
       WHERE mp.old_post_id <> mp.new_post_id
-        AND mp.new_post_number IN (:post_ids)
+        AND mp.old_post_id IN (:post_ids)
       ON CONFLICT (topic_id, post_number, user_id) DO UPDATE
         SET msecs = GREATEST(post_timings.msecs, excluded.msecs)
     SQL

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -461,9 +461,7 @@ class PostMover
 
     # copy post_timings for shifted posts to a temp table using the new_post_number
     # they'll be copied back after delete_invalid_post_timings makes room for them
-    params = { post_ids: @post_ids_after_move }
-
-    DB.exec(<<~SQL, params)
+    DB.exec(<<~SQL, post_ids: @post_ids_after_move)
       CREATE TEMPORARY TABLE temp_post_timings ON COMMIT DROP
         AS (
           SELECT pt.topic_id, mp.new_post_number as post_number, pt.user_id, pt.msecs
@@ -484,9 +482,7 @@ class PostMover
   end
 
   def copy_first_post_timings
-    params = { post_ids: @post_ids_after_move }
-
-    DB.exec(<<~SQL, params)
+    DB.exec(<<~SQL, post_ids: @post_ids_after_move)
       INSERT INTO post_timings (topic_id, user_id, post_number, msecs)
       SELECT mp.new_topic_id, pt.user_id, mp.new_post_number, pt.msecs
       FROM post_timings pt
@@ -509,9 +505,7 @@ class PostMover
   end
 
   def move_post_timings
-    params = { post_ids: @post_ids_after_move }
-
-    DB.exec(<<~SQL, params)
+    DB.exec(<<~SQL, post_ids: @post_ids_after_move)
       UPDATE post_timings pt
       SET topic_id    = mp.new_topic_id,
           post_number = mp.new_post_number

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2008,18 +2008,18 @@ RSpec.describe PostMover do
           it "allows moving posts from multiple topics into one existing topic" do
             dest_topic = Fabricate(:topic, user: user, created_at: 5.hours.ago)
             Fabricate(:post, topic: dest_topic, created_at: 5.hours.ago)
-            create_post_timing(dest_topic.first_post, user, 500)
+            create_post_timing(dest_topic.first_post, user, 100)
 
             source_1_topic = Fabricate(:topic, user: user, created_at: 4.hours.ago)
             Fabricate(:post, topic: source_1_topic, user: user, created_at: 4.hours.ago)
-            create_post_timing(source_1_topic.first_post, user, 500)
+            create_post_timing(source_1_topic.first_post, user, 200)
             source_1_post =
               Fabricate(:post, topic: source_1_topic, user: user, created_at: 3.hours.ago)
-            create_post_timing(source_1_topic.posts.second, user, 500)
+            create_post_timing(source_1_topic.posts.second, user, 300)
 
             source_2_topic = Fabricate(:topic, user: user, created_at: 2.hours.ago)
             Fabricate(:post, topic: source_2_topic, user: user, created_at: 2.hours.ago)
-            create_post_timing(source_2_topic.first_post, user, 500)
+            create_post_timing(source_2_topic.first_post, user, 400)
             source_2_post =
               Fabricate(:post, topic: source_2_topic, user: user, created_at: 1.hours.ago)
             create_post_timing(source_2_topic.posts.second, user, 500)
@@ -2044,9 +2044,13 @@ RSpec.describe PostMover do
               )
 
             expect(moved_to_too).to be_present
+
+            expect(
+              PostTiming.where(topic_id: dest_topic.id).pluck(:post_number, :msecs),
+            ).to contain_exactly([1, 100], [2, 300], [3, 500])
           end
 
-          it "handles moving two older first posts that've been frozen into a newer destination" do
+          it "handles moving two older first posts into a newer destination" do
             source_1_topic = Fabricate(:topic, user: user, created_at: 5.hours.ago)
             Fabricate(:post, topic: source_1_topic, user: user, created_at: 5.hours.ago)
             create_post_timing(source_1_topic.first_post, user, 500)
@@ -2065,7 +2069,6 @@ RSpec.describe PostMover do
                 [source_2_topic.first_post.id],
                 destination_topic_id: dest_topic.id,
                 chronological_order: true,
-                frozen: true,
               )
 
             expect(moved_to).to be_present
@@ -2076,7 +2079,6 @@ RSpec.describe PostMover do
                 [source_1_topic.first_post.id],
                 destination_topic_id: dest_topic.id,
                 chronological_order: true,
-                frozen: true,
               )
 
             expect(moved_to_too).to be_present
@@ -2085,7 +2087,7 @@ RSpec.describe PostMover do
           it "handles moving an older second post, then the first post, into a newer destination" do
             source_1_topic = Fabricate(:topic, user: user, created_at: 5.hours.ago)
             Fabricate(:post, topic: source_1_topic, user: user, created_at: 5.hours.ago)
-            create_post_timing(source_1_topic.first_post, user, 500)
+            create_post_timing(source_1_topic.first_post, user, 400)
 
             source_1_post =
               Fabricate(:post, topic: source_1_topic, user: user, created_at: 4.hours.ago)
@@ -2093,7 +2095,7 @@ RSpec.describe PostMover do
 
             dest_topic = dest_topic = Fabricate(:topic, user: user, created_at: 3.hours.ago)
             Fabricate(:post, topic: dest_topic, created_at: 3.hours.ago)
-            create_post_timing(dest_topic.first_post, user, 500)
+            create_post_timing(dest_topic.first_post, user, 600)
 
             moved_to =
               source_1_topic.move_posts(


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #30176.

When moving multiple first posts to an existing topic whilst preserving chronological ordering, the second move can trigger a PostgreSQL error:

```
PG::UniqueViolation:
  ERROR:  duplicate key value violates unique constraint "post_timings_unique"
  DETAIL:  Key (topic_id, post_number, user_id)=(1278, 2, 2261) already exists.
# ./lib/mini_sql_multisite_connection.rb:109:in `run'
# ./app/models/post_mover.rb:478:in `copy_shifted_post_timings_from_temp'
# ./app/models/post_mover.rb:137:in `handle_moved_references'
# ./app/models/post_mover.rb:108:in `move_posts_to'
# ./app/models/post_mover.rb:35:in `block in to_topic'
# ./app/models/post_mover.rb:35:in `to_topic'
# ./app/models/topic.rb:1308:in `move_posts'
```

Additionally, if you move from the same topic to a newer destination: it will fail with this error:

```
PG::CardinalityViolation:
  ERROR:  ON CONFLICT DO UPDATE command cannot affect row a second time
  HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
# ./lib/mini_sql_multisite_connection.rb:109:in `run'
# ./app/models/post_mover.rb:488:in `copy_first_post_timings'
# ./app/models/post_mover.rb:139:in `handle_moved_references'
# ./app/models/post_mover.rb:108:in `move_posts_to'
# ./app/models/post_mover.rb:35:in `block in to_topic'
# ./app/models/post_mover.rb:35:in `to_topic'
# ./app/models/topic.rb:1308:in `move_posts'
```

Both of these issues can be fixed using the same approach as in #30176: ensuring we only copy post timings for the specific posts that are being moved.

Internal ref t/142010/15

## 👑 Testing

The first error can be reproduced using this method:

- Create two source topics with no replies to either.
- Create a destination topic.
- Move the single post in the second topic to the destination.
- Move the single post in the first topic to the destination.

The second error can be reproduced with this method:

- Create a source topic, and add a reply to it.
- Create a destination topic.
- Move the reply in the source topic to the destination topic, remembering to check the “preserve chronological order” option.
- Move the first post in the source topic to the destination, again checking the “preserve chronological order” option.
