### PR TITLE
DEV: ensures channel has been created

### DIFF
--- a/plugins/chat/spec/system/create_channel_spec.rb
+++ b/plugins/chat/spec/system/create_channel_spec.rb
@@ -273,12 +273,14 @@ RSpec.describe "Create channel", type: :system do
           chat_page.visit_browse
           chat_page.new_channel_button.click
           channel_modal.select_category(category_1)
+
           expect(channel_modal).to have_name_prefilled(category_1.name)
 
           channel_modal.fill_description("All kind of cute cats")
           channel_modal.click_primary_button
 
-          expect(page).to have_content(category_1.name)
+          expect(channel_modal).to be_closed
+
           created_channel = Chat::Channel.find_by(chatable_id: category_1.id)
           expect(page).to have_current_path(
             chat.channel_path(created_channel.slug, created_channel.id),

--- a/plugins/chat/spec/system/page_objects/modals/chat_channel_create.rb
+++ b/plugins/chat/spec/system/page_objects/modals/chat_channel_create.rb
@@ -39,6 +39,10 @@ module PageObjects
       def has_name_prefilled?(name)
         has_field?("name", with: name)
       end
+
+      def closed?
+        has_no_selector?(".chat-modal-create-channel")
+      end
     end
   end
 end


### PR DESCRIPTION
We were sometimes trying to fetch the channel before it has been created.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->