### PR TITLE
FIX: double click on tag INPUT breaking expected behavior

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -76,7 +76,13 @@ export default class SelectKitHeader extends Component.extend(UtilsMixin) {
     ) {
       return false;
     }
-    this.selectKit.toggle(event);
+
+    // When users double click on a tag input we want to leave it open
+    const hasInput =
+      event.target.tagName === "INPUT" || event.target.querySelector("input");
+    if (!this.selectKit.isExpanded || !hasInput) {
+      this.selectKit.toggle(event);
+    }
   }
 
   keyUp(event) {


### PR DESCRIPTION
Double clicking on the INPUT for tag entry
was cause the INPUT to be selected but the
actual tag entry and lookup to be hidden

This adds special case handling

