### PR TITLE
DEV: add btn-transparent class to advanced search button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/advanced-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/advanced-button.hbs
@@ -1,5 +1,5 @@
 <DButton
-  class="show-advanced-search"
+  class="show-advanced-search btn-transparent"
   title={{i18n "search.open_advanced"}}
   @action={{@openAdvancedSearch}}
   @icon="sliders"


### PR DESCRIPTION
Noticed that this advanced search button unintentionally picks up some unwanted styles in themes: 

![image](https://github.com/user-attachments/assets/0bccddcd-3982-4b4d-9a98-efc2f91a9077)

adding the btn-transparent class should help