### PR TITLE
FIX: redirect to parent tag when synonym page visited

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -178,6 +178,8 @@ class TagsController < ::ApplicationController
   end
 
   def show
+    synonym_tag = Tag.where_name(params[:tag_id]).where.not(target_tag_id: nil).first
+    return redirect_to tag_show_path(synonym_tag.target_tag.name) if synonym_tag
     show_latest
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -147,8 +147,7 @@ class TagsController < ::ApplicationController
           .where_name(params[:tag_id])
           .where.not(target_tag_id: nil)
           .joins("JOIN tags parent_tags ON parent_tags.id = tags.target_tag_id")
-          .pluck("parent_tags.name")
-          .first
+          .pick("parent_tags.name")
 
       if parent_tag_name
         params[:tag_id] = parent_tag_name

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -142,6 +142,13 @@ class TagsController < ::ApplicationController
 
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
+      synonym_tag = Tag.where_name(params[:tag_id]).where.not(target_tag_id: nil).first
+
+      if synonym_tag
+        params[:tag_id] = synonym_tag.target_tag.name
+        return redirect_to url_for(params.to_unsafe_hash)
+      end
+
       @tag_id = params[:tag_id].force_encoding("UTF-8")
       @additional_tags =
         params[:additional_tag_ids].to_s.split("/").map { |t| t.force_encoding("UTF-8") }
@@ -178,8 +185,6 @@ class TagsController < ::ApplicationController
   end
 
   def show
-    synonym_tag = Tag.where_name(params[:tag_id]).where.not(target_tag_id: nil).first
-    return redirect_to tag_show_path(synonym_tag.target_tag.name) if synonym_tag
     show_latest
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -142,10 +142,16 @@ class TagsController < ::ApplicationController
 
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
-      synonym_tag = Tag.where_name(params[:tag_id]).where.not(target_tag_id: nil).first
+      parent_tag_name =
+        Tag
+          .where_name(params[:tag_id])
+          .where.not(target_tag_id: nil)
+          .joins("JOIN tags parent_tags ON parent_tags.id = tags.target_tag_id")
+          .pluck("parent_tags.name")
+          .first
 
-      if synonym_tag
-        params[:tag_id] = synonym_tag.target_tag.name
+      if parent_tag_name
+        params[:tag_id] = parent_tag_name
         return redirect_to url_for(params.to_unsafe_hash)
       end
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -428,7 +428,8 @@ RSpec.describe TagsController do
     it "should handle synonyms" do
       synonym = Fabricate(:tag, target_tag: tag)
       get "/tag/#{synonym.name}"
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(302)
+      expect(response.redirect_url).to match("/tag/#{tag.name}")
     end
 
     it "does not show staff-only tags" do

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -427,9 +427,9 @@ RSpec.describe TagsController do
 
     it "should handle synonyms" do
       synonym = Fabricate(:tag, target_tag: tag)
-      get "/tag/#{synonym.name}"
+      get "/tag/#{synonym.name}/l/top.json?period=daily"
       expect(response.status).to eq(302)
-      expect(response.redirect_url).to match("/tag/#{tag.name}")
+      expect(response.redirect_url).to match(%r{/tag/#{tag.name}/l/top.json\?period=daily})
     end
 
     it "does not show staff-only tags" do


### PR DESCRIPTION
When a synonym page is visited, the user should be redirected to the parent tag.