### PR TITLE
FIX: broken tada emoji on subfolder account activation

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/activate-account.gjs
+++ b/app/assets/javascripts/discourse/app/templates/activate-account.gjs
@@ -103,7 +103,10 @@ export default RouteTemplate(
           {{#if this.accountActivated}}
             <div class="account-activated">
               <div class="tada-image">
-                <img src="/images/wizard/tada.svg" alt="tada emoji" />
+                <img
+                  src={{getURL "/images/wizard/tada.svg"}}
+                  alt="tada emoji"
+                />
               </div>
               {{#if this.needsApproval}}
                 <p>{{i18n "user.activate_account.approval_required"}}</p>


### PR DESCRIPTION
Fixes Activate Account page's tada emoji that's currently broken (missing the base path) on subfolder installs.