### PR TITLE
FEATURE: improve post_created_edited automation triggers

### DIFF
--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -159,9 +159,15 @@ en:
             restricted_tags:
               label: Tags
               description: Optional, will trigger only if the post has any of these tags
-            restricted_category:
-              label: Category
-              description: Optional, will trigger only if the post's topic is in this category
+            restricted_categories:
+              label: Categories
+              description: Optional, will trigger only if the post's topic is in these categories
+            exclude_categories:
+              label: Exclude subcategories
+              description: Optional, will only trigger if the post's topic is exactly in the categories specified above
+            restricted_archetype:
+              label: Topic Type
+              description: Optional, allow to trigger only on topics or personal messages
             restricted_user_group:
               label: Restricted user group
               description: Optional, will trigger only if the post user is in this group
@@ -185,6 +191,8 @@ en:
               description: "Skip the trigger if the post was created via email"
           created: Created
           edited: Edited
+          topics: Topics
+          personal_messages: Personal Messages
         user_updated:
           fields:
             user_profile:

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -162,7 +162,7 @@ en:
             restricted_categories:
               label: Categories
               description: Optional, will trigger only if the post's topic is in these categories
-            exclude_categories:
+            exclude_subcategories:
               label: Exclude subcategories
               description: Optional, will only trigger if the post's topic is exactly in the categories specified above
             restricted_archetype:

--- a/plugins/automation/db/post_migrate/20250307031538_migrate_category_to_categories_post_created.rb
+++ b/plugins/automation/db/post_migrate/20250307031538_migrate_category_to_categories_post_created.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class MigrateCategoryToCategoriesPostCreated < ActiveRecord::Migration[7.2]
+  def up
+    # this is a safety net, should never happen but we don't want dupes here
+    execute <<~SQL
+      DELETE FROM discourse_automation_fields
+      WHERE name = 'restricted_categories'
+        AND target = 'trigger'
+        AND automation_id IN (
+          SELECT id FROM discourse_automation_automations
+          WHERE trigger = 'post_created_edited'
+        )
+    SQL
+
+    execute <<~SQL
+      INSERT INTO discourse_automation_fields (
+        automation_id, component, name, target, metadata, created_at, updated_at
+      )
+      SELECT
+        f.automation_id,
+        'categories' as component,
+        'restricted_categories' as name,
+        f.target,
+        jsonb_build_object('value', ARRAY[CAST(f.metadata->>'value' AS INTEGER)]) as metadata,
+        NOW() as created_at,
+        NOW() as updated_at
+      FROM discourse_automation_fields f
+      JOIN discourse_automation_automations a ON a.id = f.automation_id
+      WHERE f.component = 'category'
+      AND f.name = 'restricted_category'
+      AND f.target = 'trigger'
+      AND f.metadata->>'value' IS NOT NULL
+      AND a.trigger = 'post_created_edited'
+    SQL
+  end
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/post_created_edited.rb
@@ -12,7 +12,19 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::POST_CREATED
             { id: "edited", name: "discourse_automation.triggerables.post_created_edited.edited" },
           ],
         }
-  field :restricted_category, component: :category
+  field :restricted_archetype,
+        component: :choices,
+        extra: {
+          content: [
+            { id: "regular", name: "discourse_automation.triggerables.post_created_edited.topics" },
+            {
+              id: "private_message",
+              name: "discourse_automation.triggerables.post_created_edited.personal_messages",
+            },
+          ],
+        }
+  field :restricted_categories, component: :categories
+  field :exclude_subcategories, component: :boolean
   field :restricted_tags, component: :tags
   field :restricted_groups, component: :groups
   field :restricted_user_group, component: :group


### PR DESCRIPTION
- Allow deciding if we include or exclude sub categories
- Allow filtering to only look at PMs or Topics
- Allow selection of multiple categories
- Migrations to carry all data into new structure

