### PR TITLE
UX: add missing class to group bulk select button

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -9,7 +9,7 @@
         @icon="list"
         @action={{this.toggleBulkSelect}}
         @title="topics.bulk.toggle"
-        class="bulk-select"
+        class="btn-default bulk-select"
       />
     {{/if}}
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/2004af31-254c-4dd2-a51d-10c0d69c7fdf)


This bulk-select button on group pages is styled like a default button, but lacks the `btn-default` class, making it inconsistent to style in themes 