### PR TITLE
FIX: Correct header field name from Mime-Version to MIME-Version

### DIFF
--- a/lib/discourse_dev/email_log.rb
+++ b/lib/discourse_dev/email_log.rb
@@ -52,7 +52,7 @@ module DiscourseDev
         Return-Path: #{user.email}
         From: #{user.email}
         Date: #{Date.today}
-        Mime-Version: "1.0"
+        MIME-Version: "1.0"
         Content-Type: "text/plain"
         Content-Transfer-Encoding: "7bit"
 

--- a/spec/fabricators/incoming_email_fabricator.rb
+++ b/spec/fabricators/incoming_email_fabricator.rb
@@ -15,7 +15,7 @@ Fabricator(:incoming_email) do
     Subject: Hello world
     Date: Fri, 15 Jan 2016 00:12:43 +0100
     Message-ID: <12345@example.com>
-    Mime-Version: 1.0
+    MIME-Version: 1.0
     Content-Type: text/plain; charset=UTF-8
     Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/attached_eml_file.eml
+++ b/spec/fixtures/emails/attached_eml_file.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Sat, 30 Jan 2016 01:10:11 +0100
 Message-ID: <38@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad";
  charset=UTF-8

--- a/spec/fixtures/emails/attached_rb_file.eml
+++ b/spec/fixtures/emails/attached_rb_file.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Date: Mon, 29 Feb 2016 21:54:01 +0100
 Message-ID: <56d4afe991ed0_3ab83fdf94441a20677f0@HAL.lan.mail>
 Subject: Email with .rb file attached
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56d4afe991d17_3ab83fdf94441a206765";
  charset=UTF-8

--- a/spec/fixtures/emails/attached_txt_file.eml
+++ b/spec/fixtures/emails/attached_txt_file.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Sat, 30 Jan 2016 01:10:11 +0100
 Message-ID: <38@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad";
  charset=UTF-8

--- a/spec/fixtures/emails/attached_txt_file_2.eml
+++ b/spec/fixtures/emails/attached_txt_file_2.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Sat, 30 Jan 2016 01:10:11 +0100
 Message-ID: <38b@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad";
  charset=UTF-8

--- a/spec/fixtures/emails/auto_generated_allowlisted.eml
+++ b/spec/fixtures/emails/auto_generated_allowlisted.eml
@@ -4,7 +4,7 @@ To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <1@foo.bar.mail>
 Auto-Submitted: auto-generated
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/auto_generated_header.eml
+++ b/spec/fixtures/emails/auto_generated_header.eml
@@ -3,7 +3,7 @@ From: Foo Bar <foo@bar.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <3@foo.bar.mail>
 Auto-Submitted: auto-generated
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/auto_generated_precedence.eml
+++ b/spec/fixtures/emails/auto_generated_precedence.eml
@@ -3,7 +3,7 @@ From: Foo Bar <foo@bar.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <2@foo.bar.mail>
 Precedence: list
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/auto_generated_unblocked.eml
+++ b/spec/fixtures/emails/auto_generated_unblocked.eml
@@ -4,7 +4,7 @@ To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <52@foo.bar.mail>
 Auto-Submitted: auto-generated
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/bad_destinations.eml
+++ b/spec/fixtures/emails/bad_destinations.eml
@@ -4,7 +4,7 @@ To: wat@bar.com
 Cc: foofoo@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <9@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/blocklist_allowlist_email.eml
+++ b/spec/fixtures/emails/blocklist_allowlist_email.eml
@@ -4,7 +4,7 @@ To: some_group@bar.com, alice@foo.com
 Cc: bob@FOO.com, carol@example.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <51@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/body_with_image.eml
+++ b/spec/fixtures/emails/body_with_image.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <6@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56990c8d3f66c_7cb53ffbb98602004746e";
  charset=UTF-8

--- a/spec/fixtures/emails/cc.eml
+++ b/spec/fixtures/emails/cc.eml
@@ -5,7 +5,7 @@ CC: team@bar.com, wat@bar.com, reply+d400310beeae61d785c2ac6a2aacb210@bar.com
 Subject: The more, the merrier
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <30@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/chinese_reply.eml
+++ b/spec/fixtures/emails/chinese_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <17@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=Big5
 Content-Transfer-Encoding: base64
 

--- a/spec/fixtures/emails/dmarc_fail.eml
+++ b/spec/fixtures/emails/dmarc_fail.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 Authentication-Results: example.com; dmarc=fail

