### PR TITLE
DEV: Correct truth-helper exports

### DIFF
--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./src/index.js",
     "./*": "./src/*.js",
+    "./app/*": "./app/*.js",
     "./addon-main.js": "./addon-main.cjs"
   },
   "files": [


### PR DESCRIPTION
In modern embroider, `app-js` files need to be exported by the module.

We need to keep the separate `app/` directory because this v2 addon doesn't have a build step, and therefore the relative imports in the `src/helpers` files would break if loaded as-is into the app bundle.