### PR TITLE
DEV: Remove deprecated AuthProvider attributes

### DIFF
--- a/lib/auth/auth_provider.rb
+++ b/lib/auth/auth_provider.rb
@@ -12,48 +12,16 @@ class Auth::AuthProvider
       authenticator
       pretty_name
       title
-      message
       frame_width
       frame_height
       pretty_name_setting
       title_setting
-      full_screen_login
-      full_screen_login_setting
       custom_url
-      background_color
       icon
     ]
   end
 
   attr_accessor(*auth_attributes)
-
-  def background_color=(val)
-    Discourse.deprecate(
-      "(#{authenticator.name}) background_color is no longer functional. Please use CSS instead",
-      drop_from: "2.9.0",
-    )
-  end
-
-  def full_screen_login=(val)
-    Discourse.deprecate(
-      "(#{authenticator.name}) full_screen_login is now forced. The full_screen_login parameter can be removed from the auth_provider.",
-      drop_from: "2.9.0",
-    )
-  end
-
-  def full_screen_login_setting=(val)
-    Discourse.deprecate(
-      "(#{authenticator.name}) full_screen_login is now forced. The full_screen_login_setting parameter can be removed from the auth_provider.",
-      drop_from: "2.9.0",
-    )
-  end
-
-  def message=(val)
-    Discourse.deprecate(
-      "(#{authenticator.name}) message is no longer used because all logins are full screen. It should be removed from the auth_provider",
-      drop_from: "2.9.0",
-    )
-  end
 
   def name
     authenticator.name


### PR DESCRIPTION
### What is this change?

A number of attributes on `AuthProvider` are deprecated for and were marked for removal in 2.9.0.

This PR removes them.

### Verification

- [x] There are no deprecation warnings showing up in logs across all our hosting.
- [x] A search through all our repos yielded only one use ([PR to remove it](https://github.com/discourse/discourse-sketchup-sso/pull/19)).