### PR TITLE
FIX: Name field should appear in the signup form for login-required sites

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -214,6 +214,8 @@ class Site
             Discourse.enabled_auth_providers.map do |provider|
               AuthProviderSerializer.new(provider, root: false, scope: guardian)
             end,
+          full_name_required_for_signup:,
+          full_name_visible_in_signup:,
         }.to_json
       )
     end
@@ -251,5 +253,13 @@ class Site
     # publishing forces the sequence up
     # the cache is validated based on the sequence
     MessageBus.publish(SITE_JSON_CHANNEL, "")
+  end
+
+  def self.full_name_required_for_signup
+    SiteSetting.enable_names && SiteSetting.full_name_requirement == "required_at_signup"
+  end
+
+  def self.full_name_visible_in_signup
+    SiteSetting.enable_names && SiteSetting.full_name_requirement != "hidden_at_signup"
   end
 end

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -384,11 +384,11 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def full_name_required_for_signup
-    SiteSetting.enable_names && SiteSetting.full_name_requirement == "required_at_signup"
+    Site.full_name_required_for_signup
   end
 
   def full_name_visible_in_signup
-    SiteSetting.enable_names && SiteSetting.full_name_requirement != "hidden_at_signup"
+    Site.full_name_visible_in_signup
   end
 
   private

--- a/spec/system/page_objects/modals/signup.rb
+++ b/spec/system/page_objects/modals/signup.rb
@@ -43,6 +43,14 @@ module PageObjects
         has_no_css?("#new-account-password")
       end
 
+      def has_name_input?
+        has_css?("#new-account-name")
+      end
+
+      def has_no_name_input?
+        has_no_css?("#new-account-name")
+      end
+
       def fill_input(selector, text)
         if page.has_css?("html.mobile-view", wait: 0)
           expect(page).to have_css(".d-modal:not(.is-animating)")

--- a/spec/system/page_objects/pages/signup.rb
+++ b/spec/system/page_objects/pages/signup.rb
@@ -43,6 +43,14 @@ module PageObjects
         has_no_css?("#new-account-password")
       end
 
+      def has_name_input?
+        has_css?("#new-account-name")
+      end
+
+      def has_no_name_input?
+        has_no_css?("#new-account-name")
+      end
+
       def fill_input(selector, text)
         if page.has_css?("html.mobile-view", wait: 0)
           expect(page).to have_no_css(".d-modal.is-animating")

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -296,6 +296,57 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
 
     expect(page).to have_css(".invited-by .user-info[data-username='#{inviter.username}']")
   end
+
+  describe "full name field" do
+    context "when full_name_requirement is optional_at_signup" do
+      before { SiteSetting.full_name_requirement = "optional_at_signup" }
+
+      context "when login_required is true" do
+        before { SiteSetting.login_required = true }
+
+        it "displays the name field" do
+          signup_form.open
+          expect(signup_form).to have_name_input
+        end
+      end
+
+      context "when enable_names is false" do
+        before { SiteSetting.enable_names = false }
+
+        it "hides the name field" do
+          signup_form.open
+          expect(signup_form).to have_no_name_input
+        end
+      end
+    end
+
+    context "when full_name_requirement is hidden_at_signup" do
+      before { SiteSetting.full_name_requirement = "hidden_at_signup" }
+
+      it "hides the name field" do
+        signup_form.open
+        expect(signup_form).to have_no_name_input
+      end
+    end
+
+    context "when full_name_requirement is required_at_signup" do
+      before { SiteSetting.full_name_requirement = "required_at_signup" }
+
+      it "displays the name field" do
+        signup_form.open
+        expect(signup_form).to have_name_input
+      end
+
+      context "when enable_names is false" do
+        before { SiteSetting.enable_names = false }
+
+        it "hides the name field" do
+          signup_form.open
+          expect(signup_form).to have_no_name_input
+        end
+      end
+    end
+  end
 end
 
 describe "Signup", type: :system do


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/full-name-at-sign-up-went-missing/345662/17?u=osama

The preloaded `site` object for anons on login-required sites is a stripped down version of the full object with just a specific set of attributes and doesn't use the site serializer. This results in the `full_name_required_for_signup` and `full_name_visible_in_signup` attributes not making it to the client app when a login-required site is accessed by an anon, causing the name field in the signup form to not be rendered, even when it's required.

This PR includes those attributes in the stripped down version of the `site` object that's used for anons on login-required sites.