### PR TITLE
DEV: Plugin modifier to skip enqueue PostCreator jobs on PostMove

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -746,7 +746,12 @@ class PostMover
   end
 
   def enqueue_jobs(topic)
-    @post_creator.enqueue_jobs if @post_creator
+    enqueue_post_creator_jobs =
+      DiscoursePluginRegistry.apply_modifier(
+        :post_mover_enqueue_post_creator_jobs,
+        @post_creator.present?,
+      )
+    @post_creator.enqueue_jobs if enqueue_post_creator_jobs
 
     Jobs.enqueue(:notify_moved_posts, post_ids: @post_ids_after_move, moved_by_id: user.id)
 


### PR DESCRIPTION
This allows plugins to skip the "posted" notifications for watching users, when posts get moved. The specs are kind of wild looking, as this unit tests a private method. This is difficult to isolate otherwise, with lots of trickery needed to make sure that this actually works. 

I opted to unit test just this method instead.