### PR TITLE
UX: Clarify invite restrict to label to better indicate its purpose

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2008,7 +2008,7 @@ en:
           show_advanced: "Show Advanced Options"
           hide_advanced: "Hide Advanced Options"
 
-          restrict: "Restrict to"
+          restrict: "Restrict invitations to email or domain"
           restrict_email: "Restrict to email"
           restrict_domain: "Restrict to domain"
           email_or_domain_placeholder: "name@example.com or example.com"


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/invitation-send-by-email-confusing-behavior-texts/348087

### Before
<img width="338" alt="image" src="https://github.com/user-attachments/assets/a8c6b9ff-6539-49e7-85d5-2150ecbce89c" />


### After
<img width="315" alt="image" src="https://github.com/user-attachments/assets/62503e1a-9f5b-4d21-98b5-deba7ce6f95a" />
