### PR TITLE
DEV: Remove pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,0 @@
-<!--
-  NOTE: All pull requests should have:
-    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
-    - A descriptive title and description with context about the changes.
-    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
-    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
-    - For flakey tests, please describe the error you were having.
--->


### PR DESCRIPTION
We'd like to enable the "default commit message: pull request title and body" option for squash merges. That means we need PR bodies to be clean, and do not want HTML comments like this template to end up becoming part of the commit message body.
