### PR TITLE
UX: Fix active class targeting for sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -40,7 +40,8 @@
       }
     }
 
-    &--active {
+    &--active,
+    &.active {
       background: var(--d-selected);
       font-weight: bold;
 


### PR DESCRIPTION
This PR adds a target for the non-chat active sidebar class, which is still using `active` as most other areas in Discourse. 

**This PR does not address:**

1) In chat sidebar we are using `sidebar-section-link--active` when the recommendation from the Discourse styleguide is to separate modifiers from their main target. IE. `sidebar-section-link --active`
https://github.com/discourse/discourse/blob/fef14c004cd1708b90ca29425090b0b06b159470/plugins/styleguide/assets/javascripts/discourse/components/sections/syntax/00-bem.hbs#L29-L65
2) I am not changing the other areas in core to use `--active` as this would likely cause lots of issues with existing themes
