### PR TITLE
DEV: Extend the reviewables:populate rake task in chat

### DIFF
--- a/plugins/chat/lib/discourse_dev/message.rb
+++ b/plugins/chat/lib/discourse_dev/message.rb
@@ -24,11 +24,21 @@ module DiscourseDev
         ::Chat::UserChatChannelMembership.where(chat_channel: channel).order("RANDOM()").first
       user = membership.user
 
-      { guardian: user.guardian, message: Faker::Lorem.paragraph, chat_channel_id: channel.id }
+      {
+        guardian: user.guardian,
+        params: {
+          message: Faker::Lorem.paragraph,
+          chat_channel_id: channel.id,
+        },
+      }
     end
 
     def create!
-      Chat::CreateMessage.call(data)
+      message = nil
+      Chat::CreateMessage.call(data) do
+        on_success { |message_instance:| message = message_instance }
+      end
+      message
     end
   end
 end

--- a/plugins/chat/lib/discourse_dev/reviewable_message.rb
+++ b/plugins/chat/lib/discourse_dev/reviewable_message.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DiscourseDev
+  class ReviewableMessage < Reviewable
+    def populate!
+      channel = CategoryChannel.new.create!
+      message = Message.new(channel_id: channel.id, count: 1).create!
+      user = @users.sample
+
+      ::Chat::FlagMessage.call(
+        guardian: user.guardian,
+        params: {
+          channel_id: channel.id,
+          message_id: message.id,
+          flag_type_id:
+            ReviewableScore.types.slice(:off_topic, :inappropriate, :spam, :illegal).values.sample,
+        },
+      )
+    end
+  end
+end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -512,6 +512,8 @@ after_initialize do
   # When we eventually allow secure_uploads in chat, this will need to be
   # removed. Depending on the channel, uploads may end up being secure.
   UploadSecurity.register_custom_public_type("chat-composer")
+
+  DiscoursePluginRegistry.discourse_dev_populate_reviewable_types.add DiscourseDev::ReviewableMessage
 end
 
 if Rails.env == "test"


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/pull/30540

This also makes the chat plugin use the new plugin API for extending the `reviewables:populate` rake task.