### PR TITLE
FIX: handle more thread pool edge cases

### DIFF
--- a/lib/scheduler/thread_pool.rb
+++ b/lib/scheduler/thread_pool.rb
@@ -17,7 +17,10 @@ module Scheduler
     class ShutdownError < StandardError
     end
 
-    def initialize(min_threads:, max_threads:, idle_time:)
+    def initialize(min_threads:, max_threads:, idle_time: nil)
+      # this is there just for cases where people want to use this as
+      # a fixed size thread pool
+      idle_time ||= 30
       raise ArgumentError, "min_threads must be 0 or larger" if min_threads < 0
       raise ArgumentError, "max_threads must be 1 or larger" if max_threads < 1
       raise ArgumentError, "max_threads must be >= min_threads" if max_threads < min_threads

--- a/lib/scheduler/thread_pool.rb
+++ b/lib/scheduler/thread_pool.rb
@@ -77,7 +77,7 @@ module Scheduler
 
         if failed_to_shutdown
           @mutex.synchronize { @threads.each(&:kill) }
-          raise ShutdownError, "Failed to shutdown ThreadPool within timeout" if failed_to_shutdown
+          raise ShutdownError, "Failed to shutdown ThreadPool within timeout"
         end
       end
     end

--- a/lib/scheduler/thread_pool.rb
+++ b/lib/scheduler/thread_pool.rb
@@ -18,8 +18,10 @@ module Scheduler
     end
 
     def initialize(min_threads:, max_threads:, idle_time: nil)
-      # this is there just for cases where people want to use this as
-      # a fixed size thread pool
+      # 30 seconds is a reasonable default for idle time
+      # it is particularly useful for the use case of:
+      # ThreadPool.new(min_threads: 4, max_threads: 4)
+      # operators would get confused about idle time cause why does it matter
       idle_time ||= 30
       raise ArgumentError, "min_threads must be 0 or larger" if min_threads < 0
       raise ArgumentError, "max_threads must be 1 or larger" if max_threads < 1

--- a/spec/lib/scheduler/thread_pool_spec.rb
+++ b/spec/lib/scheduler/thread_pool_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Scheduler::ThreadPool, type: :multisite do
   end
 
   describe "when thread pool has zero min threads" do
-    it "can quickly process tasks" do
+    it "can quickly process and can be cleanly terminated" do
       # setting idle time to 1000 to ensure that there are maximal delays waiting
       # for jobs
       pool = Scheduler::ThreadPool.new(min_threads: 0, max_threads: 5, idle_time: 1000)


### PR DESCRIPTION
1. When there were zero threads, it could take a very long time to process first job
2. Properly scale up thread queue depending on actual busy work
3. Align APIs with concurrent
