### PR TITLE
DEV: Refactor composer preview rendering

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -519,8 +519,12 @@ export default class ComposerEditor extends Component {
     resolveAllShortUrls(ajax, this.siteSettings, preview);
   }
 
-  _decorateCookedElement(preview) {
-    this.appEvents.trigger("decorate-non-stream-cooked-element", preview);
+  _decorateCookedElement(preview, helper) {
+    this.appEvents.trigger(
+      "decorate-non-stream-cooked-element",
+      preview,
+      helper
+    );
   }
 
   @debounce(DEBOUNCE_JIT_MS)
@@ -896,13 +900,13 @@ export default class ComposerEditor extends Component {
   }
 
   @action
-  previewUpdated(preview) {
+  previewUpdated(preview, helper) {
     this._renderMentions(preview);
     this._renderHashtags(preview);
     this._refreshOneboxes(preview);
     this._expandShortUrls(preview);
 
-    this._decorateCookedElement(preview);
+    this._decorateCookedElement(preview, helper);
 
     this.composer.afterRefresh(preview);
   }

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -2,6 +2,7 @@ import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import EmberObject, { action } from "@ember/object";
 import { not } from "@ember/object/computed";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { classNameBindings } from "@ember-decorators/component";
 import { ajax } from "discourse/lib/ajax";
@@ -70,8 +71,10 @@ export default class ComposerMessages extends Component {
       return;
     }
 
-    this.reset();
-    this.popup(EmberObject.create(info));
+    schedule("actions", () => {
+      this.reset();
+      this.popup(EmberObject.create(info));
+    });
   }
 
   // Resets all active messages.

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -71,12 +71,16 @@
     </div>
   </div>
 
+  {{! template-lint-disable no-invalid-interactive }}
   <div
     class="d-editor-preview-wrapper {{if this.forcePreview 'force-preview'}}"
+    {{on "click" this.handlePreviewClick}}
   >
-    <div class="d-editor-preview">
-      {{html-safe this.preview}}
-    </div>
+    <DecoratedHtml
+      @className="d-editor-preview"
+      @html={{html-safe this.preview}}
+      @decorate={{this.previewUpdated}}
+    />
     <span class="d-editor-plugin">
       <PluginOutlet
         @name="editor-preview"


### PR DESCRIPTION
- Switch to use new `<DecoratedHtml` component (including `renderGlimmer` support)
- Updates click handling to use `{{on` modifier instead of manual event listener setup/teardown