### PR TITLE
DEV: Fix `s3:upload_assets` not logging newlines

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -34,9 +34,9 @@ def upload(path, remote_path, content_type, content_encoding = nil, logger:)
   options[:content_encoding] = content_encoding if content_encoding
 
   if should_skip?(remote_path)
-    logger << "Skipping: #{remote_path}"
+    logger << "Skipping: #{remote_path}\n"
   else
-    logger << "Uploading: #{remote_path}"
+    logger << "Uploading: #{remote_path}\n"
 
     File.open(path) { |file| helper.upload(file, remote_path, options) }
   end


### PR DESCRIPTION
Follow-up to 9a2e31b9afb4740d876c442ddae49003e2078170
