### PR TITLE
DEV: Run `linting` workflow on our self hosted runners

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: run
-    runs-on: ubuntu-latest
-    container: discourse/discourse_test:slim
+    runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
+    container: discourse/discourse_test:release
     timeout-minutes: 30
 
     steps:
@@ -34,12 +34,9 @@ jobs:
           git config --global user.email "ci@ci.invalid"
           git config --global user.name "Discourse CI"
 
-      - name: Bundler cache
-        uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: ${{ runner.os }}-gem-
+      - name: Symlink vendor/bundle from image
+        run: |
+          ln -s /var/www/discourse/vendor/bundle vendor/bundle
 
       - name: Setup gems
         run: |


### PR DESCRIPTION
In 15a7a84d84bb97742263228c7cd043ab6deeae18, I changed the `linting`
workflow to run on `ubuntu-latest` because it is free and helps to free
up our self hosted runners for more important workflow jobs. However,
some devs rely on the `linting` workflow for feedback so we want to
provide this feedback as soon as we can. Therefore, we are putting the
`linting` workflow back on our faster self hosted runners.
