### PR TITLE
FIX: correct emoji picker size in modal

### DIFF
--- a/app/assets/stylesheets/common/components/emoji-picker.scss
+++ b/app/assets/stylesheets/common/components/emoji-picker.scss
@@ -1,5 +1,15 @@
 .fk-d-menu[data-content][data-identifier="emoji-picker"] {
   z-index: z("modal", "dialog");
+
+  .emoji-picker {
+    max-width: 95vw;
+  }
+}
+
+.fk-d-menu-modal {
+  .emoji-picker {
+    max-width: 100vw;
+  }
 }
 
 .emoji-picker-trigger {
@@ -13,7 +23,6 @@
   flex-direction: column;
   height: 300px;
   width: 500px;
-  max-width: 95vw;
 
   .spinner-container {
     height: 100%;


### PR DESCRIPTION
Following a change in https://github.com/discourse/discourse/commit/b1e40d04b9ccec66085619a0ecef376584292374 the width of the picker has been reduced in modals when it should have been reduced only when NOT in a modal.
