### PR TITLE
UX: Use `DPageHeader` on the Site Settings page

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin.hbs
@@ -11,7 +11,7 @@
           {{#if this.currentUser.admin}}
             <NavItem
               @route="adminSiteSettings"
-              @label="admin.site_settings.title"
+              @label="admin.site_settings.nav_title"
             />
           {{/if}}
           <NavItem @route="adminUsers" @label="admin.users.title" />

--- a/app/assets/javascripts/admin/addon/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.hbs
@@ -1,3 +1,17 @@
+<DPageHeader
+  @titleLabel={{i18n "admin.site_settings.title"}}
+  @descriptionLabel={{i18n "admin.site_settings.description"}}
+  @hideTabs={{true}}
+>
+  <:breadcrumbs>
+    <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+    <DBreadcrumbsItem
+      @path="/admin/site_settings"
+      @label={{i18n "admin.site_settings.title"}}
+    />
+  </:breadcrumbs>
+</DPageHeader>
+
 <AdminSiteSettingsFilterControls
   @initialFilter={{this.filter}}
   @onChangeFilter={{this.filterChanged}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7195,11 +7195,13 @@ en:
         unmask: "unmask input"
         not_found: "Settings could not be found"
       site_settings:
+        title: "Site Settings"
+        description: "Configure the settings for your Discourse site to customize its appearance, functionality, and user experience."
         emoji_list:
           invalid_input: "Emoji list should only contain valid emoji names, eg: hugs"
           add_emoji_button:
             label: "Add Emoji"
-        title: "Settings"
+        nav_title: "Settings"
         no_results: "No results found."
         more_site_setting_results:
           one: "There is more than %{count} result. Please refine your search or select a category."


### PR DESCRIPTION
## ✨ What's This?

This PR updates the header of the admin Site Settings page to be more consistent with the rest of the admin UI.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/a0bf3f2b-5ce1-4411-b521-547b5555f7ed)
