### PR TITLE
DEV: Support a `perform_when_readonly` option for `Jobs::Scheduled`

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -367,8 +367,16 @@ module Jobs
   class Scheduled < Base
     extend MiniScheduler::Schedule
 
+    def self.perform_when_readonly
+      @perform_when_readonly = true
+    end
+
+    def self.perform_when_readonly?
+      @perform_when_readonly || false
+    end
+
     def perform(*args)
-      super if !Discourse.readonly_mode?
+      super if self.class.perform_when_readonly? || !Discourse.readonly_mode?
     end
   end
 

--- a/spec/jobs/jobs_scheduled_spec.rb
+++ b/spec/jobs/jobs_scheduled_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::Scheduled do
+  describe "#perform" do
+    context "when `Discourse.readonly_mode?` is enabled" do
+      before { Discourse.enable_readonly_mode }
+      after { Discourse.disable_readonly_mode }
+
+      it "does not perform scheduled jobs in readonly mode" do
+        Sidekiq::Testing.inline! do
+          klass =
+            Class.new(described_class) do
+              every 1.minute
+
+              @called = 0
+
+              def self.count
+                @called
+              end
+
+              def self.increment
+                @called += 1
+              end
+
+              def execute(args)
+                self.class.increment
+              end
+            end
+
+          klass.new.perform(nil)
+          expect(klass.count).to eq(0)
+        end
+      end
+
+      it "still enqueues scheduled jobs that has `perform_when_readonly` option set to true in readonly mode" do
+        Sidekiq::Testing.inline! do
+          klass =
+            Class.new(described_class) do
+              every 1.minute
+              perform_when_readonly
+
+              @called = 0
+
+              def self.count
+                @called
+              end
+
+              def self.increment
+                @called += 1
+              end
+
+              def execute(args)
+                self.class.increment
+              end
+            end
+
+          klass.new.perform(nil)
+          expect(klass.count).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is useful for scheduled jobs that should be performed even when
`Discourse.readonly_mode?` is `true`.
