### PR TITLE
FEATURE: add support for One-Click unsubscribe (RFC 8058)

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -26,7 +26,7 @@ class EmailController < ApplicationController
   def perform_unsubscribe
     RateLimiter.new(nil, "unsubscribe_#{request.ip}", 10, 1.minute).performed!
 
-    key = UnsubscribeKey.find_by(key: params[:key])
+    key = UnsubscribeKey.includes(:user).find_by(key: params[:key])
     raise Discourse::NotFound if key.nil? || key.user.nil?
     user = key.user
     updated = UnsubscribeKey.get_unsubscribe_strategy_for(key)&.unsubscribe(params)
@@ -46,10 +46,12 @@ class EmailController < ApplicationController
 
   def unsubscribed
     @email = Discourse.cache.read(params[:key])
-    @topic_id = params[:topic_id]
-    user = User.find_by_email(@email)
-    raise Discourse::NotFound unless user
-    topic = Topic.find_by(id: params[:topic_id].to_i) if @topic_id
-    @topic = topic if topic && Guardian.new(nil).can_see?(topic)
+
+    raise Discourse::NotFound unless User.find_by_email(@email)
+
+    if @topic_id = params[:topic_id]
+      topic = Topic.find_by(id: @topic_id)
+      @topic = topic if topic && Guardian.new.can_see?(topic)
+    end
   end
 end

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -223,10 +223,14 @@ module Email
 
     def header_args
       result = {}
+
       if @opts[:add_unsubscribe_link]
-        unsubscribe_url =
-          @template_args[:unsubscribe_url].presence || @template_args[:user_preferences_url]
-        result["List-Unsubscribe"] = "<#{unsubscribe_url}>"
+        if unsubscribe_url = @template_args[:unsubscribe_url].presence
+          result["List-Unsubscribe"] = "<#{unsubscribe_url}>"
+          result["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+        else
+          result["List-Unsubscribe"] = "<#{@template_args[:user_preferences_url]}>"
+        end
       end
 
       result["X-Discourse-Post-Id"] = @opts[:post_id].to_s if @opts[:post_id]

--- a/spec/lib/email/message_builder_spec.rb
+++ b/spec/lib/email/message_builder_spec.rb
@@ -335,6 +335,12 @@ RSpec.describe Email::MessageBuilder do
         expect(message_with_unsubscribe.header_args["List-Unsubscribe"]).to be_present
       end
 
+      it "has the List-Unsubscribe-Post header" do
+        expect(message_with_unsubscribe.header_args["List-Unsubscribe-Post"]).to eq(
+          "List-Unsubscribe=One-Click",
+        )
+      end
+
       it "has the unsubscribe url in the body" do
         expect(message_with_unsubscribe.body).to match("/t/1234/unsubscribe")
       end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe UserNotifications do
         expect(email.html_part.body.to_s).to be_present
         expect(email.text_part.body.to_s).to be_present
         expect(email.header["List-Unsubscribe"].to_s).to match(/\/email\/unsubscribe\/\h{64}/)
+        expect(email.header["List-Unsubscribe-Post"].to_s).to eq("List-Unsubscribe=One-Click")
         expect(email.header["X-Discourse-Topic-Ids"].to_s).to eq(
           "#{another_popular_topic.id},#{popular_topic.id}",
         )
@@ -437,6 +438,7 @@ RSpec.describe UserNotifications do
         expect(email.header["List-Unsubscribe"].to_s).to match(
           /http:\/\/test.localhost\/forum\/email\/unsubscribe\/\h{64}/,
         )
+        expect(email.header["List-Unsubscribe-Post"].to_s).to eq("List-Unsubscribe=One-Click")
 
         topic_url = "http://test.localhost/forum/t/#{popular_topic.slug}/#{popular_topic.id}"
         expect(html).to include(topic_url)


### PR DESCRIPTION
We were missing the "List-Unsubscribe-Post" header in emails we sent to allow Yahoo / GMail and others to automagically show a link to unsubscribe.

Internal ref - t/144713

