### PR TITLE
UX: Conditionally render permalinks filter

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-permalink-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-permalink-form.gjs
@@ -87,7 +87,9 @@ export default class AdminFlagsForm extends Component {
         permalink_type: data.permalinkType,
         permalink_type_value: this.valueForPermalinkType(data),
       });
-      this.adminPermalinks.model.unshift(Permalink.create(result.payload));
+      this.adminPermalinks.model.allLinks.unshift(
+        Permalink.create(result.payload)
+      );
       this.router.transitionTo("adminPermalinks");
     } catch (error) {
       popupAjaxError(error);
@@ -106,10 +108,12 @@ export default class AdminFlagsForm extends Component {
           permalink_type_value: this.valueForPermalinkType(data),
         }
       );
-      const index = this.adminPermalinks.model.findIndex(
+      const index = this.adminPermalinks.model.allLinks.findIndex(
         (permalink) => permalink.id === this.args.permalink.id
       );
-      this.adminPermalinks.model[index] = Permalink.create(result.payload);
+      this.adminPermalinks.model.allLinks[index] = Permalink.create(
+        result.payload
+      );
       this.router.transitionTo("adminPermalinks");
     } catch (error) {
       popupAjaxError(error);

--- a/app/assets/javascripts/admin/addon/controllers/admin-permalinks-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-permalinks-index.js
@@ -49,7 +49,7 @@ export default class AdminPermalinksIndexController extends Controller {
       didConfirm: async () => {
         try {
           await this.store.destroyRecord("permalink", permalink);
-          this.model.removeObject(permalink);
+          this.model.allLinks.removeObject(permalink);
         } catch {
           this.dialog.alert(i18n("generic_error"));
         }

--- a/app/assets/javascripts/admin/addon/models/permalink.js
+++ b/app/assets/javascripts/admin/addon/models/permalink.js
@@ -6,10 +6,19 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 export default class Permalink extends RestModel {
   static findAll(filter) {
-    return ajax("/admin/permalinks.json", { data: { filter } }).then(function (
-      permalinks
-    ) {
-      return permalinks.map((p) => Permalink.create(p));
+    return ajax("/admin/permalinks.json").then(function (permalinks) {
+      let allLinks = permalinks.map((p) => Permalink.create(p));
+
+      if (!filter) {
+        return { allLinks, filteredLinks: allLinks };
+      }
+
+      let filteredLinks = permalinks
+        .filter((p) => {
+          return p.url.includes(filter);
+        })
+        .map((p) => Permalink.create(p));
+      return { allLinks, filteredLinks };
     });
   }
 

--- a/app/assets/javascripts/admin/addon/models/permalink.js
+++ b/app/assets/javascripts/admin/addon/models/permalink.js
@@ -9,15 +9,10 @@ export default class Permalink extends RestModel {
     return ajax("/admin/permalinks.json").then(function (permalinks) {
       let allLinks = permalinks.map((p) => Permalink.create(p));
 
-      if (!filter) {
-        return { allLinks, filteredLinks: allLinks };
-      }
+      let filteredLinks = filter
+        ? allLinks.filter((p) => p.url.includes(filter))
+        : allLinks;
 
-      let filteredLinks = permalinks
-        .filter((p) => {
-          return p.url.includes(filter);
-        })
-        .map((p) => Permalink.create(p));
       return { allLinks, filteredLinks };
     });
   }

--- a/app/assets/javascripts/admin/addon/models/permalink.js
+++ b/app/assets/javascripts/admin/addon/models/permalink.js
@@ -10,7 +10,9 @@ export default class Permalink extends RestModel {
       let allLinks = permalinks.map((p) => Permalink.create(p));
 
       let filteredLinks = filter
-        ? allLinks.filter((p) => p.url.includes(filter))
+        ? allLinks.filter(
+            (p) => p.url.includes(filter) || p.external_url?.includes(filter)
+          )
         : allLinks;
 
       return { allLinks, filteredLinks };

--- a/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-index.hbs
@@ -1,25 +1,27 @@
 <ConditionalLoadingSpinner @condition={{this.loading}}>
-  <div class="d-admin-filter">
-    <div class="admin-filter__input-container permalink-search">
-      <TextField
-        @value={{this.filter}}
-        @placeholderKey="admin.permalink.form.filter"
-        @autocorrect="off"
-        @autocapitalize="off"
-        class="admin-filter__input"
-      />
+  {{#if this.model.allLinks.length}}
+    <div class="d-admin-filter">
+      <div class="admin-filter__input-container permalink-search">
+        <TextField
+          @value={{this.filter}}
+          @placeholderKey="admin.permalink.form.filter"
+          @autocorrect="off"
+          @autocapitalize="off"
+          class="admin-filter__input"
+        />
+      </div>
     </div>
-  </div>
+  {{/if}}
 
   <div class="permalink-results">
-    {{#if this.model.length}}
+    {{#if this.model.filteredLinks.length}}
       <table class="d-admin-table permalinks">
         <thead>
           <th>{{i18n "admin.permalink.url"}}</th>
           <th>{{i18n "admin.permalink.destination"}}</th>
         </thead>
         <tbody>
-          {{#each this.model as |pl|}}
+          {{#each this.model.filteredLinks as |pl|}}
             <tr
               class={{concat-class
                 "admin-permalink-item d-admin-row__content"

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-permalink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-permalink-test.js
@@ -26,10 +26,8 @@ acceptance("Admin - Permalinks", function (needs) {
 
   needs.user();
   needs.pretender((server, helper) => {
-    server.get("/admin/permalinks.json", (response) => {
-      const result =
-        response.queryParams.filter !== "feature" ? [] : startingData;
-      return helper.response(200, result);
+    server.get("/admin/permalinks.json", () => {
+      return helper.response(200, startingData);
     });
   });
 

--- a/spec/system/admin_permalinks_page_spec.rb
+++ b/spec/system/admin_permalinks_page_spec.rb
@@ -11,6 +11,8 @@ describe "Admin Permalinks Page", type: :system do
 
   it "allows admin to create, edit, and destroy permalink" do
     admin_permalinks_page.visit
+    expect(admin_permalinks_page).to have_no_filter
+
     admin_permalinks_page.click_add_permalink
     admin_permalink_form_page
       .fill_in_url("test")
@@ -18,6 +20,13 @@ describe "Admin Permalinks Page", type: :system do
       .fill_in_category("1")
       .click_save
     expect(admin_permalinks_page).to have_permalinks("test")
+    expect(admin_permalinks_page).to have_filter
+
+    admin_permalinks_page.filter("no results")
+    expect(admin_permalinks_page).to have_no_results
+    expect(admin_permalinks_page).to have_filter
+
+    admin_permalinks_page.filter("")
 
     admin_permalinks_page.click_edit_permalink("test")
     admin_permalink_form_page.fill_in_url("test2").click_save

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -41,6 +41,22 @@ module PageObjects
         has_no_css?(".admin-permalink-item__url")
       end
 
+      def has_no_filter?
+        has_no_css?(".permalink-search")
+      end
+
+      def has_filter?
+        has_css?(".permalink-search")
+      end
+
+      def filter(text)
+        find(".permalink-search").fill_in with: text
+      end
+
+      def has_no_results?
+        has_css?(".permalink-results__no-result")
+      end
+
       def open_permalink_menu(url)
         find("tr.#{url} .permalink-menu-trigger").click
         self


### PR DESCRIPTION
This PR attempts to implement a conditional rendering of the permalinks filter at `/admin/config/permalinks`. Currently, a filter is present when no permalinks have been created. This signals an awkward UX as there is nothing to actually filter.

I assumed I could just add an `{{#if this.model.length}}` statement to conditionally render this filter, but the model was always returning a *filtered* list, based on what was input into the filter input. It worked, except when the filter did not return any permalink results, because at that point the model's length is technically 0, due to no matches for the filter.

To correct this, I changed to model to return an object containing `allLinks` and `filteredLinks`. The filter is now conditionally able to be rendered based on the length of `allLinks`, with the list below rendering based on matches contained in `filteredLinks`.

**Before**
![CleanShot 2025-01-07 at 17 08 04@2x](https://github.com/user-attachments/assets/3412cb50-3d79-466c-a3a7-c75692e72d9a)


**After**
![CleanShot 2025-01-07 at 17 06 53@2x](https://github.com/user-attachments/assets/542409ea-1bcb-4a6b-9f0c-7c926566e811)
