### PR TITLE
FIX: Ensure popups from the chat composer dropdown gain focus

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
@@ -9,7 +9,7 @@ import DMenu from "float-kit/components/d-menu";
 export default class ChatComposerDropdown extends Component {
   @action
   onButtonClick(button, closeFn) {
-    closeFn();
+    closeFn({ focusTrigger: false });
     button.action();
   }
 


### PR DESCRIPTION
## ✨ What's This?

When inserting anything from the chat composer dropdown, any popups opened aren't properly focussed.

This is due to the default behaviour of the dropdown menu closing, which tries to return the focus to the original triggering element. This would normally be the correct behaviour, but here we want the menu to close in the background, handing focus off to the popup, instead.

## 👑 Testing

Check that popups are properly focussed when opened from the chat composer dropdown.