### PR TITLE
FEATURE: revert/re-add import quote toolbar button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -871,6 +871,15 @@ export default class ComposerEditor extends Component {
 
   @action
   extraButtons(toolbar) {
+    toolbar.addButton({
+      id: "quote",
+      group: "fontStyles",
+      icon: "far-comment",
+      sendAction: this.composer.importQuote,
+      title: "composer.quote_post_title",
+      unshift: true,
+    });
+
     if (
       this.composer.allowUpload &&
       this.composer.uploadIcon &&

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -28,6 +28,7 @@ import { getOwnerWithFallback } from "discourse/lib/get-owner";
 import getURL from "discourse/lib/get-url";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
+import { buildQuote } from "discourse/lib/quote";
 import { emojiUnescape } from "discourse/lib/text";
 import {
   authorizesOneOrMoreExtensions,
@@ -845,6 +846,45 @@ export default class ComposerService extends Service {
   fullscreenComposer() {
     this.toggleFullscreen();
     return false;
+  }
+
+  // Import a quote from the post
+  @action
+  async importQuote(toolbarEvent) {
+    const postStream = this.get("topic.postStream");
+    let postId = this.get("model.post.id");
+
+    // If there is no current post, use the first post id from the stream
+    if (!postId && postStream) {
+      postId = postStream.get("stream.firstObject");
+    }
+
+    // If we're editing a post, fetch the reply when importing a quote
+    if (this.get("model.editingPost")) {
+      const replyToPostNumber = this.get("model.post.reply_to_post_number");
+      if (replyToPostNumber) {
+        const replyPost = postStream.posts.findBy(
+          "post_number",
+          replyToPostNumber
+        );
+
+        if (replyPost) {
+          postId = replyPost.id;
+        }
+      }
+    }
+
+    if (!postId) {
+      return;
+    }
+
+    this.set("model.loading", true);
+
+    const post = await this.store.find("post", postId);
+    const quote = buildQuote(post, post.raw, { full: true });
+
+    toolbarEvent.addText(quote);
+    this.set("model.loading", false);
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/composer-editor-test.gjs
@@ -51,4 +51,10 @@ module("Integration | Component | ComposerEditor", function (hooks) {
     await fillIn(".d-editor-input", `"><svg onload="prompt(/xss/)"></svg>`);
     assert.dom(".d-editor-preview").hasHtml('<p>"&gt;<svg></svg></p>');
   });
+
+  test("has a toolbar button to quote a post", async function (assert) {
+    await render(<template><ComposerEditor /></template>);
+
+    assert.dom(".d-editor-button-bar .btn.quote").exists();
+  });
 });


### PR DESCRIPTION
This PR reverts the removal of the import quote toolbar button that happened in https://github.com/discourse/discourse/pull/30815.

It re-adds the previously existing implementation without changes.