### PR TITLE
FIX: hide none on required fields with value

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
+import { isBlank } from "@ember/utils";
 import DSelect, { DSelectOption } from "discourse/components/d-select";
 
 const SelectOption = <template>
@@ -16,7 +17,11 @@ export default class FKControlSelect extends Component {
   static controlType = "select";
 
   get includeNone() {
-    return this.args.field.validation !== "required";
+    if (isBlank(this.args.field.value)) {
+      return true;
+    }
+
+    return !this.args.field.validation?.includes("required");
   }
 
   <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
@@ -1,5 +1,7 @@
+import { hash } from "@ember/helper";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { NO_VALUE_OPTION } from "discourse/components/d-select";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
@@ -49,6 +51,63 @@ module(
       </template>);
 
       assert.dom(".form-kit__control-select").hasAttribute("disabled");
+    });
+
+    test("include none", async function (assert) {
+      await render(<template>
+        <Form as |form|>
+          <form.Field
+            @name="foo"
+            @title="Foo"
+            @validation="required"
+            as |field|
+          >
+            <field.Select />
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert
+        .form()
+        .field("foo")
+        .hasValue(NO_VALUE_OPTION, "it has the none when no value is present");
+
+      await render(<template>
+        <Form @data={{hash foo="1"}} as |form|>
+          <form.Field
+            @name="foo"
+            @title="Foo"
+            @validation="required"
+            as |field|
+          >
+            <field.Select />
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert
+        .form()
+        .field("foo")
+        .hasNoValue(
+          NO_VALUE_OPTION,
+          "it doesn’t have the none when value is present"
+        );
+
+      await render(<template>
+        <Form @data={{hash foo="1"}} as |form|>
+          <form.Field @name="foo" @title="Foo" as |field|>
+            <field.Select />
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert
+        .form()
+        .field("foo")
+        .hasValue(
+          NO_VALUE_OPTION,
+          "it has the none when value is present and field is not required"
+        );
     });
   }
 );


### PR DESCRIPTION
Prior to this fix if a field was marked as required we would never show the none option of the select, however, some forms come with default values and in this case we would show the first choice of the select as selected when it would actually be null. This commit ensures that in this case we show none, and once you select a value, you can't go back to none.