### PR TITLE
DEV: add FontAwesome 6 upgrade to deprecation warnings handler

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -21,6 +21,7 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.plugin-outlet-parent-view",
   "discourse.d-button-action-string",
   "discourse.post-menu-widget-overrides",
+  "discourse.fontawesome-6-upgrade",
 ];
 
 if (DEBUG) {


### PR DESCRIPTION
Our test suite now shows no deprecation counts from official themes/plugins for the FA6 upgrade, and we've done a few rounds of removing these in direct references & known settings, so it's time to enable the admin banner.