### PR TITLE
FEATURE: Remove unnecessary org names from PR oneboxes

### DIFF
--- a/lib/onebox/engine/github_pull_request_onebox.rb
+++ b/lib/onebox/engine/github_pull_request_onebox.rb
@@ -36,7 +36,8 @@ module Onebox
         result["created_at_time"] = created_at.strftime("%T")
 
         ulink = URI(link)
-        result["domain"] = "#{ulink.host}/#{ulink.path.split("/")[1]}/#{ulink.path.split("/")[2]}"
+        _, org, repo = ulink.path.split("/")
+        result["domain"] = "#{ulink.host}/#{org}/#{repo}"
 
         result["body"], result["excerpt"] = compute_body(result["body"])
 
@@ -50,6 +51,7 @@ module Onebox
         else
           result["pr"] = true
         end
+
         result["i18n"] = i18n
         result["i18n"]["pr_summary"] = I18n.t(
           "onebox.github.pr_summary",
@@ -61,6 +63,9 @@ module Onebox
           },
         )
         result["is_private"] = result.dig("base", "repo", "private")
+
+        result["base"]["label"].sub!(/\A#{org}:/, "")
+        result["head"]["label"].sub!(/\A#{org}:/, "")
 
         result
       end

--- a/spec/fixtures/onebox/githubpullrequest.response
+++ b/spec/fixtures/onebox/githubpullrequest.response
@@ -63,8 +63,8 @@
     "repo": null
   },
   "base": {
-    "label": "discourse:master",
-    "ref": "master",
+    "label": "discourse:main",
+    "ref": "main",
     "sha": "cc79d22f82ede170dd86a05274eb3c2c5eb02912",
     "user": {
       "login": "discourse",
@@ -165,8 +165,8 @@
       "forks": 1876,
       "open_issues": 38,
       "watchers": 7857,
-      "master_branch": "master",
-      "default_branch": "master"
+      "main_branch": "main",
+      "default_branch": "main"
     }
   },
   "_links": {

--- a/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Onebox::Engine::GithubPullRequestOnebox do
       expect(html).to include("discourse")
     end
 
+    it "includes branch names" do
+      expect(html).to include("<code>main</code> ← <code>jamesaanderson:add-audio-onebox</code>")
+    end
+
     it "includes commit author gravatar" do
       expect(html).to include("b3e9977094ce189bbb493cf7f9adea21")
     end


### PR DESCRIPTION
Instead of displaying:

`discourse:main <- discourse:feature` or `discourse:main <- user:feature`

shows:

`main <- feature` or `main <- user:feature`