### PR TITLE
UX: Admin setting page consistency - Navigation

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-fonts-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-fonts-settings.js
@@ -1,3 +1,3 @@
 import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
 
-export default class AdminConfigFontsController extends AdminAreaSettingsBaseController {}
+export default class AdminConfigFontsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-config-navigation-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-navigation-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigNavigationSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-navigation.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-navigation.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigNavigationRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.appearance.sidebar_link.navigation");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -268,6 +268,9 @@ export default function () {
         this.route("logo", function () {
           this.route("settings", { path: "/" });
         });
+        this.route("navigation", function () {
+          this.route("settings", { path: "/" });
+        });
       }
     );
 

--- a/app/assets/javascripts/admin/addon/templates/config-navigation-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/config-navigation-settings.hbs
@@ -1,0 +1,21 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.config.navigation.title"}}
+  @descriptionLabel={{i18n "admin.config.navigation.header_description"}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/config/navigation"
+      @label={{i18n "admin.config.navigation.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
+<div class="admin-config-page__main-area">
+  <AdminAreaSettings
+    @area="navigation"
+    @path="/admin/config/navigation"
+    @filter={{this.filter}}
+    @adminSettingsFilterChangedCallback={{this.adminSettingsFilterChangedCallback}}
+  />
+</div>

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -126,9 +126,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_navigation",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["all_results"],
-        query: { filter: "navigation" },
+        route: "adminConfig.navigation.settings",
         label: "admin.appearance.sidebar_link.navigation",
         icon: "diagram-project",
       },

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SiteSetting < ActiveRecord::Base
-  VALID_AREAS = %w[about embedding emojis flags fonts notifications permalinks]
+  VALID_AREAS = %w[about embedding emojis flags fonts navigation notifications permalinks]
 
   extend GlobalPath
   extend SiteSettingExtension

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5143,6 +5143,9 @@ en:
         logo:
           title: "Site logo"
           header_description: "Customize the variations of your site logo."
+        navigation:
+          title: "Navigation"
+          header_description: "Configure the navigation links and menu items for your site. This includes the location and behaviour of the primary navigation menu, the quick links at the top of the homepage, as well as the admin sidebar."
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -396,6 +396,7 @@ Discourse::Application.routes.draw do
         get "fonts" => "site_settings#index"
         get "login-and-authentication" => "site_settings#index"
         get "logo" => "site_settings#index"
+        get "navigation" => "site_settings#index"
         get "notifications" => "site_settings#index"
 
         resources :flags, only: %i[index new create update destroy] do

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -216,6 +216,7 @@ basic:
       - posted
       - bookmarks
       - hot
+    area: "navigation"
   post_menu:
     client: true
     type: list
@@ -427,6 +428,7 @@ basic:
     choices:
       - spinner
       - slider
+    area: "navigation"
   show_user_menu_avatars:
     client: true
     default: false
@@ -2504,6 +2506,7 @@ developer:
     default: "1|2"
     allow_any: false
     refresh: true
+    area: "navigation"
   warn_critical_js_deprecations:
     default: true
     client: true
@@ -2523,14 +2526,17 @@ navigation:
     default: "sidebar"
     type: enum
     enum: "NavigationMenuSiteSetting"
+    area: "navigation"
   default_navigation_menu_categories:
     type: category_list
     default: ""
     client: true
+    area: "navigation"
   default_navigation_menu_tags:
     type: tag_list
     default: ""
     client: true
+    area: "navigation"
   default_sidebar_switch_panel_position:
     default: "bottom"
     type: enum
@@ -2538,6 +2544,7 @@ navigation:
     choices:
       - "top"
       - "bottom"
+    area: "navigation"
 
 embedding:
   embed_by_username:
@@ -2729,6 +2736,7 @@ uncategorized:
   header_dropdown_category_count:
     client: true
     default: 8
+    area: "navigation"
 
   slug_generation_method:
     default: "ascii"
@@ -3157,8 +3165,12 @@ user_preferences:
   enable_offline_indicator:
     default: false
     client: true
-  default_sidebar_link_to_filtered_list: false
-  default_sidebar_show_count_of_new_items: false
+  default_sidebar_link_to_filtered_list:
+    default: false
+    area: "navigation"
+  default_sidebar_show_count_of_new_items:
+    default: false
+    area: "navigation"
 
 api:
   retain_web_hook_events_period_days:
@@ -3381,6 +3393,7 @@ experimental:
     default: ""
     allow_any: false
     refresh: true
+    area: "navigation"
   glimmer_topic_list_mode:
     client: true
     type: enum

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -284,10 +284,12 @@ basic:
     client: true
     enum: "CategoryPageStyle"
     default: "categories_and_latest_topics"
+    area: "navigation"
   mobile_category_page_style:
     client: true
     enum: "MobileCategoryPageStyle"
     default: "categories_with_featured_topics"
+    area: "navigation"
   category_colors:
     client: true
     type: list

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -123,6 +123,7 @@ chat:
     default: "never"
     type: enum
     enum: "Chat::SeparateSidebarModeSiteSetting"
+    area: "navigation"
   chat_editing_grace_period:
     client: true
     type: integer


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains navigation-related settings, to replace the setting filtered view linked to from "Navigation" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/cdfd178e-48db-4254-90d2-6d54e0769f0f)

## 👑 Testing

Check that there aren't any other settings missing from this view.