--- a/spec/fixtures/emails/email_reply_1.eml
+++ b/spec/fixtures/emails/email_reply_1.eml
@@ -5,7 +5,7 @@ Cc: two@foo.com, three@foo.com
 Subject: Testing email threading
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_2.eml
+++ b/spec/fixtures/emails/email_reply_2.eml
@@ -6,7 +6,7 @@ Subject: RE: Testing email threading
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <35@foo.bar.mail>
 In-Reply-To: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_3.eml
+++ b/spec/fixtures/emails/email_reply_3.eml
@@ -7,7 +7,7 @@ Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <36@foo.bar.mail>
 In-Reply-To: <35@foo.bar.mail>
 References: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_4.eml
+++ b/spec/fixtures/emails/email_reply_4.eml
@@ -8,7 +8,7 @@ Message-ID: <37@foo.bar.mail>
 In-Reply-To: <36@foo.bar.mail>
 References: <34@foo.bar.mail>
   <35@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_like.eml
+++ b/spec/fixtures/emails/email_reply_like.eml
@@ -6,7 +6,7 @@ Subject: RE: Testing email threading
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <38@foo.bar.mail>
 In-Reply-To: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_staged.eml
+++ b/spec/fixtures/emails/email_reply_staged.eml
@@ -6,7 +6,7 @@ Subject: RE: Testing email threading
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <35@foo.bar.mail>
 In-Reply-To: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_reply_to_group_email_username.eml
+++ b/spec/fixtures/emails/email_reply_to_group_email_username.eml
@@ -5,7 +5,7 @@ Subject: RE: Testing email threading
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <44@foo.bar.mail>
 In-Reply-To: <34@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_to_group_email_username_1.eml
+++ b/spec/fixtures/emails/email_to_group_email_username_1.eml
@@ -4,7 +4,7 @@ To: team@somesmtpaddress.com
 Subject: Full email group username flow
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <u4w8c9r4y984yh98r3h69873@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_to_group_email_username_2.eml
+++ b/spec/fixtures/emails/email_to_group_email_username_2.eml
@@ -7,7 +7,7 @@ Message-ID: <348ct38794nyt9338dsfsd@foo.bar.mail>
 In-Reply-To: <MESSAGE_ID_REPLY_TO>
 References: <u4w8c9r4y984yh98r3h69873@foo.bar.mail>
   <MESSAGE_ID_REPLY_TO>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_to_group_email_username_2_as_unknown_sender.eml
+++ b/spec/fixtures/emails/email_to_group_email_username_2_as_unknown_sender.eml
@@ -7,7 +7,7 @@ Message-ID: <348ct38794nyt9338dsfsd@foo.bar.mail>
 In-Reply-To: <MESSAGE_ID_REPLY_TO>
 References: <u4w8c9r4y984yh98r3h69873@foo.bar.mail>
   <MESSAGE_ID_REPLY_TO>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_to_group_email_username_3.eml
+++ b/spec/fixtures/emails/email_to_group_email_username_3.eml
@@ -7,7 +7,7 @@ Message-ID: <348ct38794nyt9338dsfsd@foo.bar.mail>
 In-Reply-To: MESSAGE_ID_REPLY_TO
 References: <u4w8c9r4y984yh98r3h69873@foo.bar.mail>
   <MESSAGE_ID_REPLY_TO>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/email_to_group_email_username_auto_generated.eml
+++ b/spec/fixtures/emails/email_to_group_email_username_auto_generated.eml
@@ -3,7 +3,7 @@ To: team@somesmtpaddress.com
 Subject: Your insurance is due!
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <u4w8c9r4y984yh98r3h69873@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/encoded_display_name.eml
+++ b/spec/fixtures/emails/encoded_display_name.eml
@@ -4,7 +4,7 @@ To: meat@bar.com
 Subject: I need help
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <29@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/encoded_filename.eml
+++ b/spec/fixtures/emails/encoded_filename.eml
@@ -7,8 +7,8 @@ Reply-To: xxxxxxxxx xxxxxxx <xxxxxxxxx.xxxxxxx@gmail.com>
 To: one@foo.com
 Subject: Fwd: Signed email causes file attachments
 In-Reply-To: <F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@mac.com>
