### PR TITLE
DEV: Replace Rinku native gem with PrettyText

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ gem "rake"
 
 gem "thor", require: false
 gem "diffy", require: false
-gem "rinku"
 gem "sidekiq"
 gem "mini_scheduler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,7 +435,6 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     rexml (3.4.1)
-    rinku (2.0.6)
     rotp (6.3.0)
     rouge (4.5.1)
     rqrcode (2.2.0)
@@ -746,7 +745,6 @@ DEPENDENCIES
   redcarpet
   redis (< 5.0)
   redis-namespace
-  rinku
   rotp
   rqrcode
   rrule
@@ -1000,7 +998,6 @@ CHECKSUMS
   reline (0.6.0) sha256=57620375dcbe56ec09bac7192bfb7460c716bbf0054dc94345ecaa5438e539d2
   request_store (1.7.0) sha256=e1b75d5346a315f452242a68c937ef8e48b215b9453a77a6c0acdca2934c88cb
   rexml (3.4.1) sha256=c74527a9a0a04b4ec31dbe0dc4ed6004b960af943d8db42e539edde3a871abca
-  rinku (2.0.6) sha256=8b60670e3143f3db2b37efa262971ce3619ec23092045498ef9f077d82828d7d
   rotp (6.3.0) sha256=75d40087e65ed0d8022c33055a6306c1c400d1c12261932533b5d6cbcd868854
   rouge (4.5.1) sha256=2ac81c6dee7019bbc6600d4c2d641d730d65c165941400ebd924259067e690dd
   rqrcode (2.2.0) sha256=23eea88bb44c7ee6d6cab9354d08c287f7ebcdc6112e1fe7bcc2d010d1ffefc1

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -26,7 +26,8 @@ class TwitterApi
         end
       end
       text = link_hashtags_in link_handles_in text
-      result = Rinku.auto_link(text, :all, 'target="_blank"').to_s
+      result =
+        PrettyText.cook(text, features_override: []).delete_prefix("<p>").delete_suffix("</p>")
 
       if tweet[:includes] && media = tweet[:includes][:media]
         media.each do |m|

--- a/spec/lib/twitter_api_spec.rb
+++ b/spec/lib/twitter_api_spec.rb
@@ -16,4 +16,53 @@ RSpec.describe TwitterApi do
       HTML
     end
   end
+
+  describe ".prettify_tweet" do
+    let(:api_response) do
+      {
+        data: {
+          edit_history_tweet_ids: ["1625192182859632661"],
+          created_at: "2023-02-13T17:56:25.000Z",
+          author_id: "29873662",
+          public_metrics: {
+            retweet_count: 1460,
+            reply_count: 2734,
+            like_count: 46_756,
+            quote_count: 477,
+            bookmark_count: 168,
+            impression_count: 4_017_878,
+          },
+          text:
+            "Shoutout to @discourse for making online communities thrive! Just launched a new plugin—check it out here: https://example.com/discourse-plugin 🔥 #forum",
+          entities: {
+            annotations: [
+              {
+                start: 18,
+                end: 26,
+                probability: 0.9807,
+                type: "Other",
+                normalized_text: "Minecraft",
+              },
+            ],
+          },
+          id: "1625192182859632661",
+        },
+        includes: {
+          users: [
+            {
+              name: "Marques Brownlee",
+              id: "29873662",
+              profile_image_url:
+                "https://pbs.twimg.com/profile_images/1468001914302390278/B_Xv_8gu_normal.jpg",
+              username: "MKBHD",
+            },
+          ],
+        },
+      }
+    end
+
+    it { expect(described_class.prettify_tweet(api_response)).to eq(<<~HTML.strip) }
+        Shoutout to <a href="https://twitter.com/discourse" target="_blank" rel="noopener nofollow ugc">@discourse</a> for making online communities thrive! Just launched a new plugin—check it out here: <a href="https://example.com/discourse-plugin" rel="noopener nofollow ugc">https://example.com/discourse-plugin</a> 🔥 <a href="https://twitter.com/search?q=%23forum" target="_blank" rel="noopener nofollow ugc">#forum</a>
+      HTML
+  end
 end


### PR DESCRIPTION
### What is this change?

We have a native dependency, Rinku, that's used only to make links in one place. We can get rid of this and use PrettyText instead.

This is almost a one-for-one replacement, but PrettyText adds `rel="noopener nofollow ugc"` to external links, which I suspect is actually what we want. It also wraps the result in a `<p>` tag, which we strip out for parity with Rinku.