### PR TITLE
UX: rich text for review_process_description

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/anonymous-flag.gjs
@@ -32,7 +32,7 @@ export default class AnonymousFlagModal extends Component {
       class="anonymous-flag-modal"
     >
       <:body>
-        <p>{{i18n "flagging.review_process_description"}}</p>
+        <p>{{htmlSafe (i18n "flagging.review_process_description")}}</p>
         <p>{{htmlSafe this.description}}</p>
       </:body>
     </DModal>

--- a/app/assets/javascripts/discourse/app/components/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.hbs
@@ -7,7 +7,7 @@
   {{on "keydown" this.onKeydown}}
 >
   <:body>
-    <p>{{i18n "flagging.review_process_description"}}</p>
+    <p>{{html-safe (i18n "flagging.review_process_description")}}</p>
     <PluginOutlet
       @name="after-flag-modal-review-process-description"
       @connectorTagName="div"


### PR DESCRIPTION
In this PR, information about the review process was added to the flag modal - https://github.com/discourse/discourse/pull/31300

Admins would like to use HTML tags to customise it even more.