### PR TITLE
FIX: loop detection works as expected and does not need logging

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -130,12 +130,7 @@ module DiscourseAutomation
 
     def trigger!(context = {})
       if enabled
-        if active_id = DiscourseAutomation.get_active_automation
-          Rails.logger.warn(<<~TEXT.strip)
-            [automation] potential automations infinite loop detected: skipping automation #{self.id} because automation #{active_id} is still executing.")
-          TEXT
-          return
-        end
+        return if active_id = DiscourseAutomation.get_active_automation
 
         begin
           DiscourseAutomation.set_active_automation(self.id)


### PR DESCRIPTION
Logging creates impression that something is not working while everything is working as expected.