### PR TITLE
FIX: Ensure the reviewable.type_source migration is run post-deploy.

### DIFF
--- a/db/migrate/20250212045125_add_type_source_to_reviewable.rb
+++ b/db/migrate/20250212045125_add_type_source_to_reviewable.rb
@@ -21,9 +21,11 @@ class AddTypeSourceToReviewable < ActiveRecord::Migration[7.2]
     }
 
     known_reviewables.each do |plugin, types|
-      types.each do |type|
-        Reviewable.where(type: type, type_source: "unknown").update_all(type_source: plugin)
-      end
+      DB.exec(
+        "UPDATE reviewables SET type_source = :plugin WHERE type_source = 'unknown' AND type IN (:types)",
+        plugin: plugin,
+        types: types,
+      )
     end
   end
 end

--- a/db/post_migrate/20250305233449_populate_type_source_in_reviewable.rb
+++ b/db/post_migrate/20250305233449_populate_type_source_in_reviewable.rb
@@ -18,9 +18,11 @@ class PopulateTypeSourceInReviewable < ActiveRecord::Migration[7.2]
     }
 
     known_reviewables.each do |plugin, types|
-      types.each do |type|
-        Reviewable.where(type: type, type_source: "unknown").update_all(type_source: plugin)
-      end
+      DB.exec(
+        "UPDATE reviewables SET type_source = :plugin WHERE type_source = 'unknown' AND type IN (:types)",
+        plugin: plugin,
+        types: types,
+      )
     end
   end
 end

--- a/db/post_migrate/20250305233449_populate_type_source_in_reviewable.rb
+++ b/db/post_migrate/20250305233449_populate_type_source_in_reviewable.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
-class AddTypeSourceToReviewable < ActiveRecord::Migration[7.2]
+class PopulateTypeSourceInReviewable < ActiveRecord::Migration[7.2]
   def change
-    add_column :reviewables, :type_source, :string, null: false, default: "unknown"
-
     # Migrate known reviewables to have a type_source
-    # This process is repeated in db/post_migrate/20250306045125_populate_type_source_in_reviewable.rb,
-    # to ensure that the column is populated after migrated servers are deployed to production.
+    # Copied from db/migrate/20250212045125_add_type_source_to_reviewable.rb
     known_reviewables = {
       "chat" => %w[ReviewableChatMessage],
       "core" => %w[ReviewableFlaggedPost ReviewableQueuedPost ReviewableUser ReviewablePost],


### PR DESCRIPTION
## ✨ What's This?

Follow-up to #31325.

When the upgrade process from 29a8c6ee498999f114f933d2de2b46989a407660 is run, there's a deployment race condition where old code can write a Reviewable to the database without a `type_source` (incorrectly defaulting it to 
"unknown").

This change adds a post-deploy migration script that populates any such Reviewables with the correct `type_source` value.
