### PR TITLE
UX: Add Sentence Casing for Setting Names

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -233,7 +233,8 @@ export default Mixin.create({
       .join(" ");
 
     return MIXED_CASE.reduce(
-      (acc, [key, value]) => acc.replaceAll(new RegExp(key, "gi"), value),
+      (acc, [key, value]) =>
+        acc.replaceAll(new RegExp(`\\b${key}\\b`, "gi"), value),
       formattedName
     );
   }),

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -104,12 +104,14 @@ const ACRONYMS = new Set([
   "imap",
   "ip",
   "jpg",
+  "json",
   "kb",
   "mb",
   "oidc",
   "pm",
   "png",
   "pop3",
+  "s3",
   "smtp",
   "svg",
   "tl",
@@ -124,54 +126,32 @@ const ACRONYMS = new Set([
   "ux",
 ]);
 
-const SPECIAL_CASE = {
-  github: "GitHub",
-  ios: "iOS",
-  linkedin: "LinkedIn",
-  oauth2: "OAuth2",
-  opengraph: "OpenGraph",
-  tiktok: "TikTok",
-  tos: "ToS",
-  wordpress: "WordPress",
-  youtube: "YouTube",
-};
-
-const SMALL_WORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "as",
-  "at",
-  "but",
-  "by",
-  "en",
-  "for",
-  "if",
-  "iframe",
-  "iframes",
-  "in",
-  "gzip",
-  "n",
-  "nor",
-  "of",
-  "on",
-  "or",
-  "over",
-  "per",
-  "so",
-  "some",
-  "src",
-  "than",
-  "that",
-  "the",
-  "to",
-  "upon",
-  "v",
-  "via",
-  "vs",
-  "when",
-  "with",
-  "yet",
+const MIXED_CASE = new Map([
+  ["adobe analytics", "Adobe Analytics"],
+  ["android", "Android"],
+  ["chinese", "Chinese"],
+  ["discord", "Discord"],
+  ["discourse", "Discourse"],
+  ["discourse connect", "Discourse Connect"],
+  ["discourse discover", "Discourse Discover"],
+  ["discourse narrative bot", "Discourse Narrative Bot"],
+  ["facebook", "Facebook"],
+  ["github", "GitHub"],
+  ["google", "Google"],
+  ["gravatar", "Gravatar"],
+  ["gravatars", "Gravatars"],
+  ["ios", "iOS"],
+  ["japanese", "Japanese"],
+  ["linkedin", "LinkedIn"],
+  ["oauth2", "OAuth2"],
+  ["opengraph", "OpenGraph"],
+  ["powered by discourse", "Powered by Discourse"],
+  ["tiktok", "TikTok"],
+  ["tos", "ToS"],
+  ["twitter", "Twitter"],
+  ["vimeo", "Vimeo"],
+  ["wordpress", "WordPress"],
+  ["youtube", "YouTube"],
 ]);
 
 export default Mixin.create({
@@ -238,23 +218,24 @@ export default Mixin.create({
     const label = this.setting?.label;
     const name = label || setting.replace(/\_/g, " ");
 
-    return name
+    const formattedName = (name.charAt(0).toUpperCase() + name.slice(1))
       .split(" ")
-      .map((word) => (ACRONYMS.has(word) ? word.toUpperCase() : word))
+      .map((word) =>
+        ACRONYMS.has(word.toLowerCase()) ? word.toUpperCase() : word
+      )
       .map((word) => {
         if (word.endsWith("s")) {
-          const singular = word.slice(0, -1);
+          const singular = word.slice(0, -1).toLowerCase();
           return ACRONYMS.has(singular) ? singular.toUpperCase() + "s" : word;
         }
         return word;
       })
-      .map((word) =>
-        SMALL_WORDS.has(word)
-          ? word
-          : word.charAt(0).toUpperCase() + word.slice(1)
-      )
-      .map((word) => SPECIAL_CASE[word.toLowerCase()] || word)
       .join(" ");
+
+    return MIXED_CASE[Symbol.iterator]().reduce(
+      (acc, [key, value]) => acc.replaceAll(new RegExp(key, "gi"), value),
+      formattedName
+    );
   }),
 
   componentType: computed("type", function () {

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -81,6 +81,99 @@ const DEFAULT_USER_PREFERENCES = [
   "default_sidebar_show_count_of_new_items",
 ];
 
+const ACRONYMS = new Set([
+  "acl",
+  "ai",
+  "api",
+  "bg",
+  "cdn",
+  "cors",
+  "cta",
+  "dm",
+  "eu",
+  "faq",
+  "fg",
+  "ga",
+  "gb",
+  "gtm",
+  "hd",
+  "http",
+  "https",
+  "iam",
+  "id",
+  "imap",
+  "ip",
+  "jpg",
+  "kb",
+  "mb",
+  "oidc",
+  "pm",
+  "png",
+  "pop3",
+  "smtp",
+  "svg",
+  "tl",
+  "tl0",
+  "tl1",
+  "tl2",
+  "tl3",
+  "tl4",
+  "tld",
+  "txt",
+  "url",
+  "ux",
+]);
+
+const SPECIAL_CASE = {
+  github: "GitHub",
+  ios: "iOS",
+  linkedin: "LinkedIn",
+  oauth2: "OAuth2",
+  opengraph: "OpenGraph",
+  tiktok: "TikTok",
+  tos: "ToS",
+  wordpress: "WordPress",
+  youtube: "YouTube",
+};
+
+const SMALL_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "but",
+  "by",
+  "en",
+  "for",
+  "if",
+  "iframe",
+  "iframes",
+  "in",
+  "gzip",
+  "n",
+  "nor",
+  "of",
+  "on",
+  "or",
+  "over",
+  "per",
+  "so",
+  "some",
+  "src",
+  "than",
+  "that",
+  "the",
+  "to",
+  "upon",
+  "v",
+  "via",
+  "vs",
+  "when",
+  "with",
+  "yet",
+]);
+
 export default Mixin.create({
   modal: service(),
   router: service(),
@@ -143,7 +236,25 @@ export default Mixin.create({
   settingName: computed("setting.setting", "setting.label", function () {
     const setting = this.setting?.setting;
     const label = this.setting?.label;
-    return label || setting.replace(/\_/g, " ");
+    const name = label || setting.replace(/\_/g, " ");
+
+    return name
+      .split(" ")
+      .map((word) => (ACRONYMS.has(word) ? word.toUpperCase() : word))
+      .map((word) => {
+        if (word.endsWith("s")) {
+          const singular = word.slice(0, -1);
+          return ACRONYMS.has(singular) ? singular.toUpperCase() + "s" : word;
+        }
+        return word;
+      })
+      .map((word) =>
+        SMALL_WORDS.has(word)
+          ? word
+          : word.charAt(0).toUpperCase() + word.slice(1)
+      )
+      .map((word) => SPECIAL_CASE[word.toLowerCase()] || word)
+      .join(" ");
   }),
 
   componentType: computed("type", function () {

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -126,7 +126,7 @@ const ACRONYMS = new Set([
   "ux",
 ]);
 
-const MIXED_CASE = new Map([
+const MIXED_CASE = [
   ["adobe analytics", "Adobe Analytics"],
   ["android", "Android"],
   ["chinese", "Chinese"],
@@ -152,7 +152,7 @@ const MIXED_CASE = new Map([
   ["vimeo", "Vimeo"],
   ["wordpress", "WordPress"],
   ["youtube", "YouTube"],
-]);
+];
 
 export default Mixin.create({
   modal: service(),
@@ -232,7 +232,7 @@ export default Mixin.create({
       })
       .join(" ");
 
-    return MIXED_CASE[Symbol.iterator]().reduce(
+    return MIXED_CASE.reduce(
       (acc, [key, value]) => acc.replaceAll(new RegExp(key, "gi"), value),
       formattedName
     );

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -162,7 +162,7 @@ describe "Admin Flags Page", type: :system do
     )
 
     admin_flags_page.click_settings_tab
-    expect(page.all(".setting-label h3").map(&:text)).to eq(
+    expect(page.all(".setting-label h3").map(&:text).map(&:downcase)).to eq(
       [
         "silence new user sensitivity",
         "num users to silence new user",

--- a/spec/system/admin_site_setting_label_formatting_spec.rb
+++ b/spec/system/admin_site_setting_label_formatting_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe "Admin Site Setting Formatting", type: :system do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  fab!(:admin)
+
+  before { sign_in(admin) }
+
+  it "capitalises the first letter of labels" do
+    setting_name = "default_locale"
+
+    settings_page.visit(setting_name)
+
+    expect(setting_label(setting_name)).to eq("Default locale")
+  end
+
+  it "capitalises acronyms in labels" do
+    setting_name = "faq_url"
+
+    settings_page.visit(setting_name)
+
+    expect(setting_label(setting_name)).to eq("FAQ URL")
+  end
+
+  it "matches multi-word replacements" do
+    setting_name = "enable_discourse_connect"
+
+    settings_page.visit(setting_name)
+
+    expect(setting_label(setting_name)).to eq("Enable Discourse Connect")
+  end
+
+  it "matches multiple types of replacements" do
+    setting_name = "google_oauth2_client_id"
+
+    settings_page.visit(setting_name)
+
+    expect(setting_label(setting_name)).to eq("Google OAuth2 client ID")
+  end
+
+  def setting_label(setting_name)
+    settings_page.find(settings_page.setting_row_selector(setting_name) + " h3").text
+  end
+end


### PR DESCRIPTION
## ✨ What's This?

In order to make the many lists of settings more readable, this PR transforms setting names into Sentence Case, with a handful of special cases, too:
- Transforms common acronyms to upper case (eg, URL, TLD)
- Handles plural versions of common acronyms (eg, URLs, TLDs)
- Allows for words with weird casing (eg, GitHub, iOS)

## 📺 Screenshots

<img src="https://github.com/user-attachments/assets/69cacefc-8f96-48cd-bcb1-cfa325962a6e" width="350" /> <img src="https://github.com/user-attachments/assets/903dd420-1f42-42b7-8760-43d3d881c899" width="350" />

## 👑 Testing

Browser through the site settings, see if there are any that you think should look different.

Try the settings for popular plugins, make sure they're handled correctly.