### PR TITLE
UX: move to icon for password masking

### DIFF
--- a/app/assets/javascripts/discourse/app/components/local-login-form.hbs
+++ b/app/assets/javascripts/discourse/app/components/local-login-form.hbs
@@ -48,6 +48,13 @@
       <label class="alt-placeholder" for="login-account-password">
         {{i18n "login.password"}}
       </label>
+      {{#if @loginPassword}}
+        <TogglePasswordMask
+          @maskPassword={{this.maskPassword}}
+          @togglePasswordMask={{this.togglePasswordMask}}
+          tabindex="3"
+        />
+      {{/if}}
       <div class="login__password-links">
         <a
           href
@@ -57,13 +64,6 @@
         >
           {{i18n "forgot_password.action"}}
         </a>
-        {{#if @loginPassword}}
-          <TogglePasswordMask
-            @maskPassword={{this.maskPassword}}
-            @togglePasswordMask={{this.togglePasswordMask}}
-            tabindex="3"
-          />
-        {{/if}}
       </div>
       <div class="caps-lock-warning {{unless this.capsLockOn 'hidden'}}">
         {{d-icon "triangle-exclamation"}}

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.hbs
@@ -138,7 +138,10 @@
               <label class="alt-placeholder" for="new-account-password">
                 {{i18n "user.password.title"}}
               </label>
-
+              <TogglePasswordMask
+                @maskPassword={{this.maskPassword}}
+                @togglePasswordMask={{this.togglePasswordMask}}
+              />
               <div class="create-account__password-info">
                 <div class="create-account__password-tip-validation">
                   {{#if this.showPasswordValidation}}
@@ -163,10 +166,6 @@
                     {{i18n "login.caps_lock_warning"}}
                   </div>
                 </div>
-                <TogglePasswordMask
-                  @maskPassword={{this.maskPassword}}
-                  @togglePasswordMask={{this.togglePasswordMask}}
-                />
               </div>
             {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/toggle-password-mask.hbs
+++ b/app/assets/javascripts/discourse/app/components/toggle-password-mask.hbs
@@ -1,10 +1,10 @@
 <DButton
   @action={{@togglePasswordMask}}
-  @label={{if @maskPassword "login.show_password" "login.hide_password"}}
+  @icon={{if @maskPassword "far-eye" "far-eye-slash"}}
   @title={{if
     @maskPassword
     "login.show_password_title"
     "login.hide_password_title"
   }}
-  class="btn-link toggle-password-mask"
+  class="btn-transparent toggle-password-mask"
 />

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -134,6 +134,11 @@
                   <label class="alt-placeholder" for="new-account-password">
                     {{i18n "invites.password_label"}}
                   </label>
+                  <TogglePasswordMask
+                    @maskPassword={{this.maskPassword}}
+                    @togglePasswordMask={{this.togglePasswordMask}}
+                    @parentController="invites-show"
+                  />
                   <div class="create-account__password-info">
                     <div class="create-account__password-tip-validation">
                       <InputTip
@@ -148,11 +153,6 @@
                         {{i18n "login.caps_lock_warning"}}
                       </div>
                     </div>
-                    <TogglePasswordMask
-                      @maskPassword={{this.maskPassword}}
-                      @togglePasswordMask={{this.togglePasswordMask}}
-                      @parentController="invites-show"
-                    />
                   </div>
                 </div>
               {{/unless}}

--- a/app/assets/javascripts/discourse/app/templates/signup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/signup.hbs
@@ -134,7 +134,10 @@
               <label class="alt-placeholder" for="new-account-password">
                 {{i18n "user.password.title"}}
               </label>
-
+              <TogglePasswordMask
+                @maskPassword={{this.maskPassword}}
+                @togglePasswordMask={{this.togglePasswordMask}}
+              />
               <div class="create-account__password-info">
                 <div class="create-account__password-tip-validation">
                   {{#if this.showPasswordValidation}}
@@ -159,10 +162,6 @@
                     {{i18n "login.caps_lock_warning"}}
                   </div>
                 </div>
-                <TogglePasswordMask
-                  @maskPassword={{this.maskPassword}}
-                  @togglePasswordMask={{this.togglePasswordMask}}
-                />
               </div>
             {{/if}}
 

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -61,13 +61,17 @@ body.invite-page {
   }
 }
 
+.signup-fullpage .input-group input[type="password"] {
+  padding-right: 3em;
+}
+
 .toggle-password-mask {
-  align-self: start;
-  line-height: 1.4; // aligns with input description text
+  position: absolute;
+  right: 0;
+  padding: 0.75em 0.77em; // alligns with input padding
   .ios-device & {
     // reset form-item-sizing mixin styles
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0.7em;
     font-size: var(--font-0);
   }
 }


### PR DESCRIPTION
This PR moves away from "show" text, and toward an eye/eye slash icon button within the password input for password masking. This is to save space on login/signup forms.

**Before**
![CleanShot 2024-12-17 at 07 15 29@2x](https://github.com/user-attachments/assets/f441df9b-7be3-4a6a-8607-c0f03144930b)


**After**
![CleanShot 2024-12-17 at 07 15 12@2x](https://github.com/user-attachments/assets/fc2811b4-4695-4c69-badd-13f7eb4415b6)
