### PR TITLE
UX: move "hide profile" checkbox to profile tab

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -72,7 +72,6 @@ export default class InterfaceController extends Controller {
       "allow_private_messages",
       "enable_allowed_pm_users",
       "homepage_id",
-      "hide_profile",
       "hide_presence",
       "text_size",
       "title_count_mode",

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -33,6 +33,7 @@ export default class ProfileController extends Controller {
     "date_of_birth",
     "timezone",
     "default_calendar",
+    "hide_profile",
   ];
 
   calendarOptions = [

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -197,14 +197,6 @@
       class="pref-auto-unpin"
     />
   {{/if}}
-  {{#if this.siteSettings.allow_users_to_hide_profile}}
-    <PreferenceCheckbox
-      @labelKey="user.hide_profile"
-      @checked={{this.model.user_option.hide_profile}}
-      data-setting-name="user-hide-profile"
-      class="pref-hide-profile"
-    />
-  {{/if}}
   <PreferenceCheckbox
     @labelKey="user.dynamic_favicon"
     @checked={{this.model.user_option.dynamic_favicon}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -5,6 +5,20 @@
 {{/if}}
 
 {{#unless this.showEnforcedRequiredFieldsNotice}}
+  {{#if this.siteSettings.allow_users_to_hide_profile}}
+    <div
+      class="control-group user-hide-profile"
+      data-setting-name="user-hide-profile"
+    >
+      <PreferenceCheckbox
+        @labelKey="user.hide_profile"
+        @checked={{this.model.user_option.hide_profile}}
+        data-setting-name="user-hide-profile"
+        class="pref-hide-profile"
+      />
+    </div>
+  {{/if}}
+
   {{#if this.canChangeBio}}
     <div class="control-group pref-bio" data-setting-name="user-bio">
       <label class="control-label">{{i18n "user.bio"}}</label>

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-profile-test.js
@@ -4,6 +4,38 @@ import { cloneJSON } from "discourse/lib/object";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
+acceptance(
+  "User - Preferences - Profile - Hide Profile Allowed",
+  function (needs) {
+    needs.user();
+    needs.settings({ allow_users_to_hide_profile: true });
+
+    test("user can hide profile", async function (assert) {
+      await visit("/my/preferences/profile");
+
+      assert
+        .dom(".pref-hide-profile")
+        .exists("checkbox to hide profile is shown");
+    });
+  }
+);
+
+acceptance(
+  "User - Preferences - Profile - Hide Profile Not Allowed",
+  function (needs) {
+    needs.user();
+    needs.settings({ allow_users_to_hide_profile: false });
+
+    test("user can hide profile", async function (assert) {
+      await visit("/my/preferences/profile");
+
+      assert
+        .dom(".pref-hide-profile")
+        .doesNotExist("checkbox to hide profile is hidden");
+    });
+  }
+);
+
 acceptance("User - Preferences - Profile - Featured topic", function (needs) {
   needs.user();
 

--- a/spec/system/page_objects/pages/user_preferences_profile.rb
+++ b/spec/system/page_objects/pages/user_preferences_profile.rb
@@ -8,6 +8,14 @@ module PageObjects
         self
       end
 
+      def hide_profile
+        find(".user-hide-profile .pref-hide-profile").click
+      end
+
+      def has_hidden_profile?
+        has_css?(".user-hide-profile .pref-hide-profile input[type=checkbox]:checked")
+      end
+
       def expand_profile_details
         find(".user-main .details .controls .btn-default").click
       end

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -19,6 +19,19 @@ describe "User preferences | Profile", type: :system do
     end
   end
 
+  describe "hiding profile" do
+    it "allows user to hide their profile" do
+      SiteSetting.allow_users_to_hide_profile = true
+
+      user_preferences_profile_page.visit(user)
+      user_preferences_profile_page.hide_profile
+      user_preferences_profile_page.save
+      page.refresh
+
+      expect(user_preferences_profile_page).to have_hidden_profile
+    end
+  end
+
   describe "enforcing required fields" do
     before do
       UserRequiredFieldsVersion.create!


### PR DESCRIPTION
This moves the "hide my public profile" checkbox from the /my/preferences/interface > other section into the top of the /my/preferences/profile section.

Internal ref - t/146570