### PR TITLE
DEV: More targeted cleanup in plugin registry specs

### DIFF
--- a/spec/serializers/about_serializer_spec.rb
+++ b/spec/serializers/about_serializer_spec.rb
@@ -44,7 +44,10 @@ RSpec.describe AboutSerializer do
   end
 
   describe "#stats" do
-    after { DiscoursePluginRegistry.reset! }
+    after do
+      DiscoursePluginRegistry.reset_register!(:private_stat)
+      DiscoursePluginRegistry.reset_register!(:exposable_stat)
+    end
 
     let(:plugin) { Plugin::Instance.new }
 

--- a/spec/serializers/user_bookmark_list_serializer_spec.rb
+++ b/spec/serializers/user_bookmark_list_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UserBookmarkListSerializer do
       user_bookmark
     end
 
-    after { DiscoursePluginRegistry.reset! }
+    after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }
 
     let(:post_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:post)) }
     let(:topic_bookmark) { Fabricate(:bookmark, user: user, bookmarkable: Fabricate(:topic)) }

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe UserSerializer do
         plugin.allow_public_user_custom_field :public_field
       end
 
-      after { DiscoursePluginRegistry.reset! }
+      after { DiscoursePluginRegistry.reset_register!(:public_user_custom_fields) }
 
       it "serializes the fields listed in public_user_custom_fields" do
         expect(json[:custom_fields]["public_field"]).to eq(user.custom_fields["public_field"])


### PR DESCRIPTION
When running core specs with `LOAD_PLUGINS=1`, `DiscoursePluginRegistry.reset!` throws a warning. Using specific cleanup ensures that doesn't happen. 

