### PR TITLE
FEATURE: Allow admins to remove users from chat DMs

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
@@ -44,4 +44,18 @@ class Chat::Api::ChannelsMembershipsController < Chat::Api::ChannelsController
       end
     end
   end
+
+  def destroy
+    Chat::RemoveUserFromChannel.call(service_params) do
+      on_success { render(json: success_json) }
+      on_failure { render(json: failed_json, status: 422) }
+      on_model_not_found(:channel) { raise Discourse::NotFound }
+      on_failed_policy(:can_remove_users_from_channel) do
+        render_json_error(I18n.t("chat.errors.user_cant_be_removed_from_channel"), status: 403)
+      end
+      on_failed_contract do |contract|
+        render(json: failed_json.merge(errors: contract.errors.full_messages), status: 400)
+      end
+    end
+  end
 end

--- a/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
@@ -50,6 +50,7 @@ class Chat::Api::ChannelsMembershipsController < Chat::Api::ChannelsController
       on_success { render(json: success_json) }
       on_failure { render(json: failed_json, status: 422) }
       on_model_not_found(:channel) { raise Discourse::NotFound }
+      on_model_not_found(:target_user) { raise Discourse::NotFound }
       on_failed_policy(:can_remove_users_from_channel) do
         render_json_error(I18n.t("chat.errors.user_cant_be_removed_from_channel"), status: 403)
       end

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -105,6 +105,7 @@ module Chat
     %i[
       category_channel?
       direct_message_channel?
+      direct_message_group?
       public_channel?
       chatable_has_custom_fields?
       read_restricted?

--- a/plugins/chat/app/models/chat/direct_message_channel.rb
+++ b/plugins/chat/app/models/chat/direct_message_channel.rb
@@ -28,12 +28,13 @@ module Chat
       self.slug.blank?
     end
 
-    def leave(user)
+    def remove(user)
       return super unless direct_message_group?
       transaction do
         membership_for(user)&.destroy!
         direct_message.users.delete(user)
       end
     end
+    alias leave remove
   end
 end

--- a/plugins/chat/app/serializers/chat/channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_serializer.rb
@@ -139,7 +139,7 @@ module Chat
       data[:can_moderate] = scope.can_moderate_chat?(object.chatable)
       data[:can_delete_self] = scope.can_delete_own_chats?(object.chatable)
       data[:can_delete_others] = scope.can_delete_other_chats?(object.chatable)
-      data[:can_remove_members] = scope.can_remove_members?(object.chatable)
+      data[:can_remove_members] = scope.can_remove_members?(object)
 
       data
     end

--- a/plugins/chat/app/serializers/chat/channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_serializer.rb
@@ -139,6 +139,7 @@ module Chat
       data[:can_moderate] = scope.can_moderate_chat?(object.chatable)
       data[:can_delete_self] = scope.can_delete_own_chats?(object.chatable)
       data[:can_delete_others] = scope.can_delete_other_chats?(object.chatable)
+      data[:can_remove_members] = scope.can_remove_members?(object.chatable)
 
       data
     end

--- a/plugins/chat/app/services/chat/remove_user_from_channel.rb
+++ b/plugins/chat/app/services/chat/remove_user_from_channel.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Chat
+  # Service responsible for removing users from a channel.
+  # The guardian passed in is the "acting user" when removing users.
+  # The service is essentially deleting memberships for the users.
+  #
+  # @example
+  #  ::Chat::RemoveUserFromChannel.call(
+  #    guardian: guardian,
+  #    params: {
+  #      channel_id: 1,
+  #      user_id: 9,
+  #    }
+  #  )
+  #
+  class RemoveUserFromChannel
+    include Service::Base
+
+    # @!method self.call(guardian:, params:)
+    #   @param [Guardian] guardian
+    #   @param [Hash] params
+    #   @option params [Integer] :channel_id ID of the channel
+    #   @option params [String] :user_id
+    #   @return [Service::Base::Context]
+
+    params do
+      attribute :user_id, :string
+      attribute :channel_id, :integer
+
+      validates :user_id, presence: true
+      validates :channel_id, presence: true
+    end
+
+    model :channel
+    model :target_user
+
+    policy :can_remove_users_from_channel
+
+    transaction do
+      step :remove
+      step :recompute_users_count
+    end
+
+    private
+
+    def fetch_channel(params:)
+      ::Chat::Channel.includes(:chatable).find_by(id: params.channel_id)
+    end
+
+    def fetch_target_user(params:)
+      User.find_by(id: params.user_id)
+    end
+
+    def can_remove_users_from_channel(guardian:, channel:)
+      guardian.can_remove_members?(channel.chatable)
+    end
+
+    def remove(channel:, target_user:)
+      channel.remove(target_user)
+    end
+
+    def recompute_users_count(channel:)
+      channel.update!(
+        user_count: ::Chat::ChannelMembershipsQuery.count(channel),
+        user_count_stale: false,
+      )
+    end
+  end
+end

--- a/plugins/chat/app/services/chat/remove_user_from_channel.rb
+++ b/plugins/chat/app/services/chat/remove_user_from_channel.rb
@@ -21,11 +21,11 @@ module Chat
     #   @param [Guardian] guardian
     #   @param [Hash] params
     #   @option params [Integer] :channel_id ID of the channel
-    #   @option params [String] :user_id
+    #   @option params [Integer] :user_id
     #   @return [Service::Base::Context]
 
     params do
-      attribute :user_id, :string
+      attribute :user_id, :integer
       attribute :channel_id, :integer
 
       validates :user_id, presence: true
@@ -53,7 +53,7 @@ module Chat
     end
 
     def can_remove_users_from_channel(guardian:, channel:)
-      guardian.can_remove_members?(channel.chatable)
+      guardian.can_remove_members?(channel)
     end
 
     def remove(channel:, target_user:)

--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -160,6 +160,10 @@ export default class ChatChannel {
     return this.meta.can_moderate;
   }
 
+  get canRemoveMembers() {
+    return this.meta.can_remove_members;
+  }
+
   get escapedTitle() {
     return escapeExpression(this.title);
   }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -607,6 +607,16 @@ export default class ChatApi extends Service {
     });
   }
 
