### PR TITLE
DEV: remove viewingActionType mixin

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import Controller, { inject as controller } from "@ember/controller";
 import { service } from "@ember/service";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -7,7 +8,7 @@ export default class UserActivityController extends Controller {
   @service currentUser;
   @controller user;
 
-  userActionType = null;
+  @tracked userActionType = null;
 
   @discourseComputed("currentUser.draft_count")
   draftLabel(count) {

--- a/app/assets/javascripts/discourse/app/mixins/viewing-action-type.js
+++ b/app/assets/javascripts/discourse/app/mixins/viewing-action-type.js
@@ -1,6 +1,5 @@
 export default {
   viewingActionType(userActionType) {
-    this.controllerFor("user").set("userActionType", userActionType);
     this.controllerFor("user-activity").set("userActionType", userActionType);
   },
 };

--- a/app/assets/javascripts/discourse/app/mixins/viewing-action-type.js
+++ b/app/assets/javascripts/discourse/app/mixins/viewing-action-type.js
@@ -1,5 +1,0 @@
-export default {
-  viewingActionType(userActionType) {
-    this.controllerFor("user-activity").set("userActionType", userActionType);
-  },
-};

--- a/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
@@ -1,10 +1,7 @@
-import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
-export default class UserActivityStream extends DiscourseRoute.extend(
-  ViewingActionType
-) {
+export default class UserActivityStream extends DiscourseRoute {
   templateName = "user/stream";
 
   queryParams = {
@@ -30,7 +27,7 @@ export default class UserActivityStream extends DiscourseRoute.extend(
 
   setupController() {
     super.setupController(...arguments);
-    this.viewingActionType(this.userActionType);
+    this.controllerFor("user-activity").userActionType = this.userActionType;
   }
 
   emptyState() {

--- a/app/assets/javascripts/discourse/app/routes/user-badges.js
+++ b/app/assets/javascripts/discourse/app/routes/user-badges.js
@@ -1,11 +1,8 @@
-import ViewingActionType from "discourse/mixins/viewing-action-type";
 import UserBadge from "discourse/models/user-badge";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
-export default class UserBadges extends DiscourseRoute.extend(
-  ViewingActionType
-) {
+export default class UserBadges extends DiscourseRoute {
   templateName = "user/badges";
 
   model() {
@@ -17,7 +14,7 @@ export default class UserBadges extends DiscourseRoute.extend(
 
   setupController() {
     super.setupController(...arguments);
-    this.viewingActionType(-1);
+    this.controllerFor("user-activity").userActionType = -1;
   }
 
   titleToken() {

--- a/app/assets/javascripts/discourse/app/routes/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications.js
@@ -1,4 +1,3 @@
-import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
@@ -9,9 +8,7 @@ export function setNotificationsLimit(newLimit) {
   limit = newLimit;
 }
 
-export default class UserNotifications extends DiscourseRoute.extend(
-  ViewingActionType
-) {
+export default class UserNotifications extends DiscourseRoute {
   controllerName = "user-notifications";
   queryParams = { filter: { refreshModel: true } };
 
@@ -33,7 +30,7 @@ export default class UserNotifications extends DiscourseRoute.extend(
   setupController(controller) {
     super.setupController(...arguments);
     controller.set("user", this.modelFor("user"));
-    this.viewingActionType(-1);
+    this.controllerFor("user-activity").userActionType = -1;
   }
 
   titleToken() {

--- a/app/assets/javascripts/discourse/app/routes/user-topic-list.js
+++ b/app/assets/javascripts/discourse/app/routes/user-topic-list.js
@@ -1,5 +1,4 @@
 import { setTopicList } from "discourse/lib/topic-list-tracker";
-import ViewingActionType from "discourse/mixins/viewing-action-type";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export const QUERY_PARAMS = {
@@ -7,9 +6,7 @@ export const QUERY_PARAMS = {
   order: { replace: true, refreshModel: true },
 };
 
-export default class UserTopicsListRoute extends DiscourseRoute.extend(
-  ViewingActionType
-) {
+export default class UserTopicsListRoute extends DiscourseRoute {
   templateName = "user-topics-list";
   controllerName = "user-topics-list";
   queryParams = QUERY_PARAMS;


### PR DESCRIPTION
This removes the viewing action type mixin. It was previously setting a property `userActionType` on the user controller but this property was actually removed since https://github.com/discourse/discourse/pull/4771 (Mar 2017) and doesn't seem referenced anywhere else. 

It also sets the same property on the user activity controller and this is a 1-liner so I've opted to duplicate that across the routes that need this.