### PR TITLE
DEV: Enable ember-template-imports sourcemaps

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -37,6 +37,9 @@ module.exports = function (defaults) {
     "ember-qunit": {
       insertContentForTestBody: false,
     },
+    "ember-template-imports": {
+      inline_source_map: true,
+    },
     sourcemaps: {
       // There seems to be a bug with broccoli-concat when sourcemaps are disabled
       // that causes the `app.import` statements below to fail in production mode.


### PR DESCRIPTION
This improves the developer experience, and also happens to workaround https://github.com/embroider-build/content-tag/issues/92 in our production builds.