### PR TITLE
FIX: Ensure revoke_ungranted_titles! works with user_ids

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -504,8 +504,6 @@ class BadgeGranter
   end
 
   def self.revoke_ungranted_titles!(user_ids = nil)
-    user_ids = user_ids.join(", ") if user_ids
-
     DB.exec <<~SQL, user_ids: user_ids
       UPDATE users u
       SET title = ''

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -506,7 +506,7 @@ class BadgeGranter
   def self.revoke_ungranted_titles!(user_ids = nil)
     user_ids = user_ids.join(", ") if user_ids
 
-    DB.exec <<~SQL
+    DB.exec <<~SQL, user_ids: user_ids
       UPDATE users u
       SET title = ''
       FROM user_profiles up
@@ -525,7 +525,7 @@ class BadgeGranter
         #{user_ids.present? ? "AND u.id IN (:user_ids)" : ""}
     SQL
 
-    DB.exec <<~SQL
+    DB.exec <<~SQL, user_ids: user_ids
       UPDATE user_profiles up
       SET granted_title_badge_id = NULL
       FROM users u


### PR DESCRIPTION
When `revoke_ungranted_titles!` was invoked, the optional list of `user_ids` was not passed from the argument list of to the query. This resulted in an exception because the placeholder `:user_ids` existed in the query.