### PR TITLE
DEV: more resilient homepage spec

### DIFF
--- a/spec/system/homepage_spec.rb
+++ b/spec/system/homepage_spec.rb
@@ -86,13 +86,13 @@ describe "Homepage", type: :system do
       homepage_picker.expand
       # user overrides theme custom homepage
       homepage_picker.select_row_by_name("Hot")
-      page.find(".btn-primary.save-changes").click
+      page.find(".save-changes").click
 
-      # Wait for the save to complete
-      find(".btn-primary.save-changes:not([disabled])", wait: 5)
+      expect(page).to have_content(I18n.t("js.saved"))
       expect(user.user_option.homepage_id).to eq(UserOption::HOMEPAGES.key("hot"))
 
       click_logo
+
       expect(page).to have_css(".navigation-container .hot.active", text: "Hot")
 
       visit "/u/#{user.username}/preferences/interface"


### PR DESCRIPTION
I suspect that sometimes the button was still not disabled yet when we where checking for it. Checking for saved confirmation should be more resilient.