### PR TITLE
FIX: Update nginx `types` config

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -2,6 +2,8 @@
 types {
     text/csv csv;
     application/wasm wasm;
+    font/ttf ttf;
+    font/otf otf;
 }
 
 upstream discourse {
@@ -36,12 +38,6 @@ geo $bypass_cache {
   default         0;
   127.0.0.1       1;
   ::1             1;
-}
-
-types {
-  include /etc/nginx/mime.types;
-  font/ttf ttf;
-  font/otf otf;
 }
 
 server {


### PR DESCRIPTION
Add fonts to existing block, and remove unneeded 'include' directive.

Followup to 8dbbe53dcc09766f9ce90963326caa96a5f20a03