### PR TITLE
FIX: switch panel back to forum last known url

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/switch-panel-buttons.gjs
@@ -16,7 +16,7 @@ export default class SwitchPanelButtons extends Component {
     this.isSwitching = true;
     this.sidebarState.currentPanel.lastKnownURL = this.router.currentURL;
 
-    const destination = panel?.switchButtonDefaultUrl || panel?.lastKnownURL;
+    const destination = panel?.switchButtonDefaultUrl;
     if (!destination) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/custom-sections.js
@@ -21,7 +21,7 @@ class MainSidebarPanel {
   }
 
   get switchButtonDefaultUrl() {
-    return "/";
+    return this?.lastKnownURL || "/";
   }
 }
 

--- a/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
+++ b/plugins/chat/spec/system/separate_sidebar_mode_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "Separate sidebar mode", type: :system do
         expect(channel_browse_page.component).to be_present
 
         sidebar_component.switch_to_main
-        expect(page).to have_current_path("/discuss/")
+        expect(page).to have_current_path("/discuss/about")
       end
     end
   end


### PR DESCRIPTION
Previously the return to forum link would automatically take you to the forum homepage, however this was not intended functionality. We should attempt to take the user to their last viewed forum page.

This change fixes a bug in how we determined what the destination link should be.

Internal ref: /t/110508