### PR TITLE
FIX: do not memoize score types

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -11,7 +11,7 @@ class ReviewableScore < ActiveRecord::Base
   # To keep things simple the types correspond to `PostActionType` for backwards
   # compatibility, but we can add extra reasons for scores.
   def self.types
-    PostActionType.flag_types.merge(PostActionType.score_types)
+    PostActionType.flag_types.merge(PostActionType.score_types).merge(@api_types || {})
   end
 
   def self.type_title(type)
@@ -23,14 +23,15 @@ class ReviewableScore < ActiveRecord::Base
   # When extending post action flags, we need to call this method in order to
   # get the latests flags.
   def self.reload_types
-    @types = nil
+    @api_types = nil
     types
   end
 
   def self.add_new_types(type_names)
+    @api_types ||= {}
     next_id = types.values.max + 1
 
-    type_names.each_with_index { |name, idx| @types[name] = next_id + idx }
+    type_names.each_with_index { |name, idx| @api_types[name] = next_id + idx }
   end
 
   def self.score_transitions

--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -11,7 +11,7 @@ class ReviewableScore < ActiveRecord::Base
   # To keep things simple the types correspond to `PostActionType` for backwards
   # compatibility, but we can add extra reasons for scores.
   def self.types
-    @types ||= PostActionType.flag_types.merge(PostActionType.score_types)
+    PostActionType.flag_types.merge(PostActionType.score_types)
   end
 
   def self.type_title(type)

--- a/spec/multisite/flags_spec.rb
+++ b/spec/multisite/flags_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe "Custom flags in multisite", type: :multisite do
   describe "PostACtionType#all_flags" do
     it "does not share flag definitions between sites" do
       flag_1 = Flag.create!(name: "test flag 1", position: 99, applies_to: ["Post"])
+      expect(ReviewableScore.types).to eq(
+        {
+          notify_user: 6,
+          off_topic: 3,
+          inappropriate: 4,
+          spam: 8,
+          illegal: 10,
+          notify_moderators: 7,
+          custom_test_flag_1: flag_1.id,
+          needs_approval: 9,
+        },
+      )
 
       test_multisite_connection("second") do
         flag_2 = Flag.create!(name: "test flag 2", position: 99, applies_to: ["Post"])
@@ -11,11 +23,35 @@ RSpec.describe "Custom flags in multisite", type: :multisite do
         expect(PostActionType.all_flags.last).to eq(
           flag_2.attributes.except("created_at", "updated_at").transform_keys(&:to_sym),
         )
+        expect(ReviewableScore.types).to eq(
+          {
+            notify_user: 6,
+            off_topic: 3,
+            inappropriate: 4,
+            spam: 8,
+            illegal: 10,
+            notify_moderators: 7,
+            custom_test_flag_2: flag_2.id,
+            needs_approval: 9,
+          },
+        )
       end
 
       PostActionType.new.expire_cache
       expect(PostActionType.all_flags.last).to eq(
         flag_1.attributes.except("created_at", "updated_at").transform_keys(&:to_sym),
+      )
+      expect(ReviewableScore.types).to eq(
+        {
+          notify_user: 6,
+          off_topic: 3,
+          inappropriate: 4,
+          spam: 8,
+          illegal: 10,
+          notify_moderators: 7,
+          custom_test_flag_1: flag_1.id,
+          needs_approval: 9,
+        },
       )
     end
   end


### PR DESCRIPTION
Score types are dynamic because of custom flags. Therefore we cannot memorize them on class level as it is not multisite safe.
