### PR TITLE
DEV: refactor username validation mixin to helper

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -15,17 +15,16 @@ import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed, { bind } from "discourse/lib/decorators";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
 import { userPath } from "discourse/lib/url";
+import UsernameValidationHelper from "discourse/lib/username-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
 import PasswordValidation from "discourse/mixins/password-validation";
 import UserFieldsValidation from "discourse/mixins/user-fields-validation";
-import UsernameValidation from "discourse/mixins/username-validation";
 import { findAll } from "discourse/models/login-method";
 import User from "discourse/models/user";
 import { i18n } from "discourse-i18n";
 
 export default class SignupPageController extends Controller.extend(
   PasswordValidation,
-  UsernameValidation,
   UserFieldsValidation
 ) {
   @service site;
@@ -44,6 +43,7 @@ export default class SignupPageController extends Controller.extend(
   passwordValidationVisible = false;
   emailValidationVisible = false;
   nameValidationHelper = new NameValidationHelper(this);
+  usernameValidationHelper = new UsernameValidationHelper(this);
 
   @notEmpty("authOptions") hasAuthOptions;
   @setting("enable_local_logins") canCreateLocal;
@@ -65,6 +65,11 @@ export default class SignupPageController extends Controller.extend(
 
   get nameValidation() {
     return this.nameValidationHelper.nameValidation;
+  }
+
+  @dependentKeyCompat
+  get usernameValidation() {
+    return this.usernameValidationHelper.usernameValidation;
   }
 
   @dependentKeyCompat

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -11,7 +11,6 @@ import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { setting } from "discourse/lib/computed";
 import cookie, { removeCookie } from "discourse/lib/cookie";
-import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed, { bind } from "discourse/lib/decorators";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
 import { userPath } from "discourse/lib/url";
@@ -361,7 +360,7 @@ export default class SignupPageController extends Controller.extend(
       // If email is valid and username has not been entered yet,
       // or email and username were filled automatically by 3rd party auth,
       // then look for a registered username that matches the email.
-      discourseDebounce(this, this.fetchExistingUsername, 500);
+      this.usernameValidationHelper.fetchExistingUsername.perform();
     }
   }
 

--- a/app/assets/javascripts/discourse/app/lib/username-validation-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/username-validation-helper.js
@@ -1,0 +1,119 @@
+import { tracked } from "@glimmer/tracking";
+import EmberObject, { action } from "@ember/object";
+import { isEmpty } from "@ember/utils";
+import { TrackedObject } from "@ember-compat/tracked-built-ins";
+import discourseDebounce from "discourse/lib/debounce";
+import User from "discourse/models/user";
+import { i18n } from "discourse-i18n";
+
+function failedResult(attrs) {
+  return EmberObject.create({
+    shouldCheck: false,
+    failed: true,
+    ok: false,
+    element: document.querySelector("#new-account-username"),
+    ...attrs,
+  });
+}
+
+function validResult(attrs) {
+  return EmberObject.create({ ok: true, ...attrs });
+}
+
+export default class UsernameValidationHelper {
+  @tracked usernameValidationResult = new TrackedObject();
+  checkedUsername = null;
+
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  async fetchExistingUsername() {
+    const result = await User.checkUsername(null, this.owner.accountEmail);
+
+    if (
+      result.suggestion &&
+      (isEmpty(this.owner.accountUsername) ||
+        this.owner.accountUsername === this.owner.get("authOptions.username"))
+    ) {
+      this.owner.accountUsername = result.suggestion;
+      this.owner.prefilledUsername = result.suggestion;
+    }
+  }
+
+  get usernameValidation() {
+    if (
+      this.usernameValidationResult &&
+      this.checkedUsername === this.owner.accountUsername
+    ) {
+      return this.usernameValidationResult;
+    }
+
+    const result = this.basicUsernameValidation(this.owner.accountUsername);
+
+    if (result.shouldCheck) {
+      discourseDebounce(this, this.checkUsernameAvailability, 500);
+    }
+
+    return result;
+  }
+
+  basicUsernameValidation(username) {
+    if (username && username === this.owner.prefilledUsername) {
+      return validResult({ reason: i18n("user.username.prefilled") });
+    }
+
+    if (isEmpty(username)) {
+      return failedResult({
+        message: i18n("user.username.required"),
+        reason: this.owner.forceValidationReason
+          ? i18n("user.username.required")
+          : null,
+      });
+    }
+
+    if (username.length < this.owner.siteSettings.min_username_length) {
+      return failedResult({ reason: i18n("user.username.too_short") });
+    }
+
+    if (username.length > this.owner.siteSettings.max_username_length) {
+      return failedResult({ reason: i18n("user.username.too_long") });
+    }
+
+    return failedResult({
+      shouldCheck: true,
+      reason: i18n("user.username.checking"),
+    });
+  }
+
+  @action
+  async checkUsernameAvailability() {
+    const result = await User.checkUsername(
+      this.owner.accountUsername,
+      this.owner.accountEmail
+    );
+
+    if (this.owner.isDestroying || this.owner.isDestroyed) {
+      return;
+    }
+
+    this.checkedUsername = this.owner.accountUsername;
+    this.owner.isDeveloper = !!result.is_developer;
+
+    if (result.available) {
+      this.usernameValidationResult = validResult({
+        reason: i18n("user.username.available"),
+      });
+    } else if (result.suggestion) {
+      this.usernameValidationResult = failedResult({
+        reason: i18n("user.username.not_available"),
+      });
+    } else {
+      this.usernameValidationResult = failedResult({
+        reason: result.errors
+          ? result.errors.join(" ")
+          : i18n("user.username.not_available_no_suggestion"),
+      });
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/lib/common-babel-config.js
+++ b/app/assets/javascripts/discourse/lib/common-babel-config.js
@@ -15,6 +15,7 @@ module.exports = function generateCommonBabelConfig() {
             runEarly: true,
           },
         ],
+        require.resolve("ember-concurrency/async-arrow-task-transform"),
       ],
     },
   };

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -92,6 +92,7 @@
     "ember-cli-progress-ci": "workspace:1.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
+    "ember-concurrency": "^4.0.1",
     "ember-decorators": "^6.1.1",
     "ember-exam": "^9.0.0",
     "ember-load-initializers": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,6 +498,9 @@ importers:
       ember-cli-terser:
         specifier: ^4.0.2
         version: 4.0.2
+      ember-concurrency:
+        specifier: ^4.0.1
+        version: 4.0.2(@babel/core@7.26.7)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.12)(esbuild@0.24.2)))
       ember-decorators:
         specifier: ^6.1.1
         version: 6.1.1
