### PR TITLE
DEV: Add problem check informing about admin layout deprecation

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -61,6 +61,7 @@ class ProblemCheck
   # Note: This list must come after the `config_accessor` declarations.
   #
   CORE_PROBLEM_CHECKS = [
+    ProblemCheck::AdminSidebarDeprecation,
     ProblemCheck::BadFaviconUrl,
     ProblemCheck::EmailPollingErroredRecently,
     ProblemCheck::FacebookConfig,

--- a/app/services/problem_check/admin_sidebar_deprecation.rb
+++ b/app/services/problem_check/admin_sidebar_deprecation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProblemCheck::AdminSidebarDeprecation < ProblemCheck::ProblemCheck
+  self.priority = "low"
+
+  def call
+    return no_problem if SiteSetting.admin_sidebar_enabled_groups.present?
+
+    problem
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1722,6 +1722,7 @@ en:
       google_analytics_version: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
       category_style_deprecated: "Your Discourse is currently using a deprecated category style which will be removed before the final beta release of Discourse 3.2. Please refer to <a href='https://meta.discourse.org/t/282441'>Moving to a Single Category Style Site Setting</a> for instructions on how to keep your selected category style."
       maxmind_db_configuration: 'The server has been configured to use MaxMind databases for reverse IP lookups but a valid MaxMind account ID has not been configured which may result in MaxMind databases failing to download in the future. <a href="https://meta.discourse.org/t/configure-maxmind-for-reverse-ip-lookups/173941" target="_blank">See this guide to learn more</a>.'
+      admin_sidebar_deprecation: "The old admin layout is deprecated in favour of the new <a href='https://meta.discourse.org/t/introducing-experimental-admin-sidebar-navigation/289281'>sidebar layout</a> and will be removed in the next release. You can <a href='%{base_path}/admin/config/navigation?filter=admin%20sidebar'>configure</a> the new sidebar layout now to opt in before that."
     back_from_logster_text: "Back to site"
 
   site_settings:

--- a/spec/services/problem_check/admin_sidebar_deprecation_spec.rb
+++ b/spec/services/problem_check/admin_sidebar_deprecation_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::AdminSidebarDeprecation do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before { SiteSetting.stubs(admin_sidebar_enabled_groups: configured) }
+
+    context "when sidebar is enabled for some group" do
+      let(:configured) { "1" }
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when sidebar is not enabled for any group" do
+      let(:configured) { "" }
+
+      it do
+        expect(check).to have_a_problem.with_priority("low").with_message(
+          "The old admin layout is deprecated in favour of the new <a href='https://meta.discourse.org/t/introducing-experimental-admin-sidebar-navigation/289281'>sidebar layout</a> and will be removed in the next release. You can <a href='/admin/config/navigation?filter=admin%20sidebar'>configure</a> the new sidebar layout now to opt in before that.",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

We want to avoid surprises when we make the new admin sidebar baseline, so in addition to announcements, we're also adding a problem check that informs you if you don't have it enabled for any group yet:

<img width="665" alt="Screenshot 2025-01-10 at 10 21 05 AM" src="https://github.com/user-attachments/assets/536d7a76-5581-41f3-908a-e089a4cf89d8" />
