### PR TITLE
DEV: Relax 'unexpectedly found' matcher in deprecation-silencer

### DIFF
--- a/app/assets/javascripts/deprecation-silencer/index.js
+++ b/app/assets/javascripts/deprecation-silencer/index.js
@@ -1,6 +1,6 @@
 const SILENCED_WARN_PREFIXES = [
   "Setting the `jquery-integration` optional feature flag",
-  'unexpectedly found "!', // https://github.com/emberjs/ember.js/issues/19392
+  'unexpectedly found "', // https://github.com/emberjs/ember.js/issues/19392
 ];
 
 class DeprecationSilencer {


### PR DESCRIPTION
We managed to find a slightly different way to trigger the same Ember bug. This commit makes sure that's silenced as well.