### PR TITLE
FIX: Minimum username length should be validated

### DIFF
--- a/lib/validators/min_username_length_validator.rb
+++ b/lib/validators/min_username_length_validator.rb
@@ -18,7 +18,7 @@ class MinUsernameLengthValidator
   end
 
   def error_message
-    if @min_length_violation
+    if @min_range_violation
       I18n.t(
         "site_settings.errors.invalid_integer_min_max",
         min: MIN_USERNAME_LENGTH_RANGE.begin,

--- a/spec/lib/validators/max_username_length_validator_spec.rb
+++ b/spec/lib/validators/max_username_length_validator_spec.rb
@@ -12,32 +12,52 @@ RSpec.describe MaxUsernameLengthValidator do
 
   describe "checks for valid ranges" do
     it "fails for values below the valid range" do
-      expect do SiteSetting.max_username_length = 5 end.to raise_error(Discourse::InvalidParameters)
-    end
-    it "fails for values above the valid range" do
-      expect do SiteSetting.max_username_length = 61 end.to raise_error(
-        Discourse::InvalidParameters,
+      expect { SiteSetting.max_username_length = 5 }.to raise_error(Discourse::InvalidParameters)
+
+      validator = described_class.new
+      expect(validator.valid_value?(5)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_integer_min_max",
+          min: MaxUsernameLengthValidator::MAX_USERNAME_LENGTH_RANGE.begin,
+          max: MaxUsernameLengthValidator::MAX_USERNAME_LENGTH_RANGE.end,
+        ),
       )
     end
+
+    it "fails for values above the valid range" do
+      expect { SiteSetting.max_username_length = 61 }.to raise_error(Discourse::InvalidParameters)
+
+      validator = described_class.new
+      expect(validator.valid_value?(61)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_integer_min_max",
+          min: MaxUsernameLengthValidator::MAX_USERNAME_LENGTH_RANGE.begin,
+          max: MaxUsernameLengthValidator::MAX_USERNAME_LENGTH_RANGE.end,
+        ),
+      )
+    end
+
     it "works for values within the valid range" do
-      expect do SiteSetting.max_username_length = 42 end.not_to raise_error
+      expect { SiteSetting.max_username_length = 42 }.not_to raise_error
+
+      validator = described_class.new
+      expect(validator.valid_value?(42)).to eq(true)
     end
   end
 
   it "checks for users with short usernames" do
-    username = "jackjackjack"
-    Fabricate(:user, username: username)
+    Fabricate(:user, username: "jackjackjack")
 
     validator = described_class.new
-    expect(validator.valid_value?(12)).to eq(true),
-    "Valid as 12 >= #{SiteSetting.min_username_length}"
+    expect(validator.valid_value?(12)).to eq(true)
 
     validator = described_class.new
-    expect(validator.valid_value?(11)).to eq(false),
-    "Invalid as 11 < #{SiteSetting.min_username_length}"
+    expect(validator.valid_value?(11)).to eq(false)
 
     expect(validator.error_message).to eq(
-      I18n.t("site_settings.errors.max_username_length_exists", username: username),
+      I18n.t("site_settings.errors.max_username_length_exists", username: "jackjackjack"),
     )
   end
 end

--- a/spec/lib/validators/min_username_length_validator_spec.rb
+++ b/spec/lib/validators/min_username_length_validator_spec.rb
@@ -11,20 +11,43 @@ RSpec.describe MinUsernameLengthValidator do
 
   describe "checks for valid ranges" do
     it "fails for values below the valid range" do
-      expect do SiteSetting.min_username_length = 0 end.to raise_error(Discourse::InvalidParameters)
-    end
-    it "fails for values above the valid range" do
-      expect do SiteSetting.min_username_length = 61 end.to raise_error(
-        Discourse::InvalidParameters,
+      expect { SiteSetting.min_username_length = 0 }.to raise_error(Discourse::InvalidParameters)
+
+      validator = described_class.new
+      expect(validator.valid_value?(0)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_integer_min_max",
+          min: MinUsernameLengthValidator::MIN_USERNAME_LENGTH_RANGE.begin,
+          max: MinUsernameLengthValidator::MIN_USERNAME_LENGTH_RANGE.end,
+        ),
       )
     end
+
+    it "fails for values above the valid range" do
+      expect { SiteSetting.min_username_length = 61 }.to raise_error(Discourse::InvalidParameters)
+
+      validator = described_class.new
+      expect(validator.valid_value?(61)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_integer_min_max",
+          min: MinUsernameLengthValidator::MIN_USERNAME_LENGTH_RANGE.begin,
+          max: MinUsernameLengthValidator::MIN_USERNAME_LENGTH_RANGE.end,
+        ),
+      )
+    end
+
     it "works for values within the valid range" do
-      expect do SiteSetting.min_username_length = 4 end.not_to raise_error
+      expect { SiteSetting.min_username_length = 4 }.not_to raise_error
+
+      validator = described_class.new
+      expect(validator.valid_value?(4)).to eq(true)
     end
   end
 
   it "checks for users with short usernames" do
-    user = Fabricate(:user, username: "jack")
+    Fabricate(:user, username: "jack")
 
     validator = described_class.new
     expect(validator.valid_value?(4)).to eq(true)


### PR DESCRIPTION
`@min_length_violation` was not defined and that made the range of values error to never be displayed.