### PR TITLE
DEV: supports pointerover and pointerout

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -19,6 +19,8 @@ const MOUSE_OUT_ATTRIBUTE_NAME = "_discourse_mouse_out_widget";
 const TOUCH_START_ATTRIBUTE_NAME = "_discourse_touch_start_widget";
 const TOUCH_END_ATTRIBUTE_NAME = "_discourse_touch_end_widget";
 const TOUCH_MOVE_ATTRIBUTE_NAME = "_discourse_touch_move_widget";
+const POINTER_OVER_ATTRIBUTE_NAME = "_discourse_pointer_over_widget";
+const POINTER_OUT_ATTRIBUTE_NAME = "_discourse_pointer_out_widget";
 
 class WidgetBaseHook {
   constructor(widget) {
@@ -64,6 +66,8 @@ export const WidgetMouseUpHook = buildHook(MOUSE_UP_ATTRIBUTE_NAME);
 export const WidgetMouseDownHook = buildHook(MOUSE_DOWN_ATTRIBUTE_NAME);
 export const WidgetMouseMoveHook = buildHook(MOUSE_MOVE_ATTRIBUTE_NAME);
 export const WidgetMouseOverHook = buildHook(MOUSE_OVER_ATTRIBUTE_NAME);
+export const WidgetPointerOverHook = buildHook(POINTER_OVER_ATTRIBUTE_NAME);
+export const WidgetPointerOutHook = buildHook(POINTER_OUT_ATTRIBUTE_NAME);
 export const WidgetMouseOutHook = buildHook(MOUSE_OUT_ATTRIBUTE_NAME);
 export const WidgetTouchEndHook = buildHook(TOUCH_END_ATTRIBUTE_NAME);
 
@@ -217,11 +221,39 @@ WidgetClickHook.setupDocumentCallback = function () {
   );
 
   $(document).on(
+    "pointerover.discourse-widget",
+    bind(this, (e) => {
+      nodeCallback(
+        e.target,
+        POINTER_OVER_ATTRIBUTE_NAME,
+        (w) => w.pointerOver(e),
+        {
+          rerender: false,
+        }
+      );
+    })
+  );
+
+  $(document).on(
     "mouseout.discourse-widget",
     bind(this, (e) => {
       nodeCallback(e.target, MOUSE_OUT_ATTRIBUTE_NAME, (w) => w.mouseOut(e), {
         rerender: false,
       });
+    })
+  );
+
+  $(document).on(
+    "pointerout.discourse-widget",
+    bind(this, (e) => {
+      nodeCallback(
+        e.target,
+        POINTER_OUT_ATTRIBUTE_NAME,
+        (w) => w.pointerOut(e),
+        {
+          rerender: false,
+        }
+      );
     })
   );
 

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -22,6 +22,8 @@ import {
   WidgetMouseOutHook,
   WidgetMouseOverHook,
   WidgetMouseUpHook,
+  WidgetPointerOutHook,
+  WidgetPointerOverHook,
   WidgetTouchEndHook,
   WidgetTouchMoveHook,
   WidgetTouchStartHook,
@@ -482,6 +484,14 @@ export default class Widget {
 
     if (this.mouseOver) {
       properties["widget-mouse-over"] = new WidgetMouseOverHook(this);
+    }
+
+    if (this.pointerOver) {
+      properties["widget-pointer-over"] = new WidgetPointerOverHook(this);
+    }
+
+    if (this.pointerOut) {
+      properties["widget-pointer-out"] = new WidgetPointerOutHook(this);
     }
 
     if (this.mouseOut) {


### PR DESCRIPTION
This commit adds support these events in widgets.

Usage in a widget:

```javascript
pointerOver(event) {}
pointerOut(event) {}
```