### PR TITLE
UX: Revert #30547 UX: use em units for code font-size

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -19,7 +19,7 @@ code {
   color: var(--primary-very-high);
   background: var(--hljs-bg);
   border-radius: var(--d-border-radius);
-  font-size: 0.875em;
+  font-size: 14px;
   line-height: calc((13 + 4) / 13);
 }
 
@@ -27,6 +27,15 @@ pre > code {
   display: block;
   padding: 12px;
   max-height: 500px;
+}
+
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  font-size: inherit;
 }
 
 .hljs-comment,


### PR DESCRIPTION
The solution in (https://github.com/discourse/discourse/pull/30547) using `em` units was causing readability problems for code blocks in mobile. This reverts to the previous solution (https://github.com/discourse/discourse/pull/30536) of using `font-size: inherit` for code within heading elements.

The downside is that the code in heading won't be slightly smaller than the other text like it is for inline code in paragraphs, but it seems worth it to avoid causing other size issues.