### PR TITLE
FIX: Searchable user fields do not always have an integer name

### DIFF
--- a/app/models/user_custom_field.rb
+++ b/app/models/user_custom_field.rb
@@ -8,7 +8,10 @@ class UserCustomField < ActiveRecord::Base
   scope :searchable,
         -> do
           joins(
-            "INNER JOIN user_fields ON user_fields.id = REPLACE(user_custom_fields.name, 'user_field_', '')::INTEGER AND user_fields.searchable IS TRUE AND user_custom_fields.name like 'user_field_%'",
+            "INNER JOIN user_fields ON user_fields.id = REPLACE(user_custom_fields.name, 'user_field_', '')::INTEGER",
+          ).where("user_fields.searchable = TRUE").where(
+            "user_custom_fields.name ~ ?",
+            '^user_field_\\d+$',
           )
         end
 end

--- a/spec/models/user_custom_field_spec.rb
+++ b/spec/models/user_custom_field_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe UserCustomField do
+  describe ".searchable" do
+    it "includes user_custom_fields with valid, searchable user_field references" do
+      Fabricate(:user_field, id: 123, searchable: true)
+      valid_user_custom_field = Fabricate(:user_custom_field, name: "user_field_123")
+
+      result = UserCustomField.searchable
+
+      expect(result).to include(valid_user_custom_field)
+    end
+
+    it "excludes user_custom_fields with non-searchable user_field references" do
+      Fabricate(:user_field, id: 456, searchable: false)
+      non_searchable_custom_field = Fabricate(:user_custom_field, name: "user_field_456")
+
+      result = UserCustomField.searchable
+
+      expect(result).not_to include(non_searchable_custom_field)
+    end
+
+    it "excludes user_custom_fields with invalid user_field references" do
+      invalid_user_custom_field = Fabricate(:user_custom_field, name: "user_field_invalid")
+
+      result = UserCustomField.searchable
+
+      expect(result).not_to include(invalid_user_custom_field)
+    end
+
+    it "excludes user_custom_fields with unrelated names" do
+      unrelated_custom_field = Fabricate(:user_custom_field, name: "cost_center")
+
+      result = UserCustomField.searchable
+
+      expect(result).not_to include(unrelated_custom_field)
+    end
+  end
+end


### PR DESCRIPTION
The addition of the `.where("user_custom_fields.name ~ ?", '^user_field_\\d+$')` clause prevents the error below from occurring, when a user_field is not named with the required integer suffix.

```
ERROR:
ActiveRecord::StatementInvalid: PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type integer: "invalid"
```