### PR TITLE
FIX: Correct moderator post position for full topic move with freeze_original

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -97,11 +97,15 @@ class PostMover
     @first_post_number_moved =
       posts.first.is_first_post? ? posts[1]&.post_number : posts.first.post_number
 
-    if @options[:freeze_original] # in this case we need to add the moderator post after the last copied post
-      from_posts = @original_topic.ordered_posts.where("post_number > ?", posts.last.post_number)
-      shift_post_numbers(from_posts) if !@full_move
-
-      @first_post_number_moved = posts.last.post_number + 1
+    if @options[:freeze_original]
+      # in this case we need to add the moderator post after the last copied post
+      if @full_move
+        @first_post_number_moved = @original_topic.ordered_posts.last.post_number + 1
+      else
+        from_posts = @original_topic.ordered_posts.where("post_number > ?", posts.last.post_number)
+        shift_post_numbers(from_posts)
+        @first_post_number_moved = posts.last.post_number + 1
+      end
     end
 
     move_each_post


### PR DESCRIPTION
When `freeze_original` option is passed to PostMover, and we are moving all posts there is an issue. We attempt to put the small_action right after the last moved post. The issue is when there is an existing small action after the last moved "real" post. We then try to put the moderator post at the same location of the existing small action, which causes an index conflict and the move fails.

This makes sure that we place the moderator post at the verrrrrry end of the topic :)