### PR TITLE
FEATURE: Allow pausing of restore before DB migration and uploads are restored

### DIFF
--- a/lib/backup_restore/database_restorer.rb
+++ b/lib/backup_restore/database_restorer.rb
@@ -16,7 +16,7 @@ module BackupRestore
       @current_db = current_db
     end
 
-    def restore(db_dump_path)
+    def restore(db_dump_path, interactive = false)
       BackupRestore.move_tables_between_schemas(MAIN_SCHEMA, BACKUP_SCHEMA)
 
       @db_dump_path = db_dump_path
@@ -24,6 +24,7 @@ module BackupRestore
 
       create_missing_discourse_functions
       restore_dump
+      pause_before_migration if interactive
       migrate_database
       reconnect_database
 
@@ -134,6 +135,16 @@ module BackupRestore
         port_argument, # the port to connect to (if any)
         username_argument, # the username to connect as (if any)
       ].compact.join(" ")
+    end
+
+    def pause_before_migration
+      puts ""
+      puts "Attention! Pausing restore before migrating database.".red.bold
+      puts "You can work on the restored database in a separate Rails console."
+      puts ""
+      puts "Press any key to continue with the restore.".bold
+      puts ""
+      STDIN.getch
     end
 
     def migrate_database

--- a/script/discourse
+++ b/script/discourse
@@ -154,7 +154,14 @@ class DiscourseCLI < Thor
   end
 
   desc "restore", "Restore a Discourse backup"
-  option :disable_emails, type: :boolean, default: true
+  option :disable_emails,
+         type: :boolean,
+         default: true,
+         desc: "Disable outgoing emails for non-staff users after restore"
+  option :pause,
+         type: :boolean,
+         default: false,
+         desc: "Pause before migrating database and restoring uploads"
   option :location, type: :string, enum: %w[local s3], desc: "Override the backup location"
   def restore(filename = nil)
     load_rails
@@ -179,6 +186,7 @@ class DiscourseCLI < Thor
           disable_emails: options[:disable_emails],
           location: options[:location],
           factory: BackupRestore::Factory.new(user_id: Discourse.system_user.id),
+          interactive: options[:pause],
         )
       restorer.run
       puts "Restore done."


### PR DESCRIPTION
This can be helpful if you need to fix problems in the DB before the DB gets migrated, as well as before uploads are restored.
