### PR TITLE
Revert "UX: Hide inner site settings sidebar if admin sidebar enabled (#31047)"

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-site-settings-filter-controls.gjs
@@ -6,7 +6,6 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import DButton from "discourse/components/d-button";
-import autoFocus from "discourse/modifiers/auto-focus";
 import { i18n } from "discourse-i18n";
 
 export default class AdminSiteSettingsFilterControls extends Component {
@@ -72,7 +71,6 @@ export default class AdminSiteSettingsFilterControls extends Component {
           {{/if}}
           <input
             {{on "input" this.onChangeFilterInput}}
-            {{autoFocus}}
             id="setting-filter"
             class="no-blur admin-site-settings-filter-controls__input"
             placeholder={{i18n "type_to_filter"}}

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -9,14 +9,12 @@ import SiteSettingFilter from "discourse/lib/site-setting-filter";
 
 export default class AdminSiteSettingsController extends Controller {
   @service router;
-  @service currentUser;
 
   @alias("model") allSiteSettings;
 
   filter = "";
   visibleSiteSettings = null;
   siteSettingFilter = null;
-  showSettingCategorySidebar = !this.currentUser.use_admin_sidebar;
 
   filterContentNow(filterData, category) {
     this.siteSettingFilter ??= new SiteSettingFilter(this.allSiteSettings);
@@ -25,16 +23,12 @@ export default class AdminSiteSettingsController extends Controller {
       return;
     }
 
-    // We want to land on All by default if admin sidebar is shown, in this
-    // case we are hiding the inner site setting category sidebar.
-    if (this.showSettingCategorySidebar) {
-      if (isEmpty(filterData.filter) && !filterData.onlyOverridden) {
-        this.set("visibleSiteSettings", this.allSiteSettings);
-        if (this.categoryNameKey === "all_results") {
-          this.router.transitionTo("adminSiteSettings");
-        }
-        return;
+    if (isEmpty(filterData.filter) && !filterData.onlyOverridden) {
+      this.set("visibleSiteSettings", this.allSiteSettings);
+      if (this.categoryNameKey === "all_results") {
+        this.router.transitionTo("adminSiteSettings");
       }
+      return;
     }
 
     this.set("filter", filterData.filter);

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
@@ -7,15 +7,12 @@ import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminSiteSettingsIndexRoute extends DiscourseRoute {
   @service router;
-  @service currentUser;
 
   beforeModel() {
-    if (!this.currentUser.use_admin_sidebar) {
-      this.router.replaceWith(
-        "adminSiteSettingsCategory",
-        this.controllerFor("adminSiteSettings").get("visibleSiteSettings")[0]
-          .nameKey
-      );
-    }
+    this.router.replaceWith(
+      "adminSiteSettingsCategory",
+      this.controllerFor("adminSiteSettings").get("visibleSiteSettings")[0]
+        .nameKey
+    );
   }
 }

--- a/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings-category.hbs
@@ -7,17 +7,10 @@
       />
     {{/each}}
     {{#if this.category.hasMore}}
-      {{#if this.currentUser.use_admin_sidebar}}
-        <p class="warning">{{i18n
-            "admin.site_settings.more_site_setting_results_no_category_sidebar"
-            count=this.category.maxResults
-          }}</p>
-      {{else}}
-        <p class="warning">{{i18n
-            "admin.site_settings.more_site_setting_results"
-            count=this.category.maxResults
-          }}</p>
-      {{/if}}
+      <p class="warning">{{i18n
+          "admin.site_settings.more_site_setting_results"
+          count=this.category.maxResults
+        }}</p>
     {{/if}}
   </section>
 {{else}}

--- a/app/assets/javascripts/admin/addon/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.hbs
@@ -19,39 +19,32 @@
   @onToggleMenu={{this.toggleMenu}}
 />
 
-{{#if this.showSettingCategorySidebar}}
-  <div class="admin-nav admin-site-settings-category-nav pull-left">
-    <ul class="nav nav-stacked">
-      {{#each this.visibleSiteSettings as |category|}}
-        <li
-          class={{concat-class
-            "admin-site-settings-category-nav__item"
-            category.nameKey
-          }}
+<div class="admin-nav admin-site-settings-category-nav pull-left">
+  <ul class="nav nav-stacked">
+    {{#each this.visibleSiteSettings as |category|}}
+      <li
+        class={{concat-class
+          "admin-site-settings-category-nav__item"
+          category.nameKey
+        }}
+      >
+        <LinkTo
+          @route="adminSiteSettingsCategory"
+          @model={{category.nameKey}}
+          class={{category.nameKey}}
+          title={{category.name}}
         >
-          <LinkTo
-            @route="adminSiteSettingsCategory"
-            @model={{category.nameKey}}
-            class={{category.nameKey}}
-            title={{category.name}}
-          >
-            {{category.name}}
-            {{#if category.count}}
-              <span class="count">({{category.count}})</span>
-            {{/if}}
-          </LinkTo>
-        </li>
-      {{/each}}
-    </ul>
-  </div>
-{{/if}}
+          {{category.name}}
+          {{#if category.count}}
+            <span class="count">({{category.count}})</span>
+          {{/if}}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ul>
+</div>
 
-<div
-  class={{concat-class
-    "admin-detail pull-left mobile-closed"
-    (unless this.showSettingCategorySidebar "-without-inner-sidebar")
-  }}
->
+<div class="admin-detail pull-left mobile-closed">
   {{outlet}}
 </div>
 

--- a/app/assets/stylesheets/common/admin/site-settings.scss
+++ b/app/assets/stylesheets/common/admin/site-settings.scss
@@ -19,10 +19,3 @@
     }
   }
 }
-
-.admin-site-settings {
-  .admin-detail.-without-inner-sidebar {
-    border-left: 0;
-    width: 100%;
-  }
-}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7250,9 +7250,6 @@ en:
         more_site_setting_results:
           one: "There is more than %{count} result. Please refine your search or select a category."
           other: "There are more than %{count} results. Please refine your search or select a category."
-        more_site_setting_results_no_category_sidebar:
-          one: "There is more than %{count} result. Please refine your search."
-          other: "There are more than %{count} results. Please refine your search."
         clear_filter: "Clear"
         add_url: "add URL"
         add_host: "add host"


### PR DESCRIPTION
This reverts commit 91e9c1c81343990d5ebbb3a3bb7c68ec4445d610.

After feedback, for now we are reverting this change. This is not
permanent, the settings sidebar will be removed again, after we:

* Visually group the settings the same way as the sidebar does
  on All Settings
* Add more settings pages to the main admin sidebar to cover the ~250
  settings not yet represented there
