### PR TITLE
FEATURE: customizable tag separator with value transformer in proper HTML

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -1,4 +1,5 @@
 import renderTag from "discourse/lib/render-tag";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 
 let callbacks = null;
@@ -42,41 +43,71 @@ export default function (topic, params) {
     }
   }
 
-  let customHtml = null;
+  const separator = (index) => {
+    return applyValueTransformer("tag-separator", ",", {
+      topic,
+      index,
+    });
+  };
+
+  const separatorSpan = (index) => {
+    return `<span class="discourse-tags__tag-separator">${separator(
+      index
+    )}</span>`;
+  };
+
+  const callbackResults = [];
   if (callbacks) {
     callbacks.forEach((c) => {
       const html = c(topic, params);
       if (html) {
-        if (customHtml) {
-          customHtml += html;
-        } else {
-          customHtml = html;
-        }
+        callbackResults.push(html);
       }
     });
   }
 
-  if (customHtml || (tags && tags.length > 0)) {
-    buffer = `<div class='discourse-tags' role='list'
-                aria-label=${i18n("tagging.tags")}>`;
-    if (tags) {
+  const hasContent = (tags && tags.length > 0) || callbackResults.length > 0;
+
+  if (hasContent) {
+    buffer = `<div class='discourse-tags' 
+                   role='list' 
+                   aria-label=${i18n("tagging.tags")}>`;
+
+    let currentIndex = 0;
+
+    if (tags && tags.length > 0) {
       for (let i = 0; i < tags.length; i++) {
-        buffer +=
-          renderTag(tags[i], {
-            description:
-              topic.tags_descriptions && topic.tags_descriptions[tags[i]],
-            isPrivateMessage,
-            tagsForUser,
-            tagName,
-          }) + "";
+        buffer += renderTag(tags[i], {
+          description:
+            topic.tags_descriptions && topic.tags_descriptions[tags[i]],
+          isPrivateMessage,
+          tagsForUser,
+          tagName,
+        });
+
+        // separator after each tag
+        // except if it's the last tag
+        // and there are no customizations
+        if (i < tags.length - 1 || callbackResults.length > 0) {
+          buffer += separatorSpan(currentIndex);
+          currentIndex++;
+        }
       }
     }
 
-    if (customHtml) {
-      buffer += customHtml;
+    // add custom results with separator
+    for (let i = 0; i < callbackResults.length; i++) {
+      buffer += callbackResults[i];
+
+      // don't add separator to the last item
+      if (i < callbackResults.length - 1) {
+        buffer += separatorSpan(currentIndex);
+        currentIndex++;
+      }
     }
 
     buffer += "</div>";
   }
+
   return buffer;
 }

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -30,6 +30,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "parent-category-row-class-mobile",
   "post-menu-buttons",
   "small-user-attrs",
+  "tag-separator",
   "topic-list-class",
   "topic-list-columns",
   "topic-list-header-sortable-column",

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -777,7 +777,7 @@ acceptance("Search - with tagging enabled", function (needs) {
 
     assert
       .dom(".search-menu .results ul li:nth-of-type(1) .discourse-tags")
-      .hasText("devslow", "tags displayed in search results");
+      .hasText("dev,slow", "tags displayed in search results");
   });
 
   test("initial options - topic search scope - selecting a tag defaults to searching 'in all topics'", async function (assert) {

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -118,15 +118,6 @@
   }
 }
 
-.discourse-tags,
-.list-tags,
-.search-category {
-  .discourse-tag.simple:not(:last-child)::after {
-    content: ",\00a0";
-    margin-left: 1px;
-  }
-}
-
 .d-header .topic-header-extra {
   .discourse-tags {
     font-size: var(--font-down-1);
@@ -136,6 +127,10 @@
 .discourse-tags {
   display: inline-flex;
   flex-wrap: wrap;
+
+  &__tag-separator {
+    margin-right: 0.25em;
+  }
 }
 
 .fps-result .add-full-page-tags {


### PR DESCRIPTION
We were using CSS to add commas between tags like this: 

![image](https://github.com/user-attachments/assets/9de36cd1-35c5-4778-acb6-a39fb0dfaf48)


but this is kind of a hacky way to add content and we've also ended up with a separate encoding issue side-effect


<img width="400" src="https://github.com/user-attachments/assets/dc155c69-1a3c-4f88-952c-fe1756e4cffe" />


So this avoids that whole thing by adding the commas in the HTML properly — this also unlocks a bonus feature of using our value transformer system so it's easy to change the separator like this:

```js
import { apiInitializer } from "discourse/lib/api";

export default apiInitializer((api) => {
  api.registerValueTransformer("tag-separator", ({ value, context }) => {
    return "|"
  });
});
```

to get: 

![image](https://github.com/user-attachments/assets/289bcbe1-f93d-4bb3-856d-8a16a471b3b7)


