### PR TITLE
DEV: more resilient email change spec

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -118,11 +118,10 @@ describe "Changing email", type: :system do
     visit confirm_link
 
     find(".confirm-new-email .btn-primary").click
-
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
-
     find("button[type=submit]").click
 
+    expect(page).to have_content(I18n.t("js.second_factor_auth.redirect_after_success"))
     expect(page).to have_current_path("/latest")
     expect(user.reload.email).to eq(new_email)
   end


### PR DESCRIPTION
This might not reduce the failures to zero but some screenshots of the failures clearly show we were still on the success message page.