### PR TITLE
Added duplication to name to prevent modification of frozen string exception

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -444,7 +444,7 @@ class ImportScripts::Base
       else
         # Basic massaging on the category name
         params[:name] = "Blank" if params[:name].blank?
-        params[:name].strip!
+        params[:name].dup.strip!
         params[:name] = params[:name][0..49]
 
         # make sure categories don't go more than 2 levels deep

--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -444,7 +444,7 @@ class ImportScripts::Base
       else
         # Basic massaging on the category name
         params[:name] = "Blank" if params[:name].blank?
-        params[:name].dup.strip!
+        params[:name] = params[:name].strip
         params[:name] = params[:name][0..49]
 
         # make sure categories don't go more than 2 levels deep


### PR DESCRIPTION
I take no credit for this fix. User154574 posted it and resolved my issue here:
https://meta.discourse.org/t/migrate-a-mailing-list-to-discourse-mbox-listserv-google-groups-etc/79773/240


Without adding this string mbox imports are currently broken with the error 

> /var/www/discourse/script/import_scripts/base.rb:447:in `strip!': **can't modify frozen String: "xxxxx-xxxxxxx@xxxxxxx.com" (****FrozenError****)**