### PR TITLE
FIX: relative date format consistency

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -296,7 +296,7 @@ export function relativeAgeMediumSpan(distance, leaveAgo) {
       break;
     case distanceInMinutes >= 2520 && distanceInMinutes <= 129599:
       formatted = t("x_days", {
-        count: Math.round((distanceInMinutes - 720.0) / 1440.0),
+        count: Math.round(distanceInMinutes / 1440.0),
       });
       break;
     case distanceInMinutes >= 129600 && distanceInMinutes <= 525599:

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -92,7 +92,7 @@ module("Unit | Utility | formatter", function (hooks) {
     );
     assert.strictEqual(
       strip(formatDays(4.85, { format: "medium", leaveAgo: true })),
-      "4 days ago"
+      "5 days ago"
     );
 
     assert.strictEqual(strip(formatMins(0, { format: "medium" })), "just now");
@@ -110,7 +110,7 @@ module("Unit | Utility | formatter", function (hooks) {
       "23 hours"
     );
     assert.strictEqual(strip(formatHours(23.5, { format: "medium" })), "1 day");
-    assert.strictEqual(strip(formatDays(4.85, { format: "medium" })), "4 days");
+    assert.strictEqual(strip(formatDays(4.85, { format: "medium" })), "5 days");
 
     assert.strictEqual(
       strip(formatDays(6, { format: "medium" })),


### PR DESCRIPTION
This changes makes relative date formats consistent for both tiny and medium formats.

Previously we were removing 12 hours from the date for medium format when it was more than 2520 minutes (42 hours) but not for tiny date formats.

Internal ref: /t/139852