### PR TITLE
FEATURE: Allow excluding uploads from min post length requirement

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1743,6 +1743,7 @@ en:
     support_mixed_text_direction: "Support mixed left-to-right and right-to-left text directions"
     min_post_length: "Minimum allowed post length in characters (excluding personal messages)"
     min_first_post_length: "Minimum allowed first post (topic body) length (excluding personal messages)"
+    prevent_uploads_only_posts: "Don't count upload markdown code when checking for min post length"
     min_personal_message_post_length: "Minimum allowed post length in characters for messages (both first post and replies)"
     max_post_length: "Maximum allowed post length in characters"
     topic_featured_link_enabled: "Allows users to associate a feature link with their topics. When turned on, topics can have a highlighted link attached, which is publicly visible and can be edited if the user has sufficient permissions. The feature link can enhance a topic's comprehensibility by providing related additional content."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -916,6 +916,9 @@ posting:
       ja: 8
       zh_CN: 8
       zh_TW: 8
+  prevent_uploads_only_posts:
+    client: true
+    default: false
   min_personal_message_post_length:
     client: true
     min: 1

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -48,7 +48,13 @@ class PostValidator < ActiveModel::Validator
         SiteSetting.post_length
       end
 
-    StrippedLengthValidator.validate(post, :raw, post.raw, range)
+    StrippedLengthValidator.validate(
+      post,
+      :raw,
+      post.raw,
+      range,
+      strip_uploads: SiteSetting.prevent_uploads_only_posts,
+    )
   end
 
   def max_posts_validator(post)

--- a/spec/lib/validators/post_validator_spec.rb
+++ b/spec/lib/validators/post_validator_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PostValidator do
     end
   end
 
-  describe "stripped_length" do
+  describe "#stripped_length" do
     it "adds an error for short raw" do
       post.raw = "abc"
       validator.stripped_length(post)
@@ -102,6 +102,26 @@ RSpec.describe PostValidator do
       post.raw = "<!-- <!-- an html comment --> -->"
       validator.stripped_length(post)
       expect(post.errors.count).to eq(1)
+    end
+
+    context "when configured to count uploads" do
+      before { SiteSetting.prevent_uploads_only_posts = false }
+
+      it "counts image tags" do
+        post.raw = "![A cute cat|690x472](upload://3NvZqZ2iBHjDjwNVI4QyZpkaC5r.png)"
+        validator.stripped_length(post)
+        expect(post.errors.count).to eq(0)
+      end
+    end
+
+    context "when configured to not count uploads" do
+      before { SiteSetting.prevent_uploads_only_posts = true }
+
+      it "doesn't count image tags" do
+        post.raw = "![A cute cat|690x472](upload://3NvZqZ2iBHjDjwNVI4QyZpkaC5r.png)"
+        validator.stripped_length(post)
+        expect(post.errors.count).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
### What is this feature?

Currently, the markdown for uploads is counted towards post minimum length requirements. This change introduces a site setting `prevent_uploads_only_posts` which can be flipped to exclude upload segments from the calculation.

**Note:**

We never do any stripping when checking against post maximum length requirements. I have not changed that as part of this PR.

**Caveat:**

When uploading a PDF or other non-media file, we generate something like this:

```
[filename.pdf|attachment](upload://hash.pdf) (806.1 KB)
```

That file size fragment is hard to match to the markdown part without a lot of false positives, and it is technically rendered as part of the raw text of the post, so for now that still counts towards the minimum length.