### PR TITLE
DEV: Bump discourse-fonts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
     diffy (3.4.3)
     digest (3.2.0)
     digest-xxhash (0.2.9)
-    discourse-fonts (0.0.17)
+    discourse-fonts (0.0.18)
     discourse-seed-fu (2.3.12)
       activerecord (>= 3.1)
       activesupport (>= 3.1)


### PR DESCRIPTION
This brings in the change from ttf to woff2 fonts
for all our fonts.

This brings the total distributed size of our fonts down to 1.4MB (down
from 17MB) which is ~91% decrease, and most fonts are now only around
20KB max individually :slight_smile: The biggest reduction was Noto Sans
JP, which was in .otf format and ~4MB for each file.
