### PR TITLE
DEV: Fix pnpm dedupe workflow branch matching

### DIFF
--- a/.github/workflows/dependabot-pnpm-dedupe.yml
+++ b/.github/workflows/dependabot-pnpm-dedupe.yml
@@ -3,7 +3,7 @@ name: Pnpm dedupe on Dependabot PRs
 on:
   push:
     branches:
-      - "dependabot/npm_and_yarn/*"
+      - "dependabot/npm_and_yarn/**/*"
     paths:
       - "pnpm-lock.yaml"
 


### PR DESCRIPTION
It was missing branches for updated namespaced packages