### PR TITLE
FIX: Use filename as alt for hotlinked image uploads

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -249,7 +249,7 @@ class InlineUploads
     raw =
       raw.gsub(%r{^(https?://\S+)(\s?)$}) do |match|
         if upload = blk.call(match)
-          "![](#{upload.short_url})"
+          "![#{upload.original_filename}](#{upload.short_url})"
         else
           match
         end

--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -249,7 +249,9 @@ class InlineUploads
     raw =
       raw.gsub(%r{^(https?://\S+)(\s?)$}) do |match|
         if upload = blk.call(match)
-          "![#{upload.original_filename}](#{upload.short_url})"
+          filename_modified = upload.original_filename&.gsub(/[\[\]\|]/, "").to_s
+          filename_modified = File.basename(filename_modified, File.extname(filename_modified))
+          "![#{filename_modified}](#{upload.short_url})"
         else
           match
         end

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
         https://commons.wikimedia.org/wiki/File:Brisbane_May_2013201.jpg
         <img src='#{broken_image_url}'>
         <a href='#{url}'><img src='#{large_image_url}'></a>
-        ![Longcat1.gif](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
+        ![Longcat1](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
         MD
 
         expect(post.cooked).to match(%r{<p><img src=.*/uploads})
@@ -481,7 +481,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
 
         expect(post.raw).to eq(<<~MD.chomp)
         Onebox here:
-        ![Longcat1.gif](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
+        ![Longcat1](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
         MD
 
         expect(post.cooked).to match(%r{<img src=.*/uploads})

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::PullHotlinkedImages do
-  let(:image_url) { "http://wiki.mozilla.org/images/2/2e/Longcat1.png" }
+  let(:image_url) { "http://wiki.mozilla.org/images/2/2e/Longcat1.gif" }
   let(:broken_image_url) { "http://wiki.mozilla.org/images/2/2e/Longcat2.png" }
   let(:large_image_url) { "http://wiki.mozilla.org/images/2/2e/Longcat3.png" }
   let(:encoded_image_url) { "https://example.com/אלחוט-.jpg" }
-  let(:png) do
+  let(:gif) do
     Base64.decode64(
       "R0lGODlhAQABALMAAAAAAIAAAACAAICAAAAAgIAAgACAgMDAwICAgP8AAAD/AP//AAAA//8A/wD//wBiZCH5BAEAAA8ALAAAAAABAAEAAAQC8EUAOw==",
     )
@@ -21,11 +21,11 @@ RSpec.describe Jobs::PullHotlinkedImages do
   before do
     Jobs.run_immediately!
 
-    stub_request(:get, image_url).to_return(body: png, headers: { "Content-Type" => "image/png" })
+    stub_request(:get, image_url).to_return(body: gif, headers: { "Content-Type" => "image/gif" })
     stub_request(:get, encoded_image_url).to_return(
-      body: png,
+      body: gif,
       headers: {
-        "Content-Type" => "image/png",
+        "Content-Type" => "image/gif",
       },
     )
     stub_request(:get, broken_image_url).to_return(status: 404)
@@ -173,7 +173,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
     end
 
     it "replaces correct image URL" do
-      url = image_url.sub("/2e/Longcat1.png", "")
+      url = image_url.sub("/2e/Longcat1.gif", "")
       post = Fabricate(:post, user: user, raw: "[Images](#{url})\n![](#{image_url})")
       stub_image_size
 
@@ -215,7 +215,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
 
     it "replaces images without extension" do
       url = image_url.sub(/\.[a-zA-Z0-9]+$/, "")
-      stub_request(:get, url).to_return(body: png, headers: { "Content-Type" => "image/png" })
+      stub_request(:get, url).to_return(body: gif, headers: { "Content-Type" => "image/gif" })
       post = Fabricate(:post, user: user, raw: "<img src='#{url}'>")
       stub_image_size
 
@@ -459,7 +459,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
         https://commons.wikimedia.org/wiki/File:Brisbane_May_2013201.jpg
         <img src='#{broken_image_url}'>
         <a href='#{url}'><img src='#{large_image_url}'></a>
-        ![](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
+        ![Longcat1.gif](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
         MD
 
         expect(post.cooked).to match(%r{<p><img src=.*/uploads})
@@ -481,7 +481,7 @@ RSpec.describe Jobs::PullHotlinkedImages do
 
         expect(post.raw).to eq(<<~MD.chomp)
         Onebox here:
-        ![](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
+        ![Longcat1.gif](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
         MD
 
         expect(post.cooked).to match(%r{<img src=.*/uploads})

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -712,4 +712,20 @@ RSpec.describe InlineUploads do
       expect(url).to eq("https://some-site.com/a_test?q=1&b=hello%20there")
     end
   end
+
+  describe ".replace_hotlinked_image_urls" do
+    fab!(:image_upload)
+    it "replaces URL with image markdown and uses filename as alt" do
+      origin = "http://foo.bar/#{image_upload.original_filename}"
+      raw =
+        InlineUploads.replace_hotlinked_image_urls(raw: "look at this:\n#{origin}") do |match_src|
+          expect(match_src).to eq(origin)
+          image_upload
+        end
+
+      expect(raw).to eq(
+        "look at this:\n![#{image_upload.original_filename}](#{image_upload.short_url})",
+      )
+    end
+  end
 end

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -714,18 +714,31 @@ RSpec.describe InlineUploads do
   end
 
   describe ".replace_hotlinked_image_urls" do
-    fab!(:image_upload)
-    it "replaces URL with image markdown and uses filename as alt" do
-      origin = "http://foo.bar/#{image_upload.original_filename}"
-      raw =
-        InlineUploads.replace_hotlinked_image_urls(raw: "look at this:\n#{origin}") do |match_src|
-          expect(match_src).to eq(origin)
-          image_upload
-        end
+    context "when raw has an image URL" do
+      fab!(:image_upload)
+      it "replaces URL with image markdown and uses filename as alt" do
+        origin = "http://foo.bar/#{image_upload.original_filename}"
+        raw =
+          InlineUploads.replace_hotlinked_image_urls(raw: "look at this:\n#{origin}") do |match_src|
+            expect(match_src).to eq(origin)
+            image_upload
+          end
 
-      expect(raw).to eq(
-        "look at this:\n![#{image_upload.original_filename}](#{image_upload.short_url})",
-      )
+        expect(raw).to eq("look at this:\n![logo](#{image_upload.short_url})")
+      end
+    end
+    context "when raw has an image URL with a square bracket in filename" do
+      let!(:image_upload) { Fabricate(:image_upload, original_filename: "image]1.jpg") }
+      it "does not make broken markdown" do
+        origin = "http://foo.bar/#{image_upload.original_filename}"
+        raw =
+          InlineUploads.replace_hotlinked_image_urls(raw: "look at this:\n#{origin}") do |match_src|
+            expect(match_src).to eq(origin)
+            image_upload
+          end
+
+        expect(raw).to eq("look at this:\n![image1](#{image_upload.short_url})")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, when converting raw hotlinked image urls to image upload markdown, the `alt` attribute is left blank.
This change sets the `alt` to the original filename (which means it will also appear in the lightbox).
This adds more context and accessibility to the image and is consistent with how regular uploaded images default to use the filename.

For example:
`http://foo.bar/screenshot.jpg` becomes `![screenshot](upload://bEs9WFJErcB8y7m1Ye5JopTWeX3.jpeg)`