### PR TITLE
DEV: prioritize new email styles over existing, to make customization…

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -33,7 +33,7 @@ module Email
       existing = node["style"]
       if existing.present?
         # merge styles
-        node["style"] = "#{new_styles}; #{existing}"
+        node["style"] = "#{existing}; #{new_styles}"
       else
         node["style"] = new_styles
       end


### PR DESCRIPTION
Currently some default styling can not be overridden with custom CSS for emails, because new styles are prepended before existing styles. This swaps that around so new styles will be appended, allowing customizations to override any default email CSS. 