### PR TITLE
FIX: Query syntax error in `UserBadge.update_featured_ranks!`

### DIFF
--- a/app/jobs/regular/backfill_badge.rb
+++ b/app/jobs/regular/backfill_badge.rb
@@ -20,10 +20,14 @@ module Jobs
       )
 
       affected_user_ids = (revoked_user_ids | granted_user_ids).to_a
+      revoked_user_ids = revoked_user_ids.to_a
 
-      BadgeGranter.revoke_ungranted_titles!(revoked_user_ids.to_a)
-      UserBadge.ensure_consistency!(affected_user_ids)
-      UserStat.update_distinct_badge_count(affected_user_ids)
+      BadgeGranter.revoke_ungranted_titles!(revoked_user_ids) if revoked_user_ids.present?
+
+      if affected_user_ids.present?
+        UserBadge.ensure_consistency!(affected_user_ids)
+        UserStat.update_distinct_badge_count(affected_user_ids)
+      end
     end
   end
 end

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -192,8 +192,8 @@ class UserStat < ActiveRecord::Base
     SQL
   end
 
-  def self.update_distinct_badge_count(user_ids = nil)
-    user_ids = user_ids.join(", ") if user_ids
+  def self.update_distinct_badge_count(user_ids = [])
+    user_ids = user_ids.join(", ")
 
     sql = <<~SQL
       UPDATE user_stats
@@ -206,7 +206,7 @@ class UserStat < ActiveRecord::Base
         GROUP BY users.id
       ) x
       WHERE user_stats.user_id = x.user_id AND user_stats.distinct_badge_count <> x.distinct_badge_count
-      #{"AND user_stats.user_id IN (#{user_ids})" if user_ids}
+      #{"AND user_stats.user_id IN (#{user_ids})" if !user_ids.empty?}
     SQL
 
     DB.exec sql

--- a/spec/models/user_badge_spec.rb
+++ b/spec/models/user_badge_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe UserBadge do
 
   describe "featured rank" do
     fab!(:user)
+    fab!(:user_2) { Fabricate(:user) }
     fab!(:user_badge_tl1) do
       UserBadge.create!(
         badge_id: Badge::BasicUser,
@@ -77,6 +78,15 @@ RSpec.describe UserBadge do
       UserBadge.create!(
         badge_id: Badge::FirstLike,
         user: user,
+        granted_by: Discourse.system_user,
+        granted_at: Time.now,
+      )
+    end
+
+    fab!(:user_2_badge_tl1) do
+      UserBadge.create!(
+        badge_id: Badge::BasicUser,
+        user: user_2,
         granted_by: Discourse.system_user,
         granted_at: Time.now,
       )
@@ -121,15 +131,25 @@ RSpec.describe UserBadge do
     it "can ensure consistency per user" do
       user_badge_tl2.update_column(:featured_rank, 20) # Update without hooks
       expect(user_badge_tl2.reload.featured_rank).to eq(20) # Double check
+      user_2_badge_tl1.update_column(:featured_rank, 20) # Update without hooks
+      expect(user_2_badge_tl1.reload.featured_rank).to eq(20) # Double check
+
       UserBadge.update_featured_ranks!([user.id])
+
       expect(user_badge_tl2.reload.featured_rank).to eq(1)
+      expect(user_2_badge_tl1.reload.featured_rank).to eq(20)
     end
 
     it "can ensure consistency for all users" do
       user_badge_tl2.update_column(:featured_rank, 20) # Update without hooks
       expect(user_badge_tl2.reload.featured_rank).to eq(20) # Double check
-      UserBadge.update_featured_ranks!([user.id])
+      user_2_badge_tl1.update_column(:featured_rank, 20) # Update without hooks
+      expect(user_2_badge_tl1.reload.featured_rank).to eq(20) # Double check
+
+      UserBadge.update_featured_ranks!
+
       expect(user_badge_tl2.reload.featured_rank).to eq(1)
+      expect(user_2_badge_tl1.reload.featured_rank).to eq(1)
     end
   end
 end

--- a/spec/models/user_stat_spec.rb
+++ b/spec/models/user_stat_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe UserStat do
     end
   end
 
-  describe "update_distinct_badge_count" do
+  describe ".update_distinct_badge_count" do
     fab!(:user)
     let(:stat) { user.user_stat }
     fab!(:badge1) { Fabricate(:badge) }


### PR DESCRIPTION
This commit fixes an SQL syntax error in `UserBadge.update_featured_ranks!` when
the `user_ids` param is an empty array `[]`.

This was causing the `Jobs::BackfillBadge` job to raise the following
exceptions:

```
Job exception: ERROR:  syntax error at or near ")"
LINE 6:   AND user_id IN ()
```

This commit fixes the same error in `UserState.update_distinct_badge_count` as well

Follow-up to 3e4eac0fed05daedcdea50d6275e143469d55eda
