### PR TITLE
UX: adjust progress bar position when composer preview is hidden

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -5,6 +5,10 @@ html.composer-open {
   }
 }
 
+:root {
+  --composer-max-width--hide-preview: 740px;
+}
+
 #reply-control {
   position: fixed;
   display: flex;
@@ -28,7 +32,7 @@ html.composer-open {
   }
 
   &.hide-preview {
-    max-width: 740px;
+    max-width: var(--composer-max-width--hide-preview);
   }
 
   .reply-area {

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -58,10 +58,12 @@
     margin-inline: auto;
   }
 
-  .composer-open:not(.composer-has-preview) .has-sidebar-page & {
-    max-width: calc(
-      var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
-    );
+  @media screen and (min-width: $reply-area-max-width) {
+    .composer-open:not(.composer-has-preview) .has-sidebar-page & {
+      max-width: calc(
+        var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
+      );
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -58,10 +58,12 @@
     margin-inline: auto;
   }
 
-  .composer-open:not(.composer-has-preview, .has-sidebar-page) & {
-    max-width: calc(
-      var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
-    );
+  @media screen and (min-width: $reply-area-max-width) {
+    .composer-open:not(.composer-has-preview, .has-sidebar-page) & {
+      max-width: calc(
+        var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
+      );
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -58,12 +58,10 @@
     margin-inline: auto;
   }
 
-  @media screen and (min-width: $reply-area-max-width) {
-    .composer-open:not(.composer-has-preview, .has-sidebar-page) & {
-      max-width: calc(
-        var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
-      );
-    }
+  .composer-open:not(.composer-has-preview) .has-sidebar-page & {
+    max-width: calc(
+      var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
+    );
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -48,6 +48,21 @@
   > * {
     pointer-events: auto; // this unsets the above rule so the child elements are interactive
   }
+
+  .composer-open:not(.composer-has-preview) & {
+    position: fixed;
+    max-width: var(--composer-max-width--hide-preview);
+    width: 100%;
+    left: 0;
+    right: 0;
+    margin-inline: auto;
+  }
+
+  .composer-open:not(.composer-has-preview, .has-sidebar-page) & {
+    max-width: calc(
+      var(--composer-max-width--hide-preview) + var(--d-sidebar-width)
+    );
+  }
 }
 
 #topic-progress-wrapper {


### PR DESCRIPTION
this adjusts the topic progress bar when the composer is open and the preview is hidden, so it properly aligns: 

Before:
![image](https://github.com/user-attachments/assets/7cb1868b-c608-4e02-820b-5120cc55090f)


After:
![image](https://github.com/user-attachments/assets/4f791f17-b309-4047-9085-2c3f0e34ad99)

