### PR TITLE
FIX: Add Type column to Flag Status CSV export

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -218,6 +218,9 @@ module Jobs
         elsif label[:type] == :topic
           titles[label[:properties][:id]] = label[:title]
           header << label[:properties][:id]
+        elsif label[:type] == :post
+          titles[label[:properties][:truncated_raw]] = label[:title]
+          header << label[:properties][:truncated_raw]
         else
           titles[label[:property]] = label[:title]
           header << label[:property]


### PR DESCRIPTION
This Type column is a special ":post" column on the
Flag Status report, so it did not show by default in
the CSV export of that report. This adds it so the
type of flag e.g. illegal, off topic, innapropriate
is shown in the CSV output.

![image](https://github.com/user-attachments/assets/b3839538-df75-42fe-b3eb-1470a10b2dd3)

![image](https://github.com/user-attachments/assets/aa5796fc-435d-48c5-a21c-4daf265d5447)
