### PR TITLE
FIX: quote from thread in drawer mode

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drawer-router.js
@@ -93,6 +93,7 @@ const ROUTES = {
 
     afterModel(model) {
       this.chat.activeChannel = model.channel;
+      this.chat.activeChannel.activeThread = model.thread;
     },
 
     deactivate() {
@@ -123,6 +124,7 @@ const ROUTES = {
 
     afterModel(model) {
       this.chat.activeChannel = model.channel;
+      this.chat.activeChannel.activeThread = model.thread;
     },
 
     deactivate() {


### PR DESCRIPTION
Due to a recent regression the selection management was failing in drawer mode for threads. We were not correctly setting the active thread.

This commit fixes the issue and adds a spec.