### PR TITLE
FIX: Show the correct message when no user export exists.

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-user-exports-table.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-exports-table.gjs
@@ -28,7 +28,9 @@ export default class extends Component {
     this.messageBus.subscribe(EXPORT_PROGRESS_CHANNEL, this.onExportProgress);
 
     this.model = this.args.model;
-    this.userExport = UserExport.create(this.model.latest_export?.user_export);
+    if (this.model.latest_export) {
+      this.userExport = UserExport.create(this.model.latest_export.user_export);
+    }
   }
 
   willDestroy() {
@@ -43,7 +45,9 @@ export default class extends Component {
       if (data.failed) {
         this.dialog.alert(i18n("admin.user.exports.download.export_failed"));
       } else {
-        this.userExport = UserExport.create(data.export_data.user_export);
+        if (data.export_data.user_export) {
+          this.userExport = UserExport.create(data.export_data.user_export);
+        }
         this.toasts.success({
           autoClose: false,
           data: { message: i18n("admin.user.exports.download.success") },


### PR DESCRIPTION
## ✨ What's This?

Followup to #30918.

We need to check that the user export data exists before creating a model, since having an empty model will cause the UI to incorrectly think there's a user export to display.

This change shows the correct message, instead.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/567b0e10-e9a6-47cd-a578-c838b489a21e)
