### PR TITLE
FIX: Remove groups when promotion is recalculated.

### DIFF
--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -159,6 +159,8 @@ class Promotion
     promotion.review_tl1 if granted_trust_level < TrustLevel[2]
     promotion.review_tl2 if granted_trust_level < TrustLevel[3]
 
+    Group.user_trust_level_change!(user.id, user.trust_level)
+
     if user.trust_level == TrustLevel[3] && Promotion.tl3_lost?(user)
       user.change_trust_level!(TrustLevel[2], log_action_for: performed_by || Discourse.system_user)
     end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -298,10 +298,16 @@ RSpec.describe GroupUser do
 
       group_user = Fabricate(:group_user, group: group, user: user)
       expect(user.reload.trust_level).to eq(4)
+      expect(user.groups.where(automatic: true).map(&:name)).to eq(
+        %w[trust_level_0 trust_level_1 trust_level_2 trust_level_3 trust_level_4],
+      )
 
       group_user.destroy!
       # keep in mind that we do not restore tl3, cause reqs can be lost
       expect(user.reload.trust_level).to eq(2)
+      expect(user.groups.where(automatic: true).map(&:name)).to eq(
+        %w[trust_level_0 trust_level_1 trust_level_2],
+      )
     end
 
     it "protects user trust level if all requirements are met" do


### PR DESCRIPTION
The group has `grant_trust_level` setting which automatically updates the trust level when the user is added to the group.

Similarly, when the user is removed from the group, the trust level is recalculated.

There was a bug that when the trust level was downgraded, the user was not removed from automatic groups like for example `trust_level_3`.