### PR TITLE
DEV: allows d-menu to refocus trigger

### DIFF
--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -64,7 +64,7 @@ export default class NotificationsTracking extends Component {
 
   @action
   async setNotificationLevel(level) {
-    await this.dmenuApi.close();
+    await this.dmenuApi.close({ focusTrigger: true });
     this.args.onChange?.(level);
   }
 

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -350,4 +350,43 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
     assert.dom(".fk-d-menu__trigger.first").doesNotExist();
     assert.dom(".fk-d-menu.first").exists();
   });
+
+  test("focusTrigger on close", async function (assert) {
+    this.api = null;
+    this.onRegisterApi = (api) => (this.api = api);
+    this.close = async () => await this.api.close();
+
+    await render(
+      hbs`<DMenu @onRegisterApi={{this.onRegisterApi}} @inline={{true}} @icon="xmark">
+        <DButton @icon="xmark" class="close" @action={{this.close}} />
+      </DMenu>`
+    );
+
+    await click(".fk-d-menu__trigger");
+    await triggerKeyEvent(document.activeElement, "keydown", "Tab");
+    await triggerKeyEvent(document.activeElement, "keydown", "Enter");
+
+    assert.strictEqual(
+      document.activeElement,
+      document.querySelector(".fk-d-menu__trigger")
+    );
+  });
+
+  test("focusTrigger=false on close", async function (assert) {
+    this.api = null;
+    this.onRegisterApi = (api) => (this.api = api);
+    this.close = async () => await this.api.close({ focusTrigger: false });
+
+    await render(
+      hbs`<DMenu @onRegisterApi={{this.onRegisterApi}} @inline={{true}} @icon="xmark">
+        <DButton @icon="xmark" class="close" @action={{this.close}} />
+      </DMenu>`
+    );
+
+    await click(".fk-d-menu__trigger");
+    await triggerKeyEvent(document.activeElement, "keydown", "Tab");
+    await triggerKeyEvent(document.activeElement, "keydown", "Enter");
+
+    assert.strictEqual(document.activeElement, document.body);
+  });
 });

--- a/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-float-body.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { concat, fn, hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { modifier as modifierFn } from "ember-modifier";
 import concatClass from "discourse/helpers/concat-class";
@@ -70,7 +70,9 @@ export default class DFloatBody extends Component {
         {{(if
           this.supportsCloseOnClickOutside
           (modifier
-            closeOnClickOutside @instance.close (hash target=this.content)
+            closeOnClickOutside
+            (fn @instance.close (hash focusTrigger=false))
+            (hash target=this.content)
           )
         )}}
         {{(if

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import { and } from "truth-helpers";
@@ -37,6 +38,11 @@ export default class DMenu extends Component {
   @action
   registerFloatBody(element) {
     this.body = element;
+  }
+
+  @action
+  teardownFloatBody() {
+    this.body = null;
   }
 
   @action
@@ -151,6 +157,7 @@ export default class DMenu extends Component {
           @role="dialog"
           @inline={{this.options.inline}}
           {{didInsert this.registerFloatBody}}
+          {{willDestroy this.teardownFloatBody}}
         >
           {{#if (has-block)}}
             {{yield this.componentArgs}}

--- a/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
@@ -54,7 +54,7 @@ export default class DMenuInstance extends FloatKitInstance {
   }
 
   @action
-  async close() {
+  async close(options = { focusTrigger: true }) {
     if (getOwner(this).isDestroying) {
       return;
     }
@@ -66,6 +66,10 @@ export default class DMenuInstance extends FloatKitInstance {
     }
 
     await this.menu.close(this);
+
+    if (options.focusTrigger) {
+      this.trigger?.focus();
+    }
   }
 
   @action

--- a/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
@@ -68,7 +68,7 @@ export default class DMenuInstance extends FloatKitInstance {
     await this.menu.close(this);
 
     if (options.focusTrigger) {
-      this.trigger?.focus();
+      this.trigger?.focus?.();
     }
   }
 


### PR DESCRIPTION
The trigger will now be refocused after closing the menu by default. This is very useful for tab behavior, otherwise after closing the menu, the body could be focused making it impossible to re-open the menu with Enter or just move up/down the flow.

If you want to disable this behavior:

```javascript
this.menuApi.close({focusTrigger: false});
```

This behavior is already disabled when closing after clicking outside. We don't want to risk interfering with the click of the user.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->