### PR TITLE
DEV: Include lib/stylesheet mtime in stylesheet cache

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -172,6 +172,7 @@ class Stylesheet::Manager
     globs = [
       "#{Rails.root}/app/assets/stylesheets/**/*.*css",
       "#{Rails.root}/app/assets/images/**/*.*",
+      "#{Rails.root}/lib/stylesheet/*.rb",
     ]
 
     Discourse.plugins.each do |plugin|


### PR DESCRIPTION
Followup 23edfe7cc27cd56d5806c965ac52ed2b0394e8b8

When working on changes to any of the lib/stylesheet/*.rb
files, the color_definitions.scss and other stylesheet
caches can be annoyingly persistent.

This commit adds all of these lib files to the `max_file_mtime`
part of the `fs_asset_cachebuster` cache key, so if any of
them are changed then the cache will break, making development
a lot easier.
