### PR TITLE
UX: More selectors for transparent buttons

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -437,7 +437,9 @@
 .btn-transparent {
   &,
   &.btn-default,
-  &.btn-text {
+  &.btn-text,
+  &.btn-icon,
+  &.no-text {
     background: transparent;
     border: 0;
     color: var(--primary);


### PR DESCRIPTION
This PR adds a couple more targets for transparent buttons.

