### PR TITLE
UX: prevent long category names from overflowing on mobile topic list

### DIFF
--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -13,15 +13,25 @@ div.edit-category {
     grid-area: header;
     grid-column: 1 / span 2;
     display: flex;
+    gap: 1em;
     justify-content: space-between;
     align-self: start;
     background-color: var(--primary-very-low);
     padding: 20px;
 
+    h2 {
+      @include ellipsis;
+    }
+
     .category-back {
       height: 2em;
       align-self: flex-end;
+      flex: 0 0 auto;
     }
+  }
+
+  .edit-category-title {
+    min-width: 0;
   }
 
   .edit-category-nav {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -171,6 +171,7 @@
     margin: 0;
 
     .footer-message {
+      overflow-wrap: break-word;
       padding-top: 4em;
     }
   }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -127,6 +127,7 @@
     .badge-category__wrapper {
       vertical-align: bottom;
       margin-right: 0.5em;
+      max-width: 100%;
     }
 
     .badge-wrapper,


### PR DESCRIPTION
Before:

<img src="https://github.com/user-attachments/assets/a66dcbcd-3363-404b-bd12-422b536bad2c" width="300" />

After: 

<img src="https://github.com/user-attachments/assets/511a6545-c1f4-47bb-90f7-02e723ac08f7" width="300" />