### PR TITLE
FIX: do not notify admins about PMs when suppress is on

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -301,7 +301,9 @@ module PostGuardian
 
     if is_admin? && SiteSetting.suppress_secured_categories_from_admin
       topic = post.topic
-      if !topic.private_message? && topic.category.read_restricted
+      if topic.private_message?
+        return can_see_post_topic?(post)
+      elsif topic.category.read_restricted
         return secure_category_ids.include?(topic.category_id)
       end
     end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -927,6 +927,20 @@ RSpec.describe Guardian do
 
       expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
     end
+
+    it "disallows private messages with no access" do
+      post = Fabricate(:private_message_post, user: moderator)
+
+      expect(Guardian.new(trust_level_0).can_receive_post_notifications?(post)).to be_falsey
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
+
+      SiteSetting.suppress_secured_categories_from_admin = true
+
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_falsey
+
+      post.topic.allowed_users << admin
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
+    end
   end
 
   describe "can_see?" do


### PR DESCRIPTION
When `suppress_secured_categories_from_admin` SiteSetting is enabled, it is expected that the admin will not be notified about PMs in which they are not participating - even when they watch the attributed tag.

Before it was only checking if the admin had access to a secured category assigned to a regular topic. PMs do not have categories so we need to ensure that admin in participating in that conversation.