### PR TITLE
DEV: Have group smtp email job retry

### DIFF
--- a/app/jobs/regular/group_smtp_email.rb
+++ b/app/jobs/regular/group_smtp_email.rb
@@ -84,6 +84,9 @@ module Jobs
           bcc_addresses: bcc_addresses,
         )
 
+      # Idempotency check – if the EmailLog already exists, do not send again.
+      return if EmailLog.exists?(message_id: message.message_id)
+
       begin
         Email::Sender.new(message, :group_smtp, recipient_user).send
       rescue Net::ReadTimeout => err

--- a/app/jobs/regular/group_smtp_email.rb
+++ b/app/jobs/regular/group_smtp_email.rb
@@ -95,6 +95,7 @@ module Jobs
           message: "Got SMTP read timeout when sending group SMTP email",
           env: args,
         )
+        raise err # Re-raise the error so Sidekiq's retry mechanism kicks in.
       end
 
       # Create an incoming email record to avoid importing again from IMAP

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -322,4 +322,11 @@ RSpec.describe Jobs::GroupSmtpEmail do
       ).to eq(true)
     end
   end
+
+  it "re-raises Net::ReadTimeout to trigger Sidekiq retries" do
+    allow_any_instance_of(Email::Sender).to receive(:send).and_raise(
+      Net::ReadTimeout.new("timeout"),
+    )
+    expect { job.execute(args) }.to raise_error(Net::ReadTimeout)
+  end
 end


### PR DESCRIPTION
Likely we want the group smtp email job to retry. Also added a check to see if we already have an email log entry for the message to avoid possible duplicates on retry.

Related previous commit: ed47b550266e1ab669c756b0ecb48d1685b08fee
