### PR TITLE
FIX: enforce second factor with subfolders

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -893,7 +893,7 @@ class ApplicationController < ActionController::Base
 
     redirect_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
     if !request.fullpath.start_with?(redirect_path)
-      redirect_to path(redirect_path)
+      redirect_to redirect_path
       nil
     end
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -142,6 +142,15 @@ RSpec.describe ApplicationController do
       expect(response).to redirect_to("/u/#{admin.username}/preferences/second-factor")
     end
 
+    it "should properly redirect admins when enforce_second_factor is 'all' in subfolder" do
+      set_subfolder "/forum"
+      SiteSetting.enforce_second_factor = "all"
+      sign_in(admin)
+
+      get "/"
+      expect(response).to redirect_to("/forum/u/#{admin.username}/preferences/second-factor")
+    end
+
     it "should redirect users when enforce_second_factor is 'all'" do
       SiteSetting.enforce_second_factor = "all"
       sign_in(user)


### PR DESCRIPTION
fix an improper redirect when enforcing second factor under a subfolder install

backport of #30992