### PR TITLE
UX: remove old menu border hack

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -196,22 +196,6 @@
       > .d-icon {
         color: var(--primary-medium);
       }
-
-      &::after {
-        display: block;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        z-index: z("header") + 1; // Higher than .menu-panel
-        width: 100%;
-        height: 0;
-        content: "";
-        border-top: 1px solid var(--secondary);
-      }
-
-      &:hover {
-        border-bottom: none;
-      }
     }
   }
 


### PR DESCRIPTION
We used to hide the bottom border of the header buttons when menu panels were open (so they'd appear connected), but this is no longer necessary... so all this vestigial CSS does is sometimes create a stray line like this: 

![image](https://github.com/user-attachments/assets/12357bf3-2bc7-4604-8b76-7e54460a4175)

