### PR TITLE
Allow creation of passwordless users when authenticated externally

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -756,11 +756,6 @@ class UsersController < ApplicationController
     activation = UserActivator.new(user, request, session, cookies)
     activation.start
 
-    # just assign a password if we have an authenticator and no password
-    # this is the case for Twitter
-    user.password = SecureRandom.hex if user.password.blank? &&
-      (authentication.has_authenticator? || associations.present?)
-
     if user.save
       authentication.finish
       activation.finish

--- a/app/services/user_authenticator.rb
+++ b/app/services/user_authenticator.rb
@@ -20,10 +20,9 @@ class UserAuthenticator
     if authenticated?
       @user.active = true
       @auth_result.apply_user_attributes!
-    elsif @require_password
-      @user.password_required!
     end
 
+    @user.password_required! if !@auth_result && @require_password
     @user.skip_email_validation = true if @auth_result && @auth_result.skip_email_validation
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -863,10 +863,16 @@ RSpec.describe UsersController do
           provider
         end
 
-        before { DiscoursePluginRegistry.register_auth_provider(plugin_auth_provider) }
+        before do
+          DiscoursePluginRegistry.register_auth_provider(plugin_auth_provider)
+          # Tell UserAuthenticator our user authenticated previously.
+          allow(UserAuthenticator).to receive(:new).and_wrap_original do |original_method, user|
+            authenticated_session = { authentication: { email: "foo" } }
+            original_method.call(user, authenticated_session)
+          end
+        end
 
         after { DiscoursePluginRegistry.reset! }
-
         it "creates User record" do
           params = {
             username: "foobar",


### PR DESCRIPTION
Don't require password from users with authentication in the session, regardless of email/email verification.

Before my changes we were calling `user.password_required!` based on `UserAuthenticator.authenticated?` based on whether authentication session data contained a matching email address and email verified externally. I believe `authenticated?` is intended for our own email validation during the activation process, but shouldn't be a gate for password requirement.

Even when we _were_ setting `user,password_required`, then during user creation we were creating random passwords to get around the blank password restriction when creating accounts with external auth.

After my change we can remove the random password creation because we no longer require a password when the session has previous authentication info at all.

Looks like this extra password requirement may have been introduced as a side effect during a previous refactor of UserController here: https://github.com/discourse/discourse/commit/51eff921704e15891a012c250a91e3c7ddaa636e Before that change, password requirement was simply based on whether session[:authentication] existed, but after that change it was based on the email/email_valid fields as well.