### PR TITLE
UX: Add recommended image size for category logos

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-images.hbs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-images.hbs
@@ -8,6 +8,9 @@
     @id="category-logo-uploader"
     class="no-repeat contain-image"
   />
+  <div class="category-logo-description">
+    {{i18n "category.logo_description"}}
+  </div>
 </section>
 
 <section class="field category-logo">
@@ -20,6 +23,9 @@
     @id="category-dark-logo-uploader"
     class="no-repeat contain-image"
   />
+  <div class="category-logo-description">
+    {{i18n "category.logo_description"}}
+  </div>
 </section>
 
 <section class="field category-background-image">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4117,6 +4117,7 @@ en:
       description: "Description"
       logo: "Category Logo Image"
       logo_dark: "Dark Mode Category Logo Image"
+      logo_description: "Recommended 1:1 aspect ratio with 200px minimum size. If left blank no image will be shown."
       background_image: "Category Background Image"
       background_image_dark: "Dark Category Background Image"
       badge_colors: "Badge colors"


### PR DESCRIPTION
This adds a description to the category logo image fields that informs users of the recommended image aspect ratio and minimum size to upload.