### PR TITLE
UX: use icon for create topic btn on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
@@ -3,7 +3,7 @@
     <:button>
       <DButton
         @action={{this.action}}
-        @icon="plus"
+        @icon="far-pen-to-square"
         @disabled={{this.disabled}}
         @label={{this.label}}
         id="create-topic"

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -20,7 +20,9 @@ export default class DNavigation extends Component {
 
   @setting("fixed_category_positions") fixedCategoryPositions;
 
-  createTopicLabel = "topic.create";
+  get createTopicLabel() {
+    return this.site.desktopView ? "topic.create" : "";
+  }
 
   @dependentKeyCompat
   get filterType() {


### PR DESCRIPTION
Updates the create topic button to be icon only (mobile) due to screen space restrictions. The icon is also updated to make it easier to understand what the button does, even when there is no text.

### Before 

On both desktop and mobile we used the full text button with the plus icon:

<img width="179" alt="Screenshot 2025-02-07 at 4 39 26 PM" src="https://github.com/user-attachments/assets/e8a4910f-37c2-4489-9d49-cb3f97021193" />


### After

Desktop:

<img width="176" alt="Screenshot 2025-02-07 at 4 36 19 PM" src="https://github.com/user-attachments/assets/8b8056e3-2278-4648-b7a9-0f0092cb3be8" />


Mobile:

<img width="193" alt="Screenshot 2025-02-07 at 4 35 59 PM" src="https://github.com/user-attachments/assets/e51bcc0b-ee64-4cf5-afbb-62b36f815c40" />

Internal ref: /t/145786