### PR TITLE
DEV: Better detect tablet devices

### DIFF
--- a/app/assets/javascripts/discourse/app/services/capabilities.js
+++ b/app/assets/javascripts/discourse/app/services/capabilities.js
@@ -11,12 +11,9 @@ class Capabilities {
   isIpadOS = ua.includes("Mac OS") && !/iPhone|iPod/.test(ua) && this.touch;
   isTabletScreen =
     this.touch &&
-    ((window.innerWidth >= 600 && window.innerWidth <= 1280) ||
-      (window.innerHeight >= 600 && window.innerHeight <= 1280));
-  isTablet =
-    this.isTabletScreen ||
-    this.isIpadOS ||
-    /iPad|Android(?!.*Mobile)|Tablet/.test(ua);
+    (window.innerWidth >= 600 || window.innerHeight >= 600) &&
+    window.matchMedia("(hover: none)").matches;
+  isTablet = this.isTabletScreen || this.isIpadOS;
 
   isIOS = (/iPhone|iPod/.test(ua) || this.isIpadOS) && !window.MSStream;
   isApple =


### PR DESCRIPTION
Still a WIP, the goal is to isolate tablets from touchscreen desktops. The `(hover: none)` media query check should return true for tablets and false for touchscreen desktops, in theory, need to test further.