### PR TITLE
FIX: reset the delete automatic group tooltip

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/group.js
+++ b/app/assets/javascripts/discourse/app/routes/group.js
@@ -12,4 +12,10 @@ export default class Group extends DiscourseRoute {
   serialize(model) {
     return { name: model.get("name").toLowerCase() };
   }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+
+    controller.set("showTooltip", false);
+  }
 }


### PR DESCRIPTION
Prior to this change the tooltip would forever stay even after changing a group until you hard refresh the page.

No test as it's a very niche behavior and we have a todo to have multiple other improvements at this codepath.