-Mime-Version: 1.0
-Content-Type: multipart/mixed; 
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
 	boundary="----=_Part_5028_7368284.1115579351471"
 References: <F6E2D0B4-CC35-4A91-BA4C-C7C712B10C13@mac.com>
 

--- a/spec/fixtures/emails/encoding_undefined_conversion.eml
+++ b/spec/fixtures/emails/encoding_undefined_conversion.eml
@@ -5,7 +5,7 @@ CC: team@bar.com, wat@bar.com, reply+d400310beeae61d785c2ac6a2aacb210@bar.com
 Subject: The more, the merrier
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <30@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/exchange_html_body.eml
+++ b/spec/fixtures/emails/exchange_html_body.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2017 00:12:43 +0100
 Message-ID: <180@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/exchange_html_body_and_reply.eml
+++ b/spec/fixtures/emails/exchange_html_body_and_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2017 00:12:43 +0100
 Message-ID: <180@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/exchange_html_reply.eml
+++ b/spec/fixtures/emails/exchange_html_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2017 00:12:43 +0100
 Message-ID: <180@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/existing_user.eml
+++ b/spec/fixtures/emails/existing_user.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/from_reply_by_email_address.eml
+++ b/spec/fixtures/emails/from_reply_by_email_address.eml
@@ -3,7 +3,7 @@ From: Reply Bar <reply@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <10@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/from_the_future.eml
+++ b/spec/fixtures/emails/from_the_future.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Wed, 01 Jan 3000 00:00:00 +0100
 Message-ID: <4@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/gmail_html_reply.eml
+++ b/spec/fixtures/emails/gmail_html_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <180@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/group_existing_user.eml
+++ b/spec/fixtures/emails/group_existing_user.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Subject: This is a topic to a group from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/hebrew_reply.eml
+++ b/spec/fixtures/emails/hebrew_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <16@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: base64
 

--- a/spec/fixtures/emails/html_reply.eml
+++ b/spec/fixtures/emails/html_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: alt+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <18@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/ignored.eml
+++ b/spec/fixtures/emails/ignored.eml
@@ -4,7 +4,7 @@ To: category@foo.com
 Subject: This is a FoO topic
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <53@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/inactive_sender.eml
+++ b/spec/fixtures/emails/inactive_sender.eml
@@ -2,7 +2,7 @@ Return-Path: <inactive@bar.com>
 From: Foo Bar <inactive@bar.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <8@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/inline_image.eml
+++ b/spec/fixtures/emails/inline_image.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <28@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/related; boundary=001a114b2eccff183a052998ec68
 
 --001a114b2eccff183a052998ec68

--- a/spec/fixtures/emails/inline_image_2.eml
+++ b/spec/fixtures/emails/inline_image_2.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <28@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/related; boundary="0000000000006d045f05c0e384eb"
 
 --0000000000006d045f05c0e384eb

--- a/spec/fixtures/emails/inline_mixed_replies.eml
+++ b/spec/fixtures/emails/inline_mixed_replies.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <24@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 On Tue, Jan 15, 2016 at 11:12 AM, Bar Foo <info@unconfigured.discourse.org> wrote:

--- a/spec/fixtures/emails/inline_reply.eml
+++ b/spec/fixtures/emails/inline_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <23@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 On Tue, Jan 15, 2016 at 11:12 AM, Bar Foo <info@unconfigured.discourse.org> wrote:

--- a/spec/fixtures/emails/invalid_from_1.eml
+++ b/spec/fixtures/emails/invalid_from_1.eml
@@ -3,7 +3,7 @@ From: Foo Bar [THIS IS INVALID] <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <41@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This email was sent with an invalid from header field.

--- a/spec/fixtures/emails/iphone_signature.eml
+++ b/spec/fixtures/emails/iphone_signature.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <25@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This is not the signature you're looking for.

--- a/spec/fixtures/emails/like.eml
+++ b/spec/fixtures/emails/like.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <13@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/mailinglist_unsubscribe.eml
+++ b/spec/fixtures/emails/mailinglist_unsubscribe.eml
@@ -4,7 +4,7 @@ To: list@example.com
 Date: Thu, 13 Jun 2013 17:03:48 -0400
 Message-ID: <56@foo.bar.mail>
 Subject: UnSuBScRiBe
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain;
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/mailman_1.eml
+++ b/spec/fixtures/emails/mailman_1.eml
@@ -4,7 +4,7 @@ Reply-To: Example users <list@ml.example.com>
 To: list@example.com
 Message-ID: <4460a72d7764ad03b5cecd65fe4c2fbd@foo.com>
 Subject: library 1.2.3 released!
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 X-MailFrom: some@one.com

