### PR TITLE
DEV: Add topic_published event

### DIFF
--- a/lib/topic_publisher.rb
+++ b/lib/topic_publisher.rb
@@ -41,6 +41,8 @@ class TopicPublisher
 
           op.update_columns(version: 1, public_version: 1, last_version_at: published_at)
         end
+
+        DiscourseEvent.trigger(:topic_published, @topic, published_at)
       end
 
     Jobs.enqueue(


### PR DESCRIPTION
While it is possible derive a topic published event from category id changes in a `post_edited` or `before_post_publish_changes` event, there are use cases when a dedicated event is more apposite.