### PR TITLE
UX: add placeholder title for drafts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -86,7 +86,10 @@ export default class TopicDraftsDropdown extends Component {
               <DButton
                 @action={{fn this.resumeDraft draft}}
                 @icon={{if draft.topic_id "reply" "layer-group"}}
-                @translatedLabel={{or draft.title (i18n "drafts.dropdown.untitled")}}
+                @translatedLabel={{or
+                  draft.title
+                  (i18n "drafts.dropdown.untitled")
+                }}
                 class="btn-secondary"
               />
             </dropdown.item>

--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
 import DiscourseURL from "discourse/lib/url";
@@ -85,7 +86,7 @@ export default class TopicDraftsDropdown extends Component {
               <DButton
                 @action={{fn this.resumeDraft draft}}
                 @icon={{if draft.topic_id "reply" "layer-group"}}
-                @translatedLabel={{draft.title}}
+                @translatedLabel={{or draft.title (i18n "drafts.dropdown.untitled")}}
                 class="btn-secondary"
               />
             </dropdown.item>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -499,7 +499,7 @@ en:
         no_value: "Resume editing"
       dropdown:
         title: "Open the latest drafts menu"
-        untitled: "Untitled topic draft"
+        untitled: "Untitled draft"
         view_all: "view all"
         other_drafts:
           one: "+%{count} other draft"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -499,6 +499,7 @@ en:
         no_value: "Resume editing"
       dropdown:
         title: "Open the latest drafts menu"
+        untitled: "Undefined title"
         view_all: "view all"
         other_drafts:
           one: "+%{count} other draft"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -499,7 +499,7 @@ en:
         no_value: "Resume editing"
       dropdown:
         title: "Open the latest drafts menu"
-        untitled: "Undefined title"
+        untitled: "Untitled topic draft"
         view_all: "view all"
         other_drafts:
           one: "+%{count} other draft"


### PR DESCRIPTION
Adds a placeholder title for drafts that don't have a saved title.

Before:

<img width="272" alt="Screenshot 2025-01-14 at 12 49 45 AM" src="https://github.com/user-attachments/assets/6fc1e90e-3016-4c6b-8362-3efba1a62f9a" />


After:

<img width="266" alt="Screenshot 2025-01-14 at 12 49 19 AM" src="https://github.com/user-attachments/assets/9bb32101-b3fd-475b-9b34-8852815cd5fc" />
