### PR TITLE
DEV: Move 'symlinking fonts' message to STDERR

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -236,7 +236,7 @@ module Discourse
     # Use discourse-fonts gem to symlink fonts and generate .scss file
     fonts_path = File.join(config.root, "public/fonts")
     if !File.exist?(fonts_path) || File.realpath(fonts_path) != DiscourseFonts.path_for_fonts
-      puts "Symlinking fonts from discourse-fonts gem"
+      STDERR.puts "Symlinking fonts from discourse-fonts gem"
       File.delete(fonts_path) if File.exist?(fonts_path)
       Discourse::Utils.atomic_ln_s(DiscourseFonts.path_for_fonts, fonts_path)
     end


### PR DESCRIPTION
Having it in stdout means it pollutes the output of some scripts & rake tasks, which then gets piped to other tooling

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->