### PR TITLE
DEV: Unhide admin_sidebar_enabled_groups

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2460,7 +2460,6 @@ developer:
     default: "1|2"
     allow_any: false
     refresh: true
-    hidden: true
   warn_critical_js_deprecations:
     default: true
     client: true


### PR DESCRIPTION
Followup 1bb33d15f202e6f5e06770c4ae1524ac657cd6cf

Self-hosters still need access to this for now,
we will hide it on our own hosting.
