### PR TITLE
FIX: Keep active state in sidebar button for category/tag hot routes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -174,7 +174,7 @@ export default class CategorySectionLink {
   }
 
   get currentWhen() {
-    return "discovery.unreadCategory discovery.topCategory discovery.newCategory discovery.latestCategory discovery.category discovery.categoryNone discovery.categoryAll";
+    return "discovery.unreadCategory discovery.hotCategory discovery.topCategory discovery.newCategory discovery.latestCategory discovery.category discovery.categoryNone discovery.categoryAll";
   }
 
   get title() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
@@ -48,7 +48,7 @@ export default class TagSectionLink extends BaseTagSectionLink {
   }
 
   get currentWhen() {
-    return "tag.show tag.showNew tag.showUnread tag.showTop";
+    return "tag.show tag.showNew tag.showUnread tag.showTop tag.showHot tag.showLatest";
   }
 
   get badgeText() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -70,7 +70,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    ["latest", "top", "new", "unread"].forEach((type) => {
+    ["latest", "top", "new", "unread", "hot"].forEach((type) => {
       server.get(`/c/:categorySlug/:categoryId/l/${type}.json`, () => {
         return helper.response(
           cloneJSON(discoveryFixture["/c/bug/1/l/latest.json"])
@@ -715,6 +715,26 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       )
       .exists(
         "the category1 section link is marked as active for the top route"
+      );
+  });
+
+  test("visiting category discovery hot route", async function (assert) {
+    const { category1 } = setupUserSidebarCategories();
+
+    await visit(`/c/${category1.slug}/${category1.id}/l/hot`);
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link.active"
+      )
+      .exists({ count: 1 }, "only one link is marked as active");
+
+    assert
+      .dom(
+        `.sidebar-section-link-wrapper[data-category-id="${category1.id}"] a.active`
+      )
+      .exists(
+        "the category1 section link is marked as active for the hot route"
       );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -57,7 +57,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
       });
     });
 
-    ["latest", "top", "new", "unread"].forEach((type) => {
+    ["latest", "top", "new", "unread", "hot"].forEach((type) => {
       server.get(`/tag/:tagId/l/${type}.json`, () => {
         return helper.response(
           cloneJSON(discoveryFixture["/tag/important/l/latest.json"])
@@ -269,7 +269,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
       .exists("the tag1 section link is marked as active for the top route");
   });
 
-  test("visiting tag discovery new ", async function (assert) {
+  test("visiting tag discovery new route", async function (assert) {
     await visit(`/tag/tag1/l/new`);
 
     assert
@@ -295,6 +295,20 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     assert
       .dom(".sidebar-section-link-wrapper[data-tag-name=tag1] a.active")
       .exists("the tag1 section link is marked as active for the unread route");
+  });
+
+  test("visiting tag discovery hot route", async function (assert) {
+    await visit(`/tag/tag1/l/hot`);
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='tags'] .sidebar-section-link.active"
+      )
+      .exists({ count: 1 }, "only one link is marked as active");
+
+    assert
+      .dom(".sidebar-section-link-wrapper[data-tag-name=tag1] a.active")
+      .exists("the tag1 section link is marked as active for the hot route");
   });
 
   test("show suffix indicator for new content on tag section links", async function (assert) {


### PR DESCRIPTION
Fixes issue reported in https://meta.discourse.org/t/sidebar-links-loose-active-state-on-the-hot-list-filter/348468 