### PR TITLE
DEV: fix cancel swipe callback typo

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/swipe.js
+++ b/app/assets/javascripts/discourse/app/modifiers/swipe.js
@@ -135,7 +135,7 @@ export default class SwipeModifier extends Modifier {
       enableBodyScroll(this.element);
     }
 
-    this.onDidCancelSwipe?.(event.detail);
+    this.onDidCancelSwipeCallback?.(event.detail);
   }
 
   /**


### PR DESCRIPTION
`onDidCancelSwipe` event was calling itself instead of the callback (not an actual FIX because no user of this API has set a callback so far)