### PR TITLE
FEATURE: Reason and deleted content support in the review queue

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -59,9 +59,16 @@ export default class ReviewableItem extends Component {
     "reviewable.type",
     "reviewable.last_performing_username",
     "siteSettings.blur_tl0_flagged_posts_media",
-    "reviewable.target_created_by_trust_level"
+    "reviewable.target_created_by_trust_level",
+    "reviewable.deleted_at"
   )
-  customClasses(type, lastPerformingUsername, blurEnabled, trustLevel) {
+  customClasses(
+    type,
+    lastPerformingUsername,
+    blurEnabled,
+    trustLevel,
+    deletedAt
+  ) {
     let classes = dasherize(type);
 
     if (lastPerformingUsername) {
@@ -70,6 +77,10 @@ export default class ReviewableItem extends Component {
 
     if (blurEnabled && trustLevel === 0) {
       classes = `${classes} blur-images`;
+    }
+
+    if (deletedAt) {
+      classes = `${classes} reviewable-deleted`;
     }
 
     return classes;

--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -20,6 +20,7 @@ export default class ReviewIndexController extends Controller {
     "sort_order",
     "additional_filters",
     "flagged_by",
+    "score_type",
   ];
 
   type = null;
@@ -36,6 +37,7 @@ export default class ReviewIndexController extends Controller {
   to_date = null;
   sort_order = null;
   additional_filters = null;
+  filterScoreType = null;
 
   @discourseComputed("reviewableTypes")
   allTypes() {
@@ -47,6 +49,11 @@ export default class ReviewIndexController extends Controller {
         name: i18n(`review.types.${translationKey}.title`),
       };
     });
+  }
+
+  @discourseComputed("scoreTypes")
+  allScoreTypes() {
+    return this.scoreTypes || [];
   }
 
   @discourseComputed
@@ -164,6 +171,7 @@ export default class ReviewIndexController extends Controller {
       username: this.filterUsername,
       reviewed_by: this.filterReviewedBy,
       flagged_by: this.filterFlaggedBy,
+      score_type: this.filterScoreType,
       from_date: isPresent(this.filterFromDate)
         ? this.filterFromDate.toISOString(true).split("T")[0]
         : null,

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -39,6 +39,7 @@ export default class ReviewIndex extends DiscourseRoute {
       filterCategoryId: meta.category_id,
       filterPriority: meta.priority,
       reviewableTypes: meta.reviewable_types,
+      scoreTypes: meta.score_types,
       filterUsername: meta.username,
       filterReviewedBy: meta.reviewed_by,
       filterFlaggedBy: meta.flagged_by,

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -55,6 +55,18 @@
 
       <div class="reviewable-filter">
         <label class="filter-label">
+          {{i18n "review.filters.score_type.title"}}
+        </label>
+        <ComboBox
+          @value={{this.filterScoreType}}
+          @content={{this.allScoreTypes}}
+          @onChange={{fn (mut this.filterScoreType)}}
+          @options={{hash none="review.filters.score_type.all"}}
+        />
+      </div>
+
+      <div class="reviewable-filter">
+        <label class="filter-label">
           {{i18n "review.filters.priority.title"}}
         </label>
         <ComboBox

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -305,6 +305,13 @@
   opacity: 0.7;
 }
 
+.reviewable-deleted {
+  .reviewable-contents .post-contents .post-body {
+    background-color: var(--danger-low-mid);
+    padding: 0.5em;
+  }
+}
+
 .blur-images {
   img:not(.avatar):not(.emoji) {
     filter: blur(10px);

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -75,7 +75,10 @@ class ReviewablesController < ApplicationController
           types: meta_types,
           reviewable_types: Reviewable.types,
           score_types:
-            ReviewableScore.types.map { |k, v| { id: v, name: ReviewableScore.type_title(k) } },
+            ReviewableScore
+              .types
+              .filter { |k, v| k != :notify_user }
+              .map { |k, v| { id: v, name: ReviewableScore.type_title(k) } },
           reviewable_count: current_user.reviewable_count,
           unseen_reviewable_count: Reviewable.unseen_reviewable_count(current_user),
         ),

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -45,6 +45,7 @@ class ReviewablesController < ApplicationController
       type
       sort_order
       flagged_by
+      score_type
     ].each { |filter_key| filters[filter_key] = params[filter_key] }
 
     total_rows = Reviewable.list_for(current_user, **filters).count
@@ -73,6 +74,8 @@ class ReviewablesController < ApplicationController
           total_rows_reviewables: total_rows,
           types: meta_types,
           reviewable_types: Reviewable.types,
+          score_types:
+            ReviewableScore.types.map { |k, v| { id: v, name: ReviewableScore.type_title(k) } },
           reviewable_count: current_user.reviewable_count,
           unseen_reviewable_count: Reviewable.unseen_reviewable_count(current_user),
         ),

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -8,6 +8,10 @@ class ReviewablesController < ApplicationController
   before_action :version_required, only: %i[update perform]
   before_action :ensure_can_see, except: [:destroy]
 
+  around_action :with_deleted_content,
+                only: %i[index show],
+                if: ->(controller) { controller.guardian.is_staff? }
+
   def index
     offset = params[:offset].to_i
 
@@ -317,5 +321,9 @@ class ReviewablesController < ApplicationController
 
   def ensure_can_see
     Guardian.new(current_user).ensure_can_see_review_queue!
+  end
+
+  def with_deleted_content
+    Post.unscoped { Topic.unscoped { PostAction.unscoped { yield } } }
   end
 end

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -449,7 +449,8 @@ class Reviewable < ActiveRecord::Base
     additional_filters: {},
     preload: true,
     include_claimed_by_others: true,
-    flagged_by: nil
+    flagged_by: nil,
+    score_type: nil
   )
     order =
       case sort_order
@@ -486,6 +487,16 @@ class Reviewable < ActiveRecord::Base
           SELECT 1 FROM reviewable_scores
           WHERE reviewable_scores.reviewable_id = reviewables.id AND reviewable_scores.user_id = :flagged_by_id
         )
+      SQL
+    end
+
+    if score_type
+      score_type = score_type.to_i
+      result = result.where(<<~SQL, score_type: score_type)
+      EXISTS(
+        SELECT 1 FROM reviewable_scores
+        WHERE reviewable_scores.reviewable_id = reviewables.id AND reviewable_scores.reviewable_score_type = :score_type
+      )
       SQL
     end
 

--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -14,6 +14,12 @@ class ReviewableScore < ActiveRecord::Base
     @types ||= PostActionType.flag_types.merge(PostActionType.score_types)
   end
 
+  def self.type_title(type)
+    I18n.t("post_action_types.#{type}.title", default: nil) ||
+      I18n.t("reviewable_score_types.#{type}.title", default: nil) ||
+      PostActionType.names[types[type]]
+  end
+
   # When extending post action flags, we need to call this method in order to
   # get the latests flags.
   def self.reload_types

--- a/app/serializers/reviewable_flagged_post_serializer.rb
+++ b/app/serializers/reviewable_flagged_post_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReviewableFlaggedPostSerializer < ReviewableSerializer
-  target_attributes :cooked, :raw, :reply_count, :reply_to_post_number
+  target_attributes :cooked, :raw, :reply_count, :reply_to_post_number, :deleted_at
   attributes :blank_post, :post_updated_at, :post_version
 
   def created_from_flag?

--- a/app/serializers/reviewable_score_type_serializer.rb
+++ b/app/serializers/reviewable_score_type_serializer.rb
@@ -9,8 +9,7 @@ class ReviewableScoreTypeSerializer < ApplicationSerializer
 
   # Allow us to share post action type translations for backwards compatibility
   def title
-    I18n.t("post_action_types.#{type}.title", default: nil) ||
-      I18n.t("reviewable_score_types.#{type}.title", default: nil) || PostActionType.names[id]
+    ReviewableScore.type_title(type)
   end
 
   def reviewable_priority

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -689,6 +689,9 @@ en:
         refresh: "Refresh"
         status: "Status"
         category: "Category"
+        score_type:
+          title: "Reason"
+          all: "(all reasons)"
         orders:
           score: "Score"
           score_asc: "Score (reverse)"

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -130,6 +130,31 @@ RSpec.describe ReviewablesController do
         end
       end
 
+      it "supports filtering by flag reason" do
+        # this is not flagged by the user
+        reviewable = Fabricate(:reviewable)
+        reviewable.reviewable_scores.create!(
+          user: admin,
+          score: 1000,
+          status: "pending",
+          reviewable_score_type: 1,
+        )
+
+        reviewable = Fabricate(:reviewable)
+        user = Fabricate(:user)
+        reviewable.reviewable_scores.create!(
+          user: user,
+          score: 1000,
+          status: "pending",
+          reviewable_score_type: 2,
+        )
+
+        get "/review.json?score_type=1"
+        expect(response.code).to eq("200")
+        json = response.parsed_body
+        expect(json["reviewables"].length).to eq(1)
+      end
+
       it "supports filtering by flagged_by" do
         # this is not flagged by the user
         reviewable = Fabricate(:reviewable)


### PR DESCRIPTION
Add flag reason filter and improve handling of deleted content in review queue

This commit enhances the review queue with several key improvements:

1. Adds a new "Reason" filter to allow filtering flags by their score type
2. Improves UI for deleted content by:
   - Adding visual indication for deleted posts (red background)
   - Properly handling deleted content visibility for staff (category mods can not see deleted content)
3. Refactors reviewable score type handling for better code organization
4. Adds  tests for trashed topics/posts visibility

This change will help moderators more efficiently manage the review queue by
being able to focus on specific types of flags and better identify deleted
content.