### PR TITLE
DEV: Add reactive helpers to `interfaceColor` service

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-styles.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-styles.gjs
@@ -18,40 +18,22 @@ export default class DStyles extends Component {
   }
 
   get categoryBackgrounds() {
-    let css = [];
-    const darkCss = [];
+    const css = [];
 
     this.site.categories.forEach((category) => {
       const lightUrl = category.uploaded_background?.url;
-      const darkUrl =
-        this.session.defaultColorSchemeIsDark || this.session.darkModeAvailable
-          ? category.uploaded_background_dark?.url
-          : null;
-      const defaultUrl =
-        darkUrl && this.session.defaultColorSchemeIsDark ? darkUrl : lightUrl;
+      const darkUrl = category.uploaded_background_dark?.url;
 
-      if (defaultUrl) {
-        const url = getURLWithCDN(defaultUrl);
+      let resolvedUrl = this.interfaceColor.lightMode ? lightUrl : darkUrl;
+      resolvedUrl ??= lightUrl;
+
+      if (resolvedUrl) {
+        const url = getURLWithCDN(resolvedUrl);
         css.push(
           `body.category-${category.fullSlug} { background-image: url(${url}); }`
         );
       }
-
-      if (darkUrl && defaultUrl !== darkUrl) {
-        const url = getURLWithCDN(darkUrl);
-        darkCss.push(
-          `body.category-${category.fullSlug} { background-image: url(${url}); }`
-        );
-      }
     });
-
-    if (darkCss.length > 0) {
-      if (this.interfaceColor.darkModeForced) {
-        css = darkCss;
-      } else if (!this.interfaceColor.lightModeForced) {
-        css.push("@media (prefers-color-scheme: dark) {", ...darkCss, "}");
-      }
-    }
 
     return css.join("\n");
   }

--- a/app/assets/javascripts/discourse/app/components/header/logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/logo.gjs
@@ -6,20 +6,13 @@ import getURL from "discourse/lib/get-url";
 export default class Logo extends Component {
   @service interfaceColor;
 
-  get darkMediaQuery() {
-    if (this.interfaceColor.darkModeForced) {
-      return "all";
-    } else if (this.interfaceColor.lightModeForced) {
-      return "none";
-    } else {
-      return "(prefers-color-scheme: dark)";
-    }
-  }
-
   <template>
     {{#if (and @darkUrl (notEq @url @darkUrl))}}
       <picture>
-        <source srcset={{getURL @darkUrl}} media={{this.darkMediaQuery}} />
+        <source
+          srcset={{getURL @darkUrl}}
+          media={{this.interfaceColor.darkMediaQuery}}
+        />
         <img
           id="site-logo"
           class={{@key}}

--- a/app/assets/javascripts/discourse/app/components/light-dark-img.gjs
+++ b/app/assets/javascripts/discourse/app/components/light-dark-img.gjs
@@ -29,16 +29,6 @@ export default class LightDarkImg extends Component {
     return getURLWithCDN(this.args.darkImg.url);
   }
 
-  get darkMediaQuery() {
-    if (this.interfaceColor.darkModeForced) {
-      return "all";
-    } else if (this.interfaceColor.lightModeForced) {
-      return "none";
-    } else {
-      return "(prefers-color-scheme: dark)";
-    }
-  }
-
   <template>
     {{#if this.isDarkImageAvailable}}
       <picture>
@@ -46,7 +36,7 @@ export default class LightDarkImg extends Component {
           srcset={{this.darkImgCdnSrc}}
           width={{@darkImg.width}}
           height={{@darkImg.height}}
-          media={{this.darkMediaQuery}}
+          media={{this.interfaceColor.darkMediaQuery}}
         />
         <CdnImg
           ...attributes

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -14,6 +14,7 @@ export default class ApplicationController extends Controller {
   @service footer;
   @service header;
   @service sidebarState;
+  @service interfaceColor;
 
   queryParams = [{ navigationMenuQueryParamOverride: "navigation_menu" }];
   showTop = true;

--- a/app/assets/javascripts/discourse/app/models/session.js
+++ b/app/assets/javascripts/discourse/app/models/session.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import singleton from "discourse/lib/singleton";
 import RestModel from "discourse/models/rest";
 
@@ -5,6 +6,9 @@ import RestModel from "discourse/models/rest";
 // data here you might want later. It is not stored or serialized anywhere.
 @singleton
 export default class Session extends RestModel {
+  @tracked darkModeAvailable;
+  @tracked defaultColorSchemeIsDark;
+
   hasFocus = null;
 
   init() {


### PR DESCRIPTION
- `darkMode` and `lightMode` will react automatically based on color scheme preferences, forced mode, and browser preference

- `darkMediaQuery` is extracted from a couple of components, and can be used for things like `<picture>` sources

These new helpers are tested indirectly via d-styles and other existing tests