### PR TITLE
FIX: prevents sidebar to scroll when opening channel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/api-sections.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/api-sections.gjs
@@ -43,7 +43,7 @@ export default class SidebarApiSections extends Component {
   <template>
     <PanelHeader @sections={{this.filteredSections}} />
 
-    {{#each this.filteredSections as |section|}}
+    {{#each this.filteredSections key="name" as |section|}}
       <ApiSection
         @section={{section}}
         @collapsable={{@collapsable}}


### PR DESCRIPTION
This has been a very hard to track and reproduce bug, but after a lot of profiling I detected that a scroll was showing in the trace just after a RemoveChild in div.sidebar-sections.

I suspect the performance of this is bad due to a difficulty to reconciliate object identity and using key seems to help here as I was not able to reproduce the bug after.