### PR TITLE
FIX: Limit referrerUrl redirect to topic URLs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/login.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login.js
@@ -137,8 +137,8 @@ export default class Login extends Component {
           } else if (destinationUrl) {
             removeCookie("destination_url");
             window.location.assign(destinationUrl);
-          } else if (this.args.model.referrerUrl) {
-            window.location.assign(this.args.model.referrerUrl);
+          } else if (this.args.model.referrerTopicUrl) {
+            window.location.assign(this.args.model.referrerTopicUrl);
           } else {
             window.location.reload();
           }
@@ -290,8 +290,11 @@ export default class Login extends Component {
           removeCookie("destination_url");
 
           applyHiddenFormInputValue(destinationUrl, "redirect");
-        } else if (this.args.model.referrerUrl) {
-          applyHiddenFormInputValue(this.args.model.referrerUrl, "redirect");
+        } else if (this.args.model.referrerTopicUrl) {
+          applyHiddenFormInputValue(
+            this.args.model.referrerTopicUrl,
+            "redirect"
+          );
         } else {
           applyHiddenFormInputValue(window.location.href, "redirect");
         }

--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -160,8 +160,8 @@ export default class LoginPageController extends Controller {
           } else if (destinationUrl) {
             removeCookie("destination_url");
             window.location.assign(destinationUrl);
-          } else if (this.referrerUrl) {
-            window.location.assign(this.referrerUrl);
+          } else if (this.referrerTopicUrl) {
+            window.location.assign(this.referrerTopicUrl);
           } else {
             window.location.reload();
           }
@@ -339,8 +339,8 @@ export default class LoginPageController extends Controller {
           removeCookie("destination_url");
 
           applyHiddenFormInputValue(destinationUrl, "redirect");
-        } else if (this.referrerUrl) {
-          applyHiddenFormInputValue(this.referrerUrl, "redirect");
+        } else if (this.referrerTopicUrl) {
+          applyHiddenFormInputValue(this.referrerTopicUrl, "redirect");
         } else {
           applyHiddenFormInputValue(window.location.href, "redirect");
         }

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -320,7 +320,8 @@ class DiscourseURL extends EmberObject {
     }
 
     const internalPath = url.replace(this.origin, "");
-    return /^\/t\//.test(internalPath);
+
+    return internalPath.startsWith("/t/");
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -314,6 +314,15 @@ class DiscourseURL extends EmberObject {
     return true;
   }
 
+  isInternalTopic(url) {
+    if (!this.isInternal(url)) {
+      return false;
+    }
+
+    const internalPath = url.replace(this.origin, "");
+    return /^\/t\//.test(internalPath);
+  }
+
   /**
     If the URL is in the topic form, /t/something/:topic_id/:post_number
     then we want to apply some special logic. If the post_number changes within the

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -283,7 +283,7 @@ export default class ApplicationRoute extends DiscourseRoute {
             showNotActivated: (props) => this.send("showNotActivated", props),
             showCreateAccount: (props) => this.send("showCreateAccount", props),
             canSignUp: this.controller.canSignUp,
-            referrerUrl: DiscourseURL.isInternalTopic(document.referrer)
+            referrerTopicUrl: DiscourseURL.isInternalTopic(document.referrer)
               ? document.referrer
               : null,
           },

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -283,7 +283,7 @@ export default class ApplicationRoute extends DiscourseRoute {
             showNotActivated: (props) => this.send("showNotActivated", props),
             showCreateAccount: (props) => this.send("showCreateAccount", props),
             canSignUp: this.controller.canSignUp,
-            referrerUrl: DiscourseURL.isInternal(document.referrer)
+            referrerUrl: DiscourseURL.isInternalTopic(document.referrer)
               ? document.referrer
               : null,
           },

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -54,7 +54,10 @@ export default class LoginRoute extends DiscourseRoute {
     controller.set("flashType", "");
     controller.set("flash", "");
 
-    if (this.internalReferrer || DiscourseURL.isInternal(document.referrer)) {
+    if (
+      this.internalReferrer ||
+      DiscourseURL.isInternalTopic(document.referrer)
+    ) {
       controller.set("referrerUrl", this.internalReferrer || document.referrer);
     }
 

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -58,7 +58,10 @@ export default class LoginRoute extends DiscourseRoute {
       this.internalReferrer ||
       DiscourseURL.isInternalTopic(document.referrer)
     ) {
-      controller.set("referrerUrl", this.internalReferrer || document.referrer);
+      controller.set(
+        "referrerTopicUrl",
+        this.internalReferrer || document.referrer
+      );
     }
 
     if (this.siteSettings.login_required) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -87,6 +87,30 @@ module("Unit | Utility | url", function (hooks) {
     assert.true(DiscourseURL.isInternal("#foo"), "anchor URLs are internal");
   });
 
+  test("isInternalTopic", function (assert) {
+    sinon.stub(DiscourseURL, "origin").get(() => "https://eviltrout.com");
+    assert.true(DiscourseURL.isInternalTopic("https://eviltrout.com/t/123"));
+    assert.false(DiscourseURL.isInternalTopic("https://eviltrout.com/admin"));
+    assert.false(DiscourseURL.isInternalTopic("https://eviltrout.com/u/test"));
+    assert.false(
+      DiscourseURL.isInternalTopic("https://eviltrout.com/categories")
+    );
+  });
+
+  test("isInternalTopic on subfolder install", function (assert) {
+    sinon.stub(DiscourseURL, "origin").get(() => "https://eviltrout.com/forum");
+
+    assert.true(
+      DiscourseURL.isInternalTopic("https://eviltrout.com/forum/t/123")
+    );
+    assert.false(
+      DiscourseURL.isInternalTopic("https://eviltrout.com/forum/admin")
+    );
+    assert.false(
+      DiscourseURL.isInternalTopic("https://eviltrout.com/t/something")
+    );
+  });
+
   test("userPath", function (assert) {
     assert.strictEqual(userPath(), "/u");
     assert.strictEqual(userPath("eviltrout"), "/u/eviltrout");

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -92,6 +92,7 @@ module("Unit | Utility | url", function (hooks) {
     assert.true(DiscourseURL.isInternalTopic("https://eviltrout.com/t/123"));
     assert.false(DiscourseURL.isInternalTopic("https://eviltrout.com/admin"));
     assert.false(DiscourseURL.isInternalTopic("https://eviltrout.com/u/test"));
+    assert.false(DiscourseURL.isInternalTopic("https://eviltrout.com/tamales"));
     assert.false(
       DiscourseURL.isInternalTopic("https://eviltrout.com/categories")
     );


### PR DESCRIPTION
This should avoid unwanted early redirects from other routes (like the user api key routes).