### PR TITLE
DEV: Add new admin UI header to site texts page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
@@ -1,6 +1,4 @@
 <div class="search-area">
-  <p>{{i18n "admin.site_text.description"}}</p>
-
   <TextField
     @value={{this.q}}
     @placeholderKey="admin.site_text.search"

--- a/app/assets/javascripts/admin/addon/templates/site-text.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text.hbs
@@ -1,3 +1,17 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.site_text.title"}}
+  @descriptionLabel={{i18n "admin.site_text.description"}}
+  @hideTabs={{true}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/customize/site_texts"
+      @label={{i18n "admin.site_text.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
 <div class="row site-texts">
   {{outlet}}
 </div>

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -72,6 +72,7 @@
 }
 
 .admin-customize {
+  /* TODO: Remove when admin header has been added to all /customize pages */
   h1 {
     margin-bottom: 10px;
     input {
@@ -80,6 +81,9 @@
       .ios-device & {
         font-size: var(--font-down-2);
       }
+    }
+    &.d-page-header__title {
+      margin: 0;
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7149,10 +7149,10 @@ en:
           multiselect: "Multiselect"
 
       site_text:
-        description: "You can customize any of the text on your forum. Please start by searching below:"
+        description: "You can customize any of the text on your forum."
         search: "Search for the text you'd like to edit"
-        title: "Text"
-        edit: "edit"
+        title: "Site texts"
+        edit: "Edit"
         revert: "Revert Changes"
         revert_confirm: "Are you sure you want to revert your changes?"
         go_back: "Back to Search"
@@ -7476,7 +7476,7 @@ en:
 
       reseed:
         action:
-          label: "Replace Text…"
+          label: "Replace text …"
           title: "Replace text of categories and topics with translations"
 
         modal:


### PR DESCRIPTION
### What is this change?

This adds the new admin UI header to the site texts page:

<img width="436" alt="Screenshot 2025-01-10 at 1 00 32 PM" src="https://github.com/user-attachments/assets/132de7bd-dca4-41a0-803b-63934c8091df" />
