### PR TITLE
DEV: Add `reviewables:populate` rake task

### DIFF
--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -13,6 +13,10 @@ class ReviewablePost < Reviewable
          created_or_edited_by.has_trust_level?(TrustLevel[4])
       return
     end
+    queue_for_review(post)
+  end
+
+  def self.queue_for_review(post)
     system_user = Discourse.system_user
 
     needs_review!(

--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -37,7 +37,7 @@ module DiscourseDev
         raise 'To run this rake task in a production site, set the value of `ALLOW_DEV_POPULATE` environment variable to "1"'
       end
 
-      unless ignore_current_count || @ignore_current_count
+      if !ignore_current_count && !@ignore_current_count
         if current_count >= @count
           puts "Already have #{current_count} #{type} records"
 

--- a/lib/discourse_dev/reviewable.rb
+++ b/lib/discourse_dev/reviewable.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "discourse_dev/record"
+require "faker"
+
+module DiscourseDev
+  class Reviewable < Record
+    def initialize(users, topics, posts)
+      @users = users
+      @topics = topics
+      @posts = posts
+    end
+
+    def self.populate!
+      users = create_needed_users(10)
+      topics = create_needed_topics(5)
+      posts = create_needed_posts(10, topics)
+
+      (
+        [ReviewableFlaggedPost, ReviewableQueuedPost, ReviewablePost, ReviewableUser] +
+          DiscoursePluginRegistry.discourse_dev_populate_reviewable_types.to_a
+      ).each { |klass| klass.new(users, topics, posts).populate! }
+    end
+
+    private
+
+    def self.create_needed_users(count)
+      users = ::User.human_users.limit(count).to_a
+
+      (count - users.size).times { users << User.new.create! } if users.size < count
+
+      users
+    end
+
+    def self.create_needed_topics(count)
+      topics =
+        ::Topic
+          .listable_topics
+          .where("id NOT IN (?)", ::Category.pluck(:topic_id))
+          .limit(count)
+          .to_a
+
+      (count - topics.size).times { topics << Topic.new.create! } if topics.size < count
+
+      topics
+    end
+
+    def self.create_needed_posts(count, topics)
+      per_topic = count / topics.size
+
+      posts = []
+      topics.each do |topic|
+        current_count = topic.posts.where("post_number > 1").count
+
+        (count - current_count).times { Post.new(topic, 1).create! } if current_count < count
+        posts.push(*topic.posts.where("post_number > 1").limit(per_topic).to_a)
+      end
+
+      posts
+    end
+  end
+end

--- a/lib/discourse_dev/reviewable_flagged_post.rb
+++ b/lib/discourse_dev/reviewable_flagged_post.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "discourse_dev/reviewable"
+require "faker"
+
+module DiscourseDev
+  class ReviewableFlaggedPost < Reviewable
+    def populate!
+      types = PostActionType.notify_flag_types.keys
+
+      posts = @posts.sample(types.size + 1)
+      users = @users.sample(types.size + 3)
+
+      types.each do |type|
+        post = posts.pop
+        user = users.pop
+
+        reason = nil
+
+        reason = Faker::Lorem.paragraph if type == :notify_moderators
+
+        PostActionCreator.create(user, post, type, reason:)
+      end
+
+      posts.pop.tap do |post|
+        type = types.excluding(:notify_moderators).sample
+        3.times do
+          user = users.pop
+
+          PostActionCreator.create(user, post, type)
+        end
+      end
+    end
+  end
+end

--- a/lib/discourse_dev/reviewable_post.rb
+++ b/lib/discourse_dev/reviewable_post.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "discourse_dev/reviewable"
+require "faker"
+
+module DiscourseDev
+  class ReviewablePost < Reviewable
+    def populate!
+      @posts.sample(2).each { |post| ::ReviewablePost.queue_for_review(post) }
+    end
+  end
+end

--- a/lib/discourse_dev/reviewable_queued_post.rb
+++ b/lib/discourse_dev/reviewable_queued_post.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "discourse_dev/reviewable"
+require "faker"
+
+module DiscourseDev
+  class ReviewableQueuedPost < Reviewable
+    def populate!
+      2.times do
+        topic = @topics.sample
+        manager =
+          NewPostManager.new(
+            @users.sample,
+            {
+              topic_id: topic.id,
+              raw: Faker::DiscourseMarkdown.sandwich(sentences: 3),
+              tags: nil,
+              typing_duration_msecs: Faker::Number.between(from: 2_000, to: 5_000),
+              composer_open_duration_msecs: Faker::Number.between(from: 5_500, to: 10_000),
+              reply_to_post_number: topic.posts.sample.post_number,
+            },
+          )
+        manager.enqueue(:watched_word, creator_opts: { skip_validations: true })
+      end
+    end
+  end
+end

--- a/lib/discourse_dev/reviewable_user.rb
+++ b/lib/discourse_dev/reviewable_user.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "discourse_dev/reviewable"
+require "faker"
+
+module DiscourseDev
+  class ReviewableUser < Reviewable
+    def populate!
+      reasons = %i[must_approve_users invite_only suspect_user]
+      @users
+        .sample(reasons.size)
+        .zip(reasons)
+        .each do |(user, reason)|
+          reviewable =
+            ::ReviewableUser.needs_review!(
+              target: user,
+              created_by: Discourse.system_user,
+              reviewable_by_moderator: true,
+              payload: {
+                username: user.username,
+                name: user.name,
+                email: user.email,
+                bio: user.user_profile&.bio_raw,
+                website: user.user_profile&.website,
+              },
+            )
+
+          reviewable.add_score(
+            Discourse.system_user,
+            ReviewableScore.types[:needs_approval],
+            reason:,
+            force_review: true,
+          )
+        end
+    end
+  end
+end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -73,6 +73,7 @@ class DiscoursePluginRegistry
   define_register :groups_callback_for_users_search_controller_action, Hash
   define_register :mail_pollers, Set
   define_register :site_setting_areas, Set
+  define_register :discourse_dev_populate_reviewable_types, Set
 
   define_filtered_register :staff_user_custom_fields
   define_filtered_register :public_user_custom_fields

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -253,7 +253,7 @@ class NewPostManager
   end
 
   # Enqueue this post
-  def enqueue(reason = nil)
+  def enqueue(reason = nil, creator_opts: {})
     result = NewPostResult.new(:enqueued)
     payload = { raw: @args[:raw], tags: @args[:tags] }
     %w[typing_duration_msecs composer_open_duration_msecs reply_to_post_number].each do |a|
@@ -277,7 +277,7 @@ class NewPostManager
     reviewable.category_id = args[:category] if args[:category].present?
     reviewable.created_new!
 
-    create_options = reviewable.create_options
+    create_options = reviewable.create_options.merge(creator_opts)
 
     creator =
       (

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -29,6 +29,11 @@ task "topics:populate" => ["db:load_config"] do |_, args|
   end
 end
 
+desc "Creates sample reviewables"
+task "reviewables:populate" => ["db:load_config"] do |_, args|
+  DiscourseDev::Reviewable.populate!
+end
+
 desc "Creates sample private messages"
 task "private_messages:populate", [:recipient] => ["db:load_config"] do |_, args|
   args.with_defaults(type: "string")


### PR DESCRIPTION
This PR adds a new `reviewables:populate` rake task that works in a similar fashion to the existing `*:populate` rake tasks. The rake task creates pending reviewable of all core types, with possibility for plugins to extend the task to populate their own reviewable types.

Internal topic: t/93024.