### PR TITLE
UX: only show red count in IP lookup when greater than 0

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { gt } from "truth-helpers";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import avatar from "discourse/helpers/avatar";
@@ -204,7 +205,12 @@ export default class IpLookup extends Component {
 
               <dt class="other-accounts">
                 {{i18n "ip_lookup.other_accounts"}}
-                <span class="count">{{this.totalOthersWithSameIP}}</span>
+                <span
+                  class="count
+                    {{if (gt this.totalOthersWithSameIP 0) '--nonzero'}}"
+                >
+                  {{this.totalOthersWithSameIP}}
+                </span>
                 {{#if this.otherAccounts}}
                   <DButton
                     @action={{this.deleteOtherAccounts}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -472,7 +472,9 @@ $mobile-breakpoint: 700px;
         .count {
           font-weight: bold;
           margin-left: 0.25em;
-          color: var(--danger);
+          &.--nonzero {
+            color: var(--danger);
+          }
         }
       }
     }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/4993c4f2-150e-4d47-9d65-a94975451278)


After:
![image](https://github.com/user-attachments/assets/0fea180e-63e8-4f98-9411-459499125726)


With more than 0 it's red to associate with the delete button 

![image](https://github.com/user-attachments/assets/163b558b-cf69-4ebf-9350-4f269372e4ef)
