### PR TITLE
UX: Admin setting page consistency - Spam

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-spam-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-spam-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigSpamSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-spam.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-spam.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigSpamRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.security.sidebar_link.spam");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -303,6 +303,9 @@ export default function () {
         this.route("security", function () {
           this.route("settings", { path: "/" });
         });
+        this.route("spam", function () {
+          this.route("settings", { path: "/" });
+        });
       }
     );
 

--- a/app/assets/javascripts/admin/addon/templates/config-spam-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-spam-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.spam.title"}}
+    @descriptionLabel={{i18n "admin.config.spam.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/spam"
+        @label={{i18n "admin.config.spam.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="spam"
+      @path="/admin/config/spam"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -187,9 +187,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_spam",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["spam"],
-        query: { filter: "" },
+        route: "adminConfig.spam.settings",
         label: "admin.security.sidebar_link.spam",
         icon: "robot",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5151,7 +5151,7 @@ en:
           header_description: "Customize the variations of your site logo"
         navigation:
           title: "Navigation"
-          header_description: "Configure the navigation links and menu items for your site. This includes the location and behaviour of the primary navigation menu, the quick links at the top of the homepage, as well as the admin sidebar"
+          header_description: "Configure the navigation links and menu items for your site. This includes the location and behavior of the primary navigation menu, the quick links at the top of the homepage, as well as the admin sidebar"
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation"
@@ -5161,6 +5161,9 @@ en:
         security:
           title: "Security"
           header_description: "Configure security settings, including two-factor authentication, moderator priviledges, and content security policies"
+        spam:
+          title: "Spam"
+          header_description: "Configure how user registration and posting behavior analyzed by the system to quickly identify and block spam"
         trust_levels:
           title: "Trust levels"
           header_description: "Trust level settings allow you to fine-tune the requirements and notifications for your community’s progression system, which automatically promotes users to higher trust levels as they demonstrate consistent, positive engagement with your forum"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,7 @@ Discourse::Application.routes.draw do
         get "notifications" => "site_settings#index"
         get "search" => "site_settings#index"
         get "security" => "site_settings#index"
+        get "spam" => "site_settings#index"
         get "experimental" => "site_settings#index"
         get "trust-levels" => "site_settings#index"
         get "group-permissions" => "site_settings#index"


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains security-related settings, to replace the "security" category view linked to from "Security settings" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/9728d5c5-a34e-4372-a397-39e70f06633a)
