### PR TITLE
DEV: Remove unnecessary `require`

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "distributed_mutex"
-
 module DiscourseNarrativeBot
   class NewUserNarrative < Base
     I18N_KEY = "discourse_narrative_bot.new_user_narrative".freeze


### PR DESCRIPTION
`DistributedMutex` is eager loaded in production/test and autoloaded in
development.
