### PR TITLE
DEV: Change dIcon to icon in components

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-report.gjs
@@ -12,7 +12,7 @@ import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
 import DateTimeInputRange from "discourse/components/date-time-input-range";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import number from "discourse/helpers/number";
 import { reportModeComponent } from "discourse/lib/admin-report-additional-modes";
 import { REPORT_MODES } from "discourse/lib/constants";
@@ -560,7 +560,7 @@ export default class AdminReport extends Component {
                           @interactive={{this.model.description_link.length}}
                         >
                           <:trigger>
-                            {{dIcon "circle-question"}}
+                            {{icon "circle-question"}}
                           </:trigger>
                           <:content>
                             {{#if this.model.description_link}}
@@ -595,8 +595,8 @@ export default class AdminReport extends Component {
                         }}%{{/if}}
                       {{/if}}
 
-                      {{#if this.model.trendIcon}}
-                        {{dIcon this.model.trendIcon class="icon"}}
+                      {{#if this.model.trenicon}}
+                        {{icon this.model.trenicon class="icon"}}
                       {{/if}}
                     </span>
                   </div>
@@ -609,21 +609,21 @@ export default class AdminReport extends Component {
                 {{#if this.showError}}
                   {{#if this.showTimeoutError}}
                     <div class="alert alert-error report-alert timeout">
-                      {{dIcon "triangle-exclamation"}}
+                      {{icon "triangle-exclamation"}}
                       <span>{{i18n "admin.dashboard.timeout_error"}}</span>
                     </div>
                   {{/if}}
 
                   {{#if this.showExceptionError}}
                     <div class="alert alert-error report-alert exception">
-                      {{dIcon "triangle-exclamation"}}
+                      {{icon "triangle-exclamation"}}
                       <span>{{i18n "admin.dashboard.exception_error"}}</span>
                     </div>
                   {{/if}}
 
                   {{#if this.showNotFoundError}}
                     <div class="alert alert-error report-alert not-found">
-                      {{dIcon "triangle-exclamation"}}
+                      {{icon "triangle-exclamation"}}
                       <span>{{i18n "admin.dashboard.not_found_error"}}</span>
                     </div>
                   {{/if}}
@@ -646,12 +646,12 @@ export default class AdminReport extends Component {
                   {{else}}
                     {{#if this.rateLimitationString}}
                       <div class="alert alert-error report-alert rate-limited">
-                        {{dIcon "temperature-three-quarters"}}
+                        {{icon "temperature-three-quarters"}}
                         <span>{{this.rateLimitationString}}</span>
                       </div>
                     {{else}}
                       <div class="alert alert-info report-alert no-data">
-                        {{dIcon "chart-pie"}}
+                        {{icon "chart-pie"}}
                         {{#if this.model.reportUrl}}
                           <a href={{this.model.reportUrl}} class="report-url">
                             <span>

--- a/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
@@ -7,7 +7,7 @@ import {
   PrimaryButton,
 } from "discourse/components/d-page-action-button";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class AdminSectionLandingItem extends Component {
@@ -45,7 +45,7 @@ export default class AdminSectionLandingItem extends Component {
       {{/if}}
       {{#if @icon}}
         <div class="admin-section-landing-item__icon">
-          {{dIcon @icon}}
+          {{icon @icon}}
         </div>
       {{/if}}
       <div class="admin-section-landing-item__content">

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -7,7 +7,7 @@ import { htmlSafe } from "@ember/template";
 import { and, not } from "truth-helpers";
 import CookText from "discourse/components/cook-text";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
@@ -72,7 +72,7 @@ export default class DiscourseNewFeatureItem extends Component {
             {{@item.title}}
             {{#if @item.experiment_setting}}
               <span class="admin-new-feature-item__header-experimental">
-                {{dIcon "flask"}}
+                {{icon "flask"}}
                 {{i18n "admin.dashboard.new_features.experimental"}}
               </span>
             {{/if}}

--- a/app/assets/javascripts/admin/addon/components/install-theme-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/install-theme-item.gjs
@@ -1,5 +1,5 @@
 import RadioButton from "discourse/components/radio-button";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 const InstallThemeItem = <template>
@@ -12,11 +12,11 @@ const InstallThemeItem = <template>
     />
     <label class="radio" for={{@value}}>
       {{#if @showIcon}}
-        {{dIcon "plus"}}
+        {{icon "plus"}}
       {{/if}}
       {{i18n @label}}
     </label>
-    {{dIcon "caret-right"}}
+    {{icon "caret-right"}}
   </div>
 </template>;
 

--- a/app/assets/javascripts/admin/addon/components/modal/install-theme.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/install-theme.gjs
@@ -10,7 +10,7 @@ import ConditionalLoadingSection from "discourse/components/conditional-loading-
 import CopyButton from "discourse/components/copy-button";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import withEventValue from "discourse/helpers/with-event-value";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -317,7 +317,7 @@ export default class InstallThemeModal extends Component {
                         target="_blank"
                       >
                         {{#if theme.component}}
-                          {{dIcon
+                          {{icon
                             "puzzle-piece"
                             title="admin.customize.theme.component"
                           }}
@@ -347,7 +347,7 @@ export default class InstallThemeModal extends Component {
                             rel="noopener noreferrer"
                             target="_blank"
                           >
-                            {{dIcon "desktop"}}
+                            {{icon "desktop"}}
                             {{i18n "admin.customize.theme.preview"}}
                           </a>
                         {{/if}}

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/child-tree-node.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/child-tree-node.gjs
@@ -1,5 +1,5 @@
 import { on } from "@ember/modifier";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 
 <template>
   <li
@@ -10,7 +10,7 @@ import dIcon from "discourse/helpers/d-icon";
   >
     <div class="schema-theme-setting-editor__tree-node-text">
       <span>{{@generateSchemaTitle @object @schema @index}}</span>
-      {{dIcon "chevron-right"}}
+      {{icon "chevron-right"}}
     </div>
   </li>
 </template>

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/child-tree.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/child-tree.gjs
@@ -4,7 +4,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import ChildTreeNode from "admin/components/schema-theme-setting/editor/child-tree-node";
 
 export default class SchemaThemeSettingNewEditorChildTree extends Component {
@@ -32,7 +32,7 @@ export default class SchemaThemeSettingNewEditorChildTree extends Component {
       {{on "click" this.toggleVisibility}}
     >
       {{@name}}
-      {{dIcon (if this.expanded "chevron-down" "chevron-right")}}
+      {{icon (if this.expanded "chevron-down" "chevron-right")}}
     </div>
 
     {{#if this.expanded}}

--- a/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-theme-setting/editor/tree.gjs
@@ -2,7 +2,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { eq } from "truth-helpers";
 import DButton from "discourse/components/d-button";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import TreeNode from "admin/components/schema-theme-setting/editor/tree-node";
 
 <template>
@@ -14,7 +14,7 @@ import TreeNode from "admin/components/schema-theme-setting/editor/tree-node";
         {{on "click" @clickBack}}
       >
         <div class="schema-theme-setting-editor__tree-node-text">
-          {{dIcon "arrow-left"}}
+          {{icon "arrow-left"}}
           {{@backButtonText}}
         </div>
       </li>

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -5,7 +5,7 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import AboutPageUsers from "discourse/components/about-page-users";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import escape from "discourse/lib/escape";
 import { number } from "discourse/lib/formatter";
 import I18n, { i18n } from "discourse-i18n";
@@ -230,7 +230,7 @@ export default class AboutPage extends Component {
     {{#if this.currentUser.admin}}
       <p>
         <LinkTo class="edit-about-page" @route="adminConfig.about">
-          {{dIcon "pencil"}}
+          {{icon "pencil"}}
           <span>{{i18n "about.edit"}}</span>
         </LinkTo>
       </p>
@@ -254,7 +254,7 @@ export default class AboutPage extends Component {
         <div class="about__stats">
           {{#each this.stats as |stat|}}
             <span class="about__stats-item {{stat.class}}">
-              {{dIcon stat.icon}}
+              {{icon stat.icon}}
               <span>{{stat.text}}</span>
             </span>
           {{/each}}
@@ -300,7 +300,7 @@ export default class AboutPage extends Component {
         <div class="about__activities">
           {{#each this.siteActivities as |activity|}}
             <div class="about__activities-item {{activity.class}}">
-              <span class="about__activities-item-icon">{{dIcon
+              <span class="about__activities-item-icon">{{icon
                   activity.icon
                 }}</span>
               <span class="about__activities-item-type">

--- a/app/assets/javascripts/discourse/app/components/actions-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/actions-summary.gjs
@@ -1,5 +1,5 @@
 import avatar from "discourse/helpers/bound-avatar-template";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 
 const ActionsSummary = <template>
@@ -9,7 +9,7 @@ const ActionsSummary = <template>
   {{/each}}
   {{#if @data.deleted_at}}
     <div class="post-action deleted-post">
-      {{dIcon "trash-can"}}
+      {{icon "trash-can"}}
       <a
         class="trigger-user-card"
         data-user-card={{@data.deletedByUsername}}

--- a/app/assets/javascripts/discourse/app/components/back-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/back-button.gjs
@@ -1,11 +1,11 @@
 import { LinkTo } from "@ember/routing";
 import { or } from "truth-helpers";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 <template>
   <LinkTo class="btn btn-flat back-button" @route={{@route}}>
-    {{dIcon "chevron-left"}}
+    {{icon "chevron-left"}}
     {{i18n (or @label "back_button")}}
   </LinkTo>
 </template>

--- a/app/assets/javascripts/discourse/app/components/badge-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.gjs
@@ -5,7 +5,7 @@ import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { eq, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import iconOrImage from "discourse/helpers/icon-or-image";
 import number from "discourse/helpers/number";
 import { emojiUnescape, sanitize } from "discourse/lib/text";
@@ -99,7 +99,7 @@ export default class BadgeCard extends Component {
           class="check-display status-checked"
           aria-label={{i18n "notifications.titles.granted_badge"}}
         >
-          {{dIcon "check"}}
+          {{icon "check"}}
         </div>
       {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/post-list/item/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/item/index.gjs
@@ -5,7 +5,7 @@ import ExpandPost from "discourse/components/expand-post";
 import PostListItemDetails from "discourse/components/post-list/item/details";
 import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import { userPath } from "discourse/lib/url";
 
@@ -103,7 +103,7 @@ export default class PostListItem extends Component {
 
           {{#if @post.deleted_by}}
             <span class="delete-info">
-              {{dIcon "trash-can"}}
+              {{icon "trash-can"}}
               {{avatar
                 @post.deleted_by
                 imageSize="tiny"

--- a/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
@@ -4,7 +4,7 @@ import { action } from "@ember/object";
 import { eq } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import { categoryLinkHTML } from "discourse/helpers/category-link";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
 
 const TopicLabelButton = <template>
@@ -14,25 +14,25 @@ const TopicLabelButton = <template>
         <span class="topic-statuses">
           {{#if (eq @topic.archetype "private_message")}}
             <span class="topic-status">
-              {{dIcon "envelope"}}
+              {{icon "envelope"}}
             </span>
           {{/if}}
 
           {{#if @topic.bookmarked}}
             <span class="topic-status">
-              {{dIcon "bookmark"}}
+              {{icon "bookmark"}}
             </span>
           {{/if}}
 
           {{#if @topic.closed}}
             <span class="topic-status">
-              {{dIcon "lock"}}
+              {{icon "lock"}}
             </span>
           {{/if}}
 
           {{#if @topic.pinned}}
             <span class="topic-status">
-              {{dIcon "thumbtack"}}
+              {{icon "thumbtack"}}
             </span>
           {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-map/private-message-map.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/private-message-map.gjs
@@ -6,7 +6,7 @@ import { service } from "@ember/service";
 import { and } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import avatar from "discourse/helpers/bound-avatar-template";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { groupPath } from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 
@@ -109,7 +109,7 @@ class PmMapUserGroup extends Component {
   <template>
     <div class="user group">
       <a href={{this.groupUrl}} class="group-link">
-        {{dIcon "users"}}
+        {{icon "users"}}
         <span class="group-name">{{@model.name}}</span>
       </a>
       {{#if this.canRemoveLink}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -14,7 +14,7 @@ import TopicViews from "discourse/components/topic-map/topic-views";
 import TopicViewsChart from "discourse/components/topic-map/topic-views-chart";
 import avatar from "discourse/helpers/bound-avatar-template";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import number from "discourse/helpers/number";
 import { ajax } from "discourse/lib/ajax";
 import { emojiUnescape } from "discourse/lib/text";
@@ -313,7 +313,7 @@ export default class TopicMapSummary extends Component {
                         </span>
                         <span class="like-section__likes">
                           {{post.like_count}}
-                          {{dIcon "heart"}}</span>
+                          {{icon "heart"}}</span>
                         <p>
                           {{htmlSafe (emojiUnescape post.blurb)}}
                         </p>

--- a/app/assets/javascripts/discourse/app/components/user-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream.gjs
@@ -13,7 +13,7 @@ import PostActionDescription from "discourse/components/post-action-description"
 import PostList from "discourse/components/post-list";
 import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import ClickTrack from "discourse/lib/click-track";
 import DiscourseURL from "discourse/lib/url";
@@ -192,7 +192,7 @@ export default class UserStreamComponent extends Component {
 
         {{#each post.children as |child|}}
           <div class="user-stream-item-actions">
-            {{dIcon child.icon class="icon"}}
+            {{icon child.icon class="icon"}}
             {{#each child.items as |grandChild|}}
               <a
                 href={{grandChild.userUrl}}

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
@@ -7,7 +7,7 @@ import { and, not, or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
 import EmptyChannelsList from "discourse/plugins/chat/discourse/components/empty-channels-list";
@@ -81,7 +81,7 @@ export default class ChannelsListDirect extends Component {
             }}
             data-toggleable="direct-message-channels"
           >
-            {{dIcon "angle-up"}}
+            {{icon "angle-up"}}
           </span>
         {{/if}}
 

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -7,7 +7,7 @@ import { service } from "@ember/service";
 import { and } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import EmptyChannelsList from "discourse/plugins/chat/discourse/components/empty-channels-list";
 import ChatChannelRow from "./chat-channel-row";
@@ -51,7 +51,7 @@ export default class ChannelsListPublic extends Component {
     {{#if (and this.site.desktopView this.inSidebar this.hasThreadedChannels)}}
       <LinkTo @route="chat.threads" class="chat-channel-row --threads">
         <span class="chat-channel-title">
-          {{dIcon "discourse-threads" class="chat-user-threads__icon"}}
+          {{icon "discourse-threads" class="chat-user-threads__icon"}}
           {{i18n "chat.my_threads.title"}}
         </span>
         {{#if this.hasUnreadThreads}}
@@ -75,7 +75,7 @@ export default class ChannelsListPublic extends Component {
             {{on "click" (fn this.toggleChannelSection "public-channels")}}
             data-toggleable="public-channels"
           >
-            {{dIcon "angle-up"}}
+            {{icon "angle-up"}}
           </span>
         {{/if}}
 
@@ -86,7 +86,7 @@ export default class ChannelsListPublic extends Component {
           class="btn no-text btn-flat open-browse-page-btn title-action"
           title={{i18n "chat.channels_list_popup.browse"}}
         >
-          {{dIcon "pencil"}}
+          {{icon "pencil"}}
         </LinkTo>
       </div>
     {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-card.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-card.gjs
@@ -5,7 +5,7 @@ import { service } from "@ember/service";
 import { gt } from "truth-helpers";
 import borderColor from "discourse/helpers/border-color";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { i18n } from "discourse-i18n";
 import ToggleChannelMembershipButton from "./toggle-channel-membership-button";
@@ -34,14 +34,14 @@ export default class ChatChannelCard extends Component {
               {{replaceEmoji @channel.title}}
             </span>
             {{#if @channel.chatable.read_restricted}}
-              {{dIcon "lock" class="chat-channel-card__read-restricted"}}
+              {{icon "lock" class="chat-channel-card__read-restricted"}}
             {{/if}}
             {{#if @channel.currentUserMembership.muted}}
               <span
                 class="chat-channel-card__muted"
                 aria-label={{i18n "chat.muted"}}
                 title={{i18n "chat.muted"}}
-              >{{dIcon "d-muted"}}</span>
+              >{{icon "d-muted"}}</span>
             {{/if}}
           </LinkTo>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-status.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-status.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import {
   CHANNEL_STATUSES,
@@ -66,7 +66,7 @@ export default class ChatChannelStatus extends Component {
   <template>
     {{#if this.shouldRender}}
       <div class="chat-channel-status">
-        {{dIcon this.channelStatusIcon}}
+        {{icon this.channelStatusIcon}}
         <span>{{this.channelStatusMessage}}</span>
         <ChatChannelArchiveStatus @channel={{@channel}} />
       </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.gjs
@@ -1,6 +1,6 @@
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import ChatUserAvatar from "./chat-user-avatar";
 
@@ -11,7 +11,7 @@ const ChatComposerMessageDetails = <template>
     data-action={{if @message.editing "edit" "reply"}}
   >
     <div class="chat-reply">
-      {{dIcon (if @message.editing "pencil" "reply")}}
+      {{icon (if @message.editing "pencil" "reply")}}
       <ChatUserAvatar @user={{@message.user}} />
       <span class="chat-reply__username">{{@message.user.username}}</span>
       <span class="chat-reply__excerpt">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-upload.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { isImage } from "discourse/lib/uploads";
 import { i18n } from "discourse-i18n";
 
@@ -32,10 +32,10 @@ export default class ChatComposerUpload extends Component {
             {{#if @isDone}}
               <img class="preview-img" src={{@upload.short_path}} />
             {{else}}
-              {{dIcon "far-image"}}
+              {{icon "far-image"}}
             {{/if}}
           {{else}}
-            {{dIcon "file-lines"}}
+            {{icon "file-lines"}}
           {{/if}}
         </div>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-mention-warnings.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-mention-warnings.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import getURL from "discourse/lib/get-url";
 import I18n, { i18n } from "discourse-i18n";
 
@@ -151,7 +151,7 @@ export default class ChatMentionWarnings extends Component {
     {{#if this.show}}
       <div class="chat-mention-warnings">
         <div class="chat-mention-warning__icon">
-          {{dIcon "triangle-exclamation"}}
+          {{icon "triangle-exclamation"}}
         </div>
         <div class="chat-mention-warning__text">
           <div class="chat-mention-warning__header">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-in-reply-to-indicator.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-in-reply-to-indicator.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import ChatEmojiAvatar from "./chat-emoji-avatar";
 import ChatUserAvatar from "./chat-user-avatar";
@@ -46,7 +46,7 @@ export default class ChatMessageInReplyToIndicator extends Component {
         @models={{this.model}}
         class="chat-reply is-direct-reply"
       >
-        {{dIcon "share" title="chat.in_reply_to"}}
+        {{icon "share" title="chat.in_reply_to"}}
 
         {{#if @message.inReplyTo.chatWebhookEvent.emoji}}
           <ChatEmojiAvatar

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/button.gjs
@@ -1,9 +1,9 @@
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 
 const ChatComposerButton = <template>
   <div class="chat-composer-button__wrapper">
     <button type="button" class="chat-composer-button" ...attributes>
-      {{dIcon @icon}}
+      {{icon @icon}}
     </button>
   </div>
 </template>;

--- a/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message/info.gjs
@@ -8,7 +8,7 @@ import { and } from "truth-helpers";
 import BookmarkIcon from "discourse/components/bookmark-icon";
 import UserStatusMessage from "discourse/components/user-status-message";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { i18n } from "discourse-i18n";
@@ -156,10 +156,10 @@ export default class ChatMessageInfo extends Component {
           <span class="chat-message-info__flag">
             {{#if @message.reviewableId}}
               <LinkTo @route="review.show" @model={{@message.reviewableId}}>
-                {{dIcon "flag" title="chat.flagged"}}
+                {{icon "flag" title="chat.flagged"}}
               </LinkTo>
             {{else}}
-              {{dIcon "flag" title="chat.you_flagged"}}
+              {{icon "flag" title="chat.you_flagged"}}
             {{/if}}
           </span>
         {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/message/left-gutter.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/message/left-gutter.gjs
@@ -4,7 +4,7 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { eq } from "truth-helpers";
 import BookmarkIcon from "discourse/components/bookmark-icon";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import formatChatDate from "../../../helpers/format-chat-date";
 
 export default class ChatMessageLeftGutter extends Component {
@@ -18,11 +18,11 @@ export default class ChatMessageLeftGutter extends Component {
           @model={{@message.reviewableId}}
           class="chat-message-left-gutter__flag"
         >
-          {{dIcon "flag" title="chat.flagged"}}
+          {{icon "flag" title="chat.flagged"}}
         </LinkTo>
       {{else if (eq @message.userFlagStatus 0)}}
         <div class="chat-message-left-gutter__flag">
-          {{dIcon "flag" title="chat.you_flagged"}}
+          {{icon "flag" title="chat.you_flagged"}}
         </div>
       {{else if this.site.desktopView}}
         <span class="chat-message-left-gutter__date">

--- a/plugins/chat/assets/javascripts/discourse/components/chat/notices/mention_without_membership.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/notices/mention_without_membership.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import laterFn from "../../../modifiers/chat/later-fn";
@@ -40,7 +40,7 @@ export default class MentionWithoutMembership extends Component {
           class="mention-without-membership-notice__invitation-sent"
           {{laterFn @clearNotice 3000}}
         >
-          {{dIcon "check"}}
+          {{icon "check"}}
           <span>
             {{i18n
               "chat.mention_warning.invitations_sent"

--- a/plugins/chat/assets/javascripts/discourse/components/chat/scroll-to-bottom-arrow.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/scroll-to-bottom-arrow.gjs
@@ -1,6 +1,6 @@
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 
 const ScrollToBottomArrow = <template>
   <div class="chat-scroll-to-bottom">
@@ -13,7 +13,7 @@ const ScrollToBottomArrow = <template>
       @action={{@onScrollToBottom}}
     >
       <span class="chat-scroll-to-bottom__arrow">
-        {{dIcon "arrow-down"}}
+        {{icon "arrow-down"}}
       </span>
     </DButton>
   </div>

--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.gjs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/chat-preferences.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
-import dIcon from "discourse/helpers/d-icon";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class ChatPreferences extends Component {
@@ -11,7 +11,7 @@ export default class ChatPreferences extends Component {
   <template>
     <li class="user-nav__preferences-chat">
       <LinkTo @route="preferences.chat">
-        {{dIcon "d-chat"}}
+        {{icon "d-chat"}}
         <span>{{i18n "chat.title_capitalized"}}</span>
       </LinkTo>
     </li>


### PR DESCRIPTION
Apparently `icon` is the preferred nomenclature
