### PR TITLE
UX: add automation script description for pm sender

### DIFF
--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -385,6 +385,7 @@ en:
               label: PMs
             sender:
               label: PMs sender
+              description: "Ensure the sender has the correct permissions to send PMs to receiver"
         close_topic:
           fields:
             topic:


### PR DESCRIPTION
Adds a description to highlight the need for sender to have correct permissions when sending PM. Without the correct permissions the PM is not sent and a message is added to the site logs.

<img width="748" alt="Screenshot 2025-02-24 at 3 33 07 PM" src="https://github.com/user-attachments/assets/f5561991-536c-48a1-b6d3-c78457f2e513" />
