### PR TITLE
UX: Make checkboxes respect forum's accent color

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -207,3 +207,9 @@ input[type="submit"] {
     }
   }
 }
+
+// Inputs
+// --------------------------------------------------
+input[type="checkbox"] {
+  accent-color: var(--tertiary);
+}


### PR DESCRIPTION
## :mag: Overview
This change ensures checkboxes respect the forum's accent color. Visual color change only, as such no tests.

## 📸 Screenshots
 
|Before|After|
|----|----|
|<img width="916" alt="Screenshot 2024-12-11 at 10 46 31" src="https://github.com/user-attachments/assets/9b29b8d1-4009-41f7-a050-6c2cdd6f1881" />|<img width="900" alt="Screenshot 2024-12-11 at 10 46 38" src="https://github.com/user-attachments/assets/c4080ce4-7128-421d-a89a-a29546bcce7a" />|
