### PR TITLE
UX: Admin setting page consistency - Developer

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-developer-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-developer-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigDeveloperSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-developer.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-developer.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigDeveloperRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.developer");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -291,6 +291,9 @@ export default function () {
             this.route("settings");
           }
         );
+        this.route("developer", function () {
+          this.route("settings", { path: "/" });
+        });
         this.route("fonts", function () {
           this.route("settings", { path: "/" });
         });

--- a/app/assets/javascripts/admin/addon/templates/config-developer-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-developer-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.developer.title"}}
+    @descriptionLabel={{i18n "admin.config.developer.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/developer"
+        @label={{i18n "admin.config.developer.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="developer"
+      @path="/admin/config/developer"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -228,9 +228,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_developer",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["developer"],
-        query: { filter: "" },
+        route: "adminConfig.developer.settings",
         label: "admin.advanced.sidebar_link.developer",
         icon: "keyboard",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5136,7 +5136,7 @@ en:
       config:
         developer:
           title: "Developer"
-          header_description: "Developer settings to help with development and debugging"
+          header_description: "Developer settings to control rate limits, multipliers and calculations, safe mode, and other advanced features"
         experimental:
           title: "Experimental"
           header_description: "Toggle experimental features on or off for your site, most of these can be controlled on a group basis"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5134,6 +5134,9 @@ en:
           all: "All reports"
 
       config:
+        developer:
+          title: "Developer"
+          header_description: "Developer settings to help with development and debugging"
         experimental:
           title: "Experimental"
           header_description: "Toggle experimental features on or off for your site, most of these can be controlled on a group basis"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,7 @@ Discourse::Application.routes.draw do
       namespace :config, constraints: StaffConstraint.new do
         resources :site_settings, only: %i[index]
 
+        get "developer" => "site_settings#index"
         get "fonts" => "site_settings#index"
         get "legal" => "site_settings#index"
         get "login-and-authentication" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2566,13 +2566,6 @@ developer:
   instrument_gc_stat_per_request:
     default: false
     hidden: true
-  admin_sidebar_enabled_groups:
-    type: group_list
-    list_type: compact
-    default: "1|2"
-    allow_any: false
-    refresh: true
-    area: "group_permissions|navigation"
   warn_critical_js_deprecations:
     default: true
     client: true
@@ -2611,6 +2604,13 @@ navigation:
       - "top"
       - "bottom"
     area: "navigation"
+  admin_sidebar_enabled_groups:
+    type: group_list
+    list_type: compact
+    default: "1|2"
+    allow_any: false
+    refresh: true
+    area: "group_permissions|navigation"
 
 embedding:
   embed_by_username:


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains developer-related settings, to replace the "developer" category view linked to from "Developer" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/ac08f861-b1fd-4f0b-a907-e56dce4f6242)