### PR TITLE
UX: remove main-outlet-wrapper margin reset for mobile

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -632,6 +632,11 @@ textarea {
   #main-outlet {
     grid-area: content;
   }
+
+  @include breakpoint("mobile-extra-large") {
+    margin-left: unset;
+    margin-right: unset;
+  }
 }
 
 #main-outlet {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -632,11 +632,6 @@ textarea {
   #main-outlet {
     grid-area: content;
   }
-
-  @include breakpoint("mobile-extra-large") {
-    margin-left: unset;
-    margin-right: unset;
-  }
 }
 
 #main-outlet {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -116,11 +116,6 @@ blockquote {
 }
 
 // Special elements
-#main-outlet-wrapper {
-  margin-left: unset;
-  margin-right: unset;
-}
-
 #main-outlet {
   padding-top: 1.25em;
 


### PR DESCRIPTION
Reported here https://meta.discourse.org/t/do-auto-margins-still-need-to-be-unset-on-mobile/351503

This helps better handle some situations where we want to center content on large screens while using mobile view 