### PR TITLE
UX: removes per channel context of favorites emojis

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -536,7 +536,7 @@ export default class ChatComposer extends Component {
             identifier: "emoji-picker",
             groupIdentifier: "emoji-picker",
             component: EmojiPickerDetached,
-            context: `channel_${this.args.channel.id}`,
+            context: "chat",
             modalForMobile: true,
             data: {
               didSelectEmoji: (emoji) => {

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -65,7 +65,7 @@ export default class ChatemojiReactions {
       .filter(Boolean);
 
     return this.emojiStore
-      .favoritesForContext(`channel_${this.message.channel.id}`)
+      .favoritesForContext("chat")
       .concat(defaultReactions)
       .slice(0, 3)
       .map(
@@ -413,7 +413,7 @@ export default class ChatemojiReactions {
         this.interactedChatMessage.emojiPickerOpen = false;
       },
       data: {
-        context: `channel_${this.message.channel.id}`,
+        context: "chat",
         didSelectEmoji: (emoji) => {
           this.selectReaction(emoji);
         },


### PR DESCRIPTION
This was confusing users.