### PR TITLE
FEATURE: show flag description along with additional reason

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.hbs
@@ -48,9 +48,7 @@
         />
         <div class="flag-action-type-details">
           <strong>{{this.formattedName}}</strong>
-          {{#if this.showDescription}}
-            <div class="description">{{html-safe this.description}}</div>
-          {{/if}}
+          <div class="description">{{html-safe this.description}}</div>
           {{#if this.showMessageInput}}
             <Textarea
               name="message"

--- a/app/assets/javascripts/discourse/app/components/flag-action-type.js
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.js
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { and, equal, not } from "@ember/object/computed";
+import { and, equal } from "@ember/object/computed";
 import { tagName } from "@ember-decorators/component";
 import discourseComputed from "discourse/lib/decorators";
 import { MAX_MESSAGE_LENGTH } from "discourse/models/post-action-type";
@@ -9,7 +9,6 @@ import { i18n } from "discourse-i18n";
 export default class FlagActionType extends Component {
   @and("flag.require_message", "selected") showMessageInput;
   @and("flag.isIllegal", "selected") showConfirmation;
-  @not("showMessageInput") showDescription;
   @equal("flag.name_key", "notify_user") isNotifyUser;
 
   @discourseComputed("flag.name_key")

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -44,6 +44,7 @@ describe "Flagging post", type: :system do
       topic_page.click_post_action_button(post_to_flag, :flag)
       flag_modal.choose_type(:illegal)
 
+      expect(flag_modal).to have_css(".illegal .description")
       expect(flag_modal).to have_css(".flag-confirmation")
 
       flag_modal.fill_message("This looks totally illegal to me.")


### PR DESCRIPTION
Currently, the description is hidden when an additional reason field appears on the flag modal. It can contain important guidance and therefore should never be hidden.

<img width="671" alt="Screenshot 2025-02-06 at 9 59 42 am" src="https://github.com/user-attachments/assets/97629059-f346-4696-b720-9a9da3faf8f8" />
