### PR TITLE
FIX: replace dropdown with button when there's only one option

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -59,7 +59,22 @@
     {{/each}}
 
     {{#if this.site.mobileView}}
-      {{#if this.dropdownButtons}}
+      {{#if this.loneDropdownButton}}
+        <DButton
+          @action={{this.loneDropdownButton.action}}
+          @icon={{this.loneDropdownButton.icon}}
+          @translatedLabel={{this.loneDropdownButton.label}}
+          @translatedTitle={{this.loneDropdownButton.title}}
+          @translatedAriaLabel={{this.loneDropdownButton.ariaLabel}}
+          @disabled={{this.loneDropdownButton.disabled}}
+          id={{concat "topic-footer-button-" this.loneDropdownButton.id}}
+          class={{concat-class
+            "btn-default"
+            "topic-footer-button"
+            this.loneDropdownButton.classNames
+          }}
+        />
+      {{else if (gt this.dropdownButtons.length 1)}}
         <DMenu
           @modalForMobile={{true}}
           @identifier="topic-footer-mobile-dropdown"

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -48,6 +48,11 @@ export default class TopicFooterButtons extends Component {
     return inlineButtons.filter((button) => button.dropdown);
   }
 
+  @discourseComputed("dropdownButtons.[]")
+  loneDropdownButton(dropdownButtons) {
+    return dropdownButtons.length === 1 ? dropdownButtons[0] : null;
+  }
+
   @discourseComputed("topic.isPrivateMessage")
   showNotificationsButton(isPM) {
     return !isPM || this.canSendPms;


### PR DESCRIPTION
On mobile, in the topic footer buttons, instead of showing all the buttons, we "merge" some of then into a dropdown.

If the dropdown has only one "option", then it doesn't make sense to show the "ellipsis" button. Instead, we directly show the button of the only available option. Saving a click on the way.

**BEFORE**

Here's an example where the only available option is to "⛳️ Flag" a post.

![Screenshot 2024-12-12 at 15 39 46](https://github.com/user-attachments/assets/bf26fafe-c8e1-41ff-858c-1db4b4070f48) 

![Screenshot 2024-12-12 at 15 39 54](https://github.com/user-attachments/assets/242e39ab-4a24-495b-b481-5331a6136d4d)

**AFTER**

![Screenshot 2024-12-12 at 15 40 08](https://github.com/user-attachments/assets/9ae66d89-729c-4532-a3fc-2e7bdf028f73)
