### PR TITLE
FEATURE: Allow admins to access group chats

### DIFF
--- a/plugins/chat/app/models/chat/direct_message.rb
+++ b/plugins/chat/app/models/chat/direct_message.rb
@@ -27,7 +27,7 @@ module Chat
     end
 
     def user_can_access?(user)
-      users.include?(user)
+      users.include?(user) || group? && user.admin?
     end
 
     def chat_channel_title_for_user(chat_channel, acting_user)

--- a/plugins/chat/spec/models/chat/direct_message_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_spec.rb
@@ -120,4 +120,39 @@ describe Chat::DirectMessage do
       end
     end
   end
+
+  describe "#user_can_access?" do
+    context "when user is part of the chat" do
+      it "allows access" do
+        direct_message = Fabricate(:direct_message, users: [user1, user2])
+
+        expect(direct_message.user_can_access?(user1)).to eq(true)
+      end
+    end
+
+    context "when user is not part of the chat" do
+      it "denies access" do
+        user3 = Fabricate(:user)
+        direct_message = Fabricate(:direct_message, users: [user1, user2])
+
+        expect(direct_message.user_can_access?(user3)).to eq(false)
+      end
+    end
+
+    context "when the user is an admin" do
+      it "allows access to a group chat" do
+        admin = Fabricate(:admin)
+        direct_message = Fabricate(:direct_message, users: [user1, user2], group: true)
+
+        expect(direct_message.user_can_access?(admin)).to eq(true)
+      end
+
+      it "denies access to a personal chat" do
+        admin = Fabricate(:admin)
+        direct_message = Fabricate(:direct_message, users: [user1, user2], group: false)
+
+        expect(direct_message.user_can_access?(admin)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is this change?

In #31366, we added the ability for admins to remove people from group chats. However, that only works as long as the admin is already in the group chat.

For forum-side group messages, admins can join any of them at will. This PR extends that same ability to chat for parity.