### PR TITLE
FIX: correctly extract body and/or reply from exchange emails

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -568,17 +568,16 @@ module Email
       reply = doc.css("div[name='messageReplySection']")
       body = doc.css("div[name='messageBodySection']")
 
-      if reply.blank? && body.blank?
-        # should not be possible
-        to_markdown(doc.to_html, "")
-      elsif reply.blank? && body.present?
-        to_markdown(body.to_html, "")
-      elsif reply.present? && body.blank?
-        to_markdown(reply.to_html, "")
-      else
+    if reply.present? && body.present?
         elided = doc.css("div[name='messageReplySection']").remove
         body = doc.css("div[name='messageBodySection']")
         to_markdown(body.to_html, elided.to_html)
+      elsif reply.present?
+        to_markdown(reply.to_html, "")
+      elsif body.present?
+        to_markdown(body.to_html, "")
+      else
+        to_markdown(doc.to_html, "") 
       end
     end
 

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -568,7 +568,7 @@ module Email
       reply = doc.css("div[name='messageReplySection']")
       body = doc.css("div[name='messageBodySection']")
 
-    if reply.present? && body.present?
+      if reply.present? && body.present?
         elided = doc.css("div[name='messageReplySection']").remove
         body = doc.css("div[name='messageBodySection']")
         to_markdown(body.to_html, elided.to_html)

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -564,10 +564,22 @@ module Email
     end
 
     def extract_from_exchange(doc)
-      # Exchange is using the 'messageReplySection' class for forwarded emails
-      # And 'messageBodySection' for the actual email
-      elided = doc.css("div[name='messageReplySection']").remove
-      to_markdown(doc.css("div[name='messageReplySection']").to_html, elided.to_html)
+      # Exchange is using 'messageReplySection' for forwarded emails and 'messageBodySection' for the actual email
+      reply = doc.css("div[name='messageReplySection']")
+      body = doc.css("div[name='messageBodySection']")
+
+      if reply.blank? && body.blank?
+        # should not be possible
+        to_markdown(doc.to_html, "")
+      elsif reply.blank? && body.present?
+        to_markdown(body.to_html, "")
+      elsif reply.present? && body.blank?
+        to_markdown(reply.to_html, "")
+      else
+        elided = doc.css("div[name='messageReplySection']").remove
+        body = doc.css("div[name='messageBodySection']")
+        to_markdown(body.to_html, elided.to_html)
+      end
     end
 
     def extract_from_apple_mail(doc)

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -577,7 +577,7 @@ module Email
       elsif body.present?
         to_markdown(body.to_html, "")
       else
-        to_markdown(doc.to_html, "") 
+        to_markdown(doc.to_html, "")
       end
     end
 

--- a/spec/fixtures/emails/exchange_html_body.eml
+++ b/spec/fixtures/emails/exchange_html_body.eml
@@ -1,0 +1,14 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2017 00:12:43 +0100
+Message-ID: <180@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>
+  <div name="messageBodySection">
+    <p>This is the <b>body</b> of the email.</p>
+  </div>
+</div>

--- a/spec/fixtures/emails/exchange_html_body_and_reply.eml
+++ b/spec/fixtures/emails/exchange_html_body_and_reply.eml
@@ -1,0 +1,17 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2017 00:12:43 +0100
+Message-ID: <180@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>
+  <div name="messageBodySection">
+    <p>This is the <b>body</b> of the email.</p>
+  </div>
+  <div name="messageReplySection">
+    <p>This is the <i>reply</i>!</p>
+  </div>
+</div>

--- a/spec/fixtures/emails/exchange_html_reply.eml
+++ b/spec/fixtures/emails/exchange_html_reply.eml
@@ -1,0 +1,14 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2017 00:12:43 +0100
+Message-ID: <180@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div>
+  <div name="messageReplySection">
+    <p>This is the <b>body !!</b> of the email.</p>
+  </div>
+</div>


### PR DESCRIPTION
When receiving emails sent with Exchange, we look for some markers to identify the body of the mail and the reply (aka. previous email).

For some reasons, those markers aren't 100% reliable and sometimes, only one of them is present.

The commit 20ba54d53630b57c25fa3f325b0f219581314936 introduced the bug because the `HTML_EXTRACTERS` regex for exchange looks for either `messageBodySection` or `messageReplySection` but we were only using the `reply` section. So if an email had only the `body` section, it would not be correctly extracted.

This commit handle the cases where either one of them is missing and use the other one as the actual "reply". When both are present, it correctly elides the "reply" section.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->