### PR TITLE
DEV: Bump minimum node version to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember": "pnpm --dir=app/assets/javascripts/discourse ember"
   },
   "engines": {
-    "node": ">= 18",
+    "node": ">= 22",
     "npm": "please-use-pnpm",
     "yarn": "please-use-pnpm",
     "pnpm": "^9"


### PR DESCRIPTION
Node 18 will soon be out of its support period, and many of our dependencies are now requiring node 22