### PR TITLE
UX: replace partially written emoji when using picker on chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -377,7 +377,7 @@ export default class ChatComposer extends Component {
   onSelectEmoji(emoji) {
     const code = `:${emoji}:`;
     this.chatEmojiReactionStore.track(code);
-    this.composer.textarea.addText(this.composer.textarea.getSelected(), code);
+    this.composer.textarea.emojiSelected(emoji);
 
     if (this.site.desktopView) {
       this.composer.focus();

--- a/plugins/chat/assets/javascripts/discourse/lib/textarea-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/textarea-interactor.js
@@ -116,4 +116,8 @@ export default class TextareaInteractor extends EmberObject {
   isInside() {
     return this.textManipulation.isInside(...arguments);
   }
+
+  emojiSelected(code) {
+    this.textManipulation.emojiSelected(code);
+  }
 }

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe "Chat composer", type: :system do
       expect(page).to have_selector(".chat-emoji-picker [data-emoji='fr']")
       expect(page).to have_no_selector(".chat-emoji-picker [data-emoji='grinning']")
     end
+
+    it "replaces the partially typed emoji with the selected" do
+      chat_page.visit_channel(channel_1)
+      find(".chat-composer__input").fill_in(with: "hey :gri")
+
+      click_link(I18n.t("js.composer.more_emoji"))
+      find("[data-emoji='grimacing']").click(wait: 0.5)
+
+      expect(channel_page.composer.value).to eq("hey :grimacing:")
+    end
   end
 
   context "when typing on keyboard" do


### PR DESCRIPTION
### Before

https://github.com/user-attachments/assets/26c4f338-72ae-4af0-9119-6d4bd86250a1


### After

https://github.com/user-attachments/assets/b70a2059-aaef-4fa1-9fb6-2b84df765080

