### PR TITLE
DEV: Add home-logo-minimized transformer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { and } from "truth-helpers";
 import deprecatedOutletArgument from "discourse/helpers/deprecated-outlet-argument";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import BootstrapModeNotice from "../bootstrap-mode-notice";
 import PluginOutlet from "../plugin-outlet";
 import HomeLogo from "./home-logo";
@@ -22,6 +23,18 @@ export default class Contents extends Component {
     }
 
     return "bars";
+  }
+
+  get minimized() {
+    return applyValueTransformer(
+      "home-logo-minimized",
+      this.args.topicInfoVisible,
+      {
+        topicInfo: this.args.topicInfo,
+        sidebarEnabled: this.args.sidebarEnabled,
+        showSidebar: this.args.showSidebar,
+      }
+    );
   }
 
   <template>
@@ -55,7 +68,7 @@ export default class Contents extends Component {
 
       <div class="home-logo-wrapper-outlet">
         <PluginOutlet @name="home-logo-wrapper">
-          <HomeLogo @minimized={{@topicInfoVisible}} />
+          <HomeLogo @minimized={{this.minimized}} />
         </PluginOutlet>
       </div>
 

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -12,6 +12,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "header-notifications-avatar-size",
   "home-logo-href",
   "home-logo-image-url",
+  "home-logo-minimized",
   "invite-simple-mode-topic",
   "latest-topic-list-item-class",
   "mentions-class",

--- a/app/assets/javascripts/discourse/tests/acceptance/transformers/home-logo-minimized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/transformers/home-logo-minimized-test.js
@@ -1,0 +1,24 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("home-logo-minimized transformer", function () {
+  test("can force minimize the logo", async function (assert) {
+    withPluginApi("1.34.0", (api) => {
+      api.registerValueTransformer("home-logo-minimized", () => true);
+    });
+
+    await visit("/");
+    assert.dom("#site-logo").hasClass("logo-small");
+  });
+
+  test("can force un-minimize the logo", async function (assert) {
+    withPluginApi("1.34.0", (api) => {
+      api.registerValueTransformer("home-logo-minimized", () => false);
+    });
+
+    await visit("/");
+    assert.dom("#site-logo").hasClass("logo-big");
+  });
+});


### PR DESCRIPTION
Similar to the `home-logo-href` and `home-logo-image-url` transformers, this PR adds a new `home-logo-minimized` transformer to allow plugins/themes to amend the default behavior of the header logo.

Internal topic: t/144688.