### PR TITLE
UX: Align silence reason header text with content alignment

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -164,6 +164,7 @@
             @order={{this.order}}
             @asc={{this.asc}}
             @automatic={{true}}
+            class="directory-table__column-header--silence-reason"
           />
         {{/if}}
         <PluginOutlet

--- a/app/assets/stylesheets/common/admin/users.scss
+++ b/app/assets/stylesheets/common/admin/users.scss
@@ -117,7 +117,8 @@
     margin-top: 1em;
     &__column-header {
       &--username,
-      &---email {
+      &---email,
+      &--silence-reason {
         .header-contents {
           text-align: left;
         }


### PR DESCRIPTION
### Before
<img width="482" alt="image" src="https://github.com/user-attachments/assets/ee0ca60c-484c-4d8f-80bc-076e672f5091" />


### After
<img width="404" alt="image" src="https://github.com/user-attachments/assets/d92f4cc6-e3b6-4de9-9f30-93a7cfa070ca" />
