### PR TITLE
UX: Remove half-pixel border from loading dots

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -82,7 +82,6 @@
       height: var(--splash-dot-size);
       border-radius: 50%;
 
-      border: 0.5px solid #fff;
       background-color: var(--dot-color);
       filter: saturate(2) opacity(0.85);
       opacity: 0;


### PR DESCRIPTION
That didn't render well (and was visible in dark themes only)