### PR TITLE
DEV: Add a PluginOutlet for mobile-view topic activity number

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -374,7 +374,7 @@ export default class Item extends Component {
 
                 <div class="num activity last">
                   <PluginOutlet
-                    @name="topic-list-item-mobile-num-activity"
+                    @name="topic-list-item-mobile-bumped-at"
                     @outletArgs={{hash topic=@topic}}
                   >
                     <span title={{@topic.bumpedAtTitle}} class="age activity">

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -373,13 +373,18 @@ export default class Item extends Component {
                 </span>
 
                 <div class="num activity last">
-                  <span title={{@topic.bumpedAtTitle}} class="age activity">
-                    <a href={{@topic.lastPostUrl}}>{{formatDate
-                        @topic.bumpedAt
-                        format="tiny"
-                        noTitle="true"
-                      }}</a>
-                  </span>
+                  <PluginOutlet
+                    @name="topic-list-item-mobile-num-activity"
+                    @outletArgs={{hash topic=@topic}}
+                  >
+                    <span title={{@topic.bumpedAtTitle}} class="age activity">
+                      <a href={{@topic.lastPostUrl}}>{{formatDate
+                          @topic.bumpedAt
+                          format="tiny"
+                          noTitle="true"
+                        }}</a>
+                    </span>
+                  </PluginOutlet>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This commit adds a PluginOutlet for activity number in mobile view, so I can override it with my theme component.

Why?
======

In this theme component https://meta.discourse.org/t/show-both-op-and-last-reply-on-mobile/267944, I need to add an avatar to the post time to indicate the last poster.

![image](https://github.com/user-attachments/assets/a33ff8ed-50c6-4bc4-a093-115578ad9bad)

Without this outlet, I can't do this, having to rewrite the entire `item.gjs`, or use some vanilla JavaScript tricks to do it.