### PR TITLE
FIX: Safari on iOS crashes when pinch-zooming

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -637,8 +637,6 @@ div.ac-wrap {
 .tablet-device,
 .mobile-device {
   #reply-control {
-    z-index: -1;
-
     &.open {
       z-index: z("mobile-composer");
     }


### PR DESCRIPTION
Not sure why, but it looks like this `z-index: -1` on the composer causes iOS to crash super quickly when pinch zooming . This change was introduced in 07e5f8907e2a8de27c42c2d6f5a02fc153212288 and is not strictly necessary, let's try removing. 