### PR TITLE
FIX: Include hostname in extra-locales URLs

### DIFF
--- a/app/controllers/extra_locales_controller.rb
+++ b/app/controllers/extra_locales_controller.rb
@@ -41,7 +41,7 @@ class ExtraLocalesController < ApplicationController
     end
 
     def url(bundle)
-      "#{GlobalSetting.cdn_url}#{Discourse.base_path}/extra-locales/#{bundle}?v=#{bundle_js_hash(bundle)}"
+      "#{GlobalSetting.cdn_url}#{Discourse.base_path}/extra-locales/#{bundle}?v=#{bundle_js_hash(bundle)}&__ws=#{Discourse.current_hostname}"
     end
 
     def client_overrides_exist?


### PR DESCRIPTION
Followup to 1b5e4b6b0fef9811839490f2ee3b9f31d5fbed3b

When running through a CDN in a multisite environment, the site hostname needs to be included in the path or query or the URL so that the 'current db' can be set correctly by rails multisite. Without this, the response will assume the default site in the cluster.