### PR TITLE
UX: Adjust styling of Back button in topic progress

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.hbs
@@ -8,7 +8,7 @@
       @label="topic.timeline.back"
       @action={{this.goBack}}
       @icon="arrow-down"
-      class="btn-primary progress-back"
+      class="btn-primary btn-small progress-back"
     />
   </div>
 {{/if}}

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -110,15 +110,14 @@
 
 .progress-back-container {
   z-index: z("dropdown");
-  margin-right: 0;
   animation-duration: 0.5s;
   animation-name: button-jump-up;
-  width: 145px;
   text-align: center;
   margin-bottom: 0px;
+  margin-right: 0.5em;
   position: absolute;
   right: 0;
-  top: -120%; // above parent container + some extra space
+  bottom: 100%; // above parent container + some extra space
   .btn {
     margin: 0;
   }

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -27,10 +27,6 @@
   }
 }
 
-.progress-back-container {
-  top: -100%; // above parent container + some extra space
-}
-
 .topic-error {
   padding: 18px;
   width: 90%;


### PR DESCRIPTION
Before: 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/66c07c49-9603-4eb4-84d5-db3821a7af1a" />

After: 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ba90d74a-4f63-41ae-9dd7-f5999a2d21ef" />
