### PR TITLE
UX: left-align dropdown menu button text

### DIFF
--- a/app/assets/stylesheets/common/components/dropdown-menu.scss
+++ b/app/assets/stylesheets/common/components/dropdown-menu.scss
@@ -9,6 +9,7 @@
       padding: 0.65rem 1rem;
       width: 100%;
       justify-content: flex-start;
+      text-align: left;
     }
   }
 


### PR DESCRIPTION
When dropdown button text wraps onto multiple lines, it's centered. It should be left-aligned instead. 

Before: 

<img src="https://github.com/user-attachments/assets/64db1e0c-8dc0-4e26-8b07-fea938498f80" width="250"/>

After:

<img src="https://github.com/user-attachments/assets/7f4c1795-291a-4772-bdb0-f848f3904aa4" width="250"/>
