### PR TITLE
DEV: Copy gems from Docker image in Github actions tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository != 'discourse/discourse' && 'ubuntu-22.04-8core') || 'debian-12' }}
-    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
+    container: discourse/discourse_test:${{ (github.repository == 'discourse/discourse' && 'release') || format('slim{0}', (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '') }}
     timeout-minutes: 20
 
     env:
@@ -111,9 +111,14 @@ jobs:
 
       - name: Bundler cache
         uses: actions/cache@v4
+        if: github.repository != 'discourse/discourse'
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-gem-${{ hashFiles('**/Gemfile.lock') }}-cachev2
+
+      - name: Copy gems to vendor/bundle
+        if: github.repository == 'discourse/discourse'
+        run: cp -r /var/www/discourse/vendor/bundle vendor/bundle
 
       - name: Setup gems
         run: |


### PR DESCRIPTION
On our own self hosted runners, pulling from github actions cache is quite slow and can take up to 20 seconds for the `bundler cache` step. Instead, we will now copy the gems from the `/var/www/discourse/vendor/bundle` folder in the `discourse/discourse_test:release` image which is built daily. This eliminates the need to pull from Github actions cache and also potentially reduces our costs of cache storage.

Note that `discourse/discourse_test:release` is pulled periodically on our self hosted runners so there is no impact on the time it takes to initialize the container.

### Before

<img width="2589" alt="Screenshot 2024-12-27 at 7 04 56 AM" src="https://github.com/user-attachments/assets/97b16aad-9514-4b12-8ba8-d6fabdde5c46" />


### After

<img width="2593" alt="Screenshot 2024-12-27 at 7 05 22 AM" src="https://github.com/user-attachments/assets/77e9dbde-0644-4181-8c2e-b269a16bec74" />
