### PR TITLE
DEV: replace UserFieldsValidation mixin with helper class

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
@@ -65,7 +65,10 @@ export default class CreateAccount extends Component {
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
-  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper({
+    owner: this,
+    showValidationOnInit: false,
+  });
 
   @setting("enable_local_logins") canCreateLocal;
   @setting("require_invite_code") requireInviteCode;
@@ -535,6 +538,7 @@ export default class CreateAccount extends Component {
   createAccount() {
     this.set("flash", "");
     this.nameValidationHelper.forceValidationReason = true;
+    this.userFieldsValidationHelper.validationVisible = true;
     this.set("emailValidationVisible", true);
 
     const validation = [
@@ -561,6 +565,7 @@ export default class CreateAccount extends Component {
       return;
     }
 
+    this.userFieldsValidationHelper.validationVisible = false;
     this.nameValidationHelper.forceValidationReason = false;
     this.performAccountCreation();
   }

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
@@ -36,16 +36,14 @@ import discourseComputed, { bind } from "discourse/lib/decorators";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
 import PasswordValidationHelper from "discourse/lib/password-validation-helper";
 import { userPath } from "discourse/lib/url";
+import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import UsernameValidationHelper from "discourse/lib/username-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
-import UserFieldsValidation from "discourse/mixins/user-fields-validation";
 import { findAll } from "discourse/models/login-method";
 import User from "discourse/models/user";
 import { i18n } from "discourse-i18n";
 
-export default class CreateAccount extends Component.extend(
-  UserFieldsValidation
-) {
+export default class CreateAccount extends Component {
   @service site;
   @service siteSettings;
   @service login;
@@ -62,12 +60,12 @@ export default class CreateAccount extends Component.extend(
   formSubmitted = false;
   rejectedEmails = A();
   prefilledUsername = null;
-  userFields = null;
   maskPassword = true;
   emailValidationVisible = false;
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
 
   @setting("enable_local_logins") canCreateLocal;
   @setting("require_invite_code") requireInviteCode;
@@ -86,6 +84,16 @@ export default class CreateAccount extends Component.extend(
         () => (this.skipConfirmation = false)
       );
     }
+  }
+
+  @dependentKeyCompat
+  get userFields() {
+    return this.userFieldsValidationHelper.userFields;
+  }
+
+  @dependentKeyCompat
+  get userFieldsValidation() {
+    return this.userFieldsValidationHelper.userFieldsValidation;
   }
 
   @action
@@ -436,9 +444,7 @@ export default class CreateAccount extends Component.extend(
     // Add the userFields to the data
     if (!isEmpty(this.userFields)) {
       attrs.userFields = {};
-      this.userFields.forEach(
-        (f) => (attrs.userFields[f.get("field.id")] = f.get("value"))
-      );
+      this.userFields.forEach((f) => (attrs.userFields[f.field.id] = f.value));
     }
 
     this.set("formSubmitted", true);

--- a/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/create-account.gjs
@@ -66,7 +66,8 @@ export default class CreateAccount extends Component {
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
   userFieldsValidationHelper = new UserFieldsValidationHelper({
-    owner: this,
+    getUserFields: () => this.site.get("user_fields"),
+    getAccountPassword: () => this.accountPassword,
     showValidationOnInit: false,
   });
 

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -25,7 +25,7 @@ export default class InvitesShowController extends Controller {
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
-  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper({ owner: this });
   successMessage = null;
   @readOnly("model.is_invite_link") isInviteLink;
   @readOnly("model.invited_by") invitedBy;

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -11,15 +11,13 @@ import getUrl from "discourse/lib/get-url";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
 import PasswordValidationHelper from "discourse/lib/password-validation-helper";
 import DiscourseURL from "discourse/lib/url";
+import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import UsernameValidationHelper from "discourse/lib/username-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
-import UserFieldsValidation from "discourse/mixins/user-fields-validation";
 import { findAll as findLoginMethods } from "discourse/models/login-method";
 import { i18n } from "discourse-i18n";
 
-export default class InvitesShowController extends Controller.extend(
-  UserFieldsValidation
-) {
+export default class InvitesShowController extends Controller {
   @tracked accountPassword;
   @tracked accountUsername;
   @tracked isDeveloper;
@@ -27,6 +25,7 @@ export default class InvitesShowController extends Controller.extend(
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
   successMessage = null;
   @readOnly("model.is_invite_link") isInviteLink;
   @readOnly("model.invited_by") invitedBy;
@@ -41,10 +40,18 @@ export default class InvitesShowController extends Controller.extend(
   @alias("model.different_external_email") differentExternalEmail;
   @not("externalAuthsOnly") passwordRequired;
   errorMessage = null;
-  userFields = null;
   authOptions = null;
   rejectedEmails = [];
   maskPassword = true;
+
+  get userFields() {
+    return this.userFieldsValidationHelper.userFields;
+  }
+
+  @dependentKeyCompat
+  get userFieldsValidation() {
+    return this.userFieldsValidationHelper.userFieldsValidation;
+  }
 
   @action
   setAccountUsername(event) {
@@ -320,11 +327,10 @@ export default class InvitesShowController extends Controller.extend(
 
   @action
   submit() {
-    const userFields = this.userFields;
     let userCustomFields = {};
-    if (!isEmpty(userFields)) {
-      userFields.forEach(function (f) {
-        userCustomFields[f.get("field.id")] = f.get("value");
+    if (!isEmpty(this.userFields)) {
+      this.userFields.forEach(function (f) {
+        userCustomFields[f.field.id] = f.value;
       });
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -25,7 +25,10 @@ export default class InvitesShowController extends Controller {
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
-  userFieldsValidationHelper = new UserFieldsValidationHelper({ owner: this });
+  userFieldsValidationHelper = new UserFieldsValidationHelper({
+    getUserFields: () => this.site.get("user_fields"),
+    getAccountPassword: () => this.accountPassword,
+  });
   successMessage = null;
   @readOnly("model.is_invite_link") isInviteLink;
   @readOnly("model.invited_by") invitedBy;

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -46,7 +46,8 @@ export default class SignupPageController extends Controller {
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
   userFieldsValidationHelper = new UserFieldsValidationHelper({
-    owner: this,
+    getUserFields: () => this.site.get("user_fields"),
+    getAccountPassword: () => this.accountPassword,
     showValidationOnInit: false,
   });
 

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -16,16 +16,14 @@ import discourseComputed, { bind } from "discourse/lib/decorators";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
 import PasswordValidationHelper from "discourse/lib/password-validation-helper";
 import { userPath } from "discourse/lib/url";
+import UserFieldsValidationHelper from "discourse/lib/user-fields-validation-helper";
 import UsernameValidationHelper from "discourse/lib/username-validation-helper";
 import { emailValid } from "discourse/lib/utilities";
-import UserFieldsValidation from "discourse/mixins/user-fields-validation";
 import { findAll } from "discourse/models/login-method";
 import User from "discourse/models/user";
 import { i18n } from "discourse-i18n";
 
-export default class SignupPageController extends Controller.extend(
-  UserFieldsValidation
-) {
+export default class SignupPageController extends Controller {
   @service site;
   @service siteSettings;
   @service login;
@@ -42,12 +40,12 @@ export default class SignupPageController extends Controller.extend(
   formSubmitted = false;
   rejectedEmails = A();
   prefilledUsername = null;
-  userFields = null;
   maskPassword = true;
   emailValidationVisible = false;
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
 
   @notEmpty("authOptions") hasAuthOptions;
   @setting("enable_local_logins") canCreateLocal;
@@ -61,6 +59,16 @@ export default class SignupPageController extends Controller.extend(
     }
 
     this.fetchConfirmationValue();
+  }
+
+  @dependentKeyCompat
+  get userFields() {
+    return this.userFieldsValidationHelper.userFields;
+  }
+
+  @dependentKeyCompat
+  get userFieldsValidation() {
+    return this.userFieldsValidationHelper.userFieldsValidation;
   }
 
   @dependentKeyCompat
@@ -421,9 +429,7 @@ export default class SignupPageController extends Controller.extend(
     // Add the userFields to the data
     if (!isEmpty(this.userFields)) {
       attrs.userFields = {};
-      this.userFields.forEach(
-        (f) => (attrs.userFields[f.get("field.id")] = f.get("value"))
-      );
+      this.userFields.forEach((f) => (attrs.userFields[f.field.id] = f.value));
     }
 
     this.set("formSubmitted", true);

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -45,7 +45,10 @@ export default class SignupPageController extends Controller {
   nameValidationHelper = new NameValidationHelper(this);
   usernameValidationHelper = new UsernameValidationHelper(this);
   passwordValidationHelper = new PasswordValidationHelper(this);
-  userFieldsValidationHelper = new UserFieldsValidationHelper(this);
+  userFieldsValidationHelper = new UserFieldsValidationHelper({
+    owner: this,
+    showValidationOnInit: false,
+  });
 
   @notEmpty("authOptions") hasAuthOptions;
   @setting("enable_local_logins") canCreateLocal;
@@ -520,6 +523,7 @@ export default class SignupPageController extends Controller {
   createAccount() {
     this.set("flash", "");
     this.nameValidationHelper.forceValidationReason = true;
+    this.userFieldsValidationHelper.validationVisible = true;
     this.set("emailValidationVisible", true);
 
     const validation = [
@@ -546,6 +550,7 @@ export default class SignupPageController extends Controller {
       return;
     }
 
+    this.userFieldsValidationHelper.validationVisible = false;
     this.nameValidationHelper.forceValidationReason = false;
     this.performAccountCreation();
   }

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -2132,16 +2132,13 @@ class PluginApi {
    *
    * ```
    * const IconWithDropdown = <template>
-    *
-    <DMenu @icon="foo" title={{i18n "title"}}>
-      *
-      <:content as |args|>
-        *       dropdown content here
-        *
-        <DButton @action={{args.close}} @icon="bar" />
-        *     </:content>
-      *   </DMenu>
-    * </template>;
+   *   <DMenu @icon="foo" title={{i18n "title"}}>
+   *     <:content as |args|>
+   *       dropdown content here
+   *       <DButton @action={{args.close}} @icon="bar" />
+   *     </:content>
+   *   </DMenu>
+   * </template>;
    *
    * api.headerIcons.add("icon-name", IconWithDropdown, { before: "search" })
    * ```

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -117,9 +117,10 @@ import {
   _registerTransformer,
   transformerTypes,
 } from "discourse/lib/transformer";
+import { addCustomUserFieldValidationCallback } from "discourse/lib/user-fields-validation-helper";
 import { registerUserMenuTab } from "discourse/lib/user-menu/tab";
 import { replaceFormatter } from "discourse/lib/utilities";
-import { addCustomUserFieldValidationCallback } from "discourse/mixins/user-fields-validation";
+import { addCustomUserFieldValidationCallback as addCustomUserFieldValidationCallbackDeprecated } from "discourse/mixins/user-fields-validation";
 import Composer, {
   registerCustomizationCallback,
 } from "discourse/models/composer";
@@ -1572,6 +1573,7 @@ class PluginApi {
    **/
 
   addCustomUserFieldValidationCallback(callback) {
+    addCustomUserFieldValidationCallbackDeprecated(callback);
     addCustomUserFieldValidationCallback(callback);
   }
 
@@ -2130,13 +2132,16 @@ class PluginApi {
    *
    * ```
    * const IconWithDropdown = <template>
-   *   <DMenu @icon="foo" title={{i18n "title"}}>
-   *     <:content as |args|>
-   *       dropdown content here
-   *       <DButton @action={{args.close}} @icon="bar" />
-   *     </:content>
-   *   </DMenu>
-   * </template>;
+    *
+    <DMenu @icon="foo" title={{i18n "title"}}>
+      *
+      <:content as |args|>
+        *       dropdown content here
+        *
+        <DButton @action={{args.close}} @icon="bar" />
+        *     </:content>
+      *   </DMenu>
+    * </template>;
    *
    * api.headerIcons.add("icon-name", IconWithDropdown, { before: "search" })
    * ```

--- a/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
@@ -1,0 +1,103 @@
+import { tracked } from "@glimmer/tracking";
+import EmberObject from "@ember/object";
+import { isEmpty } from "@ember/utils";
+import { TrackedArray } from "@ember-compat/tracked-built-ins";
+import { i18n } from "discourse-i18n";
+
+const addCustomUserFieldValidationCallbacks = [];
+
+export function addCustomUserFieldValidationCallback(callback) {
+  addCustomUserFieldValidationCallbacks.push(callback);
+}
+
+// each userField => EmberObject (converted to TrackedUserField)
+//   - field => UserField
+//   - value => str
+//   - validation => EmberObject
+class TrackedUserField {
+  @tracked value;
+  @tracked validation;
+  field;
+
+  constructor(field) {
+    this.field = field;
+  }
+}
+
+export default class UserFieldsValidationHelper {
+  @tracked userFields = new TrackedArray();
+
+  constructor(owner) {
+    this.owner = owner;
+    this.initializeUserFields();
+  }
+
+  initializeUserFields() {
+    if (!this.owner.site) {
+      return;
+    }
+
+    let userFields = this.owner.site.get("user_fields");
+    if (userFields) {
+      this.userFields = new TrackedArray(
+        userFields.sortBy("position").map((f) => new TrackedUserField(f))
+      );
+    }
+  }
+
+  get userFieldsValidation() {
+    if (!this.userFields) {
+      return EmberObject.create({ ok: true });
+    }
+
+    this.userFields.forEach((userField) => {
+      let validation = EmberObject.create({ ok: true });
+
+      if (
+        userField.field.required &&
+        (!userField.value || isEmpty(userField.value))
+      ) {
+        const reasonKey =
+          userField.field.field_type === "confirm"
+            ? "user_fields.required_checkbox"
+            : "user_fields.required";
+        validation = EmberObject.create({
+          failed: true,
+          reason: i18n(reasonKey, {
+            name: userField.field.name,
+          }),
+          element: userField.field.element,
+        });
+      } else if (
+        this.owner.accountPassword &&
+        userField.field.field_type === "text" &&
+        userField.value &&
+        userField.value
+          .toLowerCase()
+          .includes(this.owner.accountPassword.toLowerCase())
+      ) {
+        validation = EmberObject.create({
+          failed: true,
+          reason: i18n("user_fields.same_as_password"),
+          element: userField.field.element,
+        });
+      }
+
+      addCustomUserFieldValidationCallbacks.forEach((callback) => {
+        const customUserFieldValidationObject = callback(userField);
+        if (customUserFieldValidationObject) {
+          validation = customUserFieldValidationObject;
+        }
+      });
+
+      userField.validation = validation;
+    });
+
+    const invalidUserField = this.userFields.find((f) => f.validation.failed);
+    if (invalidUserField) {
+      return invalidUserField.validation;
+    }
+
+    return EmberObject.create({ ok: true });
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
@@ -71,22 +71,6 @@ class TrackedUserField {
 
     return validation;
   }
-
-  get failed() {
-    return !!this.validation.failed;
-  }
-
-  get ok() {
-    return !!this.validation.ok;
-  }
-
-  get reason() {
-    return this.validation.reason || null;
-  }
-
-  get element() {
-    return this.validation.element || null;
-  }
 }
 
 export default class UserFieldsValidationHelper {

--- a/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
@@ -22,12 +22,30 @@ function validResult(attrs) {
 }
 
 class TrackedUserField {
-  @tracked value;
+  @tracked value = null;
+  @tracked failed = false;
+  @tracked reason = null;
+  @tracked element = null;
   field;
-  validation;
 
   constructor(field) {
     this.field = field;
+  }
+
+  get validation() {
+    return {
+      failed: this.failed,
+      reason: this.reason,
+      ok: !this.failed,
+      element: this.element,
+    };
+  }
+
+  // Update validation state
+  updateValidation(validation = {}) {
+    this.failed = !!validation.failed;
+    this.reason = validation.reason || null;
+    this.element = validation.element || null;
   }
 }
 
@@ -95,7 +113,7 @@ export default class UserFieldsValidationHelper {
         }
       });
 
-      userField.validation = validation;
+      userField.updateValidation(validation);
     });
 
     const invalidUserField = this.userFields.find((f) => f.validation.failed);

--- a/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/user-fields-validation-helper.js
@@ -32,6 +32,10 @@ class TrackedUserField {
   }
 
   get validation() {
+    if (!this.owner.validationVisible) {
+      return validResult();
+    }
+
     let validation = validResult();
     if (this.field.required && (!this.value || isEmpty(this.value))) {
       const reasonKey =
@@ -87,9 +91,11 @@ class TrackedUserField {
 
 export default class UserFieldsValidationHelper {
   @tracked userFields = new TrackedArray();
+  @tracked validationVisible = true;
 
-  constructor(owner) {
+  constructor({ owner, showValidationOnInit = true }) {
     this.owner = owner;
+    this.validationVisible = showValidationOnInit;
     this.initializeUserFields();
   }
 
@@ -101,11 +107,13 @@ export default class UserFieldsValidationHelper {
     let userFields = this.owner.site.get("user_fields");
     if (userFields) {
       this.userFields = new TrackedArray(
-        userFields
-          .sortBy("position")
-          .map((f) => new TrackedUserField(this.owner, f))
+        userFields.sortBy("position").map((f) => new TrackedUserField(this, f))
       );
     }
+  }
+
+  get accountPassword() {
+    return this.owner.accountPassword;
   }
 
   get userFieldsValidation() {


### PR DESCRIPTION
This PR refactors the UserFieldsValidation mixin into a helper class.

### Key Changes
* moved this.userFields to a tracked collection of TrackedUserFields stored on the helper class itself
* introduced `validationVisible` property to explicitly control when to display the validation result, we expect the helper to not display validation until form submission in the `SignupController` and `CreateAccount` components. 
* added backward compatibility to the plugin API `addCustomUserFieldValidationCallback` to ensure ex-Core instances of the mixin continues working till we remove them