### PR TITLE
DEV: fixes safari bug with content including linebreaks

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -92,6 +92,7 @@
     text-overflow: ellipsis;
     cursor: inherit;
     @include chat-scrollbar();
+    white-space: pre-wrap !important;
 
     &[disabled] {
       background: none;


### PR DESCRIPTION
Chat had the following bug.

Paste the following content into chat composer:

```
a

b
```

It would render as (in safari only):

```
a





b
```

It seems this behavior occurs because of how Safari handles the white-space CSS property in conjunction with the `::placeholder` and `:placeholder-shown` pseudo-classes. Specifically when rendering multiline content in textareas where white-space: nowrap is applied to these pseudo-classes.

I couldn't find an exact source of this, but surely commenting this part of the code was making it work, it seems forcing `pre-wrap` is working.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->