### PR TITLE
DEV: Resolve flaky user-agent spec

### DIFF
--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -196,11 +196,9 @@ RSpec.describe Discourse do
 
   describe "#user_agent" do
     it "returns a user agent string" do
-      stub_const(Discourse::VERSION, :STRING, "1.2.3") do
-        Discourse.stubs(:git_version).returns("123456")
-
-        expect(Discourse.user_agent).to eq("Discourse/1.2.3-123456; +https://www.discourse.org/")
-      end
+      expect(Discourse.user_agent).to eq(
+        "Discourse/#{Discourse::VERSION::STRING}-#{Discourse.git_version}; +https://www.discourse.org/",
+      )
     end
   end
 


### PR DESCRIPTION
Followup to 8615fc6cbbd1085b37b5ec251e4acd39b16cb839

Stubbing things which are memoized means we'd need to clear the caches before & after the tests to be safe. Easier to just avoid the stubs altogether.