### PR TITLE
 UX: follow-up sidebar variable fixes for c398933 

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -55,12 +55,22 @@
           color: var(--d-sidebar-active-color);
         }
       }
-      .sidebar-section-link-content-badge,
+      .prefix-text {
+        background: var(--d-sidebar-active-prefix-background);
+      }
+      .sidebar-section-link-content-badge {
+        color: var(--d-sidebar-active-color);
+      }
       .sidebar-section-link-suffix.icon.unread svg {
         color: var(--d-sidebar-active-suffix-color);
       }
       .sidebar-section-link-hover:hover .sidebar-section-hover-button {
         background-color: var(--d-sidebar-active-background);
+      }
+      .sidebar-section-hover-button {
+        .d-icon {
+          color: var(--d-sidebar-active-suffix-color);
+        }
       }
     }
 

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -67,11 +67,6 @@
       .sidebar-section-link-hover:hover .sidebar-section-hover-button {
         background-color: var(--d-sidebar-active-background);
       }
-      .sidebar-section-hover-button {
-        .d-icon {
-          color: var(--d-sidebar-active-suffix-color);
-        }
-      }
     }
 
     &--muted {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -49,7 +49,7 @@
   --d-sidebar-active-background: var(--d-selected);
   --d-sidebar-active-color: var(--d-sidebar-link-color);
   --d-sidebar-active-icon-color: var(--d-sidebar-link-color);
-  --d-sidebar-active-prefix-background: var(--primary-300);
+  --d-sidebar-active-prefix-background: var(--primary-200);
   --d-sidebar-active-suffix-color: var(--tertiary-med-or-tertiary);
 }
 

--- a/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-user-threads.scss
@@ -62,4 +62,7 @@
   .sidebar-section-link-content-text {
     color: var(--d-sidebar-link-color);
   }
+  .active .sidebar-section-link-content-text {
+    color: var(--d-sidebar-active-color);
+  }
 }


### PR DESCRIPTION
This fixes a couple regressions from c398933, and covers a missed case

Before: 
![image](https://github.com/user-attachments/assets/ec1c8e56-0e5c-4de0-9925-cb4a01af8492)

![image](https://github.com/user-attachments/assets/523bc91f-82b1-45c7-ba34-102ecc87b0ec)


After:
![image](https://github.com/user-attachments/assets/68d2d0c8-da0e-4c5d-9854-7e49c868144c)

![image](https://github.com/user-attachments/assets/9e02ff0e-de1d-4664-a087-b4b66be87e17)
