### PR TITLE
DEV: implements register_modifier(:serialize_topic_op_likes_data)

### DIFF
--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -146,11 +146,7 @@ class TopicListItemSerializer < ListableTopicSerializer
 
   def serialize_topic_op_likes_data_enabled?
     theme_enabled = theme_modifier_helper.serialize_topic_op_likes_data
-    plugin_enabled =
-      DiscoursePluginRegistry.apply_modifier(
-        :serialize_topic_op_likes_data,
-        false
-      )
+    plugin_enabled = DiscoursePluginRegistry.apply_modifier(:serialize_topic_op_likes_data, false)
 
     theme_enabled || plugin_enabled
   end

--- a/app/serializers/topic_list_item_serializer.rb
+++ b/app/serializers/topic_list_item_serializer.rb
@@ -36,7 +36,7 @@ class TopicListItemSerializer < ListableTopicSerializer
   end
 
   def include_op_can_like?
-    theme_modifier_helper.serialize_topic_op_likes_data
+    serialize_topic_op_likes_data_enabled?
   end
 
   def op_can_like
@@ -58,7 +58,7 @@ class TopicListItemSerializer < ListableTopicSerializer
   end
 
   def include_op_liked?
-    theme_modifier_helper.serialize_topic_op_likes_data
+    serialize_topic_op_likes_data_enabled?
   end
 
   def op_liked
@@ -72,7 +72,7 @@ class TopicListItemSerializer < ListableTopicSerializer
   end
 
   def include_first_post_id?
-    theme_modifier_helper.serialize_topic_op_likes_data
+    serialize_topic_op_likes_data_enabled?
   end
 
   def first_post_id
@@ -143,6 +143,17 @@ class TopicListItemSerializer < ListableTopicSerializer
   end
 
   private
+
+  def serialize_topic_op_likes_data_enabled?
+    theme_enabled = theme_modifier_helper.serialize_topic_op_likes_data
+    plugin_enabled =
+      DiscoursePluginRegistry.apply_modifier(
+        :serialize_topic_op_likes_data,
+        false
+      )
+
+    theme_enabled || plugin_enabled
+  end
 
   def theme_modifier_helper
     @theme_modifier_helper ||= ThemeModifierHelper.new(request: scope.request)

--- a/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/spec/serializers/topic_list_item_serializer_spec.rb
@@ -124,9 +124,10 @@ RSpec.describe TopicListItemSerializer do
 
     it "serializes op_can_like when plugin modifies the serialize_topic_op_likes_data to true" do
       allow(DiscoursePluginRegistry).to receive(:apply_modifier).and_return(false)
-      allow(DiscoursePluginRegistry).to receive(:apply_modifier)
-        .with(:serialize_topic_op_likes_data, false)
-        .and_return(true)
+      allow(DiscoursePluginRegistry).to receive(:apply_modifier).with(
+        :serialize_topic_op_likes_data,
+        false,
+      ).and_return(true)
 
       json = TopicListItemSerializer.new(topic, scope: Guardian.new(moderator), root: false).as_json
 
@@ -163,9 +164,10 @@ RSpec.describe TopicListItemSerializer do
 
     it "serializes op_liked when plugin modifies the serialize_topic_op_likes_data to true" do
       allow(DiscoursePluginRegistry).to receive(:apply_modifier).and_return(false)
-      allow(DiscoursePluginRegistry).to receive(:apply_modifier)
-        .with(:serialize_topic_op_likes_data, false)
-        .and_return(true)
+      allow(DiscoursePluginRegistry).to receive(:apply_modifier).with(
+        :serialize_topic_op_likes_data,
+        false,
+      ).and_return(true)
       PostAction.create!(
         user: user,
         post: first_post,
@@ -196,9 +198,10 @@ RSpec.describe TopicListItemSerializer do
 
     it "serializes first_post_id when plugin modifies the serialize_topic_op_likes_data to true" do
       allow(DiscoursePluginRegistry).to receive(:apply_modifier).and_return(false)
-      allow(DiscoursePluginRegistry).to receive(:apply_modifier)
-        .with(:serialize_topic_op_likes_data, false)
-        .and_return(true)
+      allow(DiscoursePluginRegistry).to receive(:apply_modifier).with(
+        :serialize_topic_op_likes_data,
+        false,
+      ).and_return(true)
       json = TopicListItemSerializer.new(topic, scope: Guardian.new(moderator), root: false).as_json
 
       expect(json[:first_post_id]).to eq(first_post.id)


### PR DESCRIPTION
This commit will allow plugin developers to enable/disable the topic op likes data in serializer.

Usage:

```
register_modifier(:serialize_topic_op_likes_data) { |enabled| true }
```