### PR TITLE
UX: fix admin sidebar header width

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -370,7 +370,7 @@
   align-items: baseline;
   color: var(--d-sidebar-link-color);
   width: calc(
-    var(--d-sidebar-width) - 2 * var(--d-sidebar-row-horizontal-padding) + 2px
+    var(--d-sidebar-width) * var(--d-sidebar-row-horizontal-padding) + 2px
   );
 }
 


### PR DESCRIPTION
reported here: https://meta.discourse.org/t/minor-visual-issue-when-theres-a-vertical-scrollbar-in-the-admin-sidebar/341822

Before:
![image](https://github.com/user-attachments/assets/6cd8fad2-b709-4205-bd79-b5dd2b662929)

After:
![image](https://github.com/user-attachments/assets/048a0d24-73f7-4969-bfd3-62e5125c57a7)
