### PR TITLE
DEV: add missing button classes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-toggle.gjs
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-toggle.gjs
@@ -2,7 +2,7 @@ import DButton from "discourse/components/d-button";
 
 const BulkSelectToggle = <template>
   <DButton
-    class="bulk-select"
+    class="btn-default bulk-select"
     @action={{@bulkSelectHelper.toggleBulkSelect}}
     @icon="list"
   />

--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -101,6 +101,7 @@ export default class NotificationsTracking extends Component {
       @identifier="notifications-tracking"
       @modalForMobile={{true}}
       @triggerClass={{concatClass
+        "btn-default"
         "notifications-tracking-trigger-btn"
         @triggerClass
       }}

--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -83,7 +83,7 @@ export default class TopicDraftsDropdown extends Component {
       @onRegisterApi={{this.onRegisterApi}}
       @modalForMobile={{true}}
       @disabled={{this.loading}}
-      class="btn-small"
+      class="btn-small btn-default"
     >
       <:content>
         <DropdownMenu as |dropdown|>

--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
@@ -15,7 +15,7 @@
   <div class="panel-body-bottom">
     {{#if this.showAllHref}}
       <DButton
-        class="show-all"
+        class="btn-default show-all"
         @href={{this.showAllHref}}
         @translatedAriaLabel={{this.showAllTitle}}
         @translatedTitle={{this.showAllTitle}}


### PR DESCRIPTION
While updating a couple of themes I noticed some buttons were missing `.btn-default`, which resulted in some inconsistent button styling 