### PR TITLE
UX: allow msg select buttons to wrap

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-selection-manager.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-selection-manager.scss
@@ -10,6 +10,7 @@
 
   &__buttons {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
 
     .chat-drawer-content & {


### PR DESCRIPTION
Before
![CleanShot 2025-01-31 at 13 47 32@2x](https://github.com/user-attachments/assets/b23ead7a-0d2d-4e37-b7dd-89fc7e60959b)

After
![CleanShot 2025-01-31 at 13 47 51@2x](https://github.com/user-attachments/assets/633984f7-c989-4f82-ac31-91ef9f7acc30)
