### PR TITLE
DEV: Remove deprecated `search_tokenize_chinese_japanese_korean` setting

### DIFF
--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -6,7 +6,6 @@ end
 module SiteSettings::DeprecatedSettings
   SETTINGS = [
     # [<old setting>, <new_setting>, <override>, <version to drop>]
-    ["search_tokenize_chinese_japanese_korean", "search_tokenize_chinese", true, "2.9"],
     ["default_categories_regular", "default_categories_normal", true, "3.0"],
     ["anonymous_posting_min_trust_level", "anonymous_posting_allowed_groups", false, "3.3"],
     ["shared_drafts_min_trust_level", "shared_drafts_allowed_groups", false, "3.3"],

--- a/spec/fixtures/site_settings/deprecated_test.yml
+++ b/spec/fixtures/site_settings/deprecated_test.yml
@@ -8,3 +8,7 @@ category1:
     default: 2
     enum: "TrustLevelAndStaffSetting"
     hidden: true
+  old_one:
+    default: false
+  new_one:
+    default: false

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1098,7 +1098,15 @@ RSpec.describe Search do
       end
 
       it "works in Chinese" do
-        SiteSetting.search_tokenize_chinese_japanese_korean = true
+        SiteSetting.search_tokenize_chinese = true
+        post = new_post("I am not in English 你今天怎麼樣")
+
+        results = Search.execute("你今天", search_context: post.topic)
+        expect(results.posts.map(&:id)).to eq([post.id])
+      end
+
+      it "works in Japanese" do
+        SiteSetting.search_tokenize_japanese = true
         post = new_post("I am not in English 何点になると思いますか")
 
         results = Search.execute("何点になると思", search_context: post.topic)

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -238,13 +238,19 @@ RSpec.describe Admin::SiteSettingsController do
       end
 
       it "works for deprecated settings" do
-        put "/admin/site_settings/search_tokenize_chinese_japanese_korean.json",
-            params: {
-              search_tokenize_chinese_japanese_korean: true,
-            }
+        deprecated_test = "#{Rails.root}/spec/fixtures/site_settings/deprecated_test.yml"
+        SiteSetting.load_settings(deprecated_test)
 
-        expect(response.status).to eq(200)
-        expect(SiteSetting.search_tokenize_chinese).to eq(true)
+        stub_const(
+          SiteSettings::DeprecatedSettings,
+          "SETTINGS",
+          [["old_one", "new_one", true, "3.0"]],
+        ) do
+          put "/admin/site_settings/old_one.json", params: { old_one: true }
+
+          expect(response.status).to eq(200)
+          expect(SiteSetting.new_one).to eq(true)
+        end
       end
 
       it "throws an error when the parameter is not a configurable site setting" do


### PR DESCRIPTION
It was supposed to be removed ~3 years ago (there was [a migration](https://github.com/discourse/discourse/blob/b4f0a8748d5dbfbe97f526734ef537f52db2c660/db/migrate/20220126052157_change_segment_cjk_site_setting.rb) already)

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->