### PR TITLE
DEV: Add proper error response when searching with an invalid page param

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,7 +36,12 @@ class SearchController < ApplicationController
 
     discourse_expires_in 1.minute
 
-    search_args = { type_filter: "topic", guardian: guardian, blurb_length: 300, page: page.to_i }
+    search_args = {
+      type_filter: "topic",
+      guardian: guardian,
+      blurb_length: 300,
+      page: [page.to_i, 1].max,
+    }
 
     context, type = lookup_search_context
     if context

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -348,6 +348,11 @@ RSpec.describe SearchController do
       expect(response.status).to eq(400)
     end
 
+    it "returns a 400 error if the page parameter is above the limit" do
+      get "/search.json", params: { q: "kittens", page: 11 }
+      expect(response.status).to eq(400)
+    end
+
     it "logs the search term" do
       SiteSetting.log_search_queries = true
       get "/search.json", params: { q: "bantha" }


### PR DESCRIPTION
Previously, for a search query with `page=11` or higher, we were quietly returning the page 10 results. The frontend app isn't affected because it sets its own limit to 10 pages, but still, this response from the search endpoint does not make sense.

This change switches to returning a 400 error when the `page` parameter is above the allowed limit (a max of 10).