### PR TITLE
DEV: Fix job serialization warnings

### DIFF
--- a/app/jobs/regular/run_problem_check.rb
+++ b/app/jobs/regular/run_problem_check.rb
@@ -22,7 +22,7 @@ module Jobs
       Jobs.enqueue_in(
         check.retry_after,
         :run_problem_check,
-        args.merge(retry_count: retry_count + 1).stringify_keys,
+        args.merge(retry_count: retry_count + 1),
       )
     rescue StandardError => err
       Discourse.warn_exception(

--- a/spec/jobs/run_problem_check_spec.rb
+++ b/spec/jobs/run_problem_check_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Jobs::RunProblemCheck do
 
     it "updates the problem check tracker" do
       expect {
-        described_class.new.execute(check_identifier: :test_check, retry_count: 0)
+        described_class.new.execute(check_identifier: "test_check", retry_count: 0)
       }.to change { ProblemCheckTracker.failing.count }.by(1)
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe Jobs::RunProblemCheck do
 
     it "does not yet update the problem check tracker" do
       expect {
-        described_class.new.execute(check_identifier: :test_check, retry_count: 1)
+        described_class.new.execute(check_identifier: "test_check", retry_count: 1)
       }.not_to change { ProblemCheckTracker.where("blips > ?", 0).count }
     end
 
@@ -61,10 +61,10 @@ RSpec.describe Jobs::RunProblemCheck do
       expect_enqueued_with(
         job: :run_problem_check,
         args: {
-          check_identifier: :test_check,
+          check_identifier: "test_check",
           retry_count: 1,
         },
-      ) { described_class.new.execute(check_identifier: :test_check) }
+      ) { described_class.new.execute(check_identifier: "test_check") }
     end
   end
 
@@ -87,13 +87,13 @@ RSpec.describe Jobs::RunProblemCheck do
 
     it "updates the problem check tracker" do
       expect {
-        described_class.new.execute(check_identifier: :test_check, retry_count: 1)
+        described_class.new.execute(check_identifier: "test_check", retry_count: 1)
       }.to change { ProblemCheckTracker.where("blips > ?", 0).count }.by(1)
     end
 
     it "does not schedule a retry" do
       expect_not_enqueued_with(job: :run_problem_check) do
-        described_class.new.execute(check_identifier: :test_check, retry_count: 1)
+        described_class.new.execute(check_identifier: "test_check", retry_count: 1)
       end
     end
   end


### PR DESCRIPTION
(…and remove extraneous `stringify_keys` - enqueue already does `deep_stringify_keys`)

The warning in question:

```
Deprecation notice: Jobs::RunProblemCheck was enqueued with argument values which do not cleanly serialize to/from JSON. This means that the job will be run with slightly different values than the ones supplied to `enqueue`. Argument values should be strings, booleans, numbers, or nil (or arrays/hashes of those value types). (deprecated since Discourse 2.9) (removal in Discourse 3.0)
```