### PR TITLE
FEATURE: add trailing-paragraph rich editor extension

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/register-default.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/register-default.js
@@ -12,6 +12,7 @@ import mention from "./mention";
 import quote from "./quote";
 import strikethrough from "./strikethrough";
 import table from "./table";
+import trailingParagraph from "./trailing-paragraph";
 import typographerReplacements from "./typographer-replacements";
 import underline from "./underline";
 
@@ -34,6 +35,7 @@ const defaultExtensions = [
   underline,
   htmlInline,
   htmlBlock,
+  trailingParagraph,
   typographerReplacements,
   table,
   markdownPaste,

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
@@ -19,29 +19,25 @@ const extension = {
       },
       state: {
         init(_, state) {
-          return !isLastChildEmptyParagraph(state);
+          return !isLastChildParagraph(state);
         },
         apply(tr, value) {
           if (!tr.docChanged) {
             return value;
           }
 
-          return !isLastChildEmptyParagraph(tr);
+          return !isLastChildParagraph(tr);
         },
       },
     });
   },
 };
 
-function isLastChildEmptyParagraph(state) {
+function isLastChildParagraph(state) {
   const { doc } = state;
   const lastChild = doc.lastChild;
 
-  return (
-    lastChild.type.name === "paragraph" &&
-    lastChild.nodeSize === 2 &&
-    lastChild.content.size === 0
-  );
+  return lastChild.type.name === "paragraph";
 }
 
 export default extension;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
@@ -1,0 +1,47 @@
+/** @type {RichEditorExtension} */
+const extension = {
+  plugins({ pmState: { Plugin, PluginKey } }) {
+    const plugin = new PluginKey("trailing-paragraph");
+
+    return new Plugin({
+      key: plugin,
+      appendTransaction(_, __, state) {
+        if (!plugin.getState(state)) {
+          return;
+        }
+
+        return state.tr
+          .setMeta("addToHistory", false)
+          .insert(
+            state.doc.content.size,
+            state.schema.nodes.paragraph.create()
+          );
+      },
+      state: {
+        init(_, state) {
+          return !isLastChildEmptyParagraph(state);
+        },
+        apply(tr, value) {
+          if (!tr.docChanged) {
+            return value;
+          }
+
+          return !isLastChildEmptyParagraph(tr);
+        },
+      },
+    });
+  },
+};
+
+function isLastChildEmptyParagraph(state) {
+  const { doc } = state;
+  const lastChild = doc.lastChild;
+
+  return (
+    lastChild.type.name === "paragraph" &&
+    lastChild.nodeSize === 2 &&
+    lastChild.content.size === 0
+  );
+}
+
+export default extension;

--- a/app/assets/javascripts/discourse/tests/helpers/rich-editor-helper.gjs
+++ b/app/assets/javascripts/discourse/tests/helpers/rich-editor-helper.gjs
@@ -60,7 +60,9 @@ export async function testMarkdown(
     .replace('<img class="ProseMirror-separator" alt="">', "")
     .replace('<br class="ProseMirror-trailingBreak">', "")
     // or artifacts
-    .replace(' class=""', "");
+    .replace(' class=""', "")
+    // or a trailing-paragraph with an optional <br class="ProseMirror-trailingBreak"> inside
+    .replace(/<p>(<br class="ProseMirror-trailingBreak">)?<\/p>$/, "");
 
   assert.strictEqual(html, expectedHtml, `HTML should match for "${markdown}"`);
   assert.strictEqual(

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -253,13 +253,9 @@ describe "Composer - ProseMirror editor", type: :system do
     it "maintains exactly one trailing paragraph when typing and deleting text" do
       open_composer_and_toggle_rich_editor
 
-      # Initially there should be one empty paragraph
       expect(rich).to have_css("p", count: 1)
-
-      # Type some text
       composer.type_content("This is a test")
 
-      # Should have two paragraphs now (content + trailing)
       expect(rich).to have_css("p", count: 2)
       expect(rich).to have_css("p", text: "This is a test", count: 1)
     end

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -250,14 +250,18 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   describe "trailing paragraph" do
-    it "maintains exactly one trailing paragraph when typing and deleting text" do
+    it "ensures there is always a trailing paragraph" do
       open_composer_and_toggle_rich_editor
 
       expect(rich).to have_css("p", count: 1)
       composer.type_content("This is a test")
 
-      expect(rich).to have_css("p", count: 2)
+      expect(rich).to have_css("p", count: 1)
       expect(rich).to have_css("p", text: "This is a test", count: 1)
+
+      composer.send_keys([PLATFORM_KEY_MODIFIER, :shift, "_"]) # Insert a horizontal rule
+      expect(rich).to have_css("hr", count: 1)
+      expect(rich).to have_css("p", count: 2) # New paragraph inserted after the ruler
     end
   end
 end

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -248,4 +248,20 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("select.code-language-select", wait: 1)
     end
   end
+
+  describe "trailing paragraph" do
+    it "maintains exactly one trailing paragraph when typing and deleting text" do
+      open_composer_and_toggle_rich_editor
+
+      # Initially there should be one empty paragraph
+      expect(rich).to have_css("p", count: 1)
+
+      # Type some text
+      composer.type_content("This is a test")
+
+      # Should have two paragraphs now (content + trailing)
+      expect(rich).to have_css("p", count: 2)
+      expect(rich).to have_css("p", text: "This is a test", count: 1)
+    end
+  end
 end


### PR DESCRIPTION
Continues the work done on https://github.com/discourse/discourse/pull/30815.

Adds a plugin to enforce an empty trailing paragraph.