### PR TITLE
User menu full name (rebased)

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/messages-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/messages-list.js
@@ -77,13 +77,16 @@ export default class UserMenuMessagesList extends UserMenuNotificationsList {
     const topics = data.topics.map((t) => this.store.createRecord("topic", t));
     await Topic.applyTransformations(topics);
 
-    if (this.siteSettings.show_user_menu_avatars) {
+    if (
+      this.siteSettings.show_user_menu_avatars ||
+      !this.siteSettings.prioritize_username_in_ux
+    ) {
       // Populate avatar_template for lastPoster
       const usersById = new Map(data.users.map((u) => [u.id, u]));
       topics.forEach((t) => {
-        t.last_poster_avatar_template = usersById.get(
-          t.lastPoster.user_id
-        )?.avatar_template;
+        const lastPoster = usersById.get(t.lastPoster.user_id);
+        t.last_poster_avatar_template = lastPoster?.avatar_template;
+        t.last_poster_name = lastPoster?.name;
       });
     }
 

--- a/app/assets/javascripts/discourse/app/lib/notification-types/base.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/base.js
@@ -73,7 +73,11 @@ export default class NotificationTypeBase {
    * @returns {string} The label is the first part of the text content displayed in the notification. For example, in a like notification, the username of the user who liked the post is the label. If a falsey value is returned, the label is omitted.
    */
   get label() {
-    return this.username;
+    if (this.siteSettings.prioritize_username_in_ux) {
+      return this.username;
+    }
+
+    return this.notification.acting_user_name || this.username;
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
@@ -24,7 +24,11 @@ export default class UserMenuBookmarkItem extends UserMenuBaseItem {
   }
 
   get label() {
-    return this.bookmark.user?.username;
+    if (this.siteSettings.prioritize_username_in_ux) {
+      return this.bookmark.user?.username;
+    }
+
+    return this.bookmark.user?.name || this.bookmark.user?.username;
   }
 
   get description() {

--- a/app/assets/javascripts/discourse/app/lib/user-menu/message-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/message-item.js
@@ -31,7 +31,11 @@ export default class UserMenuMessageItem extends UserMenuBaseItem {
   }
 
   get label() {
-    return this.message.last_poster_username;
+    if (this.siteSettings.prioritize_username_in_ux) {
+      return this.message.last_poster_username;
+    }
+
+    return this.message.last_poster_name || this.message.last_poster_username;
   }
 
   get description() {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -1089,3 +1089,48 @@ acceptance("User menu - avatars", function (needs) {
     assert.dom("li.notification.replied .icon-avatar.user-avatar").exists();
   });
 });
+
+acceptance("User menu - full name prioritized", function (needs) {
+  needs.user();
+  needs.settings({ prioritize_username_in_ux: false });
+
+  test("Notifications display full name over username when present", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+    assert.strictEqual(
+      query("li.notification.edited .item-label").textContent.trim(),
+      "Veles In",
+      "Full name is used"
+    );
+
+    assert.strictEqual(
+      query("li.notification.replied .item-label").textContent.trim(),
+      "velesin",
+      "Fallback on username when full name isn't present"
+    );
+  });
+
+  test("Messages display full name over username when present", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-messages");
+
+    assert.strictEqual(
+      query("li.message .item-label").textContent.trim(),
+      "Mix Tape",
+      "Displays name instead of username"
+    );
+  });
+
+  test("Bookmarks display full name over username when present", async function (assert) {
+    await visit("/");
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-bookmarks");
+
+    assert.strictEqual(
+      query("li.bookmark .item-label").textContent.trim(),
+      "Osama S",
+      "Displays name instead of username"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/fixtures/notification-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/notification-fixtures.js
@@ -7,6 +7,7 @@ export default {
         id: 5340,
         notification_type: NOTIFICATION_TYPES.edited,
         acting_user_avatar_template: "/letter_avatar_proxy/v4/letter/o/f05b48/{size}.png",
+        acting_user_name: "Veles In",
         read: false,
         post_number: 1,
         topic_id: 130,

--- a/app/assets/javascripts/discourse/tests/fixtures/user-menu.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/user-menu.js
@@ -57,7 +57,7 @@ export default {
           user: {
             id: 1,
             username: "osama",
-            name: "Osama",
+            name: "Osama S",
             avatar_template:
               "/letter_avatar_proxy/v4/letter/o/f05b48/{size}.png",
           },
@@ -143,6 +143,7 @@ export default {
     read_notifications: [],
     users: [{id: 13,
         username: "mixtape",
+        name: "Mix Tape",
         avatar_template: "/letter_avatar_proxy/v4/letter/o/f05b48/{size}.png"
     }]
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
@@ -1,3 +1,4 @@
+import { getOwner } from "@ember/application";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import Notification from "discourse/models/notification";
@@ -41,7 +42,7 @@ module("Unit | Notification Types | liked", function (hooks) {
     const director = createRenderDirector(
       notification,
       "liked",
-      this.siteSettings
+      getOwner(this).lookup("service:site-settings")
     );
     notification.data.count = 2;
     assert.strictEqual(

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -57,8 +57,10 @@ class NotificationsController < ApplicationController
 
       notifications =
         Notification.filter_inaccessible_topic_notifications(current_user.guardian, notifications)
-      notifications =
-        Notification.populate_acting_user(notifications) if SiteSetting.show_user_menu_avatars
+
+      if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
+        notifications = Notification.populate_acting_user(notifications)
+      end
 
       json = {
         notifications: serialize_data(notifications, NotificationSerializer),
@@ -88,8 +90,10 @@ class NotificationsController < ApplicationController
       notifications = notifications.offset(offset).limit(limit)
       notifications =
         Notification.filter_inaccessible_topic_notifications(current_user.guardian, notifications)
-      notifications =
-        Notification.populate_acting_user(notifications) if SiteSetting.show_user_menu_avatars
+
+      if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
+        notifications = Notification.populate_acting_user(notifications)
+      end
       render_json_dump(
         notifications: serialize_data(notifications, NotificationSerializer),
         total_rows_notifications: total_rows,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1927,7 +1927,7 @@ class UsersController < ApplicationController
     end
 
     if reminder_notifications.present?
-      if SiteSetting.show_user_menu_avatars
+      if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
         Notification.populate_acting_user(reminder_notifications)
       end
       serialized_notifications =
@@ -2000,7 +2000,9 @@ class UsersController < ApplicationController
     end
 
     if unread_notifications.present?
-      Notification.populate_acting_user(unread_notifications) if SiteSetting.show_user_menu_avatars
+      if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
+        Notification.populate_acting_user(unread_notifications)
+      end
       serialized_unread_notifications =
         ActiveModel::ArraySerializer.new(
           unread_notifications,
@@ -2013,7 +2015,7 @@ class UsersController < ApplicationController
       serialized_messages =
         serialize_data(messages_list, TopicListSerializer, scope: guardian, root: false)[:topics]
       serialized_users =
-        if SiteSetting.show_user_menu_avatars
+        if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
           users = messages_list.topics.map { |t| t.posters.last.user }.flatten.compact.uniq(&:id)
           serialize_data(users, BasicUserSerializer, scope: guardian, root: false)
         else
@@ -2022,7 +2024,9 @@ class UsersController < ApplicationController
     end
 
     if read_notifications.present?
-      Notification.populate_acting_user(read_notifications) if SiteSetting.show_user_menu_avatars
+      if SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux
+        Notification.populate_acting_user(read_notifications)
+      end
       serialized_read_notifications =
         ActiveModel::ArraySerializer.new(
           read_notifications,

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -14,7 +14,8 @@ class NotificationSerializer < ApplicationSerializer
              :slug,
              :data,
              :is_warning,
-             :acting_user_avatar_template
+             :acting_user_avatar_template,
+             :acting_user_name
 
   def slug
     Slug.for(object.topic.title) if object.topic.present?
@@ -53,6 +54,14 @@ class NotificationSerializer < ApplicationSerializer
   end
 
   def include_acting_user_avatar_template?
+    object.acting_user.present?
+  end
+
+  def acting_user_name
+    object.acting_user&.name
+  end
+
+  def include_acting_user_full_name?
     object.acting_user.present?
   end
 end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -61,7 +61,7 @@ class NotificationSerializer < ApplicationSerializer
     object.acting_user.name
   end
 
-  def include_acting_user_full_name?
+  def include_acting_user_name?
     object.acting_user.present?
   end
 end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -58,7 +58,7 @@ class NotificationSerializer < ApplicationSerializer
   end
 
   def acting_user_name
-    object.acting_user&.name
+    object.acting_user.name
   end
 
   def include_acting_user_full_name?


### PR DESCRIPTION
resurrecting [this PR](https://github.com/discourse/discourse/tree/user-menu-full-name), which is a year old. I cherry picked commits from it into here to have a clean, new PR. 

Here I plan to just add a system test to the existing functionality, which seems to still work, and resubmit.