### PR TITLE
UX: show timeline when composer preview is hidden

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -22,6 +22,7 @@ const MIN_HEIGHT_TIMELINE = 325;
 )
 export default class TopicNavigation extends Component {
   @service modal;
+  @service composer;
 
   composerOpen = null;
   info = EmberObject.create();
@@ -56,10 +57,14 @@ export default class TopicNavigation extends Component {
       const verticalSpace =
         window.innerHeight - composerHeight - headerOffset();
 
-      this.info.set(
-        "renderTimeline",
-        this.mediaQuery.matches && verticalSpace > MIN_HEIGHT_TIMELINE
-      );
+      if (this.composer.isPreviewVisible) {
+        this.info.set(
+          "renderTimeline",
+          this.mediaQuery.matches && verticalSpace > MIN_HEIGHT_TIMELINE
+        );
+      } else {
+        this.info.set("renderTimeline", this.mediaQuery.matches);
+      }
     }
 
     this.info.set(
@@ -231,6 +236,7 @@ export default class TopicNavigation extends Component {
       this.appEvents.on("composer:opened", this, this.composerOpened);
       this.appEvents.on("composer:resize-ended", this, this.composerOpened);
       this.appEvents.on("composer:closed", this, this.composerClosed);
+      this.appEvents.on("composer:preview-toggled", this._checkSize);
       $("#reply-control").on("div-resized", this._checkSize);
     }
 
@@ -260,6 +266,7 @@ export default class TopicNavigation extends Component {
       this.appEvents.off("composer:opened", this, this.composerOpened);
       this.appEvents.off("composer:resize-ended", this, this.composerOpened);
       this.appEvents.off("composer:closed", this, this.composerClosed);
+      this.appEvents.off("composer:preview-toggled", this._checkSize);
       $("#reply-control").off("div-resized", this._checkSize);
     }
     if (this.site.mobileView) {

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -224,13 +224,13 @@ export default class TopicTimelineScrollArea extends Component {
     const minHeight = this.site.mobileView
       ? DEFAULT_MIN_SCROLLAREA_HEIGHT
       : this.composer.isPreviewVisible
-      ? desktopMinScrollAreaHeight
-      : DEFAULT_MIN_SCROLLAREA_HEIGHT;
+        ? desktopMinScrollAreaHeight
+        : DEFAULT_MIN_SCROLLAREA_HEIGHT;
     const maxHeight = this.site.mobileView
       ? DEFAULT_MAX_SCROLLAREA_HEIGHT
       : this.composer.isPreviewVisible
-      ? desktopMaxScrollAreaHeight
-      : DEFAULT_MAX_SCROLLAREA_HEIGHT;
+        ? desktopMaxScrollAreaHeight
+        : DEFAULT_MAX_SCROLLAREA_HEIGHT;
 
     return Math.max(minHeight, Math.min(availableHeight, maxHeight));
   }

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -56,6 +56,7 @@ export default class TopicTimelineScrollArea extends Component {
   @service site;
   @service siteSettings;
   @service currentUser;
+  @service composer;
 
   @tracked showButton = false;
   @tracked current;
@@ -89,6 +90,7 @@ export default class TopicTimelineScrollArea extends Component {
       this.appEvents.on("composer:opened", this.calculatePosition);
       this.appEvents.on("composer:resized", this.calculatePosition);
       this.appEvents.on("composer:closed", this.calculatePosition);
+      this.appEvents.on("composer:preview-toggled", this.calculatePosition);
       this.appEvents.on("post-stream:posted", this.calculatePosition);
     }
 
@@ -127,6 +129,7 @@ export default class TopicTimelineScrollArea extends Component {
       this.appEvents.off("composer:opened", this.calculatePosition);
       this.appEvents.off("composer:resized", this.calculatePosition);
       this.appEvents.off("composer:closed", this.calculatePosition);
+      this.appEvents.off("composer:preview-toggled", this.calculatePosition);
       this.appEvents.off("topic:current-post-scrolled", this.postScrolled);
       this.appEvents.off("post-stream:posted", this.calculatePosition);
     }
@@ -209,8 +212,9 @@ export default class TopicTimelineScrollArea extends Component {
   }
 
   get scrollareaHeight() {
-    const composerHeight =
-        document.getElementById("reply-control").offsetHeight || 0,
+    const composerHeight = this.composer.isPreviewVisible
+        ? document.getElementById("reply-control").offsetHeight || 0
+        : 0,
       headerHeight = document.querySelector(".d-header")?.offsetHeight || 0;
 
     // scrollarea takes up about half of the timeline's height
@@ -219,10 +223,14 @@ export default class TopicTimelineScrollArea extends Component {
 
     const minHeight = this.site.mobileView
       ? DEFAULT_MIN_SCROLLAREA_HEIGHT
-      : desktopMinScrollAreaHeight;
+      : this.composer.isPreviewVisible
+      ? desktopMinScrollAreaHeight
+      : DEFAULT_MIN_SCROLLAREA_HEIGHT;
     const maxHeight = this.site.mobileView
       ? DEFAULT_MAX_SCROLLAREA_HEIGHT
-      : desktopMaxScrollAreaHeight;
+      : this.composer.isPreviewVisible
+      ? desktopMaxScrollAreaHeight
+      : DEFAULT_MAX_SCROLLAREA_HEIGHT;
 
     return Math.max(minHeight, Math.min(availableHeight, maxHeight));
   }

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -147,6 +147,11 @@ export default class ComposerService extends Service {
     return this.showPreview && this.allowPreview;
   }
 
+  @observes("showPreview", "allowPreview")
+  previewVisibilityChanged() {
+    this.appEvents.trigger("composer:preview-toggled", this.isPreviewVisible);
+  }
+
   get isOpen() {
     return this.model?.composeState === Composer.OPEN;
   }


### PR DESCRIPTION
This updates the timeline behavior so that when the composer preview is closed, the full timeline is rendered. 

Before: 

![image](https://github.com/user-attachments/assets/3eee00d6-3e8d-4db7-a3df-47efa791b95a)


After: 

![image](https://github.com/user-attachments/assets/399e3c7a-4723-4cdf-96b6-0acc734c3977)

When the preview is shown again, we recalculate and switch back to the timeline if needed 

![image](https://github.com/user-attachments/assets/ca4557de-7311-4903-8900-4c2598d0b58f)

