### PR TITLE
UX: fix admin dashboard link and style regressions

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-report.hbs
@@ -7,6 +7,7 @@
             {{#unless this.showNotFoundError}}
               <DPageSubheader
                 @titleLabel={{this.model.title}}
+                @titleUrl={{this.model.reportUrl}}
                 @descriptionLabel={{this.model.description}}
                 @learnMoreUrl={{this.model.description_link}}
               />

--- a/app/assets/javascripts/discourse/app/components/d-page-subheader.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-page-subheader.gjs
@@ -21,7 +21,15 @@ export default class DPageSubheader extends Component {
   <template>
     <div class="d-page-subheader">
       <div class="d-page-subheader__title-row">
-        <h2 class="d-page-subheader__title">{{@titleLabel}}</h2>
+        <h2 class="d-page-subheader__title">
+          {{#if @titleUrl}}
+            <a href={{@titleUrl}} class="d-page-subheader__title-link">
+              {{@titleLabel}}
+            </a>
+          {{else}}
+            {{@titleLabel}}
+          {{/if}}
+        </h2>
         {{#if (has-block "actions")}}
           <div class="d-page-subheader__actions">
             {{#if this.site.mobileView}}

--- a/app/assets/stylesheets/common/admin/admin_report.scss
+++ b/app/assets/stylesheets/common/admin/admin_report.scss
@@ -186,6 +186,10 @@
       }
     }
   }
+
+  .d-page-subheader__title a {
+    color: var(--primary);
+  }
 }
 
 .rtl .admin-report {

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -150,6 +150,27 @@
       &.site-traffic {
         grid-column: span 12;
       }
+
+      .header {
+        display: grid;
+        grid-template-areas: "title trend" "description description";
+        grid-template-columns: auto 1fr;
+
+        .d-page-subheader {
+          display: contents;
+        }
+
+        .d-page-subheader__description {
+          grid-area: description;
+          margin-top: 0;
+        }
+
+        .trend {
+          grid-area: trend;
+          white-space: nowrap;
+          align-self: start;
+        }
+      }
     }
 
     @include breakpoint(medium) {


### PR DESCRIPTION
Heading link regression reported here: https://meta.discourse.org/t/admin-panel-reports-in-the-community-health-section-are-no-longer-clickable/347631


Also noticed some style regressions:


Before:
![image](https://github.com/user-attachments/assets/1b619870-fb1f-4e79-af0a-00411c111ce4)


After:
![image](https://github.com/user-attachments/assets/8a00ba70-66b2-4ba8-87a3-5d665886f095)

