### PR TITLE
DEV: ensure Rails application default headers are present in responses

### DIFF
--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -2,15 +2,27 @@
 
 module Middleware
   class DefaultHeaders
+    HTML_ONLY_HEADERS = Set.new(%w[X-Frame-Options X-XSS-Protection])
+
     def initialize(app, settings = {})
       @app = app
     end
 
     def call(env)
       status, headers, body = @app.call(env)
+      is_html_response = html_response?(headers)
+
+      if default_headers = Rails.application.config.action_dispatch.default_headers
+        default_headers.each do |header_name, value|
+          next if !is_html_response && HTML_ONLY_HEADERS.include?(header_name)
+
+          headers[header_name] = value if headers[header_name].nil?
+        end
+      end
+
       headers[
         "Cross-Origin-Opener-Policy"
-      ] = SiteSetting.cross_origin_opener_policy_header if html_response?(headers) &&
+      ] = SiteSetting.cross_origin_opener_policy_header if is_html_response &&
         headers["Cross-Origin-Opener-Policy"].nil?
 
       [status, headers, body]

--- a/lib/middleware/default_headers.rb
+++ b/lib/middleware/default_headers.rb
@@ -14,14 +14,12 @@ module Middleware
       is_html_response = html_response?(headers)
 
       default_headers =
-        Rails.application.config.action_dispatch.default_headers&.select do |header_name|
-          !EXCLUDED_HEADERS.include?(header_name)
-        end || {}
+        Rails.application.config.action_dispatch.default_headers.to_h.except(*EXCLUDED_HEADERS)
 
       default_headers.each do |header_name, value|
         next if !is_html_response && HTML_ONLY_HEADERS.include?(header_name)
 
-        headers[header_name] = value if headers[header_name].nil?
+        headers[header_name] ||= value
       end
 
       headers[

--- a/spec/requests/default_headers_spec.rb
+++ b/spec/requests/default_headers_spec.rb
@@ -2,7 +2,6 @@
 RSpec.describe Middleware::DefaultHeaders do
   let(:mock_default_headers) do
     {
-      "X-Frame-Options" => "SAMEORIGIN",
       "X-XSS-Protection" => "0",
       "X-Content-Type-Options" => "nosniff",
       "X-Permitted-Cross-Domain-Policies" => "none",


### PR DESCRIPTION
Follow up from https://github.com/discourse/discourse/pull/31559.

We expect some standard headers to be added from `Rails.application.config.action_dispatch.default_headers` for responses, however these were found to be removed in some error paths. 

This PR adds those headers back if they aren't there, with the caveats that we don't add headers that are irrelevant for non-HTML responses, and neither do we add X-Frame-Options which is intentionally removed for embeddables.