### PR TITLE
DEV: Resolve flaky terser spec

### DIFF
--- a/app/assets/javascripts/theme-transpiler/transpiler.js
+++ b/app/assets/javascripts/theme-transpiler/transpiler.js
@@ -188,7 +188,7 @@ globalThis.getMinifyResult = function () {
   lastMinifyError = lastMinifyResult = null;
 
   if (error) {
-    throw error;
+    throw error.toString();
   }
   return result;
 };


### PR DESCRIPTION
Miniracer seems to be inconsistent in how it serializes errors from JS, which caused flakiness in our specs. Throwing a simple string seems to circumvent this flakiness.