### PR TITLE
FEATURE: support more views for category page on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -16,6 +16,9 @@ import { MAX_UNOPTIMIZED_CATEGORIES } from "discourse/lib/constants";
 const mobileCompatibleViews = [
   "categories_with_featured_topics",
   "subcategories_with_featured_topics",
+  "categories_boxes",
+  "categories_boxes_with_topics",
+  "categories_only",
 ];
 
 const subcategoryComponents = {

--- a/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
@@ -127,6 +127,30 @@ acceptance(
   }
 );
 
+acceptance(
+  "Categories - 'categories_boxes_with_topics' (mobile)",
+  function (needs) {
+    needs.mobileView();
+    needs.settings({
+      desktop_category_page_style: "categories_boxes_with_topics",
+    });
+
+    test("basic functionality", async function (assert) {
+      await visit("/categories");
+      assert
+        .dom(
+          "div.category-box-inner .category-box-heading a.parent-box-link[href='/c/dev/7']"
+        )
+        .exists("shows boxes for top-level category");
+      assert
+        .dom(
+          "div.category-box-inner .featured-topics li[data-topic-id='11994']"
+        )
+        .exists("shows featured topics in boxes");
+    });
+  }
+);
+
 acceptance("Categories - preloadStore handling", function () {
   const styles = [
     "categories_only",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2236,7 +2236,7 @@ en:
 
     min_title_similar_length: "The minimum length of a title before it will be checked for similar topics."
 
-    desktop_category_page_style: "This setting determines the visual layout of the /categories page on desktop. It includes options such as displaying subcategories with featured topics, showing the latest topics, or presenting top topics. The chosen style will influence how users interact and navigate through categories on the site."
+    desktop_category_page_style: "This setting determines the visual layout of the /categories page. It includes options such as displaying subcategories with featured topics, showing the latest topics, or presenting top topics. The chosen style will influence how users interact and navigate through categories on the site."
     category_colors: "A list of hexadecimal color values allowed for categories."
     default_dark_mode_color_scheme_id: "The color palette used when in dark mode."
     dark_mode_none: "None"


### PR DESCRIPTION
This commit updates category page on mobile to use views based on setting `desktop_category_page_style`.

Boxes with Featured Topics (desktop):

<img width="1098" alt="Screenshot 2024-12-26 at 15 04 44" src="https://github.com/user-attachments/assets/b5aaf6e7-b23a-4548-add8-11ed15c991f0" />

Boxes with Featured Topics (mobile):

<img width="324" alt="Screenshot 2024-12-26 at 15 04 29" src="https://github.com/user-attachments/assets/c1f5bde5-748c-4da2-9280-a4ba2ea79bfd" />

Boxes with Subcategories (desktop):

<img width="1100" alt="Screenshot 2024-12-26 at 15 15 21" src="https://github.com/user-attachments/assets/7a7dbb56-f107-4241-8f86-43a551c06fd5" />

Boxes with Subcategories (mobile):

<img width="323" alt="Screenshot 2024-12-26 at 15 15 50" src="https://github.com/user-attachments/assets/3477ec1f-3df5-498c-a774-99abba036f90" />

Categories Only (desktop):

<img width="1106" alt="Screenshot 2024-12-26 at 15 17 36" src="https://github.com/user-attachments/assets/e45edf6f-aa89-4415-b8fd-589a4a38ed36" />

Categories Only (mobile):

<img width="317" alt="Screenshot 2024-12-26 at 15 17 52" src="https://github.com/user-attachments/assets/56389715-268c-4ee0-bca0-541747735868" />

Subcategories with Featured Topics (desktop):

<img width="1122" alt="Screenshot 2024-12-26 at 15 20 09" src="https://github.com/user-attachments/assets/25bbebb9-15ed-45c1-9586-06b97f114f90" />

Subcategories with Featured Topics (mobile):

<img width="317" alt="Screenshot 2024-12-26 at 15 20 25" src="https://github.com/user-attachments/assets/312c7ff8-e7e2-44f1-83c8-f8b9f5f02c83" />
