### PR TITLE
FIX: Fallback when embedding YouTube videos with lazy videos

### DIFF
--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_youtube.rb
@@ -20,6 +20,8 @@ class Onebox::Engine::YoutubeOnebox
         thumbnail_url = result[:image]
       end
 
+      return default_onebox_to_html if video_title.chomp("- YouTube").blank? || thumbnail_url.blank?
+
       escaped_title = ERB::Util.html_escape(video_title)
       escaped_start_time = ERB::Util.html_escape(params["t"])
       t_param = "&t=#{escaped_start_time}" if escaped_start_time.present?


### PR DESCRIPTION
<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->