### PR TITLE
UX: increase button sizes and timeline size

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -21,6 +21,7 @@ import icon from "discourse-common/helpers/d-icon";
 import { bind, debounce } from "discourse-common/utils/decorators";
 import domUtils from "discourse-common/utils/dom-utils";
 import { i18n } from "discourse-i18n";
+import TopicNotificationsButton from "select-kit/components/topic-notifications-button";
 import BackButton from "./back-button";
 import Scroller from "./scroller";
 
@@ -657,6 +658,10 @@ export default class TopicTimelineScrollArea extends Component {
             title={{i18n "topic.progress.jump_prompt_long"}}
             class="timeline-open-jump-to-post-prompt-btn jump-to-post"
           />
+        {{/if}}
+
+        {{#if (and this.currentUser this.site.desktopView)}}
+          <TopicNotificationsButton @topic={{@model}} @expanded={{false}} />
         {{/if}}
 
         <PluginOutlet

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -18,7 +18,6 @@
       display: flex;
       gap: 0.5rem;
       flex-wrap: wrap;
-      align-items: center;
     }
 
     .bookmark.bookmarked {
@@ -94,7 +93,7 @@
     background-color: var(--secondary);
     color: var(--tertiary);
 
-    padding: 0.35em 1em;
+    padding: 0.5rem 1em;
     border: 1px solid var(--tertiary-low);
 
     /* as a big ol' click target, don't let text inside be selected */
@@ -107,6 +106,7 @@
       height: 100%;
       position: relative;
       z-index: z("base");
+      font-size: var(--font-up-1);
       font-weight: bold;
     }
     .d-icon {

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -40,12 +40,6 @@
   }
 }
 
-.topic-navigation {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
 #topic-progress-wrapper {
   position: fixed;
   &.docked {

--- a/app/assets/stylesheets/mobile/topic-footer.scss
+++ b/app/assets/stylesheets/mobile/topic-footer.scss
@@ -1,10 +1,17 @@
+.container.posts .topic-navigation {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
 html:not(.anon) #topic-footer-buttons {
   .topic-footer-main-buttons {
     width: 100%;
     justify-content: space-between;
     gap: 0.75rem;
 
-    button {
+    button,
+    .topic-notifications-button,
+    .pinned-button {
       font-size: var(--font-up-1);
     }
 
@@ -20,10 +27,6 @@ html:not(.anon) #topic-footer-buttons {
     .topic-notifications-button {
       .selected-name .name {
         display: none;
-      }
-      .pinned-options,
-      .topic-notifications-options {
-        height: 100%;
       }
     }
 

--- a/app/assets/stylesheets/mobile/topic-footer.scss
+++ b/app/assets/stylesheets/mobile/topic-footer.scss
@@ -1,5 +1,17 @@
 html:not(.anon) #topic-footer-buttons {
   .topic-footer-main-buttons {
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.75rem;
+
+    button {
+      font-size: var(--font-up-1);
+    }
+
+    &__actions {
+      gap: 0.75rem;
+    }
+
     .d-button-label {
       display: none;
     }
@@ -8,6 +20,10 @@ html:not(.anon) #topic-footer-buttons {
     .topic-notifications-button {
       .selected-name .name {
         display: none;
+      }
+      .pinned-options,
+      .topic-notifications-options {
+        height: 100%;
       }
     }
 


### PR DESCRIPTION
Follow up of https://github.com/discourse/discourse/pull/30132

* the timeline on mobile turned out too small => increased in size
* same for the buttons: increased size and spacing
* use a different layout for the buttons, to make the reply button stand out more
* fix a scoping issue with the timeline on desktop
* fix the missing timeline tracking button on desktop
* fix (some) button height issues

### Before
<img width="345" alt="CleanShot 2024-12-12 at 22 26 17@2x" src="https://github.com/user-attachments/assets/6a5e980d-a01f-4ee8-8704-824607becb52" />

### After
<img width="345" alt="CleanShot 2024-12-12 at 22 25 52@2x" src="https://github.com/user-attachments/assets/afabbf61-5343-4c94-83e9-5f3f827538f9" />
