### PR TITLE
FIX: Only apply the rate limit to user exports, not downloads

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -544,11 +544,7 @@ class Guardian
 
     # Regular users can only export their archives
     return false unless entity == "user_archive"
-    return false unless entity_id == @user.id || entity_id.nil?
-    UserExport.where(
-      user_id: @user.id,
-      created_at: (Time.zone.now.beginning_of_day..Time.zone.now.end_of_day),
-    ).count == 0
+    entity_id == @user.id || entity_id.nil?
   end
 
   def can_see_emails?


### PR DESCRIPTION
## ✨ What's This?

Follow-up to #30918.

This change moves the guardian check for whether an export has been generated too recently to the endpoint handler, since we only want this check to apply when generating an export.