### PR TITLE
DEV: remove another deprecation notice when serializing args

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -229,7 +229,7 @@ class PostsController < ApplicationController
 
     raise Discourse::NotFound if post.blank?
 
-    post.image_sizes = params[:image_sizes] if params[:image_sizes].present?
+    post.image_sizes = params[:image_sizes].permit!.to_h if params[:image_sizes].present?
 
     if !guardian.public_send("can_edit?", post) && post.user_id == current_user.id &&
          post.edit_time_limit_expired?(current_user)


### PR DESCRIPTION
to background jobs