### PR TITLE
UX: fix topic progress position when composer is open

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -59,13 +59,6 @@
     border: 0;
   }
 
-  &:not(.docked) {
-    @media screen and (min-width: $reply-area-max-width) {
-      right: calc(50%); // right side of composer
-      margin-right: calc(#{$reply-area-max-width} / 2 * -1);
-    }
-  }
-
   #topic-progress {
     position: relative;
     background-color: var(--secondary);


### PR DESCRIPTION
I'm not sure what the original intention was @ZogStriP, but it seems this causes a lot of overflow... 


Before: 
![image](https://github.com/user-attachments/assets/64e12179-d948-4311-9cba-4271ebe8559e)


After: 
![image](https://github.com/user-attachments/assets/416d28b6-f116-42ab-8b8e-cfdeb477637e)
