### PR TITLE
FIX: Duplicate error for chat messages for upload-only messages

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -168,6 +168,10 @@ module Chat
       Emoji.gsub_emoji_to_unicode(message).truncate(400)
     end
 
+    def only_uploads?
+      self.message.blank? && self.uploads.present?
+    end
+
     def to_markdown
       upload_markdown =
         self

--- a/plugins/chat/lib/chat/duplicate_message_validator.rb
+++ b/plugins/chat/lib/chat/duplicate_message_validator.rb
@@ -12,14 +12,26 @@ module Chat
     def validate
       return if chat_message.nil? || chat_channel.nil?
       return if chat_message.user.bot?
+
+      # Rules are a lot looser for DMs between 2 people, allows for
+      # things like "ok", "yes", "no", "lol", "haha", "tee-hee"
+      # to be sent multiple times.
       return if chat_channel.direct_message_channel? && chat_channel.user_count <= 2
 
-      if chat_channel
-           .chat_messages
-           .where(created_at: 10.seconds.ago..)
-           .where("LOWER(message) = ?", chat_message.message.strip.downcase)
-           .where(user: chat_message.user)
-           .exists?
+      # It's not possible to duplicate a message that only contains uploads,
+      # since the message is empty.
+      return if chat_message.only_uploads?
+
+      recent_identical_message_found =
+        chat_channel
+          .chat_messages
+          .includes(:uploads)
+          .where(created_at: 10.seconds.ago..)
+          .where("LOWER(message) = ?", chat_message.message.strip.downcase)
+          .where(user: chat_message.user)
+          .exists?
+
+      if recent_identical_message_found
         chat_message.errors.add(:base, I18n.t("chat.errors.duplicate_message"))
       end
     end


### PR DESCRIPTION
This commit fixes an issue where if you tried to post
2 chat messages in quick succession which only contained
uploads (both `message` fields would be `""`), then we
would show the "You posted an identical message too recently."
error.

We should not do this for upload-only messages, they
are not identical messages.

![image](https://github.com/user-attachments/assets/a836871a-fd0d-456e-860e-79c879167411)
