### PR TITLE
FIX: change off to disabled for fast_typing_threshold setting

### DIFF
--- a/db/migrate/20250130205841_fix_incorrect_fast_typing_threshold_setting.rb
+++ b/db/migrate/20250130205841_fix_incorrect_fast_typing_threshold_setting.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FixIncorrectFastTypingThresholdSetting < ActiveRecord::Migration[7.2]
+  def change
+    execute "UPDATE site_settings SET value = 'disabled' WHERE name = 'fast_typing_threshold' AND value = 'off'"
+  end
+end


### PR DESCRIPTION
Bug introduced in migration in this PR - https://github.com/discourse/discourse/pull/30865/files#diff-ca17f6d1353d626d1664a3d55fcc7aed3c6e4587a0269cb264aa2c25c3264013R14

When the old setting was `0` then the value `for fast_typing_threshold` should be `disabled` instead of `off`. Because of that mistake, new users cannot create a topic when the `min_first_post_typing_time` value was `0`.