### PR TITLE
FIX: Expand the hidden post menu when one option is available.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu.gjs
@@ -3,6 +3,7 @@ import { cached, tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { isEmpty, isPresent } from "@ember/utils";
 import { and, eq } from "truth-helpers";
@@ -395,6 +396,11 @@ export default class PostMenu extends Component {
     return items;
   }
 
+  @action
+  expandIfOnlyOneHiddenButton() {
+    this.collapsed = this.renderableCollapsedButtons.length > 1;
+  }
+
   @cached
   get renderableCollapsedButtons() {
     return this.availableCollapsedButtons.filter((button) =>
@@ -603,6 +609,7 @@ export default class PostMenu extends Component {
             "replies-button-visible"
           )
         }}
+        {{didInsert this.expandIfOnlyOneHiddenButton}}
       >
         {{! do not include PluginOutlets here, use the PostMenu DAG API instead }}
         {{#each this.extraControls key="key" as |extraControl|}}

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test-with-glimmer-post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test-with-glimmer-post-menu-test.js
@@ -796,5 +796,21 @@ module(
 
       assert.dom(".user-status-message").doesNotExist();
     });
+
+    test("more actions button is displayed when multiple hidden items are configured", async function (assert) {
+      this.siteSettings.post_menu_hidden_items = "bookmark|edit|copyLink";
+
+      await render(hbs`
+    <MountWidget @widget="post" @model={{this.post}} @args={{this.args}} />`);
+      assert.dom(".show-more-actions").exists();
+    });
+
+    test("hidden menu expands automatically when only one hidden item is configured", async function (assert) {
+      this.siteSettings.post_menu_hidden_items = "bookmark|edit";
+
+      await render(hbs`
+    <MountWidget @widget="post" @model={{this.post}} @args={{this.args}} />`);
+      assert.dom(".show-more-actions").doesNotExist();
+    });
   }
 );

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -61,7 +61,6 @@ describe "Flagging post", type: :system do
 
     it "does not allow to mark posts as illegal" do
       topic_page.visit_topic(topic)
-      topic_page.expand_post_actions(post_to_flag)
       expect(topic_page).to have_no_flag_button
     end
 
@@ -86,7 +85,6 @@ describe "Flagging post", type: :system do
       SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
 
       topic_page.visit_topic(topic, post_number: post_to_flag.post_number)
-      topic_page.expand_post_actions(post_to_flag)
       topic_page.find_post_action_button(post_to_flag, :flag).click
 
       expect(anonymous_flag_modal.body).to have_content(
@@ -100,7 +98,6 @@ describe "Flagging post", type: :system do
 
       SiteSetting.email_address_to_report_illegal_content = "illegal@example.com"
       topic_page.visit_topic(topic)
-      topic_page.expand_post_actions(post_to_flag)
       topic_page.find_post_action_button(post_to_flag, :flag).click
 
       expect(anonymous_flag_modal.body).to have_content(


### PR DESCRIPTION
When only one option is available for the action menu, it should be automatically expanded for the glimmer component.

This is the default behaviour for the old post menu: https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/widgets/post-menu.js#L624