### PR TITLE
UX: respect user locale when sending chat notices

### DIFF
--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -287,7 +287,8 @@ module Chat
       Chat::Publisher.publish_notice(
         user_id: @user.id,
         channel_id: @chat_channel.id,
-        text_content: I18n.t("chat.mention_warning.global_mentions_disallowed"),
+        text_content:
+          I18n.t("chat.mention_warning.global_mentions_disallowed", locale: @user.effective_locale),
       )
     end
 
@@ -321,7 +322,12 @@ module Chat
 
     def mention_warning_text(single:, multiple:, first_identifier:, count:)
       translation_key = count == 1 ? single : multiple
-      I18n.t(translation_key, first_identifier: first_identifier, count: count - 1)
+      I18n.t(
+        translation_key,
+        first_identifier: first_identifier,
+        count: count - 1,
+        locale: @user.effective_locale,
+      )
     end
 
     def global_mentions_disabled

--- a/plugins/chat/spec/lib/chat/notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat/notifier_spec.rb
@@ -73,6 +73,25 @@ describe Chat::Notifier do
         )
       end
 
+      it "will respect user's locale on mention warning" do
+        SiteSetting.allow_user_locale = true
+        user_1.update!(locale: "pt_BR")
+        channel.update!(allow_channel_wide_mentions: false)
+        msg = build_cooked_msg(mention, user_1)
+
+        messages =
+          MessageBus.track_publish("/chat/#{channel.id}") do
+            to_notify = described_class.new(msg, msg.created_at).notify_new
+          end
+
+        global_mentions_disabled_message = messages.first
+
+        expect(global_mentions_disabled_message.data[:type].to_sym).to eq(:notice)
+        expect(global_mentions_disabled_message.data[:text_content]).to eq(
+          I18n.t("chat.mention_warning.global_mentions_disallowed", locale: "pt_BR"),
+        )
+      end
+
       it "includes all members of a channel except the sender" do
         msg = build_cooked_msg(mention, user_1)
 
@@ -404,7 +423,7 @@ describe Chat::Notifier do
     describe "unreachable users" do
       fab!(:user_3) { Fabricate(:user) }
 
-      it "notify poster of users who are not allowed to use chat" do
+      it "notifies poster of users who are not allowed to use chat" do
         msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
 
         messages =
@@ -419,6 +438,30 @@ describe Chat::Notifier do
         expect(unreachable_msg[:data][:type].to_sym).to eq(:notice)
         expect(unreachable_msg[:data][:text_content]).to eq(
           I18n.t("chat.mention_warning.cannot_see", first_identifier: user_3.username),
+        )
+      end
+
+      it "respects user locale on notice about users who are not allowed to use chat" do
+        SiteSetting.allow_user_locale = true
+        user_1.update!(locale: "pt_BR")
+        msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
+
+        messages =
+          MessageBus.track_publish("/chat/#{channel.id}") do
+            to_notify = described_class.new(msg, msg.created_at).notify_new
+
+            expect(to_notify[:direct_mentions]).to be_empty
+          end
+
+        unreachable_msg = messages.first
+
+        expect(unreachable_msg[:data][:type].to_sym).to eq(:notice)
+        expect(unreachable_msg[:data][:text_content]).to eq(
+          I18n.t(
+            "chat.mention_warning.cannot_see",
+            first_identifier: user_3.username,
+            locale: "pt_BR",
+          ),
         )
       end
 
@@ -687,6 +730,31 @@ describe Chat::Notifier do
         expect(mentions_disabled_msg[:data][:type].to_sym).to eq(:notice)
         expect(mentions_disabled_msg[:data][:text_content]).to eq(
           I18n.t("chat.mention_warning.group_mentions_disabled", first_identifier: group.name),
+        )
+      end
+
+      it "respects user locale on notice about group disallowing mentions" do
+        SiteSetting.allow_user_locale = true
+        user_1.update!(locale: "pt_BR")
+        group.update!(mentionable_level: Group::ALIAS_LEVELS[:only_admins])
+        msg = build_cooked_msg("Hello @#{group.name}", user_1)
+
+        messages =
+          MessageBus.track_publish("/chat/#{channel.id}") do
+            to_notify = described_class.new(msg, msg.created_at).notify_new
+
+            expect(to_notify[group.name]).to be_nil
+          end
+
+        mentions_disabled_msg = messages.first
+
+        expect(mentions_disabled_msg[:data][:type].to_sym).to eq(:notice)
+        expect(mentions_disabled_msg[:data][:text_content]).to eq(
+          I18n.t(
+            "chat.mention_warning.group_mentions_disabled",
+            first_identifier: group.name,
+            locale: "pt_BR",
+          ),
         )
       end
     end


### PR DESCRIPTION
When chat sends a notice to the client via MessageBus, it sends a translated message using the site's default locale.

This changes it to send it in the user's `effective_locale` instead.