### PR TITLE
FIX: correclty allows to untoggle a fk toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/toggle.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/toggle.gjs
@@ -8,7 +8,7 @@ export default class FKControlToggle extends Component {
 
   @action
   handleInput() {
-    this.args.field.set(!this.args.value);
+    this.args.field.set(!this.args.field.value);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/toggle-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/toggle-test.gjs
@@ -31,6 +31,14 @@ module(
       await formKit().submit();
 
       assert.deepEqual(data, { foo: true });
+
+      await formKit().field("foo").toggle();
+
+      assert.form().field("foo").hasValue(false);
+
+      await formKit().submit();
+
+      assert.deepEqual(data, { foo: false });
     });
 
     test("when disabled", async function (assert) {


### PR DESCRIPTION
A previous refactoring has incorrectly changed a variable and the test was only testing toggling to true and not to false.
