### PR TITLE
FIX: Set fixed width for email group chooser dropdown to prevent resizing based on content

### DIFF
--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -3,16 +3,20 @@
     width: unset;
   }
 
+  &.is-expanded .select-kit-body {
+    width: 300px;
+  }
+
   .select-kit-row.email-group-user-chooser-row {
     .identifier {
       color: var(--primary);
       white-space: nowrap;
       line-height: var(--line-height-medium);
+      margin-right: 0.5em;
     }
     .name {
       color: var(--primary-high);
       font-size: var(--font-down-1);
-      margin-left: 0.5em;
       @include ellipsis;
     }
     .avatar,


### PR DESCRIPTION
This PR addresses an issue where the dropdown container width was inconsistent, resizing based on its content. 

**Changes included:**
- Added a fixed width for the dropdown container.
- Adjusted margin spacing by applying it to the `.identifier` class instead of `.name`. This prevents awkward spacing when either contains a large number of characters.

Internal topic: /t/143862