### PR TITLE
DEV: Pass in old post to post_moved DiscourseEvent

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -286,7 +286,7 @@ class PostMover
     end
 
     DiscourseEvent.trigger(:first_post_moved, new_post, post)
-    DiscourseEvent.trigger(:post_moved, new_post, original_topic.id)
+    DiscourseEvent.trigger(:post_moved, new_post, original_topic.id, post)
 
     # we don't want to keep the old topic's OP bookmarked when we are
     # moving it into a new topic
@@ -323,7 +323,7 @@ class PostMover
         @post_ids_after_move.map { |post_id| post_id == post.id ? moved_post.id : post_id }
     end
 
-    DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id)
+    DiscourseEvent.trigger(:post_moved, moved_post, original_topic.id, post)
 
     # Move any links from the post to the new topic
     moved_post.topic_links.update_all(topic_id: destination_topic.id)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -2753,6 +2753,31 @@ RSpec.describe PostMover do
         expect(event[:event_name]).to eq(:post_moved)
         expect(event[:params][0]).to eq(post_2)
         expect(event[:params][1]).to eq(topic_1.id)
+        expect(event[:params][2]).to eq(post_2)
+      end
+
+      context "with 'freeze_original' option" do
+        it "passes the new post as the first argument and old post as third argument" do
+          post_mover =
+            PostMover.new(
+              topic_1,
+              Discourse.system_user,
+              [post_2.id],
+              options: {
+                freeze_original: true,
+              },
+            )
+          events = DiscourseEvent.track_events(:post_moved) { post_mover.to_topic(topic_2.id) }
+          expect(events.size).to eq(1)
+
+          moved_post = MovedPost.includes(:new_post).find_by(old_post: post_2)
+
+          event = events.first
+          expect(event[:event_name]).to eq(:post_moved)
+          expect(event[:params][0]).to eq(moved_post.new_post)
+          expect(event[:params][1]).to eq(topic_1.id)
+          expect(event[:params][2]).to eq(post_2)
+        end
       end
     end
 


### PR DESCRIPTION
With the new `freeze_original` option to PostMover, there are occasions where we want to grab the old post event handlers for this DiscourseEvent. This commit simply passes it as a third argument to the DiscourseEvent.