### PR TITLE
FIX: Ensure queued posts with watched words are processed correctly.

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -77,13 +77,11 @@ class ReviewableScoreSerializer < ApplicationSerializer
   def watched_word_reason(link)
     if object.context.nil?
       # If the words weren't recorded, try to guess them based on current settings.
-      if object.reviewable.respond_to?(:post)
-        words =
+      words = if object.reviewable.respond_to?(:post)
           WordWatcher.new(
             "#{object.reviewable.post.title} #{object.reviewable.post.raw}",
           ).word_matches_for_action?(:flag, all_matches: true)
       elsif object.reviewable.respond_to?(:payload)
-        words =
           WordWatcher.new(
             "#{object.reviewable.payload["title"]} #{object.reviewable.payload["raw"]}",
           ).word_matches_for_action?(:flag, all_matches: true)

--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -77,16 +77,15 @@ class ReviewableScoreSerializer < ApplicationSerializer
   def watched_word_reason(link)
     if object.context.nil?
       # If the words weren't recorded, try to guess them based on current settings.
-      words =
-        if object.reviewable.respond_to?(:post)
-          WordWatcher.new(
-            "#{object.reviewable.post.title} #{object.reviewable.post.raw}",
-          ).word_matches_for_action?(:flag, all_matches: true)
-        elsif object.reviewable.respond_to?(:payload)
-          WordWatcher.new(
-            "#{object.reviewable.payload["title"]} #{object.reviewable.payload["raw"]}",
-          ).word_matches_for_action?(:flag, all_matches: true)
-        end
+      if object.reviewable.respond_to?(:post)
+        s = object.reviewable.post.raw
+        s << " #{object.reviewable.post.topic.title}" if object.reviewable.post.post_number == 1
+      elsif object.reviewable.respond_to?(:payload)
+        s = object.reviewable.payload["raw"]
+        s << " #{object.reviewable.payload["title"]}" if object.reviewable.payload.key?("title")
+      end
+
+      words = WordWatcher.new(s).word_matches_across_all_actions if s
     else
       words = object.context.split(",")
     end

--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -77,15 +77,16 @@ class ReviewableScoreSerializer < ApplicationSerializer
   def watched_word_reason(link)
     if object.context.nil?
       # If the words weren't recorded, try to guess them based on current settings.
-      words = if object.reviewable.respond_to?(:post)
+      words =
+        if object.reviewable.respond_to?(:post)
           WordWatcher.new(
             "#{object.reviewable.post.title} #{object.reviewable.post.raw}",
           ).word_matches_for_action?(:flag, all_matches: true)
-      elsif object.reviewable.respond_to?(:payload)
+        elsif object.reviewable.respond_to?(:payload)
           WordWatcher.new(
             "#{object.reviewable.payload["title"]} #{object.reviewable.payload["raw"]}",
           ).word_matches_for_action?(:flag, all_matches: true)
-      end
+        end
     else
       words = object.context.split(",")
     end

--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -77,11 +77,17 @@ class ReviewableScoreSerializer < ApplicationSerializer
   def watched_word_reason(link)
     if object.context.nil?
       # If the words weren't recorded, try to guess them based on current settings.
-      words =
-        WordWatcher.new(object.reviewable.post.raw).word_matches_for_action?(
-          :flag,
-          all_matches: true,
-        )
+      if object.reviewable.respond_to?(:post)
+        words =
+          WordWatcher.new(
+            "#{object.reviewable.post.title} #{object.reviewable.post.raw}",
+          ).word_matches_for_action?(:flag, all_matches: true)
+      elsif object.reviewable.respond_to?(:payload)
+        words =
+          WordWatcher.new(
+            "#{object.reviewable.payload["title"]} #{object.reviewable.payload["raw"]}",
+          ).word_matches_for_action?(:flag, all_matches: true)
+      end
     else
       words = object.context.split(",")
     end

--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -85,12 +85,12 @@ class ReviewableScoreSerializer < ApplicationSerializer
         s << " #{object.reviewable.payload["title"]}" if object.reviewable.payload.key?("title")
       end
 
-      words = WordWatcher.new(s).word_matches_across_all_actions if s
+      words = WordWatcher.new(s).word_matches_across_all_actions
     else
       words = object.context.split(",")
     end
 
-    if words.nil?
+    if words.nil? || words.empty?
       text =
         I18n.t("reviewables.reasons.no_context.watched_word", link: link, default: "watched_word")
     else

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -223,6 +223,17 @@ class WordWatcher
     match_list
   end
 
+  def word_matches_across_all_actions
+    WatchedWord
+      .actions
+      .keys
+      .filter_map { |action| word_matches_for_action?(action, all_matches: true) }
+      .flatten
+      .compact
+      .uniq
+      .sort
+  end
+
   def word_matches?(word, case_sensitive: false)
     options = case_sensitive ? nil : Regexp::IGNORECASE
     Regexp.new(WordWatcher.word_to_regexp(word), options).match?(@raw)

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe ReviewableScoreSerializer do
         expect(score.reason).to include("bad, words")
       end
 
+      it "handles guessing the watched words when the post hasn't been created yet" do
+        queued_reviewable = Fabricate(:reviewable_queued_post_topic)
+        reviewable_score =
+          ReviewableScore.new(reviewable: queued_reviewable, reason: "watched_word")
+
+        Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "queued")
+        Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "title")
+
+        result = described_class.new(reviewable_score, scope: Guardian.new(admin), root: nil)
+        expect(result.reason).to include("queued, title")
+      end
+
       it "uses the no-context message if the post has no watched words" do
         reviewable.target = Fabricate(:post, raw: "This post contains no bad words.")
 

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -85,11 +85,11 @@ RSpec.describe ReviewableScoreSerializer do
         reviewable_score =
           ReviewableScore.new(reviewable: queued_reviewable, reason: "watched_word")
 
-        Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "queued")
+        Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "contents")
         Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "title")
 
         result = described_class.new(reviewable_score, scope: Guardian.new(admin), root: nil)
-        expect(result.reason).to include("queued, title")
+        expect(result.reason).to include("contents, title")
       end
 
       it "uses the no-context message if the post has no watched words" do

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -368,6 +368,22 @@ RSpec.describe WordWatcher do
     end
   end
 
+  describe "#word_matches_across_all_actions" do
+    it("returns an array of words") do
+      Fabricate(:watched_word, action: WatchedWord.actions[:flag], word: "foo")
+      Fabricate(:watched_word, action: WatchedWord.actions[:block], word: "bar")
+      Fabricate(:watched_word, action: WatchedWord.actions[:silence], word: "baz")
+
+      contentful_check = described_class.new("Going to match the baz, the foo, and the bar.")
+
+      expect(contentful_check.word_matches_across_all_actions).to contain_exactly(
+        "foo",
+        "bar",
+        "baz",
+      )
+    end
+  end
+
   describe "word replacement" do
     fab!(:censored_word) do
       Fabricate(:watched_word, word: "censored", action: WatchedWord.actions[:censor])


### PR DESCRIPTION
## ✨ What's This?

Follow-up to #31435.

This change ensures that queued posts that have ended up in the review queue due to matched a watched word display correctly.

It also improves the data checking to ensure that any other reviewables with watched words don't break the review queue, either. 