+  /**
+   * Remove member from a channel.
+   *
+   * @param {number} channelId - The ID of the channel.
+   * @param {string} userId - The ID of the user to remove.
+   */
+  removeMemberFromChannel(channelId, userId) {
+    return this.#deleteRequest(`/channels/${channelId}/memberships/${userId}`);
+  }
+
   get #basePath() {
     return "/chat/api";
   }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-members.scss
@@ -20,6 +20,12 @@
       padding: 0.5rem;
       cursor: pointer;
 
+      .-user-info {
+        border: 0 none;
+        display: flex;
+        flex-grow: 1;
+      }
+
       .avatar {
         cursor: pointer;
       }
@@ -56,6 +62,10 @@
             height: var(--font-0);
             width: var(--font-0);
           }
+        }
+
+        .btn {
+          margin-left: auto;
         }
       }
 

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -348,6 +348,7 @@ en:
         tabs:
           members: Members
           settings: Settings
+        remove_member: "Remove"
 
       new_message_modal:
         title: Send message

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -54,6 +54,7 @@ en:
     deleted_chat_username: deleted
     errors:
       users_cant_be_added_to_channel: "Users can't be added to this channel."
+      user_cant_be_removed_from_channel: "User can't be removed from this channel"
       channel_exists_for_category: "A channel already exists for this category and name"
       channel_new_message_disallowed:
         archived: "The channel is archived, no new messages can be sent"

--- a/plugins/chat/config/routes.rb
+++ b/plugins/chat/config/routes.rb
@@ -27,6 +27,7 @@ Chat::Engine.routes.draw do
     get "/channels/:channel_id/memberships" => "channels_memberships#index"
     post "/channels/:channel_id/memberships" => "channels_memberships#create"
     delete "/channels/:channel_id/memberships/me" => "channels_current_user_membership#destroy"
+    delete "/channels/:channel_id/memberships/:user_id" => "channels_memberships#destroy"
     delete "/channels/:channel_id/memberships/me/follows" =>
              "channels_current_user_membership_follows#destroy"
     put "/channels/:channel_id/memberships/me" => "channels_current_user_membership#update"

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -255,8 +255,8 @@ module Chat
       super && category.deletable_for_chat?
     end
 
-    def can_remove_members?(chatable)
-      is_admin? && !(chatable.is_a?(Chat::DirectMessage) && !chatable.group?)
+    def can_remove_members?(channel)
+      is_admin? && (channel.category_channel? || channel.direct_message_group?)
     end
   end
 end

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -254,5 +254,9 @@ module Chat
     def can_delete_category?(category)
       super && category.deletable_for_chat?
     end
+
+    def can_remove_members?(chatable)
+      is_admin? && !(chatable.is_a?(Chat::DirectMessage) && !chatable.group?)
+    end
   end
 end

--- a/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
@@ -2,14 +2,16 @@
 
 RSpec.describe Chat::Api::ChannelsMembershipsController do
   fab!(:current_user) { Fabricate(:user) }
+  fab!(:other_user) { Fabricate(:user) }
   fab!(:channel_1) do
-    Fabricate(:direct_message_channel, group: true, users: [current_user, Fabricate(:user)])
+    Fabricate(:direct_message_channel, group: true, users: [current_user, other_user])
   end
 
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
     channel_1.add(current_user)
