### PR TITLE
DEV: Remove unused header:update-topic triggers

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1740,7 +1740,6 @@ export default class TopicController extends Controller.extend(
     if (data.reload_topic) {
       topic.reload().then(() => {
         this.send("postChangedRoute", topic.get("post_number") || 1);
-        this.appEvents.trigger("header:update-topic", topic);
         if (data.refresh_stream) {
           postStream.refresh();
         }

--- a/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/subscribe-user-notifications.js
@@ -153,15 +153,6 @@ class SubscribeUserNotificationsInit {
       oldAllUnread !== data.all_unread_notifications_count
     ) {
       this.appEvents.trigger("notifications:changed");
-
-      if (
-        this.site.mobileView &&
-        (data.unread_notifications - oldUnread > 0 ||
-          data.unread_high_priority_notifications - oldHighPriority > 0 ||
-          data.all_unread_notifications_count - oldAllUnread > 0)
-      ) {
-        this.appEvents.trigger("header:update-topic", null, 5000);
-      }
     }
 
     const stale = this.store.findStale(

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -1,5 +1,5 @@
 import { action, get } from "@ember/object";
-import { cancel, schedule } from "@ember/runloop";
+import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import AddPmParticipants from "discourse/components/modal/add-pm-participants";
@@ -415,9 +415,5 @@ export default class TopicRoute extends DiscourseRoute {
 
     // We reset screen tracking every time a topic is entered
     this.screenTrack.start(model.get("id"), controller);
-
-    schedule("afterRender", () =>
-      this.appEvents.trigger("header:update-topic", model)
-    );
   }
 }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1184,9 +1184,6 @@ export default class ComposerService extends Service {
           this.appEvents.trigger("post-stream:refresh", {
             id: parseInt(result.responseJson.id, 10),
           });
-          if (result.responseJson.post.post_number === 1) {
-            this.appEvents.trigger("header:update-topic", composer.topic);
-          }
         } else {
           this.appEvents.trigger("post-stream:refresh");
         }


### PR DESCRIPTION
Nothing is listening to these events since we dropped the widget-based header. Now, the glimmer header re-renders automatically when topic info changes.