### PR TITLE
DEV: allows to add a draft without persisting it

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-drafts-manager.js
@@ -11,10 +11,13 @@ export default class ChatDraftsManager extends Service {
     cancel(this._persistHandler);
   }
 
-  async add(message, channelId, threadId) {
+  async add(message, channelId, threadId, persist = true) {
     try {
       this.drafts[this.key(channelId, threadId)] = message;
-      await this.persistDraft(message, channelId, threadId);
+
+      if (persist) {
+        await this.persistDraft(message, channelId, threadId);
+      }
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log("Couldn't save draft", e);

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -236,7 +236,8 @@ export default class Chat extends Service {
             )
           ),
           storedDraft.channel_id,
-          storedDraft.thread_id
+          storedDraft.thread_id,
+          false
         );
       });
 


### PR DESCRIPTION
On chat setup we get the initial state of drafts for the current users, we need to add them to the drafts manager, but we don't need to store them again on the backend.

This commit adds a persist (boolean) parameter to the `ChatDraftsManager.add` service which when set to true will only add the draft on the frontend and not send it to the backend.

No test, as the behavior is already tested and unchanged, this is only a performance improvement.