### PR TITLE
DEV: Remove unneeded -webkit prefixes from css

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -306,7 +306,7 @@ textarea {
   white-space: nowrap;
   cursor: pointer;
 
-  @include user-select(none);
+  user-select: none;
 
   .discourse-no-touch & {
     &:hover,

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -305,7 +305,6 @@ textarea {
 .sortable {
   white-space: nowrap;
   cursor: pointer;
-
   user-select: none;
 
   .discourse-no-touch & {

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -123,7 +123,7 @@
   }
 
   &__backdrop {
-    @include user-select(none);
+    user-select: none;
     position: fixed;
     top: 0;
     right: 0;
@@ -150,7 +150,7 @@
 }
 
 .modal-backdrop {
-  @include user-select(none);
+  user-select: none;
   position: fixed;
   top: 0;
   right: 0;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -329,7 +329,7 @@ nav.post-controls {
   justify-content: space-between;
   color: var(--d-post-control-text-color);
 
-  @include user-select(none);
+  user-select: none;
 
   .actions {
     display: inline-flex;
@@ -1272,7 +1272,7 @@ a.mention-group {
   @include mention;
 
   .user-status-message {
-    @include user-select(none);
+    user-select: none;
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -328,7 +328,6 @@ nav.post-controls {
   align-items: center;
   justify-content: space-between;
   color: var(--d-post-control-text-color);
-
   user-select: none;
 
   .actions {

--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -69,12 +69,9 @@ html.footer-nav-visible {
   }
 }
 
-@supports (-webkit-backdrop-filter: blur(10px)) {
+@supports (backdrop-filter: blur(10px)) {
   html:not(.footer-nav-ipad) .footer-nav {
     background-color: rgba(var(--header_background-rgb), 0.7);
-
-    /* prefix needed for iOS < 18 */
-    -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
   }
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -120,6 +120,8 @@ $hpad: 0.65em;
   padding: $vpad $hpad;
 }
 
+// Used to handle -webkit prefix, but now we have autoprefixer
+// Keeping for backward-compat with plugins/themes only
 @mixin user-select($mode) {
   user-select: $mode;
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -121,7 +121,6 @@ $hpad: 0.65em;
 }
 
 @mixin user-select($mode) {
-  -webkit-user-select: $mode;
   user-select: $mode;
 }
 

--- a/app/assets/stylesheets/common/table-builder/table-edit-decorator.scss
+++ b/app/assets/stylesheets/common/table-builder/table-edit-decorator.scss
@@ -1,6 +1,6 @@
 .btn-edit-table {
   -webkit-touch-callout: none;
-  @include user-select(none);
+  user-select: none;
 }
 
 .fullscreen-table-wrapper:hover .fullscreen-table-wrapper__buttons button {

--- a/app/assets/stylesheets/vendor/normalize.scss
+++ b/app/assets/stylesheets/vendor/normalize.scss
@@ -10,7 +10,7 @@
 
 html {
   line-height: 1.15; /* 1 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -257,7 +257,7 @@ body.wizard {
     background: var(--secondary);
     border-radius: 10px;
     cursor: grab;
-    @include user-select(none);
+    user-select: none;
 
     &.dragging {
       cursor: grabbing;

--- a/plugins/chat/assets/stylesheets/mixins/chat-reaction.scss
+++ b/plugins/chat/assets/stylesheets/mixins/chat-reaction.scss
@@ -8,7 +8,7 @@
   border: 1px solid var(--primary-300);
   background: transparent;
   cursor: pointer;
-  @include user-select(none);
+  user-select: none;
   transition: background 0.2s, border-color 0.2s;
 
   &.reacted {

--- a/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message-actions.scss
@@ -18,7 +18,7 @@
       }
 
       &.is-expanded {
-        @include user-select(text);
+        user-select: text;
         max-height: 80px;
         overflow-y: scroll;
       }

--- a/plugins/chat/assets/stylesheets/mobile/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-message.scss
@@ -9,7 +9,7 @@
   }
 
   #skip-link {
-    @include user-select(none);
+    user-select: none;
   }
 
   #skip-link,
@@ -18,7 +18,7 @@
   .chat-channel,
   .chat-thread {
     > * {
-      @include user-select(none);
+      user-select: none;
     }
   }
 

--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -1,6 +1,6 @@
 .inline-footnotes {
   a.expand-footnote {
-    @include user-select(none);
+    user-select: none;
     padding: 0 0.5em;
     margin: 0 0 0 0.25em;
     color: var(--primary-low-mid-or-secondary-high);


### PR DESCRIPTION
Now we have autoprefixer, we don't need to do this manually