### PR TITLE
DEV: removes non needed special case

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-dropdown.gjs
@@ -9,7 +9,7 @@ import DMenu from "float-kit/components/d-menu";
 export default class ChatComposerDropdown extends Component {
   @action
   async onButtonClick(button, closeFn) {
-    await closeFn({ focusTrigger: false });
+    await closeFn();
 
     button.action();
   }


### PR DESCRIPTION
Now that we correctly await for the modal to close, we dont need to special case and disable focusTrigger, the flow will now be:

- click an element of the menu
- wait for modal to close
- focus trigger
- trigger action, which will eventually open a modal and attempt to focus the first item
