### PR TITLE
FIX: do not add `_pm` suffix to locale key when email is from system user

### DIFF
--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -47,7 +47,9 @@ module Email
         else
           if @opts[:only_reply_by_email]
             string = +"user_notifications.only_reply_by_email"
-            string << "_pm" if @opts[:private_reply]
+            if @opts[:private_reply] && @opts[:username] != Discourse.system_user.username
+              string << "_pm"
+            end
           else
             string =
               (
@@ -57,7 +59,9 @@ module Email
                   +@visit_link_to_respond_key
                 end
               )
-            string << "_pm" if @opts[:private_reply]
+            if @opts[:private_reply] && @opts[:username] != Discourse.system_user.username
+              string << "_pm"
+            end
           end
           @template_args[:respond_instructions] = "---\n" + I18n.t(string, @template_args)
         end


### PR DESCRIPTION
See https://meta.discourse.org/t/email-footer-says-visit-message-to-respond-to-no-names-after-to/354359 

There may be a deeper root issue somewhere further up the stack, but this change ensures we always use the `visit_link_to_respond` locale key when the PM is from `system`. Seems cleaner than copy that says `to respond to system`. 

Before

![CleanShot 2025-02-25 at 10 38 44@2x](https://github.com/user-attachments/assets/ef12a957-72f7-418e-a109-448384e32def)

After

![CleanShot 2025-02-25 at 10 38 25@2x](https://github.com/user-attachments/assets/d8359812-63c5-444a-b36a-75a2e0bcfbb0)

