### PR TITLE
DEV: Add missing clock icon to the svg_sprite list

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -63,6 +63,7 @@ module SvgSprite
         circle-plus
         circle-question
         circle-xmark
+        clock
         clock-rotate-left
         cloud-arrow-up
         code


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/the-icon-clock-is-missing-from-the-default-svg-subset/349823/3

This adds the missing `clock` icon to the default SVG subset.
The icon is used in the GitHub PR onebox and the user's activity pending posts tab.

![image](https://github.com/user-attachments/assets/24c639ac-fb72-4180-aa3b-75b107ae4e07)

![image](https://github.com/user-attachments/assets/cffd878a-3889-4f59-87d8-8ade1f292a33)
