### PR TITLE
FEATURE: Handle youtube live url format

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -112,6 +112,9 @@ module Onebox
             # https://www.youtube.com/shorts/wi2jAtpBl0Y
             id ||= uri.path[%r{/shorts/([\w\-]+)}, 1] if uri.path["/shorts/"]
 
+            # https://www.youtube.com/live/eJemwqO0SDw
+            id ||= uri.path[%r{/live/([\w\-]+)}, 1] if uri.path["/live/"]
+
             # https://www.youtube.com/watch?v=Z0UISCEe52Y
             id ||= params["v"]
 

--- a/spec/lib/onebox/engine/youtube_onebox_spec.rb
+++ b/spec/lib/onebox/engine/youtube_onebox_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Onebox::Engine::YoutubeOnebox do
       status: 200,
       body: onebox_response("youtube"),
     )
+    stub_request(:get, "https://www.youtube.com/live/eJemwqO0SDw").to_return(
+      status: 200,
+      body: onebox_response("youtube"),
+    )
+    stub_request(:get, "https://www.youtube.com/embed/eJemwqO0SDw").to_return(
+      status: 200,
+      body: onebox_response("youtube"),
+    )
 
     stub_request(:get, "https://www.youtube.com/channel/UCL8ZULXASCc1I_oaOT0NaOQ").to_return(
       status: 200,
@@ -97,6 +105,9 @@ RSpec.describe Onebox::Engine::YoutubeOnebox do
 
   it "returns an image as the placeholder" do
     expect(Onebox.preview("https://www.youtube.com/watch?v=21Lk4YiASMo").placeholder_html).to match(
+      /<img/,
+    )
+    expect(Onebox.preview("https://www.youtube.com/live/eJemwqO0SDw").placeholder_html).to match(
       /<img/,
     )
     expect(Onebox.preview("https://youtu.be/21Lk4YiASMo").placeholder_html).to match(/<img/)
@@ -185,5 +196,11 @@ RSpec.describe Onebox::Engine::YoutubeOnebox do
     preview = expect(Onebox.preview("https://youtube.com/shorts/VvoFuaLAslw").placeholder_html)
     preview.to match(/POMBO/)
     preview.to match(/hqdefault/)
+  end
+
+  it "can parse youtube live URLs" do
+    preview = expect(Onebox.preview("https://www.youtube.com/live/eJemwqO0SDw").to_s)
+    preview.to match(/iframe/)
+    preview.to include("embed/eJemwqO0SDw")
   end
 end


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/youtube-autoembeds-for-live-streams/350920

This PR supports YouTube live URLs, such as: `https://www.youtube.com/live/eJemwqO0SDw`.

![image](https://github.com/user-attachments/assets/b7e57857-5676-4dcf-862e-1e4b4e594009)
![image](https://github.com/user-attachments/assets/f5e6f2d0-a158-41c6-bc20-0642868dbef8)
