### PR TITLE
UX: fix horizontal group nav on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-navigation.gjs
@@ -11,17 +11,20 @@ export default class GroupNavigation extends Component {
   @service site;
 
   <template>
-    {{#if this.site.mobileView}}
-      <LinkTo @route="groups.index">
-        {{i18n "groups.index.all"}}
-      </LinkTo>
-    {{else}}
+    {{#if this.site.desktopView}}
       <GroupDropdown
         @groups={{@group.extras.visible_group_names}}
         @value={{@group.name}}
       />
     {{/if}}
     <HorizontalOverflowNav class="group-nav">
+      {{#if this.site.mobileView}}
+        <li>
+          <LinkTo @route="groups.index">
+            {{i18n "groups.index.all"}}
+          </LinkTo>
+        </li>
+      {{/if}}
       {{#each @tabs as |tab|}}
         <li>
           <LinkTo


### PR DESCRIPTION
This fixes the "all groups" link on mobile, follow-up to 50136ee

Before 

![image](https://github.com/user-attachments/assets/c6044ee6-3740-47a7-a006-239980bd7605)


After

![image](https://github.com/user-attachments/assets/9d090046-3131-4a9b-a21c-06c6a47c322b)
