### PR TITLE
DEV: Remove line of code that does not work

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -40,8 +40,6 @@ def upload(path, remote_path, content_type, content_encoding = nil, logger:)
 
     File.open(path) { |file| helper.upload(file, remote_path, options) }
   end
-
-  File.delete(path) if (File.exist?(path) && ENV["DELETE_ASSETS_AFTER_S3_UPLOAD"])
 end
 
 def use_db_s3_config


### PR DESCRIPTION
We can't delete the file from disk as some of the assets are still
served by the app instead of going through the S3 bucket. It is a bug we
need to fix but it also means this ENV is unsafe now. Just drop the env
until we ensure all assets requested by the app are requested from the
S3 bucket directly.

## Reviewer Notes

I tried out the ENV on my own test site and it broke it.