### PR TITLE
DEV: Support expand-pinned modifier in legacy topic-list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -13,6 +13,7 @@ import { observes, on } from "@ember-decorators/object";
 import $ from "jquery";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import DiscourseURL, { groupPath } from "discourse/lib/url";
 import deprecated from "discourse-common/lib/deprecated";
 import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
@@ -243,6 +244,17 @@ export default class TopicListItem extends Component {
 
   @discourseComputed
   expandPinned() {
+    return applyValueTransformer(
+      "topic-list-item-expand-pinned",
+      this._expandPinned,
+      {
+        topic: this.topic,
+        mobileView: this.site.mobileView,
+      }
+    );
+  }
+
+  get _expandPinned() {
     const pinned = this.get("topic.pinned");
     if (!pinned) {
       return false;


### PR DESCRIPTION
This provides an easier upgrade path for themes/plugins. Matches the strategy used for other new topic-list-related modifiers.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->