### PR TITLE
UX: fix layout of invite modal errors

### DIFF
--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -102,4 +102,10 @@ html.modal-open {
       margin-left: 0.5em;
     }
   }
+
+  .alert-error {
+    label {
+      display: inline-block;
+    }
+  }
 }


### PR DESCRIPTION
Flex is causing odd wrapping for errors with multiple elements within.

Before: 
![image](https://github.com/user-attachments/assets/73f30c46-ef44-48ef-b249-e955c2ce71e1)

After:
![image](https://github.com/user-attachments/assets/454f2857-3eb5-4fc6-a7f3-752a0d2a3add)
