### PR TITLE
UX: Admin setting page consistency - Legal

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-legal-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-legal-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigLegalSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-legal.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-legal.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigLegalRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.community.sidebar_link.legal");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -231,6 +231,11 @@ export default function () {
             path: "/",
           });
         });
+        this.route("legal", function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route("lookAndFeel", { path: "/look-and-feel" }, function () {
           this.route("themes");
         });

--- a/app/assets/javascripts/admin/addon/templates/config-legal-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-legal-settings.hbs
@@ -1,0 +1,21 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.config.legal.title"}}
+  @descriptionLabel={{i18n "admin.config.legal.header_description"}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/config/legal"
+      @label={{i18n "admin.config.legal.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
+<div class="admin-config-page__main-area">
+  <AdminAreaSettings
+    @area="legal"
+    @path="/admin/config/legal"
+    @filter={{this.filter}}
+    @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -81,9 +81,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_legal",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["legal"],
-        query: { filter: "" },
+        route: "adminConfig.legal.settings",
         label: "admin.community.sidebar_link.legal",
         icon: "gavel",
       },

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteSetting < ActiveRecord::Base
-  VALID_AREAS = %w[about embedding emojis flags fonts notifications permalinks legal]
+  VALID_AREAS = %w[about embedding emojis flags fonts legal notifications permalinks]
 
   extend GlobalPath
   extend SiteSettingExtension

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteSetting < ActiveRecord::Base
-  VALID_AREAS = %w[about embedding emojis flags fonts notifications permalinks]
+  VALID_AREAS = %w[about embedding emojis flags fonts notifications permalinks legal]
 
   extend GlobalPath
   extend SiteSettingExtension

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5146,6 +5146,9 @@ en:
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation."
+        legal:
+          title: "Legal"
+          header_description: "Configure legal settings, such as terms of service, privacy policy, contact details, and EU-specific considerations."
 
       new_features:
         title: "What's new?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,6 +397,7 @@ Discourse::Application.routes.draw do
         get "login-and-authentication" => "site_settings#index"
         get "logo" => "site_settings#index"
         get "notifications" => "site_settings#index"
+        get "legal" => "site_settings#index"
 
         resources :flags, only: %i[index new create update destroy] do
           put "toggle"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -53,10 +53,10 @@ required:
   contact_email:
     default: ""
     type: email
-    area: "about|notifications"
+    area: "about|notifications|legal"
   contact_url:
     default: ""
-    area: "about"
+    area: "about|legal"
   notification_email:
     default: "noreply@unconfigured.discourse.org"
     type: email
@@ -75,13 +75,13 @@ required:
     list_type: simple
   company_name:
     default: ""
-    area: "about"
+    area: "about|legal"
   governing_law:
     default: ""
-    area: "about"
+    area: "about|legal"
   city_for_disputes:
     default: ""
-    area: "about"
+    area: "about|legal"
 
 branding:
   logo:
@@ -2564,17 +2564,22 @@ legal:
   tos_url:
     client: true
     default: ""
+    area: "legal"
   privacy_policy_url:
     client: true
     default: ""
+    area: "legal"
   faq_url:
     client: true
     default: ""
+    area: "legal"
   log_anonymizer_details:
     default: true
+    area: "legal"
   display_eu_visitor_stats:
     default: false
     client: true
+    area: "legal"
 
 backups:
   enable_backups:


### PR DESCRIPTION
Followup c2282439b32d879a73217eec62449f042914d7d0

Make the Legal config page reached from the sidebar
use our consistent site setting page rules.

![image](https://github.com/user-attachments/assets/5a137978-2256-4924-8685-59ab3ff23428)
