### PR TITLE
DEV: correctly applies identifier do DModal used in DMenu

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -47,11 +47,11 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     this.site.mobileView = true;
 
     await render(
-      hbs`<DMenu @inline={{true}} @modalForMobile={{true}} @content="content" />`
+      hbs`<DMenu @identifier="foo" @inline={{true}} @modalForMobile={{true}} @content="content" />`
     );
     await open();
 
-    assert.dom(".fk-d-menu-modal").hasText("content");
+    assert.dom(".fk-d-menu-modal[data-identifier='foo']").hasText("content");
   });
 
   test("@onRegisterApi", async function (assert) {

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -119,7 +119,7 @@ export default class DMenu extends Component {
             @class
           }}
           @inline={{(isTesting)}}
-          data-identifier={{@instance.options.identifier}}
+          data-identifier={{this.options.identifier}}
           data-content
         >
           <div class="fk-d-menu-modal__grip" aria-hidden="true"></div>


### PR DESCRIPTION
A previous refactor used an incorrect path. This commit also adds a simple test to ensure this identifier is present.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->