### PR TITLE
FIX: removes mousewheel edge case on messages

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { concat, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -63,12 +62,6 @@ export default class ChatMessageActionsDesktop extends Component {
   }
 
   @action
-  onWheel() {
-    // prevents menu to stop scroll on the list of messages
-    this.chat.activeMessage = null;
-  }
-
-  @action
   setup(element) {
     this.popper?.destroy();
 
@@ -119,7 +112,6 @@ export default class ChatMessageActionsDesktop extends Component {
       <div
         {{didInsert this.setup}}
         {{didUpdate this.setup this.chat.activeMessage.model.id}}
-        {{on "wheel" this.onWheel passive=true}}
         {{willDestroy this.teardown}}
         class={{concatClass
           "chat-message-actions-container"


### PR DESCRIPTION
Message action menu used to be much more intrusive and show during scroll, if your mouse was going over a menu during the scroll it would stop it. Now it shouldn't happen anymore and this hack seems un-necessary, moreover, it was causing a bug where it would close the emoji picker unexpectedly if you would scroll a little bit on the actions menu while the picker was opened.