### PR TITLE
DEV: Delete symlink when DiscourseFont path changes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -235,7 +235,11 @@ module Discourse
 
     # Use discourse-fonts gem to symlink fonts and generate .scss file
     fonts_path = File.join(config.root, "public/fonts")
-    Discourse::Utils.atomic_ln_s(DiscourseFonts.path_for_fonts, fonts_path)
+    if !File.exist?(fonts_path) || File.realpath(fonts_path) != DiscourseFonts.path_for_fonts
+      puts "Symlinking fonts from discourse-fonts gem"
+      File.delete(fonts_path) if File.exist?(fonts_path)
+      Discourse::Utils.atomic_ln_s(DiscourseFonts.path_for_fonts, fonts_path)
+    end
 
     require "stylesheet/manager"
     require "svg_sprite"


### PR DESCRIPTION
When adding new fonts to our discourse-fonts gem,
you may want to test these changes locally using the
`path` option of the gem line in bundler.

However we set a symlink for the fonts dir for public/fonts,
which does not get updated if the gem path changes. This
fix checks if the current symlink resolved path is equal to
the DiscourseFont gem path, and if not deletes + recreates it.