@@ -4032,6 +4035,9 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decorator-transforms@1.2.1:
+    resolution: {integrity: sha512-UUtmyfdlHvYoX3VSG1w5rbvBQ2r5TX1JsE4hmKU9snleFymadA3VACjl6SRfi9YgBCSjBbfQvR1bs9PRW9yBKw==}
+
   decorator-transforms@2.3.0:
     resolution: {integrity: sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==}
 
@@ -4282,6 +4288,17 @@ packages:
   ember-compatibility-helpers@1.2.6:
     resolution: {integrity: sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==}
     engines: {node: 10.* || >= 12.*}
+
+  ember-concurrency@4.0.2:
+    resolution: {integrity: sha512-enmStRE8bHIeF/kPZoDZlzP9YINN7H8l3Myk1sVkqo235ph0Vjee37AGCw44eRq6cBRvcdQmb5K3pkzVY7A6WA==}
+    engines: {node: 16.* || >= 18}
+    peerDependencies:
+      '@glimmer/tracking': ^1.1.2
+      '@glint/template': '>= 1.0.0'
+      ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
 
   ember-curry-component@0.3.0:
     resolution: {integrity: sha512-rNgroW+Uwz1htijUFYnyNEyPeWh/MtyAUcoPJGNjBj5juUxUJiLR5X9PrahQV0yNeGLyMdr3Nap7C5QqEt8NlQ==}
@@ -12131,6 +12148,13 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decorator-transforms@1.2.1(@babel/core@7.26.7):
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.7)
+      babel-import-util: 2.1.1
+    transitivePeerDependencies:
+      - '@babel/core'
+
   decorator-transforms@2.3.0(@babel/core@7.26.7):
     dependencies:
       '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.7)
@@ -12711,6 +12735,20 @@ snapshots:
       find-up: 5.0.0
       fs-extra: 9.1.0
       semver: 5.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-concurrency@4.0.2(@babel/core@7.26.7)(@glimmer/tracking@1.1.2)(@glint/template@1.5.2)(ember-source@5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.12)(esbuild@0.24.2))):
+    dependencies:
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/types': 7.26.7
+      '@embroider/addon-shim': 1.9.0
+      '@glimmer/tracking': 1.1.2
+      decorator-transforms: 1.2.1(@babel/core@7.26.7)
+      ember-source: 5.12.0(patch_hash=xx7mvsb7nmshqkkqhmf45r3hse)(@glimmer/component@1.1.2(@babel/core@7.26.7))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.97.1(@swc/core@1.10.12)(esbuild@0.24.2))
+    optionalDependencies:
+      '@glint/template': 1.5.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
This PR refactors the use of the UsernameValidation mixin to a helper class for the SignupController component. We'll extend this to the CreateAccount modal and InvitesShowController in follow-up PRs.

We introduce the use of `ember-concurrency` here to help with managing the debounce functionality while ensuring we don't leave stale timers out in the wild. This allows us to remove lifecycle checks from the validation function such as:

```
    if (this.isDestroying || this.isDestroyed) {
      return;
    }
```

On syntax: I've opted to use ember-concurrency tasks with generator functions so we don't add on more dependencies in this PR (for proper async syntax support, we either need to add https://github.com/chancancode/ember-concurrency-async or 
the `ember-concurrency/async-arrow-task-transform` babel transform plugin https://ember-concurrency.com/docs/v4-upgrade/).

