### PR TITLE
UX: close thread panel with a single escape

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
@@ -73,13 +73,8 @@ export default class ChatComposerThread extends ChatComposer {
       return;
     }
 
-    if (this.isFocused) {
-      event.stopPropagation();
-      this.composer.blur();
-    } else {
-      this.pane.close().then(() => {
-        this.channelComposer.focus();
-      });
-    }
+    this.pane.close().then(() => {
+      this.channelComposer.focus();
+    });
   }
 }

--- a/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
 
     it "closes the thread panel" do
       chat_page.visit_thread(thread_1)
-      thread_page.composer.cancel_shortcut # ensures we are not focused in the composer
+
       page.send_keys(:escape)
 
       expect(side_panel_page).to have_no_open_thread

--- a/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
+++ b/plugins/chat/spec/system/chat/composer/shortcuts/thread_spec.rb
@@ -19,16 +19,6 @@ RSpec.describe "Chat | composer | shortcuts | thread", type: :system do
   end
 
   describe "Escape" do
-    context "when composer is focused" do
-      it "blurs the composer" do
-        chat_page.visit_thread(thread_1)
-        thread_page.composer.focus
-        thread_page.composer.cancel_shortcut
-
-        expect(side_panel_page).to have_open_thread
-      end
-    end
-
     it "closes the thread panel" do
       chat_page.visit_thread(thread_1)
 


### PR DESCRIPTION
Before this commit we were requiring two escapes:
- one to un-focus composer
- one to close panel