### PR TITLE
Revert "DEV: Upload assets to S3 in parallel (#30210)"

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -193,16 +193,8 @@ task "s3:ensure_cors_rules" => :environment do
 end
 
 task "s3:upload_assets" => [:environment, "s3:ensure_cors_rules"] do
-  pool =
-    Concurrent::FixedThreadPool.new(
-      ENV["DISCOURSE_S3_UPLOAD_ASSETS_RAKE_THREAD_POOL_SIZE"] || Concurrent.processor_count,
-    )
-
   logger = Logger.new(STDOUT)
-  assets.each { |asset| pool.post { upload(*asset, logger:) } }
-
-  pool.shutdown
-  pool.wait_for_termination
+  assets.each { |asset| upload(*asset, logger:) }
 end
 
 task "s3:expire_missing_assets" => :environment do


### PR DESCRIPTION
This reverts commit b9f8a77d9ba5222bbf55172092f0b235b92d1c85.

Reverting while we work on adding error handling. At the moment, failures are logged, but the process still exits with status=0.