### PR TITLE
DEV: raise error on deprecated icon name caught on JS in system and qunit tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -146,17 +146,12 @@ function handleDeprecatedIcon(id) {
   newId = remapFromFA5(newId);
 
   if (newId !== id) {
-    if (isTesting() || isRailsTesting()) {
-      throw new Error(
-        `[FA6 deprecation error] The icon "${id}" is deprecated. Use "${newId}" instead.`
-      );
-    }
-
     deprecated(
       `The icon name "${id}" has been updated to "${newId}". Please use the new name in your code. Old names will be removed in Q2 2025.`,
       {
         id: "discourse.fontawesome-6-upgrade",
         url: "https://meta.discourse.org/t/325349",
+        raiseError: isTesting() || isRailsTesting(),
       }
     );
   }

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -148,7 +148,7 @@ function handleDeprecatedIcon(id) {
   if (newId !== id) {
     if (isTesting() || isRailsTesting()) {
       throw new Error(
-        `[Deprecation error] The icon "${id}" is deprecated. Use "${newId}" instead.`
+        `[FA6 deprecation error] The icon "${id}" is deprecated. Use "${newId}" instead.`
       );
     }
 

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -1,7 +1,11 @@
 import { h } from "virtual-dom";
 import attributeHook from "discourse/lib/attribute-hook";
 import deprecated from "discourse/lib/deprecated";
-import { isDevelopment } from "discourse/lib/environment";
+import {
+  isDevelopment,
+  isRailsTesting,
+  isTesting,
+} from "discourse/lib/environment";
 import escape from "discourse/lib/escape";
 import { i18n } from "discourse-i18n";
 
@@ -142,6 +146,12 @@ function handleDeprecatedIcon(id) {
   newId = remapFromFA5(newId);
 
   if (newId !== id) {
+    if (isTesting() || isRailsTesting()) {
+      throw new Error(
+        `[Deprecation error] The icon "${id}" is deprecated. Use "${newId}" instead.`
+      );
+    }
+
     deprecated(
       `The icon name "${id}" has been updated to "${newId}". Please use the new name in your code. Old names will be removed in Q2 2025.`,
       {
@@ -189,12 +199,12 @@ registerIconRenderer({
     }
     html += ` xmlns="${SVG_NAMESPACE}"><use href="#${id}" /></svg>`;
     if (params.label) {
-      html += `<span class='sr-only'>${escape(params.label)}</span>`;
+      html += `<span class="sr-only">${escape(params.label)}</span>`;
     }
     if (params.title) {
-      html = `<span class="svg-icon-title" title='${escape(
+      html = `<span class="svg-icon-title" title="${escape(
         i18n(params.title)
-      )}'>${html}</span>`;
+      )}">${html}</span>`;
     }
 
     if (params.translatedtitle) {
@@ -207,9 +217,9 @@ registerIconRenderer({
     }
 
     if (params.translatedTitle) {
-      html = `<span class="svg-icon-title" title='${escape(
+      html = `<span class="svg-icon-title" title="${escape(
         params.translatedTitle
-      )}'>${html}</span>`;
+      )}">${html}</span>`;
     }
     return html;
   },

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -49,21 +49,36 @@ module("Unit | Utility | icon-library", function (hooks) {
 
   test("fa5 remaps", function (assert) {
     withSilencedDeprecations("discourse.fontawesome-6-upgrade", () => {
-      const adjustIcon = iconHTML("adjust");
-      assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
-      assert.true(
-        adjustIcon.includes('href="#circle-half-stroke"'),
-        "has remapped icon"
+      assert.throws(
+        () => {
+          const adjustIcon = iconHTML("adjust");
+          assert.true(
+            adjustIcon.includes("d-icon-adjust"),
+            "class is maintained"
+          );
+          assert.true(
+            adjustIcon.includes('href="#circle-half-stroke"'),
+            "has remapped icon"
+          );
+        },
+        /FA6 deprecation error/,
+        "throws an error if icon name is deprecated"
       );
 
-      const farIcon = iconHTML("far-dot-circle");
-      assert.true(
-        farIcon.includes("d-icon-far-dot-circle"),
-        "class is maintained"
-      );
-      assert.true(
-        farIcon.includes('href="#far-circle-dot"'),
-        "has remapped icon"
+      assert.throws(
+        () => {
+          const farIcon = iconHTML("far-dot-circle");
+          assert.true(
+            farIcon.includes("d-icon-far-dot-circle"),
+            "class is maintained"
+          );
+          assert.true(
+            farIcon.includes('href="#far-circle-dot"'),
+            "has remapped icon"
+          );
+        },
+        /FA6 deprecation error/,
+        "throws an error if icon name is deprecated"
       );
     });
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -6,6 +6,10 @@ import {
   iconHTML,
   iconNode,
 } from "discourse/lib/icon-library";
+import {
+  disableRaiseOnDeprecation,
+  enableRaiseOnDeprecation,
+} from "discourse/tests/helpers/raise-on-deprecation";
 
 module("Unit | Utility | icon-library", function (hooks) {
   setupTest(hooks);
@@ -49,37 +53,42 @@ module("Unit | Utility | icon-library", function (hooks) {
 
   test("fa5 remaps", function (assert) {
     withSilencedDeprecations("discourse.fontawesome-6-upgrade", () => {
-      assert.throws(
-        () => {
-          const adjustIcon = iconHTML("adjust");
-          assert.true(
-            adjustIcon.includes("d-icon-adjust"),
-            "class is maintained"
-          );
-          assert.true(
-            adjustIcon.includes('href="#circle-half-stroke"'),
-            "has remapped icon"
-          );
-        },
-        /FA6 deprecation error/,
-        "throws an error if icon name is deprecated"
+      const adjustIcon = iconHTML("adjust");
+      assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
+      assert.true(
+        adjustIcon.includes('href="#circle-half-stroke"'),
+        "has remapped icon"
       );
 
-      assert.throws(
-        () => {
-          const farIcon = iconHTML("far-dot-circle");
-          assert.true(
-            farIcon.includes("d-icon-far-dot-circle"),
-            "class is maintained"
-          );
-          assert.true(
-            farIcon.includes('href="#far-circle-dot"'),
-            "has remapped icon"
-          );
-        },
-        /FA6 deprecation error/,
-        "throws an error if icon name is deprecated"
+      const farIcon = iconHTML("far-dot-circle");
+      assert.true(
+        farIcon.includes("d-icon-far-dot-circle"),
+        "class is maintained"
+      );
+      assert.true(
+        farIcon.includes('href="#far-circle-dot"'),
+        "has remapped icon"
       );
     });
+  });
+
+  test("fa5 remaps throws error", function (assert) {
+    disableRaiseOnDeprecation();
+    assert.throws(
+      () => {
+        iconHTML("adjust");
+      },
+      /Deprecation notice: The icon name "adjust" has been updated to "circle-half-stroke".*\[deprecation id: discourse\.fontawesome-6-upgrade\]/,
+      "throws an error if icon name is deprecated"
+    );
+
+    assert.throws(
+      () => {
+        iconHTML("far-dot-circle");
+      },
+      /Deprecation notice: The icon name "far-dot-circle" has been updated to "far-circle-dot".*\[deprecation id: discourse\.fontawesome-6-upgrade\]/,
+      "throws an error if icon name is deprecated"
+    );
+    enableRaiseOnDeprecation();
   });
 });

--- a/db/fixtures/006_badges.rb
+++ b/db/fixtures/006_badges.rb
@@ -173,7 +173,7 @@ end
 Badge.seed do |b|
   b.id = Badge::FirstShare
   b.name = "First Share"
-  b.default_icon = "share-alt"
+  b.default_icon = "share-nodes"
   b.badge_type_id = BadgeType::Bronze
   b.multiple_grant = false
   b.target_posts = true
@@ -193,7 +193,7 @@ end
   Badge.seed do |b|
     b.id = id
     b.name = name
-    b.default_icon = "share-alt"
+    b.default_icon = "share-nodes"
     b.badge_type_id = level
     b.multiple_grant = true
     b.target_posts = true
@@ -402,7 +402,7 @@ end
 Badge.seed do |b|
   b.id = Badge::FirstEmoji
   b.name = "First Emoji"
-  b.default_icon = "smile"
+  b.default_icon = "face-smile"
   b.badge_type_id = BadgeType::Bronze
   b.multiple_grant = false
   b.target_posts = true

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -523,7 +523,10 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     new_name = remap_from_fa5(new_name)
 
     if icon_name != new_name
-      Discourse.deprecate("The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.")
+      Discourse.deprecate(
+        "The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.",
+        raise_error: Rails.env.test?,
+      )
       return new_name
     end
 

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -523,10 +523,7 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     new_name = remap_from_fa5(new_name)
 
     if icon_name != new_name
-      Discourse.deprecate(
-        "The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.",
-        raise_error: Rails.env.test?,
-      )
+      Discourse.deprecate("The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.")
       return new_name
     end
 


### PR DESCRIPTION
This PR raises an error on any deprecated icon names being converted by `icon-library.js`, which will result in any deprecated icons introduced in JS-land to fail qunit/system tests. 

We'll do the same for `svg_sprite.rb` once I've resolved pre-existing deprecated icons in core/plugins that's caught by the same exception logic.