### PR TITLE
FIX: Quoting videos can show a corrupted thumbnail

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -169,7 +169,13 @@ export function selectedText() {
   div
     .querySelectorAll("div.video-placeholder-container[data-video-src]")
     .forEach((element) => {
-      element.replaceWith(`![|video](${element.dataset.videoSrc})`);
+      const videoBase62Sha1 = element.dataset.videoBase62Sha1;
+      if (videoBase62Sha1) {
+        element.replaceWith(`![|video](upload://${videoBase62Sha1})`);
+      } else {
+        // Fallback for old posts that don't contain data-video-base62-sha1
+        element.replaceWith(`![|video](${element.dataset.videoSrc})`);
+      }
     });
 
   return toMarkdown(div.outerHTML);

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -460,6 +460,9 @@ module PrettyText
           video["data-thumbnail-src"] = UrlHelper.absolute(
             GlobalPath.upload_cdn_path(thumbnail.url),
           )
+          video[
+            "data-video-base62-sha1"
+          ] = "#{Upload.base62_sha1(video_sha1)}#{File.extname(video_src)}"
         end
       end
   end

--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -45,7 +45,10 @@ module PrettyText
       urls.each do |url|
         sha1 = Upload.sha1_from_short_url(url)
         if (url.split(".")[1].nil?) # video sha1 without extension for thumbnail
-          thumbnail = Upload.where("original_filename LIKE ?", "#{sha1}.%").last
+          thumbnail = Upload.where("original_filename LIKE ?", "#{sha1}.%").last if sha1
+          # Fallback for old posts that don't contain data-video-base62-sha1
+          thumbnail = Upload.where("original_filename LIKE ?", "#{url}.%").last if thumbnail.nil? &&
+            sha1.nil?
           sha1 = thumbnail.sha1 if thumbnail
         end
         map[url] = sha1 if sha1

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2819,8 +2819,10 @@ HTML
       doc = Nokogiri::HTML5.fragment(html)
       described_class.add_video_placeholder_image(doc)
 
+      video_base62_sha1 = "#{Upload.base62_sha1(@video_upload.sha1)}.#{@video_upload.extension}"
+
       html_with_thumbnail = <<~HTML
-        <p></p><div class="video-placeholder-container" data-video-src="#{@video_upload.url}" data-thumbnail-src="http://test.localhost#{thumbnail.url}"></div><p></p>
+        <p></p><div class="video-placeholder-container" data-video-src="#{@video_upload.url}" data-thumbnail-src="http://test.localhost#{thumbnail.url}" data-video-base62-sha1="#{video_base62_sha1}"></div><p></p>
       HTML
 
       expect(doc.to_html).to eq(html_with_thumbnail)


### PR DESCRIPTION
This change ensures we use the base62 sha1 for videos when quoting
because this is what the composer is used to using. With a valid base62
sha1 the composer already knows how to fetch the placeholder image for
it.

Fallbacks have been created to continue to support the old way as well
as a fix for the old way so that the thumbnail continues to display when
quoting. These fallbacks are in place so that we don't have to rebake
all posts that contain videos. If we ever do that we may remove these
fallbacks.
