### PR TITLE
UX: add highlight for active nav in category settings

### DIFF
--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -94,8 +94,8 @@
 
     &.active {
       position: relative;
-
       --arrow-thickness: 8px;
+      background: var(--d-selected);
 
       &::after {
         position: absolute;


### PR DESCRIPTION
The nav rows in the category settings page had no indication when the route was active; despite having an arrow icon coded, which was invisible at all times.

This commit adds a background colour (`d-selected`) to the `.active` class.

| Before | After |
|--------|--------|
| <img width="924" alt="CleanShot 2024-12-23 at 12 35 43@2x" src="https://github.com/user-attachments/assets/cfb55b75-2fbe-4d4a-9c68-893bef94e612" /> | <img width="924" alt="CleanShot 2024-12-23 at 12 35 29@2x" src="https://github.com/user-attachments/assets/19e840b0-d2d1-41ad-8b4f-78b0cb556334" /> |
