### PR TITLE
DEV: upgrade mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ gem "sidekiq"
 gem "mini_scheduler"
 
 gem "execjs", require: false
-gem "mini_racer"
+gem "mini_racer", "0.17.pre13"
 
 gem "highline", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,10 +212,10 @@ GEM
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.4)
-    libv8-node (18.19.0.0-aarch64-linux)
-    libv8-node (18.19.0.0-arm64-darwin)
-    libv8-node (18.19.0.0-x86_64-darwin)
-    libv8-node (18.19.0.0-x86_64-linux)
+    libv8-node (22.7.0.4-aarch64-linux)
+    libv8-node (22.7.0.4-arm64-darwin)
+    libv8-node (22.7.0.4-x86_64-darwin)
+    libv8-node (22.7.0.4-x86_64-linux)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -247,8 +247,8 @@ GEM
       mini_racer (>= 0.6.3)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_racer (0.16.0)
-      libv8-node (~> 18.19.0.0)
+    mini_racer (0.17.0.pre13)
+      libv8-node (~> 22.7.0.4)
     mini_scheduler (0.18.0)
       sidekiq (>= 6.5, < 8.0)
     mini_sql (1.6.0)
@@ -671,7 +671,7 @@ DEPENDENCIES
   message_bus
   messageformat-wrapper
   mini_mime
-  mini_racer
+  mini_racer (= 0.17.pre13)
   mini_scheduler
   mini_sql
   mini_suffix


### PR DESCRIPTION
Previous upgrade had a runaway CPU issue due to
overly aggressive GC running.

MiniRacer was running V8 GC every 2 seconds.

New change fixes the parameter so it only issues a GC
if 2 seconds past since last MiniRacer eval.

