### PR TITLE
UX: show strikethrough, underline in post edit diff

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -212,7 +212,9 @@
   del,
   .diff-del {
     color: var(--primary);
-    text-decoration: none;
+    &:not(s, .bbcode-u, .bbcode-s) {
+      text-decoration: none;
+    }
     code,
     img {
       border: 2px solid;


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/strike-through-text-is-not-rendered-in-diff/347101

`text-decoration: none` needs a few exceptions here to avoid stripping out styling that's present in posts 


before (strikethrough and underline stripped): 
![image](https://github.com/user-attachments/assets/ecb8cdee-e04b-463f-93a3-16d92797f0cd)


after: 
![image](https://github.com/user-attachments/assets/b250c535-de2f-429a-8764-5a60e74ef953)
