### PR TITLE
FIX: CanCheckEmailsHelper should handle null this.model gracefully

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/can-check-emails-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/can-check-emails-helper.js
@@ -10,6 +10,7 @@ export default class CanCheckEmailsHelper {
   }
 
   get canCheckEmails() {
+    // Anonymous users can't check emails
     if (!this.currentUser) {
       return false;
     }
@@ -17,7 +18,7 @@ export default class CanCheckEmailsHelper {
     const canStaffCheckEmails =
       this.can_moderators_view_emails && this.currentUser.staff;
     return (
-      this.model.id === this.currentUser.id ||
+      this.model?.id === this.currentUser.id ||
       this.canAdminCheckEmails ||
       canStaffCheckEmails
     );


### PR DESCRIPTION
Bug introduced in https://github.com/discourse/discourse/pull/30315.

For staged user cards, we don't set `this.model`. The previous incarnation of this helper (as a mixin) handles this case via Ember computed properties which resolves "model.id" to a null value even if model is itself undefined. 

### How to test
As admin user, from admin controls, filter for staged users in the users index, and click on the avatar icon to trigger the user card. Email should be visible.

<img width="549" alt="Screenshot 2024-12-19 at 9 01 31 AM" src="https://github.com/user-attachments/assets/82ba7294-68c2-4222-93bc-e2f7e7466429" />
