### PR TITLE
UX: inherit font-size for code in headings

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -29,7 +29,12 @@ pre > code {
   max-height: 500px;
 }
 
-h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
   font-size: inherit;
 }
 

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -29,7 +29,7 @@ pre > code {
   max-height: 500px;
 }
 
-h1 > code, h2 > code, h3 > code, h4 > code, h5 > code, h6 > code {
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
   font-size: inherit;
 }
 

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -29,6 +29,10 @@ pre > code {
   max-height: 500px;
 }
 
+h1 > code, h2 > code, h3 > code, h4 > code, h5 > code, h6 > code {
+  font-size: inherit;
+}
+
 .hljs-comment,
 .hljs-doctag,
 .hljs-code,


### PR DESCRIPTION
**Problem:** `<code>` inside headings (`<h1>`, `<h2>`, etc) have a fixed font-size. This reduces readability for larger headings due to the dramatic size difference in the same line.

**Solution:** `code` within heading elements set to `font-size: inherit`

![image](https://github.com/user-attachments/assets/01d0a421-14ee-408a-98d5-75ef050baa36)

Internal discussion reference: /t/-/145176