### PR TITLE
A11Y: fix post control button contrast issue for WCAG colors

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -218,77 +218,8 @@ html {
   }
 
   nav.post-controls {
-    .actions {
-      button.create,
-      button.create .d-icon {
-        color: var(--primary-high-or-secondary-low);
-      }
-
-      button {
-        &.d-hover,
-        &:hover,
-        &:focus,
-        &:active {
-          background: var(--primary-medium);
-          color: var(--secondary);
-
-          .d-icon {
-            color: var(--secondary);
-          }
-        }
-
-        &.delete.d-hover,
-        &.delete:hover,
-        &.delete:focus {
-          background: var(--danger);
-          color: var(--secondary);
-
-          .d-icon {
-            color: var(--secondary);
-          }
-        }
-
-        &.bookmark {
-          &.bookmarked {
-            .d-icon {
-              color: var(--tertiary);
-            }
-
-            &.d-hover,
-            &:hover {
-              .d-icon {
-                color: var(--tertiary-medium);
-              }
-            }
-          }
-        }
-      }
-
-      .double-button .button-count {
-        color: var(--primary-medium);
-      }
-
-      .double-button:hover {
-        button,
-        .d-icon,
-        button.has-like .d-icon {
-          color: var(--love);
-        }
-      }
-    }
-
-    .show-replies {
-      color: var(--primary-medium);
-
-      &:hover,
-      &:focus {
-        color: var(--secondary);
-        background: var(--primary-medium);
-
-        .d-icon {
-          color: var(--secondary);
-        }
-      }
+    .btn.btn-flat {
+      --d-post-control-icon-color: var(--primary-high);
     }
   }
 


### PR DESCRIPTION
We had a little regression here: 

Before:

![image](https://github.com/user-attachments/assets/f486ac9b-3c68-4a89-be3d-38e0144669e8)


After: 

![image](https://github.com/user-attachments/assets/4ecbefab-01ce-44e0-8f16-25a5360da0b7)

Upon closer inspection, a lot of the post control styles here are no longer necessary, as the contrast is fine without them: 

![image](https://github.com/user-attachments/assets/f16193bb-4079-43e8-9924-c2e02016a815)


