### PR TITLE
DEV: Create plugin outlet for console site setting logging

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -462,6 +462,7 @@ module SiteSettingExtension
 
     if defined?(Rails::Console)
       details = "Updated via Rails console"
+      details = DiscoursePluginRegistry.apply_modifier(:site_setting_log_details, details)
       log(name, val, old_val, Discourse.system_user, details)
     end
 


### PR DESCRIPTION
This change allows plugins to customize the description for site setting
logs that occur via site setting changes via the rails console.
