### PR TITLE
DEV: Do not include attribute if condition resolves to false

### DIFF
--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -220,6 +220,7 @@ TEXT
           :conditional_scales,
           include_condition: -> { !!object.data&.[](:has_scales) },
         ) { 4096 }
+        @plugin.add_to_serializer(:trout, :smelly, include_condition: -> { false }) { "rainbow" }
 
         @serializer = TroutSerializer.new(@trout)
         @child_serializer = TroutJuniorSerializer.new(@trout)
@@ -317,6 +318,10 @@ TEXT
           # clear the underlying DiscourseEvent
           DiscourseEvent.off(:site_setting_changed, &event_handler)
         end
+      end
+
+      it "does not return attribute if include_condition is false" do
+        expect(@serializer.smelly).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
Currently when doing 
```
add_to_serializer(:cat, :owner, include_condition: -> { false }) do 
  "me" 
end
```

`cat.owner` is always present. Based on the following

https://github.com/discourse/discourse/blob/9abeff460ca18d22ec9c5124a4c995af56a1de14/spec/lib/plugin/instance_spec.rb#L246-L247

I am not sure if the `include` is intended to be used this way?