### PR TITLE
DEV: adds includeNone param to form-kit select

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
@@ -96,6 +96,7 @@ export default class FKControlWrapper extends Component {
           @height={{@height}}
           @preview={{@preview}}
           @selection={{@selection}}
+          @includeNone={{@includeNone}}
           id={{@field.id}}
           name={{@field.name}}
           aria-invalid={{if this.error "true"}}

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/select.gjs
@@ -21,7 +21,9 @@ export default class FKControlSelect extends Component {
       return true;
     }
 
-    return !this.args.field.validation?.includes("required");
+    return (
+      this.args.includeNone ?? !this.args.field.validation?.includes("required")
+    );
   }
 
   <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/select-test.gjs
@@ -124,6 +124,22 @@ module(
           NO_VALUE_OPTION,
           "it has the none when no value is present and field is not required"
         );
+
+      await render(<template>
+        <Form @data={{hash foo="1"}} as |form|>
+          <form.Field @name="foo" @title="Foo" as |field|>
+            <field.Select @includeNone={{false}} />
+          </form.Field>
+        </Form>
+      </template>);
+
+      assert
+        .form()
+        .field("foo")
+        .hasNoValue(
+          NO_VALUE_OPTION,
+          "it doesn’t have the none for an optional field when value is present and includeNone is false"
+        );
     });
   }
 );


### PR DESCRIPTION
This option allows to force the presence of none when a value is selected.