### PR TITLE
FEATURE: display process information on flag modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
@@ -32,7 +32,8 @@ export default class AnonymousFlagModal extends Component {
       class="anonymous-flag-modal"
     >
       <:body>
-        {{htmlSafe this.description}}
+        <p>{{i18n "flagging.review_process_description"}}</p>
+        <p>{{htmlSafe this.description}}</p>
       </:body>
     </DModal>
   </template>

--- a/app/assets/javascripts/discourse/app/components/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.hbs
@@ -7,6 +7,7 @@
   {{on "keydown" this.onKeydown}}
 >
   <:body>
+    <p>{{i18n "flagging.review_process_description"}}</p>
     <form>
       <FlagSelection
         @nameKey={{this.selected.name_key}}

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/flag.gjs
@@ -11,8 +11,7 @@ export default class PostMenuFlagButton extends Component {
     return (
       reviewable_id ||
       (canFlag && !hidden) ||
-      (helper.siteSettings
-        .allow_tl0_and_anonymous_users_to_flag_illegal_content &&
+      (helper.siteSettings.allow_all_users_to_flag_illegal_content &&
         !helper.currentUser)
     );
   }

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -215,8 +215,7 @@ registerButton(
     if (
       attrs.reviewableId ||
       (attrs.canFlag && !attrs.hidden) ||
-      (siteSettings.allow_tl0_and_anonymous_users_to_flag_illegal_content &&
-        !currentUser)
+      (siteSettings.allow_all_users_to_flag_illegal_content && !currentUser)
     ) {
       const button = {
         action: "showFlags",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4233,6 +4233,7 @@ en:
 
     flagging:
       title: "Thanks for keeping our community civil!"
+      review_process_description: "All flags are received by moderators and will be reviewed as soon as possible."
       action: "Flag Post"
       take_action: "Take Action…"
       take_action_options:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2319,7 +2319,7 @@ en:
     reviewable_default_visibility: "Don't show reviewable items unless they meet this priority"
     reviewable_low_priority_threshold: "The priority filter hides reviewable items that don't meet this score unless the '(any)' filter is used."
     high_trust_flaggers_auto_hide_posts: "New user posts are automatically hidden after being flagged as spam by a TL3+ user"
-    allow_tl0_and_anonymous_users_to_flag_illegal_content: "Anonymous users will see information that they have to e-mail administrators to report illegal content."
+    allow_all_users_to_flag_illegal_content: "Anonymous users will see information that they have to e-mail administrators to report illegal content. This setting takes precedence over 'flag post allowed groups'."
     email_address_to_report_illegal_content: "If left blank the default site admin email will be used."
     cooldown_hours_until_reflag: "How much time users will have to wait until they are able to reflag a post"
     slow_mode_prevents_editing: "Does 'Slow Mode' prevent editing, after editing_grace_period?"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1966,7 +1966,7 @@ trust:
     allow_any: false
     refresh: true
     area: "group_permissions"
-  allow_tl0_and_anonymous_users_to_flag_illegal_content:
+  allow_all_users_to_flag_illegal_content:
     default: false
     area: "flags"
     client: true

--- a/db/migrate/20250212044021_rename_allow_all_users_to_flag_illegal_content_site_setting.rb
+++ b/db/migrate/20250212044021_rename_allow_all_users_to_flag_illegal_content_site_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RenameAllowAllUsersToFlagIllegalContentSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "UPDATE site_settings SET name = 'allow_all_users_to_flag_illegal_content' where name = 'allow_tl0_and_anonymous_users_to_flag_illegal_content'"
+  end
+
+  def down
+    execute "UPDATE site_settings SET name = 'allow_tl0_and_anonymous_users_to_flag_illegal_content' where name = 'allow_all_users_to_flag_illegal_content'"
+  end
+end

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -93,11 +93,7 @@ module PostGuardian
               @user.in_any_groups?(SiteSetting.flag_post_allowed_groups_map) ||
                 post.topic.private_message?
             )
-        ) ||
-          (
-            action_key == :illegal &&
-              SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content
-          ) ||
+        ) || (action_key == :illegal && SiteSetting.allow_all_users_to_flag_illegal_content) ||
           # not a flagging action, and haven't done it already
           not(is_flag || already_taken_this_action) &&
             # nothing except flagging on archived topics

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -267,7 +267,7 @@ module SiteSettings::Validations
     validate_error :twitter_summary_large_image_no_svg
   end
 
-  def validate_allow_tl0_and_anonymous_users_to_flag_illegal_content(new_val)
+  def validate_allow_all_users_to_flag_illegal_content(new_val)
     return if new_val == "f"
     if SiteSetting.contact_email.present? ||
          SiteSetting.email_address_to_report_illegal_content.present?

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -163,13 +163,13 @@ RSpec.describe Guardian do
       Flag.reset_flag_settings!
     end
 
-    it "return true for illegal if tl0 and allow_tl0_and_anonymous_users_to_flag_illegal_content" do
+    it "return true for illegal if tl0 and allow_all_users_to_flag_illegal_content" do
       SiteSetting.flag_post_allowed_groups = ""
       user.trust_level = TrustLevel[0]
       expect(Guardian.new(user).post_can_act?(post, :illegal)).to be false
 
       SiteSetting.email_address_to_report_illegal_content = "illegal@example.com"
-      SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
+      SiteSetting.allow_all_users_to_flag_illegal_content = true
       expect(Guardian.new(user).post_can_act?(post, :illegal)).to be true
     end
 

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -475,17 +475,15 @@ RSpec.describe SiteSettings::Validations do
     end
   end
 
-  describe "#validate_allow_tl0_and_anonymous_users_to_flag_illegal_content" do
+  describe "#validate_allow_all_users_to_flag_illegal_content" do
     it "does not allow to enable when no contact email is provided" do
-      expect {
-        validations.validate_allow_tl0_and_anonymous_users_to_flag_illegal_content("t")
-      }.to raise_error(
+      expect { validations.validate_allow_all_users_to_flag_illegal_content("t") }.to raise_error(
         Discourse::InvalidParameters,
         I18n.t("errors.site_settings.tl0_and_anonymous_flag"),
       )
       SiteSetting.contact_email = "illegal@example.com"
       expect {
-        validations.validate_allow_tl0_and_anonymous_users_to_flag_illegal_content("t")
+        validations.validate_allow_all_users_to_flag_illegal_content("t")
       }.not_to raise_error
     end
   end

--- a/spec/requests/admin/config/site_settings_controller_spec.rb
+++ b/spec/requests/admin/config/site_settings_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::SiteSettingsController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["site_settings"].map { |s| s["setting"] }).to match_array(
           %w[
-            allow_tl0_and_anonymous_users_to_flag_illegal_content
+            allow_all_users_to_flag_illegal_content
             email_address_to_report_illegal_content
             silence_new_user_sensitivity
             num_users_to_silence_new_user

--- a/spec/system/admin_flags_spec.rb
+++ b/spec/system/admin_flags_spec.rb
@@ -164,7 +164,7 @@ describe "Admin Flags Page", type: :system do
     admin_flags_page.click_tab("settings")
     expect(page.all(".setting-label h3").map(&:text).map(&:downcase)).to eq(
       [
-        "allow tl0 and anonymous users to flag illegal content",
+        "allow all users to flag illegal content",
         "email address to report illegal content",
         "silence new user sensitivity",
         "num users to silence new user",

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -65,10 +65,13 @@ describe "Flagging post", type: :system do
       expect(topic_page).to have_no_flag_button
     end
 
-    it "allows to mark posts as illegal when allow_tl0_and_anonymous_users_to_flag_illegal_content setting is enabled" do
+    it "allows to mark posts as illegal when allow_all_users_to_flag_illegal_content setting is enabled" do
       SiteSetting.email_address_to_report_illegal_content = "illegal@example.com"
-      SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
+      SiteSetting.allow_all_users_to_flag_illegal_content = true
       topic_page.visit_topic(topic).open_flag_topic_modal
+      expect(flag_modal.body).to have_content(
+        ActionView::Base.full_sanitizer.sanitize(I18n.t("js.flagging.review_process_description")),
+      )
       expect(flag_modal).to have_choices(I18n.t("js.flagging.formatted_name.illegal"))
     end
   end
@@ -81,13 +84,16 @@ describe "Flagging post", type: :system do
       expect(topic_page).to have_no_post_more_actions(post_to_flag)
     end
 
-    it "allows to mark posts as illegal when allow_tl0_and_anonymous_users_to_flag_illegal_content setting is enabled" do
+    it "allows to mark posts as illegal when allow_all_users_to_flag_illegal_content setting is enabled" do
       SiteSetting.contact_email = "contact@example.com"
-      SiteSetting.allow_tl0_and_anonymous_users_to_flag_illegal_content = true
+      SiteSetting.allow_all_users_to_flag_illegal_content = true
 
       topic_page.visit_topic(topic, post_number: post_to_flag.post_number)
       topic_page.find_post_action_button(post_to_flag, :flag).click
 
+      expect(anonymous_flag_modal.body).to have_content(
+        ActionView::Base.full_sanitizer.sanitize(I18n.t("js.flagging.review_process_description")),
+      )
       expect(anonymous_flag_modal.body).to have_content(
         ActionView::Base.full_sanitizer.sanitize(
           I18n.t(


### PR DESCRIPTION
Information about the process is displayed on top of the flag modal.

In addition `allow_tl0_and_anonymous_users_to_flag_illegal_content` site setting was renamed to `allow_all_users_to_flag_illegal_content` as it is more descriptive.

<img width="629" alt="Screenshot 2025-02-12 at 3 58 12 pm" src="https://github.com/user-attachments/assets/67c74ebc-6771-490d-b2c4-cbec25db8128" />
<img width="642" alt="Screenshot 2025-02-12 at 3 58 04 pm" src="https://github.com/user-attachments/assets/5e4b8c84-601a-40c2-812f-b73d2b88a549" />