+    channel_1.add(other_user)
     sign_in(current_user)
   end
 
@@ -49,6 +51,36 @@ RSpec.describe Chat::Api::ChannelsMembershipsController do
         get "/chat/api/channels/-999/messages", params: { usernames: [Fabricate(:user).username] }
 
         expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "when acting user is an admin" do
+      let(:current_user) { Fabricate(:admin) }
+
+      describe "success" do
+        it "works" do
+          delete "/chat/api/channels/#{channel_1.id}/memberships/#{other_user.id}"
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when channel is not found" do
+        it "returns a 404" do
+          delete "/chat/api/channels/-999/memberships/#{other_user.id}"
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    context "when acting user is not an admin" do
+      it "returns a 422" do
+        delete "/chat/api/channels/#{channel_1.id}/memberships/#{other_user.id}"
+
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
@@ -74,10 +74,18 @@ RSpec.describe Chat::Api::ChannelsMembershipsController do
           expect(response.status).to eq(404)
         end
       end
+
+      context "when target user is not found" do
+        it "returns a 404" do
+          delete "/chat/api/channels/#{channel_1.id}/memberships/31337"
+
+          expect(response.status).to eq(404)
+        end
+      end
     end
 
     context "when acting user is not an admin" do
-      it "returns a 422" do
+      it "returns a 403" do
         delete "/chat/api/channels/#{channel_1.id}/memberships/#{other_user.id}"
 
         expect(response.status).to eq(403)

--- a/plugins/chat/spec/services/chat/remove_user_from_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/remove_user_from_channel_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe Chat::RemoveUserFromChannel do
   describe described_class::Contract, type: :model do
-    subject(:contract) { described_class.new(user_id: nil, channel_id: nil) }
-
     it { is_expected.to validate_presence_of :channel_id }
     it { is_expected.to validate_presence_of :user_id }
   end
@@ -45,7 +43,7 @@ RSpec.describe Chat::RemoveUserFromChannel do
           it { is_expected.to run_successfully }
 
           it "does nothing" do
-            expect { result }.to_not change { Chat::UserChatChannelMembership }
+            expect { result }.to_not change { Chat::UserChatChannelMembership.count }
           end
         end
       end
@@ -80,12 +78,12 @@ RSpec.describe Chat::RemoveUserFromChannel do
           it { is_expected.to run_successfully }
 
           it "does nothing" do
-            expect { result }.to_not change { Chat::UserChatChannelMembership }
+            expect { result }.to_not change { Chat::UserChatChannelMembership.count }
           end
         end
       end
 
-      context "when direct channel" do
+      context "when channel is a one-on-one DM" do
         context "with existing membership" do
           fab!(:channel) { Fabricate(:direct_message_channel, users: [acting_user, user]) }
 

--- a/plugins/chat/spec/services/chat/remove_user_from_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/remove_user_from_channel_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::RemoveUserFromChannel do
+  describe described_class::Contract, type: :model do
+    subject(:contract) { described_class.new(user_id: nil, channel_id: nil) }
+
+    it { is_expected.to validate_presence_of :channel_id }
+    it { is_expected.to validate_presence_of :user_id }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:acting_user) { Fabricate(:admin) }
+    fab!(:user)
+    fab!(:channel) { Fabricate(:chat_channel) }
+
+    let(:guardian) { Guardian.new(acting_user) }
+    let(:params) { { channel_id: channel.id, user_id: user.id } }
+    let(:dependencies) { { guardian: } }
+
+    context "when all steps pass" do
+      context "when category channel" do
+        context "with existing membership" do
+          before do
+            channel.add(user)
+            channel.add(acting_user)
+            Chat::Channel.ensure_consistency!
+          end
+
+          it { is_expected.to run_successfully }
+
+          it "unfollows the channel" do
+            membership = channel.membership_for(user)
+
+            expect { result }.to change { membership.reload.following }.from(true).to(false)
+          end
+
+          it "recomputes user count" do
+            expect { result }.to change { channel.reload.user_count }.from(2).to(1)
+          end
+        end
+
+        context "with no existing membership" do
+          it { is_expected.to run_successfully }
+
+          it "does nothing" do
+            expect { result }.to_not change { Chat::UserChatChannelMembership }
+          end
+        end
+      end
+
+      context "when group channel" do
+        context "with existing membership" do
+          fab!(:channel) do
+            Fabricate(:direct_message_channel, group: true, users: [acting_user, user])
+          end
+
+          before { Chat::Channel.ensure_consistency! }
+
+          it { is_expected.to run_successfully }
+
+          it "leaves the channel" do
+            membership = channel.membership_for(user)
+
+            result
+
+            expect(Chat::UserChatChannelMembership.exists?(membership.id)).to eq(false)
+            expect(channel.chatable.direct_message_users.where(user_id: user.id).exists?).to eq(
+              false,
+            )
+          end
+
+          it "recomputes user count" do
+            expect { result }.to change { channel.reload.user_count }.from(2).to(1)
+          end
+        end
+
+        context "with no existing membership" do
+          it { is_expected.to run_successfully }
+
+          it "does nothing" do
+            expect { result }.to_not change { Chat::UserChatChannelMembership }
+          end
+        end
+      end
+
+      context "when direct channel" do
+        context "with existing membership" do
+          fab!(:channel) { Fabricate(:direct_message_channel, users: [acting_user, user]) }
+
+          it { is_expected.to fail_a_policy(:can_remove_users_from_channel) }
+        end
+      end
+    end
+
+    context "when target user is not found" do
+      before do
+        params[:user_id] = 31_337
+        params[:channel_id] = channel.id
+      end
+
+      it { is_expected.to fail_to_find_a_model(:target_user) }
+    end
+
+    context "when channel is not found" do
+      before do
+        params[:user_id] = user.id
+        params[:channel_id] = -999
+      end
+
+      it { is_expected.to fail_to_find_a_model(:channel) }
+    end
+
+    context "when user is not an admin" do
+      fab!(:acting_user) { Fabricate(:user) }
+
+      it { is_expected.to fail_a_policy(:can_remove_users_from_channel) }
+    end
+  end
+end

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -61,7 +61,11 @@ RSpec.describe "Channel - Info - Members page", type: :system do
           chat_page.visit_channel_members(channel_1)
           find(".c-channel-members__filter").fill_in(with: "cat")
 
