### PR TITLE
DEV: Ignore timezone cache when getting current timezone

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -114,7 +114,7 @@ export default class ProfileController extends Controller {
 
   @action
   useCurrentTimezone() {
-    this.model.set("user_option.timezone", moment.tz.guess());
+    this.model.set("user_option.timezone", moment.tz.guess(true));
   }
 
   @action


### PR DESCRIPTION
When the user selects “Use Current Timezone” on Profile -> Preferences -> Profile, a call is made to `moment.tz.guess()`.

https://momentjs.com/timezone/docs/#/using-timezones/guessing-user-timezone/ states that, by default, previously cached responses from this function will be returned upon subsequent calls. If your physical location has changed, this may result in a cached value being returned, and thus the timezone seemingly not being updating.

By passing the `true` value to the function, the cache is bypassed, forcing an explicit recheck of the current timezone.