### PR TITLE
DEV: Only include custom admin UIs in the plugins index tabs

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-plugins-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-plugins-index.js
@@ -35,7 +35,12 @@ export default class AdminPluginsIndexController extends Controller {
 
   get allAdminRoutes() {
     return this.model
-      .filter((plugin) => plugin?.enabled && plugin?.adminRoute)
+      .filter(
+        (plugin) =>
+          plugin?.enabled &&
+          plugin?.adminRoute &&
+          !plugin?.adminRoute?.auto_generated
+      )
       .map((plugin) => {
         return Object.assign(plugin.adminRoute, { plugin_id: plugin.id });
       });

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -115,6 +115,7 @@ class Plugin::Instance
       label: label,
       location: location,
       use_new_show_route: opts.fetch(:use_new_show_route, false),
+      auto_generated: false,
     }
   end
 
@@ -128,7 +129,7 @@ class Plugin::Instance
     end
 
     route
-      .slice(:location, :label, :use_new_show_route)
+      .slice(:location, :label, :use_new_show_route, :auto_generated)
       .tap do |admin_route|
         path = admin_route[:use_new_show_route] ? "show" : admin_route[:location]
         admin_route[:full_location] = "adminPlugins.#{path}"
@@ -1495,6 +1496,11 @@ class Plugin::Instance
   end
 
   def default_admin_route
-    { label: "#{name.underscore}.title", location: name, use_new_show_route: true }
+    {
+      label: "#{name.underscore}.title",
+      location: name,
+      use_new_show_route: true,
+      auto_generated: true,
+    }
   end
 end

--- a/plugins/chat/spec/requests/application_controller_spec.rb
+++ b/plugins/chat/spec/requests/application_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ApplicationController do
             "location" => "chat",
             "full_location" => "adminPlugins.show",
             "use_new_show_route" => true,
+            "auto_generated" => false,
           },
           "enabled" => true,
         },


### PR DESCRIPTION
### What is this change?

In the current admin index page, all plugins show up as tabs. This includes plugins with auto-generated config routes.

This changes the tabs to include only plugins with custom UIs.

**Before:**

<img width="918" alt="Screenshot 2025-02-05 at 2 22 32 PM" src="https://github.com/user-attachments/assets/cb1c954c-e3c3-41ac-8ac3-36eb7b6deb9d" />

**After:**

<img width="456" alt="Screenshot 2025-02-05 at 2 22 02 PM" src="https://github.com/user-attachments/assets/ab5ad33e-db69-45d2-beb0-0926ded94181" />
