### PR TITLE
DEV: Add a `context` arg to after-topic-status outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
@@ -108,6 +108,7 @@ export default class Info extends Component {
               <TopicStatus
                 @topic={{@topicInfo}}
                 @disableActions={{@disableActions}}
+                @context="header"
               />
 
               <a

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.hbs
@@ -1,6 +1,10 @@
 <span class="topic">
   <span class="first-line">
-    <TopicStatus @topic={{@result.topic}} @disableActions={{true}} />
+    <TopicStatus
+      @topic={{@result.topic}}
+      @disableActions={{true}}
+      @context="topic-view-title"
+    />
     <span class="topic-title" data-topic-id={{@result.topic.id}}>
       {{#if
         (and

--- a/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
@@ -17,7 +17,7 @@ const onTimestampClick = function (event) {
 
 const FeaturedTopic = <template>
   <div data-topic-id={{@topic.id}} class="featured-topic --glimmer">
-    <TopicStatus @topic={{@topic}} />
+    <TopicStatus @topic={{@topic}} @context="topic-list" />
 
     <a href={{@topic.lastUnreadUrl}} class="title">{{htmlSafe
         @topic.fancyTitle

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -283,7 +283,7 @@ export default class Item extends Component {
                   @outletArgs={{hash topic=@topic}}
                 />
                 {{~! no whitespace ~}}
-                <TopicStatus @topic={{@topic}} />
+                <TopicStatus @topic={{@topic}} @context="topic-list" />
                 {{~! no whitespace ~}}
                 <TopicLink
                   {{on "focus" this.onTitleFocus}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
@@ -67,7 +67,7 @@ export default class TopicCell extends Component {
           @outletArgs={{hash topic=@topic tagsForUser=@tagsForUser}}
         >
           {{~! no whitespace ~}}
-          <TopicStatus @topic={{@topic}} />
+          <TopicStatus @topic={{@topic}} @context="topic-list" />
           {{~! no whitespace ~}}
           <TopicLink
             {{on "focus" this.onTitleFocus}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
@@ -62,7 +62,7 @@ export default class LatestTopicListItem extends Component {
 
       <div class="main-link">
         <div class="top-row">
-          <TopicStatus @topic={{@topic}} />
+          <TopicStatus @topic={{@topic}} @context="topic-list" />
 
           {{topicLink @topic}}
           {{~#if @topic.featured_link}}

--- a/app/assets/javascripts/discourse/app/components/topic-status.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-status.gjs
@@ -112,7 +112,7 @@ export default class TopicStatus extends Component {
       {{~#if this.site.useGlimmerTopicList~}}
         <PluginOutlet
           @name="after-topic-status"
-          @outletArgs={{hash topic=@topic}}
+          @outletArgs={{hash topic=@topic context=@context}}
         />
       {{~else~}}
         {{~#each TopicStatusIcons.entries as |entry|~}}


### PR DESCRIPTION
…so that plugins/themes can conditionally conditionally display their topic-status icon (e.g. just on the topic list, or everywhere but the header)