### PR TITLE
A11Y: add `aria-hidden="true"` wrapper around zero width space character in buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-button.gjs
@@ -231,8 +231,10 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
           {{~/if~}}
         </span>
       {{~else if (or @icon @isLoading)~}}
-        &#8203;
-        {{! Zero-width space character, so icon-only button height = regular button height }}
+        <span aria-hidden="true">
+          &#8203;
+          {{! Zero-width space character, so icon-only button height = regular button height }}
+        </span>
       {{~/if~}}
 
       {{yield}}


### PR DESCRIPTION
The zero width space added here as a layout fix seems to get noticed by screenreaders (tested in NVDA) and gets "read" as text. 

This means that instead of falling back to the button title, which is the normal behavior for textless buttons, the screenreader reads the blank space. This results in buttons like the post controls being read simply as "button."

Wrapping the space in `aria-hidden` corrects this, and results in the button title being read properly.  
