### PR TITLE
FEATURE: Add IP Lookup to review queue

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.hbs
@@ -135,6 +135,13 @@
       {{/if}}
     {{/if}}
 
+    {{#if this.showIpLookup}}
+      <IpLookup
+        @ip="adminLookup"
+        @userId={{this.reviewable.target_created_by.id}}
+      />
+    {{/if}}
+
     <PluginOutlet
       @name="reviewable-item-actions"
       @connectorTagName="div"

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -188,6 +188,15 @@ export default class ReviewableItem extends Component {
     return updatedCategoryId || categoryId;
   }
 
+  @discourseComputed("reviewable.type", "reviewable.target_created_by")
+  showIpLookup(reviewableType) {
+    return (
+      reviewableType !== "ReviewableUser" &&
+      this.currentUser.staff &&
+      this.reviewable.target_created_by
+    );
+  }
+
   @bind
   _performConfirmed(performableAction, additionalData = {}) {
     let reviewable = this.reviewable;


### PR DESCRIPTION
Moves the theme component https://github.com/discourse/discourse-review-ip-lookup into core, this allows looking
up a user's IP directly from the review queue and seeing if
there are other users with the same IP on the forum

![image](https://github.com/user-attachments/assets/bcf3d4ef-71b8-4ab8-9680-1ff8200d6990)
