### PR TITLE
FIX: Error when leaving group DM channel

### DIFF
--- a/plugins/chat/app/jobs/regular/chat/notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat/notify_watching.rb
@@ -51,7 +51,7 @@ module Jobs
         translation_key =
           (
             if @is_direct_message_channel
-              if @chat_channel.chatable.group
+              if @chat_channel.direct_message_group?
                 "discourse_push_notifications.popup.new_chat_message"
               else
                 "discourse_push_notifications.popup.new_direct_chat_message"
@@ -63,7 +63,7 @@ module Jobs
 
         translation_args = { username: @creator.username }
         translation_args[:channel] = @chat_channel.title(user) unless @is_direct_message_channel &&
-          !@chat_channel.chatable.group
+          !@chat_channel.direct_message_group?
         translation_args =
           DiscoursePluginRegistry.apply_modifier(
             :chat_notification_translation_args,

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -144,7 +144,10 @@ module Chat
     def remove(user)
       Chat::ChannelMembershipManager.new(self).unfollow(user)
     end
-    alias leave remove
+
+    def leave(user)
+      self.remove(user)
+    end
 
     def url
       "#{Discourse.base_url}/chat/c/#{self.slug || "-"}/#{self.id}"

--- a/plugins/chat/app/services/chat/leave_channel.rb
+++ b/plugins/chat/app/services/chat/leave_channel.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 module Chat
-  # Service responsible to flag a message.
+  # Service responsible for completely leaving a channel,
+  # which does something different depending on the channel:
+  #
+  # Category channels - Unfollows the channel similar to
+  # behaviour of Chat::UnfollowChannel
+  # DM channels with 2 users - Same as category channel
+  # DM channels with > 2 users (group DM) - Deletes the user's
+  # membership and removes them from the channel's user list.
   #
   # @example
   #  ::Chat::LeaveChannel.call(

--- a/plugins/chat/app/services/chat/remove_user_from_channel.rb
+++ b/plugins/chat/app/services/chat/remove_user_from_channel.rb
@@ -57,7 +57,11 @@ module Chat
     end
 
     def remove(channel:, target_user:)
-      channel.remove(target_user)
+      if channel.direct_message_channel?
+        channel.leave(target_user)
+      else
+        channel.remove(target_user)
+      end
     end
 
     def recompute_users_count(channel:)

--- a/plugins/chat/app/services/chat/unfollow_channel.rb
+++ b/plugins/chat/app/services/chat/unfollow_channel.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Chat
-  # Service responsible to flag a message.
+  # Service responsible to unfollow a chat channel,
+  # which means you no longer receive notifications or
+  # see it in the channel list.
   #
   # @example
   #  ::Chat::UnfollowChannel.call(

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -38,7 +38,7 @@ Fabricator(:direct_message_channel, from: :chat_channel) do
     Fabricate(
       :direct_message,
       users: attrs[:users] || [Fabricate(:user), Fabricate(:user)],
-      group: attrs[:group] || false,
+      group: attrs[:group] || attrs[:users].length > 2,
     )
   end
   status { :open }

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -35,10 +35,11 @@ end
 Fabricator(:direct_message_channel, from: :chat_channel) do
   transient :users, :group, following: true, with_membership: true
   chatable do |attrs|
+    users = attrs[:users]
     Fabricate(
       :direct_message,
-      users: attrs[:users] || [Fabricate(:user), Fabricate(:user)],
-      group: attrs[:group] || attrs[:users].length > 2,
+      users: users || [Fabricate(:user), Fabricate(:user)],
+      group: attrs[:group] || (users ? users.length > 2 : false),
     )
   end
   status { :open }

--- a/plugins/chat/spec/models/chat/category_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/category_channel_spec.rb
@@ -89,12 +89,14 @@ RSpec.describe Chat::CategoryChannel do
   end
 
   describe "#leave" do
-    let(:original_method) { channel.method(:remove) }
-    let(:aliased_method) { channel.method(:leave) }
+    let(:public_category) { Fabricate(:category, read_restricted: false) }
+    let(:channel) { Fabricate(:category_channel, chatable: public_category) }
 
-    it "is an alias to '#remove'" do
-      expect(original_method.original_name).to eq(aliased_method.original_name)
-      expect(original_method.source_location).to eq(aliased_method.source_location)
+    it "calls #remove" do
+      Fabricate(:user_chat_channel_membership, chat_channel: channel)
+      user = channel.user_chat_channel_memberships.first.user
+      channel.expects(:remove).with(user)
+      channel.leave(user)
     end
   end
 

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -113,12 +113,11 @@ RSpec.describe Chat::DirectMessageChannel do
   describe "#direct_message_group?" do
     it "returns false if the DirectMessage chatable is not for a group DM" do
       channel.chatable.update!(group: false)
-      expect(channel.direct_message_group?).to eq(false)
+      expect(channel).not_to be_direct_message_group
     end
-
     it "returns true if the DirectMessage chatable is for a group DM" do
       channel.chatable.update!(group: true)
-      expect(channel.direct_message_group?).to eq(true)
+      expect(channel).to be_direct_message_group
     end
   end
 end

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Chat::DirectMessageChannel do
   it_behaves_like "a chat channel model"
 
   it { is_expected.to delegate_method(:allowed_user_ids).to(:direct_message).as(:user_ids) }
-  it { is_expected.to delegate_method(:group?).to(:direct_message).with_prefix.allow_nil }
   it { is_expected.to validate_length_of(:description).is_at_most(500) }
   it { is_expected.to validate_length_of(:chatable_type).is_at_most(100) }
   it { is_expected.to validate_length_of(:type).is_at_most(100) }
@@ -108,6 +107,18 @@ RSpec.describe Chat::DirectMessageChannel do
       channel.name = "Cool Channel"
       channel.validate!
       expect(channel.slug).to eq(nil)
+    end
+  end
+
+  describe "#direct_message_group?" do
+    it "returns false if the DirectMessage chatable is not for a group DM" do
+      channel.chatable.update!(group: false)
+      expect(channel.direct_message_group?).to eq(false)
+    end
+
+    it "returns true if the DirectMessage chatable is for a group DM" do
+      channel.chatable.update!(group: true)
+      expect(channel.direct_message_group?).to eq(true)
     end
   end
 end

--- a/plugins/chat/spec/requests/chat/api/channels_current_user_membership_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_current_user_membership_controller_spec.rb
@@ -34,7 +34,7 @@ describe Chat::Api::ChannelsCurrentUserMembershipController do
       end
     end
 
-    context "when channel is channel" do
+    context "when channel is a category channel" do
       context "when current user can't write in channel" do
         fab!(:private_category_1) { Fabricate(:private_category, group: Fabricate(:group)) }
         fab!(:readonly_group_1) { Fabricate(:group) }

--- a/plugins/chat/spec/requests/chat/api/channels_current_user_membership_follows_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_current_user_membership_follows_controller_spec.rb
@@ -2,7 +2,6 @@
 
 describe Chat::Api::ChannelsCurrentUserMembershipController do
   fab!(:current_user) { Fabricate(:user) }
-  fab!(:channel_1) { Fabricate(:category_channel) }
 
   before do
     channel_1.add(current_user)
@@ -12,7 +11,33 @@ describe Chat::Api::ChannelsCurrentUserMembershipController do
   end
 
   describe "#destroy" do
-    describe "success" do
+    describe "for a category channel" do
+      fab!(:channel_1) { Fabricate(:category_channel) }
+
+      it "works" do
+        delete "/chat/api/channels/#{channel_1.id}/memberships/me/follows"
+
+        expect(response.status).to eq(200)
+        expect(channel_1.membership_for(current_user).following).to eq(false)
+      end
+
+      context "when channel is not found" do
+        before { channel_1.destroy! }
+        it "returns a 404" do
+          delete "/chat/api/channels/-999/memberships/me/follows"
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+
+    describe "for a group direct message channel" do
+      fab!(:other_user_1) { Fabricate(:user) }
+      fab!(:other_user_2) { Fabricate(:user) }
+      fab!(:channel_1) do
+        Fabricate(:direct_message_channel, users: [current_user, other_user_1, other_user_2])
+      end
+
       it "works" do
         delete "/chat/api/channels/#{channel_1.id}/memberships/me/follows"
 
@@ -21,11 +46,15 @@ describe Chat::Api::ChannelsCurrentUserMembershipController do
       end
     end
 
-    context "when channel is not found" do
-      it "returns a 404" do
-        delete "/chat/api/channels/-999/memberships/me/follows"
+    describe "for a direct message channel" do
+      fab!(:other_user_1) { Fabricate(:user) }
+      fab!(:channel_1) { Fabricate(:direct_message_channel, users: [current_user, other_user_1]) }
 
-        expect(response.status).to eq(404)
+      it "works" do
+        delete "/chat/api/channels/#{channel_1.id}/memberships/me/follows"
+
+        expect(response.status).to eq(200)
+        expect(channel_1.membership_for(current_user).following).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Followup b5147a4634f0fd5c98262f949a8c766bfd73d290

When we aliased `leave` to `remove` and renamed
the method in `DirectMessageChannel` in the previous
commit, this inadvertantly caused an error when
unfollowing group channels in the channel list.

When clicking the X in the channel list, we hit
ChannelsCurrentUserMembershipFollowsController for the
current user and the channel, which is supposed to only
unfollow the channel for all channel types including DMs.

Group DMs have a different Leave behaviour vs Unfollow.
Leaving the channel altogether is done from the channel
settings page, the "Leave channel" button, and that
deletes the user's membership and DM user record from that
channel.

So, we were trying to do the leave channel behaviour in the
unfollow channel controller, which was returning the wrong
record for the serializer (a User not a Membership)

This fixes the issue and removes a bit of delegate/alias indirection
which was making the code a bit harder to fllow and search, even
though it was more succinct. Also adds missing specs that would
have caught this regression.
