### PR TITLE
DEV: Run one system test process per CPU core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set PARALLEL_TEST_PROCESSORS for system tests
         if: matrix.build_type == 'system'
         run: |
-          echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2))" >> $GITHUB_ENV
+          echo "PARALLEL_TEST_PROCESSORS=$(nproc)" >> $GITHUB_ENV
 
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'


### PR DESCRIPTION
We are running on self hosted runners with more CPU and RAM so we should
be able to run one system test process per CPU core for more speedz.

This may lead to some instability in our system tests but it is hard to say unless we roll this change out. If it does lead to system tests being more unstable, we can easily roll back the change.