### PR TITLE
DEV: Add topic_hot_score association to topic.rb

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -286,6 +286,7 @@ class Topic < ActiveRecord::Base
            dependent: :destroy
 
   has_one :top_topic
+  has_one :topic_hot_score
   has_one :shared_draft, dependent: :destroy
   has_one :published_page
 


### PR DESCRIPTION
We have the other side of this association wired up -- 
https://github.com/discourse/discourse/blob/da72ad4ecddffc837cd9ec82624f51bbc22c6fc4/app/models/topic_hot_score.rb#L4

This commit simply adds the association to `Topic` model so we can reference the hot score.