### PR TITLE
FIX: Restore footer-nav backdrop-filter for iOS < 18

### DIFF
--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -78,6 +78,10 @@ html.footer-nav-visible {
 @supports (-webkit-backdrop-filter: blur(10px)) {
   html:not(.footer-nav-ipad) .footer-nav {
     background-color: rgba(var(--header_background-rgb), 0.7);
+
+    /* prefix needed for iOS < 18 */
+    /* stylelint-disable-next-line property-no-vendor-prefix */
+    -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
   }
 }


### PR DESCRIPTION
This was inadvertantly removed in d88ee33eb622e52cec5f442dd6416e68c8f758e4

See https://meta.discourse.org/t/348262/4