### PR TITLE
DEV: allows to fill in input of type number in specs

### DIFF
--- a/spec/system/page_objects/components/form_kit.rb
+++ b/spec/system/page_objects/components/form_kit.rb
@@ -98,7 +98,7 @@ module PageObjects
 
       def fill_in(value)
         case control_type
-        when "input-text", "password", "input-date"
+        when "input-text", "password", "input-date", "input-number"
           component.find("input").fill_in(with: value)
         when "textarea", "composer"
           component.find("textarea").fill_in(with: value, visible: :all)


### PR DESCRIPTION
The system spec helper was not supporting this case.

You can now properly do: `form.field("foo").fill_in(800)`