### PR TITLE
DEV: Remove log messages that are redundant

### DIFF
--- a/app/jobs/regular/sync_acls_for_uploads.rb
+++ b/app/jobs/regular/sync_acls_for_uploads.rb
@@ -9,12 +9,8 @@ module Jobs
       return if !Discourse.store.external?
       return if !args.key?(:upload_ids)
 
-      # NOTE: These log messages are set to warn to ensure this is working
-      # as intended in initial production trials, this will need to be set to debug
-      # after an acl_stale column is added to uploads.
       time =
         Benchmark.measure do
-          Rails.logger.warn("Syncing ACL for upload ids: #{args[:upload_ids].join(", ")}")
           Upload
             .includes(:optimized_images)
             .where(id: args[:upload_ids])
@@ -34,9 +30,6 @@ module Jobs
                 end
               end
             end
-          Rails.logger.warn(
-            "Completed syncing ACL for upload ids in #{time}. IDs: #{args[:upload_ids].join(", ")}",
-          )
         end
     end
   end


### PR DESCRIPTION
I think the log messages were used for initial production trials but the
log messages are actually not very useful in the grand scheme of things.
If the timing of the job is important information, one can get it by
enabling Sidekiq logging and obtain the information from there. There is
no need for us to flood the logs with these messages.

Also the messages will contain at most 100 ids so it is just alot of
noise in general.
