### PR TITLE
DEV: Don't use 0-delay for test-env discourseLater

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -25,7 +25,6 @@ import {
 import UppyComposerUpload from "discourse/lib/uppy/composer-upload";
 import { formatUsername } from "discourse/lib/utilities";
 import Composer from "discourse/models/composer";
-import { isTesting } from "discourse-common/config/environment";
 import { tinyAvatar } from "discourse-common/lib/avatar-utils";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import discourseLater from "discourse-common/lib/later";
@@ -809,7 +808,7 @@ export default class ComposerEditor extends Component {
       // need to wait a bit for the "slide down" transition of the composer
       discourseLater(
         () => this.appEvents.trigger(`${this.composerEventPrefix}:closed`),
-        isTesting() ? 0 : 400
+        400
       );
     });
 

--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -3,11 +3,10 @@ import { action } from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { scheduleOnce } from "@ember/runloop";
 import { classNameBindings } from "@ember-decorators/component";
-import { isTesting } from "discourse-common/config/environment";
 import discourseLater from "discourse-common/lib/later";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 
-const CSS_TRANSITION_DELAY = isTesting() ? 0 : 500;
+const CSS_TRANSITION_DELAY = 500;
 
 @classNameBindings("docked", "withTransitions")
 export default class TopicProgress extends Component {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-emoji-picker-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-emoji-picker-manager.js
@@ -1,15 +1,14 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import { later } from "@ember/runloop";
 import Service, { service } from "@ember/service";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { isTesting } from "discourse-common/config/environment";
 import { makeArray } from "discourse-common/lib/helpers";
+import discourseLater from "discourse-common/lib/later";
 import { bind } from "discourse-common/utils/decorators";
 
-const TRANSITION_TIME = isTesting() ? 0 : 125; // CSS transition time
+const TRANSITION_TIME = 125; // CSS transition time
 const DEFAULT_VISIBLE_SECTIONS = ["favorites", "smileys_&_emotion"];
 const DEFAULT_LAST_SECTION = "favorites";
 
@@ -39,7 +38,7 @@ export default class ChatEmojiPickerManager extends Service {
   close() {
     this.closing = true;
 
-    later(() => {
+    discourseLater(() => {
       if (this.isDestroyed || this.isDestroying) {
         return;
       }


### PR DESCRIPTION
`discourseLater` automatically uses delay of 10ms in test environment

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->