### PR TITLE
FIX: Process tag synonyms when approving reviewable queued post

### DIFF
--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -320,6 +320,16 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       expect(Topic.count).to eq(topic_count)
       expect(Post.count).to eq(post_count)
     end
+
+    it "remaps tags with synonyms when approved" do
+      syn_tag = Fabricate(:tag, name: "syntag", target_tag: Fabricate(:tag, name: "maintag"))
+      reviewable.payload["tags"] += ["syntag"]
+
+      result = reviewable.perform(moderator, :approve_post)
+
+      expect(result.success?).to eq(true)
+      expect(result.created_post_topic.tags.pluck(:name)).to match_array(%w[cool neat maintag])
+    end
   end
 
   describe "Callbacks" do


### PR DESCRIPTION
Followup 72c4709a5ab26f00e32b65d874b3a206d679181e

Previously we made a fix to allow skip validations when tagging
a topic via TopicCreator. However, this flow also skips a lot of
the more in-depth work on tags we do when creating a topic, like
processing tag synonyms. When approving reviewable queued posts,
we skip validations, so this would cause an issue where a topic
was approved and the tag synonyms weren't applied.

This commit changes the logic so we attempt the more complete
`DiscourseTagging.tag_topic_by_names` call first and if this fails
and skip validations is on, then we do `DiscourseTagging.add_or_create_tags_by_name`.
This at least gives a chance for the full workflow to work first.