--- a/spec/fixtures/emails/mailman_2.eml
+++ b/spec/fixtures/emails/mailman_2.eml
@@ -4,7 +4,7 @@ Reply-To: some@one.com
 To: list@example.com
 Message-ID: <23e86ebe4d9f211967e48d284449c856@foo.com>
 Subject: library 1.2.3 released!
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 X-MailFrom: some@one.com

--- a/spec/fixtures/emails/mailman_3.eml
+++ b/spec/fixtures/emails/mailman_3.eml
@@ -4,7 +4,7 @@ To: list@example.com
 CC: Some One <some@one.com>
 Message-ID: <5a0d382572c511c24daf1558c02f6a19@foo.com>
 Subject: library 1.2.3 released!
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 X-MailFrom: some@one.com

--- a/spec/fixtures/emails/mailman_4.eml
+++ b/spec/fixtures/emails/mailman_4.eml
@@ -3,7 +3,7 @@ From: Some One via example <list@ml.example.com>
 To: list@example.com
 Message-ID: <8df45354b9ca21a868023b2dd3296a8d@foo.com>
 Subject: library 1.2.3 released!
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 7bit
 X-Original-From: some@one.com

--- a/spec/fixtures/emails/missing_message_id.eml
+++ b/spec/fixtures/emails/missing_message_id.eml
@@ -1,7 +1,7 @@
 From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/mute.eml
+++ b/spec/fixtures/emails/mute.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <13@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/new_user.eml
+++ b/spec/fixtures/emails/new_user.eml
@@ -4,7 +4,7 @@ To: category@foo.com
 Subject: This is a topic from a complete stranger
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <31@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/no_body.eml
+++ b/spec/fixtures/emails/no_body.eml
@@ -2,6 +2,6 @@ Return-Path: <foo@bar.com>
 From: Foo Bar <foo@bar.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <5@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit

--- a/spec/fixtures/emails/no_body_with_image.eml
+++ b/spec/fixtures/emails/no_body_with_image.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <6@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/mixed;
  boundary="--==_mimepart_56990c8d3f66c_7cb53ffbb98602004746e";
  charset=UTF-8

--- a/spec/fixtures/emails/no_date.eml
+++ b/spec/fixtures/emails/no_date.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: category@foo.com
 Subject: This is a topic from a complete stranger
 Message-ID: <31@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/no_from.eml
+++ b/spec/fixtures/emails/no_from.eml
@@ -1,7 +1,7 @@
 To: meat@bar.com
 Date: Mon, 1 Feb 2016 00:12:43 +0100
 Message-ID: <40@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 Subject: Nobody sent this

--- a/spec/fixtures/emails/no_subject.eml
+++ b/spec/fixtures/emails/no_subject.eml
@@ -2,7 +2,7 @@ From: Some One <some@one.com>
 To: meat@bar.com
 Date: Mon, 1 Feb 2016 00:12:43 +0100
 Message-ID: <40@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/null_byte_in_subject.eml
+++ b/spec/fixtures/emails/null_byte_in_subject.eml
@@ -4,7 +4,7 @@ To: category@foo.com
 Subject: =?ISO_8859-1?Q?testing=00?=
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <31@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/old_destination.eml
+++ b/spec/fixtures/emails/old_destination.eml
@@ -5,7 +5,7 @@ Cc: foofoo@bar.com
 Date: Fri, 15 Jan 2018 00:12:43 +0100
 Message-ID: <999@foo.bar.mail>
 In-Reply-To: <discourse/post/:post_id@test.localhost>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 Subject: Some Old Post

--- a/spec/fixtures/emails/on_date_contact_wrote.eml
+++ b/spec/fixtures/emails/on_date_contact_wrote.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <20@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This is the actual reply.

--- a/spec/fixtures/emails/original_message.eml
+++ b/spec/fixtures/emails/original_message.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <27@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This is a reply :)

--- a/spec/fixtures/emails/paragraphs.eml
+++ b/spec/fixtures/emails/paragraphs.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <22@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 Do you like liquorice?

--- a/spec/fixtures/emails/previous_replies.eml
+++ b/spec/fixtures/emails/previous_replies.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <21@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This will not include the previous discussion that is present in this email.

