### PR TITLE
FIX: Handle `href` admin sidebar links better

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -111,10 +111,14 @@ export default class AdminSearchDataSource extends Service {
 
   #addPageLink(mapItem, link, parentLabel = "") {
     let url;
-    if (link.routeModels) {
-      url = this.router.urlFor(link.route, ...link.routeModels);
-    } else {
-      url = this.router.urlFor(link.route);
+    if (link.route) {
+      if (link.routeModels) {
+        url = this.router.urlFor(link.route, ...link.routeModels);
+      } else {
+        url = this.router.urlFor(link.route);
+      }
+    } else if (link.href) {
+      url = getURL(link.href);
     }
 
     const mapItemLabel = this.#labelOrText(mapItem);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -48,7 +48,9 @@ class SidebarAdminSectionLink extends BaseCustomSidebarSectionLink {
   }
 
   get href() {
-    return this.adminSidebarNavLink.href;
+    if (this.adminSidebarNavLink.href) {
+      return getURL(this.adminSidebarNavLink.href);
+    }
   }
 
   get query() {


### PR DESCRIPTION
Admin sidebar links can have either a `href` or a
`route`, and the admin search was not handling
this properly. Also, we should always use `getURL()`
on the href in case the link is internal, for subfolder
sites.

This is hard to test right now, I plan on adding more extensive
links for admin-search-data-source in another PR.
