### PR TITLE
UX: Show full total numbers in admin reports

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-table.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-report-table.hbs
@@ -50,9 +50,9 @@
       </tr>
       <tr class="admin-report-table-row">
         <td class="admin-report-table-cell date x">—</td>
-        <td class="admin-report-table-cell number y">{{number
-            this.model.total
-          }}</td>
+        <td
+          class="admin-report-table-cell number y"
+        >{{this.formattedTotal}}</td>
       </tr>
     {{/if}}
 
@@ -64,9 +64,9 @@
       </tr>
       <tr class="admin-report-table-row">
         <td class="admin-report-table-cell date x">—</td>
-        <td class="admin-report-table-cell number y">{{number
-            this.averageForSample
-          }}</td>
+        <td
+          class="admin-report-table-cell number y"
+        >{{this.averageForSample}}</td>
       </tr>
     {{/if}}
   </tbody>

--- a/app/assets/javascripts/admin/addon/components/admin-report-table.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-table.js
@@ -58,8 +58,7 @@ export default class AdminReportTable extends Component {
 
   @discourseComputed("totalsForSample.1.value", "model.data.length")
   averageForSample(totals, count) {
-    const averageLabel =
-      this.model.computedLabels[this.model.computedLabels.length - 1];
+    const averageLabel = this.model.computedLabels.at(-1);
     return averageLabel.compute({ y: (totals / count).toFixed(0) })
       .formattedValue;
   }
@@ -81,7 +80,7 @@ export default class AdminReportTable extends Component {
 
   @discourseComputed("model.total", "model.computedLabels")
   formattedTotal(total, labels) {
-    const totalLabel = labels[labels.length - 1];
+    const totalLabel = labels.at(-1);
     return totalLabel.compute({ y: total }).formattedValue;
   }
 

--- a/app/assets/javascripts/admin/addon/components/admin-report-table.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-table.js
@@ -58,7 +58,10 @@ export default class AdminReportTable extends Component {
 
   @discourseComputed("totalsForSample.1.value", "model.data.length")
   averageForSample(totals, count) {
-    return (totals / count).toFixed(0);
+    const averageLabel =
+      this.model.computedLabels[this.model.computedLabels.length - 1];
+    return averageLabel.compute({ y: (totals / count).toFixed(0) })
+      .formattedValue;
   }
 
   @discourseComputed("model.data.length")
@@ -74,6 +77,12 @@ export default class AdminReportTable extends Component {
       computedLabel.property = label.mainProperty;
       return computedLabel;
     });
+  }
+
+  @discourseComputed("model.total", "model.computedLabels")
+  formattedTotal(total, labels) {
+    const totalLabel = labels[labels.length - 1];
+    return totalLabel.compute({ y: total }).formattedValue;
   }
 
   @discourseComputed("model.data", "model.computedLabels")

--- a/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
@@ -10,7 +10,7 @@ export default class AdminReportsShowController extends Controller {
 
   @discourseComputed("model.type")
   reportOptions(type) {
-    let options = { table: { perPage: 50, limit: 50, formatNumbers: false } };
+    let options = { table: { perPage: 50, limit: 50 } };
 
     if (type === "top_referred_topics") {
       options.table.limit = 10;

--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -631,7 +631,8 @@ export default class Report extends EmberObject {
       ? true
       : options.formatNumbers;
 
-    const formattedValue = () => (formatNumbers ? number(value) : value);
+    const formattedValue = () =>
+      formatNumbers ? I18n.toNumber(value, { precision: 0 }) : value;
 
     return {
       value: toNumber(value),

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -378,7 +378,7 @@ module("Unit | Model | report", function (hooks) {
     assert.strictEqual(flagCountLabel.title, "Flag count");
     assert.strictEqual(flagCountLabel.type, "number");
     let computedFlagCountLabel = flagCountLabel.compute(row);
-    assert.strictEqual(computedFlagCountLabel.formattedValue, "1.9k");
+    assert.strictEqual(computedFlagCountLabel.formattedValue, "1,876");
     assert.strictEqual(computedFlagCountLabel.value, 1876);
     computedFlagCountLabel = flagCountLabel.compute(row, {
       formatNumbers: false,


### PR DESCRIPTION
This commit updates the display of totals and table
rows for reports in the admin interface. Currently
we show abbreviated numbers for totals e.g. 2.1M
which is not helpful when you need accurate data.
We are also not adding locale-specific number separators
so the row numbers are hard to read e.g. 246999 instead
of 246,999.

This commit fixes both issues to improve the UX of reports
without having to export them.

**Before (totals)**

![image](https://github.com/user-attachments/assets/6958252d-f778-495d-b799-7ebe4e9f1366)

**After (totals)**

![image](https://github.com/user-attachments/assets/2b51580a-cd09-42cd-b713-3c5018fa6727)

**Before (rows)**

![image](https://github.com/user-attachments/assets/38d36236-1382-45b2-a3dc-5b267b122e39)

**After (rows)**

![image](https://github.com/user-attachments/assets/607997b7-7a46-452a-ab6e-368671445a06)
