### PR TITLE
FEATURE: default value to fields in automation

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
@@ -2,6 +2,14 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 
 export default class BaseField extends Component {
+  constructor() {
+    super(...arguments);
+
+    if (this.args.field.extra?.default_value) {
+      this.args.field.metadata.value = this.args.field.extra.default_value;
+    }
+  }
+
   get displayPlaceholders() {
     return (
       this.args.placeholders?.length && this.args.field?.acceptsPlaceholders

--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
@@ -5,7 +5,10 @@ export default class BaseField extends Component {
   constructor() {
     super(...arguments);
 
-    if (this.args.field.extra?.default_value) {
+    if (
+      this.args.field.extra &&
+      Object.keys(this.args.field.extra).includes("default_value")
+    ) {
       this.args.field.metadata.value = this.args.field.extra.default_value;
     }
   }

--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-base-field.gjs
@@ -6,7 +6,7 @@ export default class BaseField extends Component {
     super(...arguments);
 
     if (
-      this.args.field.extra &&
+      this.args.field?.extra &&
       Object.keys(this.args.field.extra).includes("default_value")
     ) {
       this.args.field.metadata.value = this.args.field.extra.default_value;

--- a/plugins/automation/test/javascripts/integration/components/da-choices-field-test.js
+++ b/plugins/automation/test/javascripts/integration/components/da-choices-field-test.js
@@ -28,4 +28,27 @@ module("Integration | Component | da-choices-field", function (hooks) {
 
     assert.strictEqual(this.field.metadata.value, 1);
   });
+
+  test("can have a default value", async function (assert) {
+    this.field = new AutomationFabricators(getOwner(this)).field({
+      component: "choices",
+      extra: {
+        content: [
+          { name: "Zero", id: 0 },
+          { name: "One", id: 1 },
+        ],
+        default_value: 0,
+      },
+    });
+    await render(
+      hbs` <AutomationField @automation={{this.automation}} @field={{this.field}} />`
+    );
+
+    assert.strictEqual(this.field.metadata.value, 0);
+
+    await selectKit().expand();
+    await selectKit().selectRowByValue(1);
+
+    assert.strictEqual(this.field.metadata.value, 1);
+  });
 });


### PR DESCRIPTION
This PR adds the property `extra.default_value` to the fields in automation. This property is used to set the default value of the field.

Reducing the nil checks, we have to do in automation fields.

I've added only testing in the `da-choices-field-test.js` file, but we could add tests to all the fields.
