### PR TITLE
FIX: Allow `touchmove` in composer when there is a selection

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
@@ -13,7 +13,9 @@ export function setupComposerPosition(editor) {
     // when the editor does not have any content to scroll
     applyBehaviorTransformer("composer-position:editor-touch-move", () => {
       const notScrollable = editor.scrollHeight <= editor.clientHeight;
-      if (notScrollable) {
+      const selection = window.getSelection();
+
+      if (notScrollable && selection.rangeCount === 0) {
         event.preventDefault();
         event.stopPropagation();
       }


### PR DESCRIPTION
We stop propagating the `touchmove` event in the composer to ensure that the page doesn't scroll inadvertently. We should only do this if no text is selected, otherwise we block making changes to the text selection on the `textarea` element. 