### PR TITLE
FIX: prevents double set in the same computation

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -110,7 +110,7 @@ export default class ComposerService extends Service {
   @tracked
   showPreview = this.site.mobileView
     ? false
-    : this.keyValueStore.get("composer.showPreview") === "true";
+    : (this.keyValueStore.get("composer.showPreview") || "true") === "true";
 
   @tracked allowPreview = true;
   checkedMessages = false;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -107,7 +107,11 @@ export default class ComposerService extends Service {
   @service siteSettings;
   @service store;
 
-  @tracked showPreview = true;
+  @tracked
+  showPreview = this.site.mobileView
+    ? false
+    : this.keyValueStore.get("composer.showPreview") === "true";
+
   @tracked allowPreview = true;
   checkedMessages = false;
   messageCount = null;
@@ -152,14 +156,6 @@ export default class ComposerService extends Service {
 
   get privateMessageDraftKey() {
     return NEW_PRIVATE_MESSAGE_KEY + "_" + new Date().getTime();
-  }
-
-  @on("init")
-  _setupPreview() {
-    const val = this.site.mobileView
-      ? false
-      : this.keyValueStore.get("composer.showPreview") || "true";
-    this.set("showPreview", val === "true");
   }
 
   @computed(

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -4,7 +4,7 @@ import { alias, and, or, reads } from "@ember/object/computed";
 import { cancel, scheduleOnce } from "@ember/runloop";
 import Service, { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
-import { observes, on } from "@ember-decorators/object";
+import { observes } from "@ember-decorators/object";
 import $ from "jquery";
 import { Promise } from "rsvp";
 import DiscardDraftModal from "discourse/components/modal/discard-draft";


### PR DESCRIPTION
The current code was doing:
- initial value for `showPreview`
- setting another default value in `_setupPreview`

The fix is to move all the computation in one initial step when initializing the property.