### PR TITLE
UX: add color-scheme meta tag to _head

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -679,7 +679,13 @@ module ApplicationHelper
   end
 
   def discourse_color_scheme_meta_tag
-    scheme = dark_scheme_id == -1 ? "light" : "light dark"
+    scheme = if dark_scheme_id == -1
+      # no automatic client-side switching
+      dark_color_scheme? ? "dark" : "light"
+    else
+      # auto-switched based on browser setting
+      "light dark"
+    end
     <<~HTML.html_safe
         <meta name="color-scheme" content="#{scheme}">
       HTML

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -678,6 +678,13 @@ module ApplicationHelper
     result.html_safe
   end
 
+  def discourse_color_scheme_meta_tag
+    scheme = dark_scheme_id == -1 ? "light" : "light dark"
+    <<~HTML.html_safe
+        <meta name="color-scheme" content="#{scheme}">
+      HTML
+  end
+
   def dark_color_scheme?
     return false if scheme_id.blank?
     ColorScheme.find_by_id(scheme_id)&.is_dark?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -679,13 +679,14 @@ module ApplicationHelper
   end
 
   def discourse_color_scheme_meta_tag
-    scheme = if dark_scheme_id == -1
-      # no automatic client-side switching
-      dark_color_scheme? ? "dark" : "light"
-    else
-      # auto-switched based on browser setting
-      "light dark"
-    end
+    scheme =
+      if dark_scheme_id == -1
+        # no automatic client-side switching
+        dark_color_scheme? ? "dark" : "light"
+      else
+        # auto-switched based on browser setting
+        "light dark"
+      end
     <<~HTML.html_safe
         <meta name="color-scheme" content="#{scheme}">
       HTML

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,7 +7,7 @@
 <link rel="apple-touch-icon" type="image/png" href="<%= ::UrlHelper.absolute(site_apple_touch_icon_url) %>">
 <%- end %>
 <%= discourse_theme_color_meta_tags %>
-<meta name="color-scheme" content="light dark">
+<%= discourse_color_scheme_meta_tag %>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover">
 <%- if Discourse.base_path.present? %>
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,6 +7,7 @@
 <link rel="apple-touch-icon" type="image/png" href="<%= ::UrlHelper.absolute(site_apple_touch_icon_url) %>">
 <%- end %>
 <%= discourse_theme_color_meta_tags %>
+<meta name="color-scheme" content="light dark">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover">
 <%- if Discourse.base_path.present? %>
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">

--- a/app/views/layouts/finish_installation.html.erb
+++ b/app/views/layouts/finish_installation.html.erb
@@ -2,7 +2,6 @@
   <head>
     <%= discourse_stylesheet_link_tag 'wizard', theme_id: nil %>
     <%= discourse_color_scheme_stylesheets %>
-    <meta name="color-scheme" content="light dark">
 
     <%= render partial: "layouts/head" %>
     <title><%= t 'wizard.title' %></title>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -903,4 +903,30 @@ RSpec.describe ApplicationHelper do
       HTML
     end
   end
+
+  describe "#discourse_color_scheme_meta_tag" do
+    before do
+      light = Fabricate(:color_scheme)
+      light.save!
+      helper.request.cookies["color_scheme_id"] = light.id
+    end
+
+    it "renders a 'light' color-scheme if no dark scheme is set" do
+      SiteSetting.default_dark_mode_color_scheme_id = -1
+
+      expect(helper.discourse_color_scheme_meta_tag).to eq(<<~HTML)
+        <meta name="color-scheme" content="light">
+      HTML
+    end
+
+    it "renders a 'light dark' color-scheme if a dark scheme is set" do
+      dark = Fabricate(:color_scheme)
+      dark.save!
+      helper.request.cookies["dark_scheme_id"] = dark.id
+
+      expect(helper.discourse_color_scheme_meta_tag).to eq(<<~HTML)
+        <meta name="color-scheme" content="light dark">
+      HTML
+    end
+  end
 end


### PR DESCRIPTION
Adds the `color-scheme` meta tag to the `_head` partial and removes it from the finish installation template to prevent it from being added twice.