### PR TITLE
UX: user stream alignment fix for likes

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -25,12 +25,14 @@
       opacity: 0.4;
     }
 
-    .post-list-item__header {
+    .post-list-item__header,
+    .user-stream-item__header {
       display: flex;
       align-items: flex-start;
     }
 
-    .post-list-item__details {
+    .post-list-item__details,
+    .user-stream-item__details {
       flex-grow: 1;
       min-width: 0;
 
@@ -39,7 +41,8 @@
       }
     }
 
-    .post-list-item__metadata {
+    .post-list-item__metadata,
+    .user-stream-item__metadata {
       display: flex;
       align-items: center;
       justify-content: flex-start;

--- a/app/assets/stylesheets/desktop/components/user-stream-item.scss
+++ b/app/assets/stylesheets/desktop/components/user-stream-item.scss
@@ -2,6 +2,7 @@
   width: 3rem;
 }
 
-.user-stream-item .excerpt {
+.user-stream-item .excerpt,
+.user-stream-item-actions {
   margin: 0.75em 0 0 3.5em;
 }


### PR DESCRIPTION
Small alignment fix for user stream items on desktop, following changes made in #31122 

We currently have a combination of `post-list-item` and `user-stream-item` classes within these pages, so I've also applied some shared styles to these elements to provide a more consistent layout.

### Before:

<img width="496" alt="Screenshot 2025-02-07 at 2 56 27 PM" src="https://github.com/user-attachments/assets/80d8f547-0f9a-4bae-9ef6-2f5fa37891f2" />

### After:

<img width="501" alt="Screenshot 2025-02-07 at 2 56 05 PM" src="https://github.com/user-attachments/assets/1187ddb0-c3d7-46bb-b4b8-8286241cc9ba" />
