### PR TITLE
UX: Admin setting page consistency - Onebox

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-onebox-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-onebox-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigOneboxSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-onebox.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-onebox.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigOneboxRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.advanced.sidebar_link.onebox");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -303,6 +303,9 @@ export default function () {
         this.route("navigation", function () {
           this.route("settings", { path: "/" });
         });
+        this.route("onebox", function () {
+          this.route("settings", { path: "/" });
+        });
         this.route("rate-limits", function () {
           this.route("settings", { path: "/" });
         });

--- a/app/assets/javascripts/admin/addon/templates/config-onebox-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-onebox-settings.gjs
@@ -1,0 +1,29 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @titleLabel={{i18n "admin.config.onebox.title"}}
+    @descriptionLabel={{i18n "admin.config.onebox.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/onebox"
+        @label={{i18n "admin.config.onebox.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @categories="onebox"
+      @path="/admin/config/onebox"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -250,9 +250,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_onebox",
-        route: "adminSiteSettingsCategory",
-        routeModels: ["onebox"],
-        query: { filter: "" },
+        route: "adminConfig.onebox.settings",
         label: "admin.advanced.sidebar_link.onebox",
         icon: "far-square",
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5158,6 +5158,9 @@ en:
         notifications:
           title: "Notifications"
           header_description: "Configure how notifications are managed and delivered for users, including email preferences, push notifications, mention limits, and notification consolidation"
+        onebox:
+          title: "Onebox"
+          header_description: "Configure how onebox previews are generated and displayed for your site"
         rate_limits:
           title: "Rate limits"
           header_description: "Configure how often users can perform certain actions, such as creating topics, sending messages, and posting replies"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,7 @@ Discourse::Application.routes.draw do
         get "navigation" => "site_settings#index"
         get "notifications" => "site_settings#index"
         get "rate-limits" => "site_settings#index"
+        get "onebox" => "site_settings#index"
         get "search" => "site_settings#index"
         get "security" => "site_settings#index"
         get "spam" => "site_settings#index"


### PR DESCRIPTION
## ✨ What's This?

This PR creates a basic config page that only contains Onebox-related settings, to replace the "onebox" category view linked to from "Onebox" in the admin sidebar.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/b878c301-5a2d-4f0a-a7ef-18298d14ea8b)