### PR TITLE
DEV: Use intersection observer to trigger `loadMore`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -1,9 +1,12 @@
+import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import { classNames } from "@ember-decorators/component";
 import { observes, on } from "@ember-decorators/object";
 import $ from "jquery";
+import { log } from "qunit";
 import { applyBehaviorTransformer } from "discourse/lib/transformer";
 import LoadMore from "discourse/mixins/load-more";
 
@@ -11,7 +14,8 @@ import LoadMore from "discourse/mixins/load-more";
 export default class DiscoveryTopicsList extends Component.extend(LoadMore) {
   @service appEvents;
   @service documentTitle;
-  eyelineSelector = ".topic-list-item";
+  @tracked observer;
+  eyelineSelector = ".topic-list-item:last-of-type";
 
   @on("didInsertElement")
   _monitorTrackingState() {
@@ -20,10 +24,48 @@ export default class DiscoveryTopicsList extends Component.extend(LoadMore) {
     );
   }
 
+  @on("didInsertElement")
+  _setupIntersectionObserver() {
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const bcr = entry.boundingClientRect;
+          const isBottomVisible = bcr.bottom < window.innerHeight && bcr.bottom;
+          if (isBottomVisible) {
+            this.loadMore();
+            scheduleOnce("afterRender", this, this._observeLastTopic);
+          }
+        });
+      },
+      {
+        root: document.querySelector("#main-outlet"),
+        rootMargin: "0px",
+        threshold: 1.0,
+      }
+    );
+
+    scheduleOnce("afterRender", this, this._observeLastTopic);
+  }
+
   @on("willDestroyElement")
   _removeTrackingStateChangeMonitor() {
     if (this.stateChangeCallbackId) {
       this.topicTrackingState.offStateChange(this.stateChangeCallbackId);
+    }
+  }
+
+  @on("willDestroyElement")
+  _cleanupIntersectionObserver() {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  _observeLastTopic() {
+    const lastTopic = this.element.querySelector(this.eyelineSelector);
+
+    if (lastTopic) {
+      this.observer.observe(lastTopic);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -6,7 +6,6 @@ import { service } from "@ember/service";
 import { classNames } from "@ember-decorators/component";
 import { observes, on } from "@ember-decorators/object";
 import $ from "jquery";
-import { log } from "qunit";
 import { applyBehaviorTransformer } from "discourse/lib/transformer";
 import LoadMore from "discourse/mixins/load-more";
 


### PR DESCRIPTION
I did a small bit of research into this, and it looks like the way `eyeline` works is now outdated due to the availability of [IntersectionObservers](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) in the browser.

I tested swapping to use an intersectionObserver locally and it works just as well as `eyeline`, except it *also* works when styles significantly alter the height of objects.

With the help of claude sonnet 3.7, I was able to get it working within the `discovery-topics-list.js` file.

Here is a janky draft PR to view what I did. (this would not be kosher for core, but I wanted to show how it worked)