### PR TITLE
UX: make room for composer when preview is not showing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -8,6 +8,13 @@
 >
   <div class="grippie"></div>
   {{#if this.composer.visible}}
+    {{html-class
+      (if
+        this.composer.showPreview
+        "composer-open-preview"
+        "composer-open-no-preview"
+      )
+    }}
     <ComposerMessages
       @composer={{this.composer.model}}
       @messageCount={{this.composer.messageCount}}

--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -51,8 +51,11 @@ export default class TopicNavigation extends Component {
     } else if (this.site.mobileView) {
       this.info.set("renderTimeline", false);
     } else {
-      const composerHeight =
-        document.querySelector("#reply-control")?.offsetHeight || 0;
+      const composerHeight = document.documentElement.classList.contains(
+        "composer-open-no-preview"
+      )
+        ? 0
+        : document.querySelector("#reply-control")?.offsetHeight || 0;
       const verticalSpace =
         window.innerHeight - composerHeight - headerOffset();
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -60,6 +60,10 @@
   align-items: center;
 }
 
+.composer-open-no-preview .sidebar-wrapper .sidebar-container {
+  height: 100%;
+}
+
 .sidebar-wrapper {
   display: flex;
   grid-area: sidebar;

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -46,6 +46,10 @@
   z-index: z("timeline");
 }
 
+.composer-open-no-preview .with-topic-progress {
+  bottom: env(safe-area-inset-bottom);
+}
+
 #topic-progress-wrapper {
   &.docked {
     .toggle-admin-menu {


### PR DESCRIPTION
Make more room for composer when preview is not showing

![image](https://github.com/user-attachments/assets/810251eb-533b-4e11-99bc-92a0d68d4d8d)

![image](https://github.com/user-attachments/assets/08804710-1216-4c42-a556-985b3183c293)

![image](https://github.com/user-attachments/assets/11b325df-a668-42d0-8bee-8427fb10f647)
