### PR TITLE
DEV: replace passwordValidation mixin in PasswordResetController

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/password-reset.hbs
+++ b/app/assets/javascripts/discourse/app/templates/password-reset.hbs
@@ -74,7 +74,6 @@
         <div class="input">
           <PasswordField
             @value={{this.accountPassword}}
-            {{on "focusout" this.togglePasswordValidation}}
             @capsLockOn={{this.capsLockOn}}
             type={{if this.maskPassword "password" "text"}}
             autofocus="autofocus"


### PR DESCRIPTION
This replaces the password validation mixin with a helper class in the password-reset controller class. 
Also removes the redundant flag `passwordValidationVisible` that is already fully dependent on whether `passwordValidation` has a `reason`. 