### PR TITLE
DEV: pass owner instead of services

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
@@ -1,22 +1,18 @@
+import { setOwner } from "@ember/owner";
+import { service } from "@ember/service";
+
 /**
  * Base class representing a sidebar communtiy section link interface.
  */
 export default class BaseCommunitySectionLink {
-  constructor({
-    topicTrackingState,
-    currentUser,
-    appEvents,
-    router,
-    siteSettings,
-    inMoreDrawer,
-    overridenName,
-    overridenIcon,
-  } = {}) {
-    this.router = router;
-    this.topicTrackingState = topicTrackingState;
-    this.currentUser = currentUser;
-    this.appEvents = appEvents;
-    this.siteSettings = siteSettings;
+  @service currentUser;
+  @service appEvents;
+  @service router;
+  @service siteSettings;
+  @service topicTrackingState;
+
+  constructor(owner, { inMoreDrawer, overridenName, overridenIcon } = {}) {
+    setOwner(this, owner);
     this.inMoreDrawer = inMoreDrawer;
     this.overridenName = overridenName;
     this.overridenIcon = overridenIcon;

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/section.js
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { setOwner } from "@ember/owner";
+import { getOwner, setOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import AboutSectionLink from "discourse/lib/sidebar/common/community-section/about-section-link";
 import BadgesSectionLink from "discourse/lib/sidebar/common/community-section/badges-section-link";
@@ -130,12 +130,7 @@ export default class CommunitySection {
     if (this.router.isDestroying) {
       return;
     }
-    return new sectionLinkClass({
-      topicTrackingState: this.topicTrackingState,
-      currentUser: this.currentUser,
-      appEvents: this.appEvents,
-      router: this.router,
-      siteSettings: this.siteSettings,
+    return new sectionLinkClass(getOwner(this), {
       inMoreDrawer,
       overridenName,
       overridenIcon,


### PR DESCRIPTION
Passing the owner allows section class to access services without having to pass each service instance one by one.