### PR TITLE
UX: omit date in user stream for small action posts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-action-description.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-action-description.gjs
@@ -3,7 +3,7 @@ import { actionDescriptionHtml } from "discourse/widgets/post-small-action";
 
 export default class PostActionDescription extends Component {
   get description() {
-    if (this.args.actionCode && this.args.createdAt) {
+    if (this.args.actionCode) {
       return actionDescriptionHtml(
         this.args.actionCode,
         this.args.createdAt,

--- a/app/assets/javascripts/discourse/app/components/user-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream.gjs
@@ -186,7 +186,6 @@ export default class UserStreamComponent extends Component {
       <:abovePostItemExcerpt as |post|>
         <PostActionDescription
           @actionCode={{post.action_code}}
-          @createdAt={{post.created_at}}
           @username={{post.action_code_who}}
           @path={{post.action_code_path}}
         />

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -12,10 +12,11 @@ import { createWidget } from "discourse/widgets/widget";
 import { i18n } from "discourse-i18n";
 
 export function actionDescriptionHtml(actionCode, createdAt, username, path) {
-  const dt = new Date(createdAt);
-  const when = autoUpdatingRelativeAge(dt, {
-    format: "medium-with-ago-and-on",
-  });
+  const when = createdAt
+    ? autoUpdatingRelativeAge(new Date(createdAt), {
+        format: "medium-with-ago-and-on",
+      })
+    : "";
 
   let who = "";
   if (username) {


### PR DESCRIPTION
This change makes it possible to render the action code from small action posts (ie. close topic etc) without the relative date. This is applied in the user stream items to prevent duplication of dates.

Before:

<img width="438" alt="Screenshot 2025-02-07 at 4 12 08 PM" src="https://github.com/user-attachments/assets/0881fe3a-9a6a-4df4-8eff-6537b3225582" />


After:

 
<img width="451" alt="Screenshot 2025-02-07 at 4 11 51 PM" src="https://github.com/user-attachments/assets/1a6cf2e2-70d7-4bab-9e3c-744134307cac" />

Internal ref: /t/129117/10