### PR TITLE
DEV: Remove an obsolete gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,6 @@ group :test, :development do
   gem "annotate"
 
   gem "syntax_tree"
-  gem "syntax_tree-disable_ternary"
 
   gem "rspec-multi-mock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,6 @@ GEM
     stringio (3.1.5)
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
-    syntax_tree-disable_ternary (1.0.0)
     test-prof (1.4.4)
     thor (1.3.2)
     timeout (0.4.3)
@@ -748,7 +747,6 @@ DEPENDENCIES
   sshkey
   stackprof
   syntax_tree
-  syntax_tree-disable_ternary
   test-prof
   thor
   trilogy


### PR DESCRIPTION
that is now a built-in syntax_tree plugin