### PR TITLE
UX: use em units for code font-size

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -19,7 +19,7 @@ code {
   color: var(--primary-very-high);
   background: var(--hljs-bg);
   border-radius: var(--d-button-border-radius);
-  font-size: 14px;
+  font-size: 0.875em;
   line-height: calc((13 + 4) / 13);
 }
 
@@ -27,15 +27,6 @@ pre > code {
   display: block;
   padding: 12px;
   max-height: 500px;
-}
-
-h1 code,
-h2 code,
-h3 code,
-h4 code,
-h5 code,
-h6 code {
-  font-size: inherit;
 }
 
 .hljs-comment,


### PR DESCRIPTION
A follow-up to [UX: inherit font-size for code in headings #30536](https://github.com/discourse/discourse/pull/30536). Instead of defining new styling rules for code within headings, this changes the base `font-size` for code styling to use `em` units instead of `px`.

**Why 0.875em?**
Regular text is set to **1em**, or **16px**, so **0.875em** should be equal to **14px**. Therefore this change should have no discernable affect on regular code elements.

**Affect on inline code within headings**
Inline code within headings will have a size ratio consistent with code in regular paragraphs (slightly smaller than the surrounding text).
 
![image](https://github.com/user-attachments/assets/40b6f2a2-6158-4507-9017-a7d38a26b9b9)

Internal discussion reference: /t/-/145176