### PR TITLE
UX: Fix mobile chat DM row layout

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -56,14 +56,9 @@
       grid-template-areas:
         "name metadata"
         "msg msg";
+      grid-template-columns: auto 1fr;
       width: 100%;
       align-items: center;
-
-      &:has(.chat-channel-unread-indicator) {
-        grid-template-areas:
-          "name metadata"
-          "msg metadata";
-      }
     }
   }
 


### PR DESCRIPTION
Before / After

read
<img width="308" alt="Screenshot 2025-01-29 at 00 01 06" src="https://github.com/user-attachments/assets/9c90f372-701a-42f6-8d6a-0d69630e5ae1" /> <img width="308" alt="Screenshot 2025-01-29 at 00 00 57" src="https://github.com/user-attachments/assets/01e38474-8aa9-4806-bdb2-b3de727ba366" />

unread
<img width="308" alt="Screenshot 2025-01-28 at 23 59 40" src="https://github.com/user-attachments/assets/c1ee0044-be27-4d5d-83ad-fa791451f972" /> <img width="308" alt="Screenshot 2025-01-28 at 23 59 47" src="https://github.com/user-attachments/assets/d236de3b-b1d2-406b-a1dd-0c6c590319df" />
