### PR TITLE
UX: Use `position: fixed` for header when no content above

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -1,6 +1,16 @@
 .d-header-wrap {
-  @include sticky;
-  top: 0;
+  &:not(.--docked) {
+    @include sticky;
+    top: 0;
+  }
+  &.--docked {
+    position: relative;
+    height: var(--header-height);
+
+    .d-header {
+      position: fixed;
+    }
+  }
   z-index: z("header");
 }
 


### PR DESCRIPTION
We use `position: sticky;` on the header so that themes can introduce content above the header and have it behave properly. However, `position: sticky;` means that the header overscrolls with the rest of the page content, which is not ideal. Using `position: fixed` means that the header will not 'overscroll' when scrolling to the top of the page, which is a much better feeling UX.

To keep support for content above the header, this PR automatically switches the header position strategy based on whether it's at the top of the page or not. If there is no content above, it'll be `position: fixed;`. If there is content, it'll keep the existing `position: sticky;` behavior.