### PR TITLE
Revert "DEV: Prevent crawlers from loading search results. (#31535)"

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -34,25 +34,6 @@ class SearchController < ApplicationController
       raise Discourse::InvalidParameters.new("page parameter must not be greater than 10")
     end
 
-    if request.user_agent &&
-         CrawlerDetection.crawler?(request.user_agent, request.headers["HTTP_VIA"])
-      crawler_html = <<~HTML
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta name='robots' content='noindex'>
-            </head>
-            <body>
-              <p><em>*waves hand*</em> This is not the content you are looking for</p>
-            </body>
-          </html>
-        HTML
-
-      response.headers["X-Robots-Tag"] = "noindex"
-
-      return(render html: crawler_html.html_safe, layout: false, content_type: "text/html")
-    end
-
     discourse_expires_in 1.minute
 
     search_args = {

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -303,15 +303,6 @@ RSpec.describe SearchController do
         end
       end
     end
-
-    context "when visited by a crawler" do
-      it "responds with a noindex page" do
-        get "/search", params: { q: "test" }, headers: { "HTTP_USER_AGENT" => "Googlebot" }
-        expect(response.status).to eq(200)
-        expect(response.headers["X-Robots-Tag"]).to eq("noindex")
-        expect(response.body).to include("<meta name='robots' content='noindex'>")
-      end
-    end
   end
 
   describe "#show" do


### PR DESCRIPTION
This reverts commit 38de3d7bd1f503743c5d0237bc8a8d9d89effb8e. This changed seemed to be blocking our own AI helper as well if it has the “Search” tool.