### PR TITLE
UX: improve table hover states, fix table button margin issue

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/post-decorations.js
@@ -119,7 +119,7 @@ export default {
           "btn-default",
           "btn",
           "btn-icon",
-          ...(props.label ? ["no-text"] : []),
+          ...(props.label ? [] : ["no-text"]),
         ];
 
         openPopupBtn.classList.add(...defaultClasses);
@@ -197,7 +197,6 @@ export default {
           const tableEditorBtn = _createButton({
             classes: ["btn-edit-table"],
             title: "table_builder.edit.btn_edit",
-            label: "table_builder.edit.btn_edit",
             icon: {
               name: "pencil",
               class: "edit-table-icon",
@@ -208,6 +207,7 @@ export default {
           table.parentNode.classList.add("fullscreen-table-wrapper");
 
           if (attrs.canEdit) {
+            table.parentNode.classList.add("--editable");
             buttonWrapper.append(tableEditorBtn);
             tableEditorBtn.addEventListener(
               "click",
@@ -228,6 +228,8 @@ export default {
           if (site.isMobileDevice) {
             return;
           }
+
+          table.parentNode.classList.add("--has-overflow");
 
           const expandTableBtn = _createButton({
             classes: ["btn-expand-table"],

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1596,11 +1596,15 @@ iframe {
 
 html.discourse-no-touch .fullscreen-table-wrapper:hover {
   border-radius: 5px;
-  box-shadow: 0 2px 5px 0 rgba(var(--always-black-rgb), 0.1),
-    0 2px 10px 0 rgba(var(--always-black-rgb), 0.1);
 
   .open-popup-link {
     opacity: 100%;
+  }
+
+  &.--has-overflow,
+  &.--editable {
+    box-shadow: 0 2px 5px 0 rgba(var(--always-black-rgb), 0.1),
+      0 2px 10px 0 rgba(var(--always-black-rgb), 0.1);
   }
 }
 


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/table-shadow-on-hover-shouldnt-appear-when-we-cant-edit-the-table/345421


Before... can't edit or expand, but has shadow on hover: 

![image](https://github.com/user-attachments/assets/dd541005-4291-4682-acbe-b435e634c3c4)


After... no shadow on hover: 

![image](https://github.com/user-attachments/assets/58080767-862d-49a9-97fc-e82609fede5b)

...unless it's expandable: 

![image](https://github.com/user-attachments/assets/c7b6ba7c-15da-43de-a39f-9772b0fdd2c1)

...or editable: 

![image](https://github.com/user-attachments/assets/90cac490-4c1f-4463-b765-be508c44688b)

I also noticed this issue: 

![image](https://github.com/user-attachments/assets/ee1fe32c-a884-4107-88f1-a7a32fe9a055)


It appears that 

`...(props.label ? ["no-text"] : []),` 

was backwards and should be 

`...(props.label ? [] : ["no-text"]),`

which fixes that button so:

![image](https://github.com/user-attachments/assets/79f3385c-dfe2-41e5-b8e9-1f0e06ef7ac7)

 