### PR TITLE
PERF: Cache public extra-locales requests in nginx

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -228,7 +228,7 @@ server {
     # This big block is needed so we can selectively enable
     # acceleration for backups, avatars, sprites and so on.
     # see note about repetition above
-    location ~ ^/(svg-sprite/|letter_avatar/|letter_avatar_proxy/|user_avatar|highlight-js|stylesheets|theme-javascripts|favicon/proxied|service-worker) {
+    location ~ ^/(svg-sprite/|letter_avatar/|letter_avatar_proxy/|user_avatar|highlight-js|stylesheets|theme-javascripts|favicon/proxied|service-worker|extra-locales/(mf|overrides)) {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Request-Start "t=${msec}";


### PR DESCRIPTION
extra-locales bundles have unique digests in their URLs, and include an indefinite cache-control header. Therefore we should include them in the heavily-cached group of URLs in NGINX.