### PR TITLE
DEV: Adds empty device screenshot workflow file

### DIFF
--- a/.github/workflows/device-screenshots.yml
+++ b/.github/workflows/device-screenshots.yml
@@ -1,0 +1,15 @@
+name: device-screenshots
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  sanitize:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'thenonexistentguy'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Debug event data
+        run: echo "${{ toJson(github.event) }}"


### PR DESCRIPTION
This is for continued experimentation in https://github.com/discourse/discourse/pull/31410,
GitHub does not react to the issue_comment event unless the workflow file is in main already,
see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment

This workflow is a noop, it will be actually written/tested
in the linked PR
