### PR TITLE
FEATURE: Add setting to disable protection for low-trust user profiles

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2282,6 +2282,9 @@ spam:
     default: "Duplicate|Does not meet posting guidelines"
     type: list
     client: true
+  allow_low_trust_levels_to_view_user_profiles:
+    default: false
+    hidden: true
 
 rate_limits:
   unique_posts_mins: 5

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -134,11 +134,13 @@ module UserGuardian
 
     return true if user.staff? && !profile_hidden
 
-    if user.user_stat.blank? || user.user_stat.post_count == 0
+    if !SiteSetting.allow_low_trust_levels_to_view_user_profiles &&
+         (user.user_stat.blank? || user.user_stat.post_count == 0)
       return false if anonymous? || !@user.has_trust_level?(TrustLevel[2])
     end
 
-    if anonymous? || !@user.has_trust_level?(TrustLevel[1])
+    if !SiteSetting.allow_low_trust_levels_to_view_user_profiles &&
+         (anonymous? || !@user.has_trust_level?(TrustLevel[1]))
       return user.has_trust_level?(TrustLevel[1]) && !profile_hidden
     end
 

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe UserGuardian do
         expect(Guardian.new(tl1_user).can_see_profile?(user)).to eq(false)
       end
 
+      it "an anonymous user can view the user's profile if allow_low_trust_levels_to_view_user_profiles is true" do
+        SiteSetting.allow_low_trust_levels_to_view_user_profiles = true
+        expect(Guardian.new.can_see_profile?(user)).to eq(true)
+      end
+
+      it "a TL0 user can view the user's profile if allow_low_trust_levels_to_view_user_profiles is true" do
+        SiteSetting.allow_low_trust_levels_to_view_user_profiles = true
+        expect(Guardian.new(tl0_user).can_see_profile?(user)).to eq(true)
+      end
+
+      it "a TL1 user can view the user's profile if allow_low_trust_levels_to_view_user_profiles is true" do
+        SiteSetting.allow_low_trust_levels_to_view_user_profiles = true
+        expect(Guardian.new(tl1_user).can_see_profile?(user)).to eq(true)
+      end
+
       it "a TL2 user can view the user's profile" do
         expect(Guardian.new(tl2_user).can_see_profile?(user)).to eq(true)
       end
@@ -173,6 +188,18 @@ RSpec.describe UserGuardian do
       it "a TL0 user cannot view the user's profile" do
         expect(Guardian.new(Fabricate(:user, trust_level: 0)).can_see_profile?(tl0_user)).to eq(
           false,
+        )
+      end
+
+      it "an anonymous user can view the user's profile if allow_low_trust_levels_to_view_user_profiles is true" do
+        SiteSetting.allow_low_trust_levels_to_view_user_profiles = true
+        expect(Guardian.new.can_see_profile?(tl0_user)).to eq(true)
+      end
+
+      it "a TL0 user can view the user's profile if allow_low_trust_levels_to_view_user_profiles is true" do
+        SiteSetting.allow_low_trust_levels_to_view_user_profiles = true
+        expect(Guardian.new(Fabricate(:user, trust_level: 0)).can_see_profile?(tl0_user)).to eq(
+          true,
         )
       end
 


### PR DESCRIPTION
This PR adds a hidden site setting to disable the profile restriction for low-trust users that we introduced in https://github.com/discourse/discourse/pull/29981.