### PR TITLE
DEV: replace zero width space character in chat typing indicator

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
@@ -2,16 +2,12 @@
   color: var(--primary-medium);
   display: inline-flex;
   font-size: var(--font-down-2);
+  min-height: 1em;
+  line-height: normal;
 
   &-container {
     display: flex;
     height: 16px;
-  }
-
-  &::before {
-    // unicode zero width space character
-    // Ensures the span height is consistent even when empty
-    content: "\200b";
   }
 
   .chat-replying-indicator__text {

--- a/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
@@ -2,12 +2,11 @@
   color: var(--primary-medium);
   display: inline-flex;
   font-size: var(--font-down-2);
-  min-height: 1em; // Ensures the span height is consistent even when empty
-  line-height: normal;
 
   &-container {
     display: flex;
-    height: 16px;
+    height: 1em; // Ensures the height is consistent even when empty
+    line-height: normal;
   }
 
   .chat-replying-indicator__text {

--- a/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-replying-indicator.scss
@@ -2,7 +2,7 @@
   color: var(--primary-medium);
   display: inline-flex;
   font-size: var(--font-down-2);
-  min-height: 1em;
+  min-height: 1em; // Ensures the span height is consistent even when empty
   line-height: normal;
 
   &-container {


### PR DESCRIPTION
We were using a zero width space added by CSS here, but have run into occasional encoding issues for some reason? a couple people have reported getting this instead of an empty space: 

![image](https://github.com/user-attachments/assets/da39b5f5-61b0-423c-ae3e-18169e4f2f71)

I can't repro the issue, but we can avoid it by removing this space in CSS — setting the container height to `1em` along with `line-height: normal` should make it consistent with the height of the text within. 

In the blame it seems this static height on the container was added after the pseudo hack, and achieves the same goal when I test it across a Firefox/Chrome/Safari 