### PR TITLE
UX: hide user card focus until keyboard navigation begins

### DIFF
--- a/app/assets/javascripts/discourse/app/components/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/components/card-contents-base.js
@@ -230,7 +230,8 @@ export default class CardContentsBase extends Component {
       // may be offscreen and we may scroll all the way to it on focus
 
       discourseLater(() => {
-        this.element.querySelector("a.user-profile-link")?.focus();
+        this.element.setAttribute("tabindex", "-1");
+        this.element.focus();
       }, 350);
     });
   }

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -172,7 +172,7 @@
 // styles for user cards only
 .user-card {
   &:focus-visible {
-    // we move focus to the card, but the outline isn't neccessary until keyboard nav starts within
+    // we move focus to the card, but the outline isn't necessary until keyboard nav starts within
     outline: none;
   }
 

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -171,6 +171,11 @@
 
 // styles for user cards only
 .user-card {
+  &:focus-visible {
+    // we move focus to the card, but the outline isn't neccessary until keyboard nav starts within
+    outline: none;
+  }
+
   // avatar - names - controls
   .first-row {
     display: flex;


### PR DESCRIPTION
When the usercard is opened, we manually assign focus to the first link to capture focus, but this creates an undesirable focus ring for visitors not relying on focus indicators for navigation.

With this update, the focus is assigned to the container rather than the first link. This fulfills the goal of capturing focus within the user card, but hides the focus ring until navigation within the card begins. 

`tabindex="-1"` is necessary because this allows us to manually focus the container (normally unfocusable) while removing it from the tab order for subsequent navigation. 

Before:

![image](https://github.com/user-attachments/assets/1da3a4bb-181b-4cf6-815b-66199757e300)



After:

![image](https://github.com/user-attachments/assets/dda06321-8558-46bf-b16b-dead68e48b92)

then on tab: 

![image](https://github.com/user-attachments/assets/c4cc3d7b-faaf-4bc0-a7c9-d6afef4c6009)

