### PR TITLE
DEV: Add value transformer for admin reports show query params

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
@@ -1,8 +1,15 @@
 import Controller from "@ember/controller";
 import discourseComputed from "discourse/lib/decorators";
+import { applyValueTransformer } from "discourse/lib/transformer";
 
 export default class AdminReportsShowController extends Controller {
-  queryParams = ["start_date", "end_date", "filters", "chart_grouping", "mode"];
+  queryParams = applyValueTransformer("admin-reports-show-query-params", [
+    "start_date",
+    "end_date",
+    "filters",
+    "chart_grouping",
+    "mode",
+  ]);
   start_date = null;
   end_date = null;
   filters = null;

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -9,6 +9,7 @@ export const BEHAVIOR_TRANSFORMERS = Object.freeze([
 
 export const VALUE_TRANSFORMERS = Object.freeze([
   // use only lowercase names
+  "admin-reports-show-query-params",
   "category-available-views",
   "category-description-text",
   "category-display-name",


### PR DESCRIPTION
## :mag: Overview
This update adds a new value transformer to the `queryParams` property on the `AdminReportsShowController`. This is necessary so that plugins can add additional `queryParams` to the route and have it reflected when the route is transitioned.