### PR TITLE
DEV: applyBehaviorTransformer for composer-position editTouchMove

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
@@ -1,4 +1,5 @@
 import { later } from "@ember/runloop";
+import { applyBehaviorTransformer } from "discourse/lib/transformer";
 
 export function setupComposerPosition(editor) {
   // This component contains two composer positioning adjustments
@@ -10,11 +11,13 @@ export function setupComposerPosition(editor) {
     // This is an alternative to locking up the body
     // It stops scrolling in the given element from bubbling up to the body
     // when the editor does not have any content to scroll
-    const notScrollable = editor.scrollHeight <= editor.clientHeight;
-    if (notScrollable) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
+    applyBehaviorTransformer("composer-position:editor-touch-move", () => {
+      const notScrollable = editor.scrollHeight <= editor.clientHeight;
+      if (notScrollable) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    });
   }
 
   if (

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -1,5 +1,6 @@
 export const BEHAVIOR_TRANSFORMERS = Object.freeze([
   // use only lowercase names
+  "composer-position:editor-touch-move",
   "discovery-topic-list-load-more",
   "full-page-search-load-more",
 ]);


### PR DESCRIPTION
In a theme or plugin, if you have a scrollable mobile composer, you may want to allow scrolling events on the composer editor.. this allows for it!