### PR TITLE
FEATURE: limits post created edited trigger to a group

### DIFF
--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -162,11 +162,11 @@ en:
             restricted_category:
               label: Category
               description: Optional, will trigger only if the post's topic is in this category
-            restricted_group:
-              label: Group
-              description: Optional, will trigger only if the post's topic is a personal message in this group's inbox
+            restricted_user_group:
+              label: Restricted user group
+              description: Optional, will trigger only if the post user is in this group
             restricted_groups:
-              label: Groups
+              label: Restricted inboxes groups
               description: Optional, will trigger only if the post's topic is a personal message in one of the group inboxes
             ignore_group_members:
               label: Ignore group members

--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -65,6 +65,9 @@ module DiscourseAutomation
             next if ignore_group_members && post.user.in_any_groups?(restricted_group_ids)
           end
 
+          user_group = automation.trigger_field("restricted_user_group")["value"]
+          next if user_group && !post.user.in_any_groups?([user_group])
+
           ignore_automated = automation.trigger_field("ignore_automated")
           next if ignore_automated["value"] && post.incoming_email&.is_auto_generated?
 

--- a/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
@@ -15,6 +15,7 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::POST_CREATED
   field :restricted_category, component: :category
   field :restricted_tags, component: :tags
   field :restricted_groups, component: :groups
+  field :restricted_user_group, component: :group
   field :ignore_automated, component: :boolean
   field :ignore_group_members, component: :boolean
   field :valid_trust_levels, component: :"trust-levels"

--- a/plugins/automation/spec/triggers/post_created_edited_spec.rb
+++ b/plugins/automation/spec/triggers/post_created_edited_spec.rb
@@ -126,6 +126,38 @@ describe "PostCreatedEdited" do
       expect(list[0]["action"].to_s).to eq("edit")
     end
 
+    context "when user group is restricted" do
+      fab!(:group)
+
+      before do
+        automation.upsert_field!(
+          "restricted_user_group",
+          "group",
+          { value: group.id },
+          target: "trigger",
+        )
+      end
+
+      context "when user is member of the group" do
+        before { group.add(user) }
+
+        it "fires the trigger" do
+          list = capture_contexts { PostCreator.create(user, basic_topic_params) }
+
+          expect(list.length).to eq(1)
+          expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+      end
+
+      context "when user is not member of the group" do
+        it "doesn’t fire the trigger" do
+          list = capture_contexts { PostCreator.create(user, basic_topic_params) }
+
+          expect(list).to be_blank
+        end
+      end
+    end
+
     context "when trust_levels are restricted" do
       before do
         automation.upsert_field!(


### PR DESCRIPTION
This commit allows admins to limit the post created/edited trigger execution to a specific post user group.

It's for example useful if you want to auto tag all the topics created by member of a specific group.