### PR TITLE
FIX: ensures emoji picker loader is centered

### DIFF
--- a/app/assets/stylesheets/common/components/emoji-picker.scss
+++ b/app/assets/stylesheets/common/components/emoji-picker.scss
@@ -26,6 +26,7 @@
 
   .spinner-container {
     height: 100%;
+    width: 100%;
   }
 
   &__diversity-menu.fk-d-menu {


### PR DESCRIPTION
before:
![Screenshot 2025-03-06 at 21 04 32](https://github.com/user-attachments/assets/080d188b-f3ad-48a6-aee7-e8d4be36d407)

after:
![Screenshot 2025-03-06 at 21 04 28](https://github.com/user-attachments/assets/6e131e66-7cc4-45e3-a783-d2774dbf92b4)
