### PR TITLE
FIX: Scrub `Client-Ip` request header in nginx

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -109,6 +109,7 @@ server {
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type "";
       proxy_set_header X-Accel-Mapping "";
+      proxy_set_header Client-Ip "";
       proxy_pass http://discourse;
       break;
     }
@@ -121,6 +122,7 @@ server {
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type "";
       proxy_set_header X-Accel-Mapping "";
+      proxy_set_header Client-Ip "";
       proxy_pass http://discourse;
       break;
     }
@@ -141,6 +143,7 @@ server {
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type "";
       proxy_set_header X-Accel-Mapping "";
+      proxy_set_header Client-Ip "";
       proxy_pass http://discourse;
       break;
     }
@@ -244,6 +247,7 @@ server {
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type "";
       proxy_set_header X-Accel-Mapping "";
+      proxy_set_header Client-Ip "";
 
       # if Set-Cookie is in the response nothing gets cached
       # this is double bad cause we are not passing last modified in
@@ -270,6 +274,7 @@ server {
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type "";
       proxy_set_header X-Accel-Mapping "";
+      proxy_set_header Client-Ip "";
       proxy_http_version 1.1;
       proxy_buffering off;
       proxy_pass http://discourse;
@@ -293,6 +298,7 @@ server {
     proxy_set_header X-Forwarded-Proto $thescheme;
     proxy_set_header X-Sendfile-Type "";
     proxy_set_header X-Accel-Mapping "";
+    proxy_set_header Client-Ip "";
     proxy_pass http://discourse;
   }
 


### PR DESCRIPTION
We are scrubbing the `Client-Ip` request header at the nginx proxy
because it is not a request header which we have decided to trust. Our
application should only use the `X-Fowarded-For` request header instead.

This change helps to resolve `ActionDispatch::RemoteIp::IpSpoofAttackError`
errors from being raised by the `ActionDispatch::RemoteIp` when
the request headers contains both `Client-Ip` and `X-Forwarded-For`.

At the time of writing, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
also states that "The HTTP X-Forwarded-For (XFF) request header is a de-facto standard header for identifying the originating IP address of a client connecting to a web server through a proxy server."
