### PR TITLE
UX: improve the alignment of long status messages

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-status-message.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-status-message.gjs
@@ -36,14 +36,16 @@ export default class UserStatusMessage extends Component {
         </:trigger>
         <:content>
           {{emoji @status.emoji skipTitle=true}}
-          <span class="user-status-tooltip-description">
-            {{@status.description}}
-          </span>
-          {{#if this.until}}
-            <div class="user-status-tooltip-until">
-              {{this.until}}
-            </div>
-          {{/if}}
+          <div class="user-status-tooltip-wrapper">
+            <span class="user-status-tooltip-description">
+              {{@status.description}}
+            </span>
+            {{#if this.until}}
+              <span class="user-status-tooltip-until">
+                {{this.until}}
+              </span>
+            {{/if}}
+          </div>
         </:content>
       </DTooltip>
     {{/if}}

--- a/app/assets/stylesheets/common/components/user-status-message.scss
+++ b/app/assets/stylesheets/common/components/user-status-message.scss
@@ -1,4 +1,8 @@
 [data-content][data-identifier="user-status-message-tooltip"] {
+  .fk-d-tooltip__inner-content {
+    gap: 0.65em;
+  }
+
   .emoji {
     width: 1em;
     height: 1em;
@@ -9,14 +13,9 @@
     color: var(--primary-800);
   }
 
-  .user-status-tooltip-description {
-    font-weight: bold;
-    margin-left: 0.25rem;
-    vertical-align: middle;
-  }
-
   .user-status-tooltip-until {
     color: var(--primary-medium);
-    padding-left: 0.25rem;
+    white-space: nowrap;
+    margin-left: 0.15em;
   }
 }


### PR DESCRIPTION
Before: 

![image](https://github.com/user-attachments/assets/77005641-2289-4296-8988-242c139a376d)

After: 

![image](https://github.com/user-attachments/assets/25889d78-7a5d-4097-9242-5cbd82e909ca)

Short message layout stays mostly unchanged: 

![image](https://github.com/user-attachments/assets/893a8f03-0e24-4e68-bc6b-2469eba0523c)
