### PR TITLE
FIX: JS error when .header-cloak isn't present

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -259,8 +259,10 @@ export default class GlimmerSiteHeader extends Component {
 
         waitForPromise(animationFinished);
 
-        cloakElement.animate([{ opacity: 0 }], { fill: "forwards" });
-        cloakElement.style.display = "block";
+        if (cloakElement) {
+          cloakElement.animate([{ opacity: 0 }], { fill: "forwards" });
+          cloakElement.style.display = "block";
+        }
 
         animationFinished.then(() => {
           if (isTesting()) {


### PR DESCRIPTION
With some customizations, this element may not be on the page. Instead of erroring, just continue on without the cloak.