### PR TITLE
Added code for Netcore Cloud webhook implementation with tests

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -173,6 +173,43 @@ class WebhooksController < ActionController::Base
     success
   end
 
+  def netcorecloud
+    Rails.logger.info("Received Netcore webhook with events: #{params["_json"]}")
+
+    events = params["_json"]
+
+    begin
+      events.each do |event|
+        message_id = Email::MessageIdService.message_id_clean(event["X-APIHEADER"])
+        to_address = event["EMAIL"]
+
+        next if message_id.blank? || to_address.blank?
+
+        error_code = event["BOUNCE_REASONID"]
+
+        case event["EVENT"]
+        when "bounced"
+          case event["BOUNCE_TYPE"]
+          when "HARDBOUNCE"
+            process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+          when "SOFTBOUNCE"
+            process_bounce(message_id, to_address, SiteSetting.soft_bounce_score, error_code)
+          end
+        when "dropped"
+          process_bounce(message_id, to_address, SiteSetting.hard_bounce_score, error_code)
+        end
+      end
+    rescue StandardError => e
+      Rails.logger.error(
+        "Failed to process Netcore webhook: #{e.message}\n#{e.backtrace.join("\n")}",
+      )
+      render json: { error: "Internal Server Error" }, status: 500
+      return
+    end
+
+    success
+  end
+
   def aws
     raw = request.raw_post
     json = JSON.parse(raw)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Discourse::Application.routes.draw do
     post "webhooks/postmark" => "webhooks#postmark"
     post "webhooks/sendgrid" => "webhooks#sendgrid"
     post "webhooks/sparkpost" => "webhooks#sparkpost"
+    post "webhooks/netcorecloud" => "webhooks#netcorecloud"
 
     scope path: nil, format: true, constraints: { format: :xml } do
       resources :sitemap, only: [:index]

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -247,6 +247,8 @@ module Email
         merge_json_x_header("X-MC-Metadata", message_id: @message.message_id)
       when "smtp.sparkpostmail.com"
         merge_json_x_header("X-MSYS-API", metadata: { message_id: @message.message_id })
+      when "smtp.netcorecloud.net"
+        merge_json_x_header["X-APIHEADER"] = @message.message_id
       end
 
       # Parse the HTML again so we can make any final changes before

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -154,6 +154,82 @@ RSpec.describe WebhooksController do
     end
   end
 
+  describe "#netcorecloud" do
+    it "processes hard bounce" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/netcorecloud.json",
+           params: {
+             "_json" => [
+               {
+                 "TRANSID" => 15_543_162_088_093_688,
+                 "EMAIL" => email,
+                 "EVENT" => "bounced",
+                 "X-APIHEADER" => message_id,
+                 "BOUNCE_TYPE" => "HARDBOUNCE",
+                 "BOUNCE_REASONID" => 77,
+               },
+             ],
+           }
+
+      expect(response.status).to eq(200)
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("77")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+
+    it "processes soft bounce" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/netcorecloud.json",
+           params: {
+             "_json" => [
+               {
+                 "TRANSID" => 15_543_162_088_093_688,
+                 "EMAIL" => email,
+                 "EVENT" => "bounced",
+                 "X-APIHEADER" => message_id,
+                 "BOUNCE_TYPE" => "SOFTBOUNCE",
+                 "BOUNCE_REASONID" => 45,
+               },
+             ],
+           }
+
+      expect(response.status).to eq(200)
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("45")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.soft_bounce_score)
+    end
+
+    it "processes dropped email" do
+      user = Fabricate(:user, email: email)
+      email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
+
+      post "/webhooks/netcorecloud.json",
+           params: {
+             "_json" => [
+               {
+                 "TRANSID" => 15_543_162_088_093_688,
+                 "EMAIL" => email,
+                 "EVENT" => "dropped",
+                 "X-APIHEADER" => message_id,
+                 "BOUNCE_REASONID" => 90,
+               },
+             ],
+           }
+
+      expect(response.status).to eq(200)
+      email_log.reload
+      expect(email_log.bounced).to eq(true)
+      expect(email_log.bounce_error_code).to eq("90")
+      expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
+    end
+  end
+
   describe "#mailjet" do
     it "works" do
       user = Fabricate(:user, email: email)


### PR DESCRIPTION
Adds Netcore Cloud webhook support for handling e-mails that get Bounced (Hard and Soft) or Dropped. To configure the webhook, follow these steps:

Login to your NetcoreCloud Email API account, go to "General" > "Webhooks" > "Individual Event"
Set the Target URL to "http://your.discourse/webhooks/netcorecloud" next to the Bounce and Dropped event
Click Save