### PR TITLE
DEV: Refresh translation override status when updating

### DIFF
--- a/spec/jobs/check_translation_overrides_spec.rb
+++ b/spec/jobs/check_translation_overrides_spec.rb
@@ -17,11 +17,12 @@ RSpec.describe Jobs::CheckTranslationOverrides do
   end
 
   it "marks translations with invalid interpolation keys" do
-    invalid_translation.update_attribute("value", "Invalid %{foo}")
-
-    expect { described_class.new.execute({}) }.to change { invalid_translation.reload.status }.from(
-      "up_to_date",
-    ).to("invalid_interpolation_keys")
+    expect do
+      invalid_translation.update_attribute("value", "Invalid %{foo}")
+      described_class.new.execute({})
+    end.to change { invalid_translation.reload.status }.from("up_to_date").to(
+      "invalid_interpolation_keys",
+    )
   end
 
   it "marks translations that are outdated" do


### PR DESCRIPTION
### What is this change?

Translation overrides can be marked as "invalid interpolation keys" or "outdated" if the original translation is changed. We run a job every hour to check for this. We also have an admin problem check for it.

The problem is we don't refresh this status when an admin updates the override. So even if the invalid keys are removed, the override will still show up under the "invalid" filter.

There's a similar situation with the "outdated" status. The admin is shown a prompt which they can dismiss, which in turn updates the status, but updating the translation should also count as "addressing" it.

This PR runs a refresh on the override status when updating.