### PR TITLE
FIX: truncate extremely long site name titles

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -75,7 +75,7 @@ module BackupRestore
     end
 
     def get_parameterized_title
-      SiteSetting.title.parameterize.presence || "discourse"
+      SiteSetting.title.parameterize[...64].presence || "discourse"
     end
 
     def initialize_state

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe BackupRestore::Backuper do
       expect(backuper.send(:get_parameterized_title)).to eq("discourse")
     end
 
+    it "truncates the title to 64 chars" do
+      SiteSetting.title = "This is th title of a very long site that is going to be truncated"
+      backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
+
+      expect(backuper.send(:get_parameterized_title).length).to eq(64)
+    end
+
     it "returns a valid parameterized site title" do
       SiteSetting.title = "Coding Horror"
       backuper = BackupRestore::Backuper.new(Discourse.system_user.id)


### PR DESCRIPTION
This corrects an issue where very long titles on
website would cause the backup not to save
cause filename was too long

