### PR TITLE
FIX: Only include custom plugin config routes in tabs for old show page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-plugins.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-plugins.js
@@ -22,7 +22,12 @@ export default class AdminPluginsController extends Controller {
   // while we convert plugins to use_new_show_route
   get allAdminRoutes() {
     return this.model
-      .filter((plugin) => plugin?.enabled && plugin?.adminRoute)
+      .filter(
+        (plugin) =>
+          plugin?.enabled &&
+          plugin?.adminRoute &&
+          !plugin?.adminRoute?.auto_generated
+      )
       .map((plugin) => {
         return Object.assign(plugin.adminRoute, { plugin_id: plugin.id });
       });


### PR DESCRIPTION
### What is this change?

Same as #31192, but for plugins that are not yet converted to the new show page. 🙏 