### PR TITLE
FIX: Show total members count when deleting a group

### DIFF
--- a/app/assets/javascripts/discourse/app/components/dialog-messages/group-delete.hbs
+++ b/app/assets/javascripts/discourse/app/components/dialog-messages/group-delete.hbs
@@ -1,7 +1,7 @@
-{{#if @model.members.length}}
+{{#if @model.user_count}}
   <p>
     {{d-icon "users"}}
-    {{i18n "admin.groups.delete_details" count=@model.members.length}}
+    {{i18n "admin.groups.delete_details" count=@model.user_count}}
   </p>
 {{/if}}
 {{#if @model.message_count}}

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import GroupFixtures from "discourse/tests/fixtures/group-fixtures";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
@@ -174,6 +175,41 @@ acceptance("Group - Authenticated", function (needs) {
         });
       }
     );
+
+    server.get("/groups/discourse/members.json", (request) => {
+      if (request.queryParams.filter === "somefilter") {
+        return helper.response({
+          members: [
+            {
+              id: 2770,
+              username: "awesomerobot",
+              uploaded_avatar_id: 33872,
+              avatar_template:
+                "/user_avatar/meta.discourse.org/awesomerobot/{size}/33872.png",
+              name: "",
+              last_seen_at: "2015-01-23T15:53:17.844Z",
+            },
+            {
+              id: 32,
+              username: "codinghorror",
+              uploaded_avatar_id: 5297,
+              avatar_template:
+                "/user_avatar/meta.discourse.org/codinghorror/{size}/5297.png",
+              name: "Jeff Atwood",
+              last_seen_at: "2015-01-23T06:05:25.457Z",
+            },
+          ],
+          meta: {
+            total: 7,
+            limit: 50,
+            offset: 0,
+          },
+          owners: [],
+        });
+      } else {
+        return helper.response(GroupFixtures["/groups/discourse/members.json"]);
+      }
+    });
   });
 
   test("User Viewing Group", async function (assert) {
@@ -274,6 +310,21 @@ acceptance("Group - Authenticated", function (needs) {
         "/u/awesomerobot",
         "avatar link contains href (is tabbable)"
       );
+  });
+
+  test("Admin group delete confirmation", async function (assert) {
+    await visit("/g/discourse");
+
+    await fillIn(".group-username-filter", "somefilter");
+
+    await click(".group-details-button button.btn-danger");
+
+    assert.dom(".dialog-body p:nth-of-type(1)").hasText(
+      i18n("admin.groups.delete_details", {
+        count: 7,
+      }),
+      "it shows the total members count"
+    );
   });
 
   test("Moderator Viewing Group", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
@@ -55,6 +55,11 @@ export default {
     extras: {
       visible_group_names: ["discourse"],
     },
+    meta: {
+      total: 7,
+      limit: 50,
+      offset: 0,
+    }
   },
   "/groups/support.json": {
     group: {


### PR DESCRIPTION
When deleting a group, we show a confirmation dialog that includes the group members count that will lose access to the group alongside other information. However, there's currently an issue where the members count shown in the dialog is the count of members that have been loaded in the Members tab of the group. If you filter the members list and then click delete, the count you currently see is the number of members that match the filter, not the total members count.

This happens because the dialog uses the length of the members list (`members.length`) instead of the `user_count` attribute of the group.

Internal topic: t/148832.