### PR TITLE
DEV: Store selected API key scope mode in the database table

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
@@ -10,6 +10,7 @@ import DButton from "discourse/components/d-button";
 import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { API_KEY_SCOPE_MODES } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 import ApiKeyUrlsModal from "admin/components/modal/api-key-urls";
@@ -31,11 +32,9 @@ export default class AdminConfigAreasApiKeysNew extends Component {
     { id: "single", name: i18n("admin.api.single_user") },
   ];
 
-  scopeModes = [
-    { id: "global", name: i18n("admin.api.scopes.global") },
-    { id: "read_only", name: i18n("admin.api.scopes.read_only") },
-    { id: "granular", name: i18n("admin.api.scopes.granular") },
-  ];
+  scopeModes = API_KEY_SCOPE_MODES.map((scopeMode) => {
+    return { id: scopeMode, name: i18n(`admin.api.scopes.${scopeMode}`) };
+  });
 
   globalScopes = null;
 

--- a/app/assets/javascripts/discourse/app/lib/constants.js
+++ b/app/assets/javascripts/discourse/app/lib/constants.js
@@ -127,3 +127,5 @@ export const ADMIN_SEARCH_RESULT_TYPES = [
   "component",
   "report",
 ];
+
+export const API_KEY_SCOPE_MODES = ["global", "read_only", "granular"];

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,8 +4,6 @@ class ApiKey < ActiveRecord::Base
   class KeyAccessError < StandardError
   end
 
-  attr_accessor :scope_mode
-
   has_many :api_key_scopes
   belongs_to :user
   belongs_to :created_by, class_name: "User"
@@ -21,6 +19,8 @@ class ApiKey < ActiveRecord::Base
 
   validates :description, length: { maximum: 255 }
   validate :at_least_one_granular_scope
+
+  enum :scope_mode, %i[global read_only granular].freeze
 
   after_initialize :generate_key
 
@@ -146,6 +146,7 @@ end
 #  description   :text
 #  key_hash      :string           not null
 #  truncated_key :string           not null
+#  scope_mode    :integer
 #
 # Indexes
 #

--- a/db/migrate/20250304054720_add_scope_mode_to_api_keys.rb
+++ b/db/migrate/20250304054720_add_scope_mode_to_api_keys.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScopeModeToApiKeys < ActiveRecord::Migration[7.2]
+  def change
+    add_column :api_keys, :scope_mode, :integer, null: true
+  end
+end

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -173,6 +173,8 @@ task "javascript:update_constants" => :environment do
     export const REVIEWABLE_UNKNOWN_TYPE_SOURCE = "#{Reviewable::UNKNOWN_TYPE_SOURCE}";
 
     export const ADMIN_SEARCH_RESULT_TYPES = #{Admin::SearchController::RESULT_TYPES.to_json};
+
+    export const API_KEY_SCOPE_MODES = #{ApiKey.scope_modes.keys.to_json}
   JS
 
   pretty_notifications = Notification.types.map { |n| "  #{n[0]}: #{n[1]}," }.join("\n")

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ApiKey do
   it { is_expected.to belong_to :user }
   it { is_expected.to belong_to :created_by }
   it { is_expected.to validate_length_of(:description).is_at_most(255) }
+  it { is_expected.to define_enum_for(:scope_mode).with_values(%w[global read_only granular]) }
 
   it "validates at least one scope for granular mode" do
     api_key = ApiKey.new


### PR DESCRIPTION
### What is this change?

Currently, after creating an API key, there is no way in the UI to see what scope the key has. To do this we need to first store the selected scope mode when creating a new key.

**In this PR we:**

- Convert `scope_mode` from a transient attribute to a database backed enum.
- Ship the possible values through the `javascript:update_constants` rake task instead of hard coding in front-end.

**In follow-up PRs we will:**

- Backfill existing API keys based on their associated `api_key_scopes` records.
- Start showing the scope mode in the UI.