### PR TITLE
UX: update system font stack to system-ui

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -1,6 +1,5 @@
 body.invite-page {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
+  font-family: system-ui, Arial, sans-serif;
 
   #main-outlet-wrapper {
     padding: 0;

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -22,8 +22,7 @@ body.wizard {
   background-repeat: no-repeat;
   background-position: bottom;
   color: var(--primary-very-high);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, Arial, sans-serif;
+  font-family: system-ui, Arial, sans-serif;
 
   .wrap {
     max-width: 100%;


### PR DESCRIPTION
support for the `system-ui` value is widely available now, so we can drop the device specific values: https://highperformancewebfonts.com/read/ditch-BlinkMacSystemFont-and-apple-system

https://caniuse.com/?search=system-ui