### PR TITLE
FIX: Show error message when password is too common

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.js
@@ -459,11 +459,7 @@ export default class CreateAccount extends Component.extend(
           ) {
             this.rejectedEmails.pushObject(result.values.email);
           }
-          if (
-            result.errors &&
-            result.errors.password &&
-            result.errors.password.length > 0
-          ) {
+          if (result.errors?.["user_password.password"]?.length > 0) {
             this.rejectedPasswords.pushObject(attrs.accountPassword);
           }
           this.set("formSubmitted", false);

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -336,15 +336,11 @@ export default class InvitesShowController extends Controller.extend(
           ) {
             this.rejectedEmails.pushObject(result.values.email);
           }
-          if (
-            result.errors &&
-            result.errors.password &&
-            result.errors.password.length > 0
-          ) {
+          if (result.errors?.["user_password.password"]?.length > 0) {
             this.rejectedPasswords.pushObject(this.accountPassword);
             this.rejectedPasswordsMessages.set(
               this.accountPassword,
-              result.errors.password[0]
+              result.errors["user_password.password"][0]
             );
           }
           if (result.message) {

--- a/app/assets/javascripts/discourse/app/controllers/password-reset.js
+++ b/app/assets/javascripts/discourse/app/controllers/password-reset.js
@@ -145,7 +145,7 @@ export default class PasswordResetController extends Controller.extend(
             securityKeyRequired: false,
             errorMessage: null,
           });
-        } else if (result.errors?.password?.length > 0) {
+        } else if (result.errors?.["user_password.password"]?.length > 0) {
           this.rejectedPasswords.pushObject(this.accountPassword);
           this.rejectedPasswordsMessages.set(
             this.accountPassword,

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -454,11 +454,7 @@ export default class SignupPageController extends Controller.extend(
           ) {
             this.rejectedEmails.pushObject(result.values.email);
           }
-          if (
-            result.errors &&
-            result.errors.password &&
-            result.errors.password.length > 0
-          ) {
+          if (result.errors?.["user_password.password"]?.length > 0) {
             this.rejectedPasswords.pushObject(attrs.accountPassword);
           }
           this.set("formSubmitted", false);

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -22,7 +22,7 @@ acceptance("Password Reset", function (needs) {
       if (body.password === "jonesyAlienSlayer") {
         return helper.response({
           success: false,
-          errors: { password: ["is the name of your cat"] },
+          errors: { "user_password.password": ["is the name of your cat"] },
           friendly_messages: ["Password is the name of your cat"],
         });
       } else {

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -71,6 +71,20 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
       expect(page).to have_current_path("/t/#{topic.slug}/#{topic.id}")
     end
 
+    it "cannot signup with a common password" do
+      signup_form
+        .open
+        .fill_email("johndoe@example.com")
+        .fill_username("john")
+        .fill_password("0123456789")
+      expect(signup_form).to have_valid_fields
+
+      signup_form.click_create_account
+      expect(signup_form).to have_content(
+        I18n.t("activerecord.errors.models.user_password.attributes.password.common"),
+      )
+    end
+
     context "with invite code" do
       before { SiteSetting.invite_code = "cupcake" }
 


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->