### PR TITLE
DEV: Add 'include' statements for outlets in nginx config

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -1,14 +1,13 @@
 # Additional MIME types that you'd like nginx to handle go in here
 types {
-    text/csv csv;
-    application/wasm wasm;
-    font/ttf ttf;
-    font/otf otf;
+  text/csv csv;
+  application/wasm wasm;
+  font/ttf ttf;
+  font/otf otf;
 }
 
 upstream discourse {
-  server unix:/var/www/discourse/tmp/sockets/nginx.http.sock;
-  server unix:/var/www/discourse/tmp/sockets/nginx.https.sock;
+  server 127.0.0.1:3000;
 }
 
 # inactive means we keep stuff around for 1440m minutes regardless of last access (1 week)
@@ -40,11 +39,15 @@ geo $bypass_cache {
   ::1             1;
 }
 
-server {
+include conf.d/outlets/before-server/*.conf;
 
+server {
   access_log /var/log/nginx/access.log log_discourse;
 
   listen 80;
+
+  include conf.d/outlets/server/*.conf;
+
   gzip on;
   gzip_vary on;
   gzip_min_length 1000;
@@ -52,19 +55,7 @@ server {
   gzip_types application/json text/css text/javascript application/x-javascript application/javascript image/svg+xml application/wasm font/ttf font/otf;
   gzip_proxied any;
 
-  # Uncomment and configure this section for HTTPS support
-  # NOTE: Put your ssl cert in your main nginx config directory (/etc/nginx)
-  #
-  # rewrite ^/(.*) https://enter.your.web.hostname.here/$1 permanent;
-  #
-  # listen 443 ssl;
-  # ssl_certificate your-hostname-cert.pem;
-  # ssl_certificate_key your-hostname-cert.key;
-  # ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  # ssl_ciphers HIGH:!aNULL:!MD5;
-  #
-
-  server_name enter.your.web.hostname.here;
+  server_name _;
   server_tokens off;
 
   sendfile on;
@@ -178,7 +169,6 @@ server {
     }
 
     location ~ ^/uploads/ {
-
       # NOTE: it is really annoying that we can't just define headers
       # at the top level and inherit.
       #
@@ -203,14 +193,17 @@ server {
           add_header Access-Control-Allow-Origin *;
           try_files $uri =404;
       }
+
       # this allows us to bypass rails
       location ~* \.(gif|png|jpg|jpeg|bmp|tif|tiff|ico|webp|avif)$ {
           add_header Access-Control-Allow-Origin *;
           try_files $uri =404;
       }
+
       # SVG needs an extra header attached
       location ~* \.(svg)$ {
       }
+
       # thumbnails & optimized images
       location ~ /_?optimized/ {
           add_header Access-Control-Allow-Origin *;
@@ -286,6 +279,8 @@ server {
   }
 
   location @discourse {
+    include conf.d/outlets/discourse/*.conf;
+
     proxy_set_header Host $http_host;
     proxy_set_header X-Request-Start "t=${msec}";
     proxy_set_header X-Real-IP $remote_addr;
@@ -295,5 +290,4 @@ server {
     proxy_set_header X-Accel-Mapping "";
     proxy_pass http://discourse;
   }
-
 }


### PR DESCRIPTION
The 'include' statements serve as extension outlets that are populated by discourse/discourse_docker.

This also includes some whitespace changes to make the file more consistent.