### PR TITLE
DEV: skip flaky chat composer emoji spec

### DIFF
--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Chat composer", type: :system do
       expect(page).to have_no_selector(".chat-emoji-picker [data-emoji='grinning']")
     end
 
-    it "replaces the partially typed emoji with the selected" do
+    xit "replaces the partially typed emoji with the selected" do
       chat_page.visit_channel(channel_1)
       find(".chat-composer__input").fill_in(with: "hey :gri")
 


### PR DESCRIPTION
This test is flaky, sometimes it fails with the hamburger menu blocking the click on the emoji, other times it just doesn't return the list of emojis when the search term is there.

Other similar emoji tests are skipped. Stopping the bleed, but we still need to figure out a more reliable testing strategy here.

Will revisit after #28277 is merged.

ref `/t/-/145212`