### PR TITLE
DEV: Remove plugin sidebar rendering fallback

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-area.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-area.gjs
@@ -1,7 +1,5 @@
 import Component from "@glimmer/component";
-import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import concatClass from "discourse/helpers/concat-class";
 import { i18n } from "discourse-i18n";
 
 export default class AdminPluginConfigArea extends Component {
@@ -16,31 +14,6 @@ export default class AdminPluginConfigArea extends Component {
   }
 
   <template>
-    {{#if this.adminPluginNavManager.isSidebarMode}}
-      <nav class="admin-nav admin-plugin-inner-sidebar-nav pull-left">
-        <ul class="nav nav-stacked">
-          {{#each
-            this.adminPluginNavManager.currentConfigNav.links
-            as |navLink|
-          }}
-            <li
-              class={{concatClass
-                "admin-plugin-inner-sidebar-nav__item"
-                navLink.route
-              }}
-            >
-              <LinkTo
-                @route={{navLink.route}}
-                @model={{navLink.model}}
-                title={{this.linkText navLink}}
-              >
-                {{this.linkText navLink}}
-              </LinkTo>
-            </li>
-          {{/each}}
-        </ul>
-      </nav>
-    {{/if}}
     <section class="admin-plugin-config-area">
       {{yield}}
     </section>

--- a/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugin-config-page.gjs
@@ -11,18 +11,6 @@ export default class AdminPluginConfigPage extends Component {
   @service currentUser;
   @service adminPluginNavManager;
 
-  get mainAreaClasses() {
-    let classes = ["admin-plugin-config-page__main-area"];
-
-    if (this.adminPluginNavManager.isSidebarMode) {
-      classes.push("-with-inner-sidebar");
-    } else {
-      classes.push("-without-inner-sidebar");
-    }
-
-    return classes.join(" ");
-  }
-
   get actionsOutletName() {
     return `admin-plugin-config-page-actions-${this.args.plugin.dasherizedName}`;
   }
@@ -59,26 +47,24 @@ export default class AdminPluginConfigPage extends Component {
           />
         </:breadcrumbs>
         <:tabs>
-          {{#if this.adminPluginNavManager.isTopMode}}
-            {{#each
-              this.adminPluginNavManager.currentConfigNav.links
-              as |navLink|
-            }}
-              <NavItem
-                @route={{navLink.route}}
-                @i18nLabel={{this.linkText navLink}}
-                title={{this.linkText navLink}}
-                class="admin-plugin-config-page__top-nav-item"
-              >
-                {{this.linkText navLink}}
-              </NavItem>
-            {{/each}}
-          {{/if}}
+          {{#each
+            this.adminPluginNavManager.currentConfigNav.links
+            as |navLink|
+          }}
+            <NavItem
+              @route={{navLink.route}}
+              @i18nLabel={{this.linkText navLink}}
+              title={{this.linkText navLink}}
+              class="admin-plugin-config-page__top-nav-item"
+            >
+              {{this.linkText navLink}}
+            </NavItem>
+          {{/each}}
         </:tabs>
       </DPageHeader>
 
       <div class="admin-plugin-config-page__content">
-        <div class={{this.mainAreaClasses}}>
+        <div class="admin-plugin-config-page__main-area -without-inner-sidebar">
           <AdminPluginConfigArea>
             {{yield}}
           </AdminPluginConfigArea>

--- a/app/assets/javascripts/admin/addon/controllers/admin-plugins.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-plugins.js
@@ -31,8 +31,7 @@ export default class AdminPluginsController extends Controller {
   get showTopNav() {
     return (
       !this.adminPluginNavManager.viewingPluginsList &&
-      (!this.adminPluginNavManager.currentPlugin ||
-        this.adminPluginNavManager.isSidebarMode)
+      !this.adminPluginNavManager.currentPlugin
     );
   }
 }

--- a/app/assets/javascripts/admin/addon/services/admin-plugin-nav-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-plugin-nav-manager.js
@@ -1,10 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Service, { service } from "@ember/service";
-import {
-  configNavForPlugin,
-  PLUGIN_NAV_MODE_SIDEBAR,
-  PLUGIN_NAV_MODE_TOP,
-} from "discourse/lib/admin-plugin-config-nav";
+import { configNavForPlugin } from "discourse/lib/admin-plugin-config-nav";
 
 export default class AdminPluginNavManager extends Service {
   @service currentUser;
@@ -22,7 +18,6 @@ export default class AdminPluginNavManager extends Service {
   get currentConfigNav() {
     const configNav = configNavForPlugin(this.currentPlugin.id);
     const settingsNav = {
-      mode: PLUGIN_NAV_MODE_TOP,
       links: [
         {
           label: "admin.plugins.change_settings_short",
@@ -58,13 +53,5 @@ export default class AdminPluginNavManager extends Service {
     }
 
     return linksExceptSettings[0].route;
-  }
-
-  get isSidebarMode() {
-    return this.currentConfigNav.mode === PLUGIN_NAV_MODE_SIDEBAR;
-  }
-
-  get isTopMode() {
-    return this.currentConfigNav.mode === PLUGIN_NAV_MODE_TOP;
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/admin-plugin-config-nav.js
+++ b/app/assets/javascripts/discourse/app/lib/admin-plugin-config-nav.js
@@ -1,8 +1,8 @@
 export const PLUGIN_NAV_MODE_SIDEBAR = "sidebar";
 export const PLUGIN_NAV_MODE_TOP = "top";
 let pluginConfigNav = {};
-export function registerAdminPluginConfigNav(pluginId, mode, links) {
-  pluginConfigNav[pluginId] = { mode, links };
+export function registerAdminPluginConfigNav(pluginId, links) {
+  pluginConfigNav[pluginId] = { links };
 }
 export function resetAdminPluginConfigNav() {
   pluginConfigNav = {};

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3258,24 +3258,20 @@ class PluginApi {
    * And the mode must be one of "sidebar" or "top", which controls
    * where in the admin plugin show UI the links will be displayed.
    */
-  addAdminPluginConfigurationNav(pluginId, mode, links) {
+  addAdminPluginConfigurationNav(pluginId, ...links) {
     if (!pluginId) {
       // eslint-disable-next-line no-console
       console.warn(consolePrefix(), "A pluginId must be provided!");
       return;
     }
 
+    // TODO (Ted - 2024-01-27): Remove once usage discontinued in plugins.
     const validModes = [PLUGIN_NAV_MODE_SIDEBAR, PLUGIN_NAV_MODE_TOP];
-    if (!validModes.includes(mode)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        consolePrefix(),
-        `${mode} is an invalid mode for admin plugin config pages, only ${validModes} are usable.`
-      );
-      return;
+    if (validModes.includes(links[0])) {
+      links.shift();
     }
 
-    registerAdminPluginConfigNav(pluginId, mode, links);
+    registerAdminPluginConfigNav(pluginId, links.flat());
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-plugin-config-area-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-plugin-config-area-test.js
@@ -2,55 +2,15 @@ import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
-import {
-  PLUGIN_NAV_MODE_SIDEBAR,
-  PLUGIN_NAV_MODE_TOP,
-  registerAdminPluginConfigNav,
-} from "discourse/lib/admin-plugin-config-nav";
+import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AdminPlugin from "admin/models/admin-plugin";
 
 module("Integration | Component | admin-plugin-config-area", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders the plugin config nav and content in the sidebar mode but not along the top", async function (assert) {
-    registerAdminPluginConfigNav(
-      "discourse-test-plugin",
-      PLUGIN_NAV_MODE_SIDEBAR,
-      [
-        {
-          route: "adminPlugins.show.discourse-test-plugin.one",
-          label: "admin.title",
-        },
-        {
-          route: "adminPlugins.show.discourse-test-plugin.two",
-          label: "admin.back_to_forum",
-        },
-      ]
-    );
-    getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
-      new AdminPlugin({ id: "discourse-test-plugin" });
-
-    await render(hbs`
-      <AdminPluginConfigArea>
-        Test content
-      </AdminPluginConfigArea>
-    `);
-
-    assert
-      .dom(".admin-plugin-inner-sidebar-nav__item")
-      .exists(
-        { count: 3 },
-        "renders the correct number of sidebar nav items (including always adding a Settings link)"
-      );
-
-    assert
-      .dom(".admin-plugin-config-area")
-      .hasText("Test content", "renders the yielded content");
-  });
-
-  test("it does not render the nav items in the sidebar when using top mode but it does along the top", async function (assert) {
-    registerAdminPluginConfigNav("discourse-test-plugin", PLUGIN_NAV_MODE_TOP, [
+  test("it renders the nav items along the top", async function (assert) {
+    registerAdminPluginConfigNav("discourse-test-plugin", [
       {
         route: "adminPlugins.show.discourse-test-plugin.one",
         label: "admin.title",

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
@@ -1,4 +1,3 @@
-import { PLUGIN_NAV_MODE_TOP } from "discourse/lib/admin-plugin-config-nav";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import ChatAdminPluginActions from "discourse/plugins/chat/admin/components/chat-admin-plugin-actions";
 
@@ -12,7 +11,7 @@ export default {
     }
 
     withPluginApi("1.1.0", (api) => {
-      api.addAdminPluginConfigurationNav("chat", PLUGIN_NAV_MODE_TOP, [
+      api.addAdminPluginConfigurationNav("chat", [
         {
           label: "chat.incoming_webhooks.title",
           route: "adminPlugins.show.discourse-chat-incoming-webhooks",


### PR DESCRIPTION
### What is this change?

We used this flag for experimenting with admin plugin sidebars. We have now settled on a tabbed layout, and this is no longer needed.

This PR simply ignores the flag in a backwards-compatible way, so we can discontinue usage in plugins and then remove the backwards-compatibility in core.