### PR TITLE
FEATURE: Type reactions in chat

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -18,7 +18,7 @@ import Site from "discourse/models/site";
 export const SKIP = "skip";
 export const CANCELLED_STATUS = "__CANCELLED";
 
-const ALLOWED_LETTERS_REGEXP = /[\s[{(/]/;
+const ALLOWED_LETTERS_REGEXP = /[\s[{(/+]/;
 let _autoCompletePopper, _inputTimeout;
 
 const keys = {

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -184,6 +184,11 @@ export function emojiExists(code) {
   return extendedEmojiMap.has(code) || emojiMap.has(code) || aliasMap.has(code);
 }
 
+export function normalizeEmoji(code) {
+  code = code.toLowerCase();
+  return extendedEmojiMap.get(code) || emojiMap.get(code) || aliasMap.get(code);
+}
+
 let toSearch;
 export function emojiSearch(term, options) {
   const maxResults = options?.maxResults;

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -186,7 +186,10 @@ export function emojiExists(code) {
 
 export function normalizeEmoji(code) {
   code = code.toLowerCase();
-  return extendedEmojiMap.get(code) || emojiMap.get(code) || aliasMap.get(code);
+  if (extendedEmojiMap.get(code) || emojiMap.get(code)) {
+    return code;
+  }
+  return aliasMap.get(code);
 }
 
 let toSearch;

--- a/app/assets/javascripts/pretty-text/addon/emoji/data.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji/data.js
@@ -8019,6 +8019,7 @@ export const replacements = {
   "🔍": "mag",
   "🔎": "mag_right",
   "❤️": "heart",
+  "❤": "heart",
   "💛": "yellow_heart",
   "💚": "green_heart",
   "💙": "blue_heart",

--- a/app/assets/javascripts/pretty-text/addon/emoji/data.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji/data.js
@@ -8018,7 +8018,7 @@ export const replacements = {
   "🖌": "paintbrush",
   "🔍": "mag",
   "🔎": "mag_right",
-  "❤": "heart",
+  "❤️": "heart",
   "💛": "yellow_heart",
   "💚": "green_heart",
   "💙": "blue_heart",

--- a/lib/emoji/db.json
+++ b/lib/emoji/db.json
@@ -3657,7 +3657,7 @@
       "name": "mag_right"
     },
     {
-      "code": "2764",
+      "code": "2764-fe0f",
       "name": "heart"
     },
     {

--- a/lib/emoji/db.json
+++ b/lib/emoji/db.json
@@ -3661,6 +3661,10 @@
       "name": "heart"
     },
     {
+      "code": "2764",
+      "name": "heart"
+    },
+    {
       "code": "1f49b",
       "name": "yellow_heart"
     },

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -6,8 +6,13 @@ import { cancel, next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
 import $ from "jquery";
-import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
-import { emojis, replacements, translations } from "pretty-text/emoji/data";
+import {
+  emojiExists,
+  emojiSearch,
+  isSkinTonableEmoji,
+  normalizeEmoji,
+} from "pretty-text/emoji";
+import { replacements, translations } from "pretty-text/emoji/data";
 import { Promise } from "rsvp";
 import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
 import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
@@ -268,8 +273,8 @@ export default class ChatComposer extends Component {
       } else {
         // Then check if the message is +:{emoji_code}:
         const emojiCode = reaction.substring(1, reaction.length - 1);
-        if (emojis.includes(emojiCode)) {
-          reactionCode = emojiCode;
+        if (emojiExists(emojiCode)) {
+          reactionCode = normalizeEmoji(emojiCode);
         }
       }
     }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -7,7 +7,6 @@ import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
 import $ from "jquery";
 import {
-  emojiExists,
   emojiSearch,
   isSkinTonableEmoji,
   normalizeEmoji,
@@ -273,9 +272,7 @@ export default class ChatComposer extends Component {
       } else {
         // Then check if the message is +:{emoji_code}:
         const emojiCode = reaction.substring(1, reaction.length - 1);
-        if (emojiExists(emojiCode)) {
-          reactionCode = normalizeEmoji(emojiCode);
-        }
+        reactionCode = normalizeEmoji(emojiCode);
       }
     }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -248,6 +248,15 @@ export default class ChatComposer extends Component {
       return;
     }
 
+    if (await this.reactingToLastMessage()) {
+      return;
+    }
+
+    await this.args.onSendMessage(this.draft);
+    this.composer.textarea.refreshHeight();
+  }
+
+  async reactingToLastMessage() {
     // Check if the message is a reaction to the latest message in the channel.
     const message = this.draft.message.trim();
     let reactionCode = "";
@@ -265,23 +274,19 @@ export default class ChatComposer extends Component {
       }
     }
 
-    if (reactionCode) {
-      if (this.lastMessage?.id) {
-        const interactor = new ChatMessageInteractor(
-          getOwner(this),
-          this.lastMessage,
-          this.context
-        );
+    if (reactionCode && this.lastMessage?.id) {
+      const interactor = new ChatMessageInteractor(
+        getOwner(this),
+        this.lastMessage,
+        this.context
+      );
 
-        await interactor.react(reactionCode, "add");
-      }
-
+      await interactor.react(reactionCode, "add");
       this.resetDraft();
-      return;
+      return true;
     }
 
-    await this.args.onSendMessage(this.draft);
-    this.composer.textarea.refreshHeight();
+    return false;
   }
 
   reportReplyingPresence() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -7,7 +7,7 @@ import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
 import $ from "jquery";
 import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
-import { translations } from "pretty-text/emoji/data";
+import { emojis, replacements, translations } from "pretty-text/emoji/data";
 import { Promise } from "rsvp";
 import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
 import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
@@ -248,6 +248,38 @@ export default class ChatComposer extends Component {
       return;
     }
 
+    // Check if the message is a reaction to the latest message in the channel.
+    const message = this.draft.message.trim();
+    let reactionCode = "";
+    if (message.startsWith("+")) {
+      const reaction = message.substring(1);
+      // First check if the message is +{emoji}
+      if (replacements[reaction]) {
+        reactionCode = replacements[reaction];
+      } else {
+        // Then check if the message is +:{emoji_code}:
+        const emojiCode = reaction.substring(1, reaction.length - 1);
+        if (emojis.includes(emojiCode)) {
+          reactionCode = emojiCode;
+        }
+      }
+    }
+
+    if (reactionCode) {
+      if (this.lastMessage?.id) {
+        const interactor = new ChatMessageInteractor(
+          getOwner(this),
+          this.lastMessage,
+          this.context
+        );
+
+        await interactor.react(reactionCode, "add");
+      }
+
+      this.resetDraft();
+      return;
+    }
+
     await this.args.onSendMessage(this.draft);
     this.composer.textarea.refreshHeight();
   }
@@ -478,7 +510,7 @@ export default class ChatComposer extends Component {
       treatAsTextarea: true,
       onKeyUp: (text, cp) => {
         const matches =
-          /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
+          /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()+])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
             text.substring(0, cp)
           );
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/channel.js
@@ -46,7 +46,7 @@ export default class ChatComposerChannel extends ChatComposer {
   }
 
   get lastMessage() {
-    return this.args.channel.lastMessage;
+    return this.args.channel.messagesManager.findLastMessage();
   }
 
   lastUserMessage(user) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/composer/thread.js
@@ -58,6 +58,10 @@ export default class ChatComposerThread extends ChatComposer {
     return i18n("chat.placeholder_thread");
   }
 
+  get lastMessage() {
+    return this.args.thread.messagesManager.findLastMessage();
+  }
+
   lastUserMessage(user) {
     return this.args.thread.messagesManager.findLastUserMessage(user);
   }

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -140,6 +140,16 @@ module PageObjects
         end
       end
 
+      def has_reaction?(message, emoji, text = nil)
+        within(message_reactions_list(message)) do
+          has_css?("[data-emoji-name=\"#{emoji}\"]", text: text)
+        end
+      end
+
+      def message_reactions_list(message)
+        within(message_by_id(message.id)) { find(".chat-message-reaction-list") }
+      end
+
       def message_by_id(id)
         find(message_by_id_selector(id))
       end


### PR DESCRIPTION
## ✨ What's This?

This change allows you to add a reaction to the most recent message, by sending a reaction message.

A reaction message can be formatted as `+{emoji}` (eg, `+❤️`), or as `+{emoji_code}` (eg, `+:heart:`).

## 📺 Screenshots

https://github.com/user-attachments/assets/37d18353-2d23-43d6-ba5e-73c8b3ab8784

## 👑 Testing

- Test that you can react normally to messages by typing the reaction.