### PR TITLE
DEV: fix flaky chat new message spec

### DIFF
--- a/plugins/chat/spec/system/chat_new_message_spec.rb
+++ b/plugins/chat/spec/system/chat_new_message_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Chat New Message from params", type: :system do
     end
 
     it "creates a dm channel and redirects if none exists" do
-      chat_page.visit_new_message(user_2)
+      expect { chat_page.visit_new_message(user_2) }.to change { Chat::Channel.count }.by(1)
 
       expect(page).to have_current_path("/chat/c/#{user_2.username}/#{Chat::Channel.last.id}")
     end

--- a/plugins/chat/spec/system/chat_new_message_spec.rb
+++ b/plugins/chat/spec/system/chat_new_message_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe "Chat New Message from params", type: :system do
     end
 
     it "creates a dm channel and redirects if none exists" do
-      expect { chat_page.visit_new_message(user_2) }.to change { Chat::Channel.count }.by(1)
+      chat_page.visit_new_message(user_2)
 
+      expect(page).to have_css(".chat-channel-name__label", text: user_2.username)
       expect(page).to have_current_path("/chat/c/#{user_2.username}/#{Chat::Channel.last.id}")
     end
 


### PR DESCRIPTION
Ensures that visiting the route creates a new chat channel before checking the new redirected url is using the last channel.