### PR TITLE
DEV: Move a plugin related system spec to footnote plugin

### DIFF
--- a/plugins/footnote/spec/system/admin_sidebar_navigation_spec.rb
+++ b/plugins/footnote/spec/system/admin_sidebar_navigation_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe "Admin | Sidebar Navigation", type: :system do
+  fab!(:admin)
+
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+
+  before do
+    SiteSetting.navigation_menu = "sidebar"
+    SiteSetting.admin_sidebar_enabled_groups = [Group::AUTO_GROUPS[:admins]]
+
+    sign_in(admin)
+  end
+
+  it "adds an auto-generated plugin link to the admin sidebar" do
+    SiteSetting.enable_markdown_footnotes = true
+
+    visit("/admin")
+
+    sidebar.toggle_section(:plugins)
+
+    expect(page).to have_css(
+      ".sidebar-section-link-content-text",
+      text: I18n.t("js.footnote.title"),
+    )
+  end
+end

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -337,19 +337,4 @@ describe "Admin | Sidebar Navigation", type: :system do
       ],
     )
   end
-
-  it "adds auto-generated plugin links for plugins with settings" do
-    skip if Discourse.plugins.empty?
-
-    SiteSetting.enable_markdown_footnotes = true
-
-    visit("/admin")
-
-    sidebar.toggle_section(:plugins)
-
-    expect(page).to have_css(
-      ".sidebar-section-link-content-text",
-      text: I18n.t("js.footnote.title"),
-    )
-  end
 end


### PR DESCRIPTION
### What is this change?

In a previous PR, I introduced this system spec that checks that a sidebar link is auto-generated for certain plugins.

This causes problems, because the core test suite can be run with plugins either enabled or disabled, causing flaky tests.

This fixes that by moving the test to the plugin's test suite, as suggested by @martin-brennan. 💌  