### PR TITLE
FIX: Cleaned up horizontal nav scrolling so arrows show/hide properly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
+++ b/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
@@ -47,14 +47,21 @@ export default class HorizontalOverflowNav extends Component {
   }
 
   watchScroll(element) {
-    if (element.offsetWidth + element.scrollLeft === element.scrollWidth) {
+    const { scrollWidth, scrollLeft, offsetWidth } = element;
+
+    // Check if the content overflows
+    this.hasScroll = scrollWidth > offsetWidth;
+
+    // Ensure the right arrow disappears only when fully scrolled
+    if (scrollWidth - scrollLeft - offsetWidth <= 2) {
       this.hideRightScroll = true;
       clearInterval(this.scrollInterval);
     } else {
       this.hideRightScroll = false;
     }
 
-    if (element.scrollLeft === 0) {
+    // Ensure the left arrow disappears only when fully scrolled to the start
+    if (scrollLeft <= 2) {
       this.hideLeftScroll = true;
       clearInterval(this.scrollInterval);
     } else {


### PR DESCRIPTION
### What's changed?
- Resolved an issue where the right arrow would remain visible after reaching the end of the scrollable content.
- Implemented a buffer to address minor inaccuracies in scroll calculations.
- Adjusted the logic so that arrows are only displayed when the content exceeds the container width.

### Before
[Kapture 2025-01-07 at 22.20.24.webm](https://github.com/user-attachments/assets/aab4eed6-51b0-4db2-9061-821f8241477e)


### After
[Kapture 2025-01-07 at 22.17.26.webm](https://github.com/user-attachments/assets/2750f2a1-28e6-4ae2-880a-4dfab85ad65e)
