### PR TITLE
FIX: Add back API keys plugin outlet lost in translation

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/api-keys.hbs
+++ b/app/assets/javascripts/admin/addon/templates/api-keys.hbs
@@ -1,22 +1,27 @@
-<div class="admin-api-keys admin-config-page">
-  <DPageHeader
-    @titleLabel={{i18n "admin.api_keys.title"}}
-    @descriptionLabel={{i18n "admin.api_keys.description"}}
-    @hideTabs={{true}}
-  >
-    <:breadcrumbs>
-      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
-      <DBreadcrumbsItem
-        @path="/admin/api/keys"
-        @label={{i18n "admin.api_keys.title"}}
-      />
-    </:breadcrumbs>
-    <:actions as |actions|>
-      <actions.Primary @route="adminApiKeys.new" @label="admin.api_keys.add" />
-    </:actions>
-  </DPageHeader>
+<PluginOutlet @name="admin-api-keys">
+  <div class="admin-api-keys admin-config-page">
+    <DPageHeader
+      @titleLabel={{i18n "admin.api_keys.title"}}
+      @descriptionLabel={{i18n "admin.api_keys.description"}}
+      @hideTabs={{true}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/api/keys"
+          @label={{i18n "admin.api_keys.title"}}
+        />
+      </:breadcrumbs>
+      <:actions as |actions|>
+        <actions.Primary
+          @route="adminApiKeys.new"
+          @label="admin.api_keys.add"
+        />
+      </:actions>
+    </DPageHeader>
 
-  <div class="admin-container admin-config-page__main-area">
-    {{outlet}}
+    <div class="admin-container admin-config-page__main-area">
+      {{outlet}}
+    </div>
   </div>
-</div>
+</PluginOutlet>


### PR DESCRIPTION
### What is this change?

When converting the admin API keys page to the new admin UI guidelines we lost a plugin outlet. This adds that back.