--- a/spec/fixtures/emails/previous_replies_de.eml
+++ b/spec/fixtures/emails/previous_replies_de.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <21@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This will not include the previous discussion that is present in this email.

--- a/spec/fixtures/emails/quirks_exchange_xars.eml
+++ b/spec/fixtures/emails/quirks_exchange_xars.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <21@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 X-Auto-Response-Suppress: DR, RN, NRN, OOF, AutoReply
 

--- a/spec/fixtures/emails/readonly.eml
+++ b/spec/fixtures/emails/readonly.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from a restricted user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <33@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/reply_above.eml
+++ b/spec/fixtures/emails/reply_above.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <21@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 
 <p>This will not include the previous discussion that is present in this email.</p>

--- a/spec/fixtures/emails/reply_above_de.eml
+++ b/spec/fixtures/emails/reply_above_de.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <21@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/html; charset=UTF-8
 
 <p>This will not include the previous discussion that is present in this email.</p>

--- a/spec/fixtures/emails/reply_to_different_to_from.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Subject: I need some support
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 X-Original-From: Arthur Morgan <arthurmorgan@reddeadtest.com>

--- a/spec/fixtures/emails/reply_to_different_to_from_no_x_original.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from_no_x_original.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Subject: I need some support
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Subject: I need some support
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 X-Original-From: "Marston, John" <johnmarston@reddeadtest.com>

--- a/spec/fixtures/emails/reply_to_different_to_from_x_original_different.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from_x_original_different.eml
@@ -4,7 +4,7 @@ To: team@bar.com
 Subject: I need some support
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 X-Original-From: Dutch Van der Linde <dutch@reddeadtest.com>

--- a/spec/fixtures/emails/reply_user_matching.eml
+++ b/spec/fixtures/emails/reply_user_matching.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <11@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/reply_user_not_matching.eml
+++ b/spec/fixtures/emails/reply_user_not_matching.eml
@@ -3,7 +3,7 @@ From: Foo Bar <someone_else@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <10@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/reply_user_not_matching_but_known.eml
+++ b/spec/fixtures/emails/reply_user_not_matching_but_known.eml
@@ -4,7 +4,7 @@ To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 CC: Alice <discourse@bar.com>, carol@bar.com
 Date: Fri, 15 Jan 2016 02:12:43 +0100
 Message-ID: <11@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/reply_with_weird_encoding.eml
+++ b/spec/fixtures/emails/reply_with_weird_encoding.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <42@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=unicode-1-1-utf-7
 
 This is a reply with a weird encoding.

--- a/spec/fixtures/emails/screened_email.eml
+++ b/spec/fixtures/emails/screened_email.eml
@@ -2,7 +2,7 @@ Return-Path: <screened@mail.com>
 From: Not Found <screened@mail.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <51@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/silenced_sender.eml
+++ b/spec/fixtures/emails/silenced_sender.eml
@@ -2,7 +2,7 @@ Return-Path: <silenced@bar.com>
 From: Foo Bar <silenced@bar.com>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <8@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/spam_x_ses_spam_verdict.eml
+++ b/spec/fixtures/emails/spam_x_ses_spam_verdict.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 X-SES-Spam-Verdict: FAIL

--- a/spec/fixtures/emails/spam_x_spam_flag.eml
+++ b/spec/fixtures/emails/spam_x_spam_flag.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 X-Spam-Flag: YES

--- a/spec/fixtures/emails/spam_x_spam_status.eml
+++ b/spec/fixtures/emails/spam_x_spam_status.eml
@@ -4,7 +4,7 @@ To: category@bar.com
 Subject: This is a topic from an existing user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <32@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 X-Spam-Status: Yes, score=12.3 required=4.5

--- a/spec/fixtures/emails/staged_reply_restricted.eml
+++ b/spec/fixtures/emails/staged_reply_restricted.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jun 2016 00:12:43 +0100
 Message-ID: <54@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 
 This is a reply from a staged user in a topic in a restricted category.

--- a/spec/fixtures/emails/staged_sender.eml
+++ b/spec/fixtures/emails/staged_sender.eml
@@ -3,7 +3,7 @@ From: Foo Bar <staged@bar.com>
 To: reply+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <39@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/text_and_html_reply.eml
+++ b/spec/fixtures/emails/text_and_html_reply.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <19@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: multipart/alternative; boundary=001a11469b1296cf8d052963bde5
 
 --001a11469b1296cf8d052963bde5

