### PR TITLE
FIX: always search email logs including the cc: addresses

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -25,7 +25,7 @@ class Admin::EmailController < Admin::AdminController
       AND post_reply_keys.user_id = email_logs.user_id
     SQL
 
-    email_logs = filter_logs(email_logs, params, include_ccs: params[:type] == "group_smtp")
+    email_logs = filter_logs(email_logs, params)
 
     if (reply_key = params[:reply_key]).present?
       email_logs =
@@ -223,7 +223,7 @@ class Admin::EmailController < Admin::AdminController
 
   private
 
-  def filter_logs(logs, params, include_ccs: false)
+  def filter_logs(logs, params)
     table_name = logs.table_name
 
     logs =
@@ -238,7 +238,7 @@ class Admin::EmailController < Admin::AdminController
 
     if params[:address].present?
       query = "#{table_name}.to_address ILIKE :address"
-      query += " OR #{table_name}.cc_addresses ILIKE :address" if include_ccs
+      query += " OR #{table_name}.cc_addresses ILIKE :address"
 
       logs = logs.where(query, { address: "%#{params[:address]}%" })
     end

--- a/spec/requests/admin/email_controller_spec.rb
+++ b/spec/requests/admin/email_controller_spec.rb
@@ -150,33 +150,6 @@ RSpec.describe Admin::EmailController do
           )
         end
       end
-
-      context "when type is not group_smtp and filter param is address" do
-        let(:target_email) { user.email }
-
-        it "should only filter within to address" do
-          other_email = "foo@bar.com"
-          another_email = "forty@two.com"
-          email_log_matching_to_address = Fabricate(:email_log, to_address: target_email)
-          email_log_matching_cc_address =
-            Fabricate(
-              :email_log,
-              to_address: admin.email,
-              cc_addresses: "#{other_email};#{target_email};#{another_email}",
-            )
-
-          get "/admin/email/sent.json", params: { address: target_email }
-
-          expect(response.status).to eq(200)
-          logs = response.parsed_body
-          expect(logs.size).to eq(1)
-          email_log_found_with_to_address =
-            logs.find { |log| log["id"] == email_log_matching_to_address.id }
-          expect(email_log_found_with_to_address["cc_addresses"]).to be_nil
-          expect(email_log_found_with_to_address["to_address"]).to eq target_email
-          expect(logs.find { |log| log["id"] == email_log_matching_cc_address.id }).to be_nil
-        end
-      end
     end
 
     shared_examples "sent emails inaccessible" do


### PR DESCRIPTION
It seems from the original commit notes that this was only included as a query
optimisation, but doing so leads to confusion: https://meta.discourse.org/t/348688

Searching for outbound mail to an address should find that address regardless
of whether or not the mail type to search for is explicitly `group_smtp`.
