### PR TITLE
FIX: expanding / collapsing own user info panel

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -209,12 +209,12 @@ export default class UserController extends Controller.extend(CanCheckEmails) {
 
   @action
   collapseProfile() {
-    this.set("forceExpand", false);
+    this.toggleProperty("forceExpand");
   }
 
   @action
   expandProfile() {
-    this.set("forceExpand", true);
+    this.toggleProperty("forceExpand");
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -84,7 +84,7 @@ export default class UserController extends Controller.extend(CanCheckEmails) {
       ariaLabel: this.collapsedInfo
         ? "user.sr_expand_profile"
         : "user.sr_collapse_profile",
-      action: this.collapsedInfo ? "expandProfile" : "collapseProfile",
+      action: "toggleProfile",
     };
   }
 
@@ -208,12 +208,7 @@ export default class UserController extends Controller.extend(CanCheckEmails) {
   }
 
   @action
-  collapseProfile() {
-    this.toggleProperty("forceExpand");
-  }
-
-  @action
-  expandProfile() {
+  toggleProfile() {
     this.toggleProperty("forceExpand");
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-profile-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-profile-summary-test.js
@@ -25,6 +25,21 @@ acceptance("User Profile - Summary", function (needs) {
       .exists("top categories");
   });
 
+  test("Viewing Summary - Expanding / collapsing info", async function (assert) {
+    await visit("/u/eviltrout/summary");
+
+    const collapsed = `button[aria-controls="collapsed-info-panel"][aria-expanded="false"]`;
+    const expanded = `button[aria-controls="collapsed-info-panel"][aria-expanded="true"]`;
+
+    assert.dom(collapsed).exists("info panel is collapsed");
+
+    await click(collapsed);
+    assert.dom(expanded).exists("info panel is expanded");
+
+    await click(expanded);
+    assert.dom(collapsed).exists("info panel is collapsed");
+  });
+
   test("Top Categories Search", async function (assert) {
     await visit("/u/eviltrout/summary");
 


### PR DESCRIPTION
When viewing your own user profile, we offer the ability to expand / collapse your user info.

By default, the info are collapsed and the button to toggle it only worked once. Meaning you could expand the info but not collapse it back.

This fixes the issue by using `toggleProperty()` instead of directly `set()`-ing a value.

Also added an acceptance test to ensure it doesn't regress.

Was reported in https://meta.discourse.org/t/342254

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->