### PR TITLE
DEV: Add workflow to replace dependabot PR bodies with plaintext

### DIFF
--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -1,0 +1,54 @@
+name: check-pr-body
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+jobs:
+  sanitize:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} 
+      - name: "Replace PR body with commit message"
+        shell: ruby {0}
+        env: 
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          original_description = ENV['PR_BODY']
+          if !original_description.include? "Dependabot commands and options"
+            puts "PR body does not contain rich Dependabot content, skipping"
+            exit 0
+          end
+
+          new_description = `git log -1 --pretty=%b`
+          raise "Failed to get commit message" unless $?.success?
+
+          puts "Updating body to commit message...\n\n---\n#{new_description}\n---"
+
+          puts "Updating PR body..."
+          system "gh", "pr", "edit", ENV['PR_NUMBER'], "--body", new_description
+
+          comment = <<~COMMENT
+            PR body updated to plaintext for easier squash-merging. Original body content below:
+
+            ---
+
+            #{original_description}
+          COMMENT
+
+          puts "Adding comment with original info..."
+          command = ["gh", "pr", "comment", ENV['PR_NUMBER'], "--body", comment]
+          begin
+            system *command, "--edit-last", exception: true
+          rescue
+            puts "Failed to add comment, continuing..."
+            system *command, exception: true
+          end

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -29,8 +29,10 @@ jobs:
             exit 0
           end
 
-          new_description = `git log -1 --pretty=%b`
+          commit_message = `git log -1 --pretty=%b`
           raise "Failed to get commit message" unless $?.success?
+
+          new_description = commit_message.split("---").first.strip
 
           puts "Updating body to commit message...\n\n---\n#{new_description}\n---"
 

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -23,6 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           original_description = ENV['PR_BODY']
+
           if !original_description.include? "Dependabot commands and options"
             puts "PR body does not contain rich Dependabot content, skipping"
             exit 0
@@ -33,7 +34,6 @@ jobs:
 
           puts "Updating body to commit message...\n\n---\n#{new_description}\n---"
 
-          puts "Updating PR body..."
           system "gh", "pr", "edit", ENV['PR_NUMBER'], "--body", new_description
 
           comment = <<~COMMENT
@@ -49,6 +49,6 @@ jobs:
           begin
             system *command, "--edit-last", exception: true
           rescue
-            puts "Failed to add comment, continuing..."
+            puts "Failed to edit comment, adding a new one instead..."
             system *command, exception: true
           end


### PR DESCRIPTION
We'd like to enable the "default commit message: pull request title and body" option for squash merges. That doesn't currently work well for dependabot PRs, because the PR body includes rich HTML.

Therefore, this commit introduces a new workflow which replaces any dependabot PR bodies with plaintext content from the commit message. The original rich content will be added in a comment.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->