### PR TITLE
DEV: fix typo in admin.user.exports.started translation string

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6975,7 +6975,7 @@ en:
             not_available: No export available
             button: Request archive
             confirm: Do you really want to create an archive of this user's activity and preferences?
-            started: We've started collecting collecting the archive, the download link will update when the process is complete.
+            started: We've started collecting the archive, the download link will update when the process is complete.
             success: The archive is ready for download.
             export_failed: We're sorry, but the export failed. Please check the logs for further information.
         anonymize: "Anonymize User"


### PR DESCRIPTION
(credit: @moin-Jana for spotting this)

Fixes the english translation string for `admin.user.exports.started`, had an extra `collecting`.