### PR TITLE
UX: fix border around reply indicator

### DIFF
--- a/plugins/discourse-presence/assets/stylesheets/presence.scss
+++ b/plugins/discourse-presence/assets/stylesheets/presence.scss
@@ -97,7 +97,7 @@ body:has(.topic-navigation.with-topic-progress)
 }
 
 .topic-navigation-bottom-outlet.presence {
-  margin-right: auto;
+  margin: var(--below-topic-margin) auto 0 0;
+  min-height: 1.8em; // height of the avatars, prevents layout shift
   order: -1;
-  display: flex;
 }


### PR DESCRIPTION
On a narrow viewport on desktop, the margins above and below the "replying..." indicator were missing.

Also added a **minimum height** so the layout doesn't shift when the indicator is added in the DOM.

**BEFORE**

![Screenshot 2024-12-18 at 18 10 18](https://github.com/user-attachments/assets/631ed4fd-0b5e-4445-befe-4ebebee0b11f)

**AFTER**

![Screenshot 2024-12-18 at 18 09 30](https://github.com/user-attachments/assets/8e9f8d64-9aa8-46de-b9d3-f357b27a8d4a)

Internal - t/144612