### PR TITLE
DEV: Add a nofollow to /u so user profiles don't get added as a target for crawling

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -15,7 +15,7 @@
     <% @about.admins.each do |user| %>
       <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
         <meta itemprop='url' content='<%= user_path(user.encoded_username(lower: true)) %>'>
-        <a href='<%= user_path(user.encoded_username(lower: true)) %>' itemprop='item'>
+        <a rel='nofollow' href='<%= user_path(user.encoded_username(lower: true)) %>' itemprop='item'>
           <span itemprop='image'>
             <img width="45" height="45" class="avatar" src="<%= user.small_avatar_url %>">
           </span>
@@ -36,7 +36,7 @@
       <% @about.moderators.each do |user| %>
         <div itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
           <meta itemprop='url' content='<%= user_path(user.encoded_username(lower: true)) %>'>
-          <a href='<%= user_path(user.encoded_username(lower: true)) %>' itemprop='item'>
+          <a rel='nofollow' href='<%= user_path(user.encoded_username(lower: true)) %>' itemprop='item'>
             <span itemprop='image'>
               <img width="45" height="45" class="avatar" src="<%= user.small_avatar_url %>">
             </span>

--- a/app/views/email/_post.html.erb
+++ b/app/views/email/_post.html.erb
@@ -6,12 +6,12 @@
       </td>
       <td>
         <%- if SiteSetting.prioritize_username_in_ux %>
-          <a class="username username-link" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
+          <a rel='nofollow' class="username username-link" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.username %></a>
           <%- if show_name_on_post(post) %>
             <span class='user-name username-title'><%= post.user.name %></span>
           <% end %>
         <%- else %>
-          <a class="username username-link" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
+          <a rel='nofollow' class="username username-link" href="<%=Discourse.base_url%>/u/<%= post.user.username_lower%>" target="_blank"><%= post.user.name %></a>
           <%- if show_username_on_post(post) %>
             <span class='username username-title'><%= post.user.username %></span>
           <% end %>

--- a/app/views/embed/comments.html.erb
+++ b/app/views/embed/comments.html.erb
@@ -16,11 +16,11 @@
       <%- end %>
 
       <div class='author'>
-        <a href='<%= Discourse.base_url %>/u/<%= post.username %>' target="_blank"><img src='<%= post.user.small_avatar_url %>' alt=''></a>
+        <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= post.username %>' target="_blank"><img src='<%= post.user.small_avatar_url %>' alt=''></a>
       </div>
       <div class='cooked'>
         <h3 class='username'>
-          <a href='<%= Discourse.base_url %>/u/<%= post.username %>' target="_blank" class='<% if post.user.staff? %>staff<% end %><% if post.user.new_user? %>new-user<% end %>'><%= post.user.username %></a>
+          <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= post.username %>' target="_blank" class='<% if post.user.staff? %>staff<% end %><% if post.user.new_user? %>new-user<% end %>'><%= post.user.username %></a>
           <%- if post.user.title.present? %>
             <span class='title'><%= post.user.title %></span>
           <%- end %>

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -87,7 +87,7 @@
           </td>
           <td class='posters'>
             <% t.posters.each do |poster| %>
-              <a href="<%= Discourse.base_url %>/u/<%= poster.user.username %>" class="<%= poster.extras %>">
+              <a rel='nofollow' href="<%= Discourse.base_url %>/u/<%= poster.user.username %>" class="<%= poster.extras %>">
                 <%- poster_name_and_description = h(poster.name_and_description) %>
                 <img width="25" height="25" src="<%= poster.user.avatar_template.gsub('{size}', '25') %>" class="avatar" title='<%= poster_name_and_description %>' aria-label='<%= poster_name_and_description %>'>
               </a>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -55,7 +55,7 @@
         <% if @topic_view.topic.user.present? %>
           <span itemprop='author' itemscope itemtype="http://schema.org/Person">
             <meta itemprop='name' content='<%= @topic_view.topic.user.username %>'>
-            <link itemprop='url' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
+            <link itemprop='url' rel='nofollow' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
           </span>
         <% end %>
         <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
@@ -66,7 +66,7 @@
           <div id='post_<%= post.post_number %>' <%= post.is_first_post? ? "" : "itemprop='comment' itemscope itemtype='http://schema.org/Comment'".html_safe %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>
               <span class="creator" itemprop="author" itemscope itemtype="http://schema.org/Person">
-                <a itemprop="url" href='<%= Discourse.base_url %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
+                <a itemprop="url" rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
                 <%= "(#{u.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names? && !u.name.blank?) %>
                 <%
                   post_custom_fields = @topic_view.post_custom_fields[post.id] || {}


### PR DESCRIPTION
In some sites, we are noticing the following on /u routes:

<img width="500" alt="Screenshot 2025-01-10 at 4 37 13 PM" src="https://github.com/user-attachments/assets/b22e2c24-f0bd-4bfa-882c-95108f8bc444" />

(anonymized)
<img width="500" alt="Screenshot 2025-01-10 at 4 36 40 PM" src="https://github.com/user-attachments/assets/731cb9ff-9865-4ad4-8672-b53f6871f4ab" />

This PR adds a ["nofollow"](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links) on user profiles so that Google will not index these user profile URLs.