### PR TITLE
FIX: Inline oneboxes should obey the locale.

### DIFF
--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -77,6 +77,9 @@ class InlineOneboxer
             url,
             max_redirects: max_redirects,
             initial_https_redirect_ignore_limit: SiteSetting.block_onebox_on_redirect,
+            headers: {
+              "Accept-Language" => Oneboxer.accept_language,
+            },
           )
         title = nil if title && title.length < MIN_TITLE_LENGTH
         return onebox_for(url, title, opts)
@@ -115,7 +118,7 @@ class InlineOneboxer
   end
 
   def self.cache_key(url)
-    "inline_onebox:#{url}"
+    "inline_onebox:#{Oneboxer.onebox_locale}:#{url}"
   end
 
   def self.post_author_for_title(topic, post_number)

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -8,11 +8,12 @@ module RetrieveTitle
     FinalDestination::UrlEncodingError,
   ]
 
-  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
+  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false, headers: {})
     fetch_title(
       url,
       max_redirects: max_redirects,
       initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit,
+      headers: headers,
     )
   rescue *UNRECOVERABLE_ERRORS
     # ¯\_(ツ)_/¯
@@ -70,7 +71,12 @@ module RetrieveTitle
   end
 
   # Fetch the beginning of a HTML document at a url
-  def self.fetch_title(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
+  def self.fetch_title(
+    url,
+    max_redirects: nil,
+    initial_https_redirect_ignore_limit: false,
+    headers: {}
+  )
     fd =
       FinalDestination.new(
         url,
@@ -78,9 +84,7 @@ module RetrieveTitle
         stop_at_blocked_pages: true,
         max_redirects: max_redirects,
         initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit,
-        headers: {
-          Accept: "text/html,*/*",
-        },
+        headers: headers.merge({ Accept: "text/html,*/*" }),
       )
 
     current = nil


### PR DESCRIPTION
## ✨ What's This?

Following on from #30637, we need to apply a similar fix to inline oneboxes, since they use a different code path to retrieve the onebox provider data.

This change ensures the `Accept-Language` header is sent by inline onebox requests, too.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/3186f083-2984-4f2a-8a38-c5ea672e9516)

## 👑 Testing

Test that inline oneboxes appear in the expected language.