### PR TITLE
UX: Tweak footnote button styling

### DIFF
--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -1,12 +1,11 @@
 .inline-footnotes {
   a.expand-footnote {
     user-select: none;
-    padding: 0 0.5em;
-    margin: 0 0 0 0.25em;
+    padding: 0 0.4em;
     color: var(--primary-low-mid-or-secondary-high);
     background: var(--primary-low);
     border-radius: 3px;
-    min-height: 20px;
+    min-height: 1.25em;
     display: inline-flex;
     align-items: center;
 


### PR DESCRIPTION
1. remove the margin (it's displayed inline with text, so having a left margin didn't make sense)
2. use em unit in min-height
3. slighty tighten the button (inline padding 0.5em -> 0.4em) so it's more proportional