### PR TITLE
DEV: Add showLogin action to post menu buttons and prevent text selection

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu.gjs
@@ -113,6 +113,7 @@ export default class PostMenu extends Component {
       showDeleteTopicModal: this.showDeleteTopicModal,
       showFlags: this.args.showFlags,
       showMoreActions: this.showMoreActions,
+      showLogin: this.args.showLogin,
       toggleReplies: this.args.toggleReplies,
       toggleWhoLiked: this.toggleWhoLiked,
       toggleWhoRead: this.toggleWhoRead,

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -314,6 +314,8 @@ nav.post-controls {
 
   color: var(--primary-low-mid);
 
+  @include user-select(none);
+
   .actions {
     display: inline-flex;
     text-align: right;


### PR DESCRIPTION
This PR adds `showLogin` as an available action to the post menu buttons. They can use this action to show the login form when there is no user logged in.

It also adds a small CSS tweak to prevent the content from the post menu to being user selectable. This was causing small UX issues in touch devices.