### PR TITLE
DEV: Pin pnpm to v9

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -44,7 +44,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/custom-proxy/package.json
+++ b/app/assets/javascripts/custom-proxy/package.json
@@ -28,6 +28,6 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   }
 }

--- a/app/assets/javascripts/deprecation-silencer/package.json
+++ b/app/assets/javascripts/deprecation-silencer/package.json
@@ -10,6 +10,6 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   }
 }

--- a/app/assets/javascripts/dialog-holder/package.json
+++ b/app/assets/javascripts/dialog-holder/package.json
@@ -25,6 +25,6 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   }
 }

--- a/app/assets/javascripts/discourse-hbr/package.json
+++ b/app/assets/javascripts/discourse-hbr/package.json
@@ -11,7 +11,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "exports": {
     "./raw-handlebars-compiler": "./raw-handlebars-compiler.js"

--- a/app/assets/javascripts/discourse-i18n/package.json
+++ b/app/assets/javascripts/discourse-i18n/package.json
@@ -24,7 +24,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-markdown-it/package.json
+++ b/app/assets/javascripts/discourse-markdown-it/package.json
@@ -36,7 +36,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-plugins/package.json
+++ b/app/assets/javascripts/discourse-plugins/package.json
@@ -25,7 +25,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/discourse-widget-hbs/package.json
+++ b/app/assets/javascripts/discourse-widget-hbs/package.json
@@ -42,7 +42,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -130,7 +130,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/float-kit/package.json
+++ b/app/assets/javascripts/float-kit/package.json
@@ -45,7 +45,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/pretty-text/package.json
+++ b/app/assets/javascripts/pretty-text/package.json
@@ -45,7 +45,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -46,7 +46,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/theme-transpiler/package.json
+++ b/app/assets/javascripts/theme-transpiler/package.json
@@ -26,6 +26,6 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   }
 }

--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -25,7 +25,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node": ">= 18",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
-    "pnpm": ">= 9"
+    "pnpm": "^9"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
pnpm 10 changed the lockfile syntax slightly, so we need to keep everyone using v9 until we handle the upgrade.