### PR TITLE
DEV: Fix username/name mapping for Discord auth

### DIFF
--- a/lib/auth/discord_authenticator.rb
+++ b/lib/auth/discord_authenticator.rb
@@ -16,7 +16,7 @@ class Auth::DiscordAuthenticator < Auth::ManagedAuthenticator
 
     info do
       {
-        name: raw_info["global_name"],
+        name: raw_info["global_name"] || raw_info["username"],
         nickname: raw_info["username"],
         email: raw_info["verified"] ? raw_info["email"] : nil,
         image: "https://cdn.discordapp.com/avatars/#{raw_info["id"]}/#{raw_info["avatar"]}",

--- a/lib/auth/discord_authenticator.rb
+++ b/lib/auth/discord_authenticator.rb
@@ -16,7 +16,8 @@ class Auth::DiscordAuthenticator < Auth::ManagedAuthenticator
 
     info do
       {
-        name: raw_info["username"],
+        name: raw_info["global_name"],
+        nickname: raw_info["username"],
         email: raw_info["verified"] ? raw_info["email"] : nil,
         image: "https://cdn.discordapp.com/avatars/#{raw_info["id"]}/#{raw_info["avatar"]}",
       }

--- a/spec/lib/auth/discord_authenticator_spec.rb
+++ b/spec/lib/auth/discord_authenticator_spec.rb
@@ -3,11 +3,12 @@
 RSpec.describe Auth::DiscordAuthenticator do
   let(:hash) do
     OmniAuth::AuthHash.new(
-      provider: "facebook",
+      provider: "discord",
       extra: {
         raw_info: {
           id: "100",
           username: "bobbob",
+          global_name: "The Bob",
           guilds: [
             {
               id: "80351110224678912",
@@ -21,7 +22,8 @@ RSpec.describe Auth::DiscordAuthenticator do
       },
       info: {
         email: "bob@bob.com",
-        name: "bobbob",
+        name: "The Bob",
+        nickname: "bobbob",
       },
       uid: "100",
     )
@@ -34,7 +36,8 @@ RSpec.describe Auth::DiscordAuthenticator do
       result = authenticator.after_authenticate(hash)
       expect(result.user).to eq(nil)
       expect(result.failed).to eq(false)
-      expect(result.name).to eq("bobbob")
+      expect(result.name).to eq("The Bob")
+      expect(result.username).to eq("bobbob")
       expect(result.email).to eq("bob@bob.com")
     end
 
@@ -51,7 +54,8 @@ RSpec.describe Auth::DiscordAuthenticator do
       result = authenticator.after_authenticate(hash)
       expect(result.user).to eq(nil)
       expect(result.failed).to eq(false)
-      expect(result.name).to eq("bobbob")
+      expect(result.name).to eq("The Bob")
+      expect(result.username).to eq("bobbob")
       expect(result.email).to eq("bob@bob.com")
     end
   end


### PR DESCRIPTION
Previously we were applying the Discord username to both the name and the username fields in Discourse.

Supersedes https://github.com/discourse/discourse/pull/30994