### PR TITLE
UX: convert "view all notification" to a link

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
@@ -16,7 +16,7 @@
     {{#if this.showAllHref}}
       <DButton
         class="show-all"
-        @action={{this.showAll}}
+        @href={{this.showAllHref}}
         @translatedAriaLabel={{this.showAllTitle}}
         @translatedTitle={{this.showAllTitle}}
       >

--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.js
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import DiscourseURL from "discourse/lib/url";
 
 export default class UserMenuItemsList extends Component {
   @service session;
@@ -86,11 +85,5 @@ export default class UserMenuItemsList extends Component {
     throw new Error(
       `dismissButtonClick must be implemented in ${this.constructor.name}.`
     );
-  }
-
-  @action
-  showAll() {
-    DiscourseURL.routeTo(this.showAllHref);
-    this.args.closeUserMenu();
   }
 }


### PR DESCRIPTION
so it respects the user's input of opening it in another tab when CTRL/META/MIDDLE clicking it.

<img width="471" alt="Screenshot 2025-01-20 at 16 20 14" src="https://github.com/user-attachments/assets/2ba1a78a-0c12-452e-b054-ef7e7c1338c1" />
