### PR TITLE
UX: Improvements to posts route

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/posts.gjs
+++ b/app/assets/javascripts/discourse/app/templates/posts.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import RouteTemplate from "ember-route-template";
 import PostList from "discourse/components/post-list";
 import Posts from "discourse/models/posts";
+import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
   class extends Component {
@@ -15,11 +16,14 @@ export default RouteTemplate(
     }
 
     <template>
-      <PostList
-        @posts={{@model}}
-        @fetchMorePosts={{this.loadMorePosts}}
-        @titlePath="topic_html_title"
-      />
+      <section class="posts-page">
+        <h2 class="posts-page__title">{{i18n "post_list.title"}}</h2>
+        <PostList
+          @posts={{@model}}
+          @fetchMorePosts={{this.loadMorePosts}}
+          @titlePath="topic_html_title"
+        />
+      </section>
     </template>
   }
 );

--- a/app/assets/stylesheets/common/components/post-list.scss
+++ b/app/assets/stylesheets/common/components/post-list.scss
@@ -34,6 +34,13 @@
       }
     }
 
+    .expand-item,
+    .collapse-item {
+      padding: 0;
+      margin-right: 0.75rem;
+      margin-top: 0.15rem;
+    }
+
     .stream-topic-title {
       overflow-wrap: anywhere;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3763,6 +3763,7 @@ en:
       deleted_by_author_simple: "(topic deleted by author)"
 
     post_list:
+      title: "Latest posts"
       empty: "There are no posts"
       aria_post_number: "%{title} - post #%{postNumber}"
 

--- a/spec/system/page_objects/pages/posts_page.rb
+++ b/spec/system/page_objects/pages/posts_page.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Posts < PageObjects::Pages::Base
+      POSTS_PAGE_SELECTOR = ".posts-page"
+
+      def visit
+        page.visit("/posts")
+        self
+      end
+
+      def has_page_title?
+        page.find("#{POSTS_PAGE_SELECTOR} .posts-page__title")
+      end
+
+      def has_posts?(count)
+        page.has_css?("#{POSTS_PAGE_SELECTOR} .post-list .post-list-item", count: count)
+      end
+    end
+  end
+end

--- a/spec/system/posts_page_spec.rb
+++ b/spec/system/posts_page_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe "Posts page", type: :system do
+  fab!(:post)
+  fab!(:post_2) { Fabricate(:post) }
+  fab!(:post_3) { Fabricate(:post) }
+  fab!(:user)
+  let(:posts_page) { PageObjects::Pages::Posts.new }
+
+  before { sign_in(user) }
+
+  it "renders the posts page with posts" do
+    posts_page.visit
+    expect(posts_page).to have_page_title
+    expect(posts_page).to have_posts(3)
+  end
+end


### PR DESCRIPTION
### 🔍 Overview
This update makes some small improvements to the posts route front-end. Specifically, it adds a title to the page, and it improves the positioning of expand/collapse caret.

## 📸 Screenshots
### Before
<img width="975" alt="Screenshot 2025-01-23 at 15 53 52" src="https://github.com/user-attachments/assets/a1bc3c65-e04c-4c60-b183-ef709457b92f" />


### After
<img width="971" alt="Screenshot 2025-01-23 at 15 53 10" src="https://github.com/user-attachments/assets/46d001cc-57e4-4248-a6b1-ae9e36ea1723" />
