### PR TITLE
FEATURE: add check (plugin) rich editor extension

### DIFF
--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -3,12 +3,14 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { iconHTML } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { i18n } from "discourse-i18n";
+import richEditorExtension from "../../lib/rich-editor-extension";
 
 function initializePlugin(api) {
   const siteSettings = api.container.lookup("service:site-settings");
 
   if (siteSettings.checklist_enabled) {
     api.decorateCookedElement(checklistSyntax);
+    api.registerRichEditorExtension(richEditorExtension);
   }
 }
 

--- a/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
@@ -1,0 +1,70 @@
+/** @type {RichEditorExtension} */
+const extension = {
+  // TODO(renato): make the checkbox clickable
+  // TODO(renato): auto-continue checkbox list on ENTER
+  // TODO(renato): apply .has-checkbox style to the <li> to avoid :has
+  nodeSpec: {
+    check: {
+      attrs: { checked: { default: false } },
+      inline: true,
+      group: "inline",
+      draggable: true,
+      selectable: false,
+      toDOM(node) {
+        return [
+          "span",
+          {
+            class: node.attrs.checked
+              ? "chcklst-box checked fa fa-square-check-o fa-fw"
+              : "chcklst-box fa fa-square-o fa-fw",
+          },
+        ];
+      },
+      parseDOM: [
+        {
+          tag: "span.chcklst-box",
+          getAttrs: (dom) => {
+            return { checked: hasCheckedClass(dom.className) };
+          },
+        },
+      ],
+    },
+  },
+
+  inputRules: [
+    {
+      match: /(?<=^|\s)\[(x? ?)]$/,
+      handler: (state, match, start, end) =>
+        state.tr.replaceWith(
+          start,
+          end,
+          state.schema.nodes.check.create({ checked: match[1] === "x" })
+        ),
+      options: { undoable: false },
+    },
+  ],
+
+  parse: {
+    check_open: {
+      node: "check",
+      getAttrs: (token) => ({
+        checked: hasCheckedClass(token.attrGet("class")),
+      }),
+    },
+    check_close: { noCloseToken: true, ignore: true },
+  },
+
+  serializeNode: {
+    check: (state, node) => {
+      state.write(node.attrs.checked ? "[x]" : "[ ]");
+    },
+  },
+};
+
+const CHECKED_REGEX = /\bchecked\b/;
+
+function hasCheckedClass(className) {
+  return CHECKED_REGEX.test(className);
+}
+
+export default extension;

--- a/plugins/checklist/assets/stylesheets/checklist.scss
+++ b/plugins/checklist/assets/stylesheets/checklist.scss
@@ -81,3 +81,14 @@ ul li.has-checkbox {
     transform: rotate(1turn);
   }
 }
+
+.ProseMirror {
+  // TODO(renato): this is temporary, we should use `has-checkbox` instead
+  li:has(p:first-of-type > span.chcklst-box) {
+    list-style-type: none;
+
+    .chcklst-box:first-of-type {
+      margin-left: -1.33em;
+    }
+  }
+}

--- a/plugins/checklist/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/checklist/test/javascripts/integration/rich-editor-extension-test.js
@@ -1,0 +1,60 @@
+import { module, test } from "qunit";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
+import richEditorExtension from "discourse/plugins/checklist/lib/rich-editor-extension";
+
+module(
+  "Integration | Component | prosemirror-editor - checklist plugin extension",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.rich_editor = true;
+
+      resetRichEditorExtensions().then(() => {
+        registerRichEditorExtension(richEditorExtension);
+      });
+    });
+
+    const checked =
+      '<span class="chcklst-box checked fa fa-square-check-o fa-fw" contenteditable="false" draggable="true"></span>';
+    const unchecked =
+      '<span class="chcklst-box fa fa-square-o fa-fw" contenteditable="false" draggable="true"></span>';
+
+    Object.entries({
+      "renders unchecked checkbox correctly": [
+        "[ ] todo item",
+        `<p>${unchecked} todo item</p>`,
+        "[ ] todo item",
+      ],
+      "renders checked checkbox correctly": [
+        "[x] completed item",
+        `<p>${checked} completed item</p>`,
+        "[x] completed item",
+      ],
+      "handles multiple checkboxes in a single paragraph": [
+        "[] first task [x] second task",
+        `<p>${unchecked} first task ${checked} second task</p>`,
+        "[ ] first task [x] second task",
+      ],
+      "handles checkboxes in lists": [
+        "* [ ] unchecked list item\n* [x] checked list item",
+        `<ul data-tight="true"><li><p>${unchecked} unchecked list item</p></li><li><p>${checked} checked list item</p></li></ul>`,
+        "* [ ] unchecked list item\n* [x] checked list item",
+      ],
+      "handles checkboxes with formatting": [
+        "[ ] *italics* and [x] **bold**",
+        `<p>${unchecked} <em>italics</em> and ${checked} <strong>bold</strong></p>`,
+        "[ ] *italics* and [x] **bold**",
+      ],
+    }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
+      test(name, async function (assert) {
+        await testMarkdown(assert, markdown, html, expectedMarkdown);
+      });
+    });
+  }
+);


### PR DESCRIPTION
Continues the work done on https://github.com/discourse/discourse/pull/30815.

Adds a `check` node, parser, and serializer, and an input rule to convert when typing `[]`/`[ ]`/`[x]`