### PR TITLE
Use lambda to dynamically evaluate allowed user api key client scopes

### DIFF
--- a/app/models/user_api_key_client_scope.rb
+++ b/app/models/user_api_key_client_scope.rb
@@ -5,7 +5,7 @@ class UserApiKeyClientScope < ActiveRecord::Base
 
   validates :name,
             inclusion: {
-              in: UserApiKeyScope.all_scopes.keys.map(&:to_s),
+              in: -> { UserApiKeyScope.all_scopes.keys.map(&:to_s) },
               message: "%{value} is not a valid scope",
             }
 


### PR DESCRIPTION
@pmusaraj I think the issue with the AP plugin registering a client in production (e.g. on meta.discourse.org) is that dynamic calculation of the `UserApiKeyClientScope` inclusion list doesn't work in a production environment unless you use a lambda. The error I'm able to recreate in my own production environments is:

```
ActiveRecord::RecordInvalid (Validation failed: Name discourse-activity-pub:read is not a valid scope) app/controllers/user_api_key_clients_controller.rb:27
```

This error does not occur in development and test, and I'm not quite sure how to specifically test for this, however considering this same fix is used elsewhere, I think it's worth adding this and seeing if it fixes our issue in production.

Compare https://github.com/discourse/discourse/commit/e020888b0a30832697aa4735eaaba35f4668b641