### PR TITLE
DEV: Add rake task to bulk delete posts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5560,6 +5560,7 @@ en:
       revoked: Revoked
       restored: Restored
     bulk_user_delete: "deleted in a bulk delete operation"
+    cli_bulk_post_delete: "Bulk deleted from rake task"
 
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."

--- a/lib/tasks/destroy.rake
+++ b/lib/tasks/destroy.rake
@@ -50,3 +50,16 @@ task "destroy:categories" => :environment do |t, args|
   puts "Going to delete these categories: #{categories}"
   categories.each { |id| destroy_task.destroy_category(id, true) }
 end
+
+# Hard delete a list of posts by ID. Pass a comma
+# separated list either as a rake argument or through
+# STDIN, e.g. through a pipe.
+#
+#   Example: rake destroy:posts[4,8,15,16,23,42]
+#   Example: cat post_ids.txt | rake destroy:posts
+desc "Destroy a list of posts given by ID"
+task "destroy:posts" => :environment do |_task, args|
+  post_ids = args.extras.empty? ? STDIN.read.strip.split(",") : args.extras
+  puts "Going to delete these posts: #{post_ids}"
+  DestroyTask.new.destroy_posts(post_ids)
+end

--- a/spec/lib/tasks/destroy_rake_spec.rb
+++ b/spec/lib/tasks/destroy_rake_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe "destroy:posts" do # rubocop:disable RSpec/DescribeClass
+  subject(:task) { subject }
+
+  include_context "in a rake task"
+
+  # No console output in test suite, thanks.
+  before { STDOUT.stubs(:puts) }
+
+  it "accepts a list of post IDs piped through STDIN" do
+    destroy_task = instance_spy(DestroyTask)
+    DestroyTask.stubs(:new).returns(destroy_task)
+
+    STDIN.stubs(:read).returns("1,2,3\n")
+
+    task.invoke
+
+    expect(destroy_task).to have_received(:destroy_posts).with(%w[1 2 3])
+  end
+end

--- a/spec/support/rake_context.rb
+++ b/spec/support/rake_context.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rake"
+
+shared_context "in a rake task" do
+  subject { rake[task_name] }
+
+  let(:rake) { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(
+      task_path,
+      [Rails.root.to_s],
+      loaded_files_excluding_current_rake_file,
+    )
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
This PR adds a `destroy:posts` rake task that can be used to hard-delete a list of posts. Useful for dealing with large amounts of spam that has been soft deleted and needs to go.

**Notes:**

- Works on both non-deleted and soft-deleted posts. (We might want to change this to work on only soft-deleted posts?)
- Works exclusively on post IDs. We can't mix topic and post IDs as they might clash, and we have no way of resolving that ambiguity.
- Accepts either a rake-style array of IDs or, more conveniently, you can pipe the argument in through `STDIN`.
- Added a confirmation step since it's a fairly destructive operation.