### PR TITLE
FIX: Image uploads in site-settings and profile

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/upload.hbs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/upload.hbs
@@ -1,7 +1,7 @@
 <UppyImageUploader
   @imageUrl={{this.value}}
   @placeholderUrl={{this.setting.placeholder}}
-  @onUploadDone={{fn (mut this.value)}}
+  @onUploadDone={{this.uploadDone}}
   @onUploadDeleted={{fn (mut this.value) null}}
   @additionalParams={{hash for_site_setting=true}}
   @type="site_setting"

--- a/app/assets/javascripts/admin/addon/components/site-settings/upload.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/upload.js
@@ -1,3 +1,9 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 
-export default class Upload extends Component {}
+export default class Upload extends Component {
+  @action
+  uploadDone(upload) {
+    this.set("value", upload.url);
+  }
+}

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -137,6 +137,16 @@ export default class ProfileController extends Controller {
   }
 
   @action
+  profileBackgroundUploadDone(upload) {
+    this.model.set("profile_background_upload_url", upload.url);
+  }
+
+  @action
+  cardBackgroundUploadDone(upload) {
+    this.model.set("card_background_upload_url", upload.url);
+  }
+
+  @action
   save() {
     this.set("saved", false);
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -96,7 +96,7 @@
         <div class="controls">
           <UppyImageUploader
             @imageUrl={{this.model.profile_background_upload_url}}
-            @onUploadDone={{fn (mut this.model.profile_background_upload_url)}}
+            @onUploadDone={{this.profileBackgroundUploadDone}}
             @onUploadDeleted={{fn
               (mut this.model.profile_background_upload_url)
               null
@@ -121,7 +121,7 @@
         <div class="controls">
           <UppyImageUploader
             @imageUrl={{this.model.card_background_upload_url}}
-            @onUploadDone={{fn (mut this.model.card_background_upload_url)}}
+            @onUploadDone={{this.cardBackgroundUploadDone}}
             @onUploadDeleted={{fn
               (mut this.model.card_background_upload_url)
               null


### PR DESCRIPTION
Followup to 310cd513d88e3670c7008682ae4b35414084a17d. The `uploadDone` callback returns the whole upload object, so we need to extract the URL from it in these cases.