### PR TITLE
UX: Admin setting page consistency - Search

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-search-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-search-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigSearchSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-search.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-search.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigSearchRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.search");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -231,6 +231,11 @@ export default function () {
             path: "/",
           });
         });
+        this.route("search", function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route("lookAndFeel", { path: "/look-and-feel" }, function () {
           this.route("themes");
         });

--- a/app/assets/javascripts/admin/addon/templates/config-search-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-search-settings.hbs
@@ -1,0 +1,21 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.config.search.title"}}
+  @descriptionLabel={{i18n "admin.config.search.header_description"}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/config/search"
+      @label={{i18n "admin.config.search.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
+<div class="admin-config-page__main-area">
+  <AdminAreaSettings
+    @categories="search"
+    @path="/admin/config/search"
+    @filter={{this.filter}}
+    @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -284,9 +284,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_search",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["search"],
-        query: { filter: "" },
+        route: "adminConfig.search.settings",
         label: "admin.advanced.sidebar_link.search",
         icon: "magnifying-glass",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5146,6 +5146,9 @@ en:
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation."
+        search:
+          title: "Search"
+          header_description: "Configure search settings including logging and tokenization for Chinese and Japanese languages."
 
       new_features:
         title: "What's new?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,6 +397,7 @@ Discourse::Application.routes.draw do
         get "login-and-authentication" => "site_settings#index"
         get "logo" => "site_settings#index"
         get "notifications" => "site_settings#index"
+        get "search" => "site_settings#index"
 
         resources :flags, only: %i[index new create update destroy] do
           put "toggle"


### PR DESCRIPTION
Followup c2282439b32d879a73217eec62449f042914d7d0

Make the Search config page reached from the sidebar
use our consistent site setting page rules.

![image](https://github.com/user-attachments/assets/947fcb53-998b-47b7-a35a-c247311439b2)

