### PR TITLE
DEV: Compile 'common' CSS into own asset

### DIFF
--- a/app/assets/stylesheets/desktop.scss
+++ b/app/assets/stylesheets/desktop.scss
@@ -1,4 +1,3 @@
-@import "common";
 @import "desktop/_index";
 
 // Import all component-specific files

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -4,7 +4,8 @@
 
   td,
   th {
-    @extend .list-cell;
+    padding: 12px 5px;
+    color: var(--primary-med-or-secondary-high);
   }
 
   td {

--- a/app/assets/stylesheets/desktop/latest-topic-list.scss
+++ b/app/assets/stylesheets/desktop/latest-topic-list.scss
@@ -37,10 +37,25 @@
   }
 
   .main-link {
-    @extend .topic-list-main-link;
     flex: 0 1 auto;
     max-width: 65%;
     font-size: var(--font-0);
+
+    a.title {
+      padding: 15px 0;
+      word-break: break-word;
+      color: var(--primary);
+    }
+
+    .anon & {
+      a.title:visited:not(.badge-notification) {
+        color: var(--primary-medium);
+      }
+    }
+
+    a.title.visited:not(.badge-notification) {
+      color: var(--primary-medium);
+    }
 
     .top-row {
       margin-bottom: 0.1em;

--- a/app/assets/stylesheets/mobile.scss
+++ b/app/assets/stylesheets/mobile.scss
@@ -1,4 +1,3 @@
-@import "common";
 @import "mobile/_index";
 
 // Import all component-specific files

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -9,7 +9,7 @@ class BootstrapController < ApplicationController
   end
 
   def core_css_for_tests
-    targets = %w[color_definitions desktop admin]
+    targets = %w[color_definitions common desktop admin]
     render_css_for_tests(targets)
   end
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -547,12 +547,10 @@ class Theme < ActiveRecord::Base
     if target == :translations
       fields = ThemeField.find_first_locale_fields(theme_ids, I18n.fallbacks[name])
     else
+      target = :common if target == :common_theme
       target = :mobile if target == :mobile_theme
       target = :desktop if target == :desktop_theme
-      fields =
-        ThemeField.find_by_theme_ids(theme_ids).where(
-          target_id: [Theme.targets[target], Theme.targets[:common]],
-        )
+      fields = ThemeField.find_by_theme_ids(theme_ids).where(target_id: Theme.targets[target])
       fields = fields.where(name: name.to_s) unless name.nil?
       fields = fields.order(:target_id)
     end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -439,7 +439,7 @@ class Theme < ActiveRecord::Base
     all_themes: false
   )
     Stylesheet::Manager.clear_theme_cache!
-    targets = %i[mobile_theme desktop_theme]
+    targets = %i[common_theme mobile_theme desktop_theme]
 
     if with_scheme
       targets.prepend(:desktop, :mobile, :admin)

--- a/app/views/common/_discourse_preload_stylesheet.html.erb
+++ b/app/views/common/_discourse_preload_stylesheet.html.erb
@@ -1,8 +1,10 @@
 <%= discourse_preload_color_scheme_stylesheets %>
 
 <%- if rtl? %>
+  <%= discourse_stylesheet_preload_tag(:common_rtl) %>
   <%= discourse_stylesheet_preload_tag(mobile_view? ? :mobile_rtl : :desktop_rtl) %>
 <%- else %>
+  <%= discourse_stylesheet_preload_tag(:common) %>
   <%= discourse_stylesheet_preload_tag(mobile_view? ? :mobile : :desktop) %>
 <%- end %>
 

--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -29,5 +29,6 @@
 <%- end %>
 
 <%- if theme_id.present? %>
+  <%= discourse_stylesheet_link_tag(:common_theme) %>
   <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
 <%- end %>

--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -1,8 +1,10 @@
 <%= discourse_color_scheme_stylesheets %>
 
 <%- if rtl? %>
+  <%= discourse_stylesheet_link_tag(:common_rtl) %>
   <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_rtl : :desktop_rtl) %>
 <%- else %>
+  <%= discourse_stylesheet_link_tag(:common) %>
   <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile : :desktop) %>
 <%- end %>
 

--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -6,7 +6,7 @@ module Stylesheet
   class Importer
     include GlobalPath
 
-    THEME_TARGETS = %w[embedded_theme mobile_theme desktop_theme]
+    THEME_TARGETS = %w[embedded_theme common_theme mobile_theme desktop_theme]
 
     def self.plugin_assets
       @plugin_assets ||= {}

--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -206,12 +206,18 @@ module Stylesheet
     def theme_import(target)
       return "" if !@theme_id
 
-      attr = target == :embedded_theme ? :embedded_scss : :scss
+      name = :scss
+
+      if target == :embedded_theme
+        name = :embedded_scss
+        target = :common
+      end
+
       target = target.to_s.gsub("_theme", "").to_sym
 
       contents = +""
 
