### PR TITLE
FIX: Do not allow_any on fonts site_settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -408,7 +408,7 @@ basic:
     default: ""
     hidden: true
   base_font:
-    default: "arial"
+    default: "Arial"
     choices: "BaseFontSetting.values"
     refresh: true
     type: list
@@ -416,7 +416,7 @@ basic:
     area: "fonts"
     allow_any: false
   heading_font:
-    default: "arial"
+    default: "Arial"
     choices: "BaseFontSetting.values"
     refresh: true
     type: list

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -414,6 +414,7 @@ basic:
     type: list
     list_type: font
     area: "fonts"
+    allow_any: false
   heading_font:
     default: "arial"
     choices: "BaseFontSetting.values"
@@ -421,6 +422,7 @@ basic:
     type: list
     list_type: font
     area: "fonts"
+    allow_any: false
   enable_sitemap:
     default: true
   sitemap_page_size:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -408,7 +408,7 @@ basic:
     default: ""
     hidden: true
   base_font:
-    default: "Arial"
+    default: "arial"
     choices: "BaseFontSetting.values"
     refresh: true
     type: list
@@ -416,7 +416,7 @@ basic:
     area: "fonts"
     allow_any: false
   heading_font:
-    default: "Arial"
+    default: "arial"
     choices: "BaseFontSetting.values"
     refresh: true
     type: list

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -269,7 +269,11 @@ class SiteSettings::TypeSupervisor
     if type == self.class.types[:list] || type == self.class.types[:string]
       if @allow_any.key?(name) && !@allow_any[name]
         split = val.to_s.split("|")
-        diff = (split - @choices[name])
+        resolved_choices = @choices[name]
+        if resolved_choices.first.is_a?(Hash)
+          resolved_choices = resolved_choices.map { |c| c[:value] }
+        end
+        diff = (split - resolved_choices)
         if diff.length > 0
           raise Discourse::InvalidParameters.new(
                   I18n.t(


### PR DESCRIPTION
Both heading_font and body_font should not allow
additional user-defined values, these are lists with
predefined choices. The UI already prevents this
because the font selector dropdown is unique, but
we want to make sure the setting definition reflects
this too.
