### PR TITLE
UX: prevent topic map link menu from overflowing when there are many links

### DIFF
--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -312,6 +312,7 @@ body:not(.archetype-private_message) {
       margin: 0;
       padding: 0;
       list-style-type: none;
+      max-height: 80dvh;
     }
   }
 


### PR DESCRIPTION
Before (overflows, can't reach bottom): 

<img src="https://github.com/user-attachments/assets/fd3cf28a-9735-452e-82ca-8415da9fd66f" height="500">

After (max-height clipped, can scroll contents): 

<img src="https://github.com/user-attachments/assets/3b26bf84-a535-4931-9406-6a3354b76534" height="500">
