### PR TITLE
DEV: Clean up ember configuration

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -1,12 +1,14 @@
 "use strict";
 
+// This is used only in the test environment!
+// See app/helpers/application_helper.rb#discourse_config_environment
+// for the method that generates configs for other envs.
 module.exports = function (environment) {
   const ENV = {
     modulePrefix: "discourse",
     environment,
     rootURL: `${process.env.DISCOURSE_RELATIVE_URL_ROOT ?? ""}/`, // Add a trailing slash (not required by the Rails app in this env variable)
     locationType: "history",
-    historySupportMiddleware: false,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -17,9 +19,9 @@ module.exports = function (environment) {
         Date: false,
         String: false,
       },
+      _DEFAULT_ASYNC_OBSERVERS: true,
       LOG_STACKTRACE_ON_DEPRECATION: false,
     },
-    exportApplicationGlobal: true,
 
     APP: {
       // Here you can pass flags/options to your application instance
@@ -35,14 +37,6 @@ module.exports = function (environment) {
     // Default (normally false; true in core qunit runs)
   }
 
-  if (environment === "development") {
-    // ENV.APP.LOG_RESOLVER = true;
-    // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    // ENV.APP.LOG_TRANSITIONS = true;
-    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    // ENV.APP.LOG_VIEW_LOOKUPS = true;
-  }
-
   if (environment === "test") {
     // Testem prefers this...
     ENV.locationType = "none";
@@ -53,10 +47,6 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = "#ember-testing";
     ENV.APP.autoboot = false;
-  }
-
-  if (environment === "production") {
-    // here you can enable a production-specific feature
   }
 
   return ENV;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,9 @@ module ApplicationHelper
     @extra_body_classes ||= Set.new
   end
 
+  # This generated equivalent of Ember's config/environment.js is used
+  # in development, production, and theme tests. (i.e. everywhere except
+  # regular tests)
   def discourse_config_environment(testing: false)
     # TODO: Can this come from Ember CLI somehow?
     config = {
@@ -20,7 +23,6 @@ module ApplicationHelper
       environment: Rails.env,
       rootURL: Discourse.base_path,
       locationType: "history",
-      historySupportMiddleware: false,
       EmberENV: {
         FEATURES: {
         },
@@ -28,22 +30,26 @@ module ApplicationHelper
           Date: false,
           String: false,
         },
-        _APPLICATION_TEMPLATE_WRAPPER: false,
         _DEFAULT_ASYNC_OBSERVERS: true,
-        _JQUERY_INTEGRATION: true,
       },
       APP: {
         name: "discourse",
         version: "#{Discourse::VERSION::STRING} #{Discourse.git_version}",
-        exportApplicationGlobal: true,
+        # LOG_RESOLVER: true,
+        # LOG_ACTIVE_GENERATION: true,
+        # LOG_TRANSITIONS: true,
+        # LOG_TRANSITIONS_INTERNAL: true,
+        # LOG_VIEW_LOOKUPS: true,
       },
     }
 
     if testing
       config[:environment] = "test"
       config[:locationType] = "none"
-      config[:APP][:autoboot] = false
+      config[:APP][:LOG_ACTIVE_GENERATION] = false
+      config[:APP][:LOG_VIEW_LOOKUPS] = false
       config[:APP][:rootElement] = "#ember-testing"
+      config[:APP][:autoboot] = false
     end
 
     config.to_json


### PR DESCRIPTION
1. Add comments
2. Remove obsolete options: `historySupportMiddleware` (x2), `exportApplicationGlobal` (x2), `_APPLICATION_TEMPLATE_WRAPPER`, `_JQUERY_INTEGRATION`
3. Remove unused sections (dev, prod) from the test-only config
4. Add commented-out debug options to the "main" config
5. Copy options between configs for parity: `_DEFAULT_ASYNC_OBSERVERS`, `LOG_ACTIVE_GENERATION`, `LOG_VIEW_LOOKUPS`