### PR TITLE
FEATURE: allow disabling of anti spam profile hiding feature

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2432,6 +2432,7 @@ en:
     anonymous_account_duration_minutes: "To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created."
 
     hide_user_profiles_from_public: "Disable user cards, user profiles and user directory for anonymous users."
+    hide_new_user_profiles: "Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. Note: feature is disabled unconditionally on must_approve_users and invite_only sites."
     allow_users_to_hide_profile: "Allow users to hide their profile and presence"
     hide_user_activity_tab: "Hide the activity tab on user profiles except for Admin and self."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3213,6 +3213,7 @@ en:
       hide_suspension_reasons: ""
       hide_user_activity_tab: ""
       hide_user_profiles_from_public: ""
+      hide_new_user_profiles: ""
       high_trust_flaggers_auto_hide_posts: ""
       highlighted_languages: ""
       history_hours_high: ""

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2432,7 +2432,7 @@ en:
     anonymous_account_duration_minutes: "To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created."
 
     hide_user_profiles_from_public: "Disable user cards, user profiles and user directory for anonymous users."
-    hide_new_user_profiles: "Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. Note: feature is disabled unconditionally on must_approve_users and invite_only sites."
+    hide_new_user_profiles: "Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. This feature is disabled unconditionally on must_approve_users and invite_only sites."
     allow_users_to_hide_profile: "Allow users to hide their profile and presence"
     hide_user_activity_tab: "Hide the activity tab on user profiles except for Admin and self."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -779,6 +779,8 @@ users:
   hide_user_profiles_from_public:
     default: false
     client: true
+  hide_new_user_profiles:
+    default: true
   allow_featured_topic_on_user_profiles:
     default: true
     client: true

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -134,12 +134,15 @@ module UserGuardian
 
     return true if user.staff? && !profile_hidden
 
-    if user.user_stat.blank? || user.user_stat.post_count == 0
-      return false if anonymous? || !@user.has_trust_level?(TrustLevel[2])
-    end
+    if SiteSetting.hide_new_user_profiles && !SiteSetting.invite_only &&
+         !SiteSetting.must_approve_users
+      if user.user_stat.blank? || user.user_stat.post_count == 0
+        return false if anonymous? || !@user.has_trust_level?(TrustLevel[2])
+      end
 
-    if anonymous? || !@user.has_trust_level?(TrustLevel[1])
-      return user.has_trust_level?(TrustLevel[1]) && !profile_hidden
+      if anonymous? || !@user.has_trust_level?(TrustLevel[1])
+        return user.has_trust_level?(TrustLevel[1]) && !profile_hidden
+      end
     end
 
     !profile_hidden

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -107,6 +107,27 @@ RSpec.describe UserGuardian do
     context "when viewing the profile of a user with 0 posts" do
       before { user.user_stat.update!(post_count: 0) }
 
+      context "when hide_new_user_profiles is disabled" do
+        it "allows anonymous to see any profile" do
+          SiteSetting.hide_new_user_profiles = false
+          expect(Guardian.new.can_see_profile?(user)).to eq(true)
+        end
+      end
+
+      context "when site is invite only" do
+        it "allows anonymous to see any profile" do
+          SiteSetting.invite_only = true
+          expect(Guardian.new.can_see_profile?(user)).to eq(true)
+        end
+      end
+
+      context "when site requires user approval" do
+        it "allows anonymous to see any profile" do
+          SiteSetting.must_approve_users = true
+          expect(Guardian.new.can_see_profile?(user)).to eq(true)
+        end
+      end
+
       it "they can view their own profile" do
         expect(Guardian.new(user).can_see_profile?(user)).to eq(true)
       end


### PR DESCRIPTION
The profile hiding feature is particularly problematic on sites that are
private (invite only or must approve users) so it is unconditionally disabled.

Also certain sites may prefer to disable the anti spam feature, they can
opt out using `hide_new_user_profiles`
