### PR TITLE
UX: Add enter key hints for search

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.hbs
@@ -2,6 +2,7 @@
   id={{this.inputId}}
   type="search"
   autocomplete="off"
+  enterkeyhint="search"
   value={{this.search.activeGlobalSearchTerm}}
   placeholder={{i18n "search.title"}}
   aria-label={{i18n "search.title"}}

--- a/app/assets/javascripts/discourse/app/components/search-text-field.js
+++ b/app/assets/javascripts/discourse/app/components/search-text-field.js
@@ -7,6 +7,7 @@ import { i18n } from "discourse-i18n";
 
 export default class SearchTextField extends TextField {
   autocomplete = "off";
+  enterkeyhint = "search";
 
   @discourseComputed("searchService.searchContextEnabled")
   placeholder(searchContextEnabled) {

--- a/app/assets/javascripts/discourse/app/components/text-field.js
+++ b/app/assets/javascripts/discourse/app/components/text-field.js
@@ -11,6 +11,7 @@ const DEBOUNCE_MS = 500;
   "autocorrect",
   "autocapitalize",
   "autofocus",
+  "enterkeyhint",
   "maxLength",
   "dir",
   "aria-label",

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -29,7 +29,6 @@
         @enter={{action "search" (hash collapseFilters=true)}}
         @hasAutofocus={{this.hasAutofocus}}
         @aria-controls="search-result-count"
-        enterkeyhint="search"
         type="search"
         class="full-page-search search no-blur search-query"
       />

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -29,6 +29,8 @@
         @enter={{action "search" (hash collapseFilters=true)}}
         @hasAutofocus={{this.hasAutofocus}}
         @aria-controls="search-result-count"
+        enterkeyhint="search"
+        type="search"
         class="full-page-search search no-blur search-query"
       />
       <ComboBox


### PR DESCRIPTION
Adds
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint
to the search inputs.

This hint is used for mobile devices to guide what label
is shown on the onscreen keyboard. By default `return` is
shown, now for search we will see `search`.

Also add `type="search"` to the full page search input for
further guidance.

Example below is from https://arnabsen.dev/quick-html-tips-enterkeyhint

![image](https://github.com/user-attachments/assets/ba205381-6ff6-4a3f-9718-8302a736eb35)
