### PR TITLE
UX: Fix tag revert rename 404 error

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -42,9 +42,16 @@ export default class TagShowRoute extends DiscourseRoute {
   }
 
   async model(params, transition) {
+    const tagIdFromParams = escapeExpression(params.tag_id);
     const tag = this.store.createRecord("tag", {
-      id: escapeExpression(params.tag_id),
+      id: tagIdFromParams,
     });
+
+    // Handles renaming a tag, since we refer to the tag.id instead
+    // of tag.name which is the actual identifier.
+    if (tag.id !== tagIdFromParams) {
+      tag.set("id", tagIdFromParams);
+    }
 
     let additionalTags;
 

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -24,6 +24,26 @@ module PageObjects
         find(".dialog-footer .btn-primary")
       end
 
+      def open_edit_tag
+        find(".tag-name-wrapper .edit-tag").click
+      end
+
+      def fill_tag_name(new_name)
+        find("#edit-name").fill_in(with: new_name)
+      end
+
+      def fill_tag_description(new_description)
+        find("#edit-description").fill_in(with: new_description)
+      end
+
+      def save_edit
+        find(".edit-controls .submit-edit").click
+      end
+
+      def cancel_edit
+        find(".edit-controls .cancel-edit").click
+      end
+
       def add_synonyms_dropdown
         PageObjects::Components::SelectKit.new("#add-synonyms")
       end
@@ -46,8 +66,16 @@ module PageObjects
         find(".tag-box div[data-tag-name='#{tag}']")
       end
 
+      def tag_info
+        find(".tag-info")
+      end
+
       def tag_name_within_tag_info
-        find(".tag-info .tag-name-wrapper .discourse-tag").text
+        tag_info.find(".tag-name-wrapper .discourse-tag").text
+      end
+
+      def tag_description_within_tag_info
+        tag_info.find(".tag-description-wrapper").text
       end
 
       def tags_dropdown

--- a/spec/system/tag_edit_spec.rb
+++ b/spec/system/tag_edit_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "Tag Edit", type: :system do
+  let(:tags_page) { PageObjects::Pages::Tag.new }
+  fab!(:tag_1) { Fabricate(:tag, name: "design") }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before { sign_in(current_user) }
+
+  it "allows the admin to edit a tag name and description" do
+    tags_page.visit_tag(tag_1)
+    tags_page.tag_info_btn.click
+    tags_page.open_edit_tag
+    tags_page.fill_tag_name("ux")
+    tags_page.fill_tag_description("new description")
+    tags_page.save_edit
+    expect(tags_page.tag_info).to have_content("ux")
+    expect(tags_page.tag_info).to have_content("new description")
+  end
+
+  it "does not error when editing a tag name to something then reverting back to the original name" do
+    tags_page.visit_tag(tag_1)
+    tags_page.tag_info_btn.click
+    tags_page.open_edit_tag
+    tags_page.fill_tag_name("ux")
+    tags_page.save_edit
+    expect(tags_page.tag_info).to have_content("ux")
+    tags_page.open_edit_tag
+    tags_page.fill_tag_name("design")
+    tags_page.save_edit
+    expect(tags_page.tag_info).to have_content("design")
+  end
+end


### PR DESCRIPTION
Changing a tag name and reverting it to a previous tag name choice on
the same screen (meaning, without reloading the page) causes a 404
error.

Reproduction steps:

* Open an existing tag page https://your-discourse.com/tag/a
* Click the wrench, change the name and save
* Open edit again, revert the name to the original tag name
* 404 error

This was happening because of the way we find existing objects
in our store. Tags are using the name as the id/primary key
unlike other records in the UI. When we get the existing object
from the store we throw away the "new" ID, so we ended up with
the old tag ID on the existing object, which led to a 404. To
fix it we can just manually set the tag ID to what it is supposed
to be from params in the tag show route.

c.f. https://meta.discourse.org/t/404-error-when-you-revert-a-tag-name-after-changing-it-without-reloading-the-page/342559
