### PR TITLE
FIX: use relations for new_in_category

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -422,7 +422,7 @@ class TopicQuery
 
   def list_new_in_category(category)
     create_list(:new_in_category, unordered: true, category: category.id) do |list|
-      list.by_newest.first(25)
+      list.by_newest.limit(25)
     end
   end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -20,6 +20,32 @@ RSpec.describe TopicQuery do
   fab!(:moderator)
   fab!(:admin)
 
+  before do
+    @plugin_instance = Plugin::Instance.new
+    @validator_blk =
+      lambda do |topics, options, query|
+        # this is notable, we do not send in a relation for suggested
+        # it would force us to completely rewrite SuggestedTopicsBuilder
+        if options[:filter] = !"suggested"
+          expect(topics.is_a?(ActiveRecord::Relation)).to eq(true)
+        end
+        topics
+      end
+    DiscoursePluginRegistry.register_modifier(
+      @plugin_instance,
+      :topic_query_create_list_topics,
+      &@validator_blk
+    )
+  end
+
+  after do
+    DiscoursePluginRegistry.unregister_modifier(
+      @plugin_instance,
+      :topic_query_create_list_topics,
+      &@validator_blk
+    )
+  end
+
   describe "secure category" do
     it "filters categories out correctly" do
       category = Fabricate(:category_with_definition)
@@ -2228,22 +2254,28 @@ RSpec.describe TopicQuery do
     fab!(:topic1) { Fabricate(:topic, created_at: 3.days.ago, bumped_at: 1.hour.ago) }
     fab!(:topic2) { Fabricate(:topic, created_at: 2.days.ago, bumped_at: 3.hour.ago) }
 
-    after { DiscoursePluginRegistry.clear_modifiers! }
-
     it "allows changing" do
       original_topic_query = TopicQuery.new(user)
-
-      Plugin::Instance
-        .new
-        .register_modifier(:topic_query_create_list_topics) do |topics, options, topic_query|
+      plugin_instance = Plugin::Instance.new
+      blk =
+        lambda do |topics, options, topic_query|
           expect(topic_query).to eq(topic_query)
           topic_query.options[:order] = "created"
           topics
         end
 
+      DiscoursePluginRegistry.register_modifier(
+        plugin_instance,
+        :topic_query_create_list_topics,
+        &blk
+      )
       expect(original_topic_query.list_latest.topics.map(&:id)).to eq([topic1, topic2].map(&:id))
 
-      DiscoursePluginRegistry.clear_modifiers!
+      DiscoursePluginRegistry.unregister_modifier(
+        plugin_instance,
+        :topic_query_create_list_topics,
+        &blk
+      )
 
       expect(original_topic_query.list_latest.topics.map(&:id)).to eq([topic2, topic1].map(&:id))
     end

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe TopicQuery do
       lambda do |topics, options, query|
         # this is notable, we do not send in a relation for suggested
         # it would force us to completely rewrite SuggestedTopicsBuilder
-        if options[:filter] = !"suggested"
-          expect(topics.is_a?(ActiveRecord::Relation)).to eq(true)
-        end
+        expect(topics.is_a?(ActiveRecord::Relation)).to eq(true) if options[:filter] != :suggested
         topics
       end
     DiscoursePluginRegistry.register_modifier(


### PR DESCRIPTION
new_in_category was using `first` instead of `limit`

this meant it gets an array and that means that you can not operate on it easily in a modifier.

this ensures we always give the modifier a relation, with the notable exception of suggeted topics.