### PR TITLE
FIX: Cannot manually add users to automatic groups

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -64,7 +64,7 @@ export default class GroupIndexController extends Controller {
 
   @discourseComputed("model")
   canManageGroup(model) {
-    return this.currentUser?.canManageGroup(model);
+    return this.currentUser?.canManageGroup(model) && !this.model.automatic;
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -187,6 +187,11 @@ acceptance(
         .dom(".group-automatic-tooltip")
         .exists("displays automatic tooltip");
     });
+
+    test("the current user cannot invite users to automatic group", async function (assert) {
+      await visit("/g/moderators");
+      assert.dom(".group-members-add").doesNotExist();
+    });
   }
 );
 


### PR DESCRIPTION
Adding/removing users from automatic groups should not be possible.

Bug introduced in this PR https://github.com/discourse/discourse/pull/30174

Before
<img width="1435" alt="Screenshot 2025-01-30 at 3 35 12 pm" src="https://github.com/user-attachments/assets/a982bfb7-3597-4efb-82b8-c11a47493075" />

After
<img width="1391" alt="Screenshot 2025-01-30 at 3 34 47 pm" src="https://github.com/user-attachments/assets/894a9319-94b9-4fad-bf99-e357b910a209" />
