### PR TITLE
FIX: Wizard branding step null logo

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/image.js
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/image.js
@@ -31,6 +31,7 @@ export default class Image extends Component {
   hasUpload() {
     return (
       !this.uploading &&
+      this.field.value &&
       !this.field.value.includes("discourse-logo-sketch-small.png")
     );
   }

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -59,6 +59,11 @@ describe "Wizard", type: :system do
     let(:file_path_1) { file_from_fixtures("logo.png", "images").path }
     let(:file_path_2) { file_from_fixtures("logo.jpg", "images").path }
 
+    before do
+      SiteSetting.logo = nil
+      SiteSetting.logo_small = nil
+    end
+
     it "lets user configure logos" do
       wizard_page.go_to_step("branding")
       expect(wizard_page).to be_on_step("branding")


### PR DESCRIPTION
Followup 3135f472e2c4221a9348aec27514d3e2947bc9ab

Fixes an issue where the wizard branding step would
error if SiteSetting.logo was null, this did not come
up during testing because in our testing discourse-logo-sketch-small.png
is used for the logo settings.
