### PR TITLE
DEV: Add base admin page page object

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,7 @@ Dir[Rails.root.join("spec/requests/examples/*.rb")].each { |f| require f }
 
 Dir[Rails.root.join("spec/system/helpers/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/system/page_objects/**/base.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/system/page_objects/**/*_base.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/system/page_objects/**/*.rb")].each { |f| require f }
 
 Dir[Rails.root.join("spec/fabricators/*.rb")].each { |f| require f }

--- a/spec/system/admin_embeddable_hosts_spec.rb
+++ b/spec/system/admin_embeddable_hosts_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe "Admin EmbeddableHost Management", type: :system do
     admin_embedding_page.visit
     expect(page).not_to have_content("#{author.username}")
 
-    admin_embedding_page.click_posts_and_topics_tab
+    admin_embedding_page.click_tab("posts-and-topics")
 
     admin_embedding_posts_and_topics_page.fill_in_embed_by_username(author)
     admin_embedding_posts_and_topics_page.click_save
 
-    admin_embedding_page.click_hosts_tab
+    admin_embedding_page.click_tab("hosts")
     expect(page).to have_content("#{author.username}")
   end
 end

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -157,11 +157,11 @@ describe "Admin Flags Page", type: :system do
   it "has settings tab" do
     admin_flags_page.visit
 
