### PR TITLE
UX: Use `DPageHeader` on the Themes page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
@@ -1,3 +1,18 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.customize.theme.title"}}
+  @descriptionLabel={{i18n "admin.customize.theme.description"}}
+  @learnMoreUrl="https://meta.discourse.org/t/91966"
+  @hideTabs={{true}}
+>
+<:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/customize/themes"
+      @label={{i18n "admin.customize.theme.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
 <PluginOutlet @name="admin-customize-themes">
   {{#unless this.editingTheme}}
     <ThemesList

--- a/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
@@ -4,7 +4,7 @@
   @learnMoreUrl="https://meta.discourse.org/t/91966"
   @hideTabs={{true}}
 >
-<:breadcrumbs>
+  <:breadcrumbs>
     <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
     <DBreadcrumbsItem
       @path="/admin/customize/themes"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4753,7 +4753,7 @@ en:
         everyone_can_use: "Tags can be used by everyone"
         usable_only_by_groups: "Tags are visible to everyone, but only the following groups can use them"
         visible_only_to_groups: "Tags are visible only to the following groups"
-        cannot_save: 
+        cannot_save:
           empty_name: "Cannot save tag group. Make sure the tag group name is not empty."
           no_tags: "Cannot save tag group. Make sure that at least one tag is selected."
           no_groups: "Cannot save tag group. Make sure that at least one group is selected for permission."
@@ -6043,6 +6043,7 @@ en:
           browse_themes: "Browse community themes"
           customize_desc: "Customize:"
           title: "Themes"
+          description: "Themes are expansive customizations that change multiple elements of the style of your forum design, and often also include additional front-end features."
           create: "Create"
           create_type: "Type"
           create_name: "Name"


### PR DESCRIPTION
## ✨ What's This?

This PR updates the header of the admin Themes page to be more consistent with the rest of the admin UI.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/04065779-7923-42bb-a513-de9fdfa6daa2)
