### PR TITLE
PERF: Remove old fullscreen-detection code

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -67,16 +67,6 @@ export default class ScrollingPostStream extends MountWidget {
       return;
     }
 
-    // We use this because watching videos fullscreen in Chrome was super buggy
-    // otherwise. Thanks to arrendek from q23 for the technique.
-    const topLeftCornerElement = document.elementFromPoint(0, 0);
-    if (
-      topLeftCornerElement &&
-      topLeftCornerElement.tagName.toUpperCase() === "IFRAME"
-    ) {
-      return;
-    }
-
     const windowHeight = window.innerHeight;
     const slack = Math.round(windowHeight * 5);
     const onscreen = [];


### PR DESCRIPTION
This code was calling `elementFromPoint` on every scroll event. This is an expensive browser API, and also seems to trigger a premature 'paint' event during initial render. This seems to trigger cumulative-layout-shift metric problems, even though the shift was never actually visible onscreen.

This workaround was added more than 7 years ago, and it seems like `document.fullscreenElement` now correctly detects fullscreen youtube embeds. So we should be able to remove the `elementFromPoint` call without affecting any functionality.