### PR TITLE
DEV: prevent sass mixed declarations warning

### DIFF
--- a/app/assets/stylesheets/desktop/components/header-search.scss
+++ b/app/assets/stylesheets/desktop/components/header-search.scss
@@ -47,6 +47,8 @@
         .search-menu {
           height: 100%;
           width: 100%;
+          margin: 0 auto;
+          position: relative;
 
           @media screen and (max-width: 1025px) {
             width: 80%;
@@ -55,8 +57,6 @@
           @media screen and (max-width: 768px) {
             width: 95%;
           }
-          margin: 0 auto;
-          position: relative;
 
           // Hide search-icon when search-context is present
           .search-input .search-context ~ .search-icon {


### PR DESCRIPTION
Prevents deprecation warning of sass mixed declarations. We should move declarations above nested styles.

We get the following message from logs:
```
DEPRECATION WARNING [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
```

For more info see:
https://sass-lang.com/documentation/breaking-changes/mixed-decls/
