### PR TITLE
DEV: Remove invalid parsing options

### DIFF
--- a/spec/support/match_html_matcher.rb
+++ b/spec/support/match_html_matcher.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "nokogiri/xml/parse_options"
 RSpec::Matchers.define :match_html do |expected|
   match { |actual| make_canonical_html(expected).eql? make_canonical_html(actual) }
 
@@ -13,11 +12,7 @@ RSpec::Matchers.define :match_html do |expected|
   end
 
   def make_canonical_html(html)
-    doc =
-      Nokogiri.HTML5(html) do |config|
-        config[:options] = Nokogiri::XML::ParseOptions::NOBLANKS |
-          Nokogiri::XML::ParseOptions::COMPACT
-      end
+    doc = Nokogiri.HTML5(html)
 
     doc.traverse do |node|
       node.content = node.content.gsub(/\s+/, " ").strip if node.node_name&.downcase == "text"


### PR DESCRIPTION
HTML5 parser doesn't have those options

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->