### PR TITLE
UX: Use `DPageHeader` on the Components page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes.hbs
@@ -1,17 +1,33 @@
-<DPageHeader
-  @titleLabel={{i18n "admin.customize.theme.title"}}
-  @descriptionLabel={{i18n "admin.customize.theme.description"}}
-  @learnMoreUrl="https://meta.discourse.org/t/91966"
-  @hideTabs={{true}}
->
-  <:breadcrumbs>
-    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
-    <DBreadcrumbsItem
-      @path="/admin/customize/themes"
-      @label={{i18n "admin.customize.theme.title"}}
-    />
-  </:breadcrumbs>
-</DPageHeader>
+{{#if (eq this.currentTab "themes")}}
+  <DPageHeader
+    @titleLabel={{i18n "admin.customize.theme.title"}}
+    @descriptionLabel={{i18n "admin.customize.theme.description"}}
+    @learnMoreUrl="https://meta.discourse.org/t/91966"
+    @hideTabs={{true}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/customize/themes"
+        @label={{i18n "admin.customize.theme.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+{{else}}
+  <DPageHeader
+    @titleLabel={{i18n "admin.customize.theme.components"}}
+    @descriptionLabel={{i18n "admin.customize.theme.components_description"}}
+    @hideTabs={{true}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/customize/components"
+        @label={{i18n "admin.customize.theme.components"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+{{/if}}
 
 <PluginOutlet @name="admin-customize-themes">
   {{#unless this.editingTheme}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6044,6 +6044,7 @@ en:
           customize_desc: "Customize:"
           title: "Themes"
           description: "Themes are expansive customizations that change multiple elements of the style of your forum design, and often also include additional front-end features."
+          components_description: "Components are smaller customizations that can be added to themes in order to change specific elements of the style of your forum design."
           create: "Create"
           create_type: "Type"
           create_name: "Name"


### PR DESCRIPTION
## ✨ What's This?

This PR updates the header of the admin Components page to be more consistent with the rest of the admin UI.

The Themes and Components pages share the same templates, so this change switches the header based on which tab is active.

## 📺 Screenshots


![](https://github.com/user-attachments/assets/0532b7d8-eb23-4ae3-a365-40fe13b5788f)
