### PR TITLE
FIX: Use `[]()` Markdown syntax for links instead of `<>` for narrative bot

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -181,9 +181,9 @@ en:
 
           To copy any link, tap and hold on mobile, or right click your pointing device:
 
-           <https://en.wikipedia.org/wiki/Inherently_funny_word>
-           <https://en.wikipedia.org/wiki/Death_by_coconut>
-           <https://en.wikipedia.org/wiki/Calculator_spelling>
+           [https://en.wikipedia.org/wiki/Inherently_funny_word](https://en.wikipedia.org/wiki/Inherently_funny_word)
+           [https://en.wikipedia.org/wiki/Death_by_coconut](https://en.wikipedia.org/wiki/Death_by_coconut)
+           [https://en.wikipedia.org/wiki/Calculator_spelling](https://en.wikipedia.org/wiki/Calculator_spelling)
         reply: |-
           Cool! This will work for most <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-link.png" width="16" height="16"> links. Remember, it must be on a line _all by itself_, with nothing else in front, or behind.
         not_found: |-
@@ -191,7 +191,7 @@ en:
 
           Can you try adding the following link, on its own line, in your next reply?
 
-          <https://en.wikipedia.org/wiki/Exotic_Shorthair>
+          [https://en.wikipedia.org/wiki/Exotic_Shorthair](https://en.wikipedia.org/wiki/Exotic_Shorthair)
 
       images:
         instructions: |-


### PR DESCRIPTION
In one of the discourse narrative bot tutorial steps, we show the user a few links and ask them to copy one and paste it in a reply to teach them about oneboxes. In order to prevent the links from getting oneboxed in the bot's post, we enclose them in `<>` which makes the links render as-is without oneboxing.

However, if an admin attempts to customize via site texts the tutorial step about onebox, the links enclosed in `<>` get removed completely from the step content because they're interpreted as HTML tags when the text override goes through sanitization (see [relevant code](https://github.com/discourse/discourse/blob/424da95128bd2e92c4d8e42baf65a947602e9c68/app/models/translation_override.rb#L73-L74)).

To prevent that, this PR changes the default content for the onebox step to use the `[]()` syntax which doesn't get sanitized and also doesn't get oneboxed.

Internal topic: t/147912.