### PR TITLE
DEV: update deprecated icon name archive to box-archive in chat plugin

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -36,7 +36,7 @@ export function channelStatusIcon(channelStatus) {
     case CHANNEL_STATUSES.readOnly:
       return "comment-slash";
     case CHANNEL_STATUSES.archived:
-      return "archive";
+      return "box-archive";
   }
 }
 


### PR DESCRIPTION
This PR updates the deprecated `archive` icon name. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.