### PR TITLE
DEV: reintroduces category-notifications-button.js

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
@@ -1,0 +1,15 @@
+import { readOnly } from "@ember/object/computed";
+import { classNames } from "@ember-decorators/component";
+import { i18n } from "discourse-i18n";
+import NotificationOptionsComponent from "select-kit/components/notifications-button";
+import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
+@selectKitOptions({
+  i18nPrefix: "category.notifications",
+  showFullTitle: false,
+  headerAriaLabel: i18n("category.notifications.title"),
+})
+@pluginApiIdentifiers(["category-notifications-button"])
+@classNames("category-notifications-button")
+export default class CategoryNotificationsButton extends NotificationOptionsComponent {
+  @readOnly("category.deleted") isHidden;
+}


### PR DESCRIPTION
This file has been incorrectly removed in https://github.com/discourse/discourse/commit/41df7051883dca8404c38e151294058ec8525b83 while it's still being used by plugins (https://github.com/discourse/discourse-circles).

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->