### PR TITLE
Revert "DEV: prioritize new email styles over existing, to make custo…

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -33,7 +33,7 @@ module Email
       existing = node["style"]
       if existing.present?
         # merge styles
-        node["style"] = "#{existing}; #{new_styles}"
+        node["style"] = "#{new_styles}; #{existing}"
       else
         node["style"] = new_styles
       end


### PR DESCRIPTION
…mization easier (#30244)"

This reverts commit 9694dc6cb05a35cced328b133630981bfc2e97f3.

Some of our previous email styling depended on this 'incorrect' ordering, so the change caused some text to become illegible. Reverting while we work out a better solution

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->