### PR TITLE
Apply TopicEmbed url normalisation to embed urls inserted in the PostCreator

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -405,7 +405,7 @@ class PostCreator
       TopicEmbed.new(
         topic_id: @post.topic_id,
         post_id: @post.id,
-        embed_url: @opts[:embed_url],
+        embed_url: TopicEmbed.normalize_url(@opts[:embed_url]),
         content_sha1: @opts[:embed_content_sha1],
       )
     rollback_from_errors!(embed) unless embed.save

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -1512,6 +1512,20 @@ RSpec.describe PostCreator do
         expect(post.topic).not_to be_visible
       end
     end
+
+    it "normalizes the embed url" do
+      embed_url = "http://eviltrout.com/stupid-url/"
+      creator =
+        PostCreator.new(
+          user,
+          embed_url: embed_url,
+          title: "Reviews of Science Ovens",
+          raw: "Did you know that you can use microwaves to cook your dinner? Science!",
+        )
+      creator.create
+      expect(creator.errors).to be_blank
+      expect(TopicEmbed.where(embed_url: "http://eviltrout.com/stupid-url").exists?).to eq(true)
+    end
   end
 
   describe "read credit for creator" do


### PR DESCRIPTION
Reference: https://meta.discourse.org/t/wp-discourse-embedded-comments-question/343494

I originally also wrote a db migration for this:

```SQL
# downcase and remove trailing forward slashes
execute "UPDATE topic_embeds SET embed_url = lower(rtrim(embed_url, '/'))"

# replace consecutive hyphens with a single hyphen
execute "UPDATE topic_embeds SET embed_url = regexp_replace(embed_url, '\-\-+', '-', 'g')

# remove leading and trailing whitespace
execute "UPDATE topic_embeds SET embed_url = trim(embed_url)"
```

However, on reflection, I'm of two minds about whether to apply it. Interested in other thoughts on that. Here's my current thinking:

1. Un-normalised embed_urls become an issue for topics created via the PostCreator (e.g. via `discourse/wp-discourse`) in edge cases such as platform migrations (see linked discussion).
2. Other code or behaviour either in `discourse/discourse` or elsewhere may be currently relying on the exact format of un-normalised embed_urls added via the PostCreator (whether by `discourse/wp-discourse` or anything else).
3. Applying the change only going forward means that any issue of that nature (i.e. 2) will be limited to new cases.
4. A data migration can be performed in the future (i.e. after any such issues (2) have had a chance to surface) and/or can be applied to individual cases where needed.

In other words, if it ain't broke don't fix it (or only where you need to).