### PR TITLE
UX: Update email and security sidebar link copy

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5637,7 +5637,7 @@ en:
         sidebar_link:
           appearance: "Appearance"
           server_setup:
-            title: "Server setup"
+            title: "Server setup & logs"
             keywords: "email|smtp|mailgun|sendgrid|sent|skipped|bounced|received|rejected|email logs|preview summary"
 
       security:
@@ -5646,8 +5646,8 @@ en:
           security: "Security settings"
           spam: "Spam settings"
           staff_action_logs:
-            title: "Staff action logs"
-            keywords: "error logs|screened emails|screened ips|screened urls|search logs"
+            title: "Logs & screening"
+            keywords: "error logs|staff action|screened emails|screened ips|screened urls|search logs"
 
       section_landing_pages:
         account:

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -127,7 +127,12 @@ describe "Admin | Sidebar Navigation", type: :system do
     # When match section title, display all links
     filter.filter("Email Sett")
     links = page.all(".sidebar-section-link-content-text")
-    expect(links.map(&:text)).to eq(["Server setup", "Appearance"])
+    expect(links.map(&:text)).to eq(
+      [
+        I18n.t("admin_js.admin.email_settings.sidebar_link.server_setup.title"),
+        I18n.t("admin_js.admin.email_settings.sidebar_link.appearance"),
+      ],
+    )
   end
 
   it "escapes the filtered expression for regex expressions" do


### PR DESCRIPTION
Followup b3fa335c7db3b92530625cbe37db32427f567ebc

Changes these sidebar links to better reflect
what these pages contain:

* (Email) Server setup → Server setup & logs
* (Security) Staff action logs → Logs & screening
