### PR TITLE
FIX: correctly check for hasData in admin-report

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-report.gjs
@@ -156,7 +156,7 @@ export default class AdminReport extends Component {
   }
 
   get hasData() {
-    return this.model?.data?.length > 0;
+    return isPresent(this.model?.data);
   }
 
   get disabledLabel() {


### PR DESCRIPTION
Using length is not working on javascript objects and this would always be falsey.

```
const test = { foo: 1 };
test.length // undefined
```