### PR TITLE
FIX: Reports did not respect user locale

### DIFF
--- a/lib/hijack.rb
+++ b/lib/hijack.rb
@@ -13,6 +13,10 @@ module Hijack
       request.env["discourse.request_tracker.skip"] = true
       request_tracker = request.env["discourse.request_tracker"]
 
+      # need this because we can't call with_resolved_locale with around_action
+      # when we are evaluating the block
+      resolved_locale = I18n.locale
+
       # in the past unicorn would recycle env, this is not longer the case
       env = request.env
 
@@ -61,7 +65,7 @@ module Hijack
 
           view_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           begin
-            instance.instance_eval(&blk)
+            I18n.with_locale(resolved_locale) { instance.instance_eval(&blk) }
           rescue => e
             # TODO we need to reuse our exception handling in ApplicationController
             Discourse.warn_exception(

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -56,8 +56,9 @@ RSpec.describe Admin::ReportsController do
       before { sign_in(admin) }
 
       context "with valid params" do
+        fab!(:topic)
+
         it "renders the reports as JSON" do
-          Fabricate(:topic)
           get "/admin/reports/bulk.json",
               params: {
                 reports: {
@@ -72,6 +73,30 @@ RSpec.describe Admin::ReportsController do
 
           expect(response.status).to eq(200)
           expect(response.parsed_body["reports"].count).to eq(2)
+        end
+
+        it "uses the user's locale for report names and descriptions" do
+          SiteSetting.allow_user_locale = true
+          admin.update!(locale: "es")
+          get "/admin/reports/bulk.json",
+              params: {
+                reports: {
+                  topics: {
+                    limit: 10,
+                  },
+                  likes: {
+                    limit: 10,
+                  },
+                },
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["reports"].first["title"]).to eq(
+            I18n.t("reports.topics.title", locale: "es"),
+          )
+          expect(response.parsed_body["reports"].first["description"]).to eq(
+            I18n.t("reports.topics.description", locale: "es"),
+          )
         end
       end
 


### PR DESCRIPTION
Our bulk report endpoint uses `hijack`, which does not
use the current user's locale via the `with_resolved_locale`
method in `ApplicationController`. This is happening because
we are doing `around_action` to set the locale, then calling
the code in the block inside the action directly when we use
`hijack`.

We can fix this by capturing `I18n.locale` when starting the
hijack then using `I18n.with_locale` when evaluating the
block inside `hijack`, this way the translations will always
use the correct locale based on the current user.

c.f. https://meta.discourse.org/t/titles-on-graphs-in-community-health-dashboard-are-not-localized/302776/5
