### PR TITLE
DEV: Add a PluginOutlet for mobile-view topic activity number

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,8 +130,8 @@ GEM
     discourse-seed-fu (2.3.12)
       activerecord (>= 3.1)
       activesupport (>= 3.1)
-    discourse_dev_assets (0.0.5)
-      faker (~> 3.5.1)
+    discourse_dev_assets (0.0.4)
+      faker (~> 2.16)
       literate_randomizer
     docile (1.4.1)
     drb (2.2.1)
@@ -144,7 +144,7 @@ GEM
     exifr (1.4.1)
     extralite-bundle (2.10)
     fabrication (2.31.0)
-    faker (3.5.1)
+    faker (2.23.0)
       i18n (>= 1.8.11, < 2)
     fakeweb (1.3.0)
     faraday (2.12.2)
@@ -840,7 +840,7 @@ CHECKSUMS
   digest-xxhash (0.2.9) sha256=a989d8309c03c4136a4bea9981ec0a146a2750de7f3dfb7b5624a3038aa598d7
   discourse-fonts (0.0.18) sha256=a7d25c13edd3325ae40010ca277530d69fc7952a05aa7b2ff07c1d07412b72a1
   discourse-seed-fu (2.3.12) sha256=4f61d95c11ed54609046cd04eb3a51b531c5fa863fa86d1bea7d74264e5c75e4
-  discourse_dev_assets (0.0.5) sha256=a09a801a210aa3f7247dd382dfd73b389d4bd02be86be675eca2d451f9898285
+  discourse_dev_assets (0.0.4) sha256=a1e67272ff246dbd6d5b4cf65cdaea86b9371dce1ca97f6b69f8d44d86358d59
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.1) sha256=e9d472bf785f558b96b25358bae115646da0dbfd45107ad858b0bc0d935cb340
   dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
@@ -851,7 +851,7 @@ CHECKSUMS
   exifr (1.4.1) sha256=768374cc6b6ff3743acba57c1c35229bdd8c6b9fbc1285952047fc1215c4b894
   extralite-bundle (2.10) sha256=d765b84abe359f8ed8ee1735de016167ab9f7c7760e3f9b49ba7434fa81ff192
   fabrication (2.31.0) sha256=2c79f10d1b88034a2ebd47ce77acba66847fc4636581c8282b3408adc68e85aa
-  faker (3.5.1) sha256=1ad1fbea279d882f486059c23fe3ddb816ccd1d7052c05a45014b4450d859bfc
+  faker (2.23.0) sha256=8754e4bb3bc45641d276123060286a001ea5fa49a4b5daa162bf8c015fe154f3
   fakeweb (1.3.0) sha256=1ec996be13020a00b3464560c09180b424477c698f59f82edf2b99b16cfa09a8
   faraday (2.12.2) sha256=157339c25c7b8bcb739f5cf1207cb0cefe8fa1c65027266bcbc34c90c84b9ad6
   faraday-net_http (3.4.0) sha256=a1f1e4cd6a2cf21599c8221595e27582d9936819977bbd4089a601f24c64e54a

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -373,13 +373,18 @@ export default class Item extends Component {
                 </span>
 
                 <div class="num activity last">
-                  <span title={{@topic.bumpedAtTitle}} class="age activity">
-                    <a href={{@topic.lastPostUrl}}>{{formatDate
-                        @topic.bumpedAt
-                        format="tiny"
-                        noTitle="true"
-                      }}</a>
-                  </span>
+                  <PluginOutlet
+                    @name="topic-list-item-mobile-num-activity"
+                    @outletArgs={{hash topic=@topic}}
+                  >
+                    <span title={{@topic.bumpedAtTitle}} class="age activity">
+                      <a href={{@topic.lastPostUrl}}>{{formatDate
+                          @topic.bumpedAt
+                          format="tiny"
+                          noTitle="true"
+                        }}</a>
+                    </span>
+                  </PluginOutlet>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This commit adds a PluginOutlet for activity number in mobile view, so I can override it with my theme component.

## Why?

In this theme component https://meta.discourse.org/t/show-both-op-and-last-reply-on-mobile/267944, I need to add an avatar to the post time to indicate the last poster.

![image](https://github.com/user-attachments/assets/a33ff8ed-50c6-4bc4-a093-115578ad9bad)

Without this outlet, I can't do this, having to rewrite the entire item.gjs, or use some vanilla JavaScript tricks to do it.