### PR TITLE
FIX: lockup when navigating with j/k

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -775,6 +775,11 @@ export default {
       if (article.getBoundingClientRect().height > 0) {
         break;
       }
+
+      // Safeguard against infinite loops
+      if (direction === 0) {
+        break;
+      }
     }
 
     for (const a of articles) {


### PR DESCRIPTION
If, for some reasons, navigating between posts using j/k keyboard shortcuts does not select any posts, there could be an infinite loop due to setting the `direction` to `0` and then using it do "iterate" over the arrays of available "articles".

Despite many attemps, I wasn't able to reproduce the issue reported in https://dev.discourse.org/t/145565 so this is somewhat of a shot in the dark.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->