### PR TITLE
DEV: Relax Ruby version constraint to `~> 3.3`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby "~> 3.3.0"
+ruby "~> 3.3"
 
 source "https://rubygems.org"
 # if there is a super emergency and rubygems is playing up, try


### PR DESCRIPTION
This change allows updates to any 3.x version, while still restricting major updates to 4.x.