### PR TITLE
DEV: Restart unicorn when any settings.yml changes.

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -29,6 +29,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
   Listen
     .to(
       *paths,
+      # Aside from .rb files, this will also match site_settings.yml, as well as any plugin settings.yml files.
       only: /(\.rb|settings.yml)$/,
       ignore: [/node_modules/],
     ) do |modified, added, removed|

--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -29,7 +29,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
   Listen
     .to(
       *paths,
-      only: /\.rb|site_settings.yml$/,
+      only: /(\.rb|settings.yml)$/,
       ignore: [/node_modules/],
     ) do |modified, added, removed|
       supervisor_pid = UNICORN_DEV_SUPERVISOR_PID


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #30565.

Aside from `site_settings.yml`, all plugin `config/settings.yml` files are only read when the server starts, and aren't re-read if they change.

This change expands the matcher added in #30565 to match any `settings.yml` file as requiring a server restart when it changes. Unfortunately, the `Listen.to(only: ...)` filter only matches against filenames (as opposed to full paths) so we can't add a matcher against `plugins/.*/config/settings.yml` to make it explicit.