### PR TITLE
FIX: include silence_reason when admin sees user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,6 +50,7 @@ class Admin::UsersController < Admin::StaffController
       AdminDetailedUserSerializer,
       root: false,
       similar_users_count: @user.similar_users.count,
+      include_silence_reason: true,
     )
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe Admin::UsersController do
         end
       end
 
+      it "returns silence reason when user is silenced" do
+        silencer =
+          UserSilencer.new(
+            user,
+            admin,
+            message: :too_many_spam_flags,
+            reason: "because I said so",
+            keep_posts: true,
+          )
+        silencer.silence
+
+        get "/admin/users/#{user.id}.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["silence_reason"]).to eq("because I said so")
+      end
+
       context "with a non-existing user" do
         it "returns 404 error" do
           get "/admin/users/0.json"


### PR DESCRIPTION
Small regression created in this PR https://github.com/discourse/discourse/pull/30635

The reason is included only when `include_silence_reason` option is included.