### PR TITLE
FIX: Update AdminNotice details when problem check tracker changes

### DIFF
--- a/spec/models/problem_check_tracker_spec.rb
+++ b/spec/models/problem_check_tracker_spec.rb
@@ -146,6 +146,42 @@ RSpec.describe ProblemCheckTracker do
       end
     end
 
+    context "when the details of the problem change but the problem remains" do
+      let(:blips) { 1 }
+
+      it "updates the notice" do
+        original_details = {
+          themes_list:
+            "<ul><li><a href=\"/admin/customize/themes/13\">discourse-blank-theme</a></li> <li><a href=\"/admin/customize/themes/31\">Simple Theme</a></li></ul>",
+          base_path: "",
+        }
+
+        expect do problem_tracker.problem!(details: original_details) end.to change {
+          AdminNotice.problem.count
+        }.by(1)
+
+        admin_notice = AdminNotice.problem.find_by(identifier: "twitter_login")
+
+        expect(
+          admin_notice.details.merge(target: problem_tracker.target).with_indifferent_access,
+        ).to eq(original_details.merge(target: problem_tracker.target).with_indifferent_access)
+
+        new_details = {
+          themes_list: "<ul><li><a href=\"/admin/customize/themes/31\">Simple Theme</a></li></ul>",
+          base_path: "",
+        }
+        expect do problem_tracker.problem!(details: new_details) end.not_to change {
+          AdminNotice.problem.count
+        }
+
+        admin_notice.reload
+
+        expect(
+          admin_notice.details.merge(target: problem_tracker.target).with_indifferent_access,
+        ).to eq(new_details.merge(target: problem_tracker.target).with_indifferent_access)
+      end
+    end
+
     context "when there's an alarm sounding for multi-target trackers" do
       let(:blips) { 1 }
 


### PR DESCRIPTION
We have many problem check trackers, and some of them
like `OutOfDateThemes` can have a message which has variable
data in it shown to admins. In this case, a list of themes
that need updating. Currently if you resolve one of these
out of date themes and refresh the list of problems, you
do not see any change.

This is happening because we are only updating the `details`
of the `ProblemCheckTracker` record, not the corresponding
`AdminNotice` record which is what is displayed to the admins
on their dashboard. This commit fixes the issue by updating the
details of the notice at the same time as the problem check
tracker details.
