### PR TITLE
DEV: Add missing root breadcrumb to API keys page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/api-keys.hbs
+++ b/app/assets/javascripts/admin/addon/templates/api-keys.hbs
@@ -5,6 +5,7 @@
     @hideTabs={{true}}
   >
     <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
       <DBreadcrumbsItem
         @path="/admin/api/keys"
         @label={{i18n "admin.api_keys.title"}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5397,7 +5397,7 @@ en:
         no_custom_groups: "Create a new custom group"
 
       api_keys:
-        title: "API Keys"
+        title: "API keys"
         description: "The API keys feature lets you securely integrate Discourse with external systems and automate actions. Admins can create keys with specific scopes to control access to resources and sensitive data. Scopes limit functionality, ensuring enhanced security."
         add: "Add API key"
         edit: "Edit"


### PR DESCRIPTION
### What is this change?

Addressing a couple minor inconsistencies on the admin API keys page.

1. Add missing "Admin" root breadcrumb.
2. De-titleize "API Keys" -> "API keys".