### PR TITLE
DEV: Update template-override deprecation

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/component-templates.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/component-templates.js
@@ -2,21 +2,29 @@ import * as GlimmerManager from "@glimmer/manager";
 import ClassicComponent from "@ember/component";
 import deprecated from "discourse/lib/deprecated";
 import DiscourseTemplateMap from "discourse/lib/discourse-template-map";
-import { isTesting } from "discourse/lib/environment";
 import { RAW_TOPIC_LIST_DEPRECATION_OPTIONS } from "discourse/lib/plugin-api";
-
-let THROW_GJS_ERROR = isTesting();
-
-/** For use in tests/integration/component-templates-test only */
-export function overrideThrowGjsError(value) {
-  THROW_GJS_ERROR = value;
-}
+import { getThemeInfo } from "discourse/lib/source-identifier";
 
 // We're using a patched version of Ember with a modified GlimmerManager to make the code below work.
 // This patch is not ideal, but Ember does not allow us to change a component template after initial association
 // https://github.com/glimmerjs/glimmer-vm/blob/03a4b55c03/packages/%40glimmer/manager/lib/public/template.ts#L14-L20
 
 const LEGACY_TOPIC_LIST_OVERRIDES = ["topic-list", "topic-list-item"];
+
+function sourceForModuleName(name) {
+  const pluginMatch = name.match(/^discourse\/plugins\/([^\/]+)\//)?.[1];
+  if (pluginMatch) {
+    return {
+      type: "plugin",
+      name: pluginMatch,
+    };
+  }
+
+  const themeMatch = name.match(/^discourse\/theme-(\d+)\//)?.[1];
+  if (themeMatch) {
+    return getThemeInfo(parseInt(themeMatch, 10));
+  }
+}
 
 export default {
   after: ["populate-template-map", "mobile"],
@@ -31,11 +39,15 @@ export default {
       }
 
       let componentName = templateKey;
+      const finalOverrideModuleName = moduleNames[moduleNames.length - 1];
+
       if (mobile) {
         deprecated(
           `Mobile-specific hbs templates are deprecated. Use responsive CSS or {{#if this.site.mobileView}} instead. [${templateKey}]`,
           {
             id: "discourse.mobile-templates",
+            url: "https://meta.discourse.org/t/355668",
+            source: sourceForModuleName(finalOverrideModuleName),
           }
         );
         if (this.site.mobileView) {
@@ -57,32 +69,24 @@ export default {
       // patched function: Ember's OG won't return overridden templates. This version will.
       // it's safe to call it original template here because the override wasn't set yet.
       const originalTemplate = GlimmerManager.getComponentTemplate(component);
-      const isStrictMode = originalTemplate?.()?.parsedLayout?.isStrictMode;
-      const finalOverrideModuleName = moduleNames[moduleNames.length - 1];
 
-      if (isStrictMode) {
-        const message =
-          `[${finalOverrideModuleName}] ${componentName} was authored using gjs and its template cannot be overridden. ` +
-          `Ignoring override. For more information on the future of template overrides, see https://meta.discourse.org/t/247487`;
-        if (THROW_GJS_ERROR) {
-          throw new Error(message);
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(message);
-        }
-      } else if (originalTemplate) {
+      if (originalTemplate) {
         if (LEGACY_TOPIC_LIST_OVERRIDES.includes(componentName)) {
           // Special handling for these, with a different deprecation id, so the auto-feature-flag works correctly
           deprecated(
             `Overriding '${componentName}' template is deprecated. Use the value transformer 'topic-list-columns' and other new topic-list plugin APIs instead.`,
-            RAW_TOPIC_LIST_DEPRECATION_OPTIONS
+            {
+              ...RAW_TOPIC_LIST_DEPRECATION_OPTIONS,
+              source: sourceForModuleName(finalOverrideModuleName),
+            }
           );
         } else {
           deprecated(
-            `[${finalOverrideModuleName}] Overriding component templates is deprecated, and will soon be disabled. Use plugin outlets, CSS, or other customization APIs instead.`,
+            `Overriding component templates is deprecated, and will soon be disabled. Use plugin outlets, CSS, or other customization APIs instead. [${finalOverrideModuleName}]`,
             {
               id: "discourse.component-template-overrides",
-              url: "https://meta.discourse.org/t/247487",
+              url: "https://meta.discourse.org/t/355668",
+              source: sourceForModuleName(finalOverrideModuleName),
             }
           );
         }

--- a/app/assets/javascripts/discourse/app/lib/deprecated.js
+++ b/app/assets/javascripts/discourse/app/lib/deprecated.js
@@ -17,7 +17,7 @@ let emberDeprecationSilencer;
  * @param {boolean} [options.raiseError] Raise an error when this deprecation is triggered. Defaults to `false`
  */
 export default function deprecated(msg, options = {}) {
-  const { id, since, dropFrom, url, raiseError } = options;
+  const { id, since, dropFrom, url, raiseError, source } = options;
 
   if (id && disabledDeprecations.has(id)) {
     return;
@@ -42,7 +42,8 @@ export default function deprecated(msg, options = {}) {
   if (require.has("discourse/lib/source-identifier")) {
     // This module doesn't exist in pretty-text/wizard/etc.
     consolePrefix =
-      require("discourse/lib/source-identifier").consolePrefix() || "";
+      require("discourse/lib/source-identifier").consolePrefix(null, source) ||
+      "";
   }
 
   handlers.forEach((h) => h(msg, options));

--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -33,6 +33,10 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.qunit.global-exists",
   "discourse.post-stream.trigger-new-post",
   "discourse.hbr-topic-list-overrides",
+  "discourse.mobile-templates",
+  "discourse.mobile-view",
+  "discourse.mobile-templates",
+  "discourse.component-template-overrides",
 ];
 
 if (DEBUG) {
@@ -76,7 +80,7 @@ export default class DeprecationWarningHandler extends Service {
       return;
     }
 
-    const source = identifySource();
+    const source = opts.source || identifySource();
     if (source?.type === "browser-extension") {
       return;
     }

--- a/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
@@ -4,7 +4,6 @@ import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
 import sinon from "sinon";
-import { overrideThrowGjsError } from "discourse/instance-initializers/component-templates";
 import { withSilencedDeprecationsAsync } from "discourse/lib/deprecated";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -290,8 +289,6 @@ module("Integration | Initializers | plugin-component-templates", function (h) {
   });
 
   module("overriding gjs component", function (hooks) {
-    let errorStub;
-
     hooks.beforeEach(() => {
       registerTemporaryModule(
         `discourse/components/mock-gjs-component`,
@@ -304,18 +301,8 @@ module("Integration | Initializers | plugin-component-templates", function (h) {
 
       registerTemporaryModule(
         `discourse/plugins/my-plugin/discourse/templates/components/mock-gjs-component`,
-        hbs`doomed override`
+        hbs`<span class="greeting">Overridden greeting</span>`
       );
-
-      errorStub = sinon
-        .stub(console, "error")
-        .withArgs(sinon.match(/mock-gjs-component was authored using gjs/));
-
-      overrideThrowGjsError(false);
-    });
-
-    hooks.afterEach(() => {
-      overrideThrowGjsError(true);
     });
 
     setupRenderingTest(hooks);
@@ -324,9 +311,7 @@ module("Integration | Initializers | plugin-component-templates", function (h) {
       await render(hbs`<MockGjsComponent />`);
       assert
         .dom(".greeting")
-        .hasText("Hello world", "renders original implementation");
-
-      sinon.assert.calledOnce(errorStub);
+        .hasText("Overridden greeting", "it renders the overridden version");
     });
   });
 });


### PR DESCRIPTION
- Update Meta topic URLs

- Add theme/plugin identification to deprecation

- Enable admin warning banner

- Enable overriding of gjs component templates, to unblock core upgrade work between now and final removal of the template override feature

https://meta.discourse.org/t/355668