### PR TITLE
FIX: User profile not loading with an empty export

### DIFF
--- a/app/serializers/user_export_serializer.rb
+++ b/app/serializers/user_export_serializer.rb
@@ -3,6 +3,11 @@
 class UserExportSerializer < ApplicationSerializer
   attributes :id, :filename, :uri, :filesize, :extension, :retain_hours, :human_filesize
 
+  def serializable_hash(adapter_options = nil, options = {})
+    return {} unless object.upload
+    super()
+  end
+
   def filename
     object.upload.original_filename
   end

--- a/spec/serializers/user_export_serializer_spec.rb
+++ b/spec/serializers/user_export_serializer_spec.rb
@@ -28,4 +28,24 @@ RSpec.describe UserExportSerializer do
     expect(json_data["retain_hours"]).to eql user_export.retain_hours
     expect(json_data["human_filesize"]).to eql user_export.upload.human_filesize
   end
+
+  context "when upload is nil" do
+    fab!(:user_export) do
+      user = Fabricate(:user)
+      topic = Fabricate(:topic, created_at: 1.day.ago)
+      Fabricate(:post, topic: topic)
+      UserExport.create!(
+        file_name: "test",
+        user: user,
+        upload_id: nil,
+        topic_id: topic.id,
+        created_at: 1.day.ago,
+      )
+    end
+
+    it "returns an empty hash" do
+      json_data = JSON.parse(serializer.to_json)
+      expect(json_data).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
If a user has an export that doesn't have a file it can cause their
profile page to not load.
