### PR TITLE
DEV: Move admin config pages out of /customize/ sub-route

### DIFF
--- a/app/assets/javascripts/admin/addon/adapters/user-field.js
+++ b/app/assets/javascripts/admin/addon/adapters/user-field.js
@@ -1,2 +1,7 @@
-import CustomizationBase from "admin/adapters/customization-base";
-export default CustomizationBase;
+import RestAdapter from "discourse/adapters/rest";
+
+export default class UserFieldAdapter extends RestAdapter {
+  basePath() {
+    return "/admin/config/";
+  }
+}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
@@ -90,7 +90,7 @@ export default class AdminConfigAreasEmojisList extends Component {
       <AdminConfigAreaEmptyList
         @ctaLabel="admin.emoji.add"
         @ctaRoute="adminEmojis.new"
-        @ctaClass="admin-emojis__add-emoji"
+        @ctaClass="admin-emoji__add-emoji"
         @emptyLabel="admin.emoji.no_emoji"
       />
     {{/if}}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-new.gjs
@@ -29,7 +29,7 @@ export default class AdminConfigAreasEmojisNew extends Component {
   <template>
     <BackButton @route="adminEmojis.index" @label="admin.emoji.back" />
     <div class="admin-config-area">
-      <div class="admin-config-area__primary-content admin-emojis-form">
+      <div class="admin-config-area__primary-content admin-emoji-form">
         <AdminConfigAreaCard @heading="admin.emoji.add">
           <:content>
             <EmojiUploader

--- a/app/assets/javascripts/admin/addon/components/emoji-uploader.js
+++ b/app/assets/javascripts/admin/addon/components/emoji-uploader.js
@@ -12,7 +12,7 @@ export default class EmojiUploader extends Component {
   uppyUpload = new UppyUpload(getOwner(this), {
     id: "emoji-uploader",
     type: "emoji",
-    uploadUrl: "/admin/customize/emojis",
+    uploadUrl: "/admin/config/emoji",
     preventDirectS3Uploads: true,
     validateUploadedFilesOptions: {
       imagesOnly: true,

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -48,7 +48,6 @@ export default function () {
         this.route("colors", function () {
           this.route("show", { path: "/:scheme_id" });
         });
-
         this.route(
           "adminCustomizeThemes",
           { path: "/:type", resetNamespace: true },
@@ -59,41 +58,11 @@ export default function () {
             this.route("edit", { path: "/:theme_id/:target/:field_name/edit" });
           }
         );
-
         this.route(
           "adminSiteText",
           { path: "/site_texts", resetNamespace: true },
           function () {
             this.route("edit", { path: "/:id" });
-          }
-        );
-
-        this.route(
-          "adminUserFields",
-          { path: "/user_fields", resetNamespace: true },
-          function () {
-            this.route("new");
-            this.route("edit", { path: "/:id/edit" });
-            this.route("index", { path: "/" });
-          }
-        );
-        this.route(
-          "adminEmojis",
-          { path: "/emojis", resetNamespace: true },
-          function () {
-            this.route("new");
-            this.route("index", { path: "/" });
-            this.route("settings");
-          }
-        );
-        this.route(
-          "adminPermalinks",
-          { path: "/permalinks", resetNamespace: true },
-          function () {
-            this.route("new");
-            this.route("index", { path: "/" });
-            this.route("settings");
-            this.route("edit", { path: "/:permalink_id" });
           }
         );
         this.route("adminEmbedding", {
@@ -240,6 +209,34 @@ export default function () {
         this.route("lookAndFeel", { path: "/look-and-feel" }, function () {
           this.route("themes");
         });
+        this.route(
+          "adminPermalinks",
+          { path: "/permalinks", resetNamespace: true },
+          function () {
+            this.route("new");
+            this.route("index", { path: "/" });
+            this.route("settings");
+            this.route("edit", { path: "/:permalink_id" });
+          }
+        );
+        this.route(
+          "adminUserFields",
+          { path: "/user-fields", resetNamespace: true },
+          function () {
+            this.route("new");
+            this.route("edit", { path: "/:id/edit" });
+            this.route("index", { path: "/" });
+          }
+        );
+        this.route(
+          "adminEmojis",
+          { path: "/emoji", resetNamespace: true },
+          function () {
+            this.route("new");
+            this.route("index", { path: "/" });
+            this.route("settings");
+          }
+        );
       }
     );
 

--- a/app/assets/javascripts/admin/addon/services/admin-emojis.js
+++ b/app/assets/javascripts/admin/addon/services/admin-emojis.js
@@ -44,7 +44,7 @@ export default class AdminEmojis extends Service {
 
   async #fetchEmojis() {
     try {
-      const data = await ajax("/admin/customize/emojis.json");
+      const data = await ajax("/admin/config/emoji.json");
       this.emojis = data.map((emoji) => EmberObject.create(emoji));
     } catch (err) {
       popupAjaxError(err);
@@ -63,7 +63,7 @@ export default class AdminEmojis extends Service {
 
   async #destroyEmoji(emoji) {
     try {
-      await ajax("/admin/customize/emojis/" + emoji.get("name"), {
+      await ajax("/admin/config/emoji/" + emoji.get("name"), {
         type: "DELETE",
       });
       this.emojis.removeObject(emoji);

--- a/app/assets/javascripts/admin/addon/templates/emojis-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/emojis-settings.hbs
@@ -1,6 +1,6 @@
 <AdminAreaSettings
   @area="emojis"
-  @path="/admin/customize/emojis/settings"
+  @path="/admin/config/emoji/settings"
   @filter={{this.filter}}
   @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
 />

--- a/app/assets/javascripts/admin/addon/templates/emojis.hbs
+++ b/app/assets/javascripts/admin/addon/templates/emojis.hbs
@@ -1,4 +1,4 @@
-<div class="admin-emojis admin-config-page">
+<div class="admin-emoji admin-config-page">
   <DPageHeader
     @titleLabel={{i18n "admin.emoji.title"}}
     @descriptionLabel={{i18n "admin.emoji.description"}}
@@ -7,7 +7,7 @@
     <:breadcrumbs>
       <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
       <DBreadcrumbsItem
-        @path="/admin/customize/emojis"
+        @path="/admin/config/emoji"
         @label={{i18n "admin.emoji.title"}}
       />
     </:breadcrumbs>
@@ -18,12 +18,12 @@
       <NavItem
         @route="adminEmojis.settings"
         @label="settings"
-        class="admin-emojis-tabs__settings"
+        class="admin-emoji-tabs__settings"
       />
       <NavItem
         @route="adminEmojis.index"
         @label="admin.emoji.title"
-        class="admin-emojis-tabs__emoji"
+        class="admin-emoji-tabs__emoji"
       />
     </:tabs>
   </DPageHeader>

--- a/app/assets/javascripts/admin/addon/templates/permalinks-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-settings.hbs
@@ -1,6 +1,6 @@
 <AdminAreaSettings
   @area="permalinks"
-  @path="/admin/customize/permalinks/settings"
+  @path="/admin/config/permalinks/settings"
   @filter={{this.filter}}
   @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
 />

--- a/app/assets/javascripts/admin/addon/templates/permalinks.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks.hbs
@@ -7,7 +7,7 @@
     <:breadcrumbs>
       <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
       <DBreadcrumbsItem
-        @path="/admin/customize/permalinks"
+        @path="/admin/config/permalinks"
         @label={{i18n "admin.permalink.title"}}
       />
     </:breadcrumbs>

--- a/app/assets/javascripts/admin/addon/templates/user-fields.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-fields.hbs
@@ -8,7 +8,7 @@
     <:breadcrumbs>
       <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
       <DBreadcrumbsItem
-        @path="/admin/customize/user_fields"
+        @path="/admin/config/user-fields"
         @label={{i18n "admin.user_fields.title"}}
       />
     </:breadcrumbs>

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-permalink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-permalink-test.js
@@ -34,7 +34,7 @@ acceptance("Admin - Permalinks", function (needs) {
   });
 
   test("search permalinks with result", async function (assert) {
-    await visit("/admin/customize/permalinks");
+    await visit("/admin/config/permalinks");
     await fillIn(".permalink-search input", "feature");
     assert
       .dom(".permalink-results span[title='c/feature/announcements']")
@@ -42,7 +42,7 @@ acceptance("Admin - Permalinks", function (needs) {
   });
 
   test("search permalinks without results", async function (assert) {
-    await visit("/admin/customize/permalinks");
+    await visit("/admin/config/permalinks");
     await fillIn(".permalink-search input", "garboogle");
 
     assert

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
@@ -17,7 +17,7 @@ module("Integration | Component | emoji-uploader", function (hooks) {
       emojiGroups: ["default", "cool-emojis"],
     });
 
-    pretender.post("/admin/customize/emojis.json", () => {
+    pretender.post("/admin/config/emoji.json", () => {
       requestNumber++;
 
       if (requestNumber === 1) {

--- a/app/controllers/admin/emoji_controller.rb
+++ b/app/controllers/admin/emoji_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::EmojisController < Admin::AdminController
+class Admin::EmojiController < Admin::AdminController
   def index
     render_serialized(Emoji.custom, EmojiSerializer, root: false)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,7 +220,7 @@ Discourse::Application.routes.draw do
       get "customize/theme-components" => "themes#index", :constraints => AdminConstraint.new
       get "customize/colors" => "color_schemes#index", :constraints => AdminConstraint.new
       get "customize/colors/:id" => "color_schemes#index", :constraints => AdminConstraint.new
-      get "customize/permalinks" => "permalinks#index", :constraints => AdminConstraint.new
+      get "config/permalinks" => "permalinks#index", :constraints => AdminConstraint.new
       get "customize/embedding" => "embedding#show", :constraints => AdminConstraint.new
       put "customize/embedding" => "embedding#update", :constraints => AdminConstraint.new
 
@@ -243,15 +243,6 @@ Discourse::Application.routes.draw do
       end
 
       scope "/customize", constraints: AdminConstraint.new do
-        resources :user_fields,
-                  only: %i[index create update destroy],
-                  constraints: AdminConstraint.new
-        get "user_fields/new" => "user_fields#index"
-        get "user_fields/:id" => "user_fields#show"
-        get "user_fields/:id/edit" => "user_fields#edit"
-        resources :emojis, only: %i[index create destroy], constraints: AdminConstraint.new
-        get "emojis/new" => "emojis#index"
-        get "emojis/settings" => "emojis#index"
         resources :form_templates, constraints: AdminConstraint.new, path: "/form-templates" do
           collection { get "preview" => "form_templates#preview" }
         end
@@ -304,8 +295,6 @@ Discourse::Application.routes.draw do
 
         resource :email_style, only: %i[show update]
         get "email_style/:field" => "email_styles#show", :constraints => { field: /html|css/ }
-
-        resources :permalinks, only: %i[index new create show destroy]
       end
 
       resources :embeddable_hosts, only: %i[create update destroy], constraints: AdminConstraint.new
@@ -419,6 +408,26 @@ Discourse::Application.routes.draw do
                   only: %i[index] do
           collection { get "/themes" => "look_and_feel#themes" }
         end
+      end
+
+      scope "/config" do
+        resources :user_fields,
+                  path: "user_fields",
+                  only: %i[index create update destroy],
+                  constraints: AdminConstraint.new
+        get "user-fields/new" => "user_fields#index"
+        get "user-fields/:id" => "user_fields#show"
+        get "user-fields/:id/edit" => "user_fields#edit"
+        get "user-fields" => "user_fields#index"
+
+        get "user_fields/new" => "user_fields#index"
+        get "user_fields/:id" => "user_fields#show"
+        get "user_fields/:id/edit" => "user_fields#edit"
+
+        resources :emoji, only: %i[index create destroy], constraints: AdminConstraint.new
+        get "emoji/new" => "emoji#index"
+        get "emoji/settings" => "emoji#index"
+        resources :permalinks, only: %i[index new create show destroy]
       end
 
       get "section/:section_id" => "section#show", :constraints => AdminConstraint.new

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -71,7 +71,7 @@ To customize the look and feel of your community beyond what you configured in t
 - [Font styles](%{base_url}/admin/site_settings/category/all_results?filter=font)
 - [Site theme](%{base_url}/admin/customize/themes)
 - [Navigation menu](%{base_url}/admin/site_settings/category/navigation)
-- [Custom user fields](%{base_url}/admin/customize/user_fields)
+- [Custom user fields](%{base_url}/admin/config/user-fields)
 - [Terms of service and privacy policies](%{base_url}/admin/site_settings/category/legal)
 
 [details="Advanced options"]

--- a/plugins/automation/test/javascripts/integration/components/da-custom-field-test.js
+++ b/plugins/automation/test/javascripts/integration/components/da-custom-field-test.js
@@ -13,7 +13,7 @@ module("Integration | Component | da-custom-field", function (hooks) {
   hooks.beforeEach(function () {
     this.automation = new AutomationFabricators(getOwner(this)).automation();
 
-    pretender.get("/admin/config/user-fields", () => {
+    pretender.get("/admin/config/user_fields", () => {
       return response({
         user_fields: [
           {

--- a/plugins/automation/test/javascripts/integration/components/da-custom-field-test.js
+++ b/plugins/automation/test/javascripts/integration/components/da-custom-field-test.js
@@ -13,7 +13,7 @@ module("Integration | Component | da-custom-field", function (hooks) {
   hooks.beforeEach(function () {
     this.automation = new AutomationFabricators(getOwner(this)).automation();
 
-    pretender.get("/admin/customize/user_fields", () => {
+    pretender.get("/admin/config/user-fields", () => {
       return response({
         user_fields: [
           {

--- a/spec/requests/admin/emojis_controller_spec.rb
+++ b/spec/requests/admin/emojis_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Admin::EmojisController do
+RSpec.describe Admin::EmojiController do
   fab!(:admin)
   fab!(:moderator)
   fab!(:user)
@@ -10,11 +10,11 @@ RSpec.describe Admin::EmojisController do
     context "when logged in as an admin" do
       before { sign_in(admin) }
 
-      it "returns a list of custom emojis" do
+      it "returns a list of custom emoji" do
         CustomEmoji.create!(name: "osama-test-emoji", upload: upload, user: admin)
         Emoji.clear_cache
 
-        get "/admin/customize/emojis.json"
+        get "/admin/config/emoji.json"
         expect(response.status).to eq(200)
 
         json = response.parsed_body
@@ -24,9 +24,9 @@ RSpec.describe Admin::EmojisController do
       end
     end
 
-    shared_examples "custom emojis inaccessible" do
+    shared_examples "custom emoji inaccessible" do
       it "denies access with a 404 response" do
-        get "/admin/customize/emojis.json"
+        get "/admin/config/emoji.json"
 
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
@@ -36,13 +36,13 @@ RSpec.describe Admin::EmojisController do
     context "when logged in as a moderator" do
       before { sign_in(moderator) }
 
-      include_examples "custom emojis inaccessible"
+      include_examples "custom emoji inaccessible"
     end
 
     context "when logged in as a non-staff user" do
       before { sign_in(user) }
 
-      include_examples "custom emojis inaccessible"
+      include_examples "custom emoji inaccessible"
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe Admin::EmojisController do
 
       context "when upload is invalid" do
         it "should publish the right error" do
-          post "/admin/customize/emojis.json",
+          post "/admin/config/emoji.json",
                params: {
                  name: "test",
                  file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/fake.jpg"),
@@ -68,7 +68,7 @@ RSpec.describe Admin::EmojisController do
         it "should publish the right error" do
           CustomEmoji.create!(name: "test", upload: upload)
 
-          post "/admin/customize/emojis.json",
+          post "/admin/config/emoji.json",
                params: {
                  name: "test",
                  file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -85,7 +85,7 @@ RSpec.describe Admin::EmojisController do
       it "should allow an admin to add a custom emoji" do
         Emoji.expects(:clear_cache)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "test",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -108,7 +108,7 @@ RSpec.describe Admin::EmojisController do
       it "should log the action" do
         Emoji.expects(:clear_cache)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "test",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -124,7 +124,7 @@ RSpec.describe Admin::EmojisController do
       it "should allow an admin to add a custom emoji with a custom group" do
         Emoji.expects(:clear_cache)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "test",
                group: "Foo",
@@ -141,7 +141,7 @@ RSpec.describe Admin::EmojisController do
       it "should fix up the emoji name" do
         Emoji.expects(:clear_cache).times(3)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "test.png",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -154,7 +154,7 @@ RSpec.describe Admin::EmojisController do
         expect(custom_emoji.name).to eq("test")
         expect(response.status).to eq(200)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "st&#* onk$",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -164,7 +164,7 @@ RSpec.describe Admin::EmojisController do
         expect(custom_emoji.name).to eq("st_onk_")
         expect(response.status).to eq(200)
 
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "PaRTYpaRrot",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -178,7 +178,7 @@ RSpec.describe Admin::EmojisController do
 
     shared_examples "custom emoji creation not allowed" do
       it "prevents creation with a 404 response" do
-        post "/admin/customize/emojis.json",
+        post "/admin/config/emoji.json",
              params: {
                name: "test",
                file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png"),
@@ -211,7 +211,7 @@ RSpec.describe Admin::EmojisController do
         Emoji.clear_cache
 
         expect do
-          delete "/admin/customize/emojis/#{custom_emoji.name}.json", params: { name: "test" }
+          delete "/admin/config/emoji/#{custom_emoji.name}.json", params: { name: "test" }
         end.to change { CustomEmoji.count }.by(-1)
       end
 
@@ -219,7 +219,7 @@ RSpec.describe Admin::EmojisController do
         custom_emoji = CustomEmoji.create!(name: "test", upload: upload)
         Emoji.clear_cache
 
-        delete "/admin/customize/emojis/#{custom_emoji.name}.json", params: { name: "test" }
+        delete "/admin/config/emoji/#{custom_emoji.name}.json", params: { name: "test" }
 
         last_log = UserHistory.last
 
@@ -234,7 +234,7 @@ RSpec.describe Admin::EmojisController do
         custom_emoji = CustomEmoji.create!(name: "test", upload: upload)
         Emoji.clear_cache
 
-        delete "/admin/customize/emojis/#{custom_emoji.name}.json", params: { name: "test" }
+        delete "/admin/config/emoji/#{custom_emoji.name}.json", params: { name: "test" }
 
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))

--- a/spec/requests/admin/user_fields_controller_spec.rb
+++ b/spec/requests/admin/user_fields_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "creates a user field" do
         expect {
-          post "/admin/customize/user_fields.json",
+          post "/admin/config/user-fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -27,7 +27,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "creates a user field with options" do
         expect do
-          post "/admin/customize/user_fields.json",
+          post "/admin/config/user-fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -48,7 +48,7 @@ RSpec.describe Admin::UserFieldsController do
     shared_examples "user field creation not allowed" do
       it "prevents creation with a 404 response" do
         expect do
-          post "/admin/customize/user_fields.json",
+          post "/admin/config/user-fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -83,7 +83,7 @@ RSpec.describe Admin::UserFieldsController do
       before { sign_in(admin) }
 
       it "returns a list of user fields" do
-        get "/admin/customize/user_fields.json"
+        get "/admin/config/user-fields.json"
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_fields"]).to be_present
@@ -92,7 +92,7 @@ RSpec.describe Admin::UserFieldsController do
 
     shared_examples "user fields inaccessible" do
       it "denies access with a 404 response" do
-        get "/admin/customize/user_fields.json"
+        get "/admin/config/user-fields.json"
 
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
@@ -121,7 +121,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "deletes the user field" do
         expect {
-          delete "/admin/customize/user_fields/#{user_field.id}.json"
+          delete "/admin/config/user-fields/#{user_field.id}.json"
           expect(response.status).to eq(200)
         }.to change(UserField, :count).by(-1)
       end
@@ -129,7 +129,7 @@ RSpec.describe Admin::UserFieldsController do
 
     shared_examples "user field deletion not allowed" do
       it "prevents deletion with a 404 response" do
-        expect do delete "/admin/customize/user_fields/#{user_field.id}.json" end.not_to change {
+        expect do delete "/admin/config/user-fields/#{user_field.id}.json" end.not_to change {
           UserField.count
         }
 
@@ -158,7 +158,7 @@ RSpec.describe Admin::UserFieldsController do
       before { sign_in(admin) }
 
       it "updates the user field" do
-        put "/admin/customize/user_fields/#{user_field.id}.json",
+        put "/admin/config/user-fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -177,7 +177,7 @@ RSpec.describe Admin::UserFieldsController do
       end
 
       it "updates the user field options" do
-        put "/admin/customize/user_fields/#{user_field.id}.json",
+        put "/admin/config/user-fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -195,7 +195,7 @@ RSpec.describe Admin::UserFieldsController do
       end
 
       it "keeps options when updating the user field" do
-        put "/admin/customize/user_fields/#{user_field.id}.json",
+        put "/admin/config/user-fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -210,7 +210,7 @@ RSpec.describe Admin::UserFieldsController do
         user_field.reload
         expect(user_field.user_field_options.size).to eq(2)
 
-        put "/admin/customize/user_fields/#{user_field.id}.json",
+        put "/admin/config/user-fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -234,7 +234,7 @@ RSpec.describe Admin::UserFieldsController do
           position: next_position,
         )
         expect {
-          put "/admin/customize/user_fields/#{user_field.id}.json",
+          put "/admin/config/user-fields/#{user_field.id}.json",
               params: {
                 user_field: {
                   show_on_profile: false,
@@ -251,7 +251,7 @@ RSpec.describe Admin::UserFieldsController do
         user_field.reload
         original_name = user_field.name
 
-        put "/admin/customize/user_fields/#{user_field.id}.json",
+        put "/admin/config/user-fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",

--- a/spec/requests/admin/user_fields_controller_spec.rb
+++ b/spec/requests/admin/user_fields_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "creates a user field" do
         expect {
-          post "/admin/config/user-fields.json",
+          post "/admin/config/user_fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -27,7 +27,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "creates a user field with options" do
         expect do
-          post "/admin/config/user-fields.json",
+          post "/admin/config/user_fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -48,7 +48,7 @@ RSpec.describe Admin::UserFieldsController do
     shared_examples "user field creation not allowed" do
       it "prevents creation with a 404 response" do
         expect do
-          post "/admin/config/user-fields.json",
+          post "/admin/config/user_fields.json",
                params: {
                  user_field: {
                    name: "hello",
@@ -83,7 +83,7 @@ RSpec.describe Admin::UserFieldsController do
       before { sign_in(admin) }
 
       it "returns a list of user fields" do
-        get "/admin/config/user-fields.json"
+        get "/admin/config/user_fields.json"
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_fields"]).to be_present
@@ -92,7 +92,7 @@ RSpec.describe Admin::UserFieldsController do
 
     shared_examples "user fields inaccessible" do
       it "denies access with a 404 response" do
-        get "/admin/config/user-fields.json"
+        get "/admin/config/user_fields.json"
 
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
@@ -121,7 +121,7 @@ RSpec.describe Admin::UserFieldsController do
 
       it "deletes the user field" do
         expect {
-          delete "/admin/config/user-fields/#{user_field.id}.json"
+          delete "/admin/config/user_fields/#{user_field.id}.json"
           expect(response.status).to eq(200)
         }.to change(UserField, :count).by(-1)
       end
@@ -129,7 +129,7 @@ RSpec.describe Admin::UserFieldsController do
 
     shared_examples "user field deletion not allowed" do
       it "prevents deletion with a 404 response" do
-        expect do delete "/admin/config/user-fields/#{user_field.id}.json" end.not_to change {
+        expect do delete "/admin/config/user_fields/#{user_field.id}.json" end.not_to change {
           UserField.count
         }
 
@@ -158,7 +158,7 @@ RSpec.describe Admin::UserFieldsController do
       before { sign_in(admin) }
 
       it "updates the user field" do
-        put "/admin/config/user-fields/#{user_field.id}.json",
+        put "/admin/config/user_fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -177,7 +177,7 @@ RSpec.describe Admin::UserFieldsController do
       end
 
       it "updates the user field options" do
-        put "/admin/config/user-fields/#{user_field.id}.json",
+        put "/admin/config/user_fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -195,7 +195,7 @@ RSpec.describe Admin::UserFieldsController do
       end
 
       it "keeps options when updating the user field" do
-        put "/admin/config/user-fields/#{user_field.id}.json",
+        put "/admin/config/user_fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -210,7 +210,7 @@ RSpec.describe Admin::UserFieldsController do
         user_field.reload
         expect(user_field.user_field_options.size).to eq(2)
 
-        put "/admin/config/user-fields/#{user_field.id}.json",
+        put "/admin/config/user_fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",
@@ -234,7 +234,7 @@ RSpec.describe Admin::UserFieldsController do
           position: next_position,
         )
         expect {
-          put "/admin/config/user-fields/#{user_field.id}.json",
+          put "/admin/config/user_fields/#{user_field.id}.json",
               params: {
                 user_field: {
                   show_on_profile: false,
@@ -251,7 +251,7 @@ RSpec.describe Admin::UserFieldsController do
         user_field.reload
         original_name = user_field.name
 
-        put "/admin/config/user-fields/#{user_field.id}.json",
+        put "/admin/config/user_fields/#{user_field.id}.json",
             params: {
               user_field: {
                 name: "fraggle",

--- a/spec/system/page_objects/admin_emojis.rb
+++ b/spec/system/page_objects/admin_emojis.rb
@@ -4,16 +4,16 @@ module PageObjects
   module Pages
     class AdminEmojis < PageObjects::Pages::Base
       def visit_page
-        page.visit "/admin/customize/emojis"
+        page.visit "/admin/config/emoji"
         self
       end
 
       def click_tab(tab_name)
         case tab_name
         when "settings"
-          find(".admin-emojis-tabs__settings").click
+          find(".admin-emoji-tabs__settings").click
         when "index"
-          find(".admin-emojis-tabs__emoji").click
+          find(".admin-emoji-tabs__emoji").click
         end
       end
 

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Pages
     class AdminPermalinks < PageObjects::Pages::Base
       def visit
-        page.visit("/admin/customize/permalinks")
+        page.visit("/admin/config/permalinks")
         self
       end
 

--- a/spec/system/page_objects/pages/admin_user_fields.rb
+++ b/spec/system/page_objects/pages/admin_user_fields.rb
@@ -4,7 +4,7 @@ module PageObjects
   module Pages
     class AdminUserFields < PageObjects::Pages::Base
       def visit
-        page.visit "admin/customize/user_fields"
+        page.visit "admin/config/user-fields"
         self
       end
 


### PR DESCRIPTION
The customize routes add CSS classes that make these admin
config pages look different from the ones under /admin/config.
We want all config routes to be under /admin/config as well.

This commit moves the emoji, user fields, and permalinks pages
out of customize and into config, updating all references and
adding more rails routes as needed.

Also renames admin emojis route to emoji, emoji is singular and plural.
