### PR TITLE
DEV: Automatically set LOAD_PLUGINS for bin/rspec

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -15,4 +15,9 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
 require 'rubygems'
 require 'bundler/setup'
 
+if ENV["LOAD_PLUGINS"].nil? && ARGV.any? { |pattern| pattern.include?("plugins/") }
+  STDERR.puts "Detected plugin spec path, setting LOAD_PLUGINS to 1"
+  ENV["LOAD_PLUGINS"] = "1"
+end
+
 load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
When passing a `plugins/...` path to bin/rspec, it's reasonable to assume that the developer wants the tests to be run with plugins loaded. This commit automatically takes care of that.

If `LOAD_PLUGINS` is explicitly specified, then that value will always be used.

This mimics the logic we already have for database migrations in the `bin/rake` stub

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->