### PR TITLE
DEV: Setup deprecation workflow earlier

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -1,7 +1,4 @@
-import setupDeprecationWorkflow from "ember-cli-deprecation-workflow";
-import DEPRECATION_WORKFLOW from "./deprecation-workflow";
-setupDeprecationWorkflow({ workflow: DEPRECATION_WORKFLOW });
-
+import "./setup-deprecation-workflow";
 import "decorator-transforms/globals";
 import "./loader-shims";
 import "./discourse-common-loader-shims";

--- a/app/assets/javascripts/discourse/app/setup-deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/setup-deprecation-workflow.js
@@ -1,0 +1,4 @@
+import setupDeprecationWorkflow from "ember-cli-deprecation-workflow";
+import DEPRECATION_WORKFLOW from "./deprecation-workflow";
+
+setupDeprecationWorkflow({ workflow: DEPRECATION_WORKFLOW });


### PR DESCRIPTION
In 0ed4b09527857d7751dba7fb2d765e08bf46a65e, this code was moved into app.js, which means it actually ends up running after all the other imports have been completed. That's too late, and some deprecations are triggered before that.

This commit moves `setupDeprecationWorkflow` back into its own module, with a 'side effect only' import from `app.js`.