### PR TITLE
DEV: Remove DISCOURSE_HOSTNAME from test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
     timeout-minutes: 20
 
     env:
-      DISCOURSE_HOSTNAME: www.example.com
       RAILS_ENV: test
       PGUSER: discourse
       PGPASSWORD: discourse


### PR DESCRIPTION
This could cause assets (e.g. fonts) to try and load from `www.example.com`, which led to an error. In the case of theme-qunit tests this actually caused the run to fail. Not entirely sure why... font failures shouldn't be catastrophic... but this is a good fix regardless.