### PR TITLE
UX: sidebar "more" icon color fix

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -8,4 +8,8 @@
 
 .sidebar-more-section-trigger {
   justify-content: flex-start;
+
+  .d-icon {
+    color: var(--d-sidebar-link-icon-color);
+  }
 }


### PR DESCRIPTION
Currently the vertical ellipsis is slightly darker than other sidebar icons

Before: 
![image](https://github.com/user-attachments/assets/46f58bf0-681b-480a-b290-3ff1062a8c72)


After: 
![image](https://github.com/user-attachments/assets/5f84fa6b-111f-48c5-a501-c8cd2599dac7)
