### PR TITLE
DEV: Drop d-crowd plugin from official list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,13 +126,16 @@ jobs:
         run: |
           for dir in /var/www/discourse/plugins/*/gems; do
             plugin_name=$(basename "$(dirname "$dir")")
-            dest="plugins/$plugin_name/gems"
+            plugin_dir="plugins/$plugin_name"
+            gem_dir="$plugin_dir/gems"
 
-            if [ -d "$dest" ]; then
+            if [ ! -d "$plugin_dir" ]; then
+              echo "Skipping $plugin_name: Plugin directory does not exist"
+            elif [ -d "$gem_dir" ]; then
               echo "Skipping $plugin_name: Source gems directory exists"
             else
-              echo "Symlinking $dir to $dest"
-              ln -s "$dir" "$dest"
+              echo "Symlinking $dir to $gem_dir"
+              ln -s "$dir" "$gem_dir"
             fi
           done
 

--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -25,7 +25,6 @@ class Plugin::Metadata
         discourse-characters-required
         discourse-chat-integration
         discourse-code-review
-        discourse-crowd
         discourse-data-explorer
         discourse-details
         discourse-docs


### PR DESCRIPTION
This repo was archived in March 2024 and is no longer supported.

Commit also fixes up the plugin-gem-symlinking logic to support removing plugins from the list