### PR TITLE
UX: remove animation for back button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -40,6 +40,7 @@ export default class TopicProgress extends Component {
 
     const stream = this.get("postStream.stream");
     const readPos = stream.indexOf(lastReadId) || 0;
+
     return readPos < stream.length - 1 && readPos > position;
   }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -1,25 +1,3 @@
-@keyframes button-jump-up {
-  0% {
-    margin-bottom: -60px;
-  }
-
-  50% {
-    margin-bottom: 10px;
-  }
-
-  65% {
-    margin-bottom: 0;
-  }
-
-  77% {
-    margin-bottom: 5px;
-  }
-
-  100% {
-    margin-bottom: 0;
-  }
-}
-
 #main-outlet {
   --below-topic-margin: 0.75em;
 }
@@ -119,14 +97,12 @@
 
 .progress-back-container {
   z-index: z("dropdown");
-  animation-duration: 0.5s;
-  animation-name: button-jump-up;
   text-align: center;
   margin-bottom: 0;
   margin-right: 0.5em;
   position: absolute;
   right: 0;
-  bottom: 100%; // above parent container + some extra space
+  bottom: 100%;
 
   .btn {
     margin: 0;


### PR DESCRIPTION
We're seeing drops in CLS performance and the animation of this element may likely be the culprit. We can try removing and seeing if this is indeed the issue.