### PR TITLE
DEV: Block running `db:create db:migrate` in single command

### DIFF
--- a/.vscode/tasks.json.sample
+++ b/.vscode/tasks.json.sample
@@ -36,7 +36,7 @@
     {
       "label": "dev/migrate",
       "type": "shell",
-      "command": "bin/rake db:create db:migrate",
+      "command": "bin/rake db:create && bin/rake db:migrate",
       "options": {
         "env":{
           "SKIP_MULTISITE": "1",
@@ -74,7 +74,10 @@
     {
       "label": "spec/migrate",
       "type": "shell",
-      "command": "RAILS_ENV=test bin/rake db:create db:migrate parallel:create parallel:migrate",
+      "command": "bin/rake db:create && bin/rake db:migrate && bin/rake parallel:create parallel:migrate",
+      "env": {
+        "RAILS_ENV": "test"
+      },
       "problemMatcher": [],
     },
     {

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -128,6 +128,10 @@ task "multisite:migrate" => %w[
      ] do |_, args|
   raise "Multisite migrate is only supported in production" if ENV["RAILS_ENV"] != "production"
 
+  if GlobalSetting.skip_db?
+    raise "Migrate cannot be run when skip_db=true. (running `rake db:create db:migrate` in a single command is not supported)"
+  end
+
   DistributedMutex.synchronize(
     "db_migration",
     redis: Discourse.redis.without_namespace,
@@ -231,6 +235,10 @@ task "db:migrate" => %w[
        set_locale
        assets:precompile:theme_transpiler
      ] do |_, args|
+  if GlobalSetting.skip_db?
+    raise "Migrate cannot be run when skip_db=true. (running `rake db:create db:migrate` in a single command is not supported)"
+  end
+
   DistributedMutex.synchronize(
     "db_migration",
     redis: Discourse.redis.without_namespace,


### PR DESCRIPTION
By design, `db:create` initializes the Rails app with SKIP_DB=true. That means that SiteSettings get set up with the LocalProcessProvider instead of the DBProvider. In other words: any calls to site settings will return the default, rather then the actual value in the database.

Running `db:migrate` in the same rake invocation means that rails will not be re-initialized, and so skip_db will remain true. Site settings accessed during migrations and fixtures will therefore return incorrect values.

One example of this is that running `bin/rake db:create db:migrate` repeatedly in a development environment will cause the FAQ topic to be seeded repeatedly, because the seed logic does not have access to the site setting which stores the already-seeded topic id.