### PR TITLE
UX: show correct message when creating topics is disabled by a tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
@@ -12,10 +12,7 @@
     </:button>
     <:tooltip>
       {{#if @disabled}}
-        <DTooltip
-          @icon="circle-info"
-          @content={{i18n "topic.create_disabled_category"}}
-        />
+        <DTooltip @icon="circle-info" @content={{i18n this.disallowedReason}} />
       {{/if}}
     </:tooltip>
   </DButtonTooltip>

--- a/app/assets/javascripts/discourse/app/components/create-topic-button.js
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.js
@@ -5,4 +5,12 @@ import { tagName } from "@ember-decorators/component";
 export default class CreateTopicButton extends Component {
   label = "topic.create";
   btnClass = "btn-default";
+
+  get disallowedReason() {
+    if (this.canCreateTopicOnTag === false) {
+      return "topic.create_disabled_tag";
+    } else if (this.disabled) {
+      return "topic.create_disabled_category";
+    }
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3275,6 +3275,7 @@ en:
         other: "%{count} posts in topic"
       create: "New Topic"
       create_disabled_category: "You're not allowed to create topics in this category"
+      create_disabled_tag: "You're not allowed to create topics with this tag"
       create_long: "Create a new Topic"
       open_draft: "Open Draft"
       private_message: "Start a message"


### PR DESCRIPTION
Originally reported here: https://meta.discourse.org/t/wrong-reason-for-not-allowing-topic-creation/286132


Currently, if you're not allowed to post because of the current tag filter... we say:

> You're not allowed to create topics in this category

Which is incorrect, this updates it so when `this.canCreateTopicOnTag === false` we show:

> You're not allowed to create topics with this tag

When the category prevents new topics: 

![image](https://github.com/user-attachments/assets/9b7b268a-d671-43eb-9b7a-64274e37dfae)

When the tag prevents new topics: 

![image](https://github.com/user-attachments/assets/258a34bf-238e-48d1-bcb3-09fee57f9162)


