### PR TITLE
DEV: Drop deprecated `decorateTopicTitle` API

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -11,7 +11,6 @@ import {
 } from "@ember-decorators/component";
 import { observes, on } from "@ember-decorators/object";
 import $ from "jquery";
-import { topicTitleDecorators } from "discourse/components/topic-title";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import DiscourseURL, { groupPath } from "discourse/lib/url";
@@ -128,17 +127,6 @@ export default class TopicListItem extends Component {
     if (this.includeUnreadIndicator) {
       this.messageBus.subscribe(this.unreadIndicatorChannel, this.onMessage);
     }
-
-    schedule("afterRender", () => {
-      if (this.element && !this.isDestroying && !this.isDestroyed) {
-        const rawTopicLink = this.element.querySelector(".raw-topic-link");
-
-        rawTopicLink &&
-          topicTitleDecorators.forEach((cb) =>
-            cb(this.topic, rawTopicLink, "topic-list-item-title")
-          );
-      }
-    });
   }
 
   willDestroyElement() {

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { array, concat, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
@@ -12,7 +11,6 @@ import PostCountOrBadges from "discourse/components/topic-list/post-count-or-bad
 import TopicExcerpt from "discourse/components/topic-list/topic-excerpt";
 import TopicLink from "discourse/components/topic-list/topic-link";
 import TopicStatus from "discourse/components/topic-status";
-import { topicTitleDecorators } from "discourse/components/topic-title";
 import avatar from "discourse/helpers/avatar";
 import categoryLink from "discourse/helpers/category-link";
 import concatClass from "discourse/helpers/concat-class";
@@ -105,17 +103,6 @@ export default class Item extends Component {
   }
 
   @action
-  applyTitleDecorators(element) {
-    const rawTopicLink = element.querySelector(".raw-topic-link");
-
-    if (rawTopicLink) {
-      topicTitleDecorators?.forEach((cb) =>
-        cb(this.args.topic, rawTopicLink, "topic-list-item-title")
-      );
-    }
-  }
-
-  @action
   onBulkSelectToggle(e) {
     if (e.target.checked) {
       this.args.selected.addObject(this.args.topic);
@@ -193,7 +180,6 @@ export default class Item extends Component {
   <template>
     <tr
       {{! template-lint-disable no-invalid-interactive }}
-      {{didInsert this.applyTitleDecorators}}
       {{this.highlightIfNeeded}}
       {{on "keydown" this.keyDown}}
       {{on "click" this.click}}

--- a/app/assets/javascripts/discourse/app/components/topic-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-title.gjs
@@ -2,36 +2,14 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { isiPad } from "discourse/lib/utilities";
 import observeIntersection from "discourse/modifiers/observe-intersection";
 
-export let topicTitleDecorators = [];
-
-export function addTopicTitleDecorator(decorator) {
-  topicTitleDecorators.push(decorator);
-}
-
-export function resetTopicTitleDecorators() {
-  topicTitleDecorators.length = 0;
-}
-
 export default class TopicTitle extends Component {
   @service header;
-
-  @action
-  applyDecorators(element) {
-    const fancyTitle = element.querySelector(".fancy-title");
-
-    if (fancyTitle) {
-      topicTitleDecorators.forEach((cb) =>
-        cb(this.args.model, fancyTitle, "topic-title")
-      );
-    }
-  }
 
   @action
   keyDown(e) {
@@ -66,7 +44,6 @@ export default class TopicTitle extends Component {
   <template>
     {{! template-lint-disable no-invalid-interactive }}
     <div
-      {{didInsert this.applyDecorators}}
       {{on "keydown" this.keyDown}}
       {{observeIntersection this.handleIntersectionChange}}
       {{willDestroy this.handleTitleDestroy}}

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "1.39.2";
+export const PLUGIN_API_VERSION = "2.0.0";
 
 import $ from "jquery";
 import { h } from "virtual-dom";
@@ -41,7 +41,6 @@ import { addOnKeyUpCallback } from "discourse/components/search-menu/search-term
 import { REFRESH_COUNTS_APP_EVENT_NAME as REFRESH_USER_SIDEBAR_CATEGORIES_SECTION_COUNTS_APP_EVENT_NAME } from "discourse/components/sidebar/user/categories-section";
 import { addTopicParticipantClassesCallback } from "discourse/components/topic-map/topic-participant";
 import { setDesktopScrollAreaHeight } from "discourse/components/topic-timeline/container";
-import { addTopicTitleDecorator } from "discourse/components/topic-title";
 import { setNotificationsLimit as setUserMenuNotificationsLimit } from "discourse/components/user-menu/notifications-list";
 import { addUserMenuProfileTabItem } from "discourse/components/user-menu/profile-tab-content";
 import { addDiscoveryQueryParam } from "discourse/controllers/discovery/list";
@@ -2064,33 +2063,6 @@ class PluginApi {
    **/
   setDesktopTopicTimelineScrollAreaHeight(height) {
     setDesktopScrollAreaHeight(height);
-  }
-
-  /**
-   * Allows altering the topic title in the topic list, and in the topic view
-   *
-   * topicTitleType can be `topic-title` or `topic-list-item-title`
-   *
-   * For example, to replace the topic title:
-   *
-   * ```
-   * api.decorateTopicTitle((topicModel, node, topicTitleType) => {
-   *   node.innerText = "my new topic title";
-   * });
-   * ```
-   *
-   * @deprecated because modifying an Ember-rendered DOM tree can lead to very unexpected errors. Use plugin outlet connectors instead
-   **/
-  decorateTopicTitle(callback) {
-    deprecated(
-      "decorateTopicTitle is deprecated because modifying an Ember-rendered DOM tree can lead to very unexpected errors. Use plugin outlet connectors instead",
-      {
-        id: "discourse.decorate-topic-title",
-        since: "3.2",
-        dropFrom: "3.3",
-      }
-    );
-    addTopicTitleDecorator(callback);
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -6,7 +6,6 @@ import {
   visit,
 } from "@ember/test-helpers";
 import { test } from "qunit";
-import { withPluginApi } from "discourse/lib/plugin-api";
 import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import {
@@ -16,7 +15,6 @@ import {
   selectText,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
 import { cloneJSON } from "discourse-common/lib/object";
 import { i18n } from "discourse-i18n";
 
@@ -449,34 +447,6 @@ acceptance("Topic featured links", function (needs) {
     assert
       .dom(".title-wrapper .remove-featured-link")
       .exists("link to remove featured link");
-  });
-});
-
-acceptance("Topic with title decorated", function (needs) {
-  needs.user();
-  needs.hooks.beforeEach(() => {
-    withPluginApi("0.8.40", (api) => {
-      withSilencedDeprecations("discourse.decorate-topic-title", () => {
-        api.decorateTopicTitle((topic, node, topicTitleType) => {
-          node.innerText = `${node.innerText}-${topic.id}-${topicTitleType}`;
-        });
-      });
-    });
-  });
-
-  test("Decorate topic title", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-
-    assert
-      .dom(".fancy-title")
-      .hasText(/-280-topic-title$/, "decorates topic title");
-
-    assert
-      .dom(".raw-topic-link:nth-child(1)")
-      .hasText(
-        /-27331-topic-list-item-title$/,
-        "decorates topic list item title"
-      );
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -28,7 +28,6 @@ import { resetDecorators as resetPluginOutletDecorators } from "discourse/compon
 import { resetItemSelectCallbacks } from "discourse/components/search-menu/results/assistant-item";
 import { resetQuickSearchRandomTips } from "discourse/components/search-menu/results/random-quick-tip";
 import { resetOnKeyUpCallbacks } from "discourse/components/search-menu/search-term";
-import { resetTopicTitleDecorators } from "discourse/components/topic-title";
 import { resetUserMenuProfileTabItems } from "discourse/components/user-menu/profile-tab-content";
 import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { clearHTMLCache } from "discourse/helpers/custom-html";
@@ -208,7 +207,6 @@ export function testCleanup(container, app) {
   resetDecorators();
   resetPostCookedDecorators();
   resetPluginOutletDecorators();
-  resetTopicTitleDecorators();
   resetUsernameDecorators();
   resetOneboxCache();
   resetCustomPostMessageCallbacks();

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,10 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-01-07
+
+- Removed `decorateTopicTitle`. This has been deprecated for more than a year, and we are not aware of any remaining uses in the ecosystem.
+
 ## [1.39.2] - 2024-12-19
 
 - Removed the deprecation of `includePostAttributes` for now.


### PR DESCRIPTION
This was deprecated more than a year ago, and we are not aware of any remaining uses in the ecosystem.