### PR TITLE
DEV: Improve distributed cache multisite specs

### DIFF
--- a/spec/multisite/distributed_cache_spec.rb
+++ b/spec/multisite/distributed_cache_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Multisite SiteSettings", type: :multisite do
   context "without namespace" do
     let(:cache1) { cache("test", namespace: false) }
 
-    it "does leak state across multisite" do
+    it "does share a global state between multisite" do
       cache1["default"] = true
 
       expect(cache1.hash).to eq("default" => true)
@@ -33,7 +33,7 @@ RSpec.describe "Multisite SiteSettings", type: :multisite do
   context "with namespace" do
     let(:cache1) { cache("test", namespace: true) }
 
-    it "does not leak state across multisite" do
+    it "does not share a state between multisite" do
       cache1["default"] = true
 
       expect(cache1.hash).to eq("default" => true)

--- a/spec/multisite/distributed_cache_spec.rb
+++ b/spec/multisite/distributed_cache_spec.rb
@@ -8,6 +8,31 @@ RSpec.describe "Multisite SiteSettings", type: :multisite do
   context "without namespace" do
     let(:cache1) { cache("test", namespace: false) }
 
+    it "does leak state across multisite" do
+      cache1["default"] = true
+
+      expect(cache1.hash).to eq("default" => true)
+
+      test_multisite_connection("second") do
+        message =
+          MessageBus
+            .track_publish(DistributedCache::Manager::CHANNEL_NAME) { cache1["second"] = true }
+            .first
+
+        expect(message.data[:hash_key]).to eq("test")
+        expect(message.data[:op]).to eq(:set)
+        expect(message.data[:key]).to eq("second")
+        expect(message.data[:value]).to eq(true)
+        expect(cache1.hash).to eq("default" => true, "second" => true)
+      end
+
+      expect(cache1.hash).to eq("default" => true, "second" => true)
+    end
+  end
+
+  context "with namespace" do
+    let(:cache1) { cache("test", namespace: true) }
+
     it "does not leak state across multisite" do
       cache1["default"] = true
 
@@ -23,9 +48,10 @@ RSpec.describe "Multisite SiteSettings", type: :multisite do
         expect(message.data[:op]).to eq(:set)
         expect(message.data[:key]).to eq("second")
         expect(message.data[:value]).to eq(true)
+        expect(cache1.hash).to eq("second" => true)
       end
 
-      expect(cache1.hash).to eq("default" => true, "second" => true)
+      expect(cache1.hash).to eq("default" => true)
     end
   end
 end


### PR DESCRIPTION
Distributed cache when namespace is false is not multisite safe as values are shared between sites. Distributed cache with namespace option (default) is multisite safe.

Improved specs to cover both cases.