### PR TITLE
UX: add missing icon for `open_topic` small action

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -73,6 +73,7 @@ const icons = {
   removed_user: "circle-minus",
   removed_group: "circle-minus",
   public_topic: "comment",
+  open_topic: "comment",
   private_topic: "envelope",
   autobumped: "hand-point-right",
 };


### PR DESCRIPTION
Investigated here: https://meta.discourse.org/t/convert-to-topic-icon-missing/334309/8?u=awesomerobot

When a site is set to `login_required` the small action for converting a PM to a topic is `open_topic` rather than `public_topic` — and there's no icon defined for it. This adds one (the same as `public_topic`). 


Before:
![image](https://github.com/user-attachments/assets/cb271177-38af-4d68-a849-8c5a1ffe85cc)


After: 
![image](https://github.com/user-attachments/assets/4a8b47e0-b913-423d-81a0-a81c12c0276a)
