### PR TITLE
DEV: Compile theme raw-hbr to modules

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 86
+  BASE_COMPILER_VERSION = 87
 
   class SettingsMigrationError < StandardError
   end

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -210,7 +210,6 @@ class ThemeJavascriptCompiler
 
   def raw_template_name(name)
     name = name.sub(/\.(raw|hbr)\z/, "")
-    name.inspect
   end
 
   def append_raw_template(name, hbs_template)
@@ -218,16 +217,27 @@ class ThemeJavascriptCompiler
       DiscourseJsProcessor::Transpiler.new.compile_raw_template(hbs_template, theme_id: @theme_id)
     source_for_comment = hbs_template.gsub("*/", '*\/').indent(4, " ")
     modern_replacement_marker = hbs_template.include?("{{!-- has-modern-replacement --}}")
-    @output_tree << ["#{name}.js", <<~JS]
-      (function() {
-        /*
+
+    source = <<~JS
+      /*
       #{source_for_comment}
-        */
-        const addRawTemplate = requirejs('discourse-common/lib/raw-templates').addRawTemplate;
-        const template = requirejs('discourse-common/lib/raw-handlebars').template(#{compiled});
-        addRawTemplate(#{raw_template_name(name)}, template, { themeId: #{@theme_id}, themeName: #{@theme_name.to_json}, hasModernReplacement: #{modern_replacement_marker} });
-      })();
+      */
+
+      import { template as compiler } from "discourse-common/lib/raw-handlebars";
+      import { addRawTemplate } from "discourse-common/lib/raw-templates";
+
+      let template = compiler(#{compiled});
+
+      addRawTemplate(#{raw_template_name(name).to_json}, template, {
+        themeId: #{@theme_id},
+        themeName: #{@theme_name.to_json},
+        hasModernReplacement: #{modern_replacement_marker}
+      });
+
+      export default template;
     JS
+
+    append_module source, "raw-templates/#{raw_template_name(name)}", "js", include_variables: false
   rescue MiniRacer::RuntimeError, DiscourseJsProcessor::TranspileError => ex
     raise CompileError.new ex.message
   end

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -209,7 +209,7 @@ class ThemeJavascriptCompiler
   end
 
   def raw_template_name(name)
-    name = name.sub(/\.(raw|hbr)\z/, "")
+    name.sub(/\.(raw|hbr)\z/, "")
   end
 
   def append_raw_template(name, hbs_template)

--- a/spec/lib/theme_javascript_compiler_spec.rb
+++ b/spec/lib/theme_javascript_compiler_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe ThemeJavascriptCompiler do
       template = "<h1>hello</h1>"
       name = "/path/to/templates1"
       compiler.append_raw_template("#{name}.raw", template)
-      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate)(\"#{name}\"")
 
       name = "/path/to/templates2"
       compiler.append_raw_template("#{name}.hbr", template)
-      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate)(\"#{name}\"")
 
       name = "/path/to/templates3"
       compiler.append_raw_template("#{name}.hbs", template)
-      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}.hbs\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate)(\"#{name}.hbs\"")
     end
   end
 

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -257,7 +257,7 @@ HTML
     expect(theme.javascript_cache.content).to include(
       "define(\"discourse/theme-#{theme.id}/discourse/templates/discovery\", [\"exports\", ",
     )
-    expect(theme.javascript_cache.content).to include('addRawTemplate("discovery"')
+    expect(theme.javascript_cache.content).to include('addRawTemplate)("discovery"')
     expect(theme.javascript_cache.content).to include(
       "define(\"discourse/theme-#{theme.id}/discourse/controllers/discovery\"",
     )
@@ -283,8 +283,8 @@ HTML
       "discourse/controllers/discovery.blah",
       "discourse/controllers/discovery.js",
       "discourse/templates/discovery.js",
-      "discovery.js",
-      "other_discovery.js",
+      "raw-templates/discovery.js",
+      "raw-templates/other_discovery.js",
     )
     expect(map["sourceRoot"]).to eq("theme-#{theme.id}/")
     expect(map["sourcesContent"].length).to eq(6)


### PR DESCRIPTION
Previously, theme hbr files were compiled to an IIFE, which would be executed before the app is booted. That is causing silenced deprecations to be printed, because the deprecation-workflow isn't set up when the IIFE is run.

This commit updates the theme compiler so that it matches the ember-cli-based raw-hbs compiler. Templates are output to normal modules, which will then be loaded by the existing `eager-load-raw-templates` initializer. This runs after the app has started booting.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->