### PR TITLE
UX: Remove version from "What's new?" items

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -85,11 +85,6 @@ export default class DiscourseNewFeatureItem extends Component {
               </span>
             {{/if}}
           </h3>
-          {{#if @item.discourse_version}}
-            <div class="admin-new-feature-item__new-feature-version">
-              {{@item.discourse_version}}
-            </div>
-          {{/if}}
         </div>
 
         <div class="admin-new-feature-item__body-wrapper">

--- a/spec/system/admin_dashboard_new_features_spec.rb
+++ b/spec/system/admin_dashboard_new_features_spec.rb
@@ -56,7 +56,6 @@ describe "Admin New Features Page", type: :system do
       expect(new_features_page).to have_learn_more_link
       expect(new_features_page).to have_no_emoji
       expect(new_features_page).to have_date("November 2023")
-      expect(new_features_page).to have_version("3.3.0.beta4")
     end
 
     within find(".admin-config-area-card:last-child") do
@@ -64,7 +63,6 @@ describe "Admin New Features Page", type: :system do
       expect(new_features_page).to have_learn_more_link
       expect(new_features_page).to have_no_emoji
       expect(new_features_page).to have_date("August 2023")
-      expect(new_features_page).to have_version("3.3.0.beta3")
     end
   end
 

--- a/spec/system/page_objects/pages/admin_new_features.rb
+++ b/spec/system/page_objects/pages/admin_new_features.rb
@@ -32,11 +32,6 @@ module PageObjects
         page.has_no_css?(".admin-new-feature-item__new-feature-emoji")
       end
 
-      def has_version?(version)
-        element = find(".admin-new-feature-item__new-feature-version")
-        element.has_text?(version)
-      end
-
       def has_date?(date)
         element = find(".admin-config-area-card__title")
         element.has_text?(date)


### PR DESCRIPTION
This version number is a technical detail that controls
what items show up on certain sites, most admins don't
need this level of detail. Remove it here, maybe we can
add it back in some hidden way later if needed.

![image](https://github.com/user-attachments/assets/165f4f5a-974f-43f6-b9eb-567d02a5a157)
