### PR TITLE
FIX: Remove ?page=X from sitemaps as they are not canonical URLs

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -64,14 +64,8 @@ class SitemapController < ApplicationController
     raise Discourse::NotFound if !SiteSetting.enable_sitemap
   end
 
-  def build_sitemap_topic_url(slug, id, posts_count = nil)
-    base_url = [Discourse.base_url, "t", slug, id].join("/")
-    return base_url if posts_count.nil?
-
-    page, mod = posts_count.divmod(TopicView.chunk_size)
-    page += 1 if mod > 0
-
-    page > 1 ? "#{base_url}?page=#{page}" : base_url
+  def build_sitemap_topic_url(slug, id)
+    [Discourse.base_url, "t", slug, id].join("/")
   end
   helper_method :build_sitemap_topic_url
 end

--- a/app/views/sitemap/page.xml.erb
+++ b/app/views/sitemap/page.xml.erb
@@ -6,9 +6,9 @@
         http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
         http://www.google.com/schemas/sitemap-image/1.1
         http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd">
-    <% @topics.each do |(id, slug, bumped_at, updated_at, posts_count)| %>
+    <% @topics.each do |(id, slug, bumped_at, updated_at)| %>
       <url>
-        <loc><%= build_sitemap_topic_url(slug, id, posts_count) %></loc>
+        <loc><%= build_sitemap_topic_url(slug, id) %></loc>
         <lastmod><%= (bumped_at || updated_at).xmlschema %></lastmod>
       </url>
     <% end %>

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -93,26 +93,15 @@ RSpec.describe SitemapController do
       expect(all_urls).not_to include("#{Discourse.base_url}/t/#{old_topic.slug}/#{old_topic.id}")
     end
 
-    it "generates correct page numbers based on the topic post count" do
+    it "does not include page numbers" do
       topic = Fabricate(:topic, bumped_at: 1.minute.ago)
       page_size = TopicView.chunk_size
-
-      incomplete_page_size = TopicView.chunk_size - 1
-      topic.update!(posts_count: incomplete_page_size, updated_at: 4.hour.ago)
-      get "/sitemap_recent.xml"
-      url = Nokogiri::XML::Document.parse(response.body).at_css("loc").text
-      expect(url).not_to include("?page=2")
-
-      topic.update!(posts_count: page_size, updated_at: 3.hour.ago)
-      get "/sitemap_recent.xml"
-      url = Nokogiri::XML::Document.parse(response.body).at_css("loc").text
-      expect(url).not_to include("?page=2")
 
       two_page_size = page_size + 1
       topic.update!(posts_count: two_page_size, updated_at: 2.hour.ago)
       get "/sitemap_recent.xml"
       url = Nokogiri::XML::Document.parse(response.body).at_css("loc").text
-      expect(url).to include("?page=2")
+      expect(url).not_to include("?page=2")
     end
   end
 


### PR DESCRIPTION
In Discourse a canonical URL should be URLs without:
- Page numbers (/p2, /p3)
- Post numbers (#post_2, #post_3)
- Extra parameters (?u=username)

For topics, we would want `/t/{slug}/{id}`, not `/t/{slug}/{id}/20` (paginated view), not `/t/{slug}/{id}?page=2` (paginated view)

This PR removes `?page=X` as can be seen now in our sitemap @ https://meta.discourse.org/sitemap_recent.xml

<img width="714" alt="Screenshot 2025-01-09 at 5 07 42 PM" src="https://github.com/user-attachments/assets/478e0038-a60c-4c37-99e9-e0592b48dba4" />
