### PR TITLE
FIX: Restrict duplicate timings from being moved with posts

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -478,7 +478,9 @@ class PostMover
   def copy_shifted_post_timings_from_temp
     DB.exec <<~SQL
       INSERT INTO post_timings (topic_id, user_id, post_number, msecs)
-      SELECT DISTINCT topic_id, user_id, post_number, msecs FROM temp_post_timings
+      SELECT DISTINCT ON (topic_id, post_number, user_id) topic_id, user_id, post_number, msecs
+      FROM temp_post_timings
+      ORDER BY topic_id, post_number, user_id, msecs DESC
       ON CONFLICT (topic_id, post_number, user_id) DO UPDATE
         SET msecs = GREATEST(post_timings.msecs, excluded.msecs)
     SQL


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #30256.

Unfortunately, the previous PR didn't quite fix the issue, just changed it slightly:

```
Message

PG::CardinalityViolation (ERROR:  ON CONFLICT DO UPDATE command cannot affect row a second time
HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.
)
lib/mini_sql_multisite_connection.rb:109:in `run'
app/models/post_mover.rb:479:in `copy_shifted_post_timings_from_temp'
app/models/post_mover.rb:137:in `handle_moved_references'
app/models/post_mover.rb:108:in `move_posts_to'
app/models/post_mover.rb:35:in `block in to_topic'
app/models/post_mover.rb:35:in `to_topic'
app/models/topic.rb:1308:in `move_posts'
app/controllers/topics_controller.rb:1415:in `move_posts_to_destination'
app/controllers/topics_controller.rb:917:in `move_posts'
app/controllers/application_controller.rb:424:in `block in with_resolved_locale'
app/controllers/application_controller.rb:424:in `with_resolved_locale'
lib/middleware/omniauth_bypass_middleware.rb:64:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/anonymous_cache.rb:403:in `call'
lib/middleware/csp_script_nonce_injector.rb:12:in `call'
config/initializers/008-rack-cors.rb:26:in `call'
config/initializers/100-quiet_logger.rb:20:in `call'
config/initializers/100-silence_logger.rb:29:in `call'
lib/middleware/enforce_hostname.rb:24:in `call'
lib/middleware/processing_request.rb:12:in `call'
lib/middleware/request_tracker.rb:360:in `call'
```

Unfortunately, I still haven't been able to come up with a way to replicate the site state that's causing this, but ensuring we're basing the `DISTINCT` requirement on the `post_timing.post_timings_unique` index should avoid coping any data that will subsequently fall foul of that index's `UNIQUE` requirement.

Internal ref t/142010/15
