### PR TITLE
FIX: Return 404 when hide_user_profiles_from_public is true

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,7 +115,7 @@ class UsersController < ApplicationController
   end
 
   def show(for_card: false)
-    guardian.ensure_public_can_see_profiles!
+    raise Discourse::NotFound unless guardian.public_can_see_profiles?
 
     @user =
       fetch_user_from_params(
@@ -164,7 +164,7 @@ class UsersController < ApplicationController
 
   # This route is not used in core, but is used by theme components (e.g. https://meta.discourse.org/t/144479)
   def cards
-    guardian.ensure_public_can_see_profiles!
+    raise Discourse::NotFound unless guardian.public_can_see_profiles?
 
     user_ids = params.require(:user_ids).split(",").map(&:to_i)
     raise Discourse::InvalidParameters.new(:user_ids) if user_ids.length > 50
@@ -498,7 +498,7 @@ class UsersController < ApplicationController
   end
 
   def summary
-    guardian.ensure_public_can_see_profiles!
+    raise Discourse::NotFound unless guardian.public_can_see_profiles?
 
     @user =
       fetch_user_from_params(

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4281,10 +4281,10 @@ RSpec.describe UsersController do
         expect(response.status).to eq(200)
       end
 
-      it "returns 403 for anonymous users" do
+      it "returns 404 for anonymous users" do
         get "/u/#{user.username_lower}/summary.json"
 
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(404)
       end
     end
 
@@ -4669,10 +4669,10 @@ RSpec.describe UsersController do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "should 403 correctly for crawlers when profiles are hidden" do
+      it "should 404 correctly for crawlers when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}", headers: { "User-Agent" => "Googlebot" }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
         expect(response.body).to have_tag("body.crawler")
         expect(response.headers["X-Robots-Tag"]).to eq("noindex")
       end
@@ -4883,7 +4883,7 @@ RSpec.describe UsersController do
       it "should have http status 403 for anonymous user when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}/card.json"
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -4957,7 +4957,7 @@ RSpec.describe UsersController do
     it "should have http status 403 for anonymous user when profiles are hidden" do
       SiteSetting.hide_user_profiles_from_public = true
       get "/user-cards.json?user_ids=#{user.id},#{user2.id}"
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to have_http_status(:not_found)
     end
 
     context "when `hide_profile` user option is checked" do


### PR DESCRIPTION
Currently, when `hide_user_profiles_from_public=true`, we return 403 Forbidden. There are several repercussions to this in terms of "SEO" and how Google sees our site. 

Upon seeing a 403 on user profiles, we are seeing that Google does not bother to check the `noindex` header despite all user profiles having it. Despite robots.txt indicating that /u/ should be blocked, Google continues to penalise sites with this setting enabled.

Since `hide_user_profiles_from_public` is introduced to secure user profiles, we will return the following instead.

<img width="762" alt="Screenshot 2024-12-20 at 1 00 30 PM" src="https://github.com/user-attachments/assets/dfb80c85-ff40-4f5f-aeb7-135678f7b3eb" />
