### PR TITLE
UX: Admin setting page consistency - User API

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-user-api-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-user-api-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigUserApiSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-user-api.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-user-api.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigUserApiRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.user_api");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -312,6 +312,9 @@ export default function () {
         this.route("spam", function () {
           this.route("settings", { path: "/" });
         });
+        this.route("user-api", function () {
+          this.route("settings", { path: "/" });
+        });
       }
     );
 

--- a/app/assets/javascripts/admin/addon/templates/config-user-api-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-user-api-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.user_api.title"}}
+    @descriptionLabel={{i18n "admin.config.user_api.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/user-api"
+        @label={{i18n "admin.config.user_api.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="user_api"
+      @path="/admin/config/user-api"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -244,9 +244,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_user_api",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["user_api"],
-        query: { filter: "" },
+        route: "adminConfig.user-api.settings",
         label: "admin.advanced.sidebar_link.user_api",
         icon: "shuffle",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5173,6 +5173,9 @@ en:
         trust_levels:
           title: "Trust levels"
           header_description: "Trust level settings allow you to fine-tune the requirements and notifications for your community’s progression system, which automatically promotes users to higher trust levels as they demonstrate consistent, positive engagement with your forum"
+        user_api:
+          title: "User API"
+          header_description: "Configure which user groups can access the API, as well as which scopes are allowed"
         group_permissions:
           title: "Group permissions"
           header_description: "All group-based app permissions are managed here, which control access to various features within Discourse"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -404,6 +404,7 @@ Discourse::Application.routes.draw do
         get "search" => "site_settings#index"
         get "security" => "site_settings#index"
         get "spam" => "site_settings#index"
+        get "user-api" => "site_settings#index"
         get "experimental" => "site_settings#index"
         get "trust-levels" => "site_settings#index"
         get "group-permissions" => "site_settings#index"


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains user API-related settings, to replace the "user_api" category view linked to from "User API" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/334d4252-c9bc-4bf3-a98b-adadc4bdeeac)
