### PR TITLE
Added button to remove password from account 

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/services/dialog.js
+++ b/app/assets/javascripts/dialog-holder/addon/services/dialog.js
@@ -178,11 +178,12 @@ export default class DialogService extends Service {
 
   @bind
   didConfirmWrapped() {
-    if (this.didConfirm) {
-      this.didConfirm();
-    }
+    let didConfirm = this.didConfirm;
     this._confirming = true;
     this.dialogInstance.hide();
+    if (didConfirm) {
+      didConfirm();
+    }
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.gjs
@@ -116,8 +116,12 @@ export default class UserPasskeys extends Component {
       this.dialog.deleteConfirm({
         title: i18n("user.passkeys.confirm_delete_passkey"),
         didConfirm: () => {
-          this.args.model.deletePasskey(id).then(() => {
-            this.router.refresh();
+          this.args.model.deletePasskey(id).then((response) => {
+            if (response.success) {
+              this.router.refresh();
+            } else {
+              this.dialog.alert(response.message);
+            }
           });
         },
       });

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -107,11 +107,23 @@ export default class SecurityController extends Controller {
     }
   }
 
-  @discourseComputed("model", "siteSettings")
-  canRemovePassword(model, siteSettings) {
+  @discourseComputed(
+    "model.is_anonymous",
+    "model.no_password",
+    "siteSettings",
+    "model.user_passkeys",
+    "model.associated_accounts"
+  )
+  canRemovePassword(
+    isAnonymous,
+    noPassword,
+    siteSettings,
+    userPasskeys,
+    associatedAccounts
+  ) {
     if (
-      model.is_anonymous ||
-      model.no_password ||
+      isAnonymous ||
+      noPassword ||
       siteSettings.enable_discourse_connect ||
       !siteSettings.enable_local_logins
     ) {
@@ -119,8 +131,8 @@ export default class SecurityController extends Controller {
     }
 
     return (
-      model.associated_accounts?.length > 0 ||
-      (this.canUsePasskeys && model.user_passkeys?.length > 0)
+      associatedAccounts?.length > 0 ||
+      (this.canUsePasskeys && userPasskeys?.length > 0)
     );
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -107,17 +107,20 @@ export default class SecurityController extends Controller {
     }
   }
 
-  @discourseComputed(
-    "model.is_anonymous",
-    "model.no_password",
-    "model.associated_accounts"
-  )
-  canRemovePassword(isAnonymous, noPassword, associatedAccounts) {
+  @discourseComputed("model", "siteSettings")
+  canRemovePassword(model, siteSettings) {
+    if (
+      model.is_anonymous ||
+      model.no_password ||
+      siteSettings.enable_discourse_connect ||
+      !siteSettings.enable_local_logins
+    ) {
+      return false;
+    }
+
     return (
-      !isAnonymous &&
-      !noPassword &&
-      associatedAccounts &&
-      associatedAccounts.length > 0
+      model.associated_accounts?.length > 0 ||
+      (this.canUsePasskeys && model.user_passkeys?.length > 0)
     );
   }
 

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -591,6 +591,12 @@ export default class User extends RestModel.extend(Evented) {
     });
   }
 
+  async removePassword() {
+    return ajax(userPath(`${this.username}/remove-password`), {
+      type: "PUT",
+    });
+  }
+
   loadSecondFactorCodes() {
     return ajax("/u/second_factors.json", {
       type: "POST",

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -13,6 +13,34 @@
 
       {{this.passwordProgress}}
     </div>
+
+    {{#unless this.model.no_password}}
+      {{#if this.associatedAccountsLoaded}}
+        {{#if this.canRemovePassword}}
+          <div class="controls">
+            <DButton
+              @action={{this.removePassword}}
+              @icon="trash-can"
+              @label="user.change_password.remove"
+              class="btn-default"
+              @isLoading={{this.removePasswordInProgress}}
+            />
+          </div>
+          <div class="instructions">
+            {{i18n "user.change_password.remove_detail"}}
+          </div>
+        {{/if}}
+      {{else}}
+        <div class="controls">
+          <DButton
+            @action={{fn (route-action "checkEmail") this.model}}
+            @title="admin.users.check_email.title"
+            @icon="envelope"
+            @label="admin.users.check_email.text"
+          />
+        </div>
+      {{/if}}
+    {{/unless}}
   </div>
 
   {{#if this.canUsePasskeys}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -2,7 +2,12 @@
   <div class="control-group pref-password" data-setting-name="user-password">
     <label class="control-label">{{i18n "user.password.title"}}</label>
     <div class="controls">
-      <a href {{on "click" this.changePassword}} class="btn btn-default">
+      <a
+        href
+        {{on "click" this.changePassword}}
+        class="btn btn-default"
+        id="change-password-button"
+      >
         {{d-icon "envelope"}}
         {{#if this.model.no_password}}
           {{i18n "user.change_password.set_password"}}
@@ -19,6 +24,7 @@
         {{#if this.canRemovePassword}}
           <div class="controls">
             <DButton
+              id="remove-password-button"
               @action={{this.removePassword}}
               @icon="trash-can"
               @label="user.change_password.remove"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-security-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
@@ -20,6 +20,14 @@ acceptance("User Preferences - Security", function (needs) {
     });
 
     server.post("/session/forgot_password.json", () => {
+      return helper.response({ success: "Ok" });
+    });
+
+    server.post("/u/confirm-session.json", () => {
+      return helper.response({ success: "Ok" });
+    });
+
+    server.put("/u/eviltrout/remove-password", () => {
       return helper.response({ success: "Ok" });
     });
   });
@@ -219,5 +227,63 @@ acceptance("User Preferences - Security", function (needs) {
     assert
       .dom(".passkey-options-dropdown")
       .doesNotExist("does not show passkey options dropdown");
+  });
+
+  test("Remove Password availability", async function (assert) {
+    this.siteSettings.enable_passkeys = true;
+    await visit("/u/eviltrout/preferences/security");
+    // eviltrout starts with an entry in associated_accounts, can remove password
+    assert
+      .dom("#remove-password-button")
+      .exists("shows for user with associated account");
+
+    updateCurrentUser({
+      associated_accounts: null,
+    });
+
+    assert
+      .dom("#remove-password-button")
+      .doesNotExist(
+        "does not show for user with no associated account and no passkeys"
+      );
+
+    updateCurrentUser({
+      user_passkeys: [
+        {
+          id: 1,
+          name: "Password Manager",
+          last_used: "2023-10-09T20:03:20.986Z",
+          created_at: "2023-10-09T20:01:37.578Z",
+        },
+      ],
+    });
+    assert.dom("#remove-password-button").exists("shows for user with passkey");
+  });
+
+  test("Removing User Password", async function (assert) {
+    await visit("/u/eviltrout/preferences/security");
+    // eviltrout starts with an entry in associated_accounts, can remove password
+
+    await click("#remove-password-button");
+    assert
+      .dom(".dialog-body .confirm-session")
+      .exists(
+        "displays a dialog to confirm the user's identity before deleting password"
+      );
+    await fillIn(".confirm-session #password", "correct");
+    await click(".confirm-session .btn-primary");
+    assert
+      .dom(".dialog-body")
+      .hasText(i18n("user.change_password.remove_detail"));
+    await click(".dialog-footer .btn-danger");
+    assert
+      .dom("#remove-password-button")
+      .doesNotExist("hides remove password button once password is removed");
+    assert
+      .dom("#change-password-button")
+      .hasText(
+        i18n("user.change_password.set_password"),
+        "shows set password instead of change after password removed"
+      );
   });
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1695,7 +1695,7 @@ class UsersController < ApplicationController
 
     security_key = current_user.security_keys.find_by(id: params[:id].to_i)
 
-    if security_key.factor_type == UserSecurityKey.factor_types[:first_factor] &&
+    if security_key&.factor_type == UserSecurityKey.factor_types[:first_factor] &&
          current_user.passkey_credential_ids.length == 1
       if !current_user.has_password? && current_user.associated_accounts.blank?
         return render json: { success: false, message: I18n.t("user.cannot_remove_all_auth") }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -756,6 +756,11 @@ class UsersController < ApplicationController
     activation = UserActivator.new(user, request, session, cookies)
     activation.start
 
+    # just assign a password if we have an authenticator and no password
+    # this is the case for Twitter
+    user.password = SecureRandom.hex if user.password.blank? &&
+      (authentication.has_authenticator? || associations.present?)
+
     if user.save
       authentication.finish
       activation.finish

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -863,7 +863,9 @@ class UsersController < ApplicationController
 
     raise Discourse::NotFound if !user || !user.user_password
     raise Discourse::ReadOnly if staff_writes_only_mode? && !user.staff?
-    if !user.associated_accounts || user.associated_accounts.empty? || !secure_session_confirmed?
+    raise Discourse::InvalidAccess if !secure_session_confirmed?
+
+    if user.associated_accounts.blank? && user.passkey_credential_ids.blank?
       raise Discourse::InvalidAccess
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -758,7 +758,7 @@ class UsersController < ApplicationController
 
     # just assign a password if we have an authenticator and no password
     # this is the case for Twitter
-    user.password = SecureRandom.hex if user.password.blank? &&
+    user.password = SecureRandom.hex if user.password_required? && user.password.blank? &&
       (authentication.has_authenticator? || associations.present?)
 
     if user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -930,6 +930,10 @@ class User < ActiveRecord::Base
     @raw_password = pw # still required to maintain compatibility with usage of password-related User interface
   end
 
+  def remove_password()
+    user_password.destroy if user_password
+  end
+
   def password
     "" # so that validator doesn't complain that a password attribute doesn't exist
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -20,7 +20,8 @@ class UserSerializer < UserCardSerializer
              :associated_accounts,
              :profile_background_upload_url,
              :can_upload_profile_header,
-             :can_upload_user_card_background
+             :can_upload_user_card_background,
+             :no_password
 
   has_one :invited_by, embed: :object, serializer: BasicUserSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
@@ -343,6 +344,14 @@ class UserSerializer < UserCardSerializer
 
   def can_pick_theme_with_custom_homepage
     ThemeModifierHelper.new(theme_ids: Theme.enabled_theme_and_component_ids).custom_homepage
+  end
+
+  def no_password
+    true
+  end
+
+  def include_no_password?
+    !object.has_password?
   end
 
   private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1601,6 +1601,8 @@ en:
         choose: "Choose a password"
         verify_identity: "To continue, please verify your identity."
         title: "Password Reset"
+        remove: "Remove Password"
+        remove_detail: "This completely erases your password. Your account will no longer be accessible by using your password to log in unless you reset it."
 
       second_factor_backup:
         title: "Two-Factor Backup Codes"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3090,6 +3090,7 @@ en:
       one: "User %{username} has %{count} post in a public topic or personal message, so they can't be deleted."
       other: "User %{username} has %{count} posts in public topics or personal messages, so they can't be deleted."
     cannot_bulk_delete: "One or more users cannot be deleted either because they're an admin, have too many posts or have a very old post."
+    cannot_remove_all_auth: "You must have at least one associated account, a passkey, or a password set."
 
   unsubscribe_mailer:
     title: "Unsubscribe Mailer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -920,6 +920,11 @@ Discourse::Application.routes.draw do
           :constraints => {
             username: RouteFormat.username,
           }
+      put "#{root_path}/:username/remove-password" => "users#remove_password",
+          :format => :json,
+          :constraints => {
+            username: RouteFormat.username,
+          }
     end
 
     get "user-badges/:username.json" => "user_badges#username",

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -54,7 +54,7 @@ describe "User preferences | Security", type: :system do
   shared_examples "passkeys" do
     before { SiteSetting.enable_passkeys = true }
 
-    it "adds a passkey and logs in with it" do
+    it "adds a passkey, removes user password, logs in with passkey" do
       options =
         ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
           user_verification: true,
@@ -94,6 +94,11 @@ describe "User preferences | Security", type: :system do
 
       # close the dialog (don't delete the key, we need it to login in the next step)
       find(".dialog-close").click
+
+      find("#remove-password-button").click
+      # already confirmed session for the passkey, so this will go straight for the confirmation dialog
+      find(".dialog-footer .btn-danger").click
+      expect(user_preferences_security_page).to have_no_css("#remove-password-button")
 
       user_menu.sign_out
 


### PR DESCRIPTION
Available if user has at least one linked external account or a passkey login method set up.

This removes the user_password entry so the hash no longer remains in the database. Users can still reset their password with the usual password reset email methods.

