### PR TITLE
DEV: Disable Ember's LOG_STACKTRACE_ON_DEPRECATION

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -17,6 +17,7 @@ module.exports = function (environment) {
         Date: false,
         String: false,
       },
+      LOG_STACKTRACE_ON_DEPRECATION: false,
     },
     exportApplicationGlobal: true,
 

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -25,8 +25,6 @@ document.addEventListener("discourse-init", () => {
   const testingCore = !testingTheme && (!target || target === "core");
   const disableAutoStart = params.get("qunit_disable_auto_start") === "1";
 
-  window.EmberENV.LOG_STACKTRACE_ON_DEPRECATION = false;
-
   document.body.insertAdjacentHTML(
     "afterbegin",
     `


### PR DESCRIPTION
This feature writes a stack trace as part of the message. That means it is not sourcemapped by the browser, and you have further to scroll to find the real backtrace.

In the past we avoided this feature with our production 'deprecation shim', but that was removed as part of our Ember 5.12 upgrade.

Before:
<img width="1141" alt="SCR-20241213-poja" src="https://github.com/user-attachments/assets/6ca7d19b-f654-4b4d-a761-ee9c3d74a254" />

After:
<img width="1204" alt="SCR-20241213-pnsi" src="https://github.com/user-attachments/assets/e81629e8-8191-44a5-9437-c5e549cbee31" />



<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->