### PR TITLE
DEV: Downgrade highlightjs to 11.10.0

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.3.0",
     "@glimmer/syntax": "^0.93.1",
-    "@highlightjs/cdn-assets": "^11.11.0",
+    "@highlightjs/cdn-assets": "11.10.0",
     "@json-editor/json-editor": "2.15.2",
     "@messageformat/core": "^3.4.0",
     "@messageformat/runtime": "^3.0.1",
@@ -28,7 +28,7 @@
     "ember-route-template": "^1.0.3",
     "ember-tracked-storage-polyfill": "^1.0.0",
     "handlebars": "^4.7.8",
-    "highlight.js": "^11.11.0",
+    "highlight.js": "11.10.0",
     "immer": "^10.1.1",
     "jspreadsheet-ce": "^4.15.0",
     "morphlex": "^0.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
         specifier: ^0.93.1
         version: 0.93.1
       '@highlightjs/cdn-assets':
-        specifier: ^11.11.0
-        version: 11.11.0
+        specifier: 11.10.0
+        version: 11.10.0
       '@json-editor/json-editor':
         specifier: 2.15.2
         version: 2.15.2
@@ -306,8 +306,8 @@ importers:
         specifier: ^4.7.8
         version: 4.7.8
       highlight.js:
-        specifier: ^11.11.0
-        version: 11.11.0
+        specifier: 11.10.0
+        version: 11.10.0
       immer:
         specifier: ^10.1.1
         version: 10.1.1
@@ -744,7 +744,7 @@ importers:
         version: 4.2.0
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.1)(esbuild@0.24.0)))
     devDependencies:
       ember-cli:
         specifier: ~6.0.1
@@ -1087,7 +1087,7 @@ importers:
         version: 5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.1)(esbuild@0.24.0))
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.1)(esbuild@0.24.0)))
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -2315,8 +2315,8 @@ packages:
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
 
-  '@highlightjs/cdn-assets@11.11.0':
-    resolution: {integrity: sha512-RxvBfEQPriVv9cJ9oXtBPv8ailOKt+ceWssMQ0i0yRdvCT9zaOOqOZj+4WWyooLMngQWtsi9Bbl7WR2Ky33jPQ==}
+  '@highlightjs/cdn-assets@11.10.0':
+    resolution: {integrity: sha512-vWXpu+Rdm0YMJmugFdUiL/9DmgYjEiV+d5DBqlXdApnGPSIeo6+LRS5Hpx6fvVsKkvR4RsLYD9rQ6DOLkj7OKA==}
     engines: {node: '>=12.0.0'}
 
   '@humanfs/core@0.19.1':
@@ -5296,8 +5296,8 @@ packages:
   heimdalljs@0.2.6:
     resolution: {integrity: sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==}
 
-  highlight.js@11.11.0:
-    resolution: {integrity: sha512-6ErL7JlGu2CNFHyRQEuDogOyGPNiqcuWdt4iSSFUPyferNTGlNTPFqeV36Y/XwA4V/TJ8l0sxp6FTnxud/mf8g==}
+  highlight.js@11.10.0:
+    resolution: {integrity: sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==}
     engines: {node: '>=12.0.0'}
 
   homedir-polyfill@1.0.3:
@@ -9991,7 +9991,7 @@ snapshots:
 
   '@handlebars/parser@2.0.0': {}
 
-  '@highlightjs/cdn-assets@11.11.0': {}
+  '@highlightjs/cdn-assets@11.10.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -12857,7 +12857,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-this-fallback@0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)):
+  ember-this-fallback@0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.0)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.1)(esbuild@0.24.0))):
     dependencies:
       '@glimmer/syntax': 0.84.3
       babel-plugin-ember-template-compilation: 2.2.5
@@ -14068,7 +14068,7 @@ snapshots:
     dependencies:
       rsvp: 3.2.1
 
-  highlight.js@11.11.0: {}
+  highlight.js@11.10.0: {}
 
   homedir-polyfill@1.0.3:
     dependencies:


### PR DESCRIPTION
due to rustlang regression

See: https://github.com/discourse/discourse/pull/30288#issuecomment-2556373204

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->