### PR TITLE
DEV: remove empty outlet wrapper to prevent it from occupying layout space

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
@@ -17,13 +17,11 @@ const TopicMap = <template>
         />
       </section>
 
-      <section class="topic-map__additional-contents toggle-summary">
-        <PluginOutlet
-          @name="topic-map-expanded-after"
-          @defaultGlimmer={{true}}
-          @outletArgs={{hash topic=@model postStream=@postStream}}
-        />
-      </section>
+      <PluginOutlet
+        @name="topic-map-expanded-after"
+        @defaultGlimmer={{true}}
+        @outletArgs={{hash topic=@model postStream=@postStream}}
+      />
 
       {{#if @showPMMap}}
         <section class="topic-map__private-message-map">

--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -24,10 +24,7 @@ body:not(.archetype-private_message) {
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-
-    &:has(.topic-map__additional-contents *) {
-      column-gap: 0.75em;
-    }
+    column-gap: 0.75em;
   }
 }
 


### PR DESCRIPTION
The `toggle-summary` class is specific to our use in the AI plugin, so I've moved it there in https://github.com/discourse/discourse-ai/pull/1136... 

This wrapper was occupying some space even though it was empty in the PM topic map, so it's better to not have it. 

This also allows us to remove some sub-optimal CSS that was adding a gap based on content within it. Without the empty wrapper, we can always have the gap present. 