### PR TITLE
FIX: Adjust search menu buttons alignment

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -36,7 +36,6 @@ $search-pad-horizontal: 0.5em;
       margin-bottom: 0;
       width: auto;
       flex-grow: 1;
-      padding-right: 50px;
 
       &:focus {
         outline: none;
@@ -378,6 +377,9 @@ $search-pad-horizontal: 0.5em;
   }
 
   .searching {
+    display: flex;
+    align-items: center;
+
     .spinner {
       width: 12px;
       height: 12px;


### PR DESCRIPTION
### Before
<img width="485" alt="image" src="https://github.com/user-attachments/assets/869a676a-604f-461e-b008-975f9e352787" />


### After
<img width="485" alt="image" src="https://github.com/user-attachments/assets/3b91022c-9a7d-4237-8382-19b2174f6006" />
