### PR TITLE
UX: Hide before-header-panel-outlet on login page

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -16,7 +16,8 @@ body.password-reset-page,
 body.activate-account-page {
   .powered-by-discourse,
   .above-main-container-outlet,
-  .before-header-panel-outlet {
+  .before-header-panel-outlet,
+  .below-site-header-outlet {
     display: none;
   }
   #main-outlet {


### PR DESCRIPTION
This PR adds the before-header-panel-outlet to the list of outlets to be hidden on login pages.