### PR TITLE
DEV: Add DiscourseEvent to PostMover for post_duplicated

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -323,7 +323,11 @@ class PostMover
         @post_ids_after_move.map { |post_id| post_id == post.id ? moved_post.id : post_id }
     end
 
-    DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id)
+    if @options[:freeze_original]
+      DiscourseEvent.trigger(:post_duplicated, moved_post, post)
+    else
+      DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id)
+    end
 
     # Move any links from the post to the new topic
     moved_post.topic_links.update_all(topic_id: destination_topic.id)


### PR DESCRIPTION
When `freeze_original` option is used in PostMover, we create a _new post_ rather than moving the post to a new topic. Due to this, we need a new DiscourseEvent for plugins to receive both the old post and the new post.

I also changed an `if` to be more clear that a condition would only be hit if `freeze_original` is present, rather than if `moved_post.id != post.id`, which worked but was a little less clear what was going on.