### PR TITLE
FIX: Dashboard last checked date was always English

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard.js
@@ -102,7 +102,7 @@ export default class AdminDashboardController extends Controller {
 
   @discourseComputed("problemsFetchedAt")
   problemsTimestamp(problemsFetchedAt) {
-    return moment(problemsFetchedAt).locale("en").format("LLL");
+    return moment(problemsFetchedAt).format("LLL");
   }
 
   @action


### PR DESCRIPTION
The `problemsTimestamp` on the admin dashboard was always
forcing the "en" locale for some reason, we can remove the locale
entirely because we already set the locale for moment.js using
I18n on the server-side.

c.f. https://meta.discourse.org/t/last-check-date-not-localized-in-admin-dashboard/345483

![image](https://github.com/user-attachments/assets/db1dadc7-ef8a-4deb-af7e-1bd67327465e)

