### PR TITLE
UX: display groups link when disabled group directory

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -203,6 +203,13 @@ export function useAdminNavConfig(navMap) {
           moderator: true,
         },
         {
+          name: "admin_groups",
+          route: "groups",
+          label: "admin.community.sidebar_link.groups",
+          icon: "user-group",
+          moderator: true,
+        },
+        {
           name: "admin_all_site_settings",
           route: "adminSiteSettings",
           label: "admin.advanced.sidebar_link.all_site_settings",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5588,6 +5588,7 @@ en:
           permalinks: "Permalinks"
           trust_levels: "Trust Levels"
           users: "Users"
+          groups: "Groups"
           user_fields: "User Fields"
           watched_words: "Watched Words"
           legal: "Legal"

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -50,8 +50,10 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "collapses sections by default" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(4)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
+    expect(links.count).to eq(5)
+    expect(links.map(&:text)).to eq(
+      ["Dashboard", "Users", "Groups", "All Site Settings", "What's New"],
+    )
   end
 
   context "when on mobile" do
@@ -173,8 +175,10 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
   it "temporarily expands section when filter" do
     visit("/admin")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(4)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
+    expect(links.count).to eq(5)
+    expect(links.map(&:text)).to eq(
+      ["Dashboard", "Users", "Groups", "All Site Settings", "What's New"],
+    )
 
     filter.filter("ie")
     links = page.all(".sidebar-section-link-content-text")
@@ -183,8 +187,10 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
 
     filter.filter("")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.count).to eq(4)
-    expect(links.map(&:text)).to eq(["Dashboard", "Users", "All Site Settings", "What's New"])
+    expect(links.count).to eq(5)
+    expect(links.map(&:text)).to eq(
+      ["Dashboard", "Users", "Groups", "All Site Settings", "What's New"],
+    )
   end
 
   it "allows further filtering of site settings or users if links do not show results" do
@@ -223,9 +229,9 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
     expect(page).to have_selector(".sidebar-section-link-content-text", minimum: 50)
 
     sidebar.toggle_all_sections
-    expect(page).to have_selector(".sidebar-section-link-content-text", count: 4)
+    expect(page).to have_selector(".sidebar-section-link-content-text", count: 5)
     expect(all(".sidebar-section-link-content-text").map(&:text)).to eq(
-      ["Dashboard", "Users", "All Site Settings", "What's New"],
+      ["Dashboard", "Users", "Groups", "All Site Settings", "What's New"],
     )
 
     sidebar.toggle_all_sections
@@ -282,6 +288,7 @@ describe "Admin Revamp | Sidebar Navigation", type: :system do
       [
         "Dashboard",
         "Users",
+        "Groups",
         "What's New",
         "All",
         "Watched Words",


### PR DESCRIPTION
Add groups link to the admin and moderator sidebar for easy access.
Currently, the admin needs to go to `users` first.

<img width="675" alt="Screenshot 2024-12-16 at 11 49 05 AM" src="https://github.com/user-attachments/assets/1e7bfd06-6bac-418c-a6bf-9dddc7e7bced" />
