### PR TITLE
FIX: supports quoting mathjax

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -188,10 +188,6 @@ export class Tag {
 
   static div() {
     return class extends Tag.block("div") {
-      constructor() {
-        super();
-      }
-
       decorate(text) {
         const attr = this.element.attributes;
 

--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -87,7 +87,6 @@ export class Tag {
       "address",
       "article",
       "dd",
-      "div",
       "dl",
       "dt",
       "fieldset",
@@ -183,6 +182,28 @@ export class Tag {
         }
 
         return `${this.gap}${this.prefix}${text}${this.suffix}${this.gap}`;
+      }
+    };
+  }
+
+  static div() {
+    return class extends Tag.block("div") {
+      constructor() {
+        super();
+      }
+
+      decorate(text) {
+        const attr = this.element.attributes;
+
+        if (/\bmathjax-math\b/.test(attr.class)) {
+          return "";
+        }
+
+        if (/\bmath\b/.test(attr.class) && attr["data-applied-mathjax"]) {
+          return "\n$$\n" + text + "\n$$\n";
+        }
+
+        return super.decorate(text);
       }
     };
   }
@@ -290,6 +311,14 @@ export class Tag {
 
         if (attr.class === "badge badge-notification clicks") {
           return "";
+        }
+
+        if (/\bmathjax-math\b/.test(attr.class)) {
+          return "";
+        }
+
+        if (/\bmath\b/.test(attr.class) && attr["data-applied-mathjax"]) {
+          return "$" + text + "$";
         }
 
         return super.decorate(text);
@@ -689,6 +718,7 @@ function tagByName(name) {
       Tag.ol(),
       Tag.list("ul"),
       Tag.span(),
+      Tag.div(),
     ];
 
     for (const tag of allTags) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -527,4 +527,28 @@ test2
 
     assert.strictEqual(toMarkdown(html), "[quiet]hey\nthere[/quiet]");
   });
+
+  test("converts inline mathjax", function (assert) {
+    const html = `<p>Lorem ipsum <span class="math" data-applied-mathjax="true" style="display: none;">E=mc^2</span><span class="math-container,inline-math,mathjax-math" style=""><span id="MathJax-Element-1-Frame" class="mjx-chtml MathJax_CHTML" tabindex="0" style="font-size: 117%;"><span id="MJXc-Node-1" class="mjx-math"><span id="MJXc-Node-2" class="mjx-mrow"><span id="MJXc-Node-3" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.483em; padding-bottom: 0.27em; padding-right: 0.026em;">E</span></span><span id="MJXc-Node-4" class="mjx-mo MJXc-space3"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.056em; padding-bottom: 0.323em;">=</span></span><span id="MJXc-Node-5" class="mjx-mi MJXc-space3"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.216em; padding-bottom: 0.27em;">m</span></span><span id="MJXc-Node-6" class="mjx-msubsup"><span class="mjx-base"><span id="MJXc-Node-7" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.216em; padding-bottom: 0.27em;">c</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.513em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-8" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.377em; padding-bottom: 0.323em;">2</span></span></span></span></span></span></span><script type="math/tex" id="MathJax-Element-1">E=mc^2</script></span> dolor sit amet.</p>`;
+    const markdown = `Lorem ipsum $E=mc^2$ dolor sit amet.`;
+    assert.strictEqual(toMarkdown(html), markdown);
+  });
+
+  test("converts block mathjax", function (assert) {
+    const html = `<p>Before</p>
+    <div class="math" data-applied-mathjax="true" style="display: none;">
+    \\sqrt{(-1)} \\; 2^3 \\; \\sum \\; \\pi
+    </div><div class="math-container,block-math,mathjax-math" style=""><span class="mjx-chtml MJXc-display" style="text-align: center;"><span id="MathJax-Element-2-Frame" class="mjx-chtml MathJax_CHTML" tabindex="0" style="font-size: 117%; text-align: center;"><span id="MJXc-Node-9" class="mjx-math"><span id="MJXc-Node-10" class="mjx-mrow"><span id="MJXc-Node-11" class="mjx-msqrt"><span class="mjx-box" style="padding-top: 0.045em;"><span class="mjx-surd"><span class="mjx-char MJXc-TeX-size2-R" style="padding-top: 0.911em; padding-bottom: 0.911em;">√</span></span><span class="mjx-box" style="padding-top: 0.315em; border-top: 1.4px solid;"><span id="MJXc-Node-12" class="mjx-mrow"><span id="MJXc-Node-13" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.483em; padding-bottom: 0.59em;">(</span></span><span id="MJXc-Node-14" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.323em; padding-bottom: 0.43em;">−</span></span><span id="MJXc-Node-15" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.377em; padding-bottom: 0.323em;">1</span></span><span id="MJXc-Node-16" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.483em; padding-bottom: 0.59em;">)</span></span></span></span></span></span><span id="MJXc-Node-17" class="mjx-mspace" style="width: 0.278em; height: 0px;"></span><span id="MJXc-Node-18" class="mjx-msubsup"><span class="mjx-base"><span id="MJXc-Node-19" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.377em; padding-bottom: 0.323em;">2</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.591em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-20" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.377em; padding-bottom: 0.377em;">3</span></span></span></span><span id="MJXc-Node-21" class="mjx-mspace" style="width: 0.278em; height: 0px;"></span><span id="MJXc-Node-22" class="mjx-mo MJXc-space1"><span class="mjx-char MJXc-TeX-size2-R" style="padding-top: 0.751em; padding-bottom: 0.751em;">∑</span></span><span id="MJXc-Node-23" class="mjx-mspace" style="width: 0.278em; height: 0px;"></span><span id="MJXc-Node-24" class="mjx-mi MJXc-space1"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.216em; padding-bottom: 0.27em; padding-right: 0.003em;">π</span></span></span></span></span></span><script type="math/tex; mode=display" id="MathJax-Element-2">\\sqrt{(-1)} \\; 2^3 \\; \\sum \\; \\pi</script></div>
+    <p>After</p>`;
+
+    const markdown = `Before
+
+$$
+\\sqrt{(-1)} \\; 2^3 \\; \\sum \\; \\pi
+$$
+
+After`;
+
+    assert.strictEqual(toMarkdown(html), markdown);
+  });
 });


### PR DESCRIPTION
This will properly extract the text used to generate mathjax expression (both inline and block display modes) as well as remove all the cruft that mathjax is adding in the DOM.

Internal ref - t/135307