### PR TITLE
FIX: prevent multiple requests when clicking drafts trigger

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -17,6 +17,7 @@ export default class TopicDraftsDropdown extends Component {
   @service composer;
 
   @tracked drafts = [];
+  @tracked loading = false;
 
   get draftCount() {
     return this.currentUser.draft_count;
@@ -41,6 +42,12 @@ export default class TopicDraftsDropdown extends Component {
 
   @action
   async onShowMenu() {
+    if (this.loading) {
+      return;
+    }
+
+    this.loading = true;
+
     try {
       const draftsStream = this.currentUser.userDraftsStream;
       draftsStream.reset();
@@ -51,6 +58,8 @@ export default class TopicDraftsDropdown extends Component {
       // eslint-disable-next-line no-console
       console.error("Failed to fetch drafts with error:", error);
     }
+
+    this.loading = false;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -42,10 +42,6 @@ export default class TopicDraftsDropdown extends Component {
 
   @action
   async onShowMenu() {
-    if (this.loading) {
-      return;
-    }
-
     this.loading = true;
 
     try {
@@ -57,9 +53,9 @@ export default class TopicDraftsDropdown extends Component {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Failed to fetch drafts with error:", error);
+    } finally {
+      this.loading = false;
     }
-
-    this.loading = false;
   }
 
   @action
@@ -86,6 +82,7 @@ export default class TopicDraftsDropdown extends Component {
       @onShow={{this.onShowMenu}}
       @onRegisterApi={{this.onRegisterApi}}
       @modalForMobile={{true}}
+      @disabled={{this.loading}}
       class="btn-small"
     >
       <:content>

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -59,7 +59,7 @@
   > * {
     white-space: nowrap;
     &:not(:last-child) {
-      margin-right: 0.5em;
+      margin-right: 0.4em;
     }
   }
   .select-kit-header {

--- a/app/assets/stylesheets/common/components/drafts-dropdown-menu.scss
+++ b/app/assets/stylesheets/common/components/drafts-dropdown-menu.scss
@@ -1,7 +1,7 @@
 // Styles for the drafts dropdown menu
 
 .topic-drafts-menu-trigger {
-  margin-left: -0.4em;
+  margin-left: -0.3em;
 }
 
 .topic-drafts-menu-content {


### PR DESCRIPTION
Adds a loading state to prevent multiple requests when clicking the drafts menu button.

We are also making a very slight adjustment to button spacing (needed for both desktop and mobile).

#### Before (desktop) 

<img width="593" alt="Screenshot 2025-01-13 at 4 53 50 PM" src="https://github.com/user-attachments/assets/1d29e4d1-b27d-4ce6-a615-6a1f05bb38e2" />

#### After (desktop) 

<img width="596" alt="Screenshot 2025-01-13 at 4 53 39 PM" src="https://github.com/user-attachments/assets/aa5c311f-ca65-44ce-ba51-f408042c66a9" />

#### After (mobile view)

<img width="461" alt="Screenshot 2025-01-13 at 4 54 33 PM" src="https://github.com/user-attachments/assets/8592c105-a2e4-47f6-b69a-6b550854f79c" />
