### PR TITLE
UX: hide tag separator for box/bullet styles

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -131,6 +131,13 @@
   &__tag-separator {
     margin-right: 0.25em;
   }
+
+  .box,
+  .bullet {
+    + .discourse-tags__tag-separator {
+      display: none;
+    }
+  }
 }
 
 .fps-result .add-full-page-tags {


### PR DESCRIPTION
This is a follow-up to https://github.com/discourse/discourse/commit/55a3a4e69ed75b055fb4907ac5370cf1519276c6, the tag separator should be hidden for box/bullet tag styles