### PR TITLE
DEV: aliases should be considered as existing

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -62,7 +62,7 @@ class Emoji
   end
 
   def self.exists?(name)
-    Emoji[name].present?
+    Emoji[name].present? || Emoji.aliases_values.include?(name)
   end
 
   def self.[](name)
@@ -176,6 +176,10 @@ class Emoji
 
   def self.aliases_db
     @aliases_db ||= Emoji.parse_emoji_file(aliases_db_file)
+  end
+
+  def self.aliases_values
+    @aliases_values ||= Set.new(Emoji.aliases_db.values.flatten)
   end
 
   def self.search_aliases_db_file

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe Emoji do
       expect(Emoji.exists?("blonde_woman:t0")).to be(false)
       expect(Emoji.exists?("blonde_woman:t")).to be(false)
     end
+
+    it "finds aliases" do
+      expect(Emoji.exists?(":lower_left_crayon:")).to be(true)
+      expect(Emoji.exists?(":island:")).to be(true)
+      expect(Emoji.exists?(":snow_capped_mountain:")).to be(true)
+    end
   end
 
   describe ".codes_to_img" do

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -100,9 +100,10 @@ RSpec.describe Emoji do
     end
 
     it "finds aliases" do
-      expect(Emoji.exists?(Emoji.aliases_db.values[0][0])).to be(true)
-      expect(Emoji.exists?(Emoji.aliases_db.values[1][0])).to be(true)
-      expect(Emoji.exists?(Emoji.aliases_db.values[2][0])).to be(true)
+      aliases_list = Emoji.aliases_db.values
+      expect(Emoji.exists?(aliases_list[0][0])).to be(true)
+      expect(Emoji.exists?(aliases_list[1][0])).to be(true)
+      expect(Emoji.exists?(aliases_list[2][0])).to be(true)
     end
   end
 

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe Emoji do
     end
 
     it "finds aliases" do
-      expect(Emoji.exists?(":lower_left_crayon:")).to be(true)
-      expect(Emoji.exists?(":island:")).to be(true)
-      expect(Emoji.exists?(":snow_capped_mountain:")).to be(true)
+      expect(Emoji.exists?(Emoji.aliases_db.values[0][0])).to be(true)
+      expect(Emoji.exists?(Emoji.aliases_db.values[1][0])).to be(true)
+      expect(Emoji.exists?(Emoji.aliases_db.values[2][0])).to be(true)
     end
   end
 


### PR DESCRIPTION
Before this commit doing: `Emoji.exists?(some_alias)` would return false. The only important thing in emoji is to never remove an emoji code which has been used by users but changing the name of an emoji and keeping old name as an alias should not break the application in any way, this commit should ensure this is true.