### PR TITLE
DEV: return full name in /notifications.json

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -379,7 +379,9 @@ class Notification < ActiveRecord::Base
     users = User.where(username_lower: usernames.uniq).index_by(&:username_lower)
     notifications.each do |notification|
       notification.acting_user = users[notification.acting_username]
-      notification.data_hash[:original_name] = notification.acting_user&.name
+      notification.data_hash[
+        :original_name
+      ] = notification.acting_user&.name if SiteSetting.enable_names
     end
 
     notifications

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -369,10 +369,10 @@ class Notification < ActiveRecord::Base
       notifications.map do |notification|
         notification.acting_username =
           (
-            notification.data_hash[:username] || notification.data_hash[:original_username]
-            notification.data_hash[:display_username] ||
+            notification.data_hash[:username] || notification.data_hash[:display_username] ||
               notification.data_hash[:mentioned_by_username] ||
-              notification.data_hash[:invited_by_username]
+              notification.data_hash[:invited_by_username] ||
+              notification.data_hash[:original_username]
           )&.downcase
       end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -369,7 +369,8 @@ class Notification < ActiveRecord::Base
       notifications.map do |notification|
         notification.acting_username =
           (
-            notification.data_hash[:username] || notification.data_hash[:display_username] ||
+            notification.data_hash[:username] || notification.data_hash[:original_username]
+            notification.data_hash[:display_username] ||
               notification.data_hash[:mentioned_by_username] ||
               notification.data_hash[:invited_by_username]
           )&.downcase
@@ -378,6 +379,7 @@ class Notification < ActiveRecord::Base
     users = User.where(username_lower: usernames.uniq).index_by(&:username_lower)
     notifications.each do |notification|
       notification.acting_user = users[notification.acting_username]
+      notification.data_hash[:original_name] = notification.acting_user&.name
     end
 
     notifications

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -813,6 +813,7 @@ RSpec.describe Notification do
     fab!(:user2) { Fabricate(:user) }
     fab!(:user3) { Fabricate(:user) }
     fab!(:user4) { Fabricate(:user) }
+    fab!(:user5) { Fabricate(:user) }
     fab!(:notification1) do
       Fabricate(:notification, user: user, data: { username: user1.username }.to_json)
     end
@@ -825,16 +826,20 @@ RSpec.describe Notification do
     fab!(:notification4) do
       Fabricate(:notification, user: user, data: { invited_by_username: user4.username }.to_json)
     end
+    fab!(:notification5) do
+      Fabricate(:notification, user: user, data: { original_username: user5.username }.to_json)
+    end
 
     it "Sets the acting_user correctly for each notification" do
       Notification.populate_acting_user(
-        [notification1, notification2, notification3, notification4],
+        [notification1, notification2, notification3, notification4, notification5],
       )
 
       expect(notification1.acting_user).to eq(user1)
       expect(notification2.acting_user).to eq(user2)
       expect(notification3.acting_user).to eq(user3)
       expect(notification4.acting_user).to eq(user4)
+      expect(notification5.acting_user).to eq(user5)
     end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -831,15 +831,24 @@ RSpec.describe Notification do
     end
 
     it "Sets the acting_user correctly for each notification" do
+      SiteSetting.enable_names = true
       Notification.populate_acting_user(
         [notification1, notification2, notification3, notification4, notification5],
       )
-
       expect(notification1.acting_user).to eq(user1)
       expect(notification2.acting_user).to eq(user2)
       expect(notification3.acting_user).to eq(user3)
       expect(notification4.acting_user).to eq(user4)
       expect(notification5.acting_user).to eq(user5)
+      expect(notification5.data_hash[:original_name]).to eq "Bruce Wayne"
+    end
+
+    context "with SiteSettings.enable_names=false" do
+      SiteSetting.enable_names = false
+      it "doesn't set the :original_name property" do
+        Notification.populate_acting_user([notification6])
+        expect(notification6.data_hash[:original_name]).to be_nil
+      end
     end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -814,6 +814,7 @@ RSpec.describe Notification do
     fab!(:user3) { Fabricate(:user) }
     fab!(:user4) { Fabricate(:user) }
     fab!(:user5) { Fabricate(:user) }
+    fab!(:user6) { Fabricate(:user) }
     fab!(:notification1) do
       Fabricate(:notification, user: user, data: { username: user1.username }.to_json)
     end
@@ -829,6 +830,9 @@ RSpec.describe Notification do
     fab!(:notification5) do
       Fabricate(:notification, user: user, data: { original_username: user5.username }.to_json)
     end
+    fab!(:notification6) do
+      Fabricate(:notification, user: user, data: { original_username: user6.username }.to_json)
+    end
 
     it "Sets the acting_user correctly for each notification" do
       SiteSetting.enable_names = true
@@ -840,7 +844,7 @@ RSpec.describe Notification do
       expect(notification3.acting_user).to eq(user3)
       expect(notification4.acting_user).to eq(user4)
       expect(notification5.acting_user).to eq(user5)
-      expect(notification5.data_hash[:original_name]).to eq "Bruce Wayne"
+      expect(notification5.data_hash[:original_name]).to eq user5.name
     end
 
     context "with SiteSettings.enable_names=false" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -809,6 +809,8 @@ RSpec.describe Notification do
   end
 
   describe ".populate_acting_user" do
+    SiteSetting.enable_names = true
+
     fab!(:user1) { Fabricate(:user) }
     fab!(:user2) { Fabricate(:user) }
     fab!(:user3) { Fabricate(:user) }
@@ -835,7 +837,6 @@ RSpec.describe Notification do
     end
 
     it "Sets the acting_user correctly for each notification" do
-      SiteSetting.enable_names = true
       Notification.populate_acting_user(
         [notification1, notification2, notification3, notification4, notification5],
       )
@@ -848,10 +849,11 @@ RSpec.describe Notification do
     end
 
     context "with SiteSettings.enable_names=false" do
-      SiteSetting.enable_names = false
       it "doesn't set the :original_name property" do
+        SiteSetting.enable_names = false
         Notification.populate_acting_user([notification6])
         expect(notification6.data_hash[:original_name]).to be_nil
+        SiteSetting.enable_names = true
       end
     end
   end


### PR DESCRIPTION
without additional query, add the name of the originator of the notification (ie, the person who posted on a topic you're following) to the `/notifications.json` endpoint.

since this is just adding a property to the endpoint json payload, there should be very low regression risk.

NB: this would only be populated when a call to `populate_acting_user` is made. currently in the core codebase, this appears to only happen when `SiteSetting.show_user_menu_avatars` is true.

screenshot:

<img width="916" alt="image" src="https://github.com/user-attachments/assets/22d1b65d-1f55-4e31-ae82-b9a3ff47c19e" />
