### PR TITLE
DEV: add migration to remap from deprecated icon names for badges

### DIFF
--- a/db/migrate/20250124062108_remap_deprecated_icon_names_for_seeded_badges.rb
+++ b/db/migrate/20250124062108_remap_deprecated_icon_names_for_seeded_badges.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+#
+class RemapDeprecatedIconNamesForSeededBadges < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      WITH remaps AS (
+        SELECT from_icon, to_icon
+        FROM (VALUES ('smile', 'face-smile'), ('share-alt', 'share-nodes'))
+        AS mapping(from_icon, to_icon)
+      )
+      UPDATE badges
+      SET icon = remaps.to_icon
+      FROM remaps
+      WHERE icon = remaps.from_icon;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This is a very narrowly scoped migration to update badges.icon for two deprecated names `smile` and `share-alt`. Following on from this PR that updated the Badge seed fixture used as part of site creation: https://github.com/discourse/discourse/pull/30942

The migration logic closely follows that of the [previous DB migrations](https://github.com/discourse/discourse/pull/30100) that updated all deprecated FA icon names, just that we reduce the mappings to only look for `smile` and `share-alt`.