### PR TITLE
FIX: Correctly display group unread indicator in gjs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/unread-indicator.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/unread-indicator.gjs
@@ -26,12 +26,8 @@ export default class UnreadIndicator extends Component {
     return `/private-messages/unread-indicator/${this.args.topic.id}`;
   }
 
-  get isUnread() {
-    return typeof this.args.topic.get("unread_by_group_member") !== "undefined";
-  }
-
   <template>
-    {{~#if this.isUnread~}}
+    {{~#if @topic.unread_by_group_member~}}
       &nbsp;<span
         title={{i18n "topic.unread_indicator"}}
         class="badge badge-notification unread-indicator"

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.gjs
@@ -1,6 +1,7 @@
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import TopicListItem from "discourse/components/topic-list/item";
+import TopicList from "discourse/components/topic-list/list";
 import HbrTopicListItem from "discourse/components/topic-list-item";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -57,5 +58,29 @@ module("Integration | Component | topic-list-item", function (hooks) {
     assert
       .dom(".topic-list-item[data-topic-id='1235']")
       .doesNotHaveClass("bar");
+  });
+
+  test("shows unread-by-group-member indicator", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const topics = [
+      store.createRecord("topic", { id: 1234 }),
+      store.createRecord("topic", {
+        id: 1235,
+        unread_by_group_member: true,
+      }),
+      store.createRecord("topic", {
+        id: 1236,
+        unread_by_group_member: false,
+      }),
+    ];
+
+    await render(<template><TopicList @topics={{topics}} /></template>);
+
+    assert
+      .dom(".badge.badge-notification.unread-indicator")
+      .exists({ count: 1 });
+    assert
+      .dom(".topic-list-item[data-topic-id='1235'] .unread-indicator")
+      .exists();
   });
 });


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->