### PR TITLE
DEV: Restart unicorn when site_settings.yml changes.

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -27,7 +27,11 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
   end
 
   Listen
-    .to(*paths, only: /\.rb$/, ignore: [/node_modules/]) do |modified, added, removed|
+    .to(
+      *paths,
+      only: /\.rb|site_settings.yml$/,
+      ignore: [/node_modules/],
+    ) do |modified, added, removed|
       supervisor_pid = UNICORN_DEV_SUPERVISOR_PID
       auto_restart = supervisor_pid && ENV["AUTO_RESTART"] != "0"
 


### PR DESCRIPTION
## ✨ What's This?

`site_settings.yml` is read when the server starts, but isn't re-read if it changes. (Eg, adding a new setting, or changing the configuration of an existing setting.)

This change includes `site_settings.yml` as a file that requires a server restart when it changes. This behaviour obeys the `AUTO_RESTART` environment variable.