### PR TITLE
DEV: Only mark translations as htmlSafe for DButton

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -59,7 +59,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
   get computedLabel() {
     if (this.args.label) {
-      return i18n(this.args.label);
+      return htmlSafe(i18n(this.args.label));
     }
     return this.args.translatedLabel;
   }
@@ -225,7 +225,7 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
       {{~#if this.computedLabel~}}
         <span class="d-button-label">
-          {{~htmlSafe this.computedLabel~}}
+          {{~this.computedLabel~}}
           {{~#if @ellipsis~}}
             &hellip;
           {{~/if~}}


### PR DESCRIPTION
If a consumer is passing in their own string to `@translatedLabel`, then they should set it as `htmlSafe` themselves (if it is indeed safe)