### PR TITLE
FIX: correctly position emoji picker when clicking more

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -346,7 +346,7 @@ export default class DEditor extends Component {
         }
       },
 
-      transformComplete: (v) => {
+      transformComplete: (v, event) => {
         if (v.code) {
           this.emojiStore.trackEmojiForContext(v.code, "topic");
           return `${v.code}:`;
@@ -365,7 +365,26 @@ export default class DEditor extends Component {
             },
           };
 
-          const virtualElement = virtualElementFromTextRange();
+          let virtualElement;
+          if (event instanceof KeyboardEvent) {
+            // when user selects more by pressing enter
+            virtualElement = virtualElementFromTextRange();
+          } else {
+            // when user selects more by clicking on it
+            virtualElement = {
+              getBoundingClientRect: () => ({
+                x: event.pageX,
+                y: event.pageY,
+                top: event.pageY,
+                left: event.pageX,
+                bottom: 0,
+                right: 0,
+                width: 0,
+                height: 0,
+              }),
+            };
+          }
+
           this.menuInstance = this.menu.show(virtualElement, menuOptions);
           return "";
         }


### PR DESCRIPTION
The emoji picker was correctly showing in both cases, but when clicking we didn't have a valid range as the click makes us lose selection.

This commit uses the coordinates of the mouse on the click event to create a virtual element. We can't create the event target as the menu is disappearing after the click on more.

No tests as we already test it's showing, and testing position is complicated and often unreliable.

<!--
  NOTE: All pull requests should have:
    - Tests (rspec in Ruby, qunit in JavaScript). If no tests are included, please explain why.
    - A descriptive title and description with context about the changes.
    - Good commit messages with the correct prefixes, see: https://meta.discourse.org/t/-/19392
    - When there are UX/UI changes, please add before/after screenshots, including mobile and desktop.
    - For flakey tests, please describe the error you were having.
-->