### PR TITLE
PERF: Set `cluster_concurrency` for `Jobs::UpdateUsername` to 1

### DIFF
--- a/app/jobs/regular/update_username.rb
+++ b/app/jobs/regular/update_username.rb
@@ -3,6 +3,9 @@
 module Jobs
   class UpdateUsername < ::Jobs::Base
     sidekiq_options queue: "low"
+    # this is an extremely expensive job
+    # we are limiting it so only 1 per cluster runs
+    cluster_concurrency 1
 
     def execute(args)
       @user_id = args[:user_id]


### PR DESCRIPTION
This optimization is similar to the optimization applied in
eb603b246bad6df964b179a047a63e2b7894be8a. As part of the
`UserAnonymizer#make_anonymous` method call, the `Jobs::UpdateUsername`
sidekiq job is enqueued and this job runs many expensive and hard to
optimize SQL queries. Hence, we are restricting the `cluster_concurrency` for
the sidekiq job to `1` to prevent the database from being overloaded in
the event that many users are being anonymized in a short period of
time.
