### PR TITLE
UX: scope btn states to touch devices

### DIFF
--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -118,19 +118,21 @@
 
       &:hover,
       &:focus {
-        background: var(--d-hover);
-        color: var(--primary);
-
-        .d-icon {
-          color: inherit;
-        }
-
-        &.btn-danger {
-          background: var(--danger-low);
-          color: var(--danger);
+        .discourse-no-touch & {
+          background: var(--d-hover);
+          color: var(--primary);
 
           .d-icon {
-            color: var(--danger-hover);
+            color: inherit;
+          }
+
+          &.btn-danger {
+            background: var(--danger-low);
+            color: var(--danger);
+
+            .d-icon {
+              color: var(--danger-hover);
+            }
           }
         }
       }

--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -117,7 +117,8 @@
       }
 
       &:hover,
-      &:focus {
+      &:focus,
+      &:focus-visible {
         .discourse-no-touch & {
           background: var(--d-hover);
           color: var(--primary);

--- a/app/assets/stylesheets/mobile/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/mobile/float-kit/d-menu.scss
@@ -23,14 +23,41 @@
     li a:focus-visible {
       outline: 0;
     }
-  }
 
-  li > .btn,
-  li > a {
-    padding: 0.75em 1rem;
-  }
+    &__item {
+      .btn {
+        border-radius: 0; //overruling the general border-radius var on all btns
+        //all specific overrules to make sure touch devices dont show focus states, which we apply on opening of the menu
+        &:focus-visible,
+        &:active {
+          .discourse-touch & {
+            background: transparent;
+            color: var(--primary);
 
-  li > a {
-    display: block;
+            .d-icon {
+              color: inherit;
+            }
+
+            &.btn-danger {
+              background: transparent;
+              color: var(--danger);
+
+              .d-icon {
+                color: var(--danger-hover);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    li > .btn,
+    li > a {
+      padding: 0.75em 1rem;
+    }
+
+    li > a {
+      display: block;
+    }
   }
 }


### PR DESCRIPTION
Buttons used in the dMenu mobile (touch device) variant should not:
* show states like hover, or focus
* should never have round borders because the component is full-width