### PR TITLE
UX: increase limit in chat channel fetcher

### DIFF
--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -2,7 +2,7 @@
 
 module Chat
   class ChannelFetcher
-    MAX_PUBLIC_CHANNEL_RESULTS = 50
+    MAX_PUBLIC_CHANNEL_RESULTS = 100
 
     # NOTE: this should always be > than `DIRECT_MESSAGE_CHANNELS_LIMIT` in `chat-channel-manager.js`
     MAX_DM_CHANNEL_RESULTS = 75


### PR DESCRIPTION
Increases the number of chat channels loading to prevent missing notifications for channels beyond the current limit.