### PR TITLE
FIX: Lightbox chat uploads immediately after optimize

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
@@ -7,7 +7,7 @@
     />
 
     <Collapser @header={{this.uploadsHeader}} @onToggle={{@onToggleCollapse}}>
-      <div class="chat-uploads" {{didInsert this.lightbox}}>
+      <div class="chat-uploads" {{this.lightbox}}>
         {{#each @uploads as |upload|}}
           <ChatUpload @upload={{upload}} />
         {{/each}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { modifier } from "ember-modifier";
 import domFromString from "discourse/lib/dom-from-string";
 import { escapeExpression } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
@@ -9,6 +9,12 @@ import lightbox from "../lib/lightbox";
 
 export default class ChatMessageCollapser extends Component {
   @service siteSettings;
+
+  lightbox = modifier((element) => {
+    if (this.args.uploads.length > 0) {
+      lightbox(element.querySelectorAll("img.chat-img-upload"));
+    }
+  });
 
   get hasUploads() {
     return hasUploads(this.args.uploads);
@@ -138,11 +144,6 @@ export default class ChatMessageCollapser extends Component {
       }
       return acc;
     }, []);
-  }
-
-  @action
-  lightbox(element) {
-    lightbox(element.querySelectorAll("img.chat-img-upload"));
   }
 }
 


### PR DESCRIPTION
When a message is first sent, the original upload URL is used for a split-second before it's replaced by the optimised thumbnail. Using `didInsert` didn't re-run on any changes to the uploads. Switching to a proper modifier, and checking the length of the uploads array within it, will ensure that it is re-run whenever the uploads change.