### PR TITLE
FEATURE: Improve `use_email_for_username_and_name_suggestions`

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2725,7 +2725,7 @@ en:
     create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
 
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
-    use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`)."
+    use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Warning: This can make it easier for bad actors to discover your members' full email address (because a large proportion of people share common serves like `gmail.com`)."
     use_name_for_username_suggestions: "Use a user's full name when suggesting usernames."
     suggest_weekends_in_date_pickers: "Include weekends (Saturday and Sunday) in date picker suggestions (disable this if you use Discourse only on weekdays, Monday through Friday)."
     show_bottom_topic_map: "Shows the topic map at the bottom of the topic when it has 10 replies or more."

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -7,6 +7,9 @@ module UserNameSuggester
   def self.suggest(*input, current_username: nil)
     name =
       input.find do |item|
+        if !SiteSetting.use_email_for_username_and_name_suggestions
+          next if item.to_s =~ User::EMAIL
+        end
         parsed_name = parse_name_from_email(item)
         break parsed_name if sanitize_username(parsed_name).present?
       end

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -967,7 +967,7 @@ RSpec.describe Email::Receiver do
 
       user = topic.user
       expect(user.staged).to eq(true)
-      expect(user.username).to eq("random.name")
+      expect(user.username).to eq("user1")
       expect(user.name).to eq("Случайная Имя")
     end
 
@@ -1090,10 +1090,12 @@ RSpec.describe Email::Receiver do
 
       it "associates email replies using both 'In-Reply-To' and 'References' headers" do
         expect { process(:email_reply_1) }.to change(Topic, :count).by(1) &
-          change(Post, :count).by(3)
+          change(Post, :count).by(3) & change(User, :count).by(3)
 
         topic = Topic.last
+        users = User.last(3)
         ordered_posts = topic.ordered_posts
+        expect(ordered_posts.size).to eq(3)
 
         expect(ordered_posts.first.raw).to eq("This is email reply **1**.")
 
@@ -1101,7 +1103,7 @@ RSpec.describe Email::Receiver do
           expect(post.action_code).to eq("invited_user")
           expect(post.user.email).to eq("one@foo.com")
 
-          expect(%w[two three].include?(post.custom_fields["action_code_who"])).to eq(true)
+          expect(users.map(&:username)).to include(post.custom_fields["action_code_who"])
         end
 
         expect { process(:email_reply_2) }.to change { topic.posts.count }.by(1)

--- a/spec/lib/user_name_suggester_spec.rb
+++ b/spec/lib/user_name_suggester_spec.rb
@@ -42,13 +42,21 @@ RSpec.describe UserNameSuggester do
       expect(UserNameSuggester.suggest("a")).to eq("a11")
     end
 
-    it "is able to guess a decent username from an email" do
-      expect(UserNameSuggester.suggest("bob@example.com")).to eq("bob")
+    it "doesn't suggest anything based on usernames by default" do
+      expect(UserNameSuggester.suggest("bob@example.com")).to eq("user1")
     end
 
-    it "has a special case for me and i emails" do
-      expect(UserNameSuggester.suggest("me@eviltrout.com")).to eq("eviltrout")
-      expect(UserNameSuggester.suggest("i@eviltrout.com")).to eq("eviltrout")
+    context "with use_email_for_username_and_name_suggestions enabled" do
+      before { SiteSetting.use_email_for_username_and_name_suggestions = true }
+
+      it "is able to guess a decent username from an email" do
+        expect(UserNameSuggester.suggest("bob@example.com")).to eq("bob")
+      end
+
+      it "has a special case for me and i emails" do
+        expect(UserNameSuggester.suggest("me@eviltrout.com")).to eq("eviltrout")
+        expect(UserNameSuggester.suggest("i@eviltrout.com")).to eq("eviltrout")
+      end
     end
 
     it "shortens very long suggestions" do
@@ -63,12 +71,14 @@ RSpec.describe UserNameSuggester do
     end
 
     it "doesn't suggest reserved usernames" do
+      SiteSetting.use_email_for_username_and_name_suggestions = true
       SiteSetting.reserved_usernames = "myadmin|steve|steve1"
       expect(UserNameSuggester.suggest("myadmin@hissite.com")).to eq("myadmin1")
       expect(UserNameSuggester.suggest("steve")).to eq("steve2")
     end
 
     it "doesn't suggest generic usernames" do
+      SiteSetting.use_email_for_username_and_name_suggestions = true
       UserNameSuggester::GENERIC_NAMES.each do |name|
         expect(UserNameSuggester.suggest("#{name}@apple.org")).to eq("apple")
       end


### PR DESCRIPTION
Previously this setting would only control values received in an 'email' field from an identity provider. This commit extends it, so that it also applies to email-like content in other fields. This provides improved protections against partial email addresses being leaked