### PR TITLE
UX: Fix discourse topic onebox styling

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -857,12 +857,23 @@ aside.onebox.xkcd .onebox-body img {
     padding-left: calc(1em - 5px);
     margin-left: 5px;
   }
+
+  .badge-category-bg {
+    display: inline-block;
+    width: 0.625rem;
+    height: 0.625rem;
+  }
 }
 
 .onebox.discoursetopic {
   h3 {
     width: 100%;
     margin-bottom: 0.2rem !important;
+  }
+
+  .topic-category {
+    color: var(--primary-high);
+    line-height: var(--line-height-medium);
   }
 
   .discourse-tags {


### PR DESCRIPTION
Regressed possibly in https://github.com/discourse/discourse/pull/24198

Before / After

<img width="706" alt="Screenshot 2025-02-01 at 02 59 37" src="https://github.com/user-attachments/assets/328a0a20-152e-4e3b-bb71-45cc19cce92c" />
<img width="706" alt="Screenshot 2025-02-01 at 02 59 13" src="https://github.com/user-attachments/assets/d151b175-1ca4-4e40-87ee-90fa92de1f30" />
