### PR TITLE
DEV: Mark topic-list-columns transformer as mutable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
@@ -8,7 +8,10 @@ import Header from "discourse/components/topic-list/header";
 import Item from "discourse/components/topic-list/item";
 import concatClass from "discourse/helpers/concat-class";
 import DAG from "discourse/lib/dag";
-import { applyValueTransformer } from "discourse/lib/transformer";
+import {
+  applyMutableValueTransformer,
+  applyValueTransformer,
+} from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 import HeaderActivityCell from "./header/activity-cell";
 import HeaderBulkSelectCell from "./header/bulk-select-cell";
@@ -98,11 +101,10 @@ export default class TopicList extends Component {
       },
     };
 
-    return applyValueTransformer(
+    return applyMutableValueTransformer(
       "topic-list-columns",
       defaultColumns,
-      context,
-      { mutable: true }
+      context
     ).resolve();
   }
 

--- a/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
@@ -101,7 +101,8 @@ export default class TopicList extends Component {
     return applyValueTransformer(
       "topic-list-columns",
       defaultColumns,
-      context
+      context,
+      { mutable: true }
     ).resolve();
   }
 

--- a/app/assets/javascripts/discourse/app/lib/transformer.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer.js
@@ -345,11 +345,6 @@ export function applyValueTransformer(
 
     try {
       const value = valueCallback({ value: newValue, context });
-      if (mutable && typeof value !== "undefined") {
-        throw new Error(
-          `${prefix}: transformer "${transformerName}" expects the value to be mutated instead of returned. Remove the return value in your transformer.`
-        );
-      }
 
       if (!mutable) {
         newValue = value;

--- a/app/assets/javascripts/discourse/tests/unit/lib/transformer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/transformer-test.js
@@ -547,26 +547,6 @@ module("Unit | Utility | transformers", function (hooks) {
       applyMutableValueTransformer("test-mutable-transformer", value);
       assert.true(mutated, "the value is mutated");
     });
-
-    test("raises an exception if the transformer returns a value different from undefined", function (assert) {
-      assert.throws(
-        () => {
-          withPluginApi("1.34.0", (api) => {
-            api.registerValueTransformer(
-              "test-mutable-transformer",
-              () => "unexpected value"
-            );
-          });
-
-          applyMutableValueTransformer(
-            "test-mutable-transformer",
-            "default value"
-          );
-        },
-        /expects the value to be mutated instead of returned. Remove the return value in your transformer./,
-        "logs warning to the console when the transformer returns a value different from undefined"
-      );
-    });
   });
 
   module("pluginApi.addBehaviorTransformerName", function (innerHooks) {


### PR DESCRIPTION
`topic-list-columns` expects consumers to mutate the DAG, not return a new one. This change means that themes/plugins do not need to remember to `return columns` when using the transformer.

Also removes the exception when someone returns a value to a mutable valueTransformer. This is essential for backward-compatibility.