### PR TITLE
FIX: only show small user list if users has length

### DIFF
--- a/app/assets/javascripts/discourse/app/components/small-user-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/small-user-list.gjs
@@ -43,7 +43,7 @@ export default class SmallUserList extends Component {
   }
 
   get shouldShow() {
-    return this.users && this.args.isVisible;
+    return this.users.length && this.args.isVisible;
   }
 
   <template>


### PR DESCRIPTION
Need to check length here so we're not exposing the component when there are no users, fixes: https://meta.discourse.org/t/expanding-topic-actions-displays-who-liked-the-posts-but-nobody-has-liked-it/355225

follow-up to https://github.com/discourse/discourse/commit/5312550bf98431fb6c52a1f99798638820819a42