### PR TITLE
FIX: dont allow channel non-members to write messages in threads

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -34,6 +34,7 @@ import UserChatThreadMembership from "discourse/plugins/chat/discourse/models/us
 import ChatComposerThread from "./chat/composer/thread";
 import ChatScrollToBottomArrow from "./chat/scroll-to-bottom-arrow";
 import ChatSelectionManager from "./chat/selection-manager";
+import ChatChannelPreviewCard from "./chat-channel-preview-card";
 import Message from "./chat-message";
 import ChatMessagesContainer from "./chat-messages-container";
 import ChatMessagesScroller from "./chat-messages-scroller";
@@ -69,6 +70,11 @@ export default class ChatThread extends Component {
 
   get messagesManager() {
     return this.args.thread.messagesManager;
+  }
+
+  get showChannelPreview() {
+    const channel = this.args.thread.channel;
+    return channel?.isCategoryChannel && !channel?.isFollowing;
   }
 
   @action
@@ -582,13 +588,17 @@ export default class ChatThread extends Component {
           @messagesManager={{this.messagesManager}}
         />
       {{else}}
-        <ChatComposerThread
-          @channel={{@channel}}
-          @thread={{@thread}}
-          @onSendMessage={{this.onSendMessage}}
-          @uploadDropZone={{this.uploadDropZone}}
-          @scroller={{this.scroller}}
-        />
+        {{#if this.showChannelPreview}}
+          <ChatChannelPreviewCard @channel={{@thread.channel}} />
+        {{else}}
+          <ChatComposerThread
+            @channel={{@channel}}
+            @thread={{@thread}}
+            @onSendMessage={{this.onSendMessage}}
+            @uploadDropZone={{this.uploadDropZone}}
+            @scroller={{this.scroller}}
+          />
+        {{/if}}
       {{/if}}
 
       <ChatUploadDropZone @model={{@thread}} />

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,5 +1,5 @@
 .chat-channel-preview-card {
-  margin: 1rem 0 2rem 0;
+  margin: 1rem 0 0 0;
   padding: 1.5rem 1rem;
   background-color: var(--secondary-very-high);
   display: flex;

--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -8,18 +8,16 @@ RSpec.describe "Message errors", type: :system do
     let(:message) { "atoolongmessage" + "a" * max_length }
 
     fab!(:current_user) { Fabricate(:admin) }
+    fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
 
     before do
       chat_system_bootstrap
       sign_in(current_user)
+      channel.add(current_user)
     end
 
     context "when in channel" do
-      fab!(:channel) { Fabricate(:chat_channel) }
-
       let(:channel_page) { PageObjects::Pages::ChatChannel.new }
-
-      before { channel.add(current_user) }
 
       it "shows a dialog with the error and keeps the message in the input" do
         chat_page.visit_channel(channel)
@@ -34,7 +32,7 @@ RSpec.describe "Message errors", type: :system do
     end
 
     context "when in thread" do
-      fab!(:thread) { Fabricate(:chat_thread) }
+      fab!(:thread) { Fabricate(:chat_thread, channel: channel) }
 
       let(:thread_page) { PageObjects::Pages::ChatThread.new }
 

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -136,6 +136,28 @@ RSpec.describe "Visit channel", type: :system do
             expect(page).to have_content(category_channel_1.name)
             expect(channel_page.messages).to have_message(id: message_1.id)
           end
+
+          context "with a thread" do
+            fab!(:thread) do
+              Fabricate(
+                :chat_thread,
+                channel: category_channel_1,
+                original_message: message_1,
+                with_replies: 1,
+              )
+            end
+
+            before { category_channel_1.update(threading_enabled: true) }
+
+            it "allows to join it" do
+              chat.visit_thread(thread)
+
+              expect(page).to have_content(
+                I18n.t("js.chat.channel_settings.join_channel"),
+                count: 2,
+              )
+            end
+          end
         end
 
         context "when direct message channel" do


### PR DESCRIPTION
Prevents channel non-members from seeing the composer in threads. Since they do not have the correct permissions to post within the channel, we should show the join channel CTA in place of the chat composer.

Internal ref: /t/146242

### After

<img width="398" alt="Screenshot 2025-03-07 at 2 00 43 PM" src="https://github.com/user-attachments/assets/156308db-8523-42c1-9978-5439fed29ccd" />


