### PR TITLE
DEV: Hide non-en locale files in IDE search

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -6,3 +6,7 @@
 # though they're not git-tracked
 !/.vscode/settings.json
 !/.vscode/tasks.json
+
+# Hide non-en locales from IDE search. They are managed in crowdin
+**/config/locales/*.yml
+!**/config/locales/*.en.yml


### PR DESCRIPTION
These files are managed automatically via crowdin, so they should never be edited locally. Adding them to `.ignore` will stop them polluting search results in IDEs which support `.ignore` (e.g. VSCode)