### PR TITLE
FIX: ensures chat navbar is on top of content

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -187,6 +187,7 @@ body.has-full-page-chat {
   .c-navbar-container {
     position: sticky;
     top: var(--main-outlet-offset);
+    z-index: 1;
   }
 
   .chat-messages-scroller {


### PR DESCRIPTION
Since this change https://github.com/discourse/discourse/commit/6c3a7f2a674253681ef419df02c8d15d71ecab83#diff-48126857aeb1748fb1eb2500ca69b832212061db59d93ed61dde9fd5dcddf0c7 we had various behaviours in different browsers as what should be at the top was ambiguous. This commit ensures the navbar is one layer above the content.