### PR TITLE
FIX: removes blank spacing in message actions

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -29,6 +29,7 @@
   .reply-btn,
   .chat-message-thread-btn,
   .bookmark-btn {
+    margin-right: -1px;
     padding: 0.5em 0;
     width: 2.5em;
 


### PR DESCRIPTION
This is a regression of https://github.com/discourse/discourse/pull/28277

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->