### PR TITLE
FIX: Add a DB migration to update font site settings types

### DIFF
--- a/db/migrate/20250116024516_update_font_site_settings_type.rb
+++ b/db/migrate/20250116024516_update_font_site_settings_type.rb
@@ -5,6 +5,6 @@ class UpdateFontSiteSettingsType < ActiveRecord::Migration[7.2]
   end
 
   def down
-    execute "UPDATE site_settings SET data_type=1 WHERE name IN('base_font', 'heading_font')"
+    execute "UPDATE site_settings SET data_type=7 WHERE name IN('base_font', 'heading_font')"
   end
 end

--- a/db/migrate/20250116024516_update_font_site_settings_type.rb
+++ b/db/migrate/20250116024516_update_font_site_settings_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class UpdateFontSiteSettingsType < ActiveRecord::Migration[7.2]
+  def up
+    execute "UPDATE site_settings SET data_type=8 WHERE name IN('base_font', 'heading_font')"
+  end
+
+  def down
+    execute "UPDATE site_settings SET data_type=1 WHERE name IN('base_font', 'heading_font')"
+  end
+end


### PR DESCRIPTION
## ✨ What's This?

This PR is  a follow-up to #30636.

The previous change altered the `data_type` of the `base_font` and `heading_font` site settings, but didn't update the corresponding entries in the `site_settings` table to match.