### PR TITLE
FIX: reset bool site setting not updating checkbox

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/bool.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/bool.gjs
@@ -1,15 +1,15 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 
 export default class Bool extends Component {
-  @tracked
-  enabled = isEmpty(this.args.value)
-    ? false
-    : this.args.value.toString() === "true";
+  get enabled() {
+    return isEmpty(this.args.value)
+      ? false
+      : this.args.value.toString() === "true";
+  }
 
   @action
   onToggle(event) {

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
@@ -250,6 +250,33 @@ module(
         .exists("the cancel button is shown");
     });
 
+    test("resetting to the default value changes the content of checkbox field", async function (assert) {
+      this.set("setting", {
+        setting: "test_setting",
+        value: "true",
+        default: "false",
+        type: "bool",
+      });
+
+      await render(hbs`<SiteSetting @setting={{this.setting}} />`);
+      assert
+        .dom("input[type=checkbox]")
+        .isChecked("the checkbox contains the custom value");
+
+      await click(".setting-controls__undo");
+      assert
+        .dom("input[type=checkbox]")
+        .isNotChecked("the checkbox now contains the default value");
+
+      assert
+        .dom(".setting-controls__undo")
+        .doesNotExist("the reset button is not shown");
+      assert.dom(".setting-controls__ok").exists("the save button is shown");
+      assert
+        .dom(".setting-controls__cancel")
+        .exists("the cancel button is shown");
+    });
+
     test("clearing the input field keeps the cancel button and the validation error shown", async function (assert) {
       this.set("setting", {
         setting: "max_image_size_kb",


### PR DESCRIPTION
Checkboxes rendered for `bool` site settings weren't being promptly updated when resetting a non-default site setting value to the default value, because `enabled` was only set on initialization.

This PR changes `enabled` to a getter so it can track when the dependent `args` update.