### PR TITLE
FIX: correct mobile height of badge and ownership modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/change-owner.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/change-owner.hbs
@@ -21,18 +21,15 @@
       }}
     </span>
 
-    <form>
-      <label></label>
-      <EmailGroupUserChooser
-        @value={{this.newOwner}}
-        @autofocus={{true}}
-        @onChange={{this.updateNewOwner}}
-        @options={{hash
-          maximum=1
-          filterPlaceholder="topic.change_owner.placeholder"
-        }}
-      />
-    </form>
+    <EmailGroupUserChooser
+      @value={{this.newOwner}}
+      @autofocus={{true}}
+      @onChange={{this.updateNewOwner}}
+      @options={{hash
+        maximum=1
+        filterPlaceholder="topic.change_owner.placeholder"
+      }}
+    />
   </:body>
   <:footer>
     <DButton

--- a/app/assets/stylesheets/mobile/modal-overrides.scss
+++ b/app/assets/stylesheets/mobile/modal-overrides.scss
@@ -20,6 +20,8 @@
   }
 }
 
+.d-modal.change-ownership-modal,
+.d-modal.grant-badge-modal,
 .d-modal.bookmark-reminder-modal {
   .d-modal__container {
     min-height: calc(var(--composer-vh, var(--1dvh)) * 85);


### PR DESCRIPTION
These modals contain only a dropdown and have a very small height by default which doesn't give us enough space for the expanded dropdown. This commit adds two special cases to ensure we can correctly use the dropdowns.

Note I also removed label/form from change-owner modal as that seems totally unecessary.