### PR TITLE
DEV: add scope param to user_confirmed_email event

### DIFF
--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -67,7 +67,7 @@ class EmailToken < ActiveRecord::Base
       user.save!
       user.create_reviewable if !skip_reviewable
       user.set_automatic_groups
-      DiscourseEvent.trigger(:user_confirmed_email, user)
+      DiscourseEvent.trigger(:user_confirmed_email, user, scope)
       Invite.redeem_for_existing_user(user) if scope == EmailToken.scopes[:signup]
 
       user.reload


### PR DESCRIPTION
EmailToken.confirm is called in a number of contexts (hence the need for the `scope`) and this is sometimes needed in `user_confirmed_email` callbacks to distinguish those contexts.