### PR TITLE
DEV: Add before save plugin API for user profile

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -9,6 +9,14 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 
+const beforeSaveCallbacks = [];
+export function registerUserProfileBeforeSaveCallback(callback) {
+  beforeSaveCallbacks.push(callback);
+}
+export function clearUserProfileBeforeSaveCallbacks() {
+  beforeSaveCallbacks.length = 0;
+}
+
 export default class ProfileController extends Controller {
   @service dialog;
   @service modal;
@@ -141,6 +149,8 @@ export default class ProfileController extends Controller {
 
     // Update the user fields
     this.send("_updateUserFields");
+
+    beforeSaveCallbacks.forEach((callback) => callback(this.model));
 
     return this.model
       .save(this.saveAttrNames)

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "2.0.0";
+export const PLUGIN_API_VERSION = "2.1.0";
 
 import $ from "jquery";
 import { h } from "virtual-dom";
@@ -45,6 +45,7 @@ import { setNotificationsLimit as setUserMenuNotificationsLimit } from "discours
 import { addUserMenuProfileTabItem } from "discourse/components/user-menu/profile-tab-content";
 import { addDiscoveryQueryParam } from "discourse/controllers/discovery/list";
 import { registerFullPageSearchType } from "discourse/controllers/full-page-search";
+import { registerUserProfileBeforeSaveCallback } from "discourse/controllers/preferences/profile";
 import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/controllers/topic";
 import { addBeforeLoadMoreCallback as addBeforeLoadMoreNotificationsCallback } from "discourse/controllers/user-notifications";
 import { registerCustomUserNavMessagesDropdownRow } from "discourse/controllers/user-private-messages";
@@ -3377,6 +3378,17 @@ class PluginApi {
    */
   registerMoreTopicsTab(tab) {
     registeredTabs.push(tab);
+  }
+
+  /**
+   * Registers a callback to run before the user profile is saved in the user preferences
+   * Profile tab. The callback receives the `model` object for the user profile.
+   *
+   * @param {Function} callback
+   *
+   */
+  registerUserProfileBeforeSaveCallback(callback) {
+    registerUserProfileBeforeSaveCallback(callback);
   }
 
   #deprecatedWidgetOverride(widgetName, override) {

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,10 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-01-14
+
+- Add `registerUserProfileBeforeSaveCallback` which allows accessing the user profile model before save, so themes and components can add custom logic here and change properties.
+
 ## [2.0.0] - 2025-01-07
 
 - Removed `decorateTopicTitle`. This has been deprecated for more than a year, and we are not aware of any remaining uses in the ecosystem.


### PR DESCRIPTION
This commit adds registerUserProfileBeforeSaveCallback for
the user profile, which passes in the profile model,
so themes and components can add custom logic here and change properties.

Done for https://github.com/discourse/automatic-timezone/pull/1
