### PR TITLE
DEV: Remove unused `_consoleDebug`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy-plugin-base.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy-plugin-base.js
@@ -15,13 +15,6 @@ export class UppyPluginBase extends BasePlugin {
     }
   }
 
-  _consoleDebug(msg) {
-    if (this.siteSettings?.enable_upload_debug_mode) {
-      // eslint-disable-next-line no-console
-      console.log(`[${this.id}] ${msg}`);
-    }
-  }
-
   _getFile(fileId) {
     return this.uppy.getFile(fileId);
   }


### PR DESCRIPTION
`this.siteSettings` was always undefined anyway

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->