### PR TITLE
DEV: Move `merge` job in tests workflow to different runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,7 +411,7 @@ jobs:
 
   merge:
     if: github.repository == 'discourse/discourse' && github.ref == 'refs/heads/main'
-    runs-on: debian-12
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Merge Artifacts


### PR DESCRIPTION
Use the `ubuntu-latest` runner which is free thus freeing up a
self hosted runner
