### PR TITLE
UX: inherit font-settings on form controls

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -209,3 +209,11 @@ input[type="checkbox"],
 input[type="radio"] {
   accent-color: var(--tertiary);
 }
+
+textarea,
+input,
+select,
+button {
+  font-variation-settings: inherit;
+  font-feature-settings: inherit;
+}


### PR DESCRIPTION
Inherit `font-variation-settings` and `font-feature-settings` if there are any, keeping consistency for `textarea`/`input`/`button`/`select` with any `html`-set CSS.