### PR TITLE
UX: Add confirmation to crawler settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2237,14 +2237,17 @@ security:
     type: list
     default: ""
     list_type: compact
+    requires_confirmation: "simple"
   blocked_crawler_user_agents:
     type: list
     default: "mauibot|semrushbot|ahrefsbot|blexbot|seo spider"
     list_type: compact
+    requires_confirmation: "simple"
   slow_down_crawler_user_agents:
     type: list
     default: "gptbot|claudebot|anthropic-ai|brightbot"
     list_type: compact
+    requires_confirmation: "simple"
   slow_down_crawler_rate: 60
   content_security_policy:
     default: true


### PR DESCRIPTION
Adds a site setting confirmation to the following
settings, since they can be dangerous if changed
incorrectly:

* allowed_crawler_user_agents
* blocked_crawler_user_agents
* slow_down_crawler_user_agents

![image](https://github.com/user-attachments/assets/23e5106d-fc6c-4cc6-941b-7f2140c649bd)
