### PR TITLE
FIX: Authenticated x.com oneboxes failing

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -30,6 +30,7 @@ module Oneboxer
       "http://vimeo.com",
       "https://www.youtube.com",
       "https://twitter.com",
+      "https://x.com",
       Discourse.base_url,
     ]
   end


### PR DESCRIPTION
Fixes the same issue that https://github.com/discourse/discourse/commit/e9387e238c75219a02ea07762f51d01f96f28f25
did for twitter.com, but for x.com. Since they redirect
on our first FinalDestination call with onebox, the request
fails even with `twitter_consumer_secret` and `twitter_consumer_key`
settings set.
