### PR TITLE
FIX: Hijack controller for topic move posts

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -914,10 +914,12 @@ class TopicsController < ApplicationController
       end
     end
 
-    destination_topic = move_posts_to_destination(topic)
-    render_topic_changes(destination_topic)
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => ex
-    render_json_error(ex)
+    hijack do
+      destination_topic = move_posts_to_destination(topic)
+      render_topic_changes(destination_topic)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => ex
+      render_json_error(ex)
+    end
   end
 
   def change_post_owners


### PR DESCRIPTION
We have had reports of the topic post move endpoint
sometimes timing out, not necessarily with a large
number of posts, but between two topics that have a
large number of posts.

This buys us some time by `hijack`ing the controller,
which gives us 90 seconds instead of the Unicorn 30
seconds to do the work. At some point we may want to
do this in a background job.

c.f. https://meta.discourse.org/t/moving-posts-to-a-long-topic-fails/347984
