### PR TITLE
UX: Replace solid face-smile emoji picker icon with a regular one

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/index.gjs
@@ -14,7 +14,7 @@ export default class EmojiPicker extends Component {
   }
 
   get icon() {
-    return this.args.icon ?? "face-smile";
+    return this.args.icon ?? "far-face-smile";
   }
 
   get context() {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -112,7 +112,7 @@ acceptance("User Status", function (needs) {
     await visit("/");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-face-smile").exists("empty status icon is shown");
+    assert.dom(".d-icon-far-face-smile").exists("empty status icon is shown");
 
     await pickEmoji(userStatusEmoji);
 
@@ -305,7 +305,7 @@ acceptance("User Status", function (needs) {
     await click(".btn.delete-status");
     await openUserStatusModal();
 
-    assert.dom(".d-icon-face-smile").exists("empty status icon is shown");
+    assert.dom(".d-icon-far-face-smile").exists("empty status icon is shown");
     assert
       .dom(".user-status-description")
       .hasValue("", "no status description is shown");


### PR DESCRIPTION
Before/After

<img width="101" alt="image" src="https://github.com/user-attachments/assets/8cb670db-882b-43b2-b7e0-7306591f238a" /> <img width="101" alt="image" src="https://github.com/user-attachments/assets/6e0c9f6c-40ad-4914-ba71-7d0ef022bb76" />
