### PR TITLE
UX: Site setting filter background inconsistencies

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/common/admin/admin_config_area.scss
@@ -92,14 +92,19 @@
   }
 
   &__settings {
-    .admin-site-settings-filter-controls {
-      background: var(--primary-very-low);
-      margin-bottom: 1em;
-    }
-
     .setting-label {
       margin-left: 18px;
     }
+  }
+}
+
+.admin-site-settings-filter-controls {
+  background: var(--primary-very-low);
+  margin-bottom: 1em;
+
+  .controls,
+  .search.controls {
+    background: var(--primary-very-low);
   }
 }
 

--- a/app/assets/stylesheets/common/admin/site-settings.scss
+++ b/app/assets/stylesheets/common/admin/site-settings.scss
@@ -10,11 +10,6 @@
 
 .admin-plugin-config-area {
   &__settings {
-    .admin-site-settings-filter-controls {
-      background: var(--primary-very-low);
-      margin-bottom: 1em;
-    }
-
     .admin-filtered-site-settings {
       padding: 0.5em 1em;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5108,7 +5108,7 @@ en:
   # This section is exported to the javascript for i18n in the admin section
   admin_js:
     # This is a text input placeholder, keep the translation short
-    type_to_filter: "type to filter…"
+    type_to_filter: "Type to filter…"
     settings: "Settings"
 
     admin:


### PR DESCRIPTION
Followup 203f93bcaffab1f493be70c2277ef11048f2017e

This commit makes sure the background for all the admin
site settings filters (including the filter input and
override checkbox) is consistent no matter what the theme,
as it currently changes based on theme.

Before

![image](https://github.com/user-attachments/assets/c455bcee-8a01-42bd-9546-441ebdc0e434)

After

![image](https://github.com/user-attachments/assets/b23bb23b-f855-471b-855e-e3ce06d12670)
