### PR TITLE
FIX: do not show confirmation modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -824,6 +824,10 @@ export default class TopicController extends Controller.extend(
 
   @action
   deletePostWithConfirmation(post, opts) {
+    if (!post.can_delete) {
+      return;
+    }
+
     this.dialog.yesNoConfirm({
       message: i18n("post.confirm_delete"),
       didConfirm: () => this.send("deletePost", post, opts),

--- a/spec/system/keyboard_shortcuts_spec.rb
+++ b/spec/system/keyboard_shortcuts_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe "Keyboard shortcuts", type: :system do
     expect(page).to have_no_css(".keyboard-shortcuts-modal")
   end
 
+  describe "<d>" do
+    fab!(:post) { Fabricate(:post) }
+
+    let(:current_user) { Fabricate(:user) }
+    let(:topic_page) { PageObjects::Pages::Topic.new }
+    let(:dialog) { PageObjects::Components::Dialog.new }
+
+    before { sign_in(current_user) }
+
+    context "when user can't delete the post" do
+      it "doesn’t show the confirmation modal" do
+        topic_page.visit_topic(post.topic)
+
+        send_keys("j d")
+
+        expect(dialog).to be_closed
+      end
+    end
+  end
+
   describe "<a>" do
     let(:current_user) { topic.user }
     let(:topic_page) { PageObjects::Pages::Topic.new }

--- a/spec/system/keyboard_shortcuts_spec.rb
+++ b/spec/system/keyboard_shortcuts_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Keyboard shortcuts", type: :system do
   end
 
   describe "<d>" do
-    fab!(:post) { Fabricate(:post) }
+    fab!(:post)
 
     let(:current_user) { Fabricate(:user) }
     let(:topic_page) { PageObjects::Pages::Topic.new }


### PR DESCRIPTION
Currently when using the shortcuts to delete a post the UI would show you the confirmation modal even if you don't have the right to do it. This commit fixes the issue at the root in the `deletePostWithConfirmation` function.