### PR TITLE
DEV: Add `posts_controller_create_user` modifier

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -203,9 +203,7 @@ class PostsController < ApplicationController
     manager_params[:first_post_checks] = !is_api?
     manager_params[:advance_draft] = !is_api?
 
-    user =
-      DiscoursePluginRegistry.apply_modifier(:posts_controller_create_user, current_user) ||
-        current_user
+    user = DiscoursePluginRegistry.apply_modifier(:posts_controller_create_user, current_user)
     manager = NewPostManager.new(user, manager_params)
 
     json =

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -203,7 +203,12 @@ class PostsController < ApplicationController
     manager_params[:first_post_checks] = !is_api?
     manager_params[:advance_draft] = !is_api?
 
-    user = DiscoursePluginRegistry.apply_modifier(:posts_controller_create_user, current_user)
+    user =
+      DiscoursePluginRegistry.apply_modifier(
+        :posts_controller_create_user,
+        current_user,
+        create_params,
+      )
     manager = NewPostManager.new(user, manager_params)
 
     json =

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -203,7 +203,10 @@ class PostsController < ApplicationController
     manager_params[:first_post_checks] = !is_api?
     manager_params[:advance_draft] = !is_api?
 
-    manager = NewPostManager.new(current_user, manager_params)
+    user =
+      DiscoursePluginRegistry.apply_modifier(:posts_controller_create_user, current_user) ||
+        current_user
+    manager = NewPostManager.new(user, manager_params)
 
     json =
       if is_api?


### PR DESCRIPTION
Add `posts_controller_create_user` modifier to modify which user is associated with the post creation. 