### PR TITLE
UX: remove redundant `text-decoration: none`,  follow up to 912b002

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -243,7 +243,6 @@
   del,
   .diff-del {
     background: var(--danger-low);
-    text-decoration: none;
     code,
     img {
       border-color: var(--danger);


### PR DESCRIPTION
This redundant `text-decoration: none` was getting in the way of showing a strikethrough on the deleted part of the diff

before ("new strike" at the bottom missing the strikethrough): 
![image](https://github.com/user-attachments/assets/4c04696a-efe8-4bb4-a7a7-cf10fcd4b443)


after (strikethrough appears correctly):
![image](https://github.com/user-attachments/assets/22a8c658-6600-47d4-a795-dc3116971485)
