### PR TITLE
UX: unblock clicking through progress bar wrapper

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -43,6 +43,11 @@
   position: sticky;
   bottom: calc(env(safe-area-inset-bottom) + var(--composer-height, 0px));
   z-index: z("timeline");
+  pointer-events: none; // the wrapper can block mobile controls
+
+  #topic-progress-wrapper {
+    pointer-events: auto; // this unsets the above rule so the element is interactive
+  }
 }
 
 #topic-progress-wrapper {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/topic-navigation-toggle-prevents-interactions-on-the-page-in-a-certain-area/350073

The purple wrapper shown here prevents elements underneath it from being clicked/tapped, this can sometimes interfere with post controls

![image](https://github.com/user-attachments/assets/18cec59d-f150-495c-86c9-572b261f95e3)

The fix is to disable pointer events on the wrapping element, so clicks pass through. Then clicks are re-enabled on the child element. 