### PR TITLE
FIX: NULL IP for similar users caused incorrect message

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1908,6 +1908,8 @@ class User < ActiveRecord::Base
   end
 
   def similar_users
+    return User.none if self.ip_address.blank?
+
     User
       .real
       .where.not(id: self.id)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3619,4 +3619,23 @@ RSpec.describe User do
       )
     end
   end
+
+  describe "#similar_users" do
+    fab!(:user2) { Fabricate(:user, ip_address: "1.2.3.4") }
+    fab!(:user3) { Fabricate(:user, ip_address: "1.2.3.4") }
+    fab!(:admin) { Fabricate(:admin, ip_address: "1.2.3.4") }
+    fab!(:moderator) { Fabricate(:moderator, ip_address: "1.2.3.4") }
+
+    before { user.update(ip_address: "1.2.3.4") }
+
+    it "gets users that are not admin, moderator, or current user with the same IP" do
+      expect(user.similar_users).to contain_exactly(user2, user3)
+    end
+
+    it "does not get other users with a null IP if this user has a null IP" do
+      user.update!(ip_address: nil)
+      user2.update!(ip_address: nil)
+      expect(user.similar_users).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
When suspending a user, we check for similar users by
IP address and show a number of and a list of them.
However we were checking this if the current user had a
NULL IP address, which found all other users with a NULL
IP. This doesn't make sense, this commit fixes the issue.

**Before**

![image](https://github.com/user-attachments/assets/4cca8cd6-dfa7-4529-9351-ee110126211a)

**After**

![image](https://github.com/user-attachments/assets/f7a5ba6a-e474-477b-a595-def78cb6edef)
