### PR TITLE
FIX: Adjust grid-template-columns to prevent text overflow

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -435,12 +435,12 @@ pre.onebox code {
       "icon branches"
       "icon info"
       "body body";
-    grid-template-columns: 2.5em 1fr;
+    grid-template-columns: 2.5em minmax(0, 1fr);
     gap: 0.25em 0.75em;
 
     @include breakpoint(mobile-extra-large) {
       gap: 0.25em 0.5em;
-      grid-template-columns: 1.5em 1fr;
+      grid-template-columns: 1.5em minmax(0, 1fr);
       grid-template-areas:
         "icon title"
         "branches branches"


### PR DESCRIPTION
### What's changed?
Added  `minmax(0, 1fr)` to `grid-template-columns` to ensure the second column can shrink to fit within the container, avoiding overflow in smaller viewports or when the container width is limited.

### Before
<img width="489" alt="image" src="https://github.com/user-attachments/assets/047acba2-6ce7-444e-9ef1-867d3643ee45" />

### After
<img width="489" alt="image" src="https://github.com/user-attachments/assets/b5485746-8dac-422d-ba35-ab819ef78c5d" />
