### PR TITLE
UX: fix misalignment + remove border-radius of topic progress element

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -59,8 +59,6 @@
   z-index: z("timeline");
   display: flex;
   justify-content: flex-end;
-
-  border-radius: var(--d-border-radius);
   overflow: hidden;
 
   .btn {

--- a/app/assets/stylesheets/mobile/topic-footer.scss
+++ b/app/assets/stylesheets/mobile/topic-footer.scss
@@ -9,10 +9,10 @@ html:not(.anon) #topic-footer-buttons {
     justify-content: space-between;
     gap: 0.75rem;
 
-    button,
-    .topic-notifications-button,
-    .pinned-button {
-      font-size: var(--font-up-1);
+    .btn,
+    .topic-notifications-button .btn,
+    .pinned-button .btn {
+      font-size: var(--font-up-1-rem);
     }
 
     &__actions {


### PR DESCRIPTION
* fix double em font-size being applied, causing a misalignment in button height
* remove border-radius from topic-progress-wrapper