### PR TITLE
FIX: correctly display label

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.js
@@ -25,7 +25,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   test("@label", async function (assert) {
     await render(hbs`<DMenu @inline={{true}} @label="label" />`);
 
-    assert.dom(".fk-d-menu__trigger").containsText("label");
+    assert.dom(".fk-d-menu__trigger").hasText(/^\s*label\s*$/);
   });
 
   test("@icon", async function (assert) {

--- a/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-menu.gjs
@@ -85,11 +85,8 @@ export default class DMenu extends Component {
       get icon() {
         return instance.args.icon;
       },
-      get label() {
-        return instance.args.label;
-      },
       get translatedLabel() {
-        return instance.args.translatedLabel;
+        return instance.args.label;
       },
       get translatedAriaLabel() {
         return instance.args.ariaLabel;


### PR DESCRIPTION
A regression introduced in 32c8aa0aad880bcab372ffd75bce3c857060d721 incorrectly passes label to the trigger component, but also passes translatedLabel instead of label to the menu.

The existing test was checking for the presence of "label", but it was actually returning true because the test was showing "en.label". The test has been modified in consequences.