### PR TITLE
A11Y: fix color issue with delete topic button in WCAG palette 

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -31,7 +31,7 @@ html.discourse-no-touch {
 
   .btn-icon.ok,
   .btn-icon.cancel,
-  .btn-danger:not(.btn-flat, .btn-transparent) {
+  .btn-danger:not(.btn-flat, .btn-transparent, .popup-menu-btn-danger) {
     .d-icon {
       color: var(--secondary);
     }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/wcag-high-contrast-color-palettes-for-low-vision/168795/30

Before: 

![image](https://github.com/user-attachments/assets/01ac2eca-0ccc-4220-bfa4-d0821f25aa84)


After: 

![image](https://github.com/user-attachments/assets/f7ebb673-1eec-4660-bb20-7e3c09e5464b)
