### PR TITLE
DEV: Add deprecations for topic-status raw-view modifications

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -302,10 +302,11 @@ class PluginApi {
   modifyClass(resolverName, changes, opts) {
     if (
       resolverName === "component:topic-list" ||
-      resolverName === "component:topic-list-item"
+      resolverName === "component:topic-list-item" ||
+      resolverName === "raw-view:topic-status"
     ) {
       deprecated(
-        "Modifying topic-list and topic-list-item with `modifyClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+        `Modifying '${resolverName}' with 'modifyClass' is deprecated. Use the value transformer 'topic-list-columns' and other new topic-list plugin APIs instead.`,
         {
           since: "v3.4.0.beta3-dev",
           id: "discourse.hbr-topic-list-overrides",
@@ -352,10 +353,11 @@ class PluginApi {
   modifyClassStatic(resolverName, changes, opts) {
     if (
       resolverName === "component:topic-list" ||
-      resolverName === "component:topic-list-item"
+      resolverName === "component:topic-list-item" ||
+      resolverName === "raw-view:topic-status"
     ) {
       deprecated(
-        "Modifying topic-list and topic-list-item with `modifyClassStatic` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+        `Modifying '${resolverName}' with 'modifyClass' is deprecated. Use the value transformer 'topic-list-columns' and other new topic-list plugin APIs instead.`,
         {
           since: "v3.4.0.beta3-dev",
           id: "discourse.hbr-topic-list-overrides",

--- a/app/assets/javascripts/discourse/app/raw-views/topic-status.js
+++ b/app/assets/javascripts/discourse/app/raw-views/topic-status.js
@@ -1,8 +1,33 @@
 import EmberObject from "@ember/object";
+import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
 import { i18n } from "discourse-i18n";
 
 export default class TopicStatus extends EmberObject {
+  static reopen() {
+    deprecated(
+      "Modifying raw-view:topic-status with `reopen` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
+
+    return super.reopen(...arguments);
+  }
+
+  static reopenClass() {
+    deprecated(
+      "Modifying raw-view:topic-status with `reopenClass` is deprecated. Use the value transformer `topic-list-columns` and other new topic-list plugin APIs instead.",
+      {
+        since: "v3.4.0.beta3-dev",
+        id: "discourse.hbr-topic-list-overrides",
+      }
+    );
+
+    return super.reopenClass(...arguments);
+  }
+
   showDefault = null;
 
   @discourseComputed("defaultIcon")


### PR DESCRIPTION
This will make the 'auto' glimmer-topic-list feature aware of these modifications, so that the new topic-list will not be enabled until they're resolved.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->