### PR TITLE
FIX: Background color for settings overriden filter

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/common/admin/admin_config_area.scss
@@ -90,6 +90,7 @@
 
   &__settings {
     .admin-site-settings-filter-controls {
+      background: var(--primary-very-low);
       margin-bottom: 1em;
     }
 

--- a/app/assets/stylesheets/common/admin/site-settings.scss
+++ b/app/assets/stylesheets/common/admin/site-settings.scss
@@ -11,6 +11,7 @@
 .admin-plugin-config-area {
   &__settings {
     .admin-site-settings-filter-controls {
+      background: var(--primary-very-low);
       margin-bottom: 1em;
     }
 


### PR DESCRIPTION
This was fixed previously but must have regressed, we
are showing a darker grey background around the
"Only show overridden" checkbox for our Settings tab
in config pages.

**Before**

![image](https://github.com/user-attachments/assets/d54103f7-01f6-4d16-922b-92dc41ddace8)

**After**

![image](https://github.com/user-attachments/assets/570ec2ff-4fde-4f29-b392-aa67ebc7194e)
