### PR TITLE
UX: display html tags in silence reason

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -89,6 +89,11 @@ export default class AdminUsersListShowController extends Controller {
     return this._refreshUsers();
   }
 
+  stripHtml(html) {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    return doc.body.textContent || "";
+  }
+
   _refreshUsers() {
     if (!this._canLoadMore) {
       return;

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -525,7 +525,7 @@
         </LinkTo>
       </div>
       <div class="controls">
-        <b>{{i18n "admin.user.suspend_reason"}}</b>:
+        <strong>{{i18n "admin.user.suspend_reason"}}</strong>:
         <div class="full-reason">{{this.model.full_suspend_reason}}</div>
       </div>
     </div>
@@ -585,7 +585,7 @@
       </div>
       <div class="controls">
         <b>{{i18n "admin.user.silence_reason"}}</b>:
-        <div class="full-reason">{{this.model.silence_reason}}</div>
+        <div class="full-reason">{{html-safe this.model.silence_reason}}</div>
       </div>
     </div>
   {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -325,13 +325,13 @@
             {{#if this.showSilenceReason}}
               <div
                 class="directory-table__cell silence_reason"
-                title={{user.silence_reason}}
+                title={{this.stripHtml user.silence_reason}}
               >
                 <span class="directory-table__label">
                   <span>{{i18n "admin.users.silence_reason"}}</span>
                 </span>
                 <span class="directory-table__value">
-                  {{user.silence_reason}}
+                  {{html-safe user.silence_reason}}
                 </span>
               </div>
             {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -6,6 +6,20 @@ import { i18n } from "discourse-i18n";
 acceptance("Admin - Users List", function (needs) {
   needs.user();
 
+  needs.pretender((server, helper) => {
+    server.get("/admin/users/list/silenced.json", () =>
+      helper.response([
+        {
+          id: 2,
+          username: "kris",
+          email: "<small>kris@example.com</small>",
+          silenced_at: "2020-01-01T00:00:00.000Z",
+          silence_reason: "<strong>spam</strong>",
+        },
+      ])
+    );
+  });
+
   test("lists users", async function (assert) {
     await visit("/admin/users/list/active");
 
@@ -96,5 +110,11 @@ acceptance("Admin - Users List", function (needs) {
     assert
       .dom(".users-list .user:nth-child(1) .username")
       .includesText(activeUser);
+
+    await click('a[href="/admin/users/list/silenced"]');
+    assert.dom(".silence_reason").hasAttribute("title", "spam");
+    assert
+      .dom(".silence_reason .directory-table__value")
+      .hasHtml("<strong>spam</strong>");
   });
 });

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -93,6 +93,15 @@
     }
   }
 
+  &.silence-info .controls {
+    display: flex;
+    margin-left: 0;
+
+    .full-reason {
+      margin-left: 0.3em;
+    }
+  }
+
   &.username,
   &.name {
     .value {

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -324,7 +324,12 @@ class Admin::UsersController < Admin::StaffController
             silence_reason: full_reason,
             silenced_till: user.silenced_till,
             silenced_at: user.silenced_at,
-            silenced_by: BasicUserSerializer.new(current_user, root: false).as_json,
+            silenced_by:
+              BasicUserSerializer.new(
+                current_user,
+                root: false,
+                include_silence_reason: true,
+              ).as_json,
           },
         )
       end

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -122,6 +122,10 @@ class AdminUserListSerializer < BasicUserSerializer
     @options[:include_can_be_deleted]
   end
 
+  def silence_reason
+    PrettyText.cleanup(object.silence_reason)
+  end
+
   def include_silence_reason?
     @options[:include_silence_reason]
   end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -110,15 +110,14 @@ RSpec.describe Admin::UsersController do
       end
 
       it "returns silence reason when user is silenced" do
-        silencer =
-          UserSilencer.new(
-            user,
-            admin,
-            message: :too_many_spam_flags,
-            reason: "because I said so",
-            keep_posts: true,
-          )
-        silencer.silence
+        put "/admin/users/#{user.id}/silence.json",
+            params: {
+              reason: "because I said so",
+              post_action: "delete",
+              silenced_till: 2.days.from_now,
+            }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["silence"]["silence_reason"]).to eq("because I said so")
 
         get "/admin/users/#{user.id}.json"
         expect(response.status).to eq(200)


### PR DESCRIPTION
Allow HTML tags in silence reason. Tags must be stripped for title attribute.

Before
![image](https://github.com/user-attachments/assets/05d9819a-9dbf-46b2-b9c5-88187ca9af5b)


After
<img width="1079" alt="Screenshot 2025-03-04 at 11 39 05 am" src="https://github.com/user-attachments/assets/2bb41deb-227c-47a8-b840-b0316a764252" />
<img width="1096" alt="Screenshot 2025-03-04 at 11 39 22 am" src="https://github.com/user-attachments/assets/02e27fc0-317e-43df-bce8-6b68e48ac40e" />
