### PR TITLE
DEV: correct class on trigger of notifications-tracking

### DIFF
--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -42,17 +42,19 @@ class NotificationsTrackingTrigger extends Component {
   }
 
   <template>
-    {{icon @selectedLevel.icon}}
+    <button class="btn btn-icon-text btn-default" ...attributes>
+      {{icon @selectedLevel.icon}}
 
-    {{#if this.showFullTitle}}
-      <span class="d-button-label">
-        {{this.title}}
-      </span>
-    {{/if}}
+      {{#if this.showFullTitle}}
+        <span class="d-button-label">
+          {{this.title}}
+        </span>
+      {{/if}}
 
-    {{#if this.showCaret}}
-      {{icon "angle-down" class="notifications-tracking-btn__caret"}}
-    {{/if}}
+      {{#if this.showCaret}}
+        {{icon "angle-down" class="notifications-tracking-btn__caret"}}
+      {{/if}}
+    </button>
   </template>
 }
 
@@ -108,19 +110,18 @@ export default class NotificationsTracking extends Component {
       @onRegisterApi={{this.registerDmenuApi}}
       @title={{@title}}
       @autofocus={{false}}
+      @triggerComponent={{component
+        NotificationsTrackingTrigger
+        showFullTitle=@showFullTitle
+        showCaret=@showCaret
+        selectedLevel=this.selectedLevel
+        suffix=@suffix
+        prefix=@prefix
+      }}
       data-level-id={{this.selectedLevel.id}}
       data-level-name={{this.selectedLevel.key}}
       ...attributes
     >
-      <:trigger>
-        <NotificationsTrackingTrigger
-          @showFullTitle={{@showFullTitle}}
-          @showCaret={{@showCaret}}
-          @selectedLevel={{this.selectedLevel}}
-          @suffix={{@suffix}}
-          @prefix={{@prefix}}
-        />
-      </:trigger>
       <:content>
         <DropdownMenu as |dropdown|>
           {{#each this.levels as |level|}}


### PR DESCRIPTION
If we have a custom content for a `DMenu` trigger the `DButton` has no way to know there's text in this custom content so it will output the "no-text" class on the `DButton`. The correct way to fix this is to use our own `DButton` and the `@triggerComponent` so we can fully replace the behavior and set the correct classes.