### PR TITLE
FIX: Unpinning topics in glimmer topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -166,15 +166,6 @@ export default class Item extends Component {
       this.navigateToTopic(this.args.topic, this.args.topic.lastUnreadUrl);
       return;
     }
-
-    if (
-      e.target.classList.contains("d-icon-thumbtack") &&
-      e.target.closest("a.topic-status")
-    ) {
-      e.preventDefault();
-      this.args.topic.togglePinnedForUser();
-      return;
-    }
   }
 
   @action

--- a/spec/system/topic_list/glimmer_spec.rb
+++ b/spec/system/topic_list/glimmer_spec.rb
@@ -128,4 +128,17 @@ describe "glimmer topic list", type: :system do
       end
     end
   end
+
+  it "unpins globally pinned topics on click" do
+    topic = Fabricate(:topic, pinned_globally: true, pinned_at: Time.current)
+    visit("/latest")
+
+    expect(page).to have_css(".topic-list-item .d-icon-thumbtack:not(.unpinned)")
+
+    find(".topic-list-item .d-icon-thumbtack").click
+    expect(page).to have_css(".topic-list-item .d-icon-thumbtack.unpinned")
+
+    wait_for { TopicUser.exists?(topic:, user:) }
+    expect(TopicUser.find_by(topic:, user:).cleared_pinned_at).to_not be_nil
+  end
 end


### PR DESCRIPTION
it's already handled by TopicStatus component (so one was undoing the other's toggle)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->