### PR TITLE
UX: adjust mobile to avoid progress bar jitter

### DIFF
--- a/app/assets/stylesheets/mobile/topic-footer.scss
+++ b/app/assets/stylesheets/mobile/topic-footer.scss
@@ -1,8 +1,14 @@
-.container.posts .topic-navigation {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
+.container.posts {
+  grid-template-areas: "posts";
+  .topic-navigation {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    grid-area: posts;
+    grid-row: 3;
+  }
 }
+
 html:not(.anon) #topic-footer-buttons {
   .topic-footer-main-buttons {
     width: 100%;


### PR DESCRIPTION
We need a little more CSS here to avoid this jitter issue: https://meta.discourse.org/t/infinite-loop-when-scrolling-in-chrome-on-android-in-landscape-mode/345635

When the progress bar attempts to dock, the layout shifts, causing it to undock and get stuck in a jittery dock/undock loop. This adjusts the layout to avoid the shift like we do on desktop. 


Before: 

![jitter](https://github.com/user-attachments/assets/4bf03b5a-ecb2-4d06-aeba-2264365cca46)

After: 

![image](https://github.com/user-attachments/assets/94067d9f-e421-4f99-9a9b-5a230323d0cc)

