### PR TITLE
DEV: Clean up `TreeNode` component

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor.gjs
@@ -118,11 +118,6 @@ export default class SchemaThemeSettingNewEditor extends Component {
     this.inputFieldObserver[index] = callback;
   }
 
-  @action
-  unregisterInputFieldObserver(index) {
-    delete this.inputFieldObserver[index];
-  }
-
   descriptions(fieldName, key) {
     // The `property_descriptions` metadata is an object with keys in the following format as an example:
     //
@@ -279,7 +274,6 @@ export default class SchemaThemeSettingNewEditor extends Component {
             @addChildItem={{this.addChildItem}}
             @generateSchemaTitle={{this.generateSchemaTitle}}
             @registerInputFieldObserver={{this.registerInputFieldObserver}}
-            @unregisterInputFieldObserver={{this.unregisterInputFieldObserver}}
           />
 
           <div class="schema-theme-setting-editor__footer">

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree-node.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree-node.gjs
@@ -1,11 +1,11 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, get } from "@ember/helper";
+import { get } from "@ember/helper";
 import { on } from "@ember/modifier";
-import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { gt } from "truth-helpers";
-import dIcon from "discourse/helpers/d-icon";
+import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
+import { bind } from "discourse/lib/decorators";
 import ChildTree from "admin/components/schema-theme-setting/editor/child-tree";
 
 export default class SchemaThemeSettingNewEditorTreeNode extends Component {
@@ -17,18 +17,12 @@ export default class SchemaThemeSettingNewEditorTreeNode extends Component {
 
   constructor() {
     super(...arguments);
-    this.#setText();
+    this.setText();
+    this.args.registerInputFieldObserver(this.args.index, this.setText);
   }
 
-  @action
-  registerInputFieldObserver() {
-    this.args.registerInputFieldObserver(
-      this.args.index,
-      this.#setText.bind(this)
-    );
-  }
-
-  #setText() {
+  @bind
+  setText() {
     this.text = this.args.generateSchemaTitle(
       this.args.object,
       this.args.schema,
@@ -55,19 +49,20 @@ export default class SchemaThemeSettingNewEditorTreeNode extends Component {
 
   <template>
     <li
+      {{on "click" @onClick}}
       role="link"
-      class="schema-theme-setting-editor__tree-node --parent
-        {{if @active ' --active'}}"
-      {{on "click" (fn @onClick @index)}}
+      class={{concatClass
+        "schema-theme-setting-editor__tree-node --parent"
+        (if @active "--active")
+      }}
     >
       <div class="schema-theme-setting-editor__tree-node-text">
-        <span {{didInsert this.registerInputFieldObserver}}>{{this.text}}</span>
+        <span>{{this.text}}</span>
 
         {{#if (gt this.childObjectsProperties.length 0)}}
-
-          {{dIcon (if @active "chevron-down" "chevron-right")}}
+          {{icon (if @active "chevron-down" "chevron-right")}}
         {{else}}
-          {{dIcon "chevron-right"}}
+          {{icon "chevron-right"}}
         {{/if}}
       </div>
 

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree.gjs
@@ -31,7 +31,6 @@ import TreeNode from "admin/components/schema-theme-setting/editor/tree-node";
         @addChildItem={{@addChildItem}}
         @generateSchemaTitle={{@generateSchemaTitle}}
         @registerInputFieldObserver={{@registerInputFieldObserver}}
-        @unregisterInputFieldObserver={{@unregisterInputFieldObserver}}
       />
     {{/each}}
 


### PR DESCRIPTION
1. use `constructor` instead of `didInsert`
2. remove non-existent `unregisterInputFieldObserver` arg usage
3. don't curry `@index` arg twice in `@onClick`
4. use `@bind`
5. use `concatClass`
6. `dIcon` -> `icon`