### PR TITLE
UX: Admin setting page consistency - Experimental

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-experimental-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-experimental-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigExperimentalSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-experimental.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-experimental.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigExperimentalRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.experimental");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -241,6 +241,11 @@ export default function () {
             path: "/",
           });
         });
+        this.route("experimental", function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route(
           "groupPermissions",
           { path: "/group-permissions" },

--- a/app/assets/javascripts/admin/addon/templates/config-experimental-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-experimental-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.experimental.title"}}
+    @descriptionLabel={{i18n "admin.config.experimental.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/experimental"
+        @label={{i18n "admin.config.experimental.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="experimental"
+      @path="/admin/config/experimental"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -290,8 +290,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_experimental",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["experimental"],
+        route: "adminConfig.experimental.settings",
         label: "admin.advanced.sidebar_link.experimental",
         icon: "discourse-sparkles",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5134,6 +5134,9 @@ en:
           all: "All reports"
 
       config:
+        experimental:
+          title: "Experimental"
+          header_description: "Toggle experimental features on or off for your site, most of these can be controlled on a group basis"
         font_style:
           title: "Font style"
           header_description: "Customize the font styles used by your themes"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2733,10 +2733,10 @@ en:
     default_navigation_menu_tags: "Selected tags will be displayed under Navigation Menu's Tags section by default."
     experimental_new_new_view_groups: 'Enable a new topics list that combines unread and new topics and make the "Everything" link in the sidebar link to it.'
     enable_experimental_lightbox: "Replace the default image lightbox with the revamped design."
-    glimmer_topic_list_mode: "Control whether the new 'glimmer' topic-list implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. See https://meta.discourse.org/t/343404 for more info."
+    glimmer_topic_list_mode: "Control whether the new 'glimmer' topic-list implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. See <a href='https://meta.discourse.org/t/343404'>the Meta topic</a> for more information."
     glimmer_post_menu_mode: "Control whether the new 'glimmer' post menu implementation is used. 'auto' will enable automatically once all your themes and plugins are ready. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced."
     glimmer_post_menu_groups: "Enable the new 'glimmer' post menu implementation in 'auto' mode for the specified user groups. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced."
-    experimental_form_templates: "Enable the form templates feature. <b>After enabled,</b> manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
+    experimental_form_templates: "Enable the form templates feature. Manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     admin_sidebar_enabled_groups: "Enable sidebar navigation for the admin UI for the specified groups, which replaces the top-level admin navigation buttons."
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,7 @@ Discourse::Application.routes.draw do
         get "notifications" => "site_settings#index"
         get "search" => "site_settings#index"
         get "legal" => "site_settings#index"
+        get "experimental" => "site_settings#index"
         get "trust-levels" => "site_settings#index"
         get "group-permissions" => "site_settings#index"
 


### PR DESCRIPTION
Followup c2282439b32d879a73217eec62449f042914d7d0

Make the Experimental config page reached from the sidebar
use our consistent site setting page rules.

![image](https://github.com/user-attachments/assets/8b5b2f4e-4e24-44fc-804f-a13e9eade47e)
