### PR TITLE
DEV: Add translator comments for site setting keyword entries

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2811,848 +2811,3368 @@ en:
       invalid_uncategorized_category_setting: 'The "Uncategorized" category cannot be selected if ''allow uncategorized topics'' is not enabled.'
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
 
+    # Run `RAILS_ENV=development bundle exec rake site_settings:add_keyword_translation_keys` to update this section.
+
     keywords:
-      # Run `RAILS_ENV=development bundle exec rake site_settings:add_keyword_translation_keys` to update this section.
       # BEGIN KEYWORDS
+
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Do not show members of specific groups on the /about page.""
       about_page_hidden_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How frequently we update the 'last_seen_at' field, in seconds""
       active_user_rate_limit_secs: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Add rel nofollow to all submitted user content, except for internal links (including parent domains). If you change this, you must rebake all posts with: \"rake posts:rebake\"""
       add_rel_nofollow_to_user_content: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable sidebar navigation for the admin UI for the specified groups, which replaces the top-level admin navigation buttons.""
       admin_sidebar_enabled_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)""
       adobe_analytics_tags_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of errors per hour in order to trigger an admin alert. A value of 0 disables this feature. NOTE: requires restart.""
       alert_admins_if_errors_per_hour: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of errors per minute in order to trigger an admin alert. A value of 0 disables this feature. NOTE: requires restart.""
       alert_admins_if_errors_per_minute: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow all email attachments for group messages.""
       allow_all_attachments_for_group_messages: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable this setting to allow users who are browsing your site anonymously to like posts. When activated, users can opt for their identities to be hidden when liking posts or topics throughout the site. See also `allow_anonymous_posting`.""
       allow_anonymous_likes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the option for users to switch to anonymous mode for posting. When activated, users can opt for their identities to be hidden when creating posts or topics throughout the site. See also `allow_anonymous_likes`.""
       allow_anonymous_posting: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow bulk invites by uploading a CSV file""
       allow_bulk_invite: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow a staged user's category and tag notification preferences to be changed by an admin user.""
       allow_changing_staged_user_tracking: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow topics with identical, duplicate titles.""
       allow_duplicate_topic_titles: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow topics with identical, duplicate titles if the category is different. allow_duplicate_topic_titles must be disabled.""
       allow_duplicate_topic_titles_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to feature a link to a topic on their user card and profile.""
       allow_featured_topic_on_user_profiles: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If enabled, users can flag posts from staff accounts.""
       allow_flagging_staff: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify in robots.txt that this site is allowed to be indexed by web search engines. You can <a href='%{base_path}/admin/customize/robots'>override your robots.txt here.</a> <b>WARNING</b>: Misconfigured rules could prevent your site from being crawled as expected.""
       allow_index_in_robots_txt: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow new user registrations. Uncheck this to prevent anyone from creating a new account.""
       allow_new_registrations: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to upload profile backgrounds.""
       allow_profile_backgrounds: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow restore, which can replace ALL site data! Leave disabled unless you plan to restore a backup""
       allow_restore: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow staff members to upload any files in PM.""
       allow_staff_to_upload_any_file_in_pm: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow topics to be created without a category. WARNING: If there are any uncategorized topics, you must recategorize them before turning this off.""
       allow_uncategorized_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to upload custom profile pictures.""
       allow_uploaded_avatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow all caps in a topic title or a post body.""
       allow_uppercase_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of scopes allowed for user API keys""
       allow_user_api_key_scopes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to choose their own language interface preference""
       allow_user_locale: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow usernames to be included in share links. This is useful to reward badges based on unique visitors.""
       allow_username_in_share_links: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to hide their profile and presence""
       allow_users_to_hide_profile: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User agents of web crawlers that should be allowed to access the site. WARNING! SETTING THIS WILL DISALLOW ALL CRAWLERS NOT LISTED HERE!""
       allowed_crawler_user_agents: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A pipe-delimited list of email domains that users MUST register accounts with. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported. WARNING: Users with email domains other than those listed will not be allowed!""
       allowed_email_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A comma separated list of CSS elements that are allowed in embeds.""
       allowed_embed_selectors: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Schemes allowed in links in addition to http and https.""
       allowed_href_schemes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of iframe src URL prefixes that Discourse can safely allow in posts""
       allowed_iframes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of domains that will be oneboxed in miniature form if linked without a title""
       allowed_inline_onebox_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of internal hosts that discourse can safely crawl for oneboxing and other purposes""
       allowed_internal_hosts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Domains that users may link to even if they don't have the appropriate trust level to post links""
       allowed_link_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of iframe src domains which are allowed via Onebox embeds. `*` will allow all default Onebox engines.""
       allowed_onebox_iframes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of domains excluded from spam host testing. New users will never be restricted from creating posts with links to these domains.""
       allowed_spam_host_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Regular expression to allow only some Unicode characters within usernames. ASCII letters and numbers will always be allowed and don't need to be included in the allowlist.""
       allowed_unicode_username_characters: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allowed URL for authentication redirect for user API keys. Wildcard symbol * can be used to match any part of it (e.g. www.example.com/*).""
       allowed_user_api_auth_redirects: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allowed URLs for server push to user API""
       allowed_user_api_push_urls: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User website will be verified against these domains. Pipe-delimited list.""
       allowed_user_website_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of alternative templates for reply by email incoming email addresses. Example: %%{reply_key}@reply.example.com|replies+%%{reply_key}@example.com""
       alternative_reply_by_email_addresses: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Always show trimmed part of incoming emails. WARNING: might reveal email addresses.""
       always_show_trimmed_content: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How often should anonymous clients poll in milliseconds""
       anon_polling_interval: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created.""
       anonymous_account_duration_minutes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to enable anonymous posting""
       anonymous_posting_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum trust level required to enable anonymous posting""
       anonymous_posting_min_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Contents of <a href='%{base_path}/.well-known/assetlinks.json'>.well-known/assetlinks.json</a> endpoint, used for Google's Digital Asset Links API.""
       app_association_android: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Contents of <a href='%{base_path}/apple-app-site-association'>apple-app-site-association</a> endpoint, used to create Universal Links between this site and iOS apps.""
       app_association_ios: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Icon used for Apple touch devices. A transparent background is not reccomended. Will be automatically resized to 180x180. If left blank, large_icon will be used.""
       apple_touch_icon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Custom email template and css are applied to summary emails.""
       apply_custom_styles_to_digest: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""New topics created by users not in these groups must be approved. Topics created by admins and moderators are always approved.""
       approve_new_topics_unless_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""New topics created by users below this trust level must be approved""
       approve_new_topics_unless_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The amount of posts from a new or basic user that must be approved""
       approve_post_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Add suspicious users to the review queue. Suspicious users have entered a bio/website but have no reading activity.""
       approve_suspect_users: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Posts created by users not in these groups must be approved. Posts created by admins and moderators are always approved.""
       approve_unless_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""New topics and posts created by staged users must be approved""
       approve_unless_staged: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Posts created by users below this trust level must be approved""
       approve_unless_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically redirect to the external login system without user interaction. This only takes effect when login_required is true, and there is only one external authentication method""
       auth_immediately: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides local email with external site email on every login, and prevent local changes. Applies to all authentication providers. (WARNING: discrepancies can occur due to normalization of local emails)""
       auth_overrides_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides local full name with external site full name on every login, and prevent local changes.  Applies to all authentication providers.""
       auth_overrides_name: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides local username with external site username on every login, and prevent local changes.  Applies to all authentication providers. (WARNING: discrepancies can occur due to differences in username length/requirements)""
       auth_overrides_username: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When signing up via external auth, skip the create account popup. Best used alongside auth_overrides_email, auth_overrides_username and auth_overrides_name.""
       auth_skip_create_confirm: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of file extensions allowed for upload""
       authorized_extensions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of file extensions allowed for upload for staff users in addition to the list defined in the `authorized_extensions` site setting.""
       authorized_extensions_for_staff: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Users with email addresses from this list of domains will be automatically approved. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported.""
       auto_approve_email_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of posts allowed in a message before it is automatically closed (0 to disable)""
       auto_close_messages_post_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The likelihood that a flagged topic will be automatically closed""
       auto_close_topic_sensitivity: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Create a new linked topic when a topic is auto-closed based on 'auto close topics post count' setting""
       auto_close_topics_create_linked_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of posts allowed in a topic before it is automatically closed (0 to disable)""
       auto_close_topics_post_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of email addresses that won't be checked for auto-generated content. Example: foo@bar.com|discourse@bar.com""
       auto_generated_allowlist: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically handle records that are waiting to be reviewed after this many days. Flags will be ignored. Queued posts and users will be rejected. Set to 0 to disable this feature.""
       auto_handle_queued_age: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable automatic reply when disposing a flag.""
       auto_respond_to_flag_actions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum trust level to auto silence fast typers""
       auto_silence_fast_typers_max_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically silence users that do not meet min_first_post_typing_time""
       auto_silence_fast_typers_on_first_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post. DEPRECATED: Use Silence Watched Words instead.""
       auto_silence_first_post_regex: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Apply syntax highlighting to HTML-authored &lt;code&gt; blocks, even if they didn't specify a language. To configure markdown-authored code blocks, use the 'default code lang' setting.""
       autohighlight_all_code: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Run automatic backups as defined in backup frequency""
       automatic_backups_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically update the \"topic views heat\" and \"topic post like heat\" settings based on site activity.""
       automatic_topic_heat_values: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically delete tags that are not being used on any topics or personal messages on a daily basis.""
       automatically_clean_unused_tags: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Download Gravatars for users upon account creation or email change.""
       automatically_download_gravatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically unpin topics when the user reaches the bottom.""
       automatically_unpin_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of automatically generated avatar sizes.""
       avatar_sizes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How often should the clients poll in milliseconds (when the window is in the background)""
       background_polling_interval: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specifies the interval, in days, at which automatic backups of the site are created. If set to 7, for example, a new backup will be generated every week. The activation of this setting is contingent upon `automatic_backups_enabled`.""
       backup_frequency: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Gzip compression level used for compressing uploads.""
       backup_gzip_compression_level_for_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Location where backups are stored. IMPORTANT: S3 requires valid S3 credentials entered in Files settings. When changing this to S3 from Local, you must run the `s3:ensure_cors_rules` rake task.""
       backup_location: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Time of day UTC when the backup should occur.""
       backup_time_of_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include uploads in scheduled backups. Disabling this will only backup the database.""
       backup_with_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Base font to use for most text on the site. Themes can override via the `--font-family` CSS custom property.""
       base_font: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Block incoming emails identified as being auto generated.""
       block_auto_generated_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't allow passwords that are in the 10,000 most common passwords.""
       block_common_passwords: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent users from introducing remote (hotlinked) media in their posts. Remote media which is not downloaded via 'download_remote_images_to_local' will be replaced with a placeholder link.""
       block_hotlinked_media: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of base URLs which are exempt from the block_hotlinked_media setting. Include the protocol (e.g. https://example.com).""
       block_hotlinked_media_exceptions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent oneboxing for URLs that lead to a redirecting page. This configuration stops the creation of a visual card (onebox) for any URL that redirects to a different destination, ensuring that direct, non-redirecting URLs are prioritized for oneboxing.""
       block_onebox_on_redirect: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of keywords used to blocklist attachments based on the content type.""
       blocked_attachment_content_types: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of keywords used to blocklist attachments based on the filename.""
       blocked_attachment_filenames: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Unique case insensitive word in the user agent string identifying web crawlers that should not be allowed to access the site. Does not apply if allowlist is defined.""
       blocked_crawler_user_agents: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A pipe-delimited list of email domains that users are not allowed to register accounts with. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported. Example: mailinator.com|trashmail.net""
       blocked_email_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of private IP blocks that should never be crawled by Discourse""
       blocked_ip_blocks: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of domains that will never be oneboxed e.g. wikipedia.org\n(Wildcard symbols * ? not supported)""
       blocked_onebox_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Blur flagged posts images to hide potentially NSFW content.""
       blur_tl0_flagged_posts_media: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum entropy (unique characters, non-english count for more) required for a post body.""
       body_min_entropy: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of users required to disable bootstrap mode and remove Getting Started button (set to 0 to disable, can take up to 24 hours). See <a target=\"_blank\" href=\"https://meta.discourse.org/t/-/322876\">the bootstrap mode topic on Meta</a> for details.""
       bootstrap_mode_min_users: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Max bounce score before we will stop emailing a user.""
       bounce_score_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of topics to show in /categories page. If set to 0, it will automatically try to find a value to keep the two columns symmetrical (categories and topics).""
       categories_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of hexadecimal color values allowed for categories.""
       category_colors: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Weight applied to ranking for high category search priority.""
       category_search_priority_high_weight: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Weight applied to ranking for low category search priority.""
       category_search_priority_low_weight: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Words that will be automatically replaced with &#9632;&#9632;&#9632;&#9632;""
       censored_words: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify the city that will be used as the jurisdiction for resolving any disputes related to the use of this forum. This information is typically included in legal documents such as the forum's Terms of Service.""
       city_for_disputes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Grace period (in hours) before an orphan upload is removed.""
       clean_orphan_uploads_grace_period_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days before an inactive user (trust level 0 without any posts) is removed. To disable clean up set to 0.""
       clean_up_inactive_users_after_days: "deactivated|inactive|unactivated"
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days before an unused staged user (without any posts) is removed. To disable clean up set to 0.""
       clean_up_unused_staged_users_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remove orphan unreferenced uploads to prevent illegal hosting. WARNING: you may want to back up of your /uploads directory before enabling this setting.""
       clean_up_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Code button in composer will default to this code formatting style""
       code_formatting_style: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many days of conversation, the last activity date is strongly dimmed.""
       cold_age_days_high: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many days of conversation, the last activity date is slightly dimmed.""
       cold_age_days_low: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many days of conversation, the last activity date is moderately dimmed.""
       cold_age_days_medium: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Name of your company or organization. If left blank, no boilerplate Terms of Service or Privacy Notice will be provided.""
       company_name: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum image file size to trigger client-side optimization""
       composer_media_optimization_image_bytes_optimization_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enables client-side media optimization of uploaded image files.""
       composer_media_optimization_image_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""JPG encode quality used in the re-encode process.""
       composer_media_optimization_image_encode_quality: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum image width to trigger client-side resize""
       composer_media_optimization_image_resize_dimensions_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Images with widths larger than `composer_media_optimization_image_dimensions_resize_threshold` will be resized to this width. Must be >= than `composer_media_optimization_image_dimensions_resize_threshold`.""
       composer_media_optimization_image_resize_width_target: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Email address of key contact responsible for this site. Used for critical notifications, and also displayed on <a href='%{base_path}/about' target='_blank'>/about</a>. Visible to anonymous users on public sites.""
       contact_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Contact URL for this site. When present, replaces email address on <a href='%{base_path}/about' target='_blank'>/about</a> and visible to anonymous users on public sites.""
       contact_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Content-Security-Policy (CSP). CSP is an additional layer of security that helps to prevent certain types of attacks, including Cross Site Scripting (XSS) and data injection.""
       content_security_policy: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable CSP violation report collection at /csp_reports""
       content_security_policy_collect_reports: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Restrict who can embed this site in iframes via CSP. Control allowed hosts on <a href='%{base_path}/admin/customize/embedding'>Embedding</a>""
       content_security_policy_frame_ancestors: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Content-Security-Policy-Report-Only (CSP)""
       content_security_policy_report_only: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Additional allowlisted script sources. The current host and CDN are included by default. See <a href='https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243' target='_blank'>Mitigate XSS Attacks with Content Security Policy.</a> (CSP). Other host sources are ignored as strict-dynamic is enabled.""
       content_security_policy_script_src: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How much time users will have to wait until they are able to reflag a post""
       cooldown_hours_until_reflag: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of minutes a user must wait before they can edit a post hidden via community flagging""
       cooldown_minutes_after_hiding_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allowed origins for cross-origin requests (CORS). Each origin must include http:// or https://. The DISCOURSE_ENABLE_CORS env variable must be set to true to enable CORS.""
       cors_origins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Retrieve images from remote URLs to insert the correct width and height dimensions.""
       crawl_images: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Create a whisper post when a topic's category or tags change, requires whisper posts to be enabled.""
       create_post_for_category_and_tag_changes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Create revision for first posts when topics are moved into a new category in bulk.""
       create_revision_on_bulk_topic_moves: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to create tags. Admins and moderators can always create tags.""
       create_tag_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Create thumbnails and lightbox images that are too large to fit in a post.""
       create_thumbnails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to create new topics. Admins and moderators can always create topics.""
       create_topic_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""None""
       dark_mode_none: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Choose reports to be displayed as activity metrics on the general tab.""
       dashboard_general_tab_activity_metrics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow to hide the specified reports from the dashboard.""
       dashboard_hidden_reports: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Choose which dashboard tabs are visible.""
       dashboard_visible_tabs: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""URLs to avatars that will be used by default for new users until they change them.""
       default_avatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of categories that are muted by default.""
       default_categories_muted: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of categories that are not muted by default. Useful when `mute_all_categories_by_default` site setting is enabled.""
       default_categories_normal: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of categories that are tracked by default.""
       default_categories_tracking: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of categories that are watched by default.""
       default_categories_watching: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of categories in which first post in each new topic will be watched by default.""
       default_categories_watching_first_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default programming language syntax highlighting applied to markdown code blocks (auto, text, ruby, python etc.). This value must also be present in the `highlighted languages` site setting.""
       default_code_lang: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The category used to pre-populate the category dropdown when creating a new topic.""
       default_composer_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The color palette used when in dark mode.""
       default_dark_mode_color_scheme_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How often users receive summary emails by default.""
       default_email_digest_frequency: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include excerpt of replied to post in emails by default.""
       default_email_in_reply_to: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set default email notification level for regular topics.""
       default_email_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send an email for every new post by default.""
       default_email_mailing_list_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Users who enable mailing list mode will receive emails this often by default.""
       default_email_mailing_list_mode_frequency: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set default email notification level when someone messages user.""
       default_email_messages_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include previous replies in emails by default.""
       default_email_previous_replies: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disable presence features by default.""
       default_hide_presence: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Hide user public profile by default.""
       default_hide_profile: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include posts from new users in summary emails by default. Users can change this in their preferences.""
       default_include_tl0_in_digests: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default trust level (0-4) for invited users.""
       default_invitee_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The default language of this Discourse instance. You can replace the text of system generated categories and topics at <a href='%{base_path}/admin/customize/site_texts' target='_blank'>Customize / Text</a>.""
       default_locale: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Selected categories will be displayed under Navigation Menu's Categories section by default.""
       default_navigation_menu_categories: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Selected tags will be displayed under Navigation Menu's Tags section by default.""
       default_navigation_menu_tags: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Global default time before a topic is automatically tracked.""
       default_other_auto_track_topics_after_msecs: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show new/updated topic count on browser icon by default.""
       default_other_dynamic_favicon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable defer topic functionality by default.""
       default_other_enable_defer: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable quote reply for highlighted text by default.""
       default_other_enable_quoting: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable smart lists when typing in the composer by default.""
       default_other_enable_smart_lists: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Open external links in a new tab by default.""
       default_other_external_links_in_new_tab: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Sets the frequency at which users receive notifications for likes by default. Users who have not customized their notification settings will follow this default behavior.""
       default_other_like_notification_frequency: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Global default condition for which a topic is considered new.""
       default_other_new_topic_duration_minutes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Global default notification level when the user replies to a topic.""
       default_other_notification_level_when_replying: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Skip new user onboarding tips and badges.""
       default_other_skip_new_user_tips: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Make navigation menu links link to filtered list by default.""
       default_sidebar_link_to_filtered_list: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Make navigation menu links show count of new items instead of badges by default.""
       default_sidebar_show_count_of_new_items: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Position of button on sidebar to switch to chat""
       default_sidebar_switch_panel_position: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enables 'New Topic' button and selects a default subcategory to post on categories where the user is not allowed to create a new topic.""
       default_subcategory_on_read_only_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of tags that are muted by default.""
       default_tags_muted: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of tags that are tracked by default.""
       default_tags_tracking: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of tags that are watched by default.""
       default_tags_watching: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of tags in which first post in each new topic will be watched by default.""
       default_tags_watching_first_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specifies the default font size for all text elements on the site. This size can be subsequently adjusted by each user according to their preference.""
       default_text_size: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Select the default mode for the count of page titles displayed on the site. This will apply across all the pages unless individually overridden.""
       default_title_count_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically unpin topics when the user reaches the bottom by default.""
       default_topics_automatic_unpin: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default trust level (0-4) for all new users. WARNING! Changing this will put you at serious risk for spam.""
       default_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups allowed to delete posts and topics created by other users. These groups will also be able to see deleted topics and posts.""
       delete_all_posts_and_topics_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of posts that can be deleted at once with the Delete All Posts button. If a user has more than this many posts, the posts cannot all be deleted at once and the user can't be deleted.""
       delete_all_posts_max: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete user associated account when user changes the password.""
       delete_associated_accounts_on_password_reset: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete drafts that have not been changed in more than (n) days.""
       delete_drafts_older_than_n_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete email logs after (N) days. 0 to keep indefinitely""
       delete_email_logs_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days to wait before automatically deleting fully merged stub topics. Set to -1 to never delete. Set to 0 to immediately delete.""
       delete_merged_stub_topics_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Auto-delete any hidden posts that stay hidden for more than 30 days.""
       delete_old_hidden_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete rejected emails older than (n) days.""
       delete_rejected_email_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Posts removed by the author will be automatically deleted after (n) hours. If set to 0, posts will be deleted immediately.""
       delete_removed_posts_after: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't allow deleting users whose first post is older than (x) days.""
       delete_user_max_post_age: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of posts a user can have while allowing self-service account deletion. Set to -1 to disable self-service account deletion.""
       delete_user_self_max_post_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""This setting determines the visual layout of the /categories page on desktop. It includes options such as displaying subcategories with featured topics, showing the latest topics, or presenting top topics. The chosen style will influence how users interact and navigate through categories on the site.""
       desktop_category_page_style: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Provides more details to users about why they can\u2019t access a particular topic. Note: This is less secure because users will know if a URL links to a valid topic.""
       detailed_404: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Whether or not to check that users have uploaded custom profile pictures.""
       detect_custom_avatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The alternate logo image used at the top of your site's email summary. Use a wide rectangle image. Don't use an SVG image. If left blank, the image from the `logo` setting will be used.""
       digest_logo: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum post excerpt in the email summary, in characters.""
       digest_min_excerpt_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of topics to show in the 'New in topics and categories you follow' section of the email summary.""
       digest_other_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of popular posts to display in the email summary.""
       digest_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suppress these categories from summary emails.""
       digest_suppress_categories: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suppress these tags from summary emails.""
       digest_suppress_tags: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of popular topics to display in the email summary.""
       digest_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disable education message for changing avatar.""
       disable_avatar_education_message: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disable notifications for topic category edits. This includes topics which are 'published' (e.g. shared drafts).""
       disable_category_edit_notifications: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Turns off summary emails for every user on the site. All users will stop receiving emails highlighting popular topics and other content summaries from your site.""
       disable_digest_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent Discourse from sending any kind of emails. Select 'yes' to disable emails for all users. Select 'non-staff' to disable emails for non-staff users only.""
       disable_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disallow users from enabling mailing list mode (prevents any mailing list emails from being sent.)""
       disable_mailing_list_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disables edit notifications by the system user when 'download_remote_images_to_local' is active.""
       disable_system_edit_notifications: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disable notifications for topic tag edits. This includes topics which are 'published' (e.g. shared drafts).""
       disable_tags_edit_notifications: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""disable watched word checking in user fields""
       disable_watched_word_checking_in_user_fields: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""disabled""
       disabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remote images will never be downloaded from these domains. Pipe-delimited list.""
       disabled_image_download_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disallow reply by email after (N) days. 0 to keep indefinitely""
       disallow_reply_by_email_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Discord Client ID (need one? visit <a href=\"https://discordapp.com/developers/applications/me\">the Discord developer portal</a>)""
       discord_client_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Discord Client Secret Key Used for authenticating and enabling Discord related features on the site, such as Discord logins. This secret key corresponds to the Discord application created for the website, and is necessary for securely communicating with the Discord API.""
       discord_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Only allow members of these Discord guilds to log in via Discord. Use the numeric ID for the guild. For more information, check the instructions <a href=\"https://meta.discourse.org/t/configuring-discord-login-for-discourse/127129\">here</a>. Leave blank to allow any guild.""
       discord_trusted_guilds: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Restrict to these domains for return_paths provided by DiscourseConnect (by default return path must be on current site). Use * to allow any domain for return path. Subdomain wildcards (`*.foobar.com`) are not allowed.""
       discourse_connect_allowed_redirect_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Redirect unapproved DiscourseConnect accounts to this URL""
       discourse_connect_not_approved_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user avatar with value from DiscourseConnect payload. If enabled, users will not be allowed to upload avatars on Discourse.""
       discourse_connect_overrides_avatar: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user bio in user profile and prevents user from changing it""
       discourse_connect_overrides_bio: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user card background with value from DiscourseConnect payload.""
       discourse_connect_overrides_card_background: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Synchronize all manual group membership with groups specified in the groups attribute (WARNING: if you do not specify groups all manual group membership will be cleared for user)""
       discourse_connect_overrides_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user location with value from DiscourseConnect payload and prevent local changes.""
       discourse_connect_overrides_location: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user profile background with value from DiscourseConnect payload.""
       discourse_connect_overrides_profile_background: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Overrides user website with value from DiscourseConnect payload and prevent local changes.""
       discourse_connect_overrides_website: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of domain-secret pairs that are using DiscourseConnect. Make sure DiscourseConnect secret is 10 characters or longer. Wildcard symbol * can be used to match any domain or only a part of it (e.g. *.example.com).""
       discourse_connect_provider_secrets: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Secret string used to cryptographically authenticate DiscourseConnect information, be sure it is 10 characters or longer""
       discourse_connect_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""URL of DiscourseConnect endpoint (must include http:// or https://, and must not include a trailing slash)""
       discourse_connect_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show number of global and EU visitors on the /about page. It may take a few minutes for the stats to appear after turning on this setting.""
       display_eu_visitor_stats: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Display the local time based on a user's timezone when their user card is opened.""
       display_local_time_in_user_card: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Display full names on email from fields""
       display_name_on_email_from: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show a user's full name on their posts in addition to their @username.""
       display_name_on_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When enabled, count of personal messages tagged with a given tag will be displayed.""
       display_personal_messages_tag_counts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""What percentage of posts a user has to make in a topic before being reminded about overly dominating a topic.""
       dominating_topic_minimum_percent: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of flags from other users before being warned.""
       dont_feed_the_trolls_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum disk space necessary to download remote images locally (in percent)""
       download_remote_images_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Convert remote (hotlinked) images to local images by downloading them; This preserves content even if the images are removed from the remote site in future.""
       download_remote_images_to_local: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users in this group to edit other users' posts""
       edit_all_post_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users in this group to edit other users' topic titles, tags, and categories""
       edit_all_topic_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow everyone to see previous versions of an edited post. When disabled, only staff members can view.""
       edit_history_visible_to_public: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to edit posts. Admins and moderators can always edit posts.""
       edit_post_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to edit posts marked as wiki. Admins and moderators can always edit posts marked as wiki.""
       edit_wiki_post_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""For (n) seconds after posting, editing will not create a new version in the post history.""
       editing_grace_period: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of character changes allowed in editing grace period, if more changed store another post revision (trust level 0 and 1)""
       editing_grace_period_max_diff: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of character changes allowed in editing grace period, if more changed store another post revision (trust level 2 and up)""
       editing_grace_period_max_diff_high_trust: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When the user starts typing their first (n) new posts, show the pop-up new user education panel in the composer.""
       educate_until_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The accent color to be used as the background of some elements in HTML emails. Enter a color name ('red') or hex value ('#FF0000').""
       email_accent_bg_color: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The color of text rendered on the email bg color in HTML emails. Enter a color name ('white') or hex value ('#FFFFFF').""
       email_accent_fg_color: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A pipe-delimited list of custom email headers""
       email_custom_headers: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to change their e-mail address after registration.""
       email_editable: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to post new topics via email. After enabling this setting, you will be able to configure incoming email addresses for groups and categories.""
       email_in: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to post new topics via email. Admins and moderators can always post new topics via email.""
       email_in_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The identifier of the service doing authentication checks on incoming emails. See <a href='https://meta.discourse.org/t/134358'>https://meta.discourse.org/t/134358</a> for instructions on how to configure this.""
       email_in_authserv_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level a user needs to have to be allowed to post new topics via email.""
       email_in_min_trust: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Selects the specific email header to use for identifying spam. This option can be X-Spam-Flag, X-Spam-Status, or X-SES-Spam-Verdict, and the email is tagged as spam based on the header's value. For instance, if the chosen setting is X-Spam-Flag, an email with this header value set to YES would be classified as spam.""
       email_in_spam_header: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The color of links in HTML emails. Enter a color name ('blue') or hex value ('#0000FF').""
       email_link_color: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many prior replies to include as context in notification emails.""
       email_posts_context: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The [label] used in the subject of emails. It will default to 'title' if not set.""
       email_prefix: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The title of the site used as the sender of emails from the site. Default to 'title' if not set. If your 'title' contains characters that are not allowed in email sender strings, use this setting.""
       email_site_title: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Customizable subject format for standard emails. See <a href='https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801' target='_blank'>https://meta.discourse.org/t/customize-subject-format-for-standard-emails/20801</a>""
       email_subject: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Wait (n) minutes before sending any notification emails, to give users a chance to edit and finalize their posts.""
       email_time_window_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Forgot password / activate account tokens are valid for (n) hours.""
       email_token_valid_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Max total size of files attached to outgoing emails. Set to 0 to disable sending of attachments.""
       email_total_attachment_size_limit_kb: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow embeddable content regardless of origin. This is required for mobile apps with static HTML.""
       embed_any_origin: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of posts to embed.""
       embed_post_limit: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set the canonical URL for embedded topics to the embedded content's URL.""
       embed_set_canonical_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Support Markdown formatting for embedded posts.""
       embed_support_markdown: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the embedding of topic lists in HTML format. This setting allows you to incorporate lists of topics from your forum into other websites in a compatible and easy-to-use manner.""
       embed_topics_list: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Shorten the contents of posts that are embedded from external sources. This setting ensures that only the initial part of content is displayed when a post from an external URL is embedded on your site. If you prefer to display full content from the external posts, you can disable this setting.""
       embed_truncate: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Embedded topics will be unlisted until a user replies.""
       embed_unlisted: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The username for topic creation is required.""
       embed_username_required: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The users in these groups are allowed to embed media items in a post. Admins and moderators can always embed media items.""
       embedded_media_post_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of characters required to trigger autocomplete emoji popup""
       emoji_autocomplete_min_chars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""These emoji will not be available to use in menus or shortcodes.""
       emoji_deny_list: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Select your preferred style of emoji. Different emoji sets can provide unique appearances to the emojis displayed on the site.""
       emoji_set: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow administrators to create backups of the forum""
       enable_backups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the badge system, which is a form of gamification to reinforce positive user actions. See <a href='https://meta.discourse.org/t/what-are-badges/32540' _target='blank'>What are Badges?</a> on Discourse Meta for more information.""
       enable_badges: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow groups to moderate content in specific categories""
       enable_category_group_moderation: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed""
       enable_chunked_encoding: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Activate push notifications for the desktop interface. This feature enables real-time alerts from the site directly to your desktop, enhancing engagement and ensuring users are always updated. However, the effectiveness of this feature relies on browser support for push notifications.""
       enable_desktop_push_notifications: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Experimental feature which uses diffHTML to sync preview instead of full re-render""
       enable_diffhtml_preview: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allows for direct multipart uploads to Amazon S3, see https://meta.discourse.org/t/a-new-era-for-file-uploads-in-discourse/210469 for more details.""
       enable_direct_s3_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to authenticate using Discord?""
       enable_discord_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable sign on via DiscourseConnect (formerly 'Discourse SSO') (WARNING: USERS' EMAIL ADDRESSES *MUST* BE VALIDATED BY THE EXTERNAL SITE!)""
       enable_discourse_connect: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Implement DiscourseConnect (formerly 'Discourse SSO') provider protocol at the /session/sso_provider endpoint, requires discourse_connect_provider_secrets to be set""
       enable_discourse_connect_provider: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the display and use of emojis in your Discourse instance. If disabled, emojis will not be rendered and users will not be able to access or use them in text fields.""
       enable_emoji: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Common smiley text such as :) :p :( will be converted to emojis""
       enable_emoji_shortcuts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Fall back to Google's Ajax-Crawling API if no webcrawler is detected. See <a href='https://developers.google.com/webmasters/ajax-crawling/docs/learn-more' target='_blank'>https://developers.google.com/webmasters/ajax-crawling/docs/learn-more</a>""
       enable_escaped_fragments: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Replace the default image lightbox with the revamped design.""
       enable_experimental_lightbox: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Facebook authentication, requires facebook_app_id and facebook_app_secret. See <a href='https://meta.discourse.org/t/13394' target='_blank'>Configuring Facebook login for Discourse</a>.""
       enable_facebook_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Adds a button to the post selection menu to edit a small selection inline.""
       enable_fast_edit: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""\"(n) replies\" button collapses all other posts and only shows the current post and its replies.""
       enable_filtered_replies_view: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable GitHub authentication, requires github_client_id and github_client_secret. See <a href='https://meta.discourse.org/t/13745' target='_blank'>Configuring GitHub login for Discourse</a>.""
       enable_github_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Google Oauth2 authentication. This is the method of authentication that Google currently supports. Requires key and secret. See <a href='https://meta.discourse.org/t/15858' target='_blank'>Configuring Google login for Discourse</a>.""
       enable_google_oauth2_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Provide a directory of groups for browsing""
       enable_group_directory: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable IMAP for synchronizing group messages.""
       enable_imap: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use IMAP IDLE mechanism to wait for new emails.""
       enable_imap_idle: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable two-way IMAP synchronization. If disabled, all write-operations on IMAP accounts are disabled.""
       enable_imap_write: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enables translation for inline emojis (without any space or punctuation before)""
       enable_inline_emoji_translation: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Ignore allowed_inline_onebox_domains site setting and allow inline onebox on all domains.""
       enable_inline_onebox_on_all_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable LinkedIn authentication, requires linkedin_client_id and linkedin_client_secret.""
       enable_linkedin_oidc_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable regular users to find suspended users.""
       enable_listing_suspended_users_on_search: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable local username and password login based accounts. WARNING: if disabled, you may be unable to log in if you have not previously configured at least one alternate login method.""
       enable_local_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to request a one-click login link to be sent to them via email.""
       enable_local_logins_via_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically treat text that looks like a link as a link: www.example.com and https://example.com will be automatically linked""
       enable_markdown_linkify: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use typography rules to improve readability of text: replace straight quotes ' with curly quotes \u2019, (tm) with symbol, -- with emdash \u2013, etc""
       enable_markdown_typographer: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use max_tags_per_email_subject when generating the subject of an email""
       enable_max_tags_per_email_subject: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Permits users to tag or reference each other in their posts using the '@' symbol.""
       enable_mentions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Mobile devices use a mobile-friendly theme, with the ability to switch to the full site. Disable this if you want to use a custom stylesheet that is fully responsive.""
       enable_mobile_theme: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show the user's full name on their profile, user card, and emails. Disable to hide full name everywhere.""
       enable_names: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Display a message to users when it is detected that they have no network connection""
       enable_offline_indicator: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow staff members to publish topics to new URLs with their own styling.""
       enable_page_publishing: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""DEPRECATED, use the 'personal message enabled groups' setting instead. Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what.""
       enable_personal_messages: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show \u201CPowered by Discourse\u201D link to discourse.org at the bottom of most pages.""
       enable_powered_by_discourse: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Adds a button to post selection menu to copy the selection to clipboard as a markdown quote.""
       enable_quote_copy: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable automatic HTML to Markdown conversion when pasting text into the composer.""
       enable_rich_text_paste: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Place uploads on Amazon S3 storage. IMPORTANT: requires valid S3 credentials (both access key id & secret access key).""
       enable_s3_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to enter safe mode to debug plugins.""
       enable_safe_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show a notice to returning anonymous users prompting them to sign up for an account.""
       enable_signup_cta: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Generate a sitemap for your site and include it in the robots.txt file.""
       enable_sitemap: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable SMTP for sending notifications for group messages.""
       enable_smtp: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically create staged users when processing incoming emails.""
       enable_staged_users: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allows users to reply to system messages, even if personal messages are disabled""
       enable_system_message_replies: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Twitter authentication, requires twitter_consumer_key and twitter_consumer_secret. See <a href='https://meta.discourse.org/t/13395' target='_blank'>Configuring Twitter login (and rich embeds) for Discourse</a>.""
       enable_twitter_logins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Provide a directory of users for browsing""
       enable_user_directory: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to set custom status message (emoji + description).""
       enable_user_status: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable new user tips that describe key features to users""
       enable_user_tips: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Require users to enable two-factor authentication before they can access the Discourse UI. This setting does not affect API or 'DiscourseConnect provider' authentication. If enforce_second_factor_on_external_auth is enabled, users will not be able to log in with external authentication providers after they set up two-factor authentication.""
       enforce_second_factor: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Require users to use two-factor authentication at all times. When enabled this will prevent users logging in with external authentication methods like social logins if they have two-factor authentication enabled. When disabled users will only need to confirm their two-factor authentication when logging in with a username and password. Also see the `enforce_second_factor` setting.""
       enforce_second_factor_on_external_auth: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of domains where nofollow should not be added to links. example.com will automatically allow sub.example.com as well. As a minimum, you should add the domain of this site to help web crawlers find all content. If other parts of your website are at other domains, add those too.""
       exclude_rel_nofollow_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the form templates feature. <b>After enabled,</b> manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>.""
       experimental_form_templates: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable a new topics list that combines unread and new topics and make the \"Everything\" link in the sidebar link to it.""
       experimental_new_new_view_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""URL of the external service for emoji images. Leave blank to disable.""
       external_emoji_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enables the use of an external service for generating system avatars. When this setting is enabled, user avatars, instead of being produced within the Discourse system, are generated and provided by an external service defined by the `external_system_avatars_url` setting.""
       external_system_avatars_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""URL of the external system avatars service. Allowed substitutions are {username} {first_letter} {color} {size}""
       external_system_avatars_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A token generated from your Facebook app ID and secret. Used to generate Instagram oneboxes.""
       facebook_app_access_token: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""App id for Facebook authentication and sharing, registered at <a href='https://developers.facebook.com/apps/' target='_blank'>https://developers.facebook.com/apps</a>""
       facebook_app_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""App secret for Facebook authentication, registered at <a href='https://developers.facebook.com/apps/' target='_blank'>https://developers.facebook.com/apps</a>""
       facebook_app_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If you have a FAQ hosted elsewhere that you want to use, provide the full URL here.""
       faq_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A favicon for your site, see <a href='https://en.wikipedia.org/wiki/Favicon' target='_blank'>https://en.wikipedia.org/wiki/Favicon</a>. To work correctly over a CDN it must be a png. Will be resized to 32x32. If left blank, large_icon will be used.""
       favicon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Only use the 'reply key' to find the replied-to post. WARNING: disabling this allows user impersonation based on email address.""
       find_related_post_with_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If checked, you will be able to arrange categories into a fixed order. If unchecked, categories are listed in order of activity.""
       fixed_category_positions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If checked, category ordering will be maintained on topic creation dialog (requires fixed_category_positions).""
       fixed_category_positions_on_create: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to flag posts. Admins and moderators can always flag posts.""
       flag_post_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If a new user replies to a topic from the same IP address as the user who started the topic, flag both of their posts as potential spam.""
       flag_sockpuppets: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How frequently we flush timing data to the server, in seconds.""
       flush_timings_secs: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent).""
       force_custom_user_agent_hosts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Force your site to use HTTPS only. WARNING: do NOT enable this until you verify HTTPS is fully set up and working absolutely everywhere! Did you check your CDN, all social logins, and any external logos / dependencies to make sure they are all HTTPS compatible, too?""
       force_https: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Force all new tags to be entirely lowercase.""
       force_lowercase_tags: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How to treat a forwarded email to Discourse. <a href='https://meta.discourse.org/t/-/62977' target='_blank'>Learn more</a>""
       forwarded_emails_behaviour: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Make the full name field a required, optional, or optional but hidden field in the signup form.""
       full_name_requirement: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show the login and signup forms in a full page (when unchecked, users will see the forms in a modal). ""
       full_page_login: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable Google Universal Analytics cross-domain tracking. Outgoing links to these domains will have the client id added to them. See <a href='https://support.google.com/analytics/answer/1034342?hl=en' target='_blank'>Google's Cross-Domain Tracking guide.</a>""
       ga_universal_auto_link_domains: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Google Universal Analytics domain name, eg: mysite.com; see <a href='https://google.com/analytics' target='_blank'>https://google.com/analytics</a>""
       ga_universal_domain_name: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Google Universal Analytics tracking code ID, eg: UA-12345678-9; see <a href='https://google.com/analytics' target='_blank'>https://google.com/analytics</a>""
       ga_universal_tracking_code: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Version of Google Universal Analytics to use: v3 (analytics.js), v4 (gtag)""
       ga_version: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of posts a user has to make to the same person in the same topic before being warned.""
       get_a_room_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Client id for GitHub authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>""
       github_client_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Client secret for GitHub authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>""
       github_client_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A mapping of a GitHub organisation or user to a GitHub access token which is used to generate GitHub oneboxes for private repos, commits, pull requests, issues, and file contents. Without this, only public GitHub URLs will be oneboxed.""
       github_onebox_access_tokens: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the new 'glimmer' post menu implementation in 'auto' mode for the specified user groups. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced.""
       glimmer_post_menu_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Control whether the new 'glimmer' post menu implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced.""
       glimmer_post_menu_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Control whether the new 'glimmer' topic-list implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. See https://meta.discourse.org/t/343404 for more info.""
       glimmer_topic_list_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Display an URGENT, EMERGENCY, non-dismissible global banner notice to all visitors, change to blank to hide it (HTML allowed).""
       global_notice: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The unique client ID provided by your Google application, used for the authentication process.""
       google_oauth2_client_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Client secret of your Google application.""
       google_oauth2_client_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""An optional Google Apps Hosted domain that the sign-in will be limited to. See <a href='https://developers.google.com/identity/protocols/OpenIDConnect#hd-param' target='_blank'>https://developers.google.com/identity/protocols/OpenIDConnect#hd-param</a> for more details.""
       google_oauth2_hd: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Retrieve users' Google groups on the hosted domain on authentication. Retrieved Google groups can be used to grant automatic Discourse group membership (see group settings). For more information see https://meta.discourse.org/t/226850""
       google_oauth2_hd_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""An email address belonging to a Google Workspace administrator account. Will be used with the service account credentials to fetch group information.""
       google_oauth2_hd_groups_service_account_admin_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""JSON formatted key information for the Service Account. Will be used to fetch group information.""
       google_oauth2_hd_groups_service_account_json: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""An optional space-delimited list of string values that specifies whether the authorization server prompts the user for reauthentication and consent. See <a href='https://developers.google.com/identity/protocols/OpenIDConnect#prompt' target='_blank'>https://developers.google.com/identity/protocols/OpenIDConnect#prompt</a> for the possible values.""
       google_oauth2_prompt: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Log verbose Google OAuth2 related diagnostics to <a href='%{base_path}/logs' target='_blank'>/logs</a>""
       google_oauth2_verbose_logging: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify the jurisdiction that governs the legal aspects of the site, including Terms of Service and Privacy Policy. This is typically the country or state where the company operating the site is registered or conducts business.""
       governing_law: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify the URL for accessing the Gravatar provider's API. This setting is critical for converting email addresses into Gravatar URLs where avatar images are stored.""
       gravatar_base_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""URL relative to `gravatar_base_url`, which provides the user with the login to the Gravatar service.""
       gravatar_login_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site.""
       gravatar_name: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set %%{optional_pm} in email subject to name of first group in PM, see: <a href='https://meta.discourse.org/t/customize-specific-email-templates/88323' target='_blank'>Customize subject format for standard emails</a>""
       group_in_subject: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Google Tag Manager container id. eg: GTM-ABCD12E. <br/>Note: To use GTM when the Content Security Policy (CSP) is enabled, see the documentation on meta: <a href='https://meta.discourse.org/t/use-nonces-in-google-tag-manager-scripts/188296' target='_blank'>Use nonces in Google Tag Manager scripts</a>.""
       gtm_container_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Bounce score added to the user when a permanent bounce happens.""
       hard_bounce_score: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many categories can be displayed in the header dropdown menu.""
       header_dropdown_category_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Font to use for headings on the site. Themes can override via the `--heading-font-family` CSS custom property.""
       heading_font: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Name used for a @mention to allow privileged users to notify up to 'max_here_mentioned' people participating in the topic. Must not be an existing username.""
       here_mention: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to mention @here. Admins and moderators can always mention @here.""
       here_mention_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow members of these groups to view hidden posts. Staff users can always view hidden posts.""
       hidden_post_visible_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't inform users that an account exists with a given email address during signup or during forgot password flow. Require full email for 'forgotten password' requests.""
       hide_email_address_taken: ""
-      hide_post_sensitivity: ""
-      hide_suspension_reasons: ""
-      hide_user_activity_tab: ""
-      hide_user_profiles_from_public: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. This feature is disabled unconditionally on must_approve_users and invite_only sites.""
       hide_new_user_profiles: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The likelihood that a flagged post will be hidden""
+      hide_post_sensitivity: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't display suspension reasons publically on user profiles.""
+      hide_suspension_reasons: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Hide the activity tab on user profiles except for Admin and self.""
+      hide_user_activity_tab: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Disable user cards, user profiles and user directory for anonymous users.""
+      hide_user_profiles_from_public: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""New user posts are automatically hidden after being flagged as spam by a TL3+ user""
       high_trust_flaggers_auto_hide_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Included syntax highlighting rules. (Warning: including too many languages may impact performance) see: <a href='https://highlightjs.org/demo/' target='_blank'>https://highlightjs.org/demo</a> for a demo""
       highlighted_languages: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A post edited within this many hours has the edit indicator strongly highlighted.""
       history_hours_high: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A post edited within this many hours has the edit indicator slightly highlighted""
       history_hours_low: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A post edited within this many hours has the edit indicator moderately highlighted.""
       history_hours_medium: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to ignore other users. Admins and moderators can always ignore other users.""
       ignore_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Ignore incoming emails based on their title.""
       ignore_by_title: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Notify moderators if a particular user is ignored by this many other users.""
       ignored_users_count_message_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How long to wait before notifying moderators again about a user who has been ignored by many others.""
       ignored_users_message_gap_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Quality of resized image files (1 is lowest quality, 99 is best quality, 100 to disable).""
       image_preview_jpg_quality: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum number of new emails that trigger import mode (disables notifications for imported posts).""
       imap_batch_import_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of new emails (unprocessed) to be updated every time an IMAP box is polled .""
       imap_polling_new_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of old emails (processed) to be updated every time an IMAP box is polled (0 for all).""
       imap_polling_old_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The period in minutes between checking the IMAP accounts for emails.""
       imap_polling_period_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Imported embedded topics will be unlisted until a user replies (even when the `embed unlisted` site setting is unchecked).""
       import_embed_unlisted: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Let CDCK, Inc. (\u201CDiscourse\u201D) feature this community on the <a href='https://discover.discourse.org' target='_blank'>Discover page</a> and in Discourse marketing materials. By doing so, you will share the data required for your site to be included in the service. Please note that the promotion of communities is at Discourse\u2019s discretion.""
       include_in_discourse_discover: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When enabled, count of topics for a tag will include topics that are in read restricted categories for all users. When disabled, normal users are only shown a count of topics for a tag where all the topics are in public categories.""
       include_secure_categories_in_tag_counts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include generated thumbnails in backups. Disabling this will make backups smaller, but requires a rebake of all posts after a restore.""
       include_thumbnails_in_backups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use HTML instead of text for incoming email.""
       incoming_email_prefer_html: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Admin accounts that have not visited the site in this number of days will need to re-validate their email address before logging in. Set to 0 to disable.""
       invalidate_inactive_admin_email_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to invite users. Admins and moderators can always invite users.""
       invite_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User must type this code to be allowed account registration, ignored when empty (case-insensitive)""
       invite_code: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How long user invitation keys are valid, in days""
       invite_expiry_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum redemptions allowed for invite links can't be more than this value.""
       invite_link_max_redemptions_limit: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum redemptions allowed for invite links generated by regular users can't be more than this value.""
       invite_link_max_redemptions_limit_users: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""All new users must be explicitly invited by trusted users or staff. Public registration is disabled.""
       invite_only: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Image used as the base for other metadata icons. Should ideally be larger than 512 x 512. If left blank, logo_small will be used.""
       large_icon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Lazy load category information only for users of these groups. This improves performance on sites with many categories.""
       lazy_load_categories_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When matching spammer emails, number of characters difference that will still allow a fuzzy match.""
       levenshtein_distance_spammer_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Duration in minutes where liked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via `SiteSetting.notification_consolidation_threshold`.""
       likes_notification_consolidation_window_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Only show topics from the current category in suggested topics.""
       limit_suggested_to_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Duration in minutes where linked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via `SiteSetting.notification_consolidation_threshold`.""
       linked_notification_consolidation_window_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Client ID for LinkedIn authentication, registered at <a href='https://www.linkedin.com/developers/apps' target='_blank'>https://www.linkedin.com/developers/apps</a>""
       linkedin_oidc_client_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Client secret for LinkedIn authentication, registered at <a href='https://www.linkedin.com/developers/apps' target='_blank'>https://www.linkedin.com/developers/apps</a>""
       linkedin_oidc_client_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Whether to keep a user's details in the log after being anonymized.""
       log_anonymizer_details: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Log all email processing failures to <a href='%{base_path}/logs' target='_blank'>/logs</a>""
       log_mail_processing_failures: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When logging out, log out ALL sessions for the user on all devices""
       log_out_strict: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Log personal message views by Admin for other users/groups.""
       log_personal_messages_views: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Log search queries performed by users""
       log_search_queries: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Require authentication to read content on this site, disallow anonymous access.""
       login_required: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The logo image at the top left of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the site title text will be shown.""
       logo: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Dark scheme alternative for the 'logo' site setting.""
       logo_dark: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The small logo image at the top left of your site, seen when scrolling down. Use a square 120 \u00D7 120 image. If left blank, a home glyph will be shown.""
       logo_small: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Dark scheme alternative for the 'logo small' site setting.""
       logo_small_dark: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Location to redirect browser to after logout (eg: https://example.com/logout)""
       logout_redirect: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Base URL used for long polling (when a CDN is serving dynamic content, be sure to set this to origin pull) eg: http://origin.site.com""
       long_polling_base_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Mailgun Secret API key used to verify webhook messages.""
       mailgun_api_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Token used to verify webhook payload. It must be passed as the 't' query parameter of the webhook, for example: https://example.com/webhook/mailjet?t=supersecret""
       mailjet_webhook_token: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Mandrill authentication key used to verify webhook messages.""
       mandrill_authentication_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Image used as logo/splash image on Android. Will be automatically resized to 512 \u00D7 512. If left blank, large_icon will be used.""
       manifest_icon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Screenshots that showcase your instance features and functionality on its install prompt page. All images should be local uploads and of the same dimensions.""
       manifest_screenshots: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Push emails using the API for email replies.""
       manual_polling_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of top level domains that get automatically treated as links""
       markdown_linkify_tlds: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of double and single quotes replacement pairs""
       markdown_typographer_quotation_marks: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete unmatched screened email entries after (N) days.""
       max_age_unmatched_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete unmatched screened IP entries after (N) days.""
       max_age_unmatched_ips: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum recipients allowed in a message.""
       max_allowed_message_recipients: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum attachment files upload size. This must be configured in nginx (client_max_body_size) / apache or proxy as well.""
       max_attachment_size_kb: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of bookmarks per user per day.""
       max_bookmarks_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of posts in a row a user can make in a topic before being prevented from adding another reply. This limit does not apply to the topic owner, site staff, or category moderators.""
       max_consecutive_replies: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of times Discourse will check Gravatar for custom avatars in a day""
       max_daily_gravatar_crawls: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of edits per user per day.""
       max_edits_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of emails to send users per day. 0 to disable the limit""
       max_emails_per_day_per_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum allowed emojis in topic title.  If the set value is zero, it prevents the use of any emojis in topic titles.""
       max_emojis_in_title: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of badges that user can select""
       max_favorite_badges: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of flags per user per day.""
       max_flags_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum allowed length for form template content.""
       max_form_template_content_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum allowed length for form template titles.""
       max_form_template_title_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of mentioned people by @here.""
       max_here_mentioned: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum thumbnail height of images in a post. Images with a larger height will be resized and lightboxed.""
       max_image_height: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of megapixels allowed for an image. Images with a higher number of megapixels will be rejected.""
       max_image_megapixels: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum image upload size. This must be configured in nginx (client_max_body_size) / apache or proxy as well. Images larger than this and smaller than client_max_body_size will be resized to fit on upload.""
       max_image_size_kb: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum thumbnail width of images in a post. Images with a larger width will be resized and lightboxed.""
       max_image_width: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of invites a user can send per day.""
       max_invites_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of likes per user per day.""
       max_likes_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of logins allowed per IP address per hour""
       max_logins_per_ip_per_hour: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of logins allowed per IP address per minute""
       max_logins_per_ip_per_minute: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of @name notifications anyone can use in a post.""
       max_mentions_per_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If there are already (n) trust level 0 accounts from this IP (and none is a staff member or at TL2 or higher), stop accepting new signups from that IP. Set to 0 to disable the limit.""
       max_new_accounts_per_registration_ip: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum amount of notifications per user, if this number is exceeded old notifications will be deleted. Enforced weekly. Set to 0 to disable""
       max_notifications_per_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set the maximum number of oneboxes that can be included in a single post. Oneboxes provide a preview of linked content within the post.""
       max_oneboxes_per_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of new personal message topics a user can create per day.""
       max_personal_messages_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of posts a user can delete per day. Set to 0 to disable post deletions.""
       max_post_deletions_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of posts a user can delete per minute. Set to 0 to disable post deletions.""
       max_post_deletions_per_minute: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum allowed post length in characters""
       max_post_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of /print page impressions (set to 0 to disable printing)""
       max_prints_per_hour_per_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of replies a user is allowed to create in the 24 hour period after creating their first post""
       max_replies_in_first_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of replies to expand when expanding in-reply-to""
       max_reply_history: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many similar topics to show above the editor when composing a new topic. Comparison is based on title and body.""
       max_similar_results: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum amount of characters that can be used in a tag.""
       max_tag_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When searching for tags, the maximum number of results to show.""
       max_tag_search_results: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of tags to show in the filter dropdown. The most used tags will be shown.""
       max_tags_in_filter_list: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum tags that can be in the subject of an email""
       max_tags_per_email_subject: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum tags that can be applied to a topic.""
       max_tags_per_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of topic invitations a user can send per day.""
       max_topic_invitations_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of topic invitations a user can send per minute.""
       max_topic_invitations_per_minute: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum allowed topic title length in characters""
       max_topic_title_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of topics a user is allowed to create in the 24 hour period after creating their first post""
       max_topics_in_first_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of topics a user can create per day.""
       max_topics_per_day: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum username length in characters. WARNING: if any existing users or groups have names longer than this, your site will break!""
       max_username_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of users that may receive a notification if a group is mentioned (if threshold is met no notifications will be raised)""
       max_users_notified_per_group_mention: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum amount of backups to keep. Older backups are automatically deleted""
       maximum_backups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Block incoming emails with too many recipients.""
       maximum_recipients_per_new_group_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User will remain logged in for n hours since last visit""
       maximum_session_age: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of staged users created when processing an incoming email.""
       maximum_staged_users_per_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify the minimum length of the password for Admin users. It ensures that all admin passwords meet a certain length requirement for enhanced security. This setting is essential to protect the Admin account from potential unauthorized access.""
       min_admin_password_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When clicking the Roll up button, will create a new subnet ban entry if there are at least (N) entries.""
       min_ban_entries_for_roll_up: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum allowed first post (topic body) length (excluding personal messages)""
       min_first_post_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum amount of time in milliseconds a user must type during first post, if threshold is not met post will automatically enter the needs approval queue. Set to 0 to disable (not recommended)""
       min_first_post_typing_time: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Defines the least number of characters required for user passwords on the site. A value that's too low might compromise security by making it easier for unauthorized parties to guess passwords, while a value that's too high might make it more difficult for users to remember their passwords.""
       min_password_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum allowed post length in characters for messages (both first post and replies)""
       min_personal_message_post_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum allowed title length for a message in characters""
       min_personal_message_title_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum allowed post length in characters (excluding personal messages)""
       min_post_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Ratio used to crop tall images. Enter the result of width / height.""
       min_ratio_to_crop: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum valid search term length in characters""
       min_search_term_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum length of a title before it will be checked for similar topics.""
       min_title_similar_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum allowed topic title length in characters""
       min_topic_title_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum amount of views a topic must have for a confirmation popup to appear when it gets deleted""
       min_topic_views_for_delete_confirm: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level allowed to mention @here.""
       min_trust_level_for_here_mention: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Trust level required for generation of user API keys.<br>\n<b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub\n""
       min_trust_level_for_user_api_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to ignore users""
       min_trust_level_to_allow_ignore: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to invite users""
       min_trust_level_to_allow_invite: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to upload a profile background""
       min_trust_level_to_allow_profile_background: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to upload a user card background""
       min_trust_level_to_allow_user_card_background: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum trust level required to tag topics""
       min_trust_level_to_tag_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to make user's own post wiki.""
       min_trust_to_allow_self_wiki: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to create a tag.""
       min_trust_to_create_tag: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to create a new topic.""
       min_trust_to_create_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to edit posts.""
       min_trust_to_edit_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to edit post marked as wiki.""
       min_trust_to_edit_wiki_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to flag posts""
       min_trust_to_flag_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to embed media items in a post""
       min_trust_to_post_embedded_media: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to include links in posts""
       min_trust_to_post_links: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum trust level required to send personal messages via email.""
       min_trust_to_send_email_messages: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages.""
       min_trust_to_send_messages: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum username length in characters. WARNING: if any existing users or groups have names shorter than this, your site will break!""
       min_username_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many topics need to exist before similar topics are presented when composing new topics.""
       minimum_topics_similar: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The logo used on mobile version of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the image from the `logo` setting will be used.""
       mobile_logo: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Dark scheme alternative for the 'mobile logo' site setting.""
       mobile_logo_dark: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow moderators to change post ownership""
       moderators_change_post_ownership: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow moderators to create and manage categories and groups""
       moderators_manage_categories_and_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow moderators to view user email addresses.""
       moderators_view_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""All new users must wait for moderator or admin approval before being allowed to log in. (Note: enabling this setting also removes the \"arrive at topic\" invite option)""
       must_approve_users: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Set the default notification level of all the categories to muted. Require users opt-in to categories for them to appear in 'latest' and 'categories' pages. If you wish to amend the defaults for anonymous users set 'default_categories_' settings.""
       mute_all_categories_by_default: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Displays DiscourseHub app banner on Android devices to basic users (trust level 1) and up.""
       native_app_install_banner_android: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Displays DiscourseHub app banner on iOS devices to basic users (trust level 1) and up.""
       native_app_install_banner_ios: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify sidebar or header dropdown as the main navigation menu for your site. Sidebar is recommended.""
       navigation_menu: "sidebar|header dropdown"
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum trust level required to see new user post notices.""
       new_user_notice_tl: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send an email to the contact_email address when a new version of Discourse is available.""
       new_version_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many attachments a new user can add to a post.""
       newuser_max_attachments: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many embedded media items a new user can add to a post.""
       newuser_max_embedded_media: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many links a new user can add to a post.""
       newuser_max_links: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of @name notifications a new user can use in a post.""
       newuser_max_mentions_per_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of replies a new user can make in a single topic until someone replies to them.""
       newuser_max_replies_per_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many times a new user can post a link to the same host within their `newuser_spam_host_threshold` posts before being considered spam.""
       newuser_spam_host_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Check if normalized email is unique. Normalized email removes all dots from the username and everything between + and @ symbols.""
       normalize_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of liked or membership request notifications received before the notifications are consolidated into a single one. Set to 0 to disable.""
       notification_consolidation_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The from: email address used when sending all essential system emails. The domain specified here must have SPF, DKIM and reverse PTR records set correctly for email to arrive.""
       notification_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If there are posts that have been waiting to be reviewed for more than this many hours, send a notification to all moderators. Set to 0 to disable these notifications.""
       notify_about_queued_posts_after: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If there are reviewable items that haven\u2019t been handled after this many hours, send a personal message to moderators. Set to 0 to disable.""
       notify_about_reviewable_item_after: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If a user is automatically silenced, send a message to all moderators.""
       notify_mods_when_user_silenced: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When a post is flagged and then removed, all users that responded to the post and had their responses removed will be notified.""
       notify_users_after_responses_deleted_on_flagged_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of unique flaggers that is required to automatically pause a topic for intervention""
       num_flaggers_to_close_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of hours to pause a topic for intervention.""
       num_hours_to_close_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If a new user's posts get this many flags from num_tl3_users_to_silence_new_user different trust level 3 users, hide all their posts and prevent future posting. 0 to disable.""
       num_tl3_flags_to_silence_new_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If a new user's posts get num_tl3_flags_to_silence_new_user flags from this many different trust level 3 users, hide all their posts and prevent future posting. 0 to disable.""
       num_tl3_users_to_silence_new_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If a new user's posts exceed the hide_post_sensitivity setting, and has spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable.""
       num_users_to_silence_new_user: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The number of days after which a post notice is considered old. This visually differentiates it from newer notices on the site.""
       old_post_notice_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default opengraph image, used when the page has no other suitable image. If left blank, large_icon will be used""
       opengraph_image: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen.""
       page_loading_indicator: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of unique characters that a password must have.""
       password_unique_characters: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically include offending post message in email message template when silencing or suspending a user""
       penalty_include_post_message: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default penalties for silencing or suspending users in hours. First offense defaults to the first value, second offense defaults to the second value, etc.""
       penalty_step_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Notify moderators if new users have been waiting for approval for longer than this many minutes. Set to -1 to disable notifications.""
       pending_users_reminder_delay_minutes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Apply the following regex before matching permalinks, for example: /(topic.*)\?.*/\1 will strip query strings from topic routes. Format is regex+string use \1 etc. to access captures""
       permalink_normalizations: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Users will remain logged in when the web browser is closed""
       persistent_sessions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Wait (n) seconds before sending any personal message notification emails, to give users a chance to edit and finalize their messages.""
       personal_email_time_window_seconds: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users in these groups to CREATE personal messages. IMPORTANT: 1) all users can REPLY to messages. 2) Admins and mods can CREATE messages to any user. 3) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 4) Group interaction settings override this setting for messaging specific groups.""
       personal_message_enabled_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow members of included groups to tag any personal message""
       pm_tags_allowed_for_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When creating a new PM warn users when target recepient has not been seen more than n months ago.""
       pm_warn_user_last_seen_months_ago: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Quality of the converted JPG file (1 is lowest quality, 99 is best quality, 100 to disable).""
       png_to_jpg_quality: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When not long polling, how often should logged on clients poll in milliseconds""
       polling_interval: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Delete emails from server. NOTE: If you disable this you should manually clean your mail inbox""
       pop3_polling_delete_from_server: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Activate POP3 polling to receive email replies. Upon activation, the system will check a specified POP3 mailbox for emails and handle them as topic replies. See the <a href='https://meta.discourse.org/t/set-up-reply-by-email-with-pop3-polling/14003' target='_blank'>guide on Meta</a> for more information.""
       pop3_polling_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The host for the POP3 server to poll for email.""
       pop3_polling_host: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Verify TLS server certificate (Default: enabled)""
       pop3_polling_openssl_verify: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The password for the POP3 account to poll for email.""
       pop3_polling_password: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The period in minutes between checking the POP3 account for email. NOTE: Requires restart.""
       pop3_polling_period_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The port for the POP3 server to poll for email.""
       pop3_polling_port: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use SSL while connecting to the POP3 server. (Recommended)""
       pop3_polling_ssl: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The username for the POP3 account to poll for email.""
       pop3_polling_username: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A tl0 or tl1 author can edit their post for (n) minutes after posting. Set to 0 for forever.""
       post_edit_time_limit: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum length of a post excerpt / summary.""
       post_excerpt_maxlength: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""In notification emails, always send excerpts instead of full posts""
       post_excerpts_in_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to include links in posts. Admins and moderators are always allowed to post links.""
       post_links_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Configure the visibility and order of default post menu items. Additional items added by plugins or themes are managed separately and won\u2019t appear in this list.""
       post_menu: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The menu items to hide by default in the post menu unless an expansion ellipsis is clicked on. Additional items added by plugins or themes are managed separately and won\u2019t appear in this list.""
       post_menu_hidden_items: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum length of a oneboxed Discourse post in characters.""
       post_onebox_maxlength: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of minutes users are allowed to undo recent actions on a post (like, flag, etc).""
       post_undo_action_window_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Token used to verify webhook payload. It must be passed as the 't' query parameter of the webhook, for example: https://example.com/webhook/postmark?t=supersecret""
       postmark_webhook_token: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent anonymous users from downloading attachments.""
       prevent_anons_from_downloading_files: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How long a visit lasts before we consider it the 'previous' visit, in hours""
       previous_visit_timeout_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show username first on user page, user card and posts (when disabled name is shown first)""
       prioritize_username_in_ux: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If you have a Privacy Policy document hosted elsewhere that you want to use, provide the full URL here.""
       privacy_policy_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't include content from posts or topics in email title or email body. NOTE: also disables digest emails.""
       private_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to upload a profile background. Admins and moderators can always upload a profile background.""
       profile_background_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of user custom fields that can be retrieved with the API.""
       public_user_custom_fields: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Grace period (in days) before a deleted upload is erased.""
       purge_deleted_uploads_grace_period_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Grace period (in days) before a user who has not activated their account is deleted. Set to 0 to never purge unactivated users.""
       purge_unactivated_users_grace_period_days: "deactivated|inactive|unactivated"
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Wait (n) minutes before sending push notification. Helps prevent push notifications from being sent to an active online user.""
       push_notification_time_window_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The badge icon that appears in the notification corner. A 96\u00D796 monochromatic PNG with transparency is recommended.""
       push_notifications_icon: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show a user consent banner for push notifications. This setting triggers a prompt asking users for permission to send them push notifications. It only appears when push notifications are not already enabled, are supported by the user's device, and the user has either made a post or is using a Progressive Web App (PWA). The prompt will not be shown again if the user has already dismissed it or granted/denied permission.""
       push_notifications_prompt: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After posting, users must wait (n) seconds before creating another post.""
       rate_limit_create_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After creating a topic, users must wait (n) seconds before creating another topic.""
       rate_limit_create_topic: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After posting, new users must wait (n) seconds before creating another post.""
       rate_limit_new_user_create_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many characters should be stored for incoming email.""
       raw_email_max_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many characters should be stored for rejected incoming email.""
       raw_rejected_email_max_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Word count per minute for calculating estimated reading time.""
       read_time_word_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Quality of uploaded image files (1 is lowest quality, 99 is best quality, 100 to disable).""
       recompress_original_jpg_quality: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically redirect new and long absent users to the top page. Only applies when 'top' is present in the 'top menu' site setting.""
       redirect_users_to_top_page: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days after posting where post dates will be shown as relative (7d) instead of absolute (20 Feb).""
       relative_date_duration: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically remove quotation if (a) it appears at the start of a post, (b) it is of an entire post, and (c) it is from the immediately preceding post. For details, see <a href='https://meta.discourse.org/t/removal-of-full-quotes-from-direct-replies/106857' target='_blank'>Removal of full quotes from direct replies</a>""
       remove_full_quote: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show topics tagged only with muted tags in the latest topic list.""
       remove_muted_tags_from_latest: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remove backups older than the specified number of days. Leave blank to disable.""
       remove_older_backups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Template for reply by email incoming email address, for example: %%{reply_key}@reply.example.com or replies+%%{reply_key}@example.com""
       reply_by_email_address: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Activate the feature that permits users to respond to topics directly through email, instead of requiring them to log into the website. See <a href='https://meta.discourse.org/t/set-up-reply-by-email-with-pop3-polling/14003' target='_blank'>the guide on Meta</a> for more information.""
       reply_by_email_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Require non-staff users to confirm their old email address before changing it. Does not apply to staff users, they always need to confirm their old email address.""
       require_change_email_confirmation: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Usernames for which signup is not allowed. Wildcard symbol * can be used to match any character zero or more times.""
       reserved_usernames: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically reset bounce score after X days.""
       reset_bounce_score_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Resize lightbox preview images to allow for high DPI screens of the following pixel ratios. Remove all values to disable responsive images.""
       responsive_post_image_sizes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of 6-digit hexadecimal color values to be used for letter avatar background.""
       restrict_letter_avatar_colors: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days to retain web hook event aggregate records.""
       retain_web_hook_events_aggregate_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days to retain web hook event records.""
       retain_web_hook_events_period_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Automatically retry failed web hook events for 4 times. Time gaps between the retries are 1, 5, 25 and 125 minutes.""
       retry_web_hook_events: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum trust level required to see returning user post notices.""
       returning_user_notice_tl: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many days should pass before a user is considered to be returning.""
       returning_users_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send every new post to the review queue for moderation. Posts are still published immediately and are visible to all users. WARNING! Not recommended for high-traffic sites due to the potential volume of posts needing review.""
       review_every_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Staff will review posts of users with lower trust levels if they contain embedded media.""
       review_media_unless_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Does reviewable content need to be claimed before it can be acted upon?""
       reviewable_claiming: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show reviewable content grouped by topic by default""
       reviewable_default_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show reviewable items unless they meet this priority""
       reviewable_default_visibility: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The priority filter hides reviewable items that don't meet this score unless the '(any)' filter is used.""
       reviewable_low_priority_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List of reasons that can be selected when rejecting a reviewable queued post with a revision. Other is always available as well, which allows for a custom reason to be entered.""
       reviewable_revision_reasons: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days before an API key is automatically revoked (0 for never)""
       revoke_api_keys_maxlife_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days since an API key was last used before it is automatically revoked (0 for never)""
       revoke_api_keys_unused_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days before a user API key is automatically revoked (0 for never)""
       revoke_user_api_keys_maxlife_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of days since a user API key was last used before it is automatically revoked (0 for never)""
       revoke_user_api_keys_unused_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The Amazon S3 access key id that will be used to upload images, attachments, and backups.""
       s3_access_key_id: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The remote bucket to hold backups. WARNING: Make sure it is a private bucket.""
       s3_backup_bucket: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The CDN URL to use for all s3 assets (for example: https://cdn.somewhere.com). WARNING: after changing this setting you must rebake all old posts.""
       s3_cdn_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable automatic deletion policy for tombstone uploads. IMPORTANT: If disabled, no space will be reclaimed after uploads are deleted.""
       s3_configure_tombstone_policy: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent removal of old backups from S3 when there are more backups than the maximum allowed.""
       s3_disable_cleanup: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The endpoint can be modified to backup to an S3 compatible service like DigitalOcean Spaces or Minio. WARNING: Leave blank if using AWS S3.""
       s3_endpoint: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The Amazon S3 region name that will be used to upload images and backups.""
       s3_region: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The Amazon S3 secret access key that will be used to upload images, attachments, and backups.""
       s3_secret_access_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The Amazon S3 bucket name that files will be uploaded into. WARNING: must be lowercase, no periods, no underscores.""
       s3_upload_bucket: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""AWS recommends not using ACLs on S3 buckets; if you are following this advice, uncheck this option. This must be enabled if you are using secure uploads.""
       s3_use_acls: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use CDN URL for all the files uploaded to s3 instead of only for images.""
       s3_use_cdn_url_for_all_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use an <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html\">AWS EC2 instance profile</a> to grant access to the S3 bucket. NOTE: enabling this requires Discourse to be running in an appropriately-configured EC2 instance, and overrides the \"s3 access key id\" and \"s3 secret access key\" settings.""
       s3_use_iam_profile: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default sort order for full-page search""
       search_default_sort_order: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Accent marks in search queries are disregarded if this setting is enabled, allowing users to find results even if they don't input the correct accents.""
       search_ignore_accents: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If searching your large forum is slow, this option tries an index of more recent posts first""
       search_prefer_recent_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum amount of time to keep search queries, in days.""
       search_query_log_max_retention_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum amount of search queries to keep""
       search_query_log_max_size: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many recent posts to keep in the index""
       search_recent_posts_size: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Force search to tokenize Chinese even on non Chinese sites""
       search_tokenize_chinese: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Force search to tokenize Japanese even on non Japanese sites""
       search_tokenize_japanese: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Limits access to ALL uploads (images, video, audio, text, pdfs, zips, and others). If \"login required\u201D is enabled, only logged-in users can access uploads. Otherwise, access will be limited only for media uploads in personal messages and private categories. WARNING: This setting is complex and requires deep administrative understanding. See <a target=\"_blank\" href=\"https://meta.discourse.org/t/-/140017\">the secure uploads topic on Meta</a> for details.""
       secure_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allows embedding secure images that would normally be redacted in emails, if their size is smaller than the 'secure uploads max email embed image size kb' setting.""
       secure_uploads_allow_embed_images_in_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The size cutoff for secure images that will be embedded in emails if the 'secure uploads allow embed in emails' setting is enabled. Without that setting enabled, this setting has no effect.""
       secure_uploads_max_email_embed_image_size_kb: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify a collection of avatars from which users can select their profile picture. The choice will appear during user profile creation or when updating the profile avatar.""
       selectable_avatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to select an avatar from the selectable_avatars list and limit custom avatar uploads to the selected trust level.""
       selectable_avatars_mode: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users in these groups to make their own posts wiki. Admins and moderators can always make their own posts wiki.""
       self_wiki_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to send personal messages via email. Admins and moderators can always send personal messages via email.""
       send_email_messages_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remind about old credentials after days""
       send_old_credential_reminder_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send new trust level 1 users a welcome message.""
       send_tl1_welcome_message: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send new trust level 2 users a message about promotion.""
       send_tl2_promotion_message: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Send all new users a welcome message with a quick start guide.""
       send_welcome_message: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Sendgrid verification key used to verify webhook messages.""
       sendgrid_verification_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of posts a user has to make in a row in a topic before being reminded about too many sequential replies.""
       sequential_replies_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""set interface language for anonymous users from their web browser's language headers""
       set_locale_from_accept_language_header: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable sharing of anonymized usage statistics with CDCK, Inc. (\u201CDiscourse\u201D). When this setting is enabled, data concerning the usage of the site is collected and shared in anonymized form, ensuring no personal information is disclosed.""
       share_anonymized_statistics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Determine which items appear on the share dialog, and in what order.""
       share_links: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Determine which items appear in the quote sharing widget, and in what order.""
       share_quote_buttons: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Determine when to show quote sharing buttons: never, to anonymous users only or all users. ""
       share_quote_visibility: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users in these groups to see and edit Shared Drafts.""
       shared_drafts_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable the Shared Drafts feature by designating a category for topic drafts. Topics in this category will be suppressed from topic lists for staff users.""
       shared_drafts_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to see and edit Shared Drafts.""
       shared_drafts_min_trust_level: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Define the maximum length, in bytes, for an email to be classified as 'short' for image suppression. If an email's size does not exceed this setting, any images (such as avatars and emojis) within the email will be stripped out.""
       short_email_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After the number of posts in a topic goes above this number, the progress bar will only show the current post number. If you change the progress bar's width, you may need to change this value.""
       short_progress_text_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Short description in a few words. Visible to all visitors including anonymous users.""
       short_site_description: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The short title will be used on the user's home screen, launcher, or other places where space may be limited. It should be limited to 12 characters.""
       short_title: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When a user earns a badge for a particular post, display the badge in the post header.""
       show_badges_in_post_header: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Shows the topic map at the bottom of the topic when it has 10 replies or more.""
       show_bottom_topic_map: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Add a button to codeblocks to copy the block contents to the user's clipboard.""
       show_copy_button_on_codeblocks: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow logged in users to browse profiles of inactive accounts.""
       show_inactive_accounts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show excerpt on pinned topics in desktop view.""
       show_pinned_excerpt_desktop: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show excerpt on pinned topics in mobile view.""
       show_pinned_excerpt_mobile: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Anonymous users can see published pages, even when login is required.""
       show_published_pages_login_required: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show email instructions on the signup form.""
       show_signup_form_email_instructions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show full name instructions on the signup form.""
       show_signup_form_full_name_instructions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show password instructions on the signup form.""
       show_signup_form_password_instructions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show username instructions on the signup form.""
       show_signup_form_username_instructions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If two posts are made this many days apart, display the time gap in the topic.""
       show_time_gap_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show the topic featured link in the digest email.""
       show_topic_featured_link_in_digest: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Shows the topic map even if the topic has no replies.""
       show_topic_map_in_topics_without_replies: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show user avatars in the user menu""
       show_user_menu_avatars: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The likelihood that a new user will be silenced based on spam flags""
       silence_new_user_sensitivity: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum number of files that can be dragged & dropped in the composer""
       simultaneous_uploads: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A valid name of a group that gets invited to all automatically sent personal messages.""
       site_contact_group_name: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A valid staff username to send all automated messages from. If left blank the default System account will be used.""
       site_contact_username: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Describe this site in one sentence. Visible to all visitors including anonymous users.""
       site_description: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of URLs to include in each sitemap page. Max 50.000""
       sitemap_page_size: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When automatically deleting old replies, skip deleting posts with this number of likes or more.""
       skip_auto_delete_reply_likes: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Users who are not in any of these groups will have their posts sent to staff for review if the post contains embedded media. Posts created by admins and moderators are always allowed.""
       skip_review_media_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If slow_down_crawler_user_agents is specified this rate will apply to all the crawlers (number of seconds delay between requests)""
       slow_down_crawler_rate: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User agents of web crawlers that should be rate limited as configured in the \"slow down crawler rate\" setting. Each value must be at least 3 characters long.""
       slow_down_crawler_user_agents: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Does 'Slow Mode' prevent editing, after editing_grace_period?""
       slow_mode_prevents_editing: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Choose a slug generation method. 'encoded' will generate percent encoding string. 'none' will disable slug at all.""
       slug_generation_method: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Bounce score added to the user when a temporary bounce happens.""
       soft_bounce_score: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Token used to verify webhook payload. It must be passed as the 't' query parameter of the webhook, for example: https://example.com/webhook/sparkpost?t=supersecret""
       sparkpost_webhook_token: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Displays a temporary loading screen while site assets load""
       splash_screen: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Posts will be locked from editing if they are edited by staff members""
       staff_edit_locks_post: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How much weight to give staff likes (non-staff likes have a weight of 1.)""
       staff_like_weight: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of user custom fields that can be retrieved for staff members with the API.""
       staff_user_custom_fields: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable this setting to remove all the additional information from the images uploaded on the site. This includes data such as the camera model, location, creation date etc. This can be useful for privacy reasons, as it prevents users from unintentionally sharing sensitive information.""
       strip_image_metadata: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Strip images from emails having size less than 2800 Bytes""
       strip_images_from_short_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remove leading and trailing whitespaces from each line of incoming emails.""
       strip_incoming_email_lines: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Include weekends (Saturday and Sunday) in date picker suggestions (disable this if you use Discourse only on weekdays, Monday through Friday).""
       suggest_weekends_in_date_pickers: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of suggested topics shown at the bottom of a topic.""
       suggested_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suggested topics should not be more than n days old.""
       suggested_topics_max_days_old: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suggested unread topics should not be more than n days old.""
       suggested_topics_unread_max_days_old: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum likes in a topic before 'Summarize This Topic' is enabled. Changes to this setting will be applied retroactively within a week.""
       summary_likes_required: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum posts returned by 'Summarize This Topic'""
       summary_max_results: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When a user clicks 'Summarize This Topic', show the top % of posts""
       summary_percent_filter: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum posts in a topic before 'Summarize This Topic' is enabled. Changes to this setting will be applied retroactively within a week.""
       summary_posts_required: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum score required for a post to be included in 'Summarize This Topic'""
       summary_score_threshold: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show a 'Summarize' button in the timeline""
       summary_timeline_button: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Support mixed left-to-right and right-to-left text directions.""
       support_mixed_text_direction: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suppress summary emails for users not seen on the site for more than (n) days.""
       suppress_digest_email_after_days: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If tags match exact words in topic titles, don't show the tag""
       suppress_overlapping_tags_in_list: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show the expandable in-reply-to on a post when there is only a single reply directly above this post.""
       suppress_reply_directly_above: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show the expandable reply count on a post when there is only a single reply directly below this post.""
       suppress_reply_directly_below: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show the expandable in-reply-to on a post when post quotes reply.""
       suppress_reply_when_quoting: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Suppress topics and PMs from the admin UI unless they are participants. This is not a security feature: admins can always access all content on the site if needed.""
       suppress_secured_categories_from_admin: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Don't show the badge for uncategorized topics in topic lists.""
       suppress_uncategorized_badge: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Add additional FontAwesome icons that you would like to include in your assets. Use prefix 'fa-' for solid icons, 'far-' for regular icons and 'fab-' for brand icons.""
       svg_icon_subset: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Define the visual appearance of tag badges on the site. This setting allows you to customize how tags are visually represented across all areas of the site, enhancing layout consistency and user accessibility.""
       tag_style: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to tag topics. Admins and moderators can always tag topics.""
       tag_topic_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Enable tags on topics? See the <a href='https://meta.discourse.org/t/admin-guide-to-tags-in-discourse/121041'>Admin guide to tags on Meta</a> for more information.""
       tagging_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""List tags by tag group on the <a href='%{base_path}/tags' target='_blank'>Tags page</a>.""
       tags_listed_by_group: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show tags in alphabetical order. Default is to show in order of popularity.""
       tags_sort_alphabetically: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A list of file extensions allowed for theme uploads""
       theme_authorized_extensions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The name of this site. Visible to all visitors including anonymous users.""
       title: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Convert common ASCII characters to fancy HTML entities in topic titles, ala SmartyPants <a href='https://daringfireball.net/projects/smartypants/' target='_blank'>https://daringfireball.net/projects/smartypants/</a>""
       title_fancy_entities: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum allowed word length, in characters, in a topic title.""
       title_max_word_length: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum entropy (unique characters, non-english count for more) required for a topic title.""
       title_min_entropy: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Prevent common title typos and errors, including all caps, lowercase first character, multiple ! and ?, extra . at end, etc.""
       title_prettify: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Remove leading whitespaces in front of the end punctuation.""
       title_remove_extraneous_space: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many posts a new user must read before promotion to trust level 1.""
       tl1_requires_read_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many minutes a new user must read posts before promotion to trust level 1.""
       tl1_requires_time_spent_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many topics a new user must enter before promotion to trust level 1.""
       tl1_requires_topics_entered: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of edits per day for tl2 (member) by multiplying with this number""
       tl2_additional_edits_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of flags per day for tl2 (member) by multiplying with this number""
       tl2_additional_flags_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of likes per day for tl2 (member) by multiplying with this number""
       tl2_additional_likes_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""A tl2+ author can edit their post for (n) minutes after posting. Set to 0 for forever.""
       tl2_post_edit_time_limit: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many days a user must visit the site before promotion to trust level 2.""
       tl2_requires_days_visited: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many likes a user must cast before promotion to trust level 2.""
       tl2_requires_likes_given: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many likes a user must receive before promotion to trust level 2.""
       tl2_requires_likes_received: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many posts a user must read before promotion to trust level 2.""
       tl2_requires_read_posts: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many minutes a user must read posts before promotion to trust level 2.""
       tl2_requires_time_spent_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many topics user must reply to before promotion to trust level 2.""
       tl2_requires_topic_reply_count: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many topics a user must enter before promotion to trust level 2.""
       tl2_requires_topics_entered: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of edits per day for tl3 (regular) by multiplying with this number""
       tl3_additional_edits_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of flags per day for tl3 (regular) by multiplying with this number""
       tl3_additional_flags_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of likes per day for tl3 (regular) by multiplying with this number""
       tl3_additional_likes_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Do not remove rel=nofollow from links posted by trust level 3 users.""
       tl3_links_no_follow: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum number of days that a promotion to trust level 3 lasts before a user can be demoted back to trust level 2.""
       tl3_promotion_min_duration: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of days that a user needs to have visited the site in the last (tl3 time period) days to qualify for promotion to trust level 3. Set higher than tl3 time period to disable promotions to tl3. (0 or higher)""
       tl3_requires_days_visited: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum number of likes that must be given in the last (tl3 time period) days to qualify for promotion to trust level 3.""
       tl3_requires_likes_given: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum number of likes that must be received in the last (tl3 time period) days to qualify for promotion to trust level 3.""
       tl3_requires_likes_received: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""User must not have had more than x posts flagged by x different users in the last (tl3 time period) days to qualify for promotion to trust level 3, where x is this setting's value. (0 or higher)""
       tl3_requires_max_flagged: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The percentage of posts created in the last (tl3 time period) days that a user needs to have viewed to qualify for promotion to trust level 3. (0 to 100)""
       tl3_requires_posts_read: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum total number of posts a user must have read to qualify for trust level 3.""
       tl3_requires_posts_read_all_time: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum required number of posts read in the last (tl3 time period) days.""
       tl3_requires_posts_read_cap: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Minimum number of topics a user needs to have replied to in the last (tl3 time period) days to qualify for promotion to trust level 3. (0 or higher)""
       tl3_requires_topics_replied_to: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The percentage of topics created in the last (tl3 time period) days that a user needs to have viewed to qualify for promotion to trust level 3. (0 to 100)""
       tl3_requires_topics_viewed: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The minimum total number of topics a user must have viewed to qualify for trust level 3.""
       tl3_requires_topics_viewed_all_time: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum required number of topics viewed in the last (tl3 time period) days.""
       tl3_requires_topics_viewed_cap: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Trust Level 3 requirements time period (in days)""
       tl3_time_period: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of edits per day for tl4 (leader) by multiplying with this number""
       tl4_additional_edits_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of flags per day for tl4 (leader) by multiplying with this number""
       tl4_additional_flags_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Increase limit of likes per day for tl4 (leader) by multiplying with this number""
       tl4_additional_likes_per_day_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow TL4 users to delete posts and topics created by other users. TL4 users will also be able to see deleted topics and posts.""
       tl4_delete_posts_and_topics: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Determine which items appear in the homepage navigation, and in what order.""
       top_menu: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Default top page time period for anonymous users (automatically adjusts for logged in users based on their last visit).""
       top_page_default_timeframe: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""value of first post likes multiplier (n) in top topics formula: `log(views_count) * 2 + op_likes_count * (n) + LEAST(likes_count / posts_count, 3) + 10 + log(posts_count)`""
       top_topics_formula_first_post_likes_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""value of least likes per post multiplier (n) in top topics formula: `log(views_count) * 2 + op_likes_count * 0.5 + LEAST(likes_count / posts_count, (n)) + 10 + log(posts_count)`""
       top_topics_formula_least_likes_per_post_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""value of log views multiplier (n) in top topics formula: `log(views_count) * (n) + op_likes_count * 0.5 + LEAST(likes_count / posts_count, 3) + 10 + log(posts_count)`""
       top_topics_formula_log_views_multiplier: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Maximum length of a topic excerpt / summary, generated from the first post in a topic.""
       topic_excerpt_maxlength: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allows users to associate a feature link with their topics. When turned on, topics can have a highlighted link attached, which is publicly visible and can be edited if the user has sufficient permissions. The feature link can enhance a topic's comprehensibility by providing related additional content.""
       topic_featured_link_enabled: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Topic page <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title' target='_blank'>title tag</a> includes the category name.""
       topic_page_title_includes_category: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After the likes:post ratio exceeds this ratio, the post count field is strongly highlighted.""
       topic_post_like_heat_high: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After the likes:post ratio exceeds this ratio, the post count field is slightly highlighted.""
       topic_post_like_heat_low: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After the likes:post ratio exceeds this ratio, the post count field is moderately highlighted.""
       topic_post_like_heat_medium: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Count a new topic view once per IP/User every N hours""
       topic_view_duration_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many views, the views field is strongly highlighted.""
       topic_views_heat_high: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many views, the views field is slightly highlighted.""
       topic_views_heat_low: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""After this many views, the views field is moderately highlighted.""
       topic_views_heat_medium: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of top topics shown on the expanded 'Show More' top topics.""
       topics_per_period_in_top_page: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Number of top topics shown in the default top topics summary.""
       topics_per_period_in_top_summary: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""If you have a Terms of Service document hosted elsewhere that you want to use, provide the full URL here.""
       tos_url: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use traditional linebreaks in Markdown, which require two trailing spaces for a linebreak.""
       traditional_markdown_linebreaks: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Trim part of the incoming emails that isn't relevant.""
       trim_incoming_emails: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Consumer key for Twitter authentication, registered at <a href='https://developer.twitter.com/apps' target='_blank'>https://developer.twitter.com/apps</a>""
       twitter_consumer_key: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Consumer secret for Twitter authentication, registered at <a href='https://developer.twitter.com/apps' target='_blank'>https://developer.twitter.com/apps</a>""
       twitter_consumer_secret: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Twitter card 'summary large image' (should be at least 280 in width, and at least 150 in height, cannot be .svg). If left blank, regular card metadata is generated using the opengraph_image, as long as that is not also a .svg""
       twitter_summary_large_image: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow usernames and group names to contain Unicode letters and numbers.""
       unicode_usernames: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""How many minutes before a user can make a post with the same content again""
       unique_posts_mins: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to unsubscribe from emails by sending an email with 'unsubscribe' in the subject or body""
       unsubscribe_via_email: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Attach an unsubscribe via email mailto: link to the footer of sent emails""
       unsubscribe_via_email_footer: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Specify groups allowed to upload custom profile pictures.""
       uploaded_avatars_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Admins can only log in if they are at an IP address defined in the Screened IPs list (Admin > Logs > Screened Ips).""
       use_admin_ip_allowlist: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`).""
       use_email_for_username_and_name_suggestions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use a user's full name when suggesting usernames.""
       use_name_for_username_suggestions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Use the site's small logo instead of the system user's avatar. Requires the logo to be present.""
       use_site_small_logo_as_system_avatar: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Group membership required for generation of user API keys.<br>\n<b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub.<br>\n Admins and moderators can always create user API keys.\n""
       user_api_key_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups that are allowed to upload a user card background. Admins and moderators can always upload a user card background.""
       user_card_background_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Count a new user profile view once per IP/User every N hours""
       user_profile_view_duration_hours: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow users to set their own primary group""
       user_selected_primary_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""The maximum number of days after registration that accounts can change their username (0 to disallow username change).""
       username_change_period: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Log verbose DiscourseConnect related diagnostics to <a href='%{base_path}/logs' target='_blank'>/logs</a>""
       verbose_discourse_connect_logging: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Show extended localization tips in the UI""
       verbose_localization: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Ping the Discourse Hub for version updates and show new version messages on the <a href='%{base_path}/admin' target='_blank'>/admin</a> dashboard""
       version_checks: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information.""
       view_raw_email_allowed_groups: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""When someone starts replying to a topic where the last reply is older than this many days, a warning will be displayed. Disable by setting to 0.""
       warn_reviving_old_topic_age: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Notify me about topics in categories or tags I\u2019m watching that also belong to one I have muted""
       watched_precedence_over_muted: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allows the use of regular expressions for filtering words. If enabled, this feature groups sensitive words by their case-sensitivity. It then compiles all selected words into a single regular expression, adding word boundaries for regular watched words. Consequently, this regex-based filtering method adds an extra layer of control over content moderation by supporting more sophisticated word patterns. The setting also allows to easily substitute the original text with the replacement of choice.""
       watched_words_regular_expressions: ""
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is ""Allow private communication within topics for members of specified groups.""
       whispers_allowed_groups: ""
+
       # END KEYWORDS
 
     placeholder:

--- a/lib/tasks/site_settings.rake
+++ b/lib/tasks/site_settings.rake
@@ -117,9 +117,17 @@ task "site_settings:add_keyword_translation_keys" => :environment do
   removed = yml["en"]["site_settings"]["keywords"].length - new_keywords.length - added
 
   new_text = ""
-  new_keywords.keys.sort.each { |key| new_text += "      #{key}: \"#{new_keywords[key]}\"\n" }
+  new_keywords.keys.sort.each do |key|
+    # Add additional context for translators
+    new_text += <<-TEXT
+      # This is a pipe "|" separated list of keywords that are used to search through site settings in the admin panel.
+      # English keywords will always be recognised, if there are relevant keywords in your language, please include them here.
+      # For additional context, the description of this site setting is "#{yml["en"]["site_settings"][key].dump}"
+      #{key}: "#{new_keywords[key]}"
+    TEXT
+  end
 
-  text.gsub!(/(# BEGIN KEYWORDS\n)(.*)(      # END KEYWORDS)/m, "\\1#{new_text}\\3")
+  text.gsub!(/(# BEGIN KEYWORDS)(.*)(# END KEYWORDS)/m, "\\1\n\n#{new_text}\n      \\3")
 
   File.write(filename, text)
 


### PR DESCRIPTION
## ✨ What's This?

Follow-up to #30485.

The site setting keyword entries are mostly empty strings, and don't really provide any useful information to translators, allowing them to choose what to set them to. This PR adds a comment for each site setting keyword entry, providing contextual information that will be auto-populated into the Crowdin interface, informing translators of what they should do with this string.
