### PR TITLE
FIX: prevent sidebar scroll on chat composer focus

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
@@ -93,11 +93,11 @@ export default class TextareaTextManipulation {
   // ensures textarea scroll position is correct
   blurAndFocus() {
     this.textarea?.blur();
-    this.textarea?.focus();
+    this.textarea?.focus({ preventScroll: true });
   }
 
   focus() {
-    this.textarea.focus();
+    this.textarea.focus({ preventScroll: true });
   }
 
   insertBlock(text) {


### PR DESCRIPTION
This issue has been impossible to repro locally so far, but we have reports of switching from one channel to another causing the sidebar to scroll to the bottom.

Looking at the trace of events, calling `blurAndFocus` is the last function call before it happens.