### PR TITLE
DEV: Do not delay DButton actions on iOS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -19,7 +19,6 @@ const ACTION_AS_STRING_DEPRECATION_ARGS = [
 
 export default class DButton extends GlimmerComponentWithDeprecatedParentView {
   @service router;
-  @service capabilities;
 
   @notEmpty("args.icon") btnIcon;
 
@@ -103,15 +102,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
   @action
   click(event) {
-    if (this.capabilities.isIOS) {
-      // iOS needs actions to be undelayed
-      // especially important for the composer,
-      // otherwise focus isn't set properly
-      return this._triggerAction(event);
-    } else {
-      // Using `next()` to optimise INP
-      next(() => this._triggerAction(event));
-    }
+    return this._triggerAction(event);
   }
 
   @action
@@ -138,11 +129,19 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             );
           }
         } else if (typeof actionVal === "object" && actionVal.value) {
-          forwardEvent
-            ? actionVal.value(actionParam, event)
-            : actionVal.value(actionParam);
+          // Using `next()` to optimise INP
+          next(() =>
+            forwardEvent
+              ? actionVal.value(actionParam, event)
+              : actionVal.value(actionParam)
+          );
         } else if (typeof actionVal === "function") {
-          forwardEvent ? actionVal(actionParam, event) : actionVal(actionParam);
+          // Using `next()` to optimise INP
+          next(() =>
+            forwardEvent
+              ? actionVal(actionParam, event)
+              : actionVal(actionParam)
+          );
         }
       } else if (route) {
         if (routeModels) {

--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -19,6 +19,7 @@ const ACTION_AS_STRING_DEPRECATION_ARGS = [
 
 export default class DButton extends GlimmerComponentWithDeprecatedParentView {
   @service router;
+  @service capabilities;
 
   @notEmpty("args.icon") btnIcon;
 
@@ -114,6 +115,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
   _triggerAction(event) {
     const { action: actionVal, route, routeModels } = this.args;
+    const isIOS = this.capabilities?.isIOS;
 
     if (actionVal || route) {
       if (actionVal) {
@@ -129,19 +131,35 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             );
           }
         } else if (typeof actionVal === "object" && actionVal.value) {
-          // Using `next()` to optimise INP
-          next(() =>
+          if (isIOS) {
+            // Don't optimise INP in iOS
+            // it results in focus events not being triggered
             forwardEvent
               ? actionVal.value(actionParam, event)
-              : actionVal.value(actionParam)
-          );
+              : actionVal.value(actionParam);
+          } else {
+            // Using `next()` to optimise INP
+            next(() =>
+              forwardEvent
+                ? actionVal.value(actionParam, event)
+                : actionVal.value(actionParam)
+            );
+          }
         } else if (typeof actionVal === "function") {
-          // Using `next()` to optimise INP
-          next(() =>
+          if (isIOS) {
+            // Don't optimise INP in iOS
+            // it results in focus events not being triggered
             forwardEvent
               ? actionVal(actionParam, event)
-              : actionVal(actionParam)
-          );
+              : actionVal(actionParam);
+          } else {
+            // Using `next()` to optimise INP
+            next(() =>
+              forwardEvent
+                ? actionVal(actionParam, event)
+                : actionVal(actionParam)
+            );
+          }
         }
       } else if (route) {
         if (routeModels) {

--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -19,6 +19,7 @@ const ACTION_AS_STRING_DEPRECATION_ARGS = [
 
 export default class DButton extends GlimmerComponentWithDeprecatedParentView {
   @service router;
+  @service capabilities;
 
   @notEmpty("args.icon") btnIcon;
 
@@ -102,7 +103,15 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
   @action
   click(event) {
-    return this._triggerAction(event);
+    if (this.capabilities.isIOS) {
+      // iOS needs actions to be undelayed
+      // especially important for the composer,
+      // otherwise focus isn't set properly
+      return this._triggerAction(event);
+    } else {
+      // Using `next()` to optimise INP
+      next(() => this._triggerAction(event));
+    }
   }
 
   @action
@@ -129,19 +138,11 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
             );
           }
         } else if (typeof actionVal === "object" && actionVal.value) {
-          // Using `next()` to optimise INP
-          next(() =>
-            forwardEvent
-              ? actionVal.value(actionParam, event)
-              : actionVal.value(actionParam)
-          );
+          forwardEvent
+            ? actionVal.value(actionParam, event)
+            : actionVal.value(actionParam);
         } else if (typeof actionVal === "function") {
-          // Using `next()` to optimise INP
-          next(() =>
-            forwardEvent
-              ? actionVal(actionParam, event)
-              : actionVal(actionParam)
-          );
+          forwardEvent ? actionVal(actionParam, event) : actionVal(actionParam);
         }
       } else if (route) {
         if (routeModels) {


### PR DESCRIPTION
Followup to #28019, on iOS this delay means that we don't properly set focus on the composer.
