### PR TITLE
UX: multiple drafts menu improvements

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
@@ -18,6 +18,6 @@
   </DButtonTooltip>
 
   {{#if @showDrafts}}
-    <TopicDraftsDropdown />
+    <TopicDraftsDropdown @disabled={{this.disabled}} />
   {{/if}}
 {{/if}}

--- a/app/assets/stylesheets/desktop/components/drafts-dropdown-menu.scss
+++ b/app/assets/stylesheets/desktop/components/drafts-dropdown-menu.scss
@@ -1,3 +1,4 @@
 .topic-drafts-menu-content .dropdown-menu {
-  max-width: 300px;
+  max-width: 350px;
+  min-width: 275px;
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -500,7 +500,7 @@ en:
       dropdown:
         title: "Open the latest drafts menu"
         untitled: "Untitled draft"
-        view_all: "view all"
+        view_all: "view all drafts"
         other_drafts:
           one: "+%{count} other draft"
           other: "+%{count} other drafts"

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -65,14 +65,15 @@ describe "Drafts dropdown", type: :system do
       expect(drafts_dropdown.other_drafts_count).to eq(1)
     end
 
-    it "shows the view all drafts when draft count exceeds the draft menu limit" do
+    it "shows the view all drafts when there are other drafts to display" do
       page.visit "/"
       drafts_dropdown.open
 
       expect(drafts_dropdown).to be_open
-      expect(drafts_dropdown).not_to have_view_all_link
+      expect(drafts_dropdown).to have_view_all_link
+    end
 
-      # remove the last 2 drafts
+    it "does not show the view all drafts link when all drafts are displayed" do
       Draft.where(user_id: user.id).order("created_at DESC").limit(2).destroy_all
 
       page.visit "/"
@@ -84,10 +85,35 @@ describe "Drafts dropdown", type: :system do
   end
 
   describe "with private category" do
-    fab!(:category) { Fabricate(:private_category) }
+    fab!(:group)
+    fab!(:group_user) { Fabricate(:group_user, user: user, group: group) }
+    fab!(:category) { Fabricate(:private_category, group: group, permission_type: 3) }
+    fab!(:subcategory) do
+      Fabricate(
+        :private_category,
+        parent_category_id: category.id,
+        group: group,
+        permission_type: 1,
+      )
+    end
 
-    it "disabled the drafts dropdown menu" do
-      page.visit "/c/#{category.slug}"
+    let(:category_page) { PageObjects::Pages::Category.new }
+
+    before do
+      SiteSetting.default_subcategory_on_read_only_category = false
+
+      Draft.set(
+        user,
+        Draft::NEW_TOPIC,
+        0,
+        { title: "This is a test topic", reply: "Lorem ipsum dolor sit amet" }.to_json,
+      )
+    end
+
+    it "disables the drafts dropdown menu when new topic button is disabled" do
+      category_page.visit(category)
+
+      expect(category_page).to have_button("New Topic", disabled: true)
       expect(drafts_dropdown).to be_disabled
     end
   end

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -64,5 +64,31 @@ describe "Drafts dropdown", type: :system do
       expect(drafts_dropdown.draft_item_count).to eq(4)
       expect(drafts_dropdown.other_drafts_count).to eq(1)
     end
+
+    it "shows the view all drafts when draft count exceeds the draft menu limit" do
+      page.visit "/"
+      drafts_dropdown.open
+
+      expect(drafts_dropdown).to be_open
+      expect(drafts_dropdown).not_to have_view_all_link
+
+      # remove the last 2 drafts
+      Draft.where(user_id: user.id).order("created_at DESC").limit(2).destroy_all
+
+      page.visit "/"
+      drafts_dropdown.open
+
+      expect(drafts_dropdown).to be_open
+      expect(drafts_dropdown).to have_no_view_all_link
+    end
+  end
+
+  describe "with private category" do
+    fab!(:category) { Fabricate(:private_category) }
+
+    it "disabled the drafts dropdown menu" do
+      page.visit "/c/#{category.slug}"
+      expect(drafts_dropdown).to be_disabled
+    end
   end
 end

--- a/spec/system/page_objects/components/drafts_menu.rb
+++ b/spec/system/page_objects/components/drafts_menu.rb
@@ -13,6 +13,10 @@ module PageObjects
         has_no_css?(MENU_SELECTOR + "-trigger")
       end
 
+      def disabled?
+        find(MENU_SELECTOR + "-trigger")["disabled"]
+      end
+
       def open?
         has_css?(MENU_SELECTOR + "-content")
       end

--- a/spec/system/page_objects/components/drafts_menu.rb
+++ b/spec/system/page_objects/components/drafts_menu.rb
@@ -21,6 +21,14 @@ module PageObjects
         has_no_css?(MENU_SELECTOR + "-content")
       end
 
+      def has_view_all_link?
+        has_css?(MENU_SELECTOR + "-content .view-all-drafts")
+      end
+
+      def has_no_view_all_link?
+        has_no_css?(MENU_SELECTOR + "-content .view-all-drafts")
+      end
+
       def open
         find(MENU_SELECTOR + "-trigger").click
       end


### PR DESCRIPTION
This change includes the following updates:

- Rename view all to view all drafts
- Remove view all link from drop-down when all drafts are displayed in the menu
- Different icon for draft topics and PMs (adds envelope for PMs)
- Disable drop-down when New Topic button is disabled (private categories etc)
- Improve drafts drop-down loading (no longer disables the trigger btn on click)

### How it looks

Disabled menu when the New Topic button is disabled:

<img width="258" alt="Screenshot 2025-02-04 at 2 21 33 PM" src="https://github.com/user-attachments/assets/21b83152-8e81-4663-a448-d03b0533a10f" />

Drafts menu open, showing new PM icon and also hides the view all link when all drafts are shown:

<img width="370" alt="Screenshot 2025-02-05 at 2 36 12 PM" src="https://github.com/user-attachments/assets/96bbf537-c724-4e28-8bc0-3dc21172ede4" />



internal ref: /t/145786