### PR TITLE
FIX: Dashboard report change tooltip was not translated

### DIFF
--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -407,12 +407,21 @@ export default class Report extends EmberObject {
 
   changeTitle(valAtT1, valAtT2, prevPeriodString) {
     const change = this.percentChangeString(valAtT1, valAtT2);
-    let title = "";
+    const title = [];
     if (change) {
-      title += `${change} change. `;
+      title.push(
+        i18n("admin.dashboard.reports.percent_change_tooltip", {
+          percent: change,
+        })
+      );
     }
-    title += `Was ${number(valAtT1)} ${prevPeriodString}.`;
-    return title;
+    title.push(
+      i18n("admin.dashboard.reports.percent_change_tooltip_previous_value", {
+        previousValue: number(valAtT1),
+        previousPeriod: prevPeriodString,
+      })
+    );
+    return title.join(" ");
   }
 
   @discourseComputed("yesterdayCount")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5217,6 +5217,8 @@ en:
 
         reports:
           trend_title: "%{percent} change. Currently %{current}, was %{prev} in previous period."
+          percent_change_tooltip: "%{percent} change."
+          percent_change_tooltip_previous_value: "Was %{previousValue} %{previousPeriod}."
           today: "Today"
           yesterday: "Yesterday"
           last_7_days: "Last 7"


### PR DESCRIPTION
Use i18n in the JS code instead of concatenating English
strings.

c.f. https://meta.discourse.org/t/titles-on-graphs-in-community-health-dashboard-are-not-localized/302776/8?u=martin
