### PR TITLE
FIX: Link to group didn't work in locales other than English

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -308,7 +308,7 @@ en:
 
           Go ahead and **flag this post** <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-flag.png" width="16" height="16"> and select **It's Inappropriate** as the reason!
         reply: |-
-          [Our staff](%{base_uri}/groups/staff) will be privately notified about your flag. If enough community members flag a post, it will also be automatically hidden as a precaution. (Since I didn’t actually write a nasty post :angel:, I’ve gone ahead and removed the flag for now.)
+          [Our staff](%{group_url}) will be privately notified about your flag. If enough community members flag a post, it will also be automatically hidden as a precaution. (Since I didn’t actually write a nasty post :angel:, I’ve gone ahead and removed the flag for now.)
         not_found: |-
           Oh no, my nasty post hasn’t been flagged as inappropriate yet. :worried: Can you flag it as inappropriate using the **flag** <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-flag.png" width="16" height="16">? Don’t forget to use the show more button <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-ellipsis.png" width="16" height="16"> to reveal more actions for each post.
 

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -568,7 +568,7 @@ module DiscourseNarrativeBot
       return unless @post.user.id == -2
 
       raw = <<~MD
-        #{I18n.t("#{I18N_KEY}.flag.reply", i18n_post_args)}
+        #{I18n.t("#{I18N_KEY}.flag.reply", i18n_post_args(group_url: Group.find(Group::AUTO_GROUPS[:staff]).full_url))}
 
         #{instance_eval(&@next_instructions)}
       MD

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/new_user_narrative_spec.rb
@@ -1144,7 +1144,13 @@ RSpec.describe DiscourseNarrativeBot::NewUserNarrative do
         new_post = Post.last
 
         expected_raw = <<~RAW
-          #{I18n.t("discourse_narrative_bot.new_user_narrative.flag.reply", base_uri: "")}
+          #{
+          I18n.t(
+            "discourse_narrative_bot.new_user_narrative.flag.reply",
+            base_uri: "",
+            group_url: Group.find(Group::AUTO_GROUPS[:staff]).full_url,
+          )
+        }
 
           #{I18n.t("discourse_narrative_bot.new_user_narrative.search.instructions", base_uri: "")}
         RAW


### PR DESCRIPTION
Group names are translated, so the slug changes depending on the default locale. This could break the link to the staff group.