### PR TITLE
DEV: update discourse-fonts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     diffy (3.4.3)
     digest (3.2.0)
     digest-xxhash (0.2.9)
-    discourse-fonts (0.0.16)
+    discourse-fonts (0.0.17)
     discourse-seed-fu (2.3.12)
       activerecord (>= 3.1)
       activesupport (>= 3.1)


### PR DESCRIPTION
This applies some fixes to Inter which remove some features we set (like sso4)
from the core CSS.

It brings us closer to default.

