### PR TITLE
FIX: If a tag has a description, use it for the meta description.

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -163,7 +163,7 @@ class TagsController < ::ApplicationController
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
       @title = I18n.t("rss_by_tag", tag: tag_params.join(" & "))
-      @description_meta = @tag.where(name: @tag_id).pick(:description) || @title
+      @description_meta = Tag.find_by_name(@tag_id)&.description || @title
 
       canonical_params = params.slice(:category_slug_path_with_id, :tag_id)
       canonical_method = url_method(canonical_params)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -163,7 +163,7 @@ class TagsController < ::ApplicationController
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
       @title = I18n.t("rss_by_tag", tag: tag_params.join(" & "))
-      @description_meta = Tag.find_by_name(@tag_id)&.description || @title
+      @description_meta = Tag.where(name: @tag_id).pick(:description) || @title
 
       canonical_params = params.slice(:category_slug_path_with_id, :tag_id)
       canonical_method = url_method(canonical_params)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -143,6 +143,8 @@ class TagsController < ::ApplicationController
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
       @tag_id = params[:tag_id].force_encoding("UTF-8")
+      fetch_tag
+
       @additional_tags =
         params[:additional_tag_ids].to_s.split("/").map { |t| t.force_encoding("UTF-8") }
 
@@ -162,8 +164,8 @@ class TagsController < ::ApplicationController
       @list.more_topics_url = construct_url_with(:next, list_opts)
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
-      @description_meta = I18n.t("rss_by_tag", tag: tag_params.join(" & "))
-      @title = @description_meta
+      @title = I18n.t("rss_by_tag", tag: tag_params.join(" & "))
+      @description_meta = @tag&.description.presence || @title
 
       canonical_params = params.slice(:category_slug_path_with_id, :tag_id)
       canonical_method = url_method(canonical_params)
@@ -419,7 +421,8 @@ class TagsController < ::ApplicationController
   private
 
   def fetch_tag
-    @tag = Tag.find_by_name(params[:tag_id].force_encoding("UTF-8"))
+    return if params[:tag_id] == "none"
+    @tag ||= Tag.find_by_name(params[:tag_id].force_encoding("UTF-8"))
     raise Discourse::NotFound unless @tag
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -143,8 +143,6 @@ class TagsController < ::ApplicationController
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
       @tag_id = params[:tag_id].force_encoding("UTF-8")
-      fetch_tag
-
       @additional_tags =
         params[:additional_tag_ids].to_s.split("/").map { |t| t.force_encoding("UTF-8") }
 
@@ -165,7 +163,7 @@ class TagsController < ::ApplicationController
       @list.prev_topics_url = construct_url_with(:prev, list_opts)
       @rss = "tag"
       @title = I18n.t("rss_by_tag", tag: tag_params.join(" & "))
-      @description_meta = @tag&.description.presence || @title
+      @description_meta = @tag.where(name: @tag_id).pick(:description) || @title
 
       canonical_params = params.slice(:category_slug_path_with_id, :tag_id)
       canonical_method = url_method(canonical_params)
@@ -421,8 +419,7 @@ class TagsController < ::ApplicationController
   private
 
   def fetch_tag
-    return if params[:tag_id] == "none"
-    @tag ||= Tag.find_by_name(params[:tag_id].force_encoding("UTF-8"))
+    @tag = Tag.find_by_name(params[:tag_id].force_encoding("UTF-8"))
     raise Discourse::NotFound unless @tag
   end
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -465,6 +465,27 @@ RSpec.describe TagsController do
       )
     end
 
+    it "puts the tag description in the meta description" do
+      described_tag = Fabricate(:tag, name: "test2", description: "This is a description")
+      get "/tag/#{described_tag.name}"
+
+      expect(response.status).to eq(200)
+
+      expect(response.body).to include(
+        "<meta name=\"description\" content=\"#{described_tag.description}\"",
+      )
+    end
+
+    it "has a default description for tags without a description" do
+      get "/tag/test"
+
+      expect(response.status).to eq(200)
+
+      expect(response.body).to include(
+        "<meta name=\"description\" content=\"Topics tagged #{tag.name}\"",
+      )
+    end
+
     it "handles special tag 'none'" do
       SiteSetting.pm_tags_allowed_for_groups = "1|2|3"
 


### PR DESCRIPTION
## ✨ What's This?

When a tag has a description defined, we should use that in the `<meta name="description"...` tag on the tagged topic list page. This matches the behaviour on the equivalent category pages.

## 👑 Testing

Check that the description is being used correctly, and that the fallback text continues to function as expected.