### PR TITLE
DEV: Fix triple click selection in WebKit derived browsers

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -370,6 +370,19 @@ export default class PostCooked {
       cookedDiv.innerHTML = this.attrs.cooked;
     }
 
+    // On webkit based browsers, triple clicking on the last paragraph of a post won't stop at end of the paragraph.
+    // It looks like the browser is selecting EOL characters and that causes the selection to leak into the next
+    // nodes until it finds a non-empty node. This is a workaround to prevent that from happening.
+    // We insert a div after the last paragraph at the end of the cooked content containing a <br> element.
+    // The line break works as barrier causing the selection to stop at the correct place.
+    // To prevent layout shifts this div is styled to be invisible with height 0 and overflow hidden.
+    // We also set aria-hidden to true to prevent screen readers from reading it.
+    const selectionBarrier = document.createElement("div");
+    selectionBarrier.classList.add("cooked-selection-barrier");
+    selectionBarrier.ariaHidden = "true";
+    selectionBarrier.appendChild(document.createElement("br"));
+    cookedDiv.appendChild(selectionBarrier);
+
     return cookedDiv;
   }
 

--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -370,13 +370,13 @@ export default class PostCooked {
       cookedDiv.innerHTML = this.attrs.cooked;
     }
 
-    // On webkit based browsers, triple clicking on the last paragraph of a post won't stop at end of the paragraph.
-    // It looks like the browser is selecting EOL characters and that causes the selection to leak into the next
+    // On WebKit-based browsers, triple clicking on the last paragraph of a post won't stop at the end of the paragraph.
+    // It looks like the browser is selecting EOL characters, and that causes the selection to leak into the following
     // nodes until it finds a non-empty node. This is a workaround to prevent that from happening.
-    // We insert a div after the last paragraph at the end of the cooked content containing a <br> element.
-    // The line break works as barrier causing the selection to stop at the correct place.
-    // To prevent layout shifts this div is styled to be invisible with height 0 and overflow hidden.
-    // We also set aria-hidden to true to prevent screen readers from reading it.
+    // We insert a div after the last paragraph at the end of the cooked content, containing a <br> element.
+    // The line break works as a barrier, causing the selection to stop at the correct place.
+    // To prevent layout shifts this div is styled to be invisible with height 0 and overflow hidden and set aria-hidden
+    // to true to prevent screen readers from reading it.
     const selectionBarrier = document.createElement("div");
     selectionBarrier.classList.add("cooked-selection-barrier");
     selectionBarrier.ariaHidden = "true";

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -88,7 +88,7 @@ acceptance("Fast Edit", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     query("#post_2 .cooked").append(`That’s what she said!`);
-    const textNode = query("#post_2 .cooked").childNodes[2];
+    const textNode = query("#post_2 .cooked").childNodes[3];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");
@@ -101,7 +101,7 @@ acceptance("Fast Edit", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     query("#post_2 .cooked").append(`Je suis désolé, comment ça va?`);
-    const textNode = query("#post_2 .cooked").childNodes[2];
+    const textNode = query("#post_2 .cooked").childNodes[3];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");
@@ -113,7 +113,7 @@ acceptance("Fast Edit", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     query("#post_2 .cooked").append(`这是一个测试`);
-    const textNode = query("#post_2 .cooked").childNodes[2];
+    const textNode = query("#post_2 .cooked").childNodes[3];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");
@@ -125,7 +125,7 @@ acceptance("Fast Edit", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     query("#post_2 .cooked").append(`This is great 👍`);
-    const textNode = query("#post_2 .cooked").childNodes[2];
+    const textNode = query("#post_2 .cooked").childNodes[3];
 
     await selectText(textNode);
     await click(".quote-button .quote-edit-label");

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -244,6 +244,15 @@
   }
 }
 
+.cooked-selection-barrier {
+  height: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  overflow: hidden;
+  opacity: 0;
+}
+
 // add staff color
 .moderator {
   .regular > .cooked {

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -104,11 +104,6 @@ describe "Topic page", type: :system do
     it "select the last paragraph" do
       visit "/t/#{topic.slug}/#{topic.id}/1"
 
-      # ensure #test-last-cooked-paragraph is the last paragraph of #post_1.cooked just in case the cooked content of the
-      # post is changed in the future. this ensures we testing what we need.
-      last_cooked_child_id = page.find(".cooked >:last-child")[:id]
-      expect(last_cooked_child_id).to eq("test-last-cooked-paragraph")
-
       # select the last paragraph by triple clicking
       element = page.driver.browser.find_element(id: "test-last-cooked-paragraph")
       page.driver.browser.action.move_to(element).click.click.click.perform

--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -106,7 +106,7 @@ describe "Topic page", type: :system do
 
       # ensure #test-last-cooked-paragraph is the last paragraph of #post_1.cooked just in case the cooked content of the
       # post is changed in the future. this ensures we testing what we need.
-      last_cooked_child_id = page.find("#post_1 .cooked >:last-child")[:id]
+      last_cooked_child_id = page.find(".cooked >:last-child")[:id]
       expect(last_cooked_child_id).to eq("test-last-cooked-paragraph")
 
       # select the last paragraph by triple clicking


### PR DESCRIPTION
On WebKit-based browsers, triple clicking on the last paragraph of a post won't stop at the end of the paragraph, leaking the selection into the following nodes until it finds a non-empty node.

This PR introduces a workaround to fix this behavior.