### PR TITLE
FIX: ensures category is rendered

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
@@ -42,7 +42,7 @@ const TopicLabelButton = <template>
         </span>
       </div>
       <div class="topic-title__bottom-line">
-        {{categoryLinkHTML @topic (hash link=false)}}
+        {{categoryLinkHTML @topic.category (hash link=false)}}
         {{discourseTags @topic}}
       </div>
     </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -397,18 +397,28 @@ acceptance("Composer", function (needs) {
       ".d-editor-input",
       "this is the content for a different topic"
     );
-
     await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
+
     assert.strictEqual(
       currentURL(),
       "/t/1-3-0beta9-no-rate-limit-popups/28830"
     );
-    await click("#reply-control button.create");
-    assert.dom(".reply-where-modal").exists("pops up a modal");
 
-    assert.dom(".topic-title").exists({ count: 2 }); // modal buttons
+    await click("#reply-control button.create");
+
+    assert.dom(".reply-where-modal").exists("pops up a modal");
+    assert
+      .dom(".topic-title")
+      .exists({ count: 2 }, "it renders the two topics");
+    assert
+      .dom(".btn-reply-where:nth-of-type(1) .badge-category__name")
+      .hasText("test too", "it renders the category name");
+    assert
+      .dom(".btn-reply-where:nth-of-type(2) .discourse-tags")
+      .hasText("foo", "it renders the tags");
 
     await click(".btn-reply-here");
+
     assert
       .dom(".topic-post:last-of-type .cooked p")
       .hasText(

--- a/app/assets/javascripts/discourse/tests/fixtures/topic.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/topic.js
@@ -4005,7 +4005,7 @@ export default {
     chunk_size: 20,
     bookmarked: null,
     bookmarks: [],
-    tags: null,
+    tags: ["foo"],
   },
   "/t/9/1.json": {
     post_stream: {


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/30962 lost the rendering of category in topic-label-content. This commit fixes it and adds a test to ensure we render category and tags.