### PR TITLE
DEV: Refactor Notification#acting_user to be ActiveRecord relation

### DIFF
--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -37,7 +37,10 @@ class NotificationSerializer < ApplicationSerializer
   end
 
   def data
-    object.data_hash
+    object.data_hash.tap do |hash|
+      hash[:original_name] = object.acting_user.name if SiteSetting.enable_names &&
+        object.acting_user.present?
+    end
   end
 
   def external_id

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -837,9 +837,7 @@ RSpec.describe Notification do
     end
 
     it "Sets the acting_user correctly for each notification" do
-      Notification.populate_acting_user(
-        [notification1, notification2, notification3, notification4, notification5],
-      )
+      # TODO: remove this spec
       expect(notification1.acting_user).to eq(user1)
       expect(notification2.acting_user).to eq(user2)
       expect(notification3.acting_user).to eq(user3)
@@ -851,7 +849,7 @@ RSpec.describe Notification do
     context "with SiteSettings.enable_names=false" do
       it "doesn't set the :original_name property" do
         SiteSetting.enable_names = false
-        Notification.populate_acting_user([notification6])
+        # todo: refactor spec
         expect(notification6.data_hash[:original_name]).to be_nil
         SiteSetting.enable_names = true
       end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -806,52 +806,21 @@ RSpec.describe Notification do
         )
       expect(notification.shelved_notification).to be_nil
     end
-  end
 
-  describe ".populate_acting_user" do
-    SiteSetting.enable_names = true
+    describe ".acting_user" do
+      fab!(:users) { Fabricate.times(6, :user) }
+      fab!(:notifications) do
+        [
+          { username: users[0].username },
+          { display_username: users[1].username },
+          { mentioned_by_username: users[2].username },
+          { invited_by_username: users[3].username },
+          { original_username: users[4].username },
+        ].map { |data| Fabricate(:notification, user: user, data: data.to_json) }
+      end
 
-    fab!(:user1) { Fabricate(:user) }
-    fab!(:user2) { Fabricate(:user) }
-    fab!(:user3) { Fabricate(:user) }
-    fab!(:user4) { Fabricate(:user) }
-    fab!(:user5) { Fabricate(:user) }
-    fab!(:user6) { Fabricate(:user) }
-    fab!(:notification1) do
-      Fabricate(:notification, user: user, data: { username: user1.username }.to_json)
-    end
-    fab!(:notification2) do
-      Fabricate(:notification, user: user, data: { display_username: user2.username }.to_json)
-    end
-    fab!(:notification3) do
-      Fabricate(:notification, user: user, data: { mentioned_by_username: user3.username }.to_json)
-    end
-    fab!(:notification4) do
-      Fabricate(:notification, user: user, data: { invited_by_username: user4.username }.to_json)
-    end
-    fab!(:notification5) do
-      Fabricate(:notification, user: user, data: { original_username: user5.username }.to_json)
-    end
-    fab!(:notification6) do
-      Fabricate(:notification, user: user, data: { original_username: user6.username }.to_json)
-    end
-
-    it "Sets the acting_user correctly for each notification" do
-      # TODO: remove this spec
-      expect(notification1.acting_user).to eq(user1)
-      expect(notification2.acting_user).to eq(user2)
-      expect(notification3.acting_user).to eq(user3)
-      expect(notification4.acting_user).to eq(user4)
-      expect(notification5.acting_user).to eq(user5)
-      expect(notification5.data_hash[:original_name]).to eq user5.name
-    end
-
-    context "with SiteSettings.enable_names=false" do
-      it "doesn't set the :original_name property" do
-        SiteSetting.enable_names = false
-        # todo: refactor spec
-        expect(notification6.data_hash[:original_name]).to be_nil
-        SiteSetting.enable_names = true
+      it "sets the acting_user correctly for each notification" do
+        5.times { |i| expect(notifications[i].acting_user).to eq(users[i]) }
       end
     end
   end

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -3,7 +3,14 @@
 RSpec.describe NotificationSerializer do
   describe "#as_json" do
     fab!(:user)
-    let(:notification) { Fabricate(:notification, user: user) }
+    fab!(:acting_user) { Fabricate(:user) }
+    fab!(:notification) do
+      Fabricate(
+        :notification,
+        user: user,
+        data: { original_username: acting_user.username }.to_json,
+      )
+    end
     let(:serializer) { NotificationSerializer.new(notification) }
     let(:json) { serializer.as_json }
 
@@ -13,6 +20,16 @@ RSpec.describe NotificationSerializer do
 
     it "does not include external_id when sso is disabled" do
       expect(json[:notification].key?(:external_id)).to eq(false)
+    end
+
+    it "includes original_name when enable_names=true" do
+      SiteSetting.enable_names = true
+      expect(json.dig(:notification, :data, :original_name)).to eq(acting_user.name)
+    end
+
+    it "excludes original_name when enable_names=false" do
+      SiteSetting.enable_names = false
+      expect(json.dig(:notification, :data, :original_name)).to be_nil
     end
   end
 


### PR DESCRIPTION
This allows us to preload it just like any other activerecord relation.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->