--- a/spec/fixtures/emails/tl3_user.eml
+++ b/spec/fixtures/emails/tl3_user.eml
@@ -4,7 +4,7 @@ To: category@foo.com
 Subject: This is a topic from a TL3 user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <43@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/tl4_user.eml
+++ b/spec/fixtures/emails/tl4_user.eml
@@ -4,7 +4,7 @@ To: category@foo.com
 Subject: This is a topic from a TL4 user
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <44@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: quoted-printable
 

--- a/spec/fixtures/emails/too_many_mentions.eml
+++ b/spec/fixtures/emails/too_many_mentions.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <14@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/too_small.eml
+++ b/spec/fixtures/emails/too_small.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <12@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/track.eml
+++ b/spec/fixtures/emails/track.eml
@@ -3,8 +3,8 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <13@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 
-track 
+track

--- a/spec/fixtures/emails/unsubscribe_body.eml
+++ b/spec/fixtures/emails/unsubscribe_body.eml
@@ -3,7 +3,7 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Thu, 13 Jun 2013 17:03:48 -0400
 Message-ID: <55@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain;
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/unsubscribe_new_user.eml
+++ b/spec/fixtures/emails/unsubscribe_new_user.eml
@@ -4,7 +4,7 @@ To: reply@bar.com
 Date: Thu, 13 Jun 2013 17:03:48 -0400
 Message-ID: <56@foo.bar.mail>
 Subject: UnSuBScRiBe
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain;
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/unsubscribe_subject.eml
+++ b/spec/fixtures/emails/unsubscribe_subject.eml
@@ -4,7 +4,7 @@ To: reply@bar.com
 Date: Thu, 13 Jun 2013 17:03:48 -0400
 Message-ID: <56@foo.bar.mail>
 Subject: UnSuBScRiBe
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain;
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/user_not_found.eml
+++ b/spec/fixtures/emails/user_not_found.eml
@@ -2,7 +2,7 @@ Return-Path: <user@not.found>
 From: Not Found <user@not.found>
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <50@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 

--- a/spec/fixtures/emails/watch.eml
+++ b/spec/fixtures/emails/watch.eml
@@ -3,8 +3,8 @@ From: Foo Bar <discourse@bar.com>
 To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
 Date: Fri, 15 Jan 2016 00:12:43 +0100
 Message-ID: <13@foo.bar.mail>
-Mime-Version: 1.0
+MIME-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
 
-watch 
+watch

--- a/spec/jobs/poll_mailbox_spec.rb
+++ b/spec/jobs/poll_mailbox_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Jobs::PollMailbox do
         Subject: Testing email
         Date: #{1.day.ago.strftime("%a, %d %b %Y")} 03:12:43 +0100
         Message-ID: <34@foo.bar.mail>
-        Mime-Version: 1.0
+        MIME-Version: 1.0
         Content-Type: text/plain
         Content-Transfer-Encoding: 7bit
 

--- a/spec/lib/email/cleaner_spec.rb
+++ b/spec/lib/email/cleaner_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Email::Cleaner do
     email = email(:attached_txt_file)
 
     expected_message =
-      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease find some text file attached.\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
+      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease find some text file attached.\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
     expect(described_class.new(email).execute).to eq(expected_message)
   end
 
@@ -16,7 +16,7 @@ RSpec.describe Email::Cleaner do
     SiteSetting.raw_email_max_length = 10
 
     expected_message =
-      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
+      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
     expect(described_class.new(email).execute).to eq(expected_message)
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Email::Cleaner do
     SiteSetting.raw_rejected_email_max_length = 10
 
     expected_message =
-      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
+      "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
     expect(described_class.new(email, rejected: true).execute).to eq(expected_message)
   end
 end

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -417,12 +417,12 @@ RSpec.describe Email::Receiver do
       expect { process(:gmail_html_reply) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to eq <<~MD.strip
         This is a **GMAIL** reply ;)
-        
+
         <details class='elided'>
         <summary title='Show trimmed content'>&#183;&#183;&#183;</summary>
-        
+
         This is the *elided* part!
-        
+
         </details>
       MD
     end
@@ -891,7 +891,7 @@ RSpec.describe Email::Receiver do
                   Subject: Hello world
                   Date: Fri, 15 Jan 2016 00:12:43 +0100
                   Message-ID: <10@foo.bar.mail>
