### PR TITLE
DEV: Correct users create API docs

### DIFF
--- a/spec/requests/api/schemas/json/user_create_request.json
+++ b/spec/requests/api/schemas/json/user_create_request.json
@@ -15,7 +15,7 @@
     },
     "active": {
       "type": "boolean",
-      "description": "This param requires an api key in the request header or it will be ignored"
+      "description": "This param requires an admin api key in the request header or it will be ignored"
     },
     "approved": {
       "type": "boolean"


### PR DESCRIPTION
The API docs is incorrect as the `active` param is only permitted when an admin API key
is used. This has always been the case since 429f27ec96c090d9054c498263f0cb635b665d99
