### PR TITLE
DEV: Add isTablet to capabilities service

### DIFF
--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -9,6 +9,14 @@ class Capabilities {
   isAndroid = ua.includes("Android");
   isWinphone = ua.includes("Windows Phone");
   isIpadOS = ua.includes("Mac OS") && !/iPhone|iPod/.test(ua) && this.touch;
+  isTabletScreen =
+    this.touch &&
+    ((window.innerWidth >= 600 && window.innerWidth <= 1280) ||
+      (window.innerHeight >= 600 && window.innerHeight <= 1280));
+  isTablet =
+    this.isTabletScreen ||
+    this.isIpadOS ||
+    /iPad|Android(?!.*Mobile)|Tablet/.test(ua);
 
   isIOS = (/iPhone|iPod/.test(ua) || this.isIpadOS) && !window.MSStream;
   isApple =


### PR DESCRIPTION
We already had isIpadOS, but for some themes and components
we really need to do different things if the user is on
a tablet, including Android tablets.

isTablet and isTabletScreen have been introduced to the
capabilities service.

isTablet is true if the screen size is a tablet, touch
is detected, or we have already detected iPad OS, or
the device matches tablet UAs

isTabletScreen checks both portrait and landscape dimensions
of 1280x600 which should cover most cases.