-    expect(d_page_header).to have_tabs(
+    expect(admin_flags_page).to have_tabs(
       [I18n.t("admin_js.settings"), I18n.t("admin_js.admin.config_areas.flags.flags_tab")],
     )
 
-    admin_flags_page.click_settings_tab
+    admin_flags_page.click_tab("settings")
     expect(page.all(".setting-label h3").map(&:text).map(&:downcase)).to eq(
       [
         "silence new user sensitivity",

--- a/spec/system/page_objects/components/d_page_header.rb
+++ b/spec/system/page_objects/components/d_page_header.rb
@@ -4,7 +4,15 @@ module PageObjects
   module Components
     class DPageHeader < PageObjects::Pages::Base
       def has_tabs?(names)
-        expect(page.all(".d-nav-submenu__tabs a").map(&:text)).to eq(names)
+        expect(page.all("#{tabs_container_selector} a").map(&:text)).to eq(names)
+      end
+
+      def has_active_tab?(tab_name)
+        find("#{tab_selector(tab_name)} .active")
+      end
+
+      def tab(tab_name)
+        find(tab_selector(tab_name))
       end
 
       def visible?
@@ -13,6 +21,20 @@ module PageObjects
 
       def hidden?
         has_no_css?(".d-page-header")
+      end
+
+      private
+
+      def tabs_container_selector
+        "ul.d-nav-submenu__tabs"
+      end
+
+      def tab_item_selector(tab_name)
+        "li[class$='-tabs__#{tab_name}']"
+      end
+
+      def tab_selector(tab_name)
+        "#{tabs_container_selector} > #{tab_item_selector(tab_name)}"
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_backups.rb
+++ b/spec/system/page_objects/pages/admin_backups.rb
@@ -2,21 +2,10 @@
 
 module PageObjects
   module Pages
-    class AdminBackups < PageObjects::Pages::Base
+    class AdminBackups < AdminBase
       def visit_page
         page.visit "/admin/backups"
         self
-      end
-
-      def click_tab(tab_name)
-        case tab_name
-        when "settings"
-          find(".admin-backups-tabs__settings").click
-        when "files"
-          find(".admin-backups-tabs__files").click
-        when "logs"
-          find(".admin-backups-tabs__logs").click
-        end
       end
 
       def has_backup_listed?(filename)

--- a/spec/system/page_objects/pages/admin_base.rb
+++ b/spec/system/page_objects/pages/admin_base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminBase < Base
+      def click_tab(tab_name)
+        header.tab(tab_name).click
+      end
+
+      delegate(:has_tabs?, :has_active_tab?, to: :header)
+
+      private
+
+      def header
+        @header ||= Components::DPageHeader.new
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_embedding.rb
+++ b/spec/system/page_objects/pages/admin_embedding.rb
@@ -2,18 +2,10 @@
 
 module PageObjects
   module Pages
-    class AdminEmbedding < PageObjects::Pages::Base
+    class AdminEmbedding < AdminBase
       def visit
         page.visit("/admin/customize/embedding")
         self
-      end
-
-      def click_posts_and_topics_tab
-        find(".admin-embedding-tabs__posts-and-topics").click
-      end
-
-      def click_hosts_tab
-        find(".admin-embedding-tabs__hosts").click
       end
 
       def click_add_host

--- a/spec/system/page_objects/pages/admin_emojis.rb
+++ b/spec/system/page_objects/pages/admin_emojis.rb
@@ -2,19 +2,10 @@
 
 module PageObjects
   module Pages
-    class AdminEmojis < PageObjects::Pages::Base
+    class AdminEmojis < AdminBase
       def visit_page
         page.visit "/admin/config/emoji"
         self
-      end
-
-      def click_tab(tab_name)
-        case tab_name
-        when "settings"
-          find(".admin-emoji-tabs__settings").click
-        when "index"
-          find(".admin-emoji-tabs__emoji").click
-        end
       end
 
       def has_emoji_listed?(name)

--- a/spec/system/page_objects/pages/admin_flags.rb
+++ b/spec/system/page_objects/pages/admin_flags.rb
@@ -2,7 +2,7 @@
 
 module PageObjects
   module Pages
-    class AdminFlags < PageObjects::Pages::Base
+    class AdminFlags < AdminBase
       def visit
         page.visit("/admin/config/flags")
         self
@@ -104,11 +104,6 @@ module PageObjects
       def confirm_delete
         find(".dialog-footer .btn-primary").click
         expect(page).to have_no_css(".dialog-body", wait: Capybara.default_max_wait_time * 3)
-        self
-      end
-
-      def click_settings_tab
-        find(".admin-flags-tabs__settings a").click
         self
       end
     end

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -2,7 +2,7 @@
 
 module PageObjects
   module Pages
-    class AdminPermalinks < PageObjects::Pages::Base
+    class AdminPermalinks < AdminBase
       def visit
         page.visit("/admin/config/permalinks")
         self
@@ -64,15 +64,6 @@ module PageObjects
 
       def has_closed_permalink_menu?
         has_no_css?(".permalink-menu-content")
-      end
-
-      def click_tab(tab)
-        has_css?(".admin-permalinks-tabs__#{tab}")
-        find(".admin-permalinks-tabs__#{tab}").click
-      end
-
-      def has_active_tab?(tab)
-        has_css?(".admin-permalinks-tabs__#{tab} .active")
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_users.rb
+++ b/spec/system/page_objects/pages/admin_users.rb
@@ -2,7 +2,7 @@
 
 module PageObjects
   module Pages
-    class AdminUsers < PageObjects::Pages::Base
+    class AdminUsers < AdminBase
       class UserRow
         attr_reader :element
 
@@ -75,16 +75,6 @@ module PageObjects
 
       def has_none_users?
         has_content?(I18n.t("js.search.no_results"))
-      end
-
-      def click_tab(tab)
-        has_css?(".admin-users-tabs__#{tab}")
-        find(".admin-users-tabs__#{tab}").click
-      end
-
-      def has_active_tab?(tab)
-        has_css?(".admin-users-tabs__#{tab} .active")
-        has_no_css?(".loading-container .visible")
       end
 
       def has_no_emails?


### PR DESCRIPTION
### What is this change?

This PR proposes a base page object for admin pages. Since we're standardizing using components, this makes writing tests easier by abstracting away details about selectors.

This initial version instantiates a `DPageHeader` page object and delegates tab related actions to it, but over time we can add more stuff here as we standardize more.

We should probably have the components auto-generate the class names as well in the future, to further reduce manual toil and risk for mistakes.