### PR TITLE
UX: Show scope mode in API key list

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.hbs
@@ -6,6 +6,7 @@
         <th>{{i18n "admin.api.description"}}</th>
         <th>{{i18n "admin.api.user"}}</th>
         <th>{{i18n "admin.api.created"}}</th>
+        <th>{{i18n "admin.api.scope"}}</th>
         <th>{{i18n "admin.api.last_used"}}</th>
       </thead>
       <tbody>

--- a/app/assets/javascripts/admin/addon/components/api-key-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/api-key-item.gjs
@@ -7,15 +7,30 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
 import avatar from "discourse/helpers/avatar";
+import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
-export default class ApiKeysList extends Component {
+const SCOPE_ICONS = {
+  global: "globe",
+  read_only: "eye",
+  granular: "bullseye",
+};
+
+export default class ApiKeyItem extends Component {
   @service router;
 
   @tracked apiKey = this.args.apiKey;
+
+  get scopeIcon() {
+    return SCOPE_ICONS[this.apiKey.scope_mode];
+  }
+
+  get scopeName() {
+    return i18n(`admin.api.scopes.${this.apiKey.scope_mode}`);
+  }
 
   @action
   onRegisterApi(api) {
@@ -80,6 +95,11 @@ export default class ApiKeysList extends Component {
             "admin.api.created"
           }}</div>
         {{formatDate this.apiKey.created_at}}
+      </td>
+      <td class="d-admin-row__detail key-scope">
+        <div class="d-admin-row__mobile-label">{{i18n "admin.api.scope"}}</div>
+        {{icon this.scopeIcon}}
+        {{this.scopeName}}
       </td>
       <td class="d-admin-row__detail key-last-used">
         <div class="d-admin-row__mobile-label">{{i18n

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-api-key-item-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-api-key-item-test.gjs
@@ -1,0 +1,41 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ApiKeyItem from "admin/components/api-key-item";
+
+module("Integration | Component | ApiKeyItem", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("global scope mode", async function (assert) {
+    const apiKey = {
+      scope_mode: "global",
+    };
+
+    await render(<template><ApiKeyItem @apiKey={{apiKey}} /></template>);
+
+    assert.dom(".key-scope > .d-icon-globe").exists();
+    assert.dom(".key-scope").includesText("Global");
+  });
+
+  test("read-only scope mode", async function (assert) {
+    const apiKey = {
+      scope_mode: "read_only",
+    };
+
+    await render(<template><ApiKeyItem @apiKey={{apiKey}} /></template>);
+
+    assert.dom(".key-scope > .d-icon-eye").exists();
+    assert.dom(".key-scope").includesText("Read-only");
+  });
+
+  test("granular scope mode", async function (assert) {
+    const apiKey = {
+      scope_mode: "granular",
+    };
+
+    await render(<template><ApiKeyItem @apiKey={{apiKey}} /></template>);
+
+    assert.dom(".key-scope > .d-icon-bullseye").exists();
+    assert.dom(".key-scope").includesText("Granular");
+  });
+});

--- a/app/serializers/api_key_serializer.rb
+++ b/app/serializers/api_key_serializer.rb
@@ -5,6 +5,7 @@ class ApiKeySerializer < ApplicationSerializer
              :key,
              :truncated_key,
              :description,
+             :scope_mode,
              :last_used_at,
              :created_at,
              :updated_at,

--- a/app/serializers/basic_api_key_serializer.rb
+++ b/app/serializers/basic_api_key_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BasicApiKeySerializer < ApplicationSerializer
-  attributes :id, :truncated_key, :description, :created_at, :last_used_at, :revoked_at
+  attributes :id, :truncated_key, :scope_mode, :description, :created_at, :last_used_at, :revoked_at
 
   has_one :user, serializer: BasicUserSerializer, embed: :objects
   has_one :created_by, serializer: BasicUserSerializer, embed: :objects

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5704,6 +5704,7 @@ en:
         key: "Key"
         keys: "Keys"
         created: Created by
+        scope: Scope
         updated: Updated
         last_used: Last used
         never_used: Never


### PR DESCRIPTION
**Note:** Do not merge before the backfill (#31606) is merged.

### What is this change?

We're now storing the selected API key scope mode in the back-end, and can display it in the API key list.

**Screenshot:**

<img width="551" alt="Screenshot 2025-03-04 at 7 27 42 PM" src="https://github.com/user-attachments/assets/9f234242-cfaa-4a2c-93e9-740770bd9944" />
