### PR TITLE
FEATURE: Unhide 'suppress_secured_categories_from_admin' setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1916,6 +1916,7 @@ en:
     content_security_policy_frame_ancestors: "Restrict who can embed this site in iframes via CSP. Control allowed hosts on <a href='%{base_path}/admin/customize/embedding'>Embedding</a>"
     content_security_policy_script_src: "Additional allowlisted script sources. The current host and CDN are included by default. See <a href='https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243' target='_blank'>Mitigate XSS Attacks with Content Security Policy.</a> (CSP). Other host sources are ignored as strict-dynamic is enabled."
     invalidate_inactive_admin_email_after_days: "Admin accounts that have not visited the site in this number of days will need to re-validate their email address before logging in. Set to 0 to disable."
+    suppress_secured_categories_from_admin: "Suppress topics and PMs from the admin UI unless they are participants. This is not a security feature: admins can always access all content on the site if needed."
     include_secure_categories_in_tag_counts: "When enabled, count of topics for a tag will include topics that are in read restricted categories for all users. When disabled, normal users are only shown a count of topics for a tag where all the topics are in public categories."
     display_personal_messages_tag_counts: "When enabled, count of personal messages tagged with a given tag will be displayed."
     top_menu: "Determine which items appear in the homepage navigation, and in what order."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2125,7 +2125,6 @@ security:
     hidden: true
   suppress_secured_categories_from_admin:
     default: false
-    hidden: true
   include_secure_categories_in_tag_counts:
     default: false
   display_personal_messages_tag_counts:


### PR DESCRIPTION
This setting suppresses topics and PMs from the admin UI unless they are participants. This is not a security feature: admins can always access all content on the site if needed.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->