### PR TITLE
UX: Remove rounded borders from full screen chat channel

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -6,9 +6,6 @@
   &.full-page-chat-sidebar-enabled {
     grid-template-columns: 1fr;
     overflow: inherit;
-    .chat-channel {
-      border-radius: var(--full-page-border-radius);
-    }
   }
 
   .chat-channel {


### PR DESCRIPTION
This PR removes the border-radius being applied to full screen chat channels. This was causing an odd visual bug on highlighted chat messages.

**Before**
![CleanShot 2024-12-23 at 09 38 22@2x](https://github.com/user-attachments/assets/4bcc81ff-3464-4fe7-b017-dc89a7d761bb)

**After (Fixed)**
![CleanShot 2024-12-23 at 09 39 12@2x](https://github.com/user-attachments/assets/9543ca53-5b74-4200-a99e-6a34e0148b3e)


