### PR TITLE
UX: rename "hamburger menu" to "navigation menu" in keyboard help

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1925,7 +1925,7 @@ en:
         after_5_minutes: "after 5 minutes"
         after_10_minutes: "after 10 minutes"
 
-      notification_level_when_replying: 
+      notification_level_when_replying:
         label: "When posting"
         watch_topic: "Watch topic"
         track_topic: "Track topic"
@@ -4545,7 +4545,7 @@ en:
         title: "Application"
         create: "%{shortcut} Create a new topic"
         notifications: "%{shortcut} Open notifications"
-        hamburger_menu: "%{shortcut} Open hamburger menu"
+        hamburger_menu: "%{shortcut} Open navigation menu"
         user_profile_menu: "%{shortcut} Open user menu"
         show_incoming_updated_topics: "%{shortcut} Show updated topics"
         search: "%{shortcut} Search"


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/open-hamburger-menu-wording/348216

After adding the sidebar, we started calling related settings the "navigation menu" because it can either be the sidebar or the hamburger menu (dropdown) — this reflects that change in the keyboard shortcuts modal as well 


Before:

![image](https://github.com/user-attachments/assets/ae888771-8df0-4b01-9df3-5fbcfdfb5f51)


After: 

![image](https://github.com/user-attachments/assets/c0119494-4360-40d1-a7e8-358fb8dcbd32)
