### PR TITLE
FIX: automatically redirect logged in users to topic when...

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -28,6 +28,13 @@ class InvitesController < ApplicationController
 
     invite = Invite.find_by(invite_key: params[:id])
 
+    # automatically redirect to the topic if the user is logged in and can see it
+    if current_user
+      if topic = invite.topics.first
+        return redirect_to(topic.url) if current_user.guardian.can_see?(topic)
+      end
+    end
+
     if invite.present? && invite.redeemable?
       show_invite(invite)
     else

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe InvitesController do
         expect(response.location).to eq(invite.topics.first.url)
       end
 
+      it "doesn't automatically redirect to the topic if the user can't access it" do
+        secret_group = Fabricate(:group)
+        invite.update!(topics: [Fabricate(:topic, category: Fabricate(:private_category, group: secret_group))])
+
+        get "/invites/#{invite.invite_key}"
+        expect(response.status).to eq(200)
+      end
+
       it "shows the accept invite page when user's email matches the invite email" do
         invite.update_columns(email: user.email)
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -112,7 +112,9 @@ RSpec.describe InvitesController do
 
       it "doesn't automatically redirect to the topic if the user can't access it" do
         secret_group = Fabricate(:group)
-        invite.update!(topics: [Fabricate(:topic, category: Fabricate(:private_category, group: secret_group))])
+        invite.update!(
+          topics: [Fabricate(:topic, category: Fabricate(:private_category, group: secret_group))],
+        )
 
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe InvitesController do
 
       before { sign_in(user) }
 
+      it "automatically redirects to the topic if the user can access it" do
+        invite.update!(topics: [Fabricate(:topic)])
+
+        get "/invites/#{invite.invite_key}"
+        expect(response.status).to eq(302)
+        expect(response.location).to eq(invite.topics.first.url)
+      end
+
       it "shows the accept invite page when user's email matches the invite email" do
         invite.update_columns(email: user.email)
 
@@ -592,14 +600,16 @@ RSpec.describe InvitesController do
       expect(json["successful_invitations"].length).to eq(2)
     end
 
-    it "creates many invite codes with one request" do #change to
+    it "creates many invite codes with one request" do
       sign_in(admin)
-      num_emails = 5 # increase manually for load testing
+
+      num_emails = 5
+
       post "/invites/create-multiple.json",
            params: {
              email: 1.upto(num_emails).map { |i| "test#{i}@example.com" },
-             #email: %w[test+1@example.com test1@example.com]
            }
+
       expect(response.status).to eq(200)
       json = JSON(response.body)
       expect(json["failed_invitations"].length).to eq(0)


### PR DESCRIPTION
...loading an invite link that points to a topic they already have access to.

This "feature" was removed in 07ef1a80a1461123d602c57e366974aed265a91e as part of the security fix.

Internal ref - t/145628