### PR TITLE
FIX: Allow signups when full names are disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.js
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.js
@@ -134,9 +134,7 @@ export default class CreateAccount extends Component.extend(
 
   @discourseComputed
   showFullname() {
-    return (
-      this.siteSettings.enable_names && this.site.full_name_visible_in_signup
-    );
+    return this.site.full_name_visible_in_signup;
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -157,9 +157,7 @@ export default class InvitesShowController extends Controller.extend(
 
   @discourseComputed
   showFullname() {
-    return (
-      this.siteSettings.enable_names && this.site.full_name_visible_in_signup
-    );
+    return this.site.full_name_visible_in_signup;
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -117,9 +117,7 @@ export default class SignupPageController extends Controller.extend(
 
   @discourseComputed
   showFullname() {
-    return (
-      this.siteSettings.enable_names && this.site.full_name_visible_in_signup
-    );
+    return this.site.full_name_visible_in_signup;
   }
 
   @discourseComputed

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -384,11 +384,11 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def full_name_required_for_signup
-    SiteSetting.full_name_requirement == "required_at_signup"
+    SiteSetting.enable_names && SiteSetting.full_name_requirement == "required_at_signup"
   end
 
   def full_name_visible_in_signup
-    SiteSetting.full_name_requirement != "hidden_at_signup"
+    SiteSetting.enable_names && SiteSetting.full_name_requirement != "hidden_at_signup"
   end
 
   private

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -425,4 +425,76 @@ RSpec.describe SiteSerializer do
       expect(serialized[:whispers_allowed_groups_names]).to eq(nil)
     end
   end
+
+  describe "#full_name_required_for_signup" do
+    let(:site_json) do
+      described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    end
+
+    it "is false when enable_names setting is false" do
+      SiteSetting.full_name_requirement = "required_at_signup"
+      SiteSetting.enable_names = false
+      expect(site_json[:full_name_required_for_signup]).to eq(false)
+    end
+
+    it "is false when full_name_requirement setting is optional_at_signup" do
+      SiteSetting.full_name_requirement = "optional_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_required_for_signup]).to eq(false)
+    end
+
+    it "is false when full_name_requirement setting is hidden_at_signup" do
+      SiteSetting.full_name_requirement = "hidden_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_required_for_signup]).to eq(false)
+    end
+
+    it "is true when full_name_requirement setting is required_at_signup and enable_names is true" do
+      SiteSetting.full_name_requirement = "required_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_required_for_signup]).to eq(true)
+    end
+  end
+
+  describe "#full_name_visible_in_signup" do
+    let(:site_json) do
+      described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    end
+
+    it "is false when enable_names setting is false and full_name_requirement is hidden_at_signup" do
+      SiteSetting.full_name_requirement = "hidden_at_signup"
+      SiteSetting.enable_names = false
+      expect(site_json[:full_name_visible_in_signup]).to eq(false)
+    end
+
+    it "is false when enable_names setting is false and full_name_requirement is required_at_signup" do
+      SiteSetting.full_name_requirement = "required_at_signup"
+      SiteSetting.enable_names = false
+      expect(site_json[:full_name_visible_in_signup]).to eq(false)
+    end
+
+    it "is false when enable_names setting is false and full_name_requirement is optional_at_signup" do
+      SiteSetting.full_name_requirement = "optional_at_signup"
+      SiteSetting.enable_names = false
+      expect(site_json[:full_name_visible_in_signup]).to eq(false)
+    end
+
+    it "is true when enable_names setting is true and full_name_requirement is optional_at_signup" do
+      SiteSetting.full_name_requirement = "optional_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_visible_in_signup]).to eq(true)
+    end
+
+    it "is true when enable_names setting is true and full_name_requirement is required_at_signup" do
+      SiteSetting.full_name_requirement = "required_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_visible_in_signup]).to eq(true)
+    end
+
+    it "is false when enable_names setting is true and full_name_requirement is hidden_at_signup" do
+      SiteSetting.full_name_requirement = "hidden_at_signup"
+      SiteSetting.enable_names = true
+      expect(site_json[:full_name_visible_in_signup]).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/30471

When the `enable_names` setting is false and the `full_name_requirement` setting is set to `required_at_signup`, the name field in the signup form should effectively be not required (and hidden). However, that is not actually the case at the moment because the `name-validation.js` mixin only checks for the `full_name_requirement` setting when determining whether the name field should block a new signup.

This PR fixes the issue by making the `full_name_required_for_signup` and `full_name_visible_in_signup` site attributes check for the `enable_names` setting themselves. This spares any consumers of these properties from having to remember to include a check for the `enable_names` setting.