### PR TITLE
UX: Tweak plugin and customize-based admin page margins

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize.hbs
@@ -58,6 +58,6 @@
   </AdminNav>
 {{/unless}}
 
-<div class="admin-container">
+<div class="admin-config-page">
   {{outlet}}
 </div>

--- a/app/assets/javascripts/admin/addon/templates/plugins.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins.hbs
@@ -32,7 +32,7 @@
   </div>
 {{/if}}
 
-<div class="admin-container -no-header">
+<div class="admin-config-page -no-header">
   {{#each this.brokenAdminRoutes as |route|}}
     <div class="alert alert-error">
       {{i18n "admin.plugins.broken_route" name=(i18n route.label)}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-plugins-test.js
@@ -47,7 +47,7 @@ acceptance("Admin - Plugins", function (needs) {
       .hasText("Some Test Plugin", "displays the plugin in the table");
 
     assert
-      .dom(".admin-plugins .admin-container .alert-error")
+      .dom(".admin-plugins .admin-config-page .alert-error")
       .exists("shows an error for unknown routes");
 
     assert


### PR DESCRIPTION
## ✨ What's This?

Admin pages that are based off the customize or plugin templates were wrapped in the `admin-container` class, which has slightly different margins to the `admin-config-page` class, which is used on most admin pages.

This change ensures that all the admin pages have the same alignment.

## 👑 Testing

Click between different admin pages, make sure the breadcrumb and heading all appear in the same location.