### PR TITLE
DEV: update mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer"
+gem "mini_racer", "0.17.pre6"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre8"
+gem "mini_racer", "0.17.pre9"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre7"
+gem "mini_racer", "0.17.pre8"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre9"
+gem "mini_racer", "0.17.pre10"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre6"
+gem "mini_racer", "0.17.pre7"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre10"
+gem "mini_racer", "0.17.pre11"
 
 gem "highline", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer", "0.17.pre11"
+gem "mini_racer", "0.17.pre12"
 
 gem "highline", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre10)
+    mini_racer (0.17.0.pre11)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre10)
+  mini_racer (= 0.17.pre11)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre8)
+    mini_racer (0.17.0.pre9)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre8)
+  mini_racer (= 0.17.pre9)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre7)
+    mini_racer (0.17.0.pre8)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre7)
+  mini_racer (= 0.17.pre8)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre6)
+    mini_racer (0.17.0.pre7)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre6)
+  mini_racer (= 0.17.pre7)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre9)
+    mini_racer (0.17.0.pre10)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre9)
+  mini_racer (= 0.17.pre10)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,10 +210,10 @@ GEM
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.3)
-    libv8-node (18.19.0.0-aarch64-linux)
-    libv8-node (18.19.0.0-arm64-darwin)
-    libv8-node (18.19.0.0-x86_64-darwin)
-    libv8-node (18.19.0.0-x86_64-linux)
+    libv8-node (22.7.0.4-aarch64-linux)
+    libv8-node (22.7.0.4-arm64-darwin)
+    libv8-node (22.7.0.4-x86_64-darwin)
+    libv8-node (22.7.0.4-x86_64-linux)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -245,8 +245,8 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.14.1)
-      libv8-node (~> 18.19.0.0)
+    mini_racer (0.17.0.pre6)
+      libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
     mini_sql (1.6.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer
+  mini_racer (= 0.17.pre6)
   mini_scheduler
   mini_sql
   mini_suffix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.17.0.pre11)
+    mini_racer (0.17.0.pre12)
       libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
@@ -665,7 +665,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer (= 0.17.pre11)
+  mini_racer (= 0.17.pre12)
   mini_scheduler
   mini_sql
   mini_suffix


### PR DESCRIPTION
Mini_racer was redesigned to keep all V8 vm integration on a dedicated thread.

Previous attempts at upgrades had lots of stack poisoning across V8 owned
and Ruby owned threads that were leading to segfaults.

We will monitor the new design in production to see how robust the new solution is.
