### PR TITLE
DEV: add transformer for default category view setting

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.js
@@ -4,6 +4,7 @@ import { buildCategoryPanel } from "discourse/components/edit-category-panel";
 import { setting } from "discourse/lib/computed";
 import { SEARCH_PRIORITIES } from "discourse/lib/constants";
 import discourseComputed from "discourse/lib/decorators";
+import { applyMutableValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 
 const categorySortCriteria = [];
@@ -49,12 +50,23 @@ export default class EditCategorySettings extends buildCategoryPanel(
     ];
   }
 
-  @discourseComputed
-  availableViews() {
-    return [
+  @discourseComputed("category.id", "category.custom_fields")
+  availableViews(categoryId, customFields) {
+    const views = [
       { name: i18n("filters.latest.title"), value: "latest" },
       { name: i18n("filters.top.title"), value: "top" },
     ];
+
+    const context = {
+      categoryId,
+      customFields,
+    };
+
+    return applyMutableValueTransformer(
+      "category-available-views",
+      views,
+      context
+    );
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -7,6 +7,7 @@ export const BEHAVIOR_TRANSFORMERS = Object.freeze([
 
 export const VALUE_TRANSFORMERS = Object.freeze([
   // use only lowercase names
+  "category-available-views",
   "category-description-text",
   "category-display-name",
   "composer-service-cannot-submit-post",


### PR DESCRIPTION
This allows us to set custom values here, like "Voting" from the topic voting plugin: https://github.com/discourse/discourse-topic-voting/pull/232