### PR TITLE
UX: remove padding in admin card section

### DIFF
--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -154,7 +154,6 @@
   &__content {
     margin-top: 0.5rem;
     padding-right: 1em;
-    padding-left: 0.5em;
     padding-bottom: 1em;
     gap: 1.5em;
     display: flex;


### PR DESCRIPTION
Before
<img width="1064" alt="Screenshot 2025-03-06 at 3 05 55 pm" src="https://github.com/user-attachments/assets/38acc2cd-1204-42ec-aac7-18dfee32e8bc" />


After
<img width="949" alt="Screenshot 2025-03-06 at 3 06 44 pm" src="https://github.com/user-attachments/assets/ded3c81f-8057-483d-b997-d1983ccf1318" />