### PR TITLE
FIX: Minor i18n problems on admin webhooks pages

### DIFF
--- a/app/assets/javascripts/admin/addon/components/webhook-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/webhook-item.gjs
@@ -54,7 +54,7 @@ export default class WebhookItem extends Component {
           <DButton
             @action={{this.edit}}
             @label="admin.web_hooks.edit"
-            @title="admin.api.show_details"
+            @title="admin.web_hooks.edit"
             class="btn-small"
           />
           <DMenu

--- a/app/assets/javascripts/admin/addon/templates/web-hooks-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/web-hooks-show.hbs
@@ -10,7 +10,7 @@
     <DButton
       @action={{this.edit}}
       @icon="far-pen-to-square"
-      @title={{i18n "admin.web_hooks.edit"}}
+      @title="admin.web_hooks.edit"
       class="no-text admin-webhooks__edit-button"
     />
 


### PR DESCRIPTION
### What is this change?

This fixes two minor problems on the admin webhooks page.

- Wrong key used for edit button title in listing.
- Duplicated use of `i18n` leading to "en.Edit" in show page.