### PR TITLE
UX: add HTML class for composer preview to manage sidebar height

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.hbs
@@ -8,6 +8,7 @@
 >
   <div class="grippie"></div>
   {{#if this.composer.visible}}
+    {{html-class (if this.composer.showPreview "composer-has-preview")}}
     <ComposerMessages
       @composer={{this.composer.model}}
       @messageCount={{this.composer.messageCount}}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -88,6 +88,10 @@
 
     // allows sidebar to scroll to the bottom when the composer is open
     height: calc(100% - var(--composer-height, 0px));
+
+    html:not(.composer-has-preview) & {
+      height: 100%;
+    }
   }
 
   .sidebar-sections {


### PR DESCRIPTION
This adds the class `composer-has-preview` to the HTML element when the composer is opened and the preview is visible. 

This allows us to adjust the sidebar height, so that the previewless composer can overlap the sidebar and better utilize the available space. 


Before:
![image](https://github.com/user-attachments/assets/8780f159-5d24-4ac0-8a4f-43a9b1665532)



After: 
![image](https://github.com/user-attachments/assets/baf69856-0ece-453f-aa0f-e7be9939af97)
