### PR TITLE
UX: Remove flat icons from wizard step two

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
@@ -54,9 +54,6 @@ export default class Radio extends Component {
                 {{on "change" (withEventValue this.selectionChanged)}}
               />
               <span class="wizard-container__radio-label">
-                {{#if choice.icon}}
-                  {{icon choice.icon}}
-                {{/if}}
                 <span>{{choice.label}}</span>
               </span>
             </PluginOutlet>

--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
@@ -4,7 +4,6 @@ import { on } from "@ember/modifier";
 import { action, set } from "@ember/object";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
-import icon from "discourse/helpers/d-icon";
 import withEventValue from "discourse/helpers/with-event-value";
 
 export default class Radio extends Component {

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -90,8 +90,8 @@ class Wizard
           type: "radio",
           value: SiteSetting.invite_only ? "invite_only" : "sign_up",
         ) do |field|
-          field.add_choice("sign_up", icon: "user-plus")
-          field.add_choice("invite_only", icon: "paper-plane")
+          field.add_choice("sign_up")
+          field.add_choice("invite_only")
         end
 
         step.add_field(


### PR DESCRIPTION
### What's changed?
This PR removes the flat icons from wizard step 2, as they are not used elsewhere in the wizard. Keeping the steps consistent with the existing style improves visual alignment and avoids unnecessary elements.

### Before
<img width="511" alt="image" src="https://github.com/user-attachments/assets/9e8b6f46-7c35-433b-9f5e-511579bc4768" />


### After
<img width="514" alt="image" src="https://github.com/user-attachments/assets/028e52af-9777-4733-8ff4-1daab5b39e22" />
