### PR TITLE
DEV: Remove more ember options

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -19,7 +19,6 @@ module.exports = function (environment) {
         Date: false,
         String: false,
       },
-      _DEFAULT_ASYNC_OBSERVERS: true,
       LOG_STACKTRACE_ON_DEPRECATION: false,
     },
 

--- a/app/assets/javascripts/discourse/config/optional-features.json.js
+++ b/app/assets/javascripts/discourse/config/optional-features.json.js
@@ -3,5 +3,4 @@ module.exports = {
   "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true,
-  "no-implicit-route-model": true,
 };

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,6 @@ module ApplicationHelper
           Date: false,
           String: false,
         },
-        _DEFAULT_ASYNC_OBSERVERS: true,
       },
       APP: {
         name: "discourse",


### PR DESCRIPTION
A follow-up to 560c1875a54da2e3c539ce9bae4ddf72252b8993

1. `_DEFAULT_ASYNC_OBSERVERS` is already configured in optional-features
2. `no-implicit-route-model` defaults to `true` now (see: `pnpm ember feature:list`)