### PR TITLE
FIX: Prevent wrapping of select box container by applying nowrap

### DIFF
--- a/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
+++ b/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
@@ -4,6 +4,7 @@
       display: inline-flex;
       min-width: auto;
       border: none;
+      white-space: nowrap;
 
       &.is-expanded {
         .select-kit-collection,


### PR DESCRIPTION
Applied `white-space: nowrap` to ensure text remains on a single line.

### Before
![image](https://github.com/user-attachments/assets/f148e216-fce3-46c6-9934-fb43da7f8f47)


### After
<img width="728" alt="image" src="https://github.com/user-attachments/assets/fce31f33-9a29-4a6d-85c0-d1566c9acd26" />
