### PR TITLE
UX: Show parent category name for category hashtags

### DIFF
--- a/app/services/category_hashtag_data_source.rb
+++ b/app/services/category_hashtag_data_source.rb
@@ -18,7 +18,14 @@ class CategoryHashtagDataSource
 
   def self.category_to_hashtag_item(category)
     HashtagAutocompleteService::HashtagItem.new.tap do |item|
-      item.text = category.name
+      item.text =
+        (
+          if category.parent_category
+            "#{category.parent_category.name} > #{category.name}"
+          else
+            category.name
+          end
+        )
       item.slug = category.slug
       item.description = category.description_text
       item.icon = icon

--- a/spec/services/hashtag_autocomplete_service_spec.rb
+++ b/spec/services/hashtag_autocomplete_service_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe HashtagAutocompleteService do
 
       expect(service.search("book", %w[category tag]).map(&:ref)).to eq(
         [
-          "book-reviews:book", # category exact match on slug, name sorted
           "book-library:book",
+          "book-reviews:book", # category exact match on slug, name sorted
           "book-library", # category starts with match on slug, name sorted
           "book-reviews",
           "bookmania", # tag starts with match on slug, name sorted
@@ -226,8 +226,8 @@ RSpec.describe HashtagAutocompleteService do
       )
       expect(service.search("book", %w[category tag]).map(&:text)).to eq(
         [
-          "Good Books",
-          "Horror",
+          "Book Library > Horror",
+          "Book Reviews > Good Books",
           "Book Library",
           "Book Reviews",
           "bookmania",


### PR DESCRIPTION
This commit changes the display of category hashtag
autocomplete to show the parent category name in this
format:

* Parent Name > Child Name

This helps further distinguish categories in the autocomplete
where there may be multiple different parent categories with
the same name child category, e.g. if every category has an
Announcements subcategory.

![image](https://github.com/user-attachments/assets/5c479ba8-f53a-4ed4-93fb-f5e3e58e059c)

![image](https://github.com/user-attachments/assets/322d0854-1d12-4bf7-8113-6fbd42be40b6)

