### PR TITLE
UX: Add highlight for active nav in admin secondary sidebar

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -778,14 +778,17 @@ $mobile-breakpoint: 700px;
 
     a.active {
       color: var(--primary);
-      background-color: initial;
+      background-color: var(--d-sidebar-admin-background);
       font-weight: 700;
-      border-right: 4px solid var(--d-nav-color--active);
 
       &::after {
-        display: none; // Hides the arrow
+        border-left-color: var(--primary-medium);
       }
     }
+  }
+
+  .admin-site-settings-category-nav__item:hover {
+    background: var(--d-sidebar-highlight-background);
   }
 }
 

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -782,7 +782,7 @@ $mobile-breakpoint: 700px;
       font-weight: 700;
 
       &::after {
-        border-left-color: var(--primary-medium);
+        display: none; // Hides the arrow
       }
     }
   }


### PR DESCRIPTION
This PR makes the secondary sidebar in the admin UI more consistent navigation experience:

* Added a coloured background for links on hover
* Replaced the bold text and line style with a distinct background highlight, ensuring it complements the admin sidebar while maintaining its own identity
* Bringing in arrow indicators to match the active navigation state in the category settings

### Before
<img width="488" alt="image" src="https://github.com/user-attachments/assets/aa843766-0ed7-435a-8880-6f0598aa4782" />


### After
<img width="475" alt="image" src="https://github.com/user-attachments/assets/ec31bab9-0f51-4757-ab06-95a961ae17ee" />