### PR TITLE
WIP: Add test for user api key creation with omniauth

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -32,6 +32,9 @@ class UserApiKeysController < ApplicationController
       return
     end
 
+    pp "meets_tl? #{meets_tl?}"
+    pp "current_user.groups #{current_user.groups.pluck(:name)}"
+    pp "current_user.username #{current_user.username}"
     unless meets_tl?
       @no_trust_level = true
       return

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -177,6 +177,69 @@ shared_examples "login scenarios" do |login_page_object|
 
       expect(page).to have_css("#topic-title")
     end
+
+    context "with user api key and omniauth" do
+      include OmniauthHelpers
+
+      let :public_key do
+        <<~TXT
+    -----BEGIN PUBLIC KEY-----
+    MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDh7BS7Ey8hfbNhlNAW/47pqT7w
+    IhBz3UyBYzin8JurEQ2pY9jWWlY8CH147KyIZf1fpcsi7ZNxGHeDhVsbtUKZxnFV
+    p16Op3CHLJnnJKKBMNdXMy0yDfCAHZtqxeBOTcCo1Vt/bHpIgiK5kmaekyXIaD0n
+    w0z/BYpOgZ8QwnI5ZwIDAQAB
+    -----END PUBLIC KEY-----
+    TXT
+      end
+
+      let :private_key do
+        <<~TXT
+    -----BEGIN RSA PRIVATE KEY-----
+    MIICWwIBAAKBgQDh7BS7Ey8hfbNhlNAW/47pqT7wIhBz3UyBYzin8JurEQ2pY9jW
+    WlY8CH147KyIZf1fpcsi7ZNxGHeDhVsbtUKZxnFVp16Op3CHLJnnJKKBMNdXMy0y
+    DfCAHZtqxeBOTcCo1Vt/bHpIgiK5kmaekyXIaD0nw0z/BYpOgZ8QwnI5ZwIDAQAB
+    AoGAeHesbjzCivc+KbBybXEEQbBPsThY0Y+VdgD0ewif2U4UnNhzDYnKJeTZExwQ
+    vAK2YsRDV3KbhljnkagQduvmgJyCKuV/CxZvbJddwyIs3+U2D4XysQp3e1YZ7ROr
+    YlOIoekHCx1CNm6A4iImqGxB0aJ7Owdk3+QSIaMtGQWaPTECQQDz2UjJ+bomguNs
+    zdcv3ZP7W3U5RG+TpInSHiJXpt2JdNGfHItozGJCxfzDhuKHK5Cb23bgldkvB9Xc
+    p/tngTtNAkEA7S4cqUezA82xS7aYPehpRkKEmqzMwR3e9WeL7nZ2cdjZAHgXe49l
+    3mBhidEyRmtPqbXo1Xix8LDuqik0IdnlgwJAQeYTnLnHS8cNjQbnw4C/ECu8Nzi+
+    aokJ0eXg5A0tS4ttZvGA31Z0q5Tz5SdbqqnkT6p0qub0JZiZfCNNdsBe9QJAaGT5
+    fJDwfGYW+YpfLDCV1bUFhMc2QHITZtSyxL0jmSynJwu02k/duKmXhP+tL02gfMRy
+    vTMorxZRllgYeCXeXQJAEGRXR8/26jwqPtKKJzC7i9BuOYEagqj0nLG2YYfffCMc
+    d3JGCf7DMaUlaUE8bJ08PtHRJFSGkNfDJLhLKSjpbw==
+    -----END RSA PRIVATE KEY-----
+    TXT
+      end
+
+      let :args do
+        {
+          scopes: "one_time_password",
+          client_id: "x" * 32,
+          auth_redirect: "discourse://auth_redirect",
+          application_name: "foo",
+          public_key: public_key,
+          nonce: SecureRandom.hex,
+        }
+      end
+
+      before do
+        OmniAuth.config.test_mode = true
+        SiteSetting.auth_skip_create_confirm = true
+        SiteSetting.enable_facebook_logins = true
+        SiteSetting.enable_local_logins = false
+      end
+
+      after { reset_omniauth_config(:facebook) }
+
+      it "completes signup and redirects to the user api key permissions page" do
+        mock_facebook_auth
+        visit("/user-api-key/new?#{args.to_query}")
+
+        # once logged in, it should redirect back to `/user-api-key/new` with the authorization form
+        expect(page).to have_css(".authorize-api-key .scopes")
+      end
+    end
   end
 
   context "with two-factor authentication" do
@@ -297,18 +360,20 @@ shared_examples "login scenarios" do |login_page_object|
 end
 
 describe "Login", type: :system do
-  context "when desktop" do
-    include_examples "login scenarios", PageObjects::Modals::Login.new
-  end
+  # DO NOT COMMIT: commenting these out only to isolate the test above to 1 run
+  #
+  # context "when desktop" do
+  #   include_examples "login scenarios", PageObjects::Modals::Login.new
+  # end
 
-  context "when mobile", mobile: true do
-    include_examples "login scenarios", PageObjects::Modals::Login.new
-  end
+  # context "when mobile", mobile: true do
+  #   include_examples "login scenarios", PageObjects::Modals::Login.new
+  # end
 
-  context "when fullpage desktop" do
-    before { SiteSetting.full_page_login = true }
-    include_examples "login scenarios", PageObjects::Pages::Login.new
-  end
+  # context "when fullpage desktop" do
+  #   before { SiteSetting.full_page_login = true }
+  #   include_examples "login scenarios", PageObjects::Pages::Login.new
+  # end
 
   context "when fullpage mobile", mobile: true do
     before { SiteSetting.full_page_login = true }


### PR DESCRIPTION
To demonstrate an issue during signup via `/user-api-key/new`, after auth the user gets redirected but `current_user` is missing the group membership and trust level.