### PR TITLE
DEV: Remove deprecated plugin config nav mode option

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/admin-plugin-config-nav.js
+++ b/app/assets/javascripts/discourse/app/lib/admin-plugin-config-nav.js
@@ -1,5 +1,3 @@
-export const PLUGIN_NAV_MODE_SIDEBAR = "sidebar";
-export const PLUGIN_NAV_MODE_TOP = "top";
 let pluginConfigNav = {};
 export function registerAdminPluginConfigNav(pluginId, links) {
   pluginConfigNav[pluginId] = { links };

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -55,11 +55,7 @@ import {
 import { addUsernameSelectorDecorator } from "discourse/helpers/decorate-username-selector";
 import { registerCustomAvatarHelper } from "discourse/helpers/user-avatar";
 import { addBeforeAuthCompleteCallback } from "discourse/instance-initializers/auth-complete";
-import {
-  PLUGIN_NAV_MODE_SIDEBAR,
-  PLUGIN_NAV_MODE_TOP,
-  registerAdminPluginConfigNav,
-} from "discourse/lib/admin-plugin-config-nav";
+import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
 import { registerPluginHeaderActionComponent } from "discourse/lib/admin-plugin-header-actions";
 import { registerReportModeComponent } from "discourse/lib/admin-report-additional-modes";
 import classPrepend, {
@@ -3255,24 +3251,15 @@ class PluginApi {
    *
    * * route
    * * label OR text
-   *
-   * And the mode must be one of "sidebar" or "top", which controls
-   * where in the admin plugin show UI the links will be displayed.
    */
-  addAdminPluginConfigurationNav(pluginId, ...links) {
+  addAdminPluginConfigurationNav(pluginId, links) {
     if (!pluginId) {
       // eslint-disable-next-line no-console
       console.warn(consolePrefix(), "A pluginId must be provided!");
       return;
     }
 
-    // TODO (Ted - 2024-01-27): Remove once usage discontinued in plugins.
-    const validModes = [PLUGIN_NAV_MODE_SIDEBAR, PLUGIN_NAV_MODE_TOP];
-    if (validModes.includes(links[0])) {
-      links.shift();
-    }
-
-    registerAdminPluginConfigNav(pluginId, links.flat());
+    registerAdminPluginConfigNav(pluginId, links);
   }
 
   /**


### PR DESCRIPTION
### What is this change?

In #31012 we deprecated this nav mode option when registering a plugin in a backwards compatible way.

We have now removed its use in all relevant plugins:

- [new-features-feed](https://github.com/discourse-org/discourse-new-features-feeds/blob/b51f054032bb0e66a9d80b58653c86d050565c42/assets/javascripts/discourse/initializers/discourse-new-features-feeds-admin-plugin-configuration-nav.js#L13)
- [ai](https://github.com/discourse/discourse-ai/blob/a7d032fa28ee4c2e19b2a7b36769e4ccdc656ec3/assets/javascripts/initializers/admin-plugin-configuration-nav.js#L13)
- [chat](https://github.com/discourse/discourse/blob/503f9b6f02ac5c4918d41611848c886b8755e5a0/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js#L14)
- [gamification](https://github.com/discourse/discourse-gamification/blob/1708b57254273a42b0fc47b2232219da3e2b2189/assets/javascripts/initializers/admin-plugin-configuration-nav.js#L13)
- [antivirus](https://github.com/discourse/discourse-antivirus/blob/e2273ec5784434a5186c004fe875ca3d2bb7647a/assets/javascripts/discourse/initializers/admin-plugin-configuration-nav.js#L13)

and should be ready to completely remove it from core.