### PR TITLE
DEV: Populate all subtypes of ReviewableQueuedPost

### DIFF
--- a/lib/discourse_dev/reviewable_queued_post.rb
+++ b/lib/discourse_dev/reviewable_queued_post.rb
@@ -6,21 +6,57 @@ require "faker"
 module DiscourseDev
   class ReviewableQueuedPost < Reviewable
     def populate!
-      2.times do
+      :new_topics_unless_allowed_groups.tap do |reason|
+        manager =
+          NewPostManager.new(
+            @users.sample,
+            custom_payload_for_reason(reason).merge(
+              title: Faker::Lorem.sentence,
+              raw: Faker::DiscourseMarkdown.sandwich(sentences: 3),
+              tags: nil,
+              typing_duration_msecs: Faker::Number.between(from: 2_000, to: 5_000),
+              composer_open_duration_msecs: Faker::Number.between(from: 5_500, to: 10_000),
+            ),
+          )
+        manager.enqueue(reason, creator_opts: { skip_validations: true })
+      end
+
+      %i[
+        email_auth_res_enqueue
+        email_spam
+        post_count
+        group
+        fast_typer
+        auto_silence_regex
+        staged
+        category
+        contains_media
+      ].each do |reason|
         topic = @topics.sample
         manager =
           NewPostManager.new(
             @users.sample,
-            {
+            custom_payload_for_reason(reason).merge(
               topic_id: topic.id,
               raw: Faker::DiscourseMarkdown.sandwich(sentences: 3),
               tags: nil,
               typing_duration_msecs: Faker::Number.between(from: 2_000, to: 5_000),
               composer_open_duration_msecs: Faker::Number.between(from: 5_500, to: 10_000),
               reply_to_post_number: topic.posts.sample.post_number,
-            },
+            ),
           )
-        manager.enqueue(:watched_word, creator_opts: { skip_validations: true })
+        manager.enqueue(reason, creator_opts: { skip_validations: true })
+      end
+    end
+
+    private
+
+    def custom_payload_for_reason(reason)
+      case reason
+      when :email_auth_res_enqueue, :email_spam
+        { via_email: true, raw_email: Faker::Lorem.paragraph }
+      else
+        {}
       end
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/30540

There are many scenarios that can result in creating a `ReviewableQueuedPost` record, however in the original PR we only added once scenario to the populate rake task. This PR adds the remaining scenarios to the rake task.