### PR TITLE
 DEV: Add plugin modifiers to `ChannelMembershipManager` `#follow` and `#all_for_user`

### DIFF
--- a/plugins/chat/lib/chat/channel_membership_manager.rb
+++ b/plugins/chat/lib/chat/channel_membership_manager.rb
@@ -3,7 +3,7 @@
 module Chat
   class ChannelMembershipManager
     def self.all_for_user(user)
-      override = DiscoursePluginRegistry.apply_modifier(:list_user_channels_modifier, nil, user)
+      override = DiscoursePluginRegistry.apply_modifier(:channel_memberships, nil, user)
 
       return override if !override.nil?
 

--- a/plugins/chat/spec/lib/chat/channel_membership_manager_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_membership_manager_spec.rb
@@ -10,20 +10,16 @@ RSpec.describe Chat::ChannelMembershipManager do
 
   describe "#all_for_user" do
     it "works with plugin modifier" do
-      DiscoursePluginRegistry.register_modifier(plugin, :list_user_channels_modifier, &deny_block)
+      DiscoursePluginRegistry.register_modifier(plugin, :channel_memberships, &deny_block)
       action = described_class.all_for_user(user)
       expect(action).to eq(false)
 
-      DiscoursePluginRegistry.register_modifier(plugin, :list_user_channels_modifier, &allow_block)
+      DiscoursePluginRegistry.register_modifier(plugin, :channel_memberships, &allow_block)
       action = described_class.all_for_user(user)
       expect(action).to eq(true)
     ensure
-      DiscoursePluginRegistry.unregister_modifier(plugin, :list_user_channels_modifier, &deny_block)
-      DiscoursePluginRegistry.unregister_modifier(
-        plugin,
-        :list_user_channels_modifier,
-        &allow_block
-      )
+      DiscoursePluginRegistry.unregister_modifier(plugin, :channel_memberships, &deny_block)
+      DiscoursePluginRegistry.unregister_modifier(plugin, :channel_memberships, &allow_block)
     end
   end
 


### PR DESCRIPTION
**Description**

We need to add these plugin modifiers as part of changes made to the `discourse-livestream` plugin to allow the user chat allow list setting to work properly, check [this](https://github.com/discourse/discourse-livestream/pull/43) for more context