### PR TITLE
FIX: do not store 0 has min width for thead panel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.gjs
@@ -27,7 +27,7 @@ export default class ChatSidePanel extends Component {
     }
 
     const validWidth = Math.min(
-      this.store.getObject("width"),
+      this.store.getObject("width") ?? MIN_PANEL_WIDTH,
       this.mainContainerWidth - MIN_PANEL_WIDTH
     );
 


### PR DESCRIPTION
When we had no width stored for the side panel in the local storage, essentially the computation would end up being:

```javascript
Math.min(null, 1000);
```

Which would output: 0. This commit ensures we have a default for store width: MIN_PANEL_WIDTH.

Tried to wite a test but couldn't get something reliable.