### PR TITLE
FEATURE: Allow a gjs initializer to be authored in local themes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -39,10 +39,10 @@ export default class AdminThemeEditor extends Component {
 
   @discourseComputed("currentTargetName", "fieldName")
   activeSectionMode(targetName, fieldName) {
-    if (["color_definitions"].includes(fieldName)) {
+    if (fieldName === "color_definitions") {
       return "scss";
     }
-    if (["js"].includes(fieldName)) {
+    if (fieldName === "js") {
       return "javascript";
     }
     return fieldName && fieldName.includes("scss") ? "scss" : "html";

--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -6,6 +6,13 @@ import discourseComputed from "discourse/lib/decorators";
 import { isDocumentRTL } from "discourse/lib/text-direction";
 import { i18n } from "discourse-i18n";
 
+const JS_DEFAULT_VALUE = `import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api) => {
+  // Your code here
+});
+`;
+
 export default class AdminThemeEditor extends Component {
   warning = null;
 
@@ -35,6 +42,9 @@ export default class AdminThemeEditor extends Component {
     if (["color_definitions"].includes(fieldName)) {
       return "scss";
     }
+    if (["js"].includes(fieldName)) {
+      return "javascript";
+    }
     return fieldName && fieldName.includes("scss") ? "scss" : "html";
   }
 
@@ -55,10 +65,20 @@ export default class AdminThemeEditor extends Component {
 
   @computed("fieldName", "currentTargetName", "theme")
   get activeSection() {
-    return this.theme.getField(this.currentTargetName, this.fieldName);
+    const themeValue = this.theme.getField(
+      this.currentTargetName,
+      this.fieldName
+    );
+    if (!themeValue && this.fieldName === "js") {
+      return JS_DEFAULT_VALUE;
+    }
+    return themeValue;
   }
 
   set activeSection(value) {
+    if (this.fieldName === "js" && value === JS_DEFAULT_VALUE) {
+      value = "";
+    }
     this.theme.setField(this.currentTargetName, this.fieldName, value);
   }
 

--- a/app/assets/javascripts/admin/addon/models/theme.js
+++ b/app/assets/javascripts/admin/addon/models/theme.js
@@ -8,11 +8,13 @@ import { i18n } from "discourse-i18n";
 import ThemeSettings from "admin/models/theme-settings";
 
 const THEME_UPLOAD_VAR = 2;
-const FIELDS_IDS = [0, 1, 5];
+const FIELDS_IDS = [0, 1, 5, 6];
 
 export const THEMES = "themes";
 export const COMPONENTS = "components";
 const SETTINGS_TYPE_ID = 5;
+
+const JS_FILENAME = "discourse/api-initializers/theme-initializer.gjs";
 
 class Theme extends RestModel {
   static munge(json) {
@@ -59,6 +61,7 @@ class Theme extends RestModel {
     return {
       common: [
         ...common,
+        "js",
         "color_definitions",
         "embedded_scss",
         "embedded_header",
@@ -172,6 +175,10 @@ class Theme extends RestModel {
   }
 
   getField(target, name) {
+    if (target === "common" && name === "js") {
+      target = "extra_js";
+      name = JS_FILENAME;
+    }
     let themeFields = this.themeFields;
     let key = this.getKey({ target, name });
     let field = themeFields[key];
@@ -191,6 +198,10 @@ class Theme extends RestModel {
     this.set("changed", true);
     let themeFields = this.themeFields;
     let field = { name, target, value, upload_id, type_id };
+    if (field.name === "js" && target === "common") {
+      field.target = "extra_js";
+      field.name = JS_FILENAME;
+    }
 
     // slow path for uploads and so on
     if (type_id && type_id > 1) {

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-edit.hbs
@@ -52,7 +52,7 @@
           @action={{this.save}}
           @disabled={{this.saveDisabled}}
           @translatedLabel={{this.saveButtonText}}
-          class="btn-primary"
+          class="btn-primary save-theme"
         />
       </div>
     </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6249,7 +6249,7 @@ en:
             title: "Define theme settings in YAML format"
           js:
             text: "JS"
-            title: "Define a javascript initializer"
+            title: "Define a JavaScript initializer"
           scss_color_variables_warning: 'Using core SCSS color variables in themes is deprecated. Please use CSS custom properties instead. See <a href="https://meta.discourse.org/t/-/77551#color-variables-2" target="_blank">this guide</a> for more details.'
           scss_warning_inline: "Using core SCSS color variables in themes is deprecated."
           all_filter: "All"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6247,6 +6247,9 @@ en:
           yaml:
             text: "YAML"
             title: "Define theme settings in YAML format"
+          js:
+            text: "JS"
+            title: "Define a javascript initializer"
           scss_color_variables_warning: 'Using core SCSS color variables in themes is deprecated. Please use CSS custom properties instead. See <a href="https://meta.discourse.org/t/-/77551#color-variables-2" target="_blank">this guide</a> for more details.'
           scss_warning_inline: "Using core SCSS color variables in themes is deprecated."
           all_filter: "All"

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -108,6 +108,30 @@ describe "Admin Customize Themes", type: :system do
       ace_content = find(".ace_content")
       expect(ace_content.text).to eq("console.log('test')")
     end
+
+    it "can edit the js field" do
+      visit("/admin/customize/themes/#{theme.id}/common/js/edit")
+
+      ace_content = find(".ace_content")
+      expect(ace_content.text).to include("// Your code here")
+      find(".ace_text-input", visible: false).fill_in(with: "console.log('test')\n")
+      find(".save-theme").click
+
+      try_until_success do
+        expect(
+          theme.theme_fields.find_by(target_id: Theme.targets[:extra_js])&.value,
+        ).to start_with("console.log('test')\n")
+      end
+
+      # Check content is loaded from db correctly
+      theme
+        .theme_fields
+        .find_by(target_id: Theme.targets[:extra_js])
+        .update!(value: "console.log('second test')")
+      visit("/admin/customize/themes/#{theme.id}/common/js/edit")
+      ace_content = find(".ace_content")
+      expect(ace_content.text).to include("console.log('second test')")
+    end
   end
 
   describe "when editing theme translations" do


### PR DESCRIPTION
Previously, the only way to author js/hbs via the admin panel was to use `<script>` tags. This strategy is not pretty, and doesn't provide access to proper ES module imports or gjs `<template>` syntax.

Our recommendation for most themes is still that they should be authored using a proper IDE, the `discourse_theme` CLI, and version-controlled using git. However, we understand that this isn't a good fit for everyone, and that there's still a place for simple admin-panel-ui-authored themes.

This commit introduces a "JS" tab in the admin theme editor, which corresponds to a file named `discourse/api-initializers/theme-initializer.gjs` in the theme. This means that everyone will be able to move towards the more modern syntaxes, and away from the old `<script>` patterns.

<img width="1106" alt="SCR-20250220-qhpj" src="https://github.com/user-attachments/assets/fe314ed9-f03a-4e4c-ba8b-47d8cd13d2ef" />
