### PR TITLE
UX: Admin setting page consistency - Trust levels

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-trust-levels-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-trust-levels-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigTrustLevelsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-trust-levels.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-trust-levels.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigTrustLevelsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.community.sidebar_link.trust_levels");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -231,6 +231,11 @@ export default function () {
             path: "/",
           });
         });
+        this.route("trustLevels", { path: "/trust-levels" }, function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route("lookAndFeel", { path: "/look-and-feel" }, function () {
           this.route("themes");
         });

--- a/app/assets/javascripts/admin/addon/templates/config-trust-levels-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-trust-levels-settings.hbs
@@ -1,0 +1,22 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.config.trust_levels.title"}}
+  @descriptionLabel={{i18n "admin.config.trust_levels.header_description"}}
+  @learnMoreUrl="https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/config/trust-levels"
+      @label={{i18n "admin.config.trust_levels.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
+<div class="admin-config-page__main-area">
+  <AdminAreaSettings
+    @categories="trust"
+    @path="/admin/config/trust-levels"
+    @filter={{this.filter}}
+    @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -60,9 +60,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_trust_levels",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["trust"],
-        query: { filter: "" },
+        route: "adminConfig.trustLevels.settings",
         label: "admin.community.sidebar_link.trust_levels",
         icon: "user-shield",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5146,6 +5146,9 @@ en:
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation."
+        trust_levels:
+          title: "Trust levels"
+          header_description: "Trust level settings allow you to fine-tune the requirements and notifications for your community’s progression system, which automatically promotes users to higher trust levels as they demonstrate consistent, positive engagement with your forum."
 
       new_features:
         title: "What's new?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,6 +397,7 @@ Discourse::Application.routes.draw do
         get "login-and-authentication" => "site_settings#index"
         get "logo" => "site_settings#index"
         get "notifications" => "site_settings#index"
+        get "trust-levels" => "site_settings#index"
 
         resources :flags, only: %i[index new create update destroy] do
           put "toggle"


### PR DESCRIPTION
Followup c2282439b32d879a73217eec62449f042914d7d0

Make the trust levels config page reached from the sidebar
use our consistent site setting page rules.

![image](https://github.com/user-attachments/assets/f04a47a8-8c07-463a-9e81-6bdba5d2bf7a)

