### PR TITLE
UX: Admin setting page consistency - Rate Limits

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-rate-limits-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-rate-limits-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigRateLimitsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-rate-limits.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-rate-limits.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigRateLimitsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.rate_limits");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -303,6 +303,9 @@ export default function () {
         this.route("navigation", function () {
           this.route("settings", { path: "/" });
         });
+        this.route("rate-limits", function () {
+          this.route("settings", { path: "/" });
+        });
         this.route("security", function () {
           this.route("settings", { path: "/" });
         });

--- a/app/assets/javascripts/admin/addon/templates/config-rate-limits-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-rate-limits-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.rate_limits.title"}}
+    @descriptionLabel={{i18n "admin.config.rate_limits.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/rate-limits"
+        @label={{i18n "admin.config.rate_limits.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="rate_limits"
+      @path="/admin/config/rate-limits"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -238,9 +238,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_rate_limits",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["rate_limits"],
-        query: { filter: "" },
+        route: "adminConfig.rate-limits.settings",
         label: "admin.advanced.sidebar_link.rate_limits",
         icon: "rocket",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5158,6 +5158,9 @@ en:
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation"
+        rate_limits:
+          title: "Rate limits"
+          header_description: "Configure how often users can perform certain actions, such as creating topics, sending messages, and posting replies"
         search:
           title: "Search"
           header_description: "Configure search settings including logging and tokenization for Chinese and Japanese languages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,7 @@ Discourse::Application.routes.draw do
         get "logo" => "site_settings#index"
         get "navigation" => "site_settings#index"
         get "notifications" => "site_settings#index"
+        get "rate-limits" => "site_settings#index"
         get "search" => "site_settings#index"
         get "security" => "site_settings#index"
         get "spam" => "site_settings#index"


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains rate limiting-related settings, to replace the "rate_limits" category view linked to from "Rate limits" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/cba163ef-36d8-48af-9cf9-0b78a331e0bb)