### PR TITLE
Add PKCS1_OAEP_PADDING option to UserAPIKeySpec

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -89,7 +89,7 @@ class UserApiKeysController < ApplicationController
 
     public_key_str = @client.public_key.present? ? @client.public_key : params[:public_key]
     public_key = OpenSSL::PKey::RSA.new(public_key_str)
-    @payload = Base64.encode64(public_key.public_encrypt(@payload))
+    @payload = Base64.encode64(public_key.public_encrypt(@payload, OpenSSL::PKey::RSA.const_get(SiteSetting.user_api_key_encryption_padding)))
 
     if scopes.include?("one_time_password")
       # encrypt one_time_password separately to bypass 128 chars encryption limit

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3345,6 +3345,12 @@ user_api:
     allow_any: false
     refresh: true
     area: "group_permissions"
+  user_api_key_encryption_padding:
+    type: enum
+    default: "PKCS1_PADDING"
+    choices:
+      - PKCS1_PADDING
+      - PKCS1_OAEP_PADDING
   allowed_user_api_push_urls:
     default: ""
     type: list


### PR DESCRIPTION
This commit adds a new site setting to the User API Keys options. The padding option specified here will be used to encrypt the user api key created and sent back to the client.

The default, PKCS1_PADDING, is the value currently in place (so existing) integrations won't break),but if a user chooses to use PKCS1_OAEP_PADDING, they can implement it and use it as they see fit.