### PR TITLE
DEV: add `topic-footer-button` class to all topic footer buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -89,7 +89,7 @@ export default class TopicAdminMenu extends Component {
         @onRegisterApi={{this.onRegisterApi}}
         @modalForMobile={{true}}
         @autofocus={{true}}
-        @triggerClass="btn-default btn-icon toggle-admin-menu {{this.args.buttonClasses}}"
+        @triggerClass="btn-default btn-icon toggle-admin-menu {{@buttonClasses}}"
       >
         <:trigger>
           {{icon "wrench"}}

--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -89,7 +89,7 @@ export default class TopicAdminMenu extends Component {
         @onRegisterApi={{this.onRegisterApi}}
         @modalForMobile={{true}}
         @autofocus={{true}}
-        @triggerClass="btn-default btn-icon toggle-admin-menu"
+        @triggerClass="btn-default btn-icon toggle-admin-menu {{this.args.buttonClasses}}"
       >
         <:trigger>
           {{icon "wrench"}}

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -16,6 +16,7 @@
       @resetBumpDate={{this.resetBumpDate}}
       @convertToPublicTopic={{this.convertToPublicTopic}}
       @convertToPrivateMessage={{this.convertToPrivateMessage}}
+      @buttonClasses="topic-footer-button"
     />
 
     {{#each this.inlineActionables as |actionable|}}
@@ -24,7 +25,7 @@
           <BookmarkMenu
             @showLabel={{this.showBookmarkLabel}}
             @bookmarkManager={{this.topicBookmarkManager}}
-            @buttonClasses="btn-default"
+            @buttonClasses="btn-default topic-footer-button"
           />
         {{else}}
           <DButton
@@ -134,7 +135,7 @@
       @action={{this.replyToPost}}
       @label="topic.reply.title"
       @title="topic.reply.help"
-      class="btn-primary create"
+      class="btn-primary create topic-footer-button"
     />
   {{/if}}
 


### PR DESCRIPTION
While working with some themes, I noticed that all of these buttons don't have the `topic-footer-button` class, so it can't really be used effectively. The admin menu, bookmark button, and reply button were all missing it. This adds the class. 

![image](https://github.com/user-attachments/assets/3d374896-5d45-445a-9970-1d3f3f4f06de)
