### PR TITLE
UX: check category permission before new topic quote

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1178,7 +1178,6 @@ export default class TopicController extends Controller.extend(
     const composerController = this.composer;
     const { quoteState } = this;
     const quotedText = buildQuote(post, quoteState.buffer, quoteState.opts);
-    const categoryPermission = this.get("model.category.permission");
 
     quoteState.clear();
 
@@ -1202,9 +1201,9 @@ export default class TopicController extends Controller.extend(
       options = {
         action: Composer.CREATE_TOPIC,
         draftKey: post.topic.draft_key,
-        topicCategoryId: categoryPermission
-          ? this.get("model.category.id")
-          : null,
+        topicCategoryId:
+          this.get("model.category.permission") &&
+          this.get("model.category.id"),
         prioritizedCategoryId: this.get("model.category.id"),
       };
     }

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1178,6 +1178,7 @@ export default class TopicController extends Controller.extend(
     const composerController = this.composer;
     const { quoteState } = this;
     const quotedText = buildQuote(post, quoteState.buffer, quoteState.opts);
+    const categoryPermission = this.get("model.category.permission");
 
     quoteState.clear();
 
@@ -1201,7 +1202,9 @@ export default class TopicController extends Controller.extend(
       options = {
         action: Composer.CREATE_TOPIC,
         draftKey: post.topic.draft_key,
-        topicCategoryId: this.get("model.category.id"),
+        topicCategoryId: categoryPermission
+          ? this.get("model.category.id")
+          : null,
         prioritizedCategoryId: this.get("model.category.id"),
       };
     }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/quoting-a-closed-topic-prefills-category-in-composer-that-should-be-off-limits/260009

Currently, if someone tries to quote a topic they don't have permission to reply to, we'll open a new topic composer with the quote so they can "continue the discussion". When doing this, we populate the current category, even if the user doesn't have permission to post in it. 

This is misleading, as when the user attempts to submit their topic they get an error because they lack the category permissions. 

This change checks the category permissions before populating it. 