### PR TITLE
FIX: Adds further support for 'prioritize_full_name_in_ux' setting

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -639,6 +639,10 @@ class PostAlerter
       display_username: opts[:display_username] || post.user.username,
     }
 
+    if display_name = opts[:display_name] || post.user.name
+      notification_data[:display_name] = display_name
+    end
+
     opts[:custom_data].each { |k, v| notification_data[k] = v } if opts[:custom_data].is_a?(Hash)
 
     if group = opts[:group]

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1164,6 +1164,20 @@ RSpec.describe PostAlerter do
       )
     end
 
+    it "adds display name to notification_data" do
+      Plugin::Instance
+        .new
+        .register_modifier(:notification_data) do |notification_data|
+          notification_data[:display_name] = "Benji McCool"
+          notification_data
+        end
+
+      notification = PostAlerter.new.create_notification(user, type, post)
+      expect(notification.data_hash[:display_name]).to eq("Benji McCool")
+
+      DiscoursePluginRegistry.clear_modifiers!
+    end
+
     it "applies modifiers to notification_data" do
       Plugin::Instance
         .new


### PR DESCRIPTION
This sets the stage for being able to consolidate Like notifications using full names. It also is crucial to this [Reactions plugin PR](https://github.com/discourse/discourse/pull/31292).

The Like consolidation PR will come after these.