-      fields = theme.list_baked_fields(target, attr)
+      fields = theme.list_baked_fields(target, name)
       fields.map do |field|
         contents << "@import \"theme-entrypoint/#{field.scss_entrypoint_name}\";\n"
       end

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -105,7 +105,7 @@ class Stylesheet::Manager
             builder =
               Stylesheet::Manager::Builder.new(target: target, theme: theme, manager: manager)
 
-            next if theme.component && !scss_checker.has_scss(theme.id)
+            next if !scss_checker.has_scss(theme.id)
             $stderr.puts "precompile target: #{target} #{theme.name}"
             builder.compile(force: true)
             compiled << "#{target}_#{theme.id}"

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -86,7 +86,7 @@ class Stylesheet::Manager
     color_schemes << ColorScheme.base
     color_schemes = color_schemes.compact.uniq
 
-    targets = %i[desktop_theme mobile_theme]
+    targets = %i[common_theme desktop_theme mobile_theme]
     compiled = Set.new
 
     themes.each do |theme_id, color_scheme_id|
@@ -315,7 +315,7 @@ class Stylesheet::Manager
             }
             builder = Builder.new(target: target, theme: theme, manager: self)
 
-            next if builder.theme&.component && !scss_checker.has_scss(theme_id)
+            next if !scss_checker.has_scss(theme_id)
             builder.compile unless File.exist?(builder.stylesheet_fullpath)
             href = builder.stylesheet_absolute_url
 

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -50,7 +50,8 @@ class Stylesheet::Manager
   end
 
   def self.precompile_css
-    targets = %i[desktop mobile admin wizard desktop_rtl mobile_rtl admin_rtl wizard_rtl]
+    targets = %i[common desktop mobile admin wizard]
+    targets += targets.map { |t| :"#{t}_rtl" }
 
     targets +=
       Discourse.find_plugin_css_assets(

--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -177,7 +177,7 @@ class Stylesheet::Manager::Builder
   end
 
   def scss_digest
-    if %i[mobile_theme desktop_theme].include?(@target)
+    if %i[common_theme mobile_theme desktop_theme].include?(@target)
       resolve_baked_field(@target.to_s.sub("_theme", ""), :scss)
     elsif @target == :embedded_theme
       resolve_baked_field(:common, :embedded_scss)
@@ -275,13 +275,13 @@ class Stylesheet::Manager::Builder
     theme_ids = [theme_ids.first] if name != :color_definitions
 
     baked_fields = []
-    targets = [Theme.targets[target.to_sym], Theme.targets[:common]]
+    target_id = Theme.targets[target.to_sym]
 
     @manager
       .load_themes(theme_ids)
       .each do |theme|
         theme.builder_theme_fields.each do |theme_field|
-          if theme_field.name == name.to_s && targets.include?(theme_field.target_id)
+          if theme_field.name == name.to_s && theme_field.target_id == target_id
             baked_fields << theme_field
           end
         end

--- a/lib/stylesheet/manager/scss_checker.rb
+++ b/lib/stylesheet/manager/scss_checker.rb
@@ -16,7 +16,7 @@ class Stylesheet::Manager::ScssChecker
     @themes_with_scss ||=
       begin
         theme_target = @target.to_sym
-        theme_target = :common if theme_target == :common_theme
+        theme_target = :common if theme_target == :common_theme || theme_target == :embedded_theme
         theme_target = :mobile if theme_target == :mobile_theme
         theme_target = :desktop if theme_target == :desktop_theme
         name = @target == :embedded_theme ? :embedded_scss : :scss

--- a/lib/stylesheet/manager/scss_checker.rb
+++ b/lib/stylesheet/manager/scss_checker.rb
@@ -16,6 +16,7 @@ class Stylesheet::Manager::ScssChecker
     @themes_with_scss ||=
       begin
         theme_target = @target.to_sym
+        theme_target = :common if theme_target == :common_theme
         theme_target = :mobile if theme_target == :mobile_theme
         theme_target = :desktop if theme_target == :desktop_theme
         name = @target == :embedded_theme ? :embedded_scss : :scss
@@ -24,12 +25,7 @@ class Stylesheet::Manager::ScssChecker
           Theme
             .where(id: @theme_ids)
             .left_joins(:theme_fields)
-            .where(
-              theme_fields: {
-                target_id: [Theme.targets[theme_target], Theme.targets[:common]],
-                name: name,
-              },
-            )
+            .where(theme_fields: { target_id: Theme.targets[theme_target], name: name })
             .group(:id)
             .size
 

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe Discourse do
       css_link_tag =
         Nokogiri::HTML5
           .fragment(
-            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:desktop_theme, "all"),
+            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:common_theme, "all"),
           )
           .css("link")
           .first
