### PR TITLE
DEV: Add command to `execute_command` errors

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -169,13 +169,8 @@ module Discourse
         stdout, stderr, status = Open3.capture3(*args, chdir: chdir)
 
         if !status.exited? || !success_status_codes.include?(status.exitstatus)
-          failure_message = "#{failure_message}\n" if !failure_message.blank?
-          raise CommandError.new(
-                  "#{caller[0]}: #{failure_message}#{stderr}",
-                  stdout: stdout,
-                  stderr: stderr,
-                  status: status,
-                )
+          message = [command, failure_message, stderr].filter(&:present?).join("\n")
+          raise CommandError.new(message, stdout: stdout, stderr: stderr, status: status)
         end
 
         stdout

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -550,6 +550,12 @@ RSpec.describe Discourse do
         "a b c",
       )
     end
+
+    it "includes the command in the error message" do
+      expect do
+        Discourse::Utils.execute_command("false", failure_message: "oops")
+      end.to raise_error(RuntimeError, "false\noops")
+    end
   end
 
   describe ".clear_all_theme_cache!" do


### PR DESCRIPTION
…and remove `caller[0]`, we already have the stack