### PR TITLE
UX: set mobile read state indicator to static size to avoid overflow

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -425,10 +425,9 @@ span.highlighted {
   // contained within the padding to prevent vertical overflow
   max-width: var(--d-wrap-padding-h);
   right: calc(var(--d-wrap-padding-h) * -1);
-  font-size: var(--font-down-5);
-
+  font-size: 6px; // static size to avoid overflow issues
   svg {
-    right: -0.25em;
+    right: -2px;
   }
 }
 


### PR DESCRIPTION
This fixes an issue where topics could scroll horizontally on mobile: https://meta.discourse.org/t/topic-page-layout-issue/348262?u=pmusaraj

It seems some recent core change impacted the read state size/position 

This sets the size and position to more static values (not based on global font changes) to avoid the issue, and removes the horizontal scroll. 