@@ -672,7 +672,7 @@ RSpec.describe Discourse do
       css_link_tag =
         Nokogiri::HTML5
           .fragment(
-            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:desktop_theme, "all"),
+            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:common_theme, "all"),
           )
           .css("link")
           .first
@@ -697,7 +697,7 @@ RSpec.describe Discourse do
       css_link_tag =
         Nokogiri::HTML5
           .fragment(
-            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:desktop_theme, "all"),
+            Stylesheet::Manager.new(theme_id: theme.id).stylesheet_link_tag(:common_theme, "all"),
           )
           .css("link")
           .first

--- a/spec/lib/scss_checker_spec.rb
+++ b/spec/lib/scss_checker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Stylesheet::Manager::ScssChecker do
 
       theme_ids = [scss_theme.id, embedded_scss_theme.id]
 
-      desktop_theme_checker = described_class.new(:desktop_theme, theme_ids)
+      desktop_theme_checker = described_class.new(:common_theme, theme_ids)
 
       expect(desktop_theme_checker.has_scss(scss_theme.id)).to eq(true)
       expect(desktop_theme_checker.has_scss(embedded_scss_theme.id)).to eq(false)

--- a/spec/lib/stylesheet/compiler_spec.rb
+++ b/spec/lib/stylesheet/compiler_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Stylesheet::Compiler do
       theme.reload.with_scss_load_paths do |load_paths|
         css, _map =
           Stylesheet::Compiler.compile_asset(
-            "desktop_theme",
+            "common_theme",
             theme_id: theme.id,
             theme_variables: theme.scss_variables,
             load_paths: load_paths,

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -65,11 +65,9 @@ RSpec.describe Stylesheet::Manager do
       css = File.read(builder.stylesheet_fullpath)
       _source_map = File.read(builder.source_map_fullpath)
 
-      expect(css).to match(/\.common/)
       expect(css).to match(/\.desktop/)
 
       # child theme CSS is no longer bundled with main theme
-      expect(css).not_to match(/child_common/)
       expect(css).not_to match(/child_desktop/)
 
       child_theme_builder =
@@ -84,7 +82,6 @@ RSpec.describe Stylesheet::Manager do
       child_css = File.read(child_theme_builder.stylesheet_fullpath)
       _child_source_map = File.read(child_theme_builder.source_map_fullpath)
 
-      expect(child_css).to match(/child_common/)
       expect(child_css).to match(/child_desktop/)
 
       child_theme.set_field(target: :desktop, name: :scss, value: ".nothing{color: green;}")
@@ -887,7 +884,7 @@ RSpec.describe Stylesheet::Manager do
         manager = manager(theme.id)
 
         child_theme_manager =
-          Stylesheet::Manager::Builder.new(target: :desktop_theme, theme: child, manager: manager)
+          Stylesheet::Manager::Builder.new(target: :common_theme, theme: child, manager: manager)
 
         child_theme_manager.compile(force: true)
 
@@ -917,7 +914,7 @@ RSpec.describe Stylesheet::Manager do
       %w[common desktop mobile admin wizard common_rtl desktop_rtl mobile_rtl admin_rtl wizard_rtl]
     end
 
-    let(:theme_targets) { %i[desktop_theme mobile_theme] }
+    let(:theme_targets) { %i[common_theme desktop_theme mobile_theme] }
 
     before do
       STDERR.stubs(:write)
@@ -962,8 +959,8 @@ RSpec.describe Stylesheet::Manager do
       output = capture_output(:stderr) { Stylesheet::Manager.precompile_theme_css }
 
       # Ensure we force compile each theme only once
-      expect(output.scan(/#{child_theme_with_css.name}/).length).to eq(2)
-      expect(StylesheetCache.count).to eq(38) # (3 themes * 2 targets) + 32 color schemes (2 themes * 8 color schemes (7 defaults + 1 theme scheme) * 2 (light and dark mode per scheme))
+      expect(output.scan(/#{child_theme_with_css.name}/).length).to eq(1)
+      expect(StylesheetCache.count).to eq(33) # (1 theme with css) + 32 color schemes (2 themes * 8 color schemes (7 defaults + 1 theme scheme) * 2 (light and dark mode per scheme))
     end
 
     it "generates precompiled CSS - core and themes" do
@@ -971,13 +968,9 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(48) # 10 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
+      expect(results.size).to eq(43) # 10 core targets + 1 theme + 32 color schemes (light and dark mode per scheme)
 
-      theme_targets.each do |tar|
-        expect(
-          results.count { |target| target =~ /^#{tar}_(#{user_theme.id}|#{default_theme.id})$/ },
-        ).to eq(2)
-      end
+      expect(results.count { |target| target =~ /^common_theme_/ }).to eq(1)
     end
 
     it "correctly generates precompiled CSS - core and themes and no default theme" do
@@ -987,7 +980,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(48) # 10 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
+      expect(results.size).to eq(43) # 10 core targets + 1 theme + 32 color schemes (light and dark mode per scheme)
 
       expect(results).to include("color_definitions_#{scheme1.name}_#{scheme1.id}_#{user_theme.id}")
       expect(results).to include(
@@ -1027,7 +1020,7 @@ RSpec.describe Stylesheet::Manager do
       manager = manager(default_theme.id)
       theme_builder =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: default_theme,
           manager: manager,
         )

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -914,7 +914,7 @@ RSpec.describe Stylesheet::Manager do
 
   describe ".precompile_css" do
     let(:core_targets) do
-      %w[desktop mobile admin wizard desktop_rtl mobile_rtl admin_rtl wizard_rtl]
+      %w[common desktop mobile admin wizard common_rtl desktop_rtl mobile_rtl admin_rtl wizard_rtl]
     end
 
     let(:theme_targets) { %i[desktop_theme mobile_theme] }
@@ -971,7 +971,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(46) # 8 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
+      expect(results.size).to eq(48) # 10 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
 
       theme_targets.each do |tar|
         expect(
@@ -987,7 +987,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(46) # 8 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
+      expect(results.size).to eq(48) # 10 core targets + 6 theme + 32 color schemes (light and dark mode per scheme)
 
       expect(results).to include("color_definitions_#{scheme1.name}_#{scheme1.id}_#{user_theme.id}")
       expect(results).to include(

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -292,7 +292,7 @@ HTML
 
       scss, _map =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: theme,
           manager: manager,
         ).compile(force: true)
@@ -319,7 +319,7 @@ HTML
 
       scss, _map =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: theme,
           manager: manager,
         ).compile(force: true)
@@ -333,7 +333,7 @@ HTML
 
       scss, _map =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: theme,
           manager: manager,
         ).compile(force: true)
@@ -351,7 +351,7 @@ HTML
 
       scss, _map =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: theme,
           manager: manager,
         ).compile(force: true)
@@ -575,12 +575,16 @@ HTML
 
     theme = Fabricate(:theme, user_selectable: true, user: user, color_scheme_id: cs1.id)
 
-    messages = MessageBus.track_publish { theme.save! }.filter { |m| m.channel == "/file-change" }
+    messages =
+      MessageBus
+        .track_publish do
+          theme.set_field(target: :common, name: :scss, value: "body { color: red; }")
+          theme.save!
+        end
+        .filter { |m| m.channel == "/file-change" }
     expect(messages.count).to eq(1)
-    expect(messages.first.data.map { |d| d[:target] }).to contain_exactly(
-      :desktop_theme,
-      :mobile_theme,
-    )
+
+    expect(messages.first.data.map { |d| d[:target] }).to contain_exactly(:common_theme)
 
     # With color scheme change:
     messages =
@@ -594,9 +598,8 @@ HTML
     expect(messages.first.data.map { |d| d[:target] }).to contain_exactly(
       :admin,
       :desktop,
-      :desktop_theme,
       :mobile,
-      :mobile_theme,
+      :common_theme,
     )
   end
 
@@ -883,7 +886,7 @@ HTML
       manager = Stylesheet::Manager.new(theme_id: theme.id)
 
       builder =
-        Stylesheet::Manager::Builder.new(target: :desktop_theme, theme: theme, manager: manager)
+        Stylesheet::Manager::Builder.new(target: :common_theme, theme: theme, manager: manager)
 
       builder.compile(force: true)
     end
@@ -917,7 +920,7 @@ HTML
 
       builder =
         Stylesheet::Manager::Builder.new(
-          target: :desktop_theme,
+          target: :common_theme,
           theme: child_theme,
           manager: manager,
         )

--- a/spec/requests/safe_mode_controller_spec.rb
+++ b/spec/requests/safe_mode_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SafeModeController do
     it "never includes customizations" do
       theme = Fabricate(:theme)
       theme.set_field(target: :common, name: "header", value: "My Custom Header")
+      theme.set_field(target: :common, name: :scss, value: "body { background: red; }")
       theme.save!
       theme.set_default!
 


### PR DESCRIPTION
Previously we were compiling core and theme CSS into two targets: Desktop and Mobile. The majority of both files was the 'common' css. This commit splits those common styles into their own targets so that there is less duplication. This should improve compilation times + cache reuse, as well as opening the door for experiments with media-query-based mobile-modes.

The only functional change is that we can no longer use `@extend` to copy 'common' rules in core to mobile/desktop. This is probably for the best. Duplication and/or mixins are a more native-css pattern for this.

Plugins already have a common / mobile / desktop pattern, so are unchanged by this commit.