### PR TITLE
FIX: only validate length when value is set

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
@@ -35,6 +35,10 @@ export default class Validator {
   }
 
   lengthValidator(value, rule) {
+    if (isBlank(value)) {
+      return;
+    }
+
     if (rule.max) {
       if (value?.length > rule.max) {
         return i18n("form_kit.errors.too_long", {

--- a/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
@@ -17,15 +17,15 @@ module("Unit | Lib | FormKit | Validator", function (hooks) {
   });
 
   test("length", async function (assert) {
-    let errors = await new Validator("", {
-      length: { min: 1, max: 5 },
+    let errors = await new Validator("a", {
+      length: { min: 2, max: 5 },
     }).validate();
 
     assert.deepEqual(
       errors,
       [
         i18n("form_kit.errors.too_short", {
-          count: 1,
+          count: 2,
         }),
       ],
       "it returns an error when the value is too short"
@@ -51,6 +51,15 @@ module("Unit | Lib | FormKit | Validator", function (hooks) {
       errors,
       [],
       "it returns no errors when the value is valid"
+    );
+
+    errors = await new Validator("", {
+      length: { min: 1, max: 5 },
+    }).validate();
+    assert.deepEqual(
+      errors,
+      [],
+      "it returns no errors when the value is blank"
     );
   });
 


### PR DESCRIPTION
When using the following validation: `length:5,10`, if the field had no value we would fail the validation which is incorrect. This commit ensures we return early in this case and don't fail anymore. If you want the same behavior you need to do: `required|length:5,10`