### PR TITLE
FIX: cross origin opener policy should apply to public error responses

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -80,6 +80,7 @@ module Discourse
         super
       end
     end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -168,6 +169,9 @@ module Discourse
       require "middleware/enforce_hostname"
       config.middleware.insert_after Rack::MethodOverride, Middleware::EnforceHostname
     end
+
+    require "middleware/default_headers"
+    config.middleware.insert_before ActionDispatch::ShowExceptions, Middleware::DefaultHeaders
 
     require "content_security_policy/middleware"
     config.middleware.swap ActionDispatch::ContentSecurityPolicy::Middleware,

--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -10,7 +10,9 @@ module Middleware
       status, headers, body = @app.call(env)
       headers[
         "Cross-Origin-Opener-Policy"
-      ] = SiteSetting.cross_origin_opener_policy_header if html_response?(headers)
+      ] = SiteSetting.cross_origin_opener_policy_header if html_response?(headers) &&
+        headers["Cross-Origin-Opener-Policy"].nil?
+
       [status, headers, body]
     end
 

--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Middleware
+  class DefaultHeaders
+    def initialize(app, settings = {})
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      headers[
+        "Cross-Origin-Opener-Policy"
+      ] = SiteSetting.cross_origin_opener_policy_header if html_response?(headers)
+      [status, headers, body]
+    end
+
+    private
+
+    def html_response?(headers)
+      headers["Content-Type"] && headers["Content-Type"] =~ /html/
+    end
+  end
+end

--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -7,7 +7,6 @@ module Middleware
     require "middleware/default_headers"
     # These middlewares will be re-run when the exception response is generated
     EXCEPTION_RESPONSE_MIDDLEWARES = [
-      Middleware::DefaultHeaders,
       ContentSecurityPolicy::Middleware,
       Middleware::CspScriptNonceInjector,
     ]

--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -4,8 +4,10 @@
 # we need to handle certain exceptions here
 module Middleware
   class DiscoursePublicExceptions < ::ActionDispatch::PublicExceptions
+    require "middleware/default_headers"
     # These middlewares will be re-run when the exception response is generated
     EXCEPTION_RESPONSE_MIDDLEWARES = [
+      Middleware::DefaultHeaders,
       ContentSecurityPolicy::Middleware,
       Middleware::CspScriptNonceInjector,
     ]

--- a/spec/integrity/middleware_order_spec.rb
+++ b/spec/integrity/middleware_order_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Middleware order" do
       Middleware::EnforceHostname,
       ActionDispatch::RequestId,
       SilenceLogger,
+      Middleware::DefaultHeaders,
       ActionDispatch::ShowExceptions,
       ActionDispatch::DebugExceptions,
       ActionDispatch::Callbacks,
@@ -44,5 +45,11 @@ RSpec.describe "Middleware order" do
 
   it "ensures that ActionDispatch::RemoteIp comes before Middleware::RequestTracker" do
     expect(remote_ip_index).to be < request_tracker_index
+  end
+
+  it "ensures that Middleware::DefaultHeaders comes before ActionDispatch::ShowExceptions" do
+    default_headers_index = actual_middlewares.index(Middleware::DefaultHeaders)
+    show_exceptions_index = actual_middlewares.index(ActionDispatch::ShowExceptions)
+    expect(default_headers_index).to be < show_exceptions_index
   end
 end

--- a/spec/requests/default_headers_spec.rb
+++ b/spec/requests/default_headers_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-describe "Default Headers", type: :system do
+RSpec.describe Middleware::DefaultHeaders do
   context "when a public exception(like RoutingError) is raised" do
     context "when requesting an HTML page" do
       let(:html_path) { "/nonexistent" }

--- a/spec/system/default_headers_spec.rb
+++ b/spec/system/default_headers_spec.rb
@@ -37,7 +37,7 @@ describe "Default Headers", type: :system do
       bad_str = (+"d\xDE").force_encoding("utf-8")
       expect(bad_str.valid_encoding?).to eq(false)
 
-      get "/latest.json", params: { test: bad_str }
+      get "/latest", params: { test: bad_str }
 
       log = @logs.string
       expect(log).not_to include("exception app middleware")

--- a/spec/system/default_headers_spec.rb
+++ b/spec/system/default_headers_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+describe "Default Headers", type: :system do
+  context "when a public exception(like RoutingError) is raised" do
+    context "when requesting an HTML page" do
+      let(:html_path) { "/nonexistent" }
+
+      it "sets the Cross-Origin-Opener-Policy header" do
+        SiteSetting.bootstrap_error_pages = true
+        get html_path # triggers a RoutingError, handled by the exceptions_app
+        expect(response.headers).to have_key("Cross-Origin-Opener-Policy")
+        expect(response.headers["Cross-Origin-Opener-Policy"]).to eq("same-origin-allow-popups")
+      end
+    end
+
+    context "when requesting a JSON response for an invalid URL" do
+      let(:json_path) { "/nonexistent.json" }
+
+      it "does not include the Cross-Origin-Opener-Policy header" do
+        SiteSetting.bootstrap_error_pages = true
+        SiteSetting.cross_origin_opener_policy_header = "same-origin"
+        get json_path
+        expect(response.headers["Cross-Origin-Opener-Policy"]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some error paths, headers that were set earlier can get overwritten (e.g. `Cross-Origin-Opener-Policy`) by middleware such as ActionDispatch::ShowExceptions.

This PR sets the `Cross-Origin-Opener-Policy` header to the value of the SiteSetting `cross_origin_opener_policy_header` if it's missing and if the response is for HTML. 

In future, this DefaultHeaders middleware can be used to set other default headers that relate to security or other purposes.

### Testing
<img width="631" alt="test" src="https://github.com/user-attachments/assets/05106a40-2bc7-435d-91a2-4dd2a098f349" />
