### PR TITLE
FIX: Clean up not secure uploads with access_control_post_id

### DIFF
--- a/spec/jobs/clean_up_uploads_spec.rb
+++ b/spec/jobs/clean_up_uploads_spec.rb
@@ -321,13 +321,22 @@ RSpec.describe Jobs::CleanUpUploads do
     expect(Upload.exists?(id: upload2.id)).to eq(true)
   end
 
-  it "does not delete uploads with an access control post ID (secure uploads)" do
-    upload = fabricate_upload(access_control_post_id: Fabricate(:post).id, secure: true)
+  it "does not delete uploads with an access control post ID that are marked secure" do
+    secure_upload = fabricate_upload(access_control_post_id: Fabricate(:post).id, secure: true)
 
     Jobs::CleanUpUploads.new.execute(nil)
 
     expect(Upload.exists?(id: expired_upload.id)).to eq(false)
-    expect(Upload.exists?(id: upload.id)).to eq(true)
+    expect(Upload.exists?(id: secure_upload.id)).to eq(true)
+  end
+
+  it "does delete uploads with an access control post ID that are not marked secure" do
+    secure_upload = fabricate_upload(access_control_post_id: Fabricate(:post).id, secure: false)
+
+    Jobs::CleanUpUploads.new.execute(nil)
+
+    expect(Upload.exists?(id: expired_upload.id)).to eq(false)
+    expect(Upload.exists?(id: secure_upload.id)).to eq(false)
   end
 
   it "does not delete custom emojis" do


### PR DESCRIPTION
Until now, we were excluding uploads with a not null
access_control_post_id from cleanup, because we were still
considering them "secure" even though they might have been
`secure: false`.

It's not necessary to keep these around, these are no more
important than regular uploads if they are not referenced
by anything.
