### PR TITLE
FIX: Adjust badge selector for proper nesting in plugin list

### DIFF
--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -45,7 +45,7 @@
       font-size: var(--font-down-2);
       background-color: var(--primary-low);
       color: var(--primary-high);
-      padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+      padding: var(--space-1) var(--space-2);
       border-radius: var(--d-border-radius);
 
       & + .admin-plugins-list__badge {

--- a/app/assets/stylesheets/common/admin/plugins.scss
+++ b/app/assets/stylesheets/common/admin/plugins.scss
@@ -27,7 +27,9 @@
     .admin-plugins-list__row-admin-search-filtered {
       background-color: var(--primary-low);
     }
+  }
 
+  .admin-plugins-list {
     &__name-with-badges {
       display: flex;
       flex-wrap: wrap;
@@ -38,11 +40,13 @@
     }
 
     &__badge {
+      --d-border-radius: var(--space-4);
       font-weight: 400;
       font-size: var(--font-down-2);
       background-color: var(--primary-low);
-      color: var(--primary-medium);
-      padding: 4px 8px;
+      color: var(--primary-high);
+      padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+      border-radius: var(--d-border-radius);
 
       & + .admin-plugins-list__badge {
         margin-left: var(--space-1);


### PR DESCRIPTION
This PR fixes an issue where badges weren’t displaying correctly due to improper CSS targeting. 

/t/147165
