### PR TITLE
FIX: Force pagination only if more than 1000 subcategories

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/discovery/list.gjs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/list.gjs
@@ -39,6 +39,7 @@ export default RouteTemplate(
           <CategoriesDisplay
             @categories={{@controller.model.subcategoryList.categories}}
             @parentCategory={{@controller.model.subcategoryList.parentCategory}}
+            @loadMore={{@controller.model.subcategoryList.loadMore}}
           />
         {{/if}}
         {{#if (and @controller.showTagInfo @controller.model.tag)}}

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -444,4 +444,31 @@ RSpec.describe CategoryList do
       end
     end
   end
+
+  describe "with many categories (more than MAX_UNOPTIMIZED_CATEGORIES)" do
+    fab!(:category)
+    fab!(:subcategory) { Fabricate(:category, parent_category: category) }
+
+    it "returns at most CATEGORIES_PER_PAGE categories" do
+      stub_const(CategoryList, "MAX_UNOPTIMIZED_CATEGORIES", 1) do
+        category_list = CategoryList.new(Guardian.new(user))
+
+        expect(category_list.categories).to eq(
+          [Category.find(SiteSetting.uncategorized_category_id), category, subcategory],
+        )
+      end
+    end
+
+    context "with parent_category_id" do
+      it "returns at most CATEGORIES_PER_PAGE subcategories" do
+        subcategory_2 = Fabricate(:category, parent_category: category)
+
+        stub_const(CategoryList, "MAX_UNOPTIMIZED_CATEGORIES", 1) do
+          category_list = CategoryList.new(Guardian.new(user), parent_category_id: category.id)
+
+          expect(category_list.categories).to eq([subcategory, subcategory_2])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Commit f1700ca58929bcbfad23565861d1d3084ae1b3f8 ensures that categories are loaded lazily, in pages, if the number of visible categories is over
1000. This affected the list of subcategories on the category page too.

The logic has been changed to only paginate if the number of categories that would have been returned is grater than 1000. For example, if there is a parent category filter, pagination will only be enforced if the number of subcategories is over 1000.