### PR TITLE
FIX: `S3Inventory#backfill_etags_and_list_missing` need to unescape key

### DIFF
--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -65,7 +65,7 @@ class S3Inventory
                 next if key.exclude?("#{type}/")
 
                 url = File.join(Discourse.store.absolute_base_url, key)
-                connection.put_copy_data("#{url},#{row[CSV_ETAG_INDEX]}\n")
+                connection.put_copy_data("#{CGI.unescape(url)},#{row[CSV_ETAG_INDEX]}\n")
               end
             end
 

--- a/spec/fixtures/csv/s3_inventory.csv
+++ b/spec/fixtures/csv/s3_inventory.csv
@@ -1,4 +1,5 @@
 "abc","uploads/default/original/1X/0184537a4f419224404d013414e913a4f56018f2.jpg","defcaac0b4aca535c284e95f30d608d0"
 "abc","uploads/default/original/1X/050afc0ab01debe8cf48fd2ce50fbbf5eb072815.jpg","0cdc623af39cde0adb382670a6dc702a"
 "abc","uploads/default/original/1X/0789fbf5490babc68326b9cec90eeb0d6590db05.png","25c02eaceef4cb779fc17030d33f7f06"
+"abc","uploads/default/original/1X/583bd7617044b269ae87a98684365d794e17b493.png%28test","25c02eaceef4cb779fc17030d33f7f51"
 "abc","uploads/second/original/1X/f789fbf5490babc68326b9cec90eeb0d6590db03.png","15c02eaceef4cb779fc17030d33f7f04"

--- a/spec/lib/s3_inventory_multisite_spec.rb
+++ b/spec/lib/s3_inventory_multisite_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "S3Inventory", type: :multisite do
     db1 = files["default"].read
     db2 = files["second"].read
 
-    expect(db1.lines.count).to eq(3)
+    expect(db1.lines.count).to eq(4)
     expect(db2.lines.count).to eq(1)
 
     files.values.each do |f|


### PR DESCRIPTION
The `key` provided in the S3 inventory file will esacpe any special
characters in the filename of the key so we need to unescape. Otherwise,
uploads with extensions that conatins special characters will fail to
match records which we insert into the temporary table based off the
s3 inventory file.
