### PR TITLE
FIX: ChangeFullNameRequiredSetting could fail if setting was already in DB

### DIFF
--- a/db/migrate/20241224191732_change_full_name_required_setting.rb
+++ b/db/migrate/20241224191732_change_full_name_required_setting.rb
@@ -20,11 +20,10 @@ class ChangeFullNameRequiredSetting < ActiveRecord::Migration[7.2]
     SQL
 
     DB.exec(<<~SQL, value: new_setting) if new_setting
-        INSERT INTO site_settings
-        (name, data_type, value, created_at, updated_at)
-        VALUES
-        ('full_name_requirement', 7, :value, NOW(), NOW())
-      SQL
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES ('full_name_requirement', 7, :value, NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
   end
 
   def down


### PR DESCRIPTION
Followup 3187606d3402003437c2ccd6121a26f874939228

Fix full_name_requirement INSERT by adding ON CONFLICT DO NOTHING,
on sites that already have this setting this migration will fail.
