### PR TITLE
UX: Improve balance on login & signup pages

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -13,9 +13,23 @@ body.login-page,
 body.signup-page,
 body.invite-page,
 body.password-reset-page {
-  & ~ .powered-by-discourse,
+  .powered-by-discourse,
   .above-main-container-outlet {
     display: none;
+  }
+  #main-outlet {
+    padding: 0;
+  }
+  .d-header {
+    box-shadow: none;
+    border: none;
+    background-color: var(--secondary);
+  }
+  .d-header .home-logo-wrapper-outlet {
+    width: 100%;
+  }
+  .d-header .title a {
+    margin: 0 auto;
   }
 }
 
@@ -51,6 +65,7 @@ body.signup-page {
 
     &__existing-account,
     &__no-account-yet {
+      font-size: var(--font-down-1);
       color: var(--primary-medium);
     }
 
@@ -209,6 +224,7 @@ body.signup-page {
 
     .btn-social {
       border: 1px solid var(--primary-low);
+      padding: 0.75em 0.77em; // matches input padding
     }
   }
 

--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -12,7 +12,8 @@
 body.login-page,
 body.signup-page,
 body.invite-page,
-body.password-reset-page {
+body.password-reset-page,
+body.activate-account-page {
   .powered-by-discourse,
   .above-main-container-outlet {
     display: none;

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -200,11 +200,8 @@
 .btn-social {
   color: #000;
   background: #fff;
-  border: 1px solid transparent;
   border-radius: var(--d-border-radius);
-  &:hover,
   &:focus {
-    box-shadow: var(--shadow-card);
     outline: 1px solid #000;
   }
   &[href] {
@@ -218,19 +215,6 @@
   &.btn:hover .d-icon {
     color: #000;
   }
-  &.google_oauth2 {
-    background: var(--google);
-    color: #333;
-    // non-FA SVG icon for Google in login-buttons.hbs
-    .d-icon {
-      opacity: 0.9;
-    }
-    &:hover,
-    &:focus {
-      color: inherit;
-    }
-  }
-
   &.cas {
     .d-icon {
       color: var(--cas);


### PR DESCRIPTION
This pr correctly removes the powered by discourse content, along with balancing spacing on social login buttons, and cleans up the header for login / signup / invite pages.

| Before | After |
| --- | --- |
| ![CleanShot 2024-12-17 at 15 40 28@2x](https://github.com/user-attachments/assets/9587e584-c0c8-4508-b175-a53b3db00ed8)|![CleanShot 2024-12-17 at 15 38 04@2x](https://github.com/user-attachments/assets/5cce8c95-8c77-41d5-8bea-f29544e68afb) |
| ![CleanShot 2024-12-17 at 15 39 53@2x](https://github.com/user-attachments/assets/d4eaff40-e6e6-4025-ae7b-e672d5816de8) | ![CleanShot 2024-12-17 at 15 38 33@2x](https://github.com/user-attachments/assets/7ca94951-4804-42dc-93bf-e45312ae3d49) |
| ![CleanShot 2024-12-17 at 15 41 04@2x](https://github.com/user-attachments/assets/ebb35af3-5adf-4458-ab3f-1d76ada12002) | ![CleanShot 2024-12-17 at 15 38 56@2x](https://github.com/user-attachments/assets/1c23863c-2caa-4e29-9a29-759c10a5e80c)|
| ![CleanShot 2024-12-17 at 15 41 26@2x](https://github.com/user-attachments/assets/65552ad2-3b07-45e2-8934-b7aa68c149ff) | ![CleanShot 2024-12-17 at 15 39 16@2x](https://github.com/user-attachments/assets/5288b416-cd23-4a38-ae0a-2c5bb0d27f04)|


