### PR TITLE
DEV: add missing class to top replies button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -428,7 +428,7 @@ export default class TopicMapSummary extends Component {
               @translatedTitle={{this.topRepliesTitle}}
               @translatedLabel={{this.topRepliesLabel}}
               @icon={{this.topRepliesIcon}}
-              class="top-replies"
+              class="btn-default top-replies"
             />
           </div>
         {{/if}}


### PR DESCRIPTION
This button in the topic map has our default button styling, but misses the btn-default class, making it inconsistent in themes 

![image](https://github.com/user-attachments/assets/acdbdffa-e8df-4879-83f2-615f1cbf6b57)
