### PR TITLE
FIX: Improve the user badge alignment on mobile devices.

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -361,6 +361,14 @@ span.highlighted {
       order: 4;
       flex-basis: 100%;
     }
+
+    .user-badge-buttons {
+      order: 5;
+      .user-badge {
+        padding-top: 0;
+      }
+    }
+
     span {
       margin-right: 0.26em;
     }


### PR DESCRIPTION
## ✨ What's This?

Reported on [meta](https://meta.discourse.org/t/badges-in-posts-look-misaligned-on-mobile/346054).

Due to more explicit CSS flex arrangement on mobile devices, user badges were being shoved out of alignment. This PR nudges them back into line.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/c432ea80-18ae-4811-8ab2-b545bccd9e05)

## 👑 Testing

Test on additional mobile device sizes, check that user badges are correctly aligned.