### PR TITLE
DEV: Add div with className around Search no results header

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -17,7 +17,9 @@
           {{html-safe this.resultCountLabel}}
         </div>
       {{else}}
-        {{i18n "search.full_page_title"}}
+        <div class="search-page-heading__page-title">
+          {{i18n "search.full_page_title"}}
+        </div>
       {{/if}}
     </h1>
     <div class="search-bar">


### PR DESCRIPTION
Another case of text node missing container with a selectable class.