### PR TITLE
DEV: Ensure consistency in PostCreator hook order

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -214,10 +214,10 @@ class PostCreator
       publish
 
       track_latest_on_category
+      trigger_after_events unless opts[:skip_events]
+
       enqueue_jobs unless @opts[:skip_jobs]
       BadgeGranter.queue_badge_grant(Badge::Trigger::PostRevision, post: @post)
-
-      trigger_after_events unless opts[:skip_events]
 
       auto_close
     end


### PR DESCRIPTION
Previously we would enqueue sidekiq jobs like `PostProcessCooked` **before** triggering the `topic_created` and `post_created` DiscourseEvents. That means that, depending on the speed/availability of Sidekiq, PostProcessCooked might start running on another host before the DiscourseEvents have been executed.

This commit moves the event triggers before enqueue_jobs, so that ordering is guaranteed to be consistent, regardless of Sidekiq performance.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->