### PR TITLE
FEATURE: Allow chat incoming webhooks to work without `.json` extension

### DIFF
--- a/plugins/chat/app/models/chat/incoming_webhook.rb
+++ b/plugins/chat/app/models/chat/incoming_webhook.rb
@@ -19,7 +19,7 @@ module Chat
     validates :emoji, length: { maximum: 100 }
 
     def url
-      "#{Discourse.base_url}/chat/hooks/#{key}.json"
+      "#{Discourse.base_url}/chat/hooks/#{key}"
     end
   end
 end

--- a/plugins/chat/config/routes.rb
+++ b/plugins/chat/config/routes.rb
@@ -69,10 +69,22 @@ Chat::Engine.routes.draw do
   get "/direct_messages" => "direct_messages#index"
 
   # incoming_webhooks_controller routes
-  post "/hooks/:key" => "incoming_webhooks#create_message"
+  post "/hooks/:key" => "incoming_webhooks#create_message",
+       :constraints => {
+         format: :json,
+       },
+       :defaults => {
+         format: :json,
+       }
 
   # incoming_webhooks_controller routes
-  post "/hooks/:key/slack" => "incoming_webhooks#create_message_slack_compatible"
+  post "/hooks/:key/slack" => "incoming_webhooks#create_message_slack_compatible",
+       :constraints => {
+         format: :json,
+       },
+       :defaults => {
+         format: :json,
+       }
 
   # chat_controller routes
   get "/" => "chat#respond"

--- a/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
@@ -147,5 +147,14 @@ RSpec.describe Chat::IncomingWebhooksController do
         "New alert: \"[StatusCake] https://www.test_notification.com (StatusCake Test Alert): Down,\" [46353](https://eu.opsg.in/a/i/test/blahguid)\nTags:",
       )
     end
+
+    it "works without .json extension" do
+      expect { post "/chat/hooks/#{webhook.key}", params: valid_payload }.to change {
+        Chat::Message.where(chat_channel: chat_channel).count
+      }.by(1)
+      expect(response.status).to eq(200)
+      chat_webhook_event = Chat::WebhookEvent.last
+      expect(chat_webhook_event.chat_message_id).to eq(Chat::Message.last.id)
+    end
   end
 end


### PR DESCRIPTION
This provides a slightly nicer-looking URL, and also helps when external systems have strict validations on the webhook URL.