### PR TITLE
FIX: relative links in the insert hyperlink modal

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -483,9 +483,21 @@ export function setURLContainer(container) {
 }
 
 export function prefixProtocol(url) {
-  return !url.includes("://") && !url.startsWith("mailto:")
-    ? "https://" + url
-    : url;
+  if (!url || typeof url !== "string") {
+    return url;
+  }
+
+  url = url.trim();
+
+  if (url.startsWith("//")) {
+    return `https:${url}`;
+  }
+
+  if (url.startsWith("/") || url.includes("://") || url.startsWith("mailto:")) {
+    return url;
+  }
+
+  return `https://${url}`;
 }
 
 export function getCategoryAndTagUrl(category, subcategories, tag) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -184,6 +184,15 @@ module("Unit | Utility | url", function (hooks) {
       prefixProtocol("www.discourse.org/mailto:foo"),
       "https://www.discourse.org/mailto:foo"
     );
+    assert.strictEqual(
+      prefixProtocol("http://www.discourse.org"),
+      "http://www.discourse.org"
+    );
+    assert.strictEqual(
+      prefixProtocol("ftp://www.discourse.org"),
+      "ftp://www.discourse.org"
+    );
+    assert.strictEqual(prefixProtocol("/my/preferences"), "/my/preferences");
   });
 
   test("getCategoryAndTagUrl", function (assert) {


### PR DESCRIPTION
When trying to insert schemaless or relative links using the "insert hyperlink modal" in the composer, the resulting link would be wrongly prefixed with "https://"