### PR TITLE
DEV: Add removed & back to transparent styling

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -435,6 +435,7 @@
 }
 
 .btn-transparent {
+  &,
   &.btn-default,
   &.btn-text {
     background: transparent;


### PR DESCRIPTION
This PR adds the & line back to the transparent styling scss block. It was accidentally removed in this commit: https://github.com/discourse/discourse/pull/31138/files#diff-79939a573d667edf74bf255677d7cd3a87fe916be27b7b62c1fd48cbf9ce73f3