### PR TITLE
FIX: Block Googlebot from `/search`

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -15,13 +15,14 @@ class RobotsTxtController < ApplicationController
     /auth/
     /assets/browser-update*.js
     /email/
+    /search
     /session
     /user-api-key
     /*?api_key*
     /*?*api_key*
   ]
 
-  DISALLOWED_WITH_HEADER_PATHS = %w[/badges /my /search /tag/*/l /g /t/*/*.rss /c/*.rss]
+  DISALLOWED_WITH_HEADER_PATHS = %w[/badges /my /tag/*/l /g /t/*/*.rss /c/*.rss]
 
   def index
     if (overridden = SiteSetting.overridden_robots_txt.dup).present?

--- a/db/migrate/20250226001048_add_search_to_overriden_robots.rb
+++ b/db/migrate/20250226001048_add_search_to_overriden_robots.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class AddSearchToOverridenRobots < ActiveRecord::Migration[7.2]
+  def up
+    googlebot_agent_disallow =
+      "User-agent: Googlebot\nDisallow: /admin/\nDisallow: /auth/\nDisallow: /assets/browser-update*.js\nDisallow: /email/\nDisallow: /session"
+    googlebot_agent_disallow_search_added =
+      "User-agent: Googlebot\nDisallow: /admin/\nDisallow: /auth/\nDisallow: /assets/browser-update*.js\nDisallow: /email/\nDisallow: /search\nDisallow: /session"
+    if select_value(
+         "SELECT value FROM site_settings WHERE name = 'overridden_robots_txt' AND value LIKE '%#{googlebot_agent_disallow}%'",
+       )
+      execute <<~SQL
+        UPDATE site_settings
+        SET value = REPLACE(value, '#{googlebot_agent_disallow}', '#{googlebot_agent_disallow_search_added}')
+        WHERE name = 'overridden_robots_txt'
+      SQL
+    end
+  end
+
+  def down
+    # raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## ✨ What's This?

Our `robots.txt` currently disallows `/search` for all crawlers, except for Googlebot. As per [the Googlebot docs](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt), Googlebot will ignore the `User-agent: *` section if it finds a more specific section (eg, our `User-agent: Googlebot` section).

This change keeps `/search` in the section for all bots, whilst adding it to the Googlebot section, too. It also attempts to add it to customised `robots.txt` files, if they haven't changed the Googlebot section.

## 👑 Testing

- For customised `robots.txt` files, check that `/search` is added to the Googlebot section, and nothing else is touched when running the migration.
- For default `robots.txt` files, check that `/search` is added to the Googlebot section, and remains in the section for all bots, too.