### PR TITLE
DEV: uses capybara helper has_field

### DIFF
--- a/plugins/chat/spec/system/chat_composer_draft_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_draft_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Chat composer draft", type: :system do
     it "loads the draft" do
       chat_page.visit_channel(channel_1)
 
-      expect(channel_page.composer.value).to eq("draft")
+      expect(channel_page.composer).to have_value("draft")
     end
 
     context "when loading another channel and back" do
@@ -42,15 +42,15 @@ RSpec.describe "Chat composer draft", type: :system do
       it "loads the correct drafts" do
         chat_page.visit_channel(channel_1)
 
-        expect(channel_page.composer.value).to eq("draft")
+        expect(channel_page.composer).to have_value("draft")
 
         chat_page.visit_channel(channel_2)
 
-        expect(channel_page.composer.value).to eq("draft2")
+        expect(channel_page.composer).to have_value("draft2")
 
         chat_page.visit_channel(channel_1)
 
-        expect(channel_page.composer.value).to eq("draft")
+        expect(channel_page.composer).to have_value("draft")
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe "Chat composer draft", type: :system do
       it "loads the draft with the upload" do
         chat_page.visit_channel(channel_1)
 
-        expect(channel_page.composer.value).to eq("draft")
+        expect(channel_page.composer).to have_value("draft")
         expect(page).to have_selector(".chat-composer-upload--image", count: 1)
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe "Chat composer draft", type: :system do
       it "loads the draft with replied to message" do
         chat_page.visit_channel(channel_1)
 
-        expect(channel_page.composer.value).to eq("draft")
+        expect(channel_page.composer).to have_value("draft")
         expect(page).to have_selector(".chat-reply__username", text: message_1.user.username)
         expect(page).to have_selector(".chat-reply__excerpt", text: message_1.excerpt)
       end
@@ -153,7 +153,7 @@ RSpec.describe "Chat composer draft", type: :system do
     it "loads the draft" do
       chat_page.visit_thread(thread_1)
 
-      expect(thread_page.composer.value).to eq("draft")
+      expect(thread_page.composer).to have_value("draft")
     end
 
     context "when loading another channel and back" do
@@ -168,15 +168,15 @@ RSpec.describe "Chat composer draft", type: :system do
       it "loads the correct drafts" do
         chat_page.visit_thread(thread_1)
 
-        expect(thread_page.composer.value).to eq("draft")
+        expect(thread_page.composer).to have_value("draft")
 
         chat_page.visit_thread(thread_2)
 
-        expect(thread_page.composer.value).to eq("draft2")
+        expect(thread_page.composer).to have_value("draft2")
 
         chat_page.visit_thread(thread_1)
 
-        expect(thread_page.composer.value).to eq("draft")
+        expect(thread_page.composer).to have_value("draft")
       end
     end
 
@@ -239,7 +239,7 @@ RSpec.describe "Chat composer draft", type: :system do
       it "loads the draft with the upload" do
         chat_page.visit_thread(thread_1)
 
-        expect(thread_page.composer.value).to eq("draft")
+        expect(thread_page.composer).to have_value("draft")
         expect(page).to have_selector(".chat-composer-upload--image", count: 1)
       end
     end

--- a/plugins/chat/spec/system/page_objects/chat/components/composer.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/composer.rb
@@ -13,7 +13,7 @@ module PageObjects
         end
 
         def blank?
-          input.value.blank?
+          has_value?("")
         end
 
         def enabled?
@@ -49,7 +49,7 @@ module PageObjects
         end
 
         def has_value?(expected)
-          value == expected
+          has_field?(input[:id], with: expected)
         end
 
         def reply_to_last_message_shortcut
@@ -91,11 +91,11 @@ module PageObjects
         end
 
         def editing_message?(message)
-          value == message.message && message_details.editing?(message)
+          has_value?(message.message) && message_details.editing?(message)
         end
 
         def editing_no_message?
-          value == "" && message_details.has_no_message?
+          blank? && message_details.has_no_message?
         end
 
         def focus

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -64,7 +64,7 @@ module PageObjects
       end
 
       def has_content?(content)
-        has_field?(COMPOSER_ID, with: content)
+        composer_input.value == content
       end
 
       def has_popup_content?(content)

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -64,7 +64,7 @@ module PageObjects
       end
 
       def has_content?(content)
-        composer_input.value == content
+        composer_input.has_value?(content)
       end
 
       def has_popup_content?(content)

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -64,7 +64,7 @@ module PageObjects
       end
 
       def has_content?(content)
-        has_field(COMPOSER_ID, with: content)
+        has_field?(COMPOSER_ID, with: content)
       end
 
       def has_popup_content?(content)

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -64,7 +64,7 @@ module PageObjects
       end
 
       def has_content?(content)
-        composer_input.has_value?(content)
+        has_field(COMPOSER_ID, with: content)
       end
 
       def has_popup_content?(content)


### PR DESCRIPTION
Checking for value of input directly is not waiting for value to be present.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->