### PR TITLE
FEATURE: new `fast_typing_threshold` site setting

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -7,7 +7,7 @@ class ReviewableScoreSerializer < ApplicationSerializer
     group: "approve_unless_allowed_groups",
     new_topics_unless_trust_level: "approve_new_topics_unless_trust_level",
     new_topics_unless_allowed_groups: "approve_new_topics_unless_allowed_groups",
-    fast_typer: "min_first_post_typing_time",
+    fast_typer: "first_post_typing_time",
     auto_silence_regex: "auto_silence_first_post_regex",
     staged: "approve_unless_staged",
     must_approve_users: "must_approve_users",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2301,7 +2301,8 @@ en:
 
     auto_respond_to_flag_actions: "Enable automatic reply when disposing a flag."
     min_first_post_typing_time: "Minimum amount of time in milliseconds a user must type during first post, if threshold is not met post will automatically enter the needs approval queue. Set to 0 to disable (not recommended)"
-    auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet min_first_post_typing_time"
+    fast_typing_threshold: "Minimum amount of time in milliseconds a user must type during the first post, if the threshold is not met, the post will automatically enter the needs approval queue. Low is 1 second, standard is 3 seconds, high is 5 seconds."
+    auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet `fast typing threshold`"
     auto_silence_fast_typers_max_trust_level: "Maximum trust level to auto silence fast typers"
     auto_silence_first_post_regex: "Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post. DEPRECATED: Use Silence Watched Words instead."
     reviewable_claiming: "Does reviewable content need to be claimed before it can be acted upon?"
@@ -2432,7 +2433,7 @@ en:
     enable_group_directory: "Provide a directory of groups for browsing"
     enable_category_group_moderation: "Allow groups to moderate content in specific categories"
     group_in_subject: "Set %%{optional_pm} in email subject to name of first group in PM, see: <a href='https://meta.discourse.org/t/customize-specific-email-templates/88323' target='_blank'>Customize subject format for standard emails</a>"
-    allow_anonymous_posting: "Enable the option for users to switch to anonymous mode for posting. When activated, users can opt for their identities to be hidden when creating posts or topics throughout the site. See also `allow_anonymous_likes`."
+    allow_anonymous_posting: "Enable the option for users to switch to anonymous mode for posting. When activated, users can opt for their identities to be hidden when creating posts or topics throughout the site. See also `allow anonymous likes`."
     allow_anonymous_likes: "Enable this setting to allow users who are browsing your site anonymously to like posts. When activated, users can opt for their identities to be hidden when liking posts or topics throughout the site. See also `allow_anonymous_posting`."
     anonymous_posting_min_trust_level: "Minimum trust level required to enable anonymous posting"
     anonymous_posting_allowed_groups: "Groups that are allowed to enable anonymous posting"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2301,7 +2301,7 @@ en:
 
     auto_respond_to_flag_actions: "Enable automatic reply when disposing a flag."
     min_first_post_typing_time: "Minimum amount of time in milliseconds a user must type during first post, if threshold is not met post will automatically enter the needs approval queue. Set to 0 to disable (not recommended)"
-    fast_typing_threshold: "Minimum amount of time in milliseconds a user must type during the first post, if the threshold is not met, the post will automatically enter the needs approval queue. Low is 1 second, standard is 3 seconds, high is 5 seconds."
+    fast_typing_threshold: "Minimum amount of time in milliseconds a user must type for their first post. If the threshold is not met, the post will automatically enter the review queue. Low is 1 second, standard is 3 seconds, high is 5 seconds."
     auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet `fast typing threshold`"
     auto_silence_fast_typers_max_trust_level: "Maximum trust level to auto silence fast typers"
     auto_silence_first_post_regex: "Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post. DEPRECATED: Use Silence Watched Words instead."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2370,7 +2370,17 @@ spam:
   auto_respond_to_flag_actions:
     default: true
     area: "flags"
-  min_first_post_typing_time: 3000
+  min_first_post_typing_time:
+    default: 3000
+    hidden: true
+  fast_typing_threshold:
+    type: enum
+    default: standard
+    choices:
+      - disabled
+      - low
+      - standard
+      - high
   auto_silence_fast_typers_on_first_post: true
   auto_silence_fast_typers_max_trust_level:
     default: 0

