### PR TITLE
DEV: Ensure sequential `replaceText` calls work correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
@@ -1,5 +1,5 @@
 import { setOwner } from "@ember/owner";
-import { next, schedule } from "@ember/runloop";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import $ from "jquery";
@@ -127,20 +127,16 @@ export default class TextareaTextManipulation {
   }
 
   selectText(from, length, opts = { scroll: true }) {
-    next(() => {
-      this.textarea.selectionStart = from;
-      this.textarea.selectionEnd = from + length;
-      if (opts.scroll === true || typeof opts.scroll === "number") {
-        const oldScrollPos =
-          typeof opts.scroll === "number"
-            ? opts.scroll
-            : this.textarea.scrollTop;
-        if (!this.capabilities.isIOS) {
-          this.textarea.focus();
-        }
-        this.textarea.scrollTop = oldScrollPos;
+    this.textarea.selectionStart = from;
+    this.textarea.selectionEnd = from + length;
+    if (opts.scroll === true || typeof opts.scroll === "number") {
+      const oldScrollPos =
+        typeof opts.scroll === "number" ? opts.scroll : this.textarea.scrollTop;
+      if (!this.capabilities.isIOS) {
+        this.textarea.focus();
       }
-    });
+      this.textarea.scrollTop = oldScrollPos;
+    }
   }
 
   replaceText(oldVal, newVal, opts = {}) {


### PR DESCRIPTION
`replaceText` will replace some text, then call `selectText()` to restore the cursor position. However, selectText was asynchronous, so calling `replaceText()` multiple times in the same runloop iteration would cause the cursor to jump to an unexpected place. This likely explains some of the weird behavior we've seen with upload-markdown replacement