### PR TITLE
FIX: Correct typo in property name for save button component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-save-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.gjs
@@ -16,7 +16,7 @@ export default class ComposerSaveButton extends Component {
       @icon={{@icon}}
       @translatedTitle={{this.translatedTitle}}
       @forwardEvent={{@forwardEvent}}
-      class={{concatClass "btn-primary create" (if @disabledSubmit "disabled")}}
+      class={{concatClass "btn-primary create" (if @disableSubmit "disabled")}}
       ...attributes
     />
   </template>


### PR DESCRIPTION
`disabled` -> `disable` to match:
 
https://github.com/discourse/discourse/blob/0e61565b2bb5aa24da060b701378b22dee056312/app/assets/javascripts/discourse/app/components/composer-container.hbs#L238