### PR TITLE
DEV: Ensure only one csrftoken request is running simultaneously

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -45,10 +45,18 @@ function handleRedirect(xhr) {
   }
 }
 
+let csrfPromise;
+
 export function updateCsrfToken() {
-  return ajax("/session/csrf").then((result) => {
-    Session.currentProp("csrfToken", result.csrf);
-  });
+  if (csrfPromise) {
+    return csrfPromise;
+  }
+
+  csrfPromise = ajax("/session/csrf")
+    .then((result) => Session.currentProp("csrfToken", result.csrf))
+    .finally(() => (csrfPromise = null));
+
+  return csrfPromise;
 }
 
 /**

--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -45,18 +45,16 @@ function handleRedirect(xhr) {
   }
 }
 
-let csrfPromise;
+let activeCsrfRequest;
 
 export function updateCsrfToken() {
-  if (csrfPromise) {
-    return csrfPromise;
+  if (!activeCsrfRequest) {
+    activeCsrfRequest = ajax("/session/csrf")
+      .then((result) => Session.currentProp("csrfToken", result.csrf))
+      .finally(() => (activeCsrfRequest = null));
   }
 
-  csrfPromise = ajax("/session/csrf")
-    .then((result) => Session.currentProp("csrfToken", result.csrf))
-    .finally(() => (csrfPromise = null));
-
-  return csrfPromise;
+  return activeCsrfRequest;
 }
 
 /**


### PR DESCRIPTION
Before this, triggering two ajax requests close together would 'race' to create a csrf-token, and only one would succeed