-          expect(page).to have_selector(".c-channel-members__list-item", count: 1, text: "cat")
+          expect(page).to have_selector(
+            ".c-channel-members__list-item .-user-info",
+            count: 1,
+            text: "cat",
+          )
         end
       end
 
@@ -88,7 +92,7 @@ RSpec.describe "Channel - Info - Members page", type: :system do
     end
   end
 
-  context "when category channel" do
+  context "when group DM channel" do
     fab!(:channel_1) do
       Fabricate(
         :direct_message_channel,
@@ -115,6 +119,54 @@ RSpec.describe "Channel - Info - Members page", type: :system do
           count: 1,
         ),
       )
+    end
+  end
+
+  describe "removing members" do
+    fab!(:current_user) { Fabricate(:admin) }
+
+    before { channel_1.add(Fabricate(:user)) }
+
+    context "when the channel is a category channel" do
+      it "allows removing members" do
+        chat_page.visit_channel_members(channel_1)
+
+        expect(chat_page).to have_css(".c-channel-members__list-item .-remove-member")
+      end
+    end
+
+    context "when the channel is a group DM" do
+      fab!(:channel_1) do
+        Fabricate(
+          :direct_message_channel,
+          slug: "test-channel",
+          users: [current_user, Fabricate(:user), Fabricate(:user)],
+          group: true,
+        )
+      end
+
+      it "allows removing members" do
+        chat_page.visit_channel_members(channel_1)
+
+        expect(chat_page).to have_css(".c-channel-members__list-item .-remove-member")
+      end
+    end
+
+    context "when the channel is a one-on-one DM" do
+      fab!(:channel_1) do
+        Fabricate(
+          :direct_message_channel,
+          slug: "test-channel",
+          users: [current_user, Fabricate(:user)],
+          group: false,
+        )
+      end
+
+      it "does not allow removing members" do
+        chat_page.visit_channel_members(channel_1)
+
+        expect(chat_page).to have_no_css(".c-channel-members__list-item .-remove-member")
+      end
     end
   end
 


### PR DESCRIPTION
### What is this feature?

This feature allows admins to remove users from channels. This is allowed for category channels and group DMs, but not one-on-one DMs, as that wouldn't make any sense. 😉 

**Screenshot:**

<img width="263" alt="Screenshot 2025-02-19 at 10 59 49 AM" src="https://github.com/user-attachments/assets/049aa77d-67ae-42f8-a190-f640e4285118" />

### Implementation details

This PR attempts to follow the existing structure as much as possible. The major moving parts are:

- A new back-end service for removing users from channels.
- A guardian extension checking the ability to do so. This is also propagated to the front-end.
- A new method in the front-end chat API.
- UI changes.
- Tests.

### Known limitations

- When removing a member from a group DM, the header doesn't update to reflect this. This is a pre-existing issue. (It also doesn't update when adding members.) I have created a task to fix this separately.
- The terms `users` and `members` are mixed throughout the code base. I tried as best I could to follow the terminology of the _directly adjacent code_. We could potentially fix this up later.