### PR TITLE
DEV: set field type in control wrapper

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
@@ -11,8 +11,14 @@ import FKTooltip from "discourse/form-kit/components/fk/tooltip";
 import concatClass from "discourse/helpers/concat-class";
 
 export default class FKControlWrapper extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.args.field.type = this.args.component.controlType;
+  }
+
   get controlType() {
-    if (this.args.component.controlType === "input") {
+    if (this.args.field.type === "input") {
       return this.args.field.type + "-" + (this.args.type || "text");
     }
 

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/field.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/field.gjs
@@ -63,8 +63,6 @@ export default class FKField extends Component {
       );
     }
 
-    field.type = component.controlType;
-
     return curryComponent(FKControlWrapper, baseArguments, getOwner(this));
   }
 


### PR DESCRIPTION
Calling `<field.Calendar>` will ultimately call `componentFor` which will mutate the type of the field. Problem is the way we use a hash to define all the available controls, would work correctly on first render, but because of the mutation in `componentFor` if something would trigger a re-render it would have to evaluate all the `componentFor` calls, and the last one would "win" (currently calendar), which would mean that a field rendered as custom would for example become calendar.

The easiest repro was:

```gjs
<Form as |form|>
  <form.field as |field|>
    {{log field}}
    <field.Custom>
      Hello world
    </field.Custom>
  </form.field>
</Form>
```

The fix for now is to mutate the value at the point where the component is actually rendered, in control-wrapper.

A possibly more correct longer term fix could be to change the API, to set the type on the field when defined in the template, and render a generic component which would use this type to know what to render:

```gjs
<form.field @type="calendar" as |field|>
  <field.Control @someCalendarOption="bar" />
</form.field>
```