### PR TITLE
UX: Add a gap between topic-navigation items

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -105,6 +105,7 @@
       grid-area: posts;
       grid-row: 3;
       width: auto;
+      gap: 0.5em;
     }
 
     .timeline-container:not(.timeline-fullscreen) {


### PR DESCRIPTION
When using the `topic-navigation` outlet, we currently do not space items inside. This adds a gap for flexible spacing in the flex container.
![image](https://github.com/user-attachments/assets/3a37d9bf-501b-40f0-ae31-21afec91cf46)