### PR TITLE
FIX: more... should not show when there are not links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/custom-section.gjs
@@ -34,9 +34,7 @@ export default class SidebarCustomSection extends Component {
 
     if (this.args.sectionData.section_type !== "community") {
       return new Section(opts);
-    }
-
-    if (this.currentUser?.admin) {
+    } else if (this.currentUser?.admin) {
       return new AdminCommunitySection(opts);
     } else {
       return new CommonCommunitySection(opts);
@@ -89,7 +87,7 @@ export default class SidebarCustomSection extends Component {
               @text={{this.section.moreSectionButtonText}}
             />
           {{/if}}
-        {{else if this.section.moreLinks}}
+        {{else}}
           <MoreSectionLinks
             @sectionLinks={{this.section.moreLinks}}
             @moreButtonAction={{this.section.moreSectionButtonAction}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
@@ -77,7 +77,8 @@ export default class CommunitySection {
 
         return filtered;
       }, [])
-      .concat(this.apiPrimaryLinks);
+      .concat(this.apiPrimaryLinks)
+      .filter((link) => link.shouldDisplay);
 
     this.moreLinks = this.section.links
       .reduce((filtered, link) => {
@@ -91,7 +92,8 @@ export default class CommunitySection {
 
         return filtered;
       }, [])
-      .concat(this.apiSecondaryLinks);
+      .concat(this.apiSecondaryLinks)
+      .filter((link) => link.shouldDisplay);
   }
 
   teardown() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -83,3 +83,34 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
       );
   });
 });
+
+acceptance(
+  "Sidebar - Anonymous user - Community Section with hidden links",
+  function (needs) {
+    needs.settings({ navigation_menu: "sidebar" });
+
+    needs.site({
+      anonymous_sidebar_sections: [
+        {
+          id: 1,
+          title: "The A Team",
+          section_type: "community",
+          links: [
+            {
+              id: 2,
+              name: "Admin",
+              value: "/admin",
+              segment: "secondary",
+            },
+          ],
+        },
+      ],
+    });
+
+    test("more... is not shown when there are no displayable links", async function (assert) {
+      await visit("/");
+
+      assert.dom(".sidebar-more-section-links-details-summary").doesNotExist();
+    });
+  }
+);

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -214,8 +214,8 @@ RSpec.describe SiteSerializer do
 
     it "is not included in the serialised object when user is not anonymous" do
       guardian = Guardian.new(user)
-
       serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized).not_to have_key(:anonymous_sidebar_sections)
     end
 
     it "includes only public sidebar sections serialised object when user is anonymous" do


### PR DESCRIPTION
When lurking on a Discourse as anonymous, if the sidebar is enabled, and a section contains only secondary links that are not visible to anonymous users, we should not display the "more..." button.

Otherwise it feels broken because clicking on it does nothing, since there are no "visible" links to be shown.

Internal ref t/144716

**BEFORE**

As an admin, I can see the "Admin" section

![image](https://github.com/user-attachments/assets/ffde2e8a-a1fb-4324-b8f1-db985cdaa423)

As an anon, I can't see the "Admin" section, so the "more..." menu is empty

![image](https://github.com/user-attachments/assets/7139112c-c7d8-4b98-a6cc-ba827b475cef)

**AFTER**

As an anon, I can't see the "Admin" section, so the "more..." menu is not displayed since it's the only link

![image](https://github.com/user-attachments/assets/f4653d2d-e6d0-4f22-98ef-35469d087362)
