### PR TITLE
FEATURE: setting allowing tl0/anonymous flag illegal content

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
@@ -42,6 +42,7 @@
         <input
           id="radio_{{this.flag.name_key}}"
           {{on "click" (fn this.changePostActionType this.flag)}}
+          checked={{this.selected}}
           type="radio"
           name="post_action_type_index"
         />

--- a/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
@@ -4,15 +4,16 @@ import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import DModal from "discourse/components/d-modal";
 import { i18n } from "discourse-i18n";
+import { getAbsoluteURL } from "discourse/lib/get-url";
 
 export default class AnonymousFlagModal extends Component {
   @service siteSettings;
 
   get description() {
     return i18n("anonymous_flagging.description", {
-      contact_info: `<a href="mailto:${this.#email}?subject=${i18n(
-        "anonymous_flagging.illegal_content"
-      )}${this.args.model.flagModel.topic.title}">${this.#email}</a>`,
+      contact_info: `<a href="mailto:${this.#email}?subject=${
+        this.#subject
+      }&body=${this.#body}">${this.#email}</a>`,
     });
   }
 
@@ -21,6 +22,17 @@ export default class AnonymousFlagModal extends Component {
       return this.siteSettings.contact_email;
     }
     return this.siteSettings.email_address_to_report_illegal_content;
+  }
+
+  get #subject() {
+    return i18n("anonymous_flagging.email_subject", {
+      title: this.args.model.flagModel.topic.title,
+    });
+  }
+  get #body() {
+    return i18n("anonymous_flagging.email_body", {
+      url: getAbsoluteURL(this.args.model.flagModel.url),
+    });
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
@@ -1,0 +1,38 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
+import { isEmpty } from "@ember/utils";
+import DModal from "discourse/components/d-modal";
+import { i18n } from "discourse-i18n";
+
+export default class AnonymousFlagModal extends Component {
+  @service siteSettings;
+
+  get description() {
+    return i18n("anonymous_flagging.description", {
+      contact_info: `<a href="mailto:${this.#email}?subject=${i18n(
+        "anonymous_flagging.illegal_content"
+      )}${this.args.model.flagModel.topic.title}">${this.#email}</a>`,
+    });
+  }
+
+  get #email() {
+    if (isEmpty(this.siteSettings.email_address_to_report_illegal_content)) {
+      return this.siteSettings.contact_email;
+    }
+    return this.siteSettings.email_address_to_report_illegal_content;
+  }
+
+  <template>
+    <DModal
+      @title={{i18n "anonymous_flagging.title"}}
+      @closeModal={{@closeModal}}
+      @bodyClass="anonymous-flag-modal__body"
+      class="anonymous-flag-modal"
+    >
+      <:body>
+        {{htmlSafe this.description}}
+      </:body>
+    </DModal>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
@@ -3,17 +3,17 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import DModal from "discourse/components/d-modal";
-import { i18n } from "discourse-i18n";
 import { getAbsoluteURL } from "discourse/lib/get-url";
