### PR TITLE
DEV: removes caret from notifications-tracking on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -21,12 +22,14 @@ function constructKey(prefix, level, suffix, key) {
 }
 
 class NotificationsTrackingTrigger extends Component {
+  @service site;
+
   get showFullTitle() {
     return this.args.showFullTitle ?? true;
   }
 
   get showCaret() {
-    return this.args.showCaret ?? true;
+    return this.site.desktopView && (this.args.showCaret ?? true);
   }
 
   get title() {
@@ -48,7 +51,7 @@ class NotificationsTrackingTrigger extends Component {
     {{/if}}
 
     {{#if this.showCaret}}
-      {{icon "angle-down"}}
+      {{icon "angle-down" class="notifications-tracking-btn__caret"}}
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/notifications-tracking-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/notifications-tracking-test.gjs
@@ -78,4 +78,22 @@ module("Integration | Component | TopicTracking", function (hooks) {
       );
     });
   });
+
+  test("caret", async function (assert) {
+    await render(<template><TopicNotificationsTracking /></template>);
+
+    assert.dom(".notifications-tracking-btn__caret").exists();
+  });
+});
+
+module("Integration | Component | TopicTracking - Mobile", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("no caret", async function (assert) {
+    this.site.desktopView = false;
+
+    await render(<template><TopicNotificationsTracking /></template>);
+
+    assert.dom(".notifications-tracking-btn__caret").doesNotExist();
+  });
 });


### PR DESCRIPTION
We never want to show this caret on mobile.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->