### PR TITLE
Adding Import Support for Discourse Reactions Plugin

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -925,6 +925,18 @@ class BulkImport::Base
 
   CHAT_MENTION_COLUMNS = %i[chat_message_id target_id type created_at updated_at]
 
+  REACTION_USER_COLUMNS = %i[reaction_id user_id created_at updated_at post_id]
+
+  REACTION_COLUMNS = %i[
+    id
+    post_id
+    reaction_type
+    reaction_value
+    reaction_users_count
+    created_at
+    updated_at
+  ]
+
   def create_groups(rows, &block)
     create_records(rows, "group", GROUP_COLUMNS, &block)
   end
@@ -1155,6 +1167,14 @@ class BulkImport::Base
 
   def create_chat_mentions(rows, &block)
     create_records(rows, "chat_mention", CHAT_MENTION_COLUMNS, &block)
+  end
+
+  def create_reaction_users(rows, &block)
+    create_records(rows, "discourse_reactions_reaction_user", REACTION_USER_COLUMNS, &block)
+  end
+
+  def create_reactions(rows, &block)
+    create_records(rows, "discourse_reactions_reaction", REACTION_COLUMNS, &block)
   end
 
   def process_group(group)
@@ -1960,6 +1980,19 @@ class BulkImport::Base
     mention[:updated_at] ||= NOW
 
     mention
+  end
+
+  def process_discourse_reactions_reaction_user(reaction_user)
+    reaction_user[:created_at] ||= NOW
+    reaction_user[:updated_at] ||= NOW
+    reaction_user
+  end
+
+  def process_discourse_reactions_reaction(reaction)
+    reaction[:created_at] ||= NOW
+    reaction[:updated_at] ||= NOW
+    reaction[:reaction_users_count] ||= 0
+    reaction
   end
 
   def create_records(all_rows, name, columns, &block)

--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -120,6 +120,7 @@ class BulkImport::Base
       chat_channel: 6,
       chat_thread: 7,
       chat_message: 8,
+      discourse_reactions_reaction: 9,
     )
 
   def create_migration_mappings_table
@@ -309,6 +310,10 @@ class BulkImport::Base
 
     @chat_message_mapping = load_index(MAPPING_TYPES[:chat_message])
     @last_chat_message_id = last_id(Chat::Message)
+
+    puts "Loading reaction indexes..."
+    @discourse_reaction_mapping = load_index(MAPPING_TYPES[:discourse_reactions_reaction])
+    @last_discourse_reaction_id = last_id(DiscourseReactions::Reaction)
   end
 
   def use_bbcode_to_md?
@@ -388,6 +393,11 @@ class BulkImport::Base
     if @last_chat_message_id > 0
       @raw_connection.exec(
         "SELECT setval('#{Chat::Message.sequence_name}', #{@last_chat_message_id})",
+      )
+    end
+    if @last_discourse_reaction_id > 0
+      @raw_connection.exec(
+        "SELECT setval('#{DiscourseReactions::Reaction.sequence_name}', #{@last_discourse_reaction_id})",
       )
     end
   end
@@ -473,6 +483,10 @@ class BulkImport::Base
 
   def chat_message_id_from_original_id(id)
     @chat_message_mapping[id.to_s]&.to_i
+  end
+
+  def discourse_reaction_id_from_original_id(id)
+    @discourse_reaction_mapping[id.to_s]&.to_i
   end
 
   GROUP_COLUMNS = %i[
@@ -1174,7 +1188,7 @@ class BulkImport::Base
   end
 
   def create_reactions(rows, &block)
-    create_records(rows, "discourse_reactions_reaction", REACTION_COLUMNS, &block)
+    create_records_with_mapping(rows, "discourse_reactions_reaction", REACTION_COLUMNS, &block)
   end
 
   def process_group(group)
@@ -1989,9 +2003,14 @@ class BulkImport::Base
   end
 
   def process_discourse_reactions_reaction(reaction)
+    reaction[:id] = @last_discourse_reaction_id += 1
     reaction[:created_at] ||= NOW
     reaction[:updated_at] ||= NOW
     reaction[:reaction_users_count] ||= 0
+
+    @imported_records[reaction[:original_id].to_s] = reaction[:id]
+    @discourse_reaction_mapping[reaction[:original_id].to_s] = reaction[:id]
+
     reaction
   end
 

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2972,16 +2972,17 @@ class BulkImport::Generic < BulkImport::Base
 
       user_id = user_id_from_imported_id(row["user_id"])
       post_id = post_id_from_imported_id(row["post_id"])
+      reaction_id = discourse_reaction_id_from_original_id(row["reaction_id"])
 
-      next if post_id.blank? || user_id.blank?
-      next unless existing_reaction_users.add?([row["reaction_id"], user_id, post_id])
+      next if post_id.blank? || user_id.blank? || reaction_id.blank?
+      next unless existing_reaction_users.add?([reaction_id, user_id, post_id])
 
       {
-        reaction_id: row["reaction_id"],
-        user_id: user_id,
+        reaction_id:,
+        user_id:,
         created_at: to_datetime(row["created_at"]),
         updated_at: to_datetime(row["updated_at"]),
-        post_id: post_id,
+        post_id:,
       }
     end
 
@@ -3014,7 +3015,7 @@ class BulkImport::Generic < BulkImport::Base
       next unless existing_reactions.add?([post_id, row["reaction_value"]])
 
       {
-        id: row["id"],
+        original_id: row["id"],
         post_id: post_id,
         reaction_type: reaction_type_id,
         reaction_value: row["reaction_value"],

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2988,6 +2988,15 @@ class BulkImport::Generic < BulkImport::Base
     end
 
     reaction_users.close
+
+    puts "", "Updating reaction counts..."
+
+    ActiveRecord::Base.transaction do
+      DiscourseReactions::Reaction.find_each do |reaction|
+        actual_count = DiscourseReactions::ReactionUser.where(reaction_id: reaction.id).count
+        reaction.update_column(:reaction_users_count, actual_count)
+      end
+    end
   end
 
   def import_reactions

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2988,15 +2988,6 @@ class BulkImport::Generic < BulkImport::Base
     end
 
     reaction_users.close
-
-    puts "", "Updating reaction counts..."
-
-    ActiveRecord::Base.transaction do
-      DiscourseReactions::Reaction.find_each do |reaction|
-        actual_count = DiscourseReactions::ReactionUser.where(reaction_id: reaction.id).count
-        reaction.update_column(:reaction_users_count, actual_count)
-      end
-    end
   end
 
   def import_reactions


### PR DESCRIPTION
### **Launch Date December 26th, hoping to get it ready for review on December 23rd**

This pull request implements bulk import for discourse reactions plugin.

**Key Changes:**

- Implemented bulk import functionality discourse reactions plugin.
- Updated the Importing category permissions for the ability to change regular category permissions and not just for tags.

**Additional Context:**

- Ensured compatibility with existing Discourse infrastructure.
- No UX/UI changes were made, so no screenshots are included.

Please review and let me know if there are any questions or further improvements needed.