### PR TITLE
DEV: Use github hosted runners for simple workflows

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: run
-    runs-on: ${{ (github.repository != 'discourse/discourse' && 'ubuntu-latest') || 'debian-12' }}
+    runs-on: ubuntu-latest
     container: discourse/discourse_test:slim
     timeout-minutes: 10
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: run
-    runs-on: ${{ (github.repository != 'discourse/discourse' && 'ubuntu-latest') || 'debian-12' }}
+    runs-on: ubuntu-latest
     container: discourse/discourse_test:slim
     timeout-minutes: 30
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build:
     name: run
-    runs-on: ${{ (github.repository != 'discourse/discourse' && 'ubuntu-latest') || 'debian-12' }}
+    runs-on: ubuntu-latest
     container: discourse/discourse_test:slim
     timeout-minutes: 10
     env:

--- a/.github/workflows/stale-pr-closer.yml
+++ b/.github/workflows/stale-pr-closer.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ${{ (github.repository != 'discourse/discourse' && 'ubuntu-latest') || 'debian-12' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
Our self hosted runners are limited in quantity so we should preserve
them for workflows that actually require the additional resources
instead of tying them up on workflows that do not benefit from the
additional resources.
