### PR TITLE
UX: Admin setting page consistency - Notifications

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-notifications-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-notifications-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigNotificationsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-notifications.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-notifications.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigNotificationsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.community.sidebar_link.notifications");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -206,9 +206,18 @@ export default function () {
         });
 
         this.route("about");
-        this.route("loginAndAuthentication", { path: "/" }, function () {
+        this.route(
+          "loginAndAuthentication",
+          { path: "/login-and-authentication" },
+          function () {
+            this.route("settings", {
+              path: "/",
+            });
+          }
+        );
+        this.route("notifications", function () {
           this.route("settings", {
-            path: "/login-and-authentication",
+            path: "/",
           });
         });
         this.route("lookAndFeel", { path: "/look-and-feel" }, function () {

--- a/app/assets/javascripts/admin/addon/templates/config-notifications-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-notifications-settings.hbs
@@ -1,0 +1,21 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.config.notifications.title"}}
+  @descriptionLabel={{i18n "admin.config.notifications.header_description"}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/config/notifications"
+      @label={{i18n "admin.config.notifications.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
+<div class="admin-config-page__main-area">
+  <AdminAreaSettings
+    @area="notifications"
+    @path="/admin/config/notifications"
+    @filter={{this.filter}}
+    @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -48,9 +48,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_notifications",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["all_results"],
-        query: { filter: "notifications" },
+        route: "adminConfig.notifications.settings",
         label: "admin.community.sidebar_link.notifications",
         icon: "bell",
       },

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteSetting < ActiveRecord::Base
-  VALID_AREAS = %w[flags about emojis permalinks]
+  VALID_AREAS = %w[flags about emojis permalinks notifications]
 
   extend GlobalPath
   extend SiteSettingExtension

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5137,6 +5137,9 @@ en:
         login_and_authentication:
           title: "Login and authentication"
           header_description: "Configure how users log in and authenticate, secrets and keys, OAuth2 providers, and more."
+        notifications:
+          title: "Notifications"
+          header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation."
 
       new_features:
         title: "What's new?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,9 +391,9 @@ Discourse::Application.routes.draw do
       end
       namespace :config, constraints: StaffConstraint.new do
         resources :site_settings, only: %i[index]
-        resources :login_and_authentication, only: %i[index]
 
         get "login-and-authentication" => "site_settings#index"
+        get "notifications" => "site_settings#index"
 
         resources :flags, only: %i[index new create update destroy] do
           put "toggle"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -53,7 +53,7 @@ required:
   contact_email:
     default: ""
     type: email
-    area: "about"
+    area: "about|notifications"
   contact_url:
     default: ""
     area: "about"
@@ -369,15 +369,19 @@ basic:
   push_notifications_prompt:
     default: true
     client: true
+    area: "notifications"
   push_notifications_icon:
     default: ""
     type: upload
+    area: "notifications"
   enable_desktop_push_notifications:
     default: true
     client: true
+    area: "notifications"
   push_notification_time_window_mins:
     default: 1
     min: 0
+    area: "notifications"
   short_title:
     default: ""
     max: 12
@@ -817,6 +821,7 @@ users:
   max_notifications_per_user:
     default: 10000
     hidden: true
+    area: "notifications"
   gravatar_name:
     default: Gravatar
     client: true
@@ -1034,12 +1039,17 @@ posting:
   enable_mentions:
     default: true
     client: true
-  max_mentions_per_post: 10
+  max_mentions_per_post:
+    default: 10
+    area: "notifications"
   max_users_notified_per_group_mention:
     default: 100
     client: true
+    area: "notifications"
   newuser_max_replies_per_topic: 3
-  newuser_max_mentions_per_post: 2
+  newuser_max_mentions_per_post:
+    default: 2
+    area: "notifications"
   here_mention:
     default: "here"
     validator: "NotUsernameValidator"
@@ -1188,6 +1198,7 @@ posting:
     type: float
     default: 24
     min: 0
+    area: "notifications"
   auto_close_messages_post_count:
     default: 500
   auto_close_topics_post_count:
@@ -2832,25 +2843,32 @@ uncategorized:
   enable_listing_suspended_users_on_search:
     default: false
 
-  disable_system_edit_notifications: true
+  disable_system_edit_notifications:
+    default: true
+    area: "notifications"
 
   disable_category_edit_notifications:
     default: false
+    area: "notifications"
 
   disable_tags_edit_notifications:
     default: false
+    area: "notifications"
 
   notification_consolidation_threshold:
     default: 3
     min: 0
+    area: "notifications"
 
   likes_notification_consolidation_window_mins:
     default: 120
     min: 1
+    area: "notifications"
 
   linked_notification_consolidation_window_mins:
     default: 120
     min: 1
+    area: "notifications"
 
   delete_drafts_older_than_n_days:
     default: 180
@@ -3050,6 +3068,7 @@ user_preferences:
   default_other_notification_level_when_replying:
     enum: "NotificationLevelWhenReplyingSiteSetting"
     default: 2
+    area: "notifications"
   default_other_external_links_in_new_tab: false
   default_other_enable_quoting: true
   default_other_enable_defer: false
@@ -3059,6 +3078,7 @@ user_preferences:
   default_other_like_notification_frequency:
     enum: "LikeNotificationFrequencySiteSetting"
     default: 1
+    area: "notifications"
 
   default_topics_automatic_unpin:
     default: true

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -114,6 +114,7 @@ chat:
     default: 5
     max: 10
     min: 0
+    area: "notifications"
   max_chat_draft_length:
     default: 50_000
     hidden: true


### PR DESCRIPTION
Followup c2282439b32d879a73217eec62449f042914d7d0

![image](https://github.com/user-attachments/assets/f96bae57-819e-4c8c-8541-382173847e6f)

Make the Notifications config page reached from the sidebar
use our consistent site setting page rules.
