### PR TITLE
DEV: Remove extraneous rubocop arguments

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Rubocop
         if: ${{ !cancelled() }}
-        run: bundle exec rubocop --parallel .
+        run: bundle exec rubocop
 
       - name: syntax_tree
         if: ${{ !cancelled() }}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
   commands:
     rubocop:
       glob: "*.rb"
-      run: bundle exec rubocop --parallel --force-exclusion {staged_files}
+      run: bundle exec rubocop --force-exclusion {staged_files}
     syntax_tree:
       glob: "*.{rb,rake}"
       run: bundle exec stree check Gemfile {staged_files}
@@ -58,7 +58,7 @@ lints:
   commands:
     rubocop:
       glob: "*.rb"
-      run: bundle exec rubocop --parallel
+      run: bundle exec rubocop
     prettier:
       run: pnpm pprettier --list-different **/*.js
     prettier-scss:

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -164,7 +164,7 @@ task "docker:test" do
       puts "prettier #{`pnpm prettier -v`}"
 
       if ENV["SINGLE_PLUGIN"]
-        @good &&= run_or_fail("bundle exec rubocop --parallel plugins/#{ENV["SINGLE_PLUGIN"]}")
+        @good &&= run_or_fail("bundle exec rubocop plugins/#{ENV["SINGLE_PLUGIN"]}")
         @good &&=
           run_or_fail(
             "bundle exec ruby script/i18n_lint.rb plugins/#{ENV["SINGLE_PLUGIN"]}/config/locales/{client,server}.en.yml",
@@ -182,7 +182,7 @@ task "docker:test" do
           )
       else
         @good &&= run_or_fail("bundle exec rake plugin:update_all") unless ENV["SKIP_PLUGINS"]
-        @good &&= run_or_fail("bundle exec rubocop --parallel") unless ENV["SKIP_CORE"]
+        @good &&= run_or_fail("bundle exec rubocop") unless ENV["SKIP_CORE"]
         @good &&= run_or_fail("pnpm eslint app/assets/javascripts") unless ENV["SKIP_CORE"]
         @good &&=
           run_or_fail(


### PR DESCRIPTION
1. `--parallel` is the default
2. it runs in the current directory by default