### PR TITLE
DEV: add IDs of old deprecations to admin warning banner

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -22,6 +22,16 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.d-button-action-string",
   "discourse.post-menu-widget-overrides",
   "discourse.fontawesome-6-upgrade",
+  "discourse.add-flag-property",
+  "discourse.breadcrumbs.childCategories",
+  "discourse.breadcrumbs.firstCategory",
+  "discourse.breadcrumbs.parentCategories",
+  "discourse.breadcrumbs.parentCategoriesSorted",
+  "discourse.breadcrumbs.parentCategory",
+  "discourse.breadcrumbs.secondCategory",
+  "discourse.qunit.acceptance-function",
+  "discourse.qunit.global-exists",
+  "discourse.post-stream.trigger-new-post",
 ];
 
 if (DEBUG) {


### PR DESCRIPTION
We are adding some old deprecations (deprecated since 2022 at least) to the admin warning banner. 