### PR TITLE
UX: Only add trailing paragraph when last child is not paragraph

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/trailing-paragraph.js
@@ -19,29 +19,25 @@ const extension = {
       },
       state: {
         init(_, state) {
-          return !isLastChildEmptyParagraph(state);
+          return !isLastChildParagraph(state);
         },
         apply(tr, value) {
           if (!tr.docChanged) {
             return value;
           }
 
-          return !isLastChildEmptyParagraph(tr);
+          return !isLastChildParagraph(tr);
         },
       },
     });
   },
 };
 
-function isLastChildEmptyParagraph(state) {
+function isLastChildParagraph(state) {
   const { doc } = state;
   const lastChild = doc.lastChild;
 
-  return (
-    lastChild.type.name === "paragraph" &&
-    lastChild.nodeSize === 2 &&
-    lastChild.content.size === 0
-  );
+  return lastChild.type.name === "paragraph";
 }
 
 export default extension;

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -250,14 +250,18 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   describe "trailing paragraph" do
-    it "maintains exactly one trailing paragraph when typing and deleting text" do
+    it "ensures there is always a trailing paragraph" do
       open_composer_and_toggle_rich_editor
 
       expect(rich).to have_css("p", count: 1)
       composer.type_content("This is a test")
 
-      expect(rich).to have_css("p", count: 2)
+      expect(rich).to have_css("p", count: 1)
       expect(rich).to have_css("p", text: "This is a test", count: 1)
+
+      composer.send_keys([PLATFORM_KEY_MODIFIER, :shift, "_"]) # Insert a horizontal rule
+      expect(rich).to have_css("hr", count: 1)
+      expect(rich).to have_css("p", count: 2) # New paragraph inserted after the ruler
     end
   end
 end


### PR DESCRIPTION
Unconditionally adding an empty trailing paragraph feels a bit weird. As long as the last child is some kind of paragraph, the user can move their cursor to the end and hit return, just like any other text editor.