### PR TITLE
FIX: strip unsubscribe links in incoming emails

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -517,7 +517,12 @@ module Email
             .join
       end
 
-      [text, elided_text, text_format]
+      [strip_unsubscribe_links(text), strip_unsubscribe_links(elided_text), text_format]
+    end
+
+    def strip_unsubscribe_links(text)
+      @unsubscribe_regex ||= %r|#{Discourse.base_url}/email/unsubscribe/\h{64}|
+      (text.presence || "").gsub(@unsubscribe_regex, "")
     end
 
     def to_markdown(html, elided_html)


### PR DESCRIPTION
When we send an email notification to a user, we always include a link that will allow them unsubscribe to these emails.

If the user reply to the email notification, the link to unsubscribe might still be present in the final post (often in the elided part).

Since those links do not require authentication to unsubscribe a user (this is a feature, not a bug), we would like to avoid showing them to other users on Discourse.

(If such an email is forwarded elsewhere, then it's totally out of our control.)

This commmit ensures we always strip those unsubscribe links from any incoming email to avoid making it easier to unsubscribe another user.

Since the format we use for those links might be similar to the ones used by other applications, the regular expression used to match those links uses the absolute URL of the Discourse (aka. `Discourse.base_url`).