+import { i18n } from "discourse-i18n";
 
 export default class AnonymousFlagModal extends Component {
   @service siteSettings;
 
   get description() {
     return i18n("anonymous_flagging.description", {
-      contact_info: `<a href="mailto:${this.#email}?subject=${
-        this.#subject
-      }&body=${this.#body}">${this.#email}</a>`,
+      email: this.#email,
+      topic_title: this.args.model.flagModel.topic.title,
+      url: getAbsoluteURL(this.args.model.flagModel.url),
     });
   }
 
@@ -22,17 +22,6 @@ export default class AnonymousFlagModal extends Component {
       return this.siteSettings.contact_email;
     }
     return this.siteSettings.email_address_to_report_illegal_content;
-  }
-
-  get #subject() {
-    return i18n("anonymous_flagging.email_subject", {
-      title: this.args.model.flagModel.topic.title,
-    });
-  }
-  get #body() {
-    return i18n("anonymous_flagging.email_body", {
-      url: getAbsoluteURL(this.args.model.flagModel.url),
-    });
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/modal/flag.js
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.js
@@ -29,6 +29,10 @@ export default class Flag extends Component {
     this.adminTools
       ?.checkSpammer(this.args.model.flagModel.user_id)
       .then((result) => (this.spammerDetails = result));
+
+    if (this.flagsAvailable.length === 1) {
+      this.selected = this.flagsAvailable[0];
+    }
   }
 
   get flagActions() {

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/flag.gjs
@@ -6,9 +6,21 @@ import concatClass from "discourse/helpers/concat-class";
 import DiscourseURL from "discourse/lib/url";
 
 export default class PostMenuFlagButton extends Component {
-  static shouldRender(args) {
+  static shouldRender(args, helper) {
     const { reviewable_id, canFlag, hidden } = args.post;
-    return reviewable_id || (canFlag && !hidden);
+    return (
+      reviewable_id ||
+      (canFlag && !hidden) ||
+      (helper.siteSettings
+        .allow_tl0_and_anonymous_users_to_flag_illegal_content &&
+        !helper.currentUser)
+    );
+  }
+
+  get title() {
+    return this.args.post.currentUser
+      ? "post.controls.flag"
+      : "post.controls.anonymous_flag";
   }
 
   @action
@@ -36,7 +48,7 @@ export default class PostMenuFlagButton extends Component {
         @action={{@buttonActions.showFlags}}
         @icon="flag"
         @label={{if @showLabel "post.controls.flag_action"}}
-        @title="post.controls.flag"
+        @title={{this.title}}
       />
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -3,6 +3,7 @@ import { cancel, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import AddPmParticipants from "discourse/components/modal/add-pm-participants";
+import AnonymousFlagModal from "discourse/components/modal/anonymous-flag";
 import ChangeOwnerModal from "discourse/components/modal/change-owner";
 import ChangeTimestampModal from "discourse/components/modal/change-timestamp";
 import EditSlowModeModal from "discourse/components/modal/edit-slow-mode";
@@ -27,6 +28,7 @@ const SCROLL_DELAY = 500;
 export default class TopicRoute extends DiscourseRoute {
   @service composer;
   @service screenTrack;
+  @service currentUser;
   @service modal;
   @service router;
 
@@ -104,7 +106,7 @@ export default class TopicRoute extends DiscourseRoute {
 
   @action
   showFlags(model) {
-    this.modal.show(FlagModal, {
+    this.modal.show(this.currentUser ? FlagModal : AnonymousFlagModal, {
       model: {
         flagTarget: new PostFlag(),
         flagModel: model,

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -220,7 +220,7 @@ registerButton(
       (siteSettings.allow_tl0_and_anonymous_users_to_flag_illegal_content &&
         !currentUser)
     ) {
-      let button = {
+      const button = {
         action: "showFlags",
         title: currentUser
           ? "post.controls.flag"

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -211,20 +211,30 @@ registerButton("flag-count", (attrs) => {
   };
 });
 
-registerButton("flag", (attrs) => {
-  if (attrs.reviewableId || (attrs.canFlag && !attrs.hidden)) {
-    let button = {
-      action: "showFlags",
-      title: "post.controls.flag",
-      icon: "flag",
-      className: "create-flag",
-    };
-    if (attrs.reviewableId) {
-      button.before = "flag-count";
+registerButton(
+  "flag",
+  (attrs, _state, siteSettings, _postMenuSettings, currentUser) => {
+    if (
+      attrs.reviewableId ||
+      (attrs.canFlag && !attrs.hidden) ||
+      (siteSettings.allow_tl0_and_anonymous_users_to_flag_illegal_content &&
+        !currentUser)
+    ) {
+      let button = {
+        action: "showFlags",
+        title: currentUser
+          ? "post.controls.flag"
+          : "post.controls.anonymous_flag",
+        icon: "flag",
+        className: "create-flag",
+      };
+      if (attrs.reviewableId) {
+        button.before = "flag-count";
+      }
+      return button;
     }
-    return button;
   }
-});
+);
 
 registerButton("edit", (attrs) => {
   if (attrs.canEdit) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3890,6 +3890,7 @@ en:
         edit_anonymous: "Sorry, but you need to be logged in to edit this post."
         flag_action: "Flag"
         flag: "privately flag this post for attention or send a personal message about it"
+        anonymous_flag: "send an email to staff to flag this post"
         delete_action: "Delete post"
         delete: "delete this post"
         undelete_action: "Undelete post"
@@ -4206,6 +4207,11 @@ en:
         all: "all topics"
         none: "no subcategories"
       colors_disabled: "You can’t select colors because you have a category style of none."
+
+    anonymous_flagging:
+      title: "Report illegal content"
+      description: "To report illegal content, please contact %{contact_info}."
+      illegal_content: "Illegal content: "
 
     flagging:
       title: "Thanks for keeping our community civil!"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4211,7 +4211,8 @@ en:
     anonymous_flagging:
       title: "Report illegal content"
       description: "To report illegal content, please contact %{contact_info}."
-      illegal_content: "Illegal content: "
+      email_subject: "Illegal content: %{title}"
+      email_body: "The post %{url} contains illegal content."
 
     flagging:
       title: "Thanks for keeping our community civil!"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4210,9 +4210,7 @@ en:
 
     anonymous_flagging:
       title: "Report illegal content"
-      description: "To report illegal content, please contact %{contact_info}."
-      email_subject: "Illegal content: %{title}"
-      email_body: "The post %{url} contains illegal content."
+      description: "To report illegal content, please contact <a href='mailto:%{email}?subject=Illegal content: %{topic_title}&body=This post %{url} contains illegal content.'>%{email}</a>"
 
     flagging:
       title: "Thanks for keeping our community civil!"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -364,7 +364,7 @@ en:
       slow_down_crawler_user_agent_cannot_be_popular_browsers: "You cannot add any of the following values to the setting: %{values}."
       strip_image_metadata_cannot_be_disabled_if_composer_media_optimization_image_enabled: "You cannot disable strip image metadata if 'composer media optimization image enabled' is enabled. Disable 'composer media optimization image enabled' before disabling strip image metadata."
       twitter_summary_large_image_no_svg: "Twitter summary images used for twitter:image metadata cannot be an .svg image."
-      tl0_and_anonymous_flag: "Either site contact email or email address to report illegal content must be provided for anonymous users."
+      tl0_and_anonymous_flag: "Either 'site contact email' or 'email address to report illegal content' must be provided for anonymous users."
 
     conflicting_google_user_id: 'The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to <br><a href="https://meta.discourse.org/t/76575">https://meta.discourse.org/t/76575</a>'
     onebox:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -364,6 +364,8 @@ en:
       slow_down_crawler_user_agent_cannot_be_popular_browsers: "You cannot add any of the following values to the setting: %{values}."
       strip_image_metadata_cannot_be_disabled_if_composer_media_optimization_image_enabled: "You cannot disable strip image metadata if 'composer media optimization image enabled' is enabled. Disable 'composer media optimization image enabled' before disabling strip image metadata."
       twitter_summary_large_image_no_svg: "Twitter summary images used for twitter:image metadata cannot be an .svg image."
+      tl0_and_anonymous_flag: "Either site contact email or email address to report illegal content must be provided for anonymous users."
+
     conflicting_google_user_id: 'The Google Account ID for this account has changed; staff intervention is required for security reasons. Please contact staff and point them to <br><a href="https://meta.discourse.org/t/76575">https://meta.discourse.org/t/76575</a>'
     onebox:
       invalid_address: "Sorry, we were unable to generate a preview for this web page, because the server '%{hostname}' could not be found. Instead of a preview, only a link will appear in your post. :cry:"
@@ -2307,6 +2309,8 @@ en:
     reviewable_default_visibility: "Don't show reviewable items unless they meet this priority"
     reviewable_low_priority_threshold: "The priority filter hides reviewable items that don't meet this score unless the '(any)' filter is used."
     high_trust_flaggers_auto_hide_posts: "New user posts are automatically hidden after being flagged as spam by a TL3+ user"
+    allow_tl0_and_anonymous_users_to_flag_illegal_content: "Anonymous users will see information that they have to e-mail administrators to report illegal content."
+    email_address_to_report_illegal_content: "If left blank the default site admin email will be used."
     cooldown_hours_until_reflag: "How much time users will have to wait until they are able to reflag a post"
     slow_mode_prevents_editing: "Does 'Slow Mode' prevent editing, after editing_grace_period?"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -54,6 +54,7 @@ required:
     default: ""
     type: email
     area: "about|notifications|legal"
+    client: true
   contact_url:
     default: ""
     area: "about|legal"
@@ -1938,6 +1939,14 @@ trust:
     allow_any: false
     refresh: true
     area: "group_permissions"
+  allow_tl0_and_anonymous_users_to_flag_illegal_content:
+    default: false
+    area: "flags"
+    client: true
+  email_address_to_report_illegal_content:
+    default: ""
+    area: "flags"
+    client: true
   min_trust_to_post_links:
     default: 0
     enum: "TrustLevelSetting"

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -94,6 +94,10 @@ module PostGuardian
                 post.topic.private_message?
             )
         ) ||
+          (
+            action_key == :illegal &&
+              SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content
+          ) ||
           # not a flagging action, and haven't done it already
           not(is_flag || already_taken_this_action) &&
             # nothing except flagging on archived topics

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -267,6 +267,14 @@ module SiteSettings::Validations
     validate_error :twitter_summary_large_image_no_svg
   end
 
+  def validate_allow_tl0_and_anonymous_users_to_flag_illegal_content(new_val)
+    return if new_val == "f"
+    return if SiteSetting.contact_email.present?
+    return if SiteSetting.email_address_to_report_illegal_content.present?
+
+    validate_error :tl0_and_anonymous_flag
+  end
+
   private
 
   def validate_bucket_setting(setting_name, upload_bucket, backup_bucket)

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -269,8 +269,7 @@ module SiteSettings::Validations
 
   def validate_allow_tl0_and_anonymous_users_to_flag_illegal_content(new_val)
     return if new_val == "f"
-    return if SiteSetting.contact_email.present?
-    return if SiteSetting.email_address_to_report_illegal_content.present?
+    return if SiteSetting.contact_email.present? || SiteSetting.email_address_to_report_illegal_content.present?
 
     validate_error :tl0_and_anonymous_flag
   end

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -269,7 +269,10 @@ module SiteSettings::Validations
 
   def validate_allow_tl0_and_anonymous_users_to_flag_illegal_content(new_val)
     return if new_val == "f"
-    return if SiteSetting.contact_email.present? || SiteSetting.email_address_to_report_illegal_content.present?
+    if SiteSetting.contact_email.present? ||
+         SiteSetting.email_address_to_report_illegal_content.present?
+      return
+    end
 
     validate_error :tl0_and_anonymous_flag
   end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -163,6 +163,16 @@ RSpec.describe Guardian do
       Flag.reset_flag_settings!
     end
 
+    it "return true for illegal if tl0 and allow_tl0_and_anonymous_users_to_flag_illegal_content" do
+      SiteSetting.flag_post_allowed_groups = ""
+      user.trust_level = TrustLevel[0]
+      expect(Guardian.new(user).post_can_act?(post, :illegal)).to be false
+
+      SiteSetting.email_address_to_report_illegal_content = "illegal@example.com"
+      SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
+      expect(Guardian.new(user).post_can_act?(post, :illegal)).to be true
+    end
+
     it "works as expected for silenced users" do
       UserSilencer.silence(user, admin)
 

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -474,4 +474,19 @@ RSpec.describe SiteSettings::Validations do
       expect { validations.validate_twitter_summary_large_image(nil) }.not_to raise_error
     end
   end
+
+  describe "#validate_allow_tl0_and_anonymous_users_to_flag_illegal_content" do
+    it "does not allow to enable when no contact email is provided" do
+      expect {
+        validations.validate_allow_tl0_and_anonymous_users_to_flag_illegal_content("t")
+      }.to raise_error(
+        Discourse::InvalidParameters,
+        I18n.t("errors.site_settings.tl0_and_anonymous_flag"),
+      )
+      SiteSetting.contact_email = "illegal@example.com"
+      expect {
+        validations.validate_allow_tl0_and_anonymous_users_to_flag_illegal_content("t")
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/requests/admin/config/site_settings_controller_spec.rb
+++ b/spec/requests/admin/config/site_settings_controller_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe Admin::SiteSettingsController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["site_settings"].map { |s| s["setting"] }).to match_array(
           %w[
+            allow_tl0_and_anonymous_users_to_flag_illegal_content
+            email_address_to_report_illegal_content
             silence_new_user_sensitivity
             num_users_to_silence_new_user
             flag_sockpuppets

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -164,6 +164,8 @@ describe "Admin Flags Page", type: :system do
     admin_flags_page.click_settings_tab
     expect(page.all(".setting-label h3").map(&:text).map(&:downcase)).to eq(
       [
+        "allow tl0 and anonymous users to flag illegal content",
+        "email address to report illegal content",
         "silence new user sensitivity",
         "num users to silence new user",
         "flag sockpuppets",

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -67,7 +67,7 @@ describe "Flagging post", type: :system do
       SiteSetting.email_address_to_report_illegal_content = "illegal@example.com"
       SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
       topic_page.visit_topic(post_to_flag.topic).open_flag_topic_modal
-      expect(flag_modal).to have_choices("It's Illegal")
+      expect(flag_modal).to have_choices(I18n.t("js.flagging.formatted_name.illegal"))
     end
   end
 

--- a/spec/system/page_objects/modals/anonoymous_flag.rb
+++ b/spec/system/page_objects/modals/anonoymous_flag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class AnonymousFlag < PageObjects::Modals::Base
+      BODY_SELECTOR = ".anonymous-flag-modal__body"
+    end
+  end
+end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -78,6 +78,10 @@ module PageObjects
         ".topic-post:not(.staged) #post_#{post_number}"
       end
 
+      def has_no_post_more_actions?(post)
+        within_post(post) { has_no_css?(".show-more-actions") }
+      end
+
       def has_post_more_actions?(post)
         within_post(post) { has_css?(".show-more-actions") }
       end
@@ -298,6 +302,10 @@ module PageObjects
 
       def move_to_public_modal
         find(".modal.convert-to-public-topic")
+      end
+
+      def has_no_flag_button?
+        has_no_css?(".post-action-menu__flag.create-flag")
       end
 
       def open_flag_topic_modal


### PR DESCRIPTION
The new site setting `allow_anonymous_and_tl0_to_flag_illegal` allows tl0 users to flag illegal content. In addition, anonymous users are instructed on how to flag illegal content by sending emails.

Also `email_address_to_report_illegal_content` setting is added. If not provided, then the site contact email is used.

<img width="1374" alt="Screenshot 2025-01-15 at 3 20 33 PM" src="https://github.com/user-attachments/assets/807fcc3f-b4bc-4abc-b936-fc3181fe8b95" />
<img width="1384" alt="Screenshot 2025-01-15 at 3 20 14 PM" src="https://github.com/user-attachments/assets/7c8829db-8605-42ca-adee-505c20327c19" />
