### PR TITLE
DEV: Destroy posts rake task enhancements

### DIFF
--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -49,6 +49,11 @@ class DestroyTask
   end
 
   def destroy_posts(post_ids, require_confirmation: true)
+    if !SiteSetting.can_permanently_delete
+      @io.puts "The can_permanently_delete site setting needs to be enabled to destroy posts."
+      exit 1
+    end
+
     posts = Post.with_deleted.where(id: post_ids)
 
     @io.puts "There are #{posts.count} posts to delete"

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -166,7 +166,7 @@ class PostDestroyer
     # All posts in the topic must be force deleted if the first is force
     # deleted (except @post which is destroyed by current instance).
     if @topic && @post.is_first_post? && permanent?
-      @topic.ordered_posts.with_deleted.reverse_order.find_each do |post|
+      @topic.posts.with_deleted.find_each do |post|
         PostDestroyer.new(@user, post, @opts).destroy if post.id != @post.id
       end
     end


### PR DESCRIPTION
### What is this change?

This improves the new rake task to bulk delete posts based on feedback:

- Honour the `can_permanently_delete` site setting.
- Fix a warning about a scope order no being applied due to batching.
- Fix an issue where double delete would result in duplicate user histories.