-                  Mime-Version: 1.0
+                  MIME-Version: 1.0
                   Content-Type: text/plain; charset=UTF-8
                   Content-Transfer-Encoding: quoted-printable
 
@@ -1128,7 +1128,7 @@ RSpec.describe Email::Receiver do
           Date: Fri, 15 Jan 2016 00:12:43 +0100
           Message-ID: <44@foo.bar.mail>
           In-Reply-To: <#{message_id}>
-          Mime-Version: 1.0
+          MIME-Version: 1.0
           Content-Type: text/plain
           Content-Transfer-Encoding: 7bit
 

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1768,7 +1768,7 @@ RSpec.describe PostAlerter do
                           Subject: Hello world
                           Date: Fri, 15 Jan 2016 00:12:43 +0100
                           Message-ID: <12345@example.com>
-                          Mime-Version: 1.0
+                          MIME-Version: 1.0
                           Content-Type: text/plain; charset=UTF-8
                           Content-Transfer-Encoding: quoted-printable
 
@@ -2451,7 +2451,7 @@ RSpec.describe PostAlerter do
       Subject: Full email group username flow
       Date: Fri, 15 Jan 2021 00:12:43 +0100
       Message-ID: <u4w8c9r4y984yh98r3h69873@example.com.mail>
-      Mime-Version: 1.0
+      MIME-Version: 1.0
       Content-Type: text/plain
       Content-Transfer-Encoding: 7bit
 
@@ -2632,7 +2632,7 @@ RSpec.describe PostAlerter do
       Date: Fri, 16 Jan 2021 00:12:43 +0100
       Message-ID: <sdugj3o4iyu4832x3487@discourse.org.mail>
       In-Reply-To: #{email.message_id}
-      Mime-Version: 1.0
+      MIME-Version: 1.0
       Content-Type: text/plain
       Content-Transfer-Encoding: 7bit
 
@@ -2683,7 +2683,7 @@ RSpec.describe PostAlerter do
       Date: Fri, 16 Jan 2021 00:12:43 +0100
       Message-ID: <sgk094238uc0348c334483@discourse.org.mail>
       In-Reply-To: #{email.message_id}
-      Mime-Version: 1.0
+      MIME-Version: 1.0
       Content-Type: text/plain
       Content-Transfer-Encoding: 7bit
 
@@ -2725,7 +2725,7 @@ RSpec.describe PostAlerter do
       Subject: Full email group username flow
       Date: Fri, 14 Jan 2021 00:12:43 +0100
       Message-ID: <f4832ujfc3498u398i3@example.com.mail>
-      Mime-Version: 1.0
+      MIME-Version: 1.0
       Content-Type: text/plain
       Content-Transfer-Encoding: 7bit
 
@@ -2749,7 +2749,7 @@ RSpec.describe PostAlerter do
       Date: Fri, 16 Jan 2021 00:12:43 +0100
       Message-ID: <3849cu9843yncr9834yr9348x934@discourse.org.mail>
       In-Reply-To: #{email.message_id}
-      Mime-Version: 1.0
+      MIME-Version: 1.0
       Content-Type: text/plain
       Content-Transfer-Encoding: 7bit
 

--- a/spec/support/imap_helper.rb
+++ b/spec/support/imap_helper.rb
@@ -25,7 +25,7 @@ def EmailFabricator(options)
   email += "References: #{options[:in_reply_to]}\n" if options[:in_reply_to]
   email += "Message-ID: <#{options[:message_id]}>\n" if options[:message_id]
   email += "Subject: #{options[:subject] || "This is a test email subject"}\n"
-  email += "Mime-Version: 1.0\n"
+  email += "MIME-Version: 1.0\n"
   email += "Content-Type: #{options[:content_type] || "text/plain;\n charset=UTF-8"}\n"
   email += "Content-Transfer-Encoding: 7bit\n"
   email += "\n#{options[:body] || "This is an email *body*. :smile:"}"


### PR DESCRIPTION
According to **RFC1521** section 3 (https://datatracker.ietf.org/doc/html/rfc1521#section-3), `MIME-Version` is the standard capitalization for this header field. 
Incorrect capitalization will trigger `RSPAMD` **MV_CASE**(https://github.com/rspamd/rspamd/blob/aac7da0952a2a4c298a309086c58ca97dcadef57/rules/headers_checks.lua#L643) check (`-0.5` score).