### PR TITLE
UX: Introduce <DStatTiles /> component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-stat-tiles.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-stat-tiles.gjs
@@ -1,6 +1,4 @@
-import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
-import { service } from "@ember/service";
 import { number } from "discourse/lib/formatter";
 import DTooltip from "float-kit/components/d-tooltip";
 
@@ -26,12 +24,10 @@ const DStatTile = <template>
   </div>
 </template>;
 
-export default class DStatTiles extends Component {
-  @service currentUser;
+const DStatTiles = <template>
+  <div class="d-stat-tiles" ...attributes>
+    {{yield (hash Tile=DStatTile)}}
+  </div>
+</template>;
 
-  <template>
-    <div class="d-stat-tiles" ...attributes>
-      {{yield (hash Tile=DStatTile)}}
-    </div>
-  </template>
-}
+export default DStatTiles;

--- a/app/assets/javascripts/discourse/app/components/d-stat-tiles.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-stat-tiles.gjs
@@ -1,0 +1,37 @@
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { service } from "@ember/service";
+import { number } from "discourse/lib/formatter";
+import DTooltip from "float-kit/components/d-tooltip";
+
+const DStatTile = <template>
+  <div class="d-stat-tile" role="group">
+    <div class="d-stat-tile__top">
+      <span class="d-stat-tile__label">{{@label}}</span>
+      {{#if @tooltip}}
+        <DTooltip
+          class="d-stat-tile__tooltip"
+          @icon="circle-question"
+          @content={{@tooltip}}
+        />
+      {{/if}}
+    </div>
+    {{#if @url}}
+      <a href={{@url}} class="d-stat-tile__value" title={{@value}}>
+        {{number @value}}
+      </a>
+    {{else}}
+      <span class="d-stat-tile__value" title={{@value}}>{{number @value}}</span>
+    {{/if}}
+  </div>
+</template>;
+
+export default class DStatTiles extends Component {
+  @service currentUser;
+
+  <template>
+    <div class="d-stat-tiles" ...attributes>
+      {{yield (hash Tile=DStatTile)}}
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/tests/integration/components/d-stat-tiles-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-stat-tiles-test.gjs
@@ -9,10 +9,9 @@ module("Integration | Component | DStatTiles", function (hooks) {
 
   test("formats the @value in a readable way with the raw number as the title attr", async function (assert) {
     await render(<template>
-      <DStatTiles as |tiles|><tiles.Tile
-          @value="12555999"
-          @label={{i18n "bootstrap_mode"}}
-        /></DStatTiles>
+      <DStatTiles as |tiles|>
+        <tiles.Tile @value="12555999" @label={{i18n "bootstrap_mode"}} />
+      </DStatTiles>
     </template>);
 
     assert
@@ -25,10 +24,9 @@ module("Integration | Component | DStatTiles", function (hooks) {
 
   test("renders the @label", async function (assert) {
     await render(<template>
-      <DStatTiles as |tiles|><tiles.Tile
-          @value="12555999"
-          @label={{i18n "bootstrap_mode"}}
-        /></DStatTiles>
+      <DStatTiles as |tiles|>
+        <tiles.Tile @value="12555999" @label={{i18n "bootstrap_mode"}} />
+      </DStatTiles>
     </template>);
 
     assert
@@ -38,11 +36,13 @@ module("Integration | Component | DStatTiles", function (hooks) {
 
   test("renders the optional @tooltip", async function (assert) {
     await render(<template>
-      <DStatTiles as |tiles|><tiles.Tile
+      <DStatTiles as |tiles|>
+        <tiles.Tile
           @value="12555999"
           @label={{i18n "bootstrap_mode"}}
           @tooltip={{i18n "bootstrap_mode"}}
-        /></DStatTiles>
+        />
+      </DStatTiles>
     </template>);
 
     assert.dom(".d-stat-tile__tooltip").exists();
@@ -52,11 +52,13 @@ module("Integration | Component | DStatTiles", function (hooks) {
 
   test("wraps the value in a link if @url is provided", async function (assert) {
     await render(<template>
-      <DStatTiles as |tiles|><tiles.Tile
+      <DStatTiles as |tiles|>
+        <tiles.Tile
           @value="12555999"
           @label={{i18n "bootstrap_mode"}}
           @url="https://meta.discourse.org"
-        /></DStatTiles>
+        />
+      </DStatTiles>
     </template>);
 
     assert

--- a/app/assets/javascripts/discourse/tests/integration/components/d-stat-tiles-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-stat-tiles-test.gjs
@@ -1,0 +1,66 @@
+import { render, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DStatTiles from "discourse/components/d-stat-tiles";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | DStatTiles", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("formats the @value in a readable way with the raw number as the title attr", async function (assert) {
+    await render(<template>
+      <DStatTiles as |tiles|><tiles.Tile
+          @value="12555999"
+          @label={{i18n "bootstrap_mode"}}
+        /></DStatTiles>
+    </template>);
+
+    assert
+      .dom(".d-stat-tiles .d-stat-tile .d-stat-tile__value")
+      .hasText("12.6M");
+    assert
+      .dom(".d-stat-tiles .d-stat-tile .d-stat-tile__value")
+      .hasAttribute("title", "12555999");
+  });
+
+  test("renders the @label", async function (assert) {
+    await render(<template>
+      <DStatTiles as |tiles|><tiles.Tile
+          @value="12555999"
+          @label={{i18n "bootstrap_mode"}}
+        /></DStatTiles>
+    </template>);
+
+    assert
+      .dom(".d-stat-tiles .d-stat-tile .d-stat-tile__label")
+      .hasText(i18n("bootstrap_mode"));
+  });
+
+  test("renders the optional @tooltip", async function (assert) {
+    await render(<template>
+      <DStatTiles as |tiles|><tiles.Tile
+          @value="12555999"
+          @label={{i18n "bootstrap_mode"}}
+          @tooltip={{i18n "bootstrap_mode"}}
+        /></DStatTiles>
+    </template>);
+
+    assert.dom(".d-stat-tile__tooltip").exists();
+    await triggerEvent(".fk-d-tooltip__trigger", "mousemove");
+    assert.dom(".fk-d-tooltip__content").hasText(i18n("bootstrap_mode"));
+  });
+
+  test("wraps the value in a link if @url is provided", async function (assert) {
+    await render(<template>
+      <DStatTiles as |tiles|><tiles.Tile
+          @value="12555999"
+          @label={{i18n "bootstrap_mode"}}
+          @url="https://meta.discourse.org"
+        /></DStatTiles>
+    </template>);
+
+    assert
+      .dom(".d-stat-tiles .d-stat-tile a.d-stat-tile__value")
+      .hasAttribute("href", "https://meta.discourse.org");
+  });
+});

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -1,6 +1,7 @@
 @import "badges";
 @import "banner";
 @import "d-breadcrumbs";
+@import "d-stat-tiles";
 @import "bookmark-list";
 @import "bookmark-modal";
 @import "bookmark-menu";

--- a/app/assets/stylesheets/common/components/d-stat-tiles.scss
+++ b/app/assets/stylesheets/common/components/d-stat-tiles.scss
@@ -1,0 +1,26 @@
+.d-stat-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1em;
+  margin-bottom: 2em;
+
+  .d-stat-tile {
+    display: flex;
+    flex-direction: column;
+    padding: 1em;
+    background: var(--primary-very-low);
+    border-radius: 0.25em;
+
+    &__label {
+      color: var(--primary-medium);
+      font-size: 0.875em;
+      margin-bottom: 0.5em;
+    }
+
+    &__value {
+      color: var(--primary);
+      font-size: 1.5em;
+      font-weight: bold;
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new component used to show a grid of stats
on any page, mostly used for dashboards and config pages.
This component yields a hash with a `Tile` component property,
and the caller can loop through their stats and display them
using this component.

Each stat needs a `@label` and a `@value` at minimum, but can
also pass in a `@tooltip` and a `@url`.

Here is an example, but note the title and the white box around
the stats is a separate component, `<AdminConfigAreaCard />`,
which may be ported to core eventually.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/2192c959-9386-4295-8423-99b33caa5e2a" />
