### PR TITLE
UX: improve link copy status transition

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/post-action-feedback.js
+++ b/app/assets/javascripts/discourse/app/lib/post-action-feedback.js
@@ -2,6 +2,7 @@ import { SVG_NAMESPACE } from "discourse-common/lib/icon-library";
 import { i18n } from "discourse-i18n";
 
 const TIMEOUT = 2500;
+const TRANSITION_BUFFER = 250;
 
 export default function postActionFeedback({
   postId,
@@ -73,7 +74,10 @@ function createCheckmark(btn, actionClass, postId) {
 
 function styleBtn(btn) {
   btn.classList.add("--activated", "--transition");
-  setTimeout(() => btn.classList.remove("--activated"), TIMEOUT - 250); // gives transition time to complete
+  setTimeout(
+    () => btn.classList.remove("--activated"),
+    TIMEOUT - TRANSITION_BUFFER
+  );
   setTimeout(() => btn.classList.remove("--transition"), TIMEOUT);
 }
 

--- a/app/assets/javascripts/discourse/app/lib/post-action-feedback.js
+++ b/app/assets/javascripts/discourse/app/lib/post-action-feedback.js
@@ -1,6 +1,8 @@
 import { SVG_NAMESPACE } from "discourse-common/lib/icon-library";
 import { i18n } from "discourse-i18n";
 
+const TIMEOUT = 2500;
+
 export default function postActionFeedback({
   postId,
   actionClass,
@@ -58,8 +60,7 @@ function createAlert(message, postId, actionBtn) {
 
   actionBtn.appendChild(alertDiv);
 
-  setTimeout(() => alertDiv.classList.add("slide-out"), 1000);
-  setTimeout(() => removeElement(alertDiv), 2500);
+  setTimeout(() => removeElement(alertDiv), TIMEOUT);
 }
 
 function createCheckmark(btn, actionClass, postId) {
@@ -67,13 +68,13 @@ function createCheckmark(btn, actionClass, postId) {
   const checkmark = makeCheckmarkSvg(postId, actionClass, svgId);
   btn.appendChild(checkmark.content);
 
-  setTimeout(() => checkmark.classList.remove("is-visible"), 3000);
-  setTimeout(() => removeElement(document.getElementById(svgId)), 3500);
+  setTimeout(() => removeElement(document.getElementById(svgId)), TIMEOUT);
 }
 
 function styleBtn(btn) {
-  btn.classList.add("is-copied");
-  setTimeout(() => btn.classList.remove("is-copied"), 3200);
+  btn.classList.add("--activated", "--transition");
+  setTimeout(() => btn.classList.remove("--activated"), TIMEOUT - 250); // gives transition time to complete
+  setTimeout(() => btn.classList.remove("--transition"), TIMEOUT);
 }
 
 function makeCheckmarkSvg(postId, actionClass, svgId) {

--- a/app/assets/stylesheets/common/post-action-feedback.scss
+++ b/app/assets/stylesheets/common/post-action-feedback.scss
@@ -9,8 +9,8 @@
     position: relative;
     height: 100%;
 
-    &.is-copied,
-    &.is-copied:hover {
+    &.--activated,
+    &.--activated:hover {
       .d-icon-d-post-share {
         color: var(--success);
       }
@@ -25,11 +25,6 @@
     display: block;
     stroke: var(--success);
     opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-
-    &.is-visible {
-      opacity: 1;
-    }
 
     path {
       stroke: var(--success);

--- a/app/assets/stylesheets/desktop/post-action-feedback.scss
+++ b/app/assets/stylesheets/desktop/post-action-feedback.scss
@@ -1,24 +1,32 @@
 .post-action-feedback-alert {
   position: absolute;
   top: -1.5rem;
-  left: 50%;
+  left: 60%;
   transform: translateX(-50%);
   color: var(--success);
   padding: 0.25rem 0.5rem;
   white-space: nowrap;
   font-size: var(--font-down-2);
-  opacity: 1;
-  transition: opacity 0.5s ease-in-out;
+  opacity: 0;
   z-index: calc(z("timeline") + 1);
-  &.-success {
-    color: var(--success);
+}
+.--transition {
+  .post-action-feedback-alert,
+  .post-action-feedback-svg {
+    transition: opacity 0.25s, color 0.25s;
   }
-
-  &.-fail {
-    color: var(--danger);
+}
+.--activated {
+  .post-action-feedback-alert,
+  .post-action-feedback-svg {
+    opacity: 1;
   }
-
-  &.slide-out {
-    animation: slide 1s cubic-bezier(0, 0, 0, 2) forwards;
+  .post-action-feedback-alert {
+    &.-success {
+      color: var(--success);
+    }
+    &.-fail {
+      color: var(--danger);
+    }
   }
 }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/share-link-copy-confirmation-text-shifts-on-double-click/343484

This improves the transition for the copy success message — there was an issue where some elements would linger when a sibling button was clicked... I also noticed some transitions that weren't being applied and fixed those 

Before:
![old-transition(3)](https://github.com/user-attachments/assets/d0c87f96-8c41-4608-b355-2b2de3affe7a)


After:
![new-transition(1)](https://github.com/user-attachments/assets/d500b5f6-b287-424e-bb3c-bd91b8371e0e)

