### PR TITLE
FIX: consistent delete button for admin permalinks page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
@@ -70,26 +70,11 @@
                     @routeModels={{pl}}
                     @label="admin.config_areas.permalinks.edit"
                   />
-
-                  <DMenu
-                    @identifier="permalink-menu"
-                    @title={{i18n "admin.permalinks.more_options"}}
-                    @icon="ellipsis-vertical"
-                    @onRegisterApi={{this.onRegisterApi}}
-                  >
-                    <:content>
-                      <DropdownMenu as |dropdown|>
-                        <dropdown.item>
-                          <DButton
-                            @action={{fn this.destroyRecord pl}}
-                            @icon="trash-can"
-                            class="btn-transparent admin-permalink-item__delete"
-                            @label="admin.config_areas.permalinks.delete"
-                          />
-                        </dropdown.item>
-                      </DropdownMenu>
-                    </:content>
-                  </DMenu>
+                  <DButton
+                    @action={{fn this.destroyRecord pl}}
+                    class="btn-default btn-small admin-permalink-item__delete"
+                    @label="admin.config_areas.permalinks.delete"
+                  />
                 </div>
               </td>
             </tr>

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -817,17 +817,6 @@
   padding-left: 18px;
 }
 
-.admin-permalink-item {
-  &__delete.btn,
-  &__delete.btn:hover {
-    border-top: 1px solid var(--primary-low);
-    color: var(--danger);
-    svg {
-      color: var(--danger);
-    }
-  }
-}
-
 // embedding
 .embeddable-hosts {
   margin-bottom: 2em;
@@ -893,19 +882,6 @@
       td.controls {
         text-align: left;
       }
-    }
-  }
-}
-
-.admin-embedding {
-  .admin-embeddable-host-item__delete {
-    &:hover {
-      svg.d-icon {
-        color: var(--primary-medium);
-      }
-    }
-    svg.d-icon {
-      color: var(--primary-low-mid);
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7383,7 +7383,6 @@ en:
         no_permalinks: "You don't have any permalinks yet."
         add: "Add permalink"
         back: "Back to Permalinks"
-        more_options: "More options"
         copy_success: "Permalink copied to clipboard"
         nav:
           settings: "Settings"

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -25,7 +25,6 @@ module PageObjects
       end
 
       def click_delete_permalink(url)
-        open_permalink_menu(url)
         find(".admin-permalink-item__delete").click
         find(".dialog-footer .btn-primary").click
         expect(page).to have_no_css(".dialog-body")
@@ -39,11 +38,6 @@ module PageObjects
 
       def has_no_permalinks?
         has_no_css?(".admin-permalink-item__url")
-      end
-
-      def open_permalink_menu(url)
-        find("tr.#{url} .permalink-menu-trigger").click
-        self
       end
 
       def has_closed_permalink_menu?


### PR DESCRIPTION
The delete button should always be available when there are no more options.

<img width="425" alt="Screenshot 2025-01-06 at 1 59 31 PM" src="https://github.com/user-attachments/assets/4669d6c3-bb04-466c-9ca5-b786eaa24b79" />

<img width="1410" alt="Screenshot 2025-01-06 at 1 59 17 PM" src="https://github.com/user-attachments/assets/39193b45-b9bf-4c0d-aec6-13386f3ecb0c" />
