### PR TITLE
FEATURE: Localization admin settings config page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-localization-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-localization-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigLocalizationSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-localization.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-localization.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigLocalizationRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.community.sidebar_link.localization.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -227,6 +227,11 @@ export default function () {
             });
           }
         );
+        this.route("localization", function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route("notifications", function () {
           this.route("settings", {
             path: "/",

--- a/app/assets/javascripts/admin/addon/templates/config-localization-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-localization-settings.gjs
@@ -1,0 +1,31 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(<template>
+  <DPageHeader
+    @hideTabs={{true}}
+    @titleLabel={{i18n "admin.config.localization.title"}}
+    @descriptionLabel={{i18n "admin.config.localization.header_description"}}
+  >
+    <:breadcrumbs>
+      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+      <DBreadcrumbsItem
+        @path="/admin/config/localization"
+        @label={{i18n "admin.config.localization.title"}}
+      />
+    </:breadcrumbs>
+  </DPageHeader>
+
+  <div class="admin-config-page__main-area">
+    <AdminAreaSettings
+      @showBreadcrumb={{false}}
+      @area="localization"
+      @path="/admin/config/localization"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </div>
+</template>);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -53,6 +53,12 @@ export const ADMIN_NAV_MAP = [
         icon: "bell",
       },
       {
+        name: "admin_localization",
+        route: "adminConfig.localization.settings",
+        label: "admin.community.sidebar_link.localization.title",
+        icon: "globe",
+      },
+      {
         name: "admin_permalinks",
         route: "adminPermalinks",
         label: "admin.community.sidebar_link.permalinks",

--- a/app/controllers/admin/config/site_settings_controller.rb
+++ b/app/controllers/admin/config/site_settings_controller.rb
@@ -24,7 +24,7 @@ class Admin::Config::SiteSettingsController < Admin::AdminController
           filter_area: params[:filter_area],
           filter_plugin: params[:plugin],
           filter_categories: Array.wrap(params[:categories]),
-          include_locale_setting: false,
+          include_locale_setting: params[:filter_area] == "localization",
           include_hidden: true,
           filter_allowed_hidden: ADMIN_CONFIG_AREA_ALLOWLISTED_HIDDEN_SETTINGS,
         ),

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -9,6 +9,7 @@ class SiteSetting < ActiveRecord::Base
     fonts
     group_permissions
     legal
+    localization
     navigation
     notifications
     permalinks

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5154,6 +5154,9 @@ en:
         legal:
           title: "Legal"
           header_description: "Configure legal settings, such as terms of service, privacy policy, contact details, and EU-specific considerations"
+        localization:
+          title: "Localization"
+          header_description: "Configure your community’s interface language and other localization options for your members"
         login_and_authentication:
           title: "Login & authentication"
           header_description: "Configure how users log in and authenticate, secrets and keys, OAuth2 providers, and more"
@@ -5692,6 +5695,9 @@ en:
           group_permissions: "Group permissions"
           users: "Users"
           groups: "Groups"
+          localization:
+            title: "Localization"
+            keywords: "locale|language|timezone|unicode|ltr"
           user_fields: "User fields"
           watched_words: "Watched words"
           legal: "Legal"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1735,10 +1735,10 @@ en:
     delete_old_hidden_posts: "Auto-delete any hidden posts that stay hidden for more than 30 days."
     default_locale: "The default language of this Discourse instance. You can replace the text of system generated categories and topics at <a href='%{base_path}/admin/customize/site_texts' target='_blank'>Customize / Text</a>."
     allow_user_locale: "Allow users to choose their own language interface preference"
-    set_locale_from_accept_language_header: "set interface language for anonymous users from their web browser's language headers"
+    set_locale_from_accept_language_header: "Set interface language for anonymous users from their web browser's language headers"
     set_locale_from_cookie: "Allows setting an anonymous user's locale via the 'locale' browser cookie"
     set_locale_from_param: "Allows setting an anonymous user's locale via the 'lang' URL param, e.g. ?lang=es"
-    support_mixed_text_direction: "Support mixed left-to-right and right-to-left text directions."
+    support_mixed_text_direction: "Support mixed left-to-right and right-to-left text directions"
     min_post_length: "Minimum allowed post length in characters (excluding personal messages)"
     min_first_post_length: "Minimum allowed first post (topic body) length (excluding personal messages)"
     min_personal_message_post_length: "Minimum allowed post length in characters for messages (both first post and replies)"
@@ -1808,7 +1808,7 @@ en:
     block_onebox_on_redirect: "Prevent oneboxing for URLs that lead to a redirecting page. This configuration stops the creation of a visual card (onebox) for any URL that redirects to a different destination, ensuring that direct, non-redirecting URLs are prioritized for oneboxing."
     allowed_inline_onebox_domains: "A list of domains that will be oneboxed in miniature form if linked without a title"
     enable_inline_onebox_on_all_domains: "Ignore allowed_inline_onebox_domains site setting and allow inline onebox on all domains."
-    onebox_locale: "The locale sent to onebox providers. If left blank, the default locale will be used."
+    onebox_locale: "The locale sent to onebox providers. If left blank, the default locale will be used"
     force_custom_user_agent_hosts: "Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent)."
     max_oneboxes_per_post: "Set the maximum number of oneboxes that can be included in a single post. Oneboxes provide a preview of linked content within the post."
     facebook_app_access_token: "A token generated from your Facebook app ID and secret. Used to generate Instagram oneboxes."
@@ -1974,8 +1974,8 @@ en:
 
     min_username_length: "Minimum username length in characters. WARNING: if any existing users or groups have names shorter than this, your site will break!"
     max_username_length: "Maximum username length in characters. WARNING: if any existing users or groups have names longer than this, your site will break!"
-    unicode_usernames: "Allow usernames and group names to contain Unicode letters and numbers."
-    allowed_unicode_username_characters: "Regular expression to allow only some Unicode characters within usernames. ASCII letters and numbers will always be allowed and don't need to be included in the allowlist."
+    unicode_usernames: "Allow usernames and group names to contain Unicode letters and numbers"
+    allowed_unicode_username_characters: "Regular expression to allow only some Unicode characters within usernames. ASCII letters and numbers will always be allowed and don't need to be included in the allowlist"
 
     reserved_usernames: "Usernames for which signup is not allowed. Wildcard symbol * can be used to match any character zero or more times."
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,7 @@ Discourse::Application.routes.draw do
         get "fonts" => "site_settings#index"
         get "files" => "site_settings#index"
         get "legal" => "site_settings#index"
+        get "localization" => "site_settings#index"
         get "login-and-authentication" => "site_settings#index"
         get "logo" => "site_settings#index"
         get "navigation" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -149,24 +149,30 @@ basic:
   display_local_time_in_user_card:
     client: true
     default: false
+    area: "localization"
   allow_user_locale:
     client: true
     default: false
+    area: "localization"
   set_locale_from_accept_language_header:
     default: false
     client: true
     validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
   set_locale_from_cookie:
     default: false
     client: true
     validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
   set_locale_from_param:
     default: false
     client: true
     validator: "AllowUserLocaleEnabledValidator"
+    area: "localization"
   support_mixed_text_direction:
     client: true
     default: false
+    area: "localization"
   categories_topics:
     default: 20
     validator: "CategoriesTopicsValidator"
@@ -697,6 +703,7 @@ users:
     default: false
     client: true
     validator: "UnicodeUsernameValidator"
+    area: "localization"
   allowed_unicode_username_characters:
     validator: "UnicodeUsernameAllowlistValidator"
     default: ""
@@ -708,6 +715,7 @@ users:
       ko: '\p{Hangul}'
       zh_CN: '\p{Han}'
       zh_TW: '\p{Han}'
+    area: "localization"
   reserved_usernames:
     type: list
     list_type: compact
@@ -2312,6 +2320,7 @@ onebox:
     default: ""
     type: enum
     enum: "OneboxLocaleSiteSetting"
+    area: "localization"
   force_custom_user_agent_hosts:
     default: "http://codepen.io"
     type: list

--- a/plugins/discourse-local-dates/config/locales/server.en.yml
+++ b/plugins/discourse-local-dates/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    discourse_local_dates_enabled: "Enable the discourse-local-dates feature. This will add support to local timezone aware dates in posts using the [date] element."
+    discourse_local_dates_enabled: "Enable the discourse-local-dates feature. This will add support to local timezone aware dates in posts using the [date] element"
     discourse_local_dates_default_formats: "Frequently used date time formats, see: <a target='_blank' rel='noopener' href='https://momentjs.com/docs/#/parsing/string-format/'>momentjs string format</a>"
     discourse_local_dates_default_timezones: "Default list of timezones, must be a valid <a target='_blank' rel='noopener' href='https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>TZ</a>"
-    discourse_local_dates_email_format: "Format used to display a date in emails."
+    discourse_local_dates_email_format: "Format used to display a date in emails"

--- a/plugins/discourse-local-dates/config/settings.yml
+++ b/plugins/discourse-local-dates/config/settings.yml
@@ -5,6 +5,7 @@ plugins:
   discourse_local_dates_enabled:
     default: true
     client: true
+    area: "localization"
   discourse_local_dates_default_formats:
     default: "LLL|LTS|LL|LLLL"
     client: true


### PR DESCRIPTION
This commit adds a new Localization config page for
admins, as a basic filtered site setting page similar
to Legal and Notifications. Included settings are:

* default locale
* allow user locale
* set locale from accept langauge header
* onebox locale
* display local time in user card
* discourse local dates enabled
* support mixed text direction
* unicode usernames
* allowed unicode username characters

![image](https://github.com/user-attachments/assets/11698f98-2cee-4e25-8633-98c2923e95c9)

