### PR TITLE
UX: Make radio buttons respect forum's accent color

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -210,6 +210,7 @@ input[type="submit"] {
 
 // Inputs
 // --------------------------------------------------
-input[type="checkbox"] {
+input[type="checkbox"],
+input[type="radio"] {
   accent-color: var(--tertiary);
 }


### PR DESCRIPTION
## :mag: Overview
Similar to https://github.com/discourse/discourse/commit/601780aadf19649434203ad68fde89995aad270f, this change ensures radio buttons respect the forum's accent color. Visual color change only, as such no tests.

## 📸 Screenshots
|Before|After|
|----|----|
|![Screenshot 2024-12-11 at 14 34 08](https://github.com/user-attachments/assets/ea1ff7cc-69e6-4f9d-9c63-2b7c15dac6d7)|![Screenshot 2024-12-11 at 14 34 24](https://github.com/user-attachments/assets/897cf407-57ca-4053-9705-f8b945767735)|
