### PR TITLE
UX: restore CSS tag comma separator for Discourse oneboxes

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -888,6 +888,11 @@ aside.onebox.xkcd .onebox-body img {
       align-self: center;
     }
   }
+
+  .discourse-tag:not(:last-child)::after {
+    content: ",";
+    margin-right: 0.15em;
+  }
 }
 
 .onebox.gfycat p {


### PR DESCRIPTION
This is a follow-up to 55a3a4e, this restores the tag separator using CSS — core's tags are no longer separated this way but it's necessary in the Discourse oneboxes

Before:
![image](https://github.com/user-attachments/assets/d2cce1de-58df-49f3-93df-25aa26b89500)


After:
![image](https://github.com/user-attachments/assets/9a6dc82f-c82e-4c91-b695-2f855c0661b6)
