### PR TITLE
FIX: ensure all children of `.with-topic-progress` are clickable (#31176)

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -45,8 +45,8 @@
   z-index: z("timeline");
   pointer-events: none; // the wrapper can block mobile controls
 
-  #topic-progress-wrapper {
-    pointer-events: auto; // this unsets the above rule so the element is interactive
+  > * {
+    pointer-events: auto; // this unsets the above rule so the child elements are interactive
   }
 }
 


### PR DESCRIPTION
This is a follow-up to 71eb2f6cda9ad8a69ba1ae7d506440c3ff0bc9cb, we have outlets in this wrapper too — so best to re-enable pointer events on all immediate children of the disabled wrapper.