### PR TITLE
DEV: Fix flaky users_email_controller_spec test case

### DIFF
--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -208,6 +208,8 @@ RSpec.describe UsersEmailController do
         fab!(:other_user) { Fabricate(:user, email: "case.insensitive@gmail.com") }
 
         context "when hiding taken e-mails" do
+          before { SiteSetting.hide_email_address_taken = true }
+
           it "raises an error" do
             put "/u/#{user.username}/preferences/email.json",
                 params: {


### PR DESCRIPTION
### What is this change?

This should be the last fallout from changing `hide_email_address_taken` default. 🤞 