### PR TITLE
UX: Remove enable_quote_copy site setting

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -285,10 +285,7 @@ export default class PostTextSelection extends Component {
   }
 
   get canCopyQuote() {
-    return (
-      this.siteSettings.enable_quote_copy &&
-      this.currentUser?.get("user_option.enable_quoting")
-    );
+    return this.currentUser?.get("user_option.enable_quoting");
   }
 
   // on Desktop, shows the bar at the beginning of the selection

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2592,8 +2592,6 @@ en:
 
     enable_diffhtml_preview: "Experimental feature which uses diffHTML to sync preview instead of full re-render"
     enable_fast_edit: "Adds a button to the post selection menu to edit a small selection inline."
-    enable_quote_copy: "Adds a button to post selection menu to copy the selection to clipboard as a markdown quote."
-
     old_post_notice_days: "The number of days after which a post notice is considered old. This visually differentiates it from newer notices on the site."
     new_user_notice_tl: "Minimum trust level required to see new user post notices."
     returning_user_notice_tl: "Minimum trust level required to see returning user post notices."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1308,9 +1308,6 @@ posting:
   enable_fast_edit:
     default: true
     client: true
-  enable_quote_copy:
-    default: true
-    client: true
   old_post_notice_days:
     default: 14
     max: 36500

--- a/spec/system/post_selection_copy_quote_spec.rb
+++ b/spec/system/post_selection_copy_quote_spec.rb
@@ -25,8 +25,8 @@ describe "Post selection | Copy quote", type: :system do
     QUOTE
     end
 
-    it "does not show the copy quote button if it has been disabled" do
-      SiteSetting.enable_quote_copy = false
+    it "does not show the copy quote button if quoting has been disabled by the user" do
+      current_user.user_option.update!(enable_quoting: false)
       topic_page.visit_topic(topic)
 
       select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)


### PR DESCRIPTION
This setting was introduced a year ago for
51016e56dd99a9ad4bd82cdc6c0cf968754c70ed, which was
formerly a design experiment.

In practice on our hosting, noone has ever disabled this
setting, and it's for a useful feature. There is no
point keeping it.
