### PR TITLE
FIX: Regression allowing async calls to finish before removing uploads

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -356,14 +356,14 @@ export default class UppyComposerUpload {
         }
         let upload = response.body;
 
-        // Only remove in progress after async resolvers finish:
-        this.#removeInProgressUpload(file.id);
-        cacheShortUploadUrl(upload.short_url, upload);
-
         const markdown = await this.uploadMarkdownResolvers.reduce(
           (md, resolver) => resolver(upload) || md,
           getUploadMarkdown(upload)
         );
+
+        // Only remove in progress after async resolvers finish:
+        this.#removeInProgressUpload(file.id);
+        cacheShortUploadUrl(upload.short_url, upload);
 
         new ComposerVideoThumbnailUppy(getOwner(this)).generateVideoThumbnail(
           file,


### PR DESCRIPTION
This PR fixes a recent regression in https://github.com/discourse/discourse/commit/e37952c9dbfe6c5bd2d914ba4a51c8ae7db3b0e3 that reverted a fix made in https://github.com/discourse/discourse/commit/1c4d5dae1cb39b35de9244a390d6a80fec2e1909, which allowed for async calls to finish first before removing in progress uploads.

No tests as this is something that's quite difficult to test.