### PR TITLE
FIX: Improve sidebar invite link highlight persisting, link tabbing and activation behavior

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -242,9 +242,11 @@ export default class CreateInvite extends Component {
   }
 
   @action
-  showAdvancedMode() {
+  showAdvancedMode(event) {
     this.displayAdvancedOptions = true;
-  }
+    event.preventDefault();
+    event.stopPropagation();
+   }
 
   @action
   async createLink() {
@@ -326,7 +328,9 @@ export default class CreateInvite extends Component {
             <a
               class="edit-link-options"
               role="button"
+              tabindex="0"
               {{on "click" this.showAdvancedMode}}
+              {{on "keydown" this.showAdvancedMode}}
             >{{i18n "user.invited.invite.edit_link_options"}}</a>
           </p>
         {{else}}
@@ -485,6 +489,7 @@ export default class CreateInvite extends Component {
               }}
               @action={{this.saveInviteAndSendEmail}}
               @disabled={{this.saving}}
+              autofocus="true"
               class="btn-primary save-invite-and-send-email"
             />
           {{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -246,7 +246,7 @@ export default class CreateInvite extends Component {
     this.displayAdvancedOptions = true;
     event.preventDefault();
     event.stopPropagation();
-   }
+  }
 
   @action
   async createLink() {
@@ -467,7 +467,7 @@ export default class CreateInvite extends Component {
             @action={{this.createLink}}
             @disabled={{this.saving}}
             class="btn-primary save-invite"
-            autofocus=true
+            autofocus="true"
           />
         {{else}}
           <DButton

--- a/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-invite.gjs
@@ -463,6 +463,7 @@ export default class CreateInvite extends Component {
             @action={{this.createLink}}
             @disabled={{this.saving}}
             class="btn-primary save-invite"
+            autofocus=true
           />
         {{else}}
           <DButton


### PR DESCRIPTION
### What's changed?
- Fixed an issue where the invite link in the sidebar remained highlighted after the invite popup was closed.
- Included the link inside the modal in the tabbing order by adding tabindex="0" (previously excluded due to the absence of an href).
- Resolved a bug where pressing Enter on the focused link incorrectly triggered the "Create Link" button instead of performing the intended action.

Internal topic: /t/141364