### PR TITLE
FIX: When testing multiple flagged words, ensure test matches expected word order.

### DIFF
--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe WatchedWord do
         ReviewableScore.where(
           reviewable: reviewable,
           reason: "watched_word",
-          context: "#{flag_word.word},#{another_flag_word.word}",
+          context: [flag_word.word, another_flag_word.word].sort.join(","),
         ),
       ).to be_present
     end


### PR DESCRIPTION
## ✨ What's This?

This fixes a flaky test, where the generated flagged words would sometimes not be in alphabetical order.

## 👑 Testing

This is the random seed that would previously fail:

```
bundle exec rspec --order random:48156 spec/integration/watched_words_spec.rb
```