### PR TITLE
UX: Removed a redundant git pull statement from the docs

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -155,7 +155,6 @@ Alternatively, you can ssh into your server and rebuild using:
 
 ```
 cd /var/discourse
-git pull
 ./launcher rebuild app
 ```
 

--- a/plugins/spoiler-alert/README.md
+++ b/plugins/spoiler-alert/README.md
@@ -32,7 +32,6 @@ hooks:
 
 ```
 cd /var/discourse
-git pull
 ./launcher rebuild app
 ```
 


### PR DESCRIPTION
`git pull` statement is now redundant and not needed