### PR TITLE
UX: do not tab to an already active tab

### DIFF
--- a/app/assets/javascripts/discourse/app/components/more-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/more-topics.gjs
@@ -64,6 +64,11 @@ export default class MoreTopics extends Component {
     });
   }
 
+  @action
+  isActiveTab(tab) {
+    return tab?.id === this.selectedTab?.id;
+  }
+
   <template>
     <div class="more-topics__container">
       {{#if (gt this.tabs.length 1)}}
@@ -76,7 +81,8 @@ export default class MoreTopics extends Component {
                   @translatedLabel={{tab.name}}
                   @translatedTitle={{tab.name}}
                   @icon={{tab.icon}}
-                  class={{if (eq tab.id this.activeTab.id) "active"}}
+                  class={{if (this.isActiveTab tab) "active"}}
+                  tabindex={{if (this.isActiveTab tab) -1 0}}
                 />
               </li>
             {{/each}}


### PR DESCRIPTION
There's no action you can do on the active tab of more topics so tabbing to it doesn't make sense.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->