### PR TITLE
bug(fix): Improper Neutralization of Directives in Dynamically Evaluated Code (Code Injection)

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -67,6 +67,10 @@ class Admin::SiteSettingsController < Admin::AdminController
     params.require(:site_setting_id)
     id = params[:site_setting_id]
     raise Discourse::NotFound unless id.start_with?("default_")
+
+    allowed_methods = SiteSetting.public_methods(false).map(&:to_s)
+    raise Discourse::InvalidParameters, "Invalid site setting ID" unless allowed_methods.include?(id)
+
     new_value = value_or_default(params[id])
 
     raise_access_hidden_setting(id)


### PR DESCRIPTION
https://github.com/discourse/discourse/blob/a19c45fdc0375f4e8ed1ee774aa7a229b0660973/app/controllers/admin/site_settings_controller.rb#L73-L73

To fix the problem, we need to ensure that the `id` parameter is properly validated and sanitized before being used in the `public_send` method. One way to achieve this is by using a whitelist of allowed method names that can be invoked. This approach ensures that only safe and expected methods are called, preventing arbitrary code execution.

Directly evaluating user input (an HTTP request parameter) as code without first sanitizing the input allows an attacker arbitrary code execution. This can occur when user input is passed to code that interprets it as an expression to be evaluated, using methods such as `Kernel.eval` or `Kernel.send`.

## POC
The following vulnerable shows two functions setting a name from a request. The first function uses `eval` to execute the `set_name` method. This is dangerous as it can allow a malicious user to execute arbitrary code on the server. For example, the user could supply the value `"' + exec('rm -rf') + '"` to destroy the server's file system. The second function calls the `set_name` method directly and is thus safe.
```rb
class UsersController < ActionController::Base
  # BAD - Allow user to define code to be run.
  def create_bad
    first_name = params[:first_name]
    eval("set_name(#{first_name})")
  end

  # GOOD - Call code directly
  def create_good
    first_name = params[:first_name]
    set_name(first_name)
  end

  def set_name(name)
    @name = name
  end
end
```
References
- [Code Injection](https://www.owasp.org/index.php/Code_Injection)
- [Code Injection](https://en.wikipedia.org/wiki/Code_injection)
- [CWE-94](https://cwe.mitre.org/data/definitions/94.html)
- [CWE-95](https://cwe.mitre.org/data/definitions/95.html)
- [CWE-116](https://cwe.mitre.org/data/definitions/116.html)