### PR TITLE
UX: makes smile the default emoji-picker icon

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
@@ -14,7 +14,7 @@ export default class EmojiPicker extends Component {
   }
 
   get icon() {
-    return this.args.icon ?? "discourse-emojis";
+    return this.args.icon ?? "smile";
   }
 
   get context() {
@@ -38,10 +38,10 @@ export default class EmojiPicker extends Component {
       @onClose={{@onClose}}
     >
       <:trigger>
-        {{#if @icon}}
-          {{replaceEmoji (concat ":" @icon ":")}}
+        {{#if @emoji}}
+          {{replaceEmoji (concat ":" @emoji ":")}}
         {{else}}
-          {{icon "discourse-emojis"}}
+          {{icon this.icon}}
         {{/if}}
 
         {{#if @label}}

--- a/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
@@ -14,7 +14,7 @@ export default class EmojiPicker extends Component {
   }
 
   get icon() {
-    return this.args.icon ?? "smile";
+    return this.args.icon ?? "face-smile";
   }
 
   get context() {

--- a/app/assets/javascripts/discourse/app/components/user-status-picker.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-status-picker.gjs
@@ -46,7 +46,7 @@ export default class UserStatusPicker extends Component {
         }}
       >
         <EmojiPicker
-          @icon={{@status.emoji}}
+          @emoji={{@status.emoji}}
           @didSelectEmoji={{this.emojiSelected}}
           @btnClass="btn-emoji"
           @modalForMobile={{false}}

--- a/app/assets/javascripts/discourse/app/instance-initializers/enable-emoji.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/enable-emoji.js
@@ -16,7 +16,7 @@ export default {
         toolbar.addButton({
           id: "emoji",
           group: "extras",
-          icon: "smile",
+          icon: "face-smile",
           sendAction: () => {
             const menu = api.container.lookup("service:menu");
             menu.show(document.querySelector(".insert-composer-emoji"), {

--- a/app/assets/javascripts/discourse/app/instance-initializers/enable-emoji.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/enable-emoji.js
@@ -16,7 +16,7 @@ export default {
         toolbar.addButton({
           id: "emoji",
           group: "extras",
-          icon: "discourse-emojis",
+          icon: "smile",
           sendAction: () => {
             const menu = api.container.lookup("service:menu");
             menu.show(document.querySelector(".insert-composer-emoji"), {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -112,7 +112,7 @@ acceptance("User Status", function (needs) {
     await visit("/");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-smile").exists("empty status icon is shown");
+    assert.dom(".d-icon-face-smile").exists("empty status icon is shown");
 
     await pickEmoji(userStatusEmoji);
 
@@ -305,7 +305,7 @@ acceptance("User Status", function (needs) {
     await click(".btn.delete-status");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-smile").exists("empty status icon is shown");
+    assert.dom(".d-icon-face-smile").exists("empty status icon is shown");
     assert
       .dom(".user-status-description")
       .hasValue("", "no status description is shown");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -112,7 +112,7 @@ acceptance("User Status", function (needs) {
     await visit("/");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-discourse-emojis").exists("empty status icon is shown");
+    assert.dom(".d-icon-smile").exists("empty status icon is shown");
 
     await pickEmoji(userStatusEmoji);
 
@@ -305,7 +305,7 @@ acceptance("User Status", function (needs) {
     await click(".btn.delete-status");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-discourse-emojis").exists("empty status icon is shown");
+    assert.dom(".d-icon-smile").exists("empty status icon is shown");
     assert
       .dom(".user-status-description")
       .hasValue("", "no status description is shown");

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -64,7 +64,7 @@ class ChatSetupInit {
           label: "chat.emoji",
           id: "emoji",
           class: "chat-emoji-btn",
-          icon: "discourse-emojis",
+          icon: "smile",
           position: "dropdown",
           displayed: owner.lookup("service:site").mobileView,
           action(context) {


### PR DESCRIPTION
discourse-emojis is used in chat only for message actions to show a difference with the the other emojis so people don't think it's just the smiley emoji.