### PR TITLE
DEV: Improve checking for selected text

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/composer-position.js
@@ -14,8 +14,7 @@ export function setupComposerPosition(editor) {
     applyBehaviorTransformer("composer-position:editor-touch-move", () => {
       const notScrollable = editor.scrollHeight <= editor.clientHeight;
       const selection = window.getSelection();
-
-      if (notScrollable && selection.rangeCount === 0) {
+      if (notScrollable && selection.toString() === "") {
         event.preventDefault();
         event.stopPropagation();
       }


### PR DESCRIPTION
After you've selected and deselected text, `selection.rangeCount` will return `true` on future events. Checking for `selection.toString` is more robust.

Followup to f1bdd86a8c9bec03b962167c37963b1d11d0e5ea