### PR TITLE
FIX: `Demon::EmailSync` heartbeat check not consistent

### DIFF
--- a/spec/lib/demon/email_sync_spec.rb
+++ b/spec/lib/demon/email_sync_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Demon::EmailSync do
         described_class.set_demons({ "daemon" => daemon })
 
         Discourse.redis.set(
-          described_class::HEARTBEAT_KEY,
+          described_class.heartbeat_key,
           Time.now.to_i - described_class::HEARTBEAT_INTERVAL.to_i - 1,
         )
 
@@ -36,7 +36,7 @@ RSpec.describe Demon::EmailSync do
 
         described_class.set_demons({ "daemon" => daemon })
 
-        Discourse.redis.set(described_class::HEARTBEAT_KEY, Time.now.to_i)
+        Discourse.redis.set(described_class.heartbeat_key, Time.now.to_i)
 
         daemon.expects(:restart)
 


### PR DESCRIPTION
In `Demon::EmailSync#after_fork`, we had the following lines of code:

```
loop do
  break if Discourse.redis.set(HEARTBEAT_KEY, Time.now.to_i, ex: HEARTBEAT_INTERVAL, nx:
true)
  sleep HEARTBEAT_INTERVAL
end
```

What this means is that if the key already exists in Redis, we will
sleep for `Demon::EmailSync::HEARTBEAT_INTERVAL` seconds which has been
set to 60 seconds. This is highly problematic because the expiry of the
Redis key uses the same interval. That means that by the time we break
out of the loop, the Redis key could have expired. The key expiring
is an indication the process is no longer alive leading to the heartbeat
test failing and causing the process to restart for no good reason.

The solution to resolve this problem is to just remove those lines as I
cannot figure out why those lines would even be necessary. There is no
reason why we would need to sleep for a given interval before booting up
the process.

This commit also updates the Redis key, which is used to store the
heartbeat timestamp, to include the process's hostname and pid. We
should not be restarting all `Demon::EmailSync` processes across
different hosts just because one process on a particular host failed.

### Reviewer notes

Some useful context while reviewing this PR:

1. In the unicorn master process, we [run a thread](https://github.com/discourse/discourse/blob/690ffcf1d53079cfea8283bf22f30b82d961540c/config/unicorn.conf.rb#L124-L147) that calls `Demon::EmailSync.ensure_running` every 60 seconds. `Demon::EmailSync.ensure_running` basically grabs the heartbeat timestamp and checks that the difference between the time now and the last heartbeat timestamp has not exceed `Demon::EmailSync::HEARTBEAT_INTERVAL`.
