### PR TITLE
DEV: Add mobile_view toggle to dev-tools toolbar

### DIFF
--- a/app/assets/javascripts/discourse/app/static/dev-tools/mobile-view/button.gjs
+++ b/app/assets/javascripts/discourse/app/static/dev-tools/mobile-view/button.gjs
@@ -1,0 +1,30 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
+import mobile from "discourse/lib/mobile";
+
+export default class MobileViewButton extends Component {
+  get mobileViewActive() {
+    return mobile.mobileView;
+  }
+
+  @action
+  toggleMobileView() {
+    mobile.toggleMobileView();
+  }
+
+  <template>
+    <button
+      title="Toggle mobile view"
+      class={{concatClass
+        "toggle-mobile-view"
+        (if this.mobileViewActive "--active")
+      }}
+      {{on "click" this.toggleMobileView}}
+    >
+      {{icon "mobile-screen-button"}}
+    </button>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/static/dev-tools/toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/static/dev-tools/toolbar.gjs
@@ -7,6 +7,7 @@ import icon from "discourse/helpers/d-icon";
 import draggable from "discourse/modifiers/draggable";
 import onResize from "discourse/modifiers/on-resize";
 import I18n from "discourse-i18n";
+import MobileViewButton from "./mobile-view/button";
 import PluginOutletDebugButton from "./plugin-outlet-debug/button";
 import SafeModeButton from "./safe-mode/button";
 import VerboseLocalizationButton from "./verbose-localization/button";
@@ -62,6 +63,7 @@ export default class Toolbar extends Component {
       <PluginOutletDebugButton />
       <SafeModeButton />
       <VerboseLocalizationButton />
+      <MobileViewButton />
       <button
         title="Disable dev tools"
         class="disable-dev-tools"


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/introducing-discourse-developer-toolbar/346215/15?u=arkshine
Followup https://github.com/discourse/discourse/commit/498481e5be21780c20e3646bd934eb9d7316a8f8

With David's approval, this PR adds a new button to toggle the mobile view.
 
![chrome_YWpxrSdN98](https://github.com/user-attachments/assets/7ba7fa29-25e8-453f-9e14-0487d8d772c2)
