### PR TITLE
A11Y: retain focus on highlighted post to avoid scroll jump

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -87,11 +87,6 @@ export function highlightPost(postNumber) {
   if (postNumber > 1) {
     // Transport screenreader to correct post by focusing it
     element.setAttribute("tabindex", "0");
-    element.addEventListener(
-      "focusin",
-      () => element.removeAttribute("tabindex"),
-      { once: true }
-    );
     element.focus();
   }
 }


### PR DESCRIPTION
Here we correctly focus a mid-stream post for screenreaders so they know where to start, but once focus is removed NVDA becomes unmoored and will jump back up the post stream to a previous post if someone tries to navigate with the arrow keys. 

Retaining the focus prevents this and shouldn't have any major side-effects. 

Tested using Chrome and NVDA
