### PR TITLE
DEV: add missing button classes to topic-footer-mobile-dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.hbs
@@ -79,6 +79,7 @@
         <DMenu
           @modalForMobile={{true}}
           @identifier="topic-footer-mobile-dropdown"
+          class="topic-footer-button btn-default"
         >
           <:trigger>
             {{d-icon "ellipsis-vertical"}}


### PR DESCRIPTION
Adds a couple missing classes to this mobile-specific button: 

![footer-btn](https://github.com/user-attachments/assets/9f6e9fdd-a34b-4c2b-98bd-7e55b698fb50)
