### PR TITLE
UX: Do not use generic username suggestions for invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -519,7 +519,7 @@ class InvitesController < ApplicationController
 
     hidden_email = email != invite.email
 
-    if hidden_email || invite.email.nil?
+    if hidden_email || invite.email.nil? || !SiteSetting.use_email_for_username_and_name_suggestions
       username = ""
     else
       username = UserNameSuggester.suggest(invite.email)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe InvitesController do
       end
     end
 
+    it "includes unobfuscated email when email_token present" do
+      get "/invites/#{invite.invite_key}?t=#{invite.email_token}"
+      expect(response.status).to eq(200)
+      expect(response.body).to include(invite.email)
+
+      expect(response.body).to have_tag("div#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        invite_info = JSON.parse(json["invite_info"])
+        expect(invite_info["username"]).to eq("") # Default is that we don't use emails to suggest usernames
+        expect(invite_info["email"]).to eq(invite.email)
+      end
+    end
+
     context "when email data is present in authentication data" do
       let(:store) { ActionDispatch::Session::CookieStore.new({}) }
       let(:session_stub) do

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -269,6 +269,7 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
       visit "/invites/#{invite.invite_key}?t=#{invite.email_token}"
 
       find("#new-account-password").fill_in(with: "supersecurepassword")
+      find("#new-account-username").fill_in(with: "johndoe")
       find(".username-input").has_css?("#username-validation.good")
       find(".create-account__password-tip-validation").has_css?("#password-validation.good")
       find(".invitation-cta__accept").click


### PR DESCRIPTION
6fd577d97d3923cec3d2458f45ebd2704703fd22 widened the scope of `use_email_for_username_and_name_suggestions` (default false) to include invites, which means that it fell back to a generic username like `user1`.

This commit makes it bail out earlier in this situation, so that no suggestion is attempted.