### PR TITLE
FEATURE: add spoiler (plugin) rich editor extension

### DIFF
--- a/plugins/spoiler-alert/assets/javascripts/initializers/spoiler-alert.js
+++ b/plugins/spoiler-alert/assets/javascripts/initializers/spoiler-alert.js
@@ -4,6 +4,7 @@ import {
   addTagDecorateCallback,
 } from "discourse/lib/to-markdown";
 import applySpoiler from "discourse/plugins/spoiler-alert/lib/apply-spoiler";
+import richEditorExtension from "../lib/rich-editor-extension";
 
 function spoil(element) {
   element.querySelectorAll(".spoiler").forEach((spoiler) => {
@@ -45,6 +46,7 @@ export function initializeSpoiler(api) {
       return text.trim();
     }
   });
+  api.registerRichEditorExtension(richEditorExtension);
 }
 
 export default {

--- a/plugins/spoiler-alert/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/spoiler-alert/assets/javascripts/lib/rich-editor-extension.js
@@ -1,0 +1,84 @@
+const SPOILER_NODES = ["inline_spoiler", "spoiler"];
+
+/** @type {RichEditorExtension} */
+const extension = {
+  nodeSpec: {
+    spoiler: {
+      attrs: { blurred: { default: true } },
+      group: "block",
+      content: "block+",
+      parseDOM: [{ tag: "div.spoiled" }],
+      toDOM: () => ["div", { class: "spoiled" }, 0],
+    },
+    inline_spoiler: {
+      attrs: { blurred: { default: true } },
+      group: "inline",
+      inline: true,
+      content: "inline*",
+      parseDOM: [{ tag: "span.spoiled" }],
+      toDOM: () => ["span", { class: "spoiled" }, 0],
+    },
+  },
+  parse: {
+    bbcode_spoiler: { block: "inline_spoiler" },
+    wrap_bbcode(state, token) {
+      if (token.nesting === 1 && token.attrGet("class") === "spoiler") {
+        state.openNode(state.schema.nodes.spoiler);
+        return true;
+      } else if (token.nesting === -1 && state.top().type.name === "spoiler") {
+        state.closeNode();
+        return true;
+      }
+    },
+  },
+  serializeNode: {
+    spoiler(state, node) {
+      state.write("[spoiler]\n");
+      state.renderContent(node);
+      state.write("[/spoiler]\n\n");
+    },
+    inline_spoiler(state, node) {
+      state.write("[spoiler]");
+      state.renderInline(node);
+      state.write("[/spoiler]");
+    },
+  },
+  plugins({ pmState: { Plugin }, pmView: { Decoration, DecorationSet } }) {
+    return new Plugin({
+      props: {
+        decorations(state) {
+          return this.getState(state);
+        },
+        handleClickOn(view, pos, node, nodePos) {
+          if (SPOILER_NODES.includes(node.type.name)) {
+            const decoSet = this.getState(view.state) || DecorationSet.empty;
+
+            const isBlurred =
+              decoSet.find(nodePos, nodePos + node.nodeSize).length > 0;
+
+            const newDeco = isBlurred
+              ? decoSet.remove(decoSet.find(nodePos, nodePos + node.nodeSize))
+              : decoSet.add(view.state.doc, [
+                  Decoration.node(nodePos, nodePos + node.nodeSize, {
+                    class: "spoiler-blurred",
+                  }),
+                ]);
+
+            view.dispatch(view.state.tr.setMeta(this, newDeco));
+            return true;
+          }
+        },
+      },
+      state: {
+        init() {
+          return DecorationSet.empty;
+        },
+        apply(tr, set) {
+          return tr.getMeta(this) || set.map(tr.mapping, tr.doc);
+        },
+      },
+    });
+  },
+};
+
+export default extension;

--- a/plugins/spoiler-alert/assets/stylesheets/discourse_spoiler_alert.scss
+++ b/plugins/spoiler-alert/assets/stylesheets/discourse_spoiler_alert.scss
@@ -52,3 +52,12 @@
     }
   }
 }
+
+.ProseMirror {
+  .spoiled:not(.spoiler-blurred) {
+    box-shadow: 0 0 4px 4px rgba(var(--primary-rgb), 0.2);
+    inline-size: max-content;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+}

--- a/plugins/spoiler-alert/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/spoiler-alert/test/javascripts/integration/rich-editor-extension-test.js
@@ -1,0 +1,40 @@
+import { module, test } from "qunit";
+import {
+  registerRichEditorExtension,
+  resetRichEditorExtensions,
+} from "discourse/lib/composer/rich-editor-extensions";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
+import richEditorExtension from "discourse/plugins/spoiler-alert/lib/rich-editor-extension";
+
+module(
+  "Integration | Component | prosemirror-editor - spoiler plugin extension",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.rich_editor = true;
+
+      resetRichEditorExtensions().then(() => {
+        registerRichEditorExtension(richEditorExtension);
+      });
+    });
+
+    Object.entries({
+      "inline spoiler": [
+        "Hey [spoiler]did you know the good guys die[/spoiler] in the end?",
+        '<p>Hey <span class="spoiled">did you know the good guys die</span> in the end?</p>',
+        "Hey [spoiler]did you know the good guys die[/spoiler] in the end?",
+      ],
+      "block spoiler": [
+        "hey\n\n[spoiler]\n> did you know the good guys die\n\n[/spoiler]\n\nin the end?",
+        '<p>hey</p><div class="spoiled"><blockquote><p>did you know the good guys die</p></blockquote></div><p>in the end?</p>',
+        "hey\n\n[spoiler]\n> did you know the good guys die\n\n[/spoiler]\n\nin the end?",
+      ],
+    }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
+      test(name, async function (assert) {
+        await testMarkdown(assert, markdown, html, expectedMarkdown);
+      });
+    });
+  }
+);


### PR DESCRIPTION
Continues the work done on https://github.com/discourse/discourse/pull/30815.

Adds `spoiler` and `inline_spoiler` nodes, parsers, and serializers, and a click handler to toggle its blurriness in the editor.