### PR TITLE
DEV: Fix a warning in a chat spec

### DIFF
--- a/plugins/chat/spec/system/chat_message_interaction_spec.rb
+++ b/plugins/chat/spec/system/chat_message_interaction_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe "Interacting with a message", type: :system do
       DiscourseEvent.on(:chat_message_interaction, &blk)
       find(".block__button").click
 
-      try_until_success { expect(chat_channel_page.messages).to have_text(action_id) }
+      try_until_success do
+        expect(action_id).to_not be_nil
+        expect(chat_channel_page.messages).to have_text(action_id)
+      end
     ensure
       DiscourseEvent.off(:chat_message_interaction, &blk)
     end


### PR DESCRIPTION
```
Checking for expected text of nil is confusing and/or pointless
since it will always match. Please specify a string or regexp instead.
plugins/chat/spec/system/chat_message_interaction_spec.rb:51
```