--- a/db/migrate/20250119222805_fill_fast_typing_threshold_based_on_deprecated_setting.rb
+++ b/db/migrate/20250119222805_fill_fast_typing_threshold_based_on_deprecated_setting.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class FillFastTypingThresholdBasedOnDeprecatedSetting < ActiveRecord::Migration[7.2]
+  def up
+    old_setting_value =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'min_first_post_typing_time' LIMIT 1",
+      ).first
+
+    if old_setting_value.present?
+      fast_typing_threshold_setting =
+        case
+        when old_setting_value.to_i == NewPostManager::FAST_TYPING_THRESHOLD_MAP[:disabled]
+          "off"
+        when old_setting_value.to_i < NewPostManager::FAST_TYPING_THRESHOLD_MAP[:standard]
+          "low"
+        when old_setting_value.to_i < NewPostManager::FAST_TYPING_THRESHOLD_MAP[:high]
+          "standard"
+        else
+          "high"
+        end
+      puts fast_typing_threshold_setting
+
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('fast_typing_threshold', :setting, '7', NOW(), NOW())
+        ON CONFLICT DO NOTHING",
+        setting: fast_typing_threshold_setting,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20250119222805_fill_fast_typing_threshold_based_on_deprecated_setting.rb
+++ b/db/migrate/20250119222805_fill_fast_typing_threshold_based_on_deprecated_setting.rb
@@ -10,16 +10,15 @@ class FillFastTypingThresholdBasedOnDeprecatedSetting < ActiveRecord::Migration[
     if old_setting_value.present?
       fast_typing_threshold_setting =
         case
-        when old_setting_value.to_i == NewPostManager::FAST_TYPING_THRESHOLD_MAP[:disabled]
+        when old_setting_value.to_i == 0
           "off"
-        when old_setting_value.to_i < NewPostManager::FAST_TYPING_THRESHOLD_MAP[:standard]
+        when old_setting_value.to_i < 3000
           "low"
-        when old_setting_value.to_i < NewPostManager::FAST_TYPING_THRESHOLD_MAP[:high]
+        when old_setting_value.to_i < 5000
           "standard"
         else
           "high"
         end
-      puts fast_typing_threshold_setting
 
       DB.exec(
         "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -8,6 +8,8 @@
 class NewPostManager
   attr_reader :user, :args
 
+  FAST_TYPING_THRESHOLD_MAP = { disabled: 0, low: 1000, standard: 3000, high: 5000 }
+
   def self.sorted_handlers
     @sorted_handlers ||= clear_handlers!
   end
@@ -44,7 +46,8 @@ class NewPostManager
     args = manager.args
 
     is_first_post?(manager) &&
-      args[:typing_duration_msecs].to_i < SiteSetting.min_first_post_typing_time &&
+      args[:typing_duration_msecs].to_i <
+        FAST_TYPING_THRESHOLD_MAP[SiteSetting.fast_typing_threshold.to_sym] &&
       SiteSetting.auto_silence_fast_typers_on_first_post &&
       manager.user.trust_level <= SiteSetting.auto_silence_fast_typers_max_trust_level
   end

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -45,6 +45,7 @@ module SiteSettings::DeprecatedSettings
       false,
       "3.3",
     ],
+    ["min_first_post_typing_time", "fast_typing_threshold", false, "3.4"],
   ]
 
   OVERRIDE_TL_GROUP_SETTINGS = %w[

--- a/plugins/poll/spec/controllers/posts_controller_spec.rb
+++ b/plugins/poll/spec/controllers/posts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PostsController do
   let!(:title) { "Testing Poll Plugin" }
 
   before do
-    SiteSetting.min_first_post_typing_time = 0
+    SiteSetting.fast_typing_threshold = "disabled"
     log_in_user(user)
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -890,7 +890,7 @@ RSpec.describe PostsController do
     include_examples "action requires login", :post, "/posts.json"
 
     before do
-      SiteSetting.min_first_post_typing_time = 0
+      SiteSetting.fast_typing_threshold = "disabled"
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
     end
 
@@ -1148,11 +1148,11 @@ RSpec.describe PostsController do
 
       context "when fast typing" do
         before do
-          SiteSetting.min_first_post_typing_time = 3000
+          SiteSetting.fast_typing_threshold = "standard"
           SiteSetting.auto_silence_fast_typers_max_trust_level = 1
         end
 
-        it "queues the post if min_first_post_typing_time is not met" do
+        it "queues the post if fast_typing_threshold is not met" do
           post "/posts.json",
                params: {
                  raw: "this is the test content",
@@ -3085,7 +3085,7 @@ RSpec.describe PostsController do
 
       before do
         sign_in(user)
-        SiteSetting.min_first_post_typing_time = 0
+        SiteSetting.fast_typing_threshold = "disabled"
       end
 
       it "allows strings to be added" do


### PR DESCRIPTION
Rename `min_first_post_typing_time` to `fast_typing_threshold` and provide admin 4 options:
- disabled
- low - 1 second
- standard - 3 seconds
- high - 5 seconds

<img width="1392" alt="Screenshot 2025-01-20 at 4 11 01 PM" src="https://github.com/user-attachments/assets/7b723294-4983-4f5b-90d7-5166261278f6" />

Related PRs:
- https://github.com/discourse/discourse-zoom/pull/112
