### PR TITLE
FIX: uploader lightbox preview for new images

### DIFF
--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.gjs
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.gjs
@@ -123,7 +123,9 @@ export default class UppyImageUploader extends Component {
     );
 
     if (lightboxElement) {
-      $(lightboxElement).magnificPopup("open");
+      this.applyLightbox(lightboxElement.parentElement).then(() => {
+        $(lightboxElement).magnificPopup("open");
+      });
     }
   }
 
@@ -140,7 +142,6 @@ export default class UppyImageUploader extends Component {
 
   <template>
     <div
-      {{this.applyLightbox}}
       id={{@id}}
       class="image-uploader {{if @imageUrl 'has-image' 'no-image'}}"
       ...attributes

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -37,98 +37,100 @@ export default function lightbox(elem, siteSettings) {
   const caps = helperContext().capabilities;
   const imageClickNavigation = caps.touch;
 
-  loadScript("/javascripts/jquery.magnific-popup.min.js").then(function () {
-    $(lightboxes).magnificPopup({
-      type: "image",
-      closeOnContentClick: false,
-      removalDelay: isTesting() ? 0 : 300,
-      mainClass: "mfp-zoom-in",
-      tClose: i18n("lightbox.close"),
-      tLoading: spinnerHTML,
-      prependTo: isTesting() && document.getElementById("ember-testing"),
+  return loadScript("/javascripts/jquery.magnific-popup.min.js").then(
+    function () {
+      $(lightboxes).magnificPopup({
+        type: "image",
+        closeOnContentClick: false,
+        removalDelay: isTesting() ? 0 : 300,
+        mainClass: "mfp-zoom-in",
+        tClose: i18n("lightbox.close"),
+        tLoading: spinnerHTML,
+        prependTo: isTesting() && document.getElementById("ember-testing"),
 
-      gallery: {
-        enabled: true,
-        tPrev: i18n("lightbox.previous"),
-        tNext: i18n("lightbox.next"),
-        tCounter: i18n("lightbox.counter"),
-        navigateByImgClick: imageClickNavigation,
-      },
+        gallery: {
+          enabled: true,
+          tPrev: i18n("lightbox.previous"),
+          tNext: i18n("lightbox.next"),
+          tCounter: i18n("lightbox.counter"),
+          navigateByImgClick: imageClickNavigation,
+        },
 
-      ajax: {
-        tError: i18n("lightbox.content_load_error"),
-      },
+        ajax: {
+          tError: i18n("lightbox.content_load_error"),
+        },
 
-      callbacks: {
-        open() {
-          if (!imageClickNavigation) {
-            const wrap = this.wrap,
-              img = this.currItem.img,
-              maxHeight = img.css("max-height");
+        callbacks: {
+          open() {
+            if (!imageClickNavigation) {
+              const wrap = this.wrap,
+                img = this.currItem.img,
+                maxHeight = img.css("max-height");
 
-            wrap.on("click.pinhandler", "img", function () {
-              wrap.toggleClass("mfp-force-scrollbars");
-              img.css(
-                "max-height",
-                wrap.hasClass("mfp-force-scrollbars") ? "none" : maxHeight
+              wrap.on("click.pinhandler", "img", function () {
+                wrap.toggleClass("mfp-force-scrollbars");
+                img.css(
+                  "max-height",
+                  wrap.hasClass("mfp-force-scrollbars") ? "none" : maxHeight
+                );
+              });
+            }
+
+            if (caps.isAppWebview) {
+              postRNWebviewMessage(
+                "headerBg",
+                $(".mfp-bg").css("background-color")
               );
-            });
-          }
+            }
+          },
+          change() {
+            this.wrap.removeClass("mfp-force-scrollbars");
+          },
+          beforeClose() {
+            this.wrap.off("click.pinhandler");
+            this.wrap.removeClass("mfp-force-scrollbars");
+            if (caps.isAppWebview) {
+              postRNWebviewMessage(
+                "headerBg",
+                $(".d-header").css("background-color")
+              );
+            }
+          },
+        },
 
-          if (caps.isAppWebview) {
-            postRNWebviewMessage(
-              "headerBg",
-              $(".mfp-bg").css("background-color")
-            );
-          }
-        },
-        change() {
-          this.wrap.removeClass("mfp-force-scrollbars");
-        },
-        beforeClose() {
-          this.wrap.off("click.pinhandler");
-          this.wrap.removeClass("mfp-force-scrollbars");
-          if (caps.isAppWebview) {
-            postRNWebviewMessage(
-              "headerBg",
-              $(".d-header").css("background-color")
-            );
-          }
-        },
-      },
-
-      image: {
-        tError: i18n("lightbox.image_load_error"),
-        titleSrc(item) {
-          const href = item.el.data("download-href") || item.src;
-          let src = [
-            escapeExpression(item.el.attr("title")),
-            $("span.informations", item.el).text(),
-          ];
-          if (
-            !siteSettings.prevent_anons_from_downloading_files ||
-            User.current()
-          ) {
+        image: {
+          tError: i18n("lightbox.image_load_error"),
+          titleSrc(item) {
+            const href = item.el.data("download-href") || item.src;
+            let src = [
+              escapeExpression(item.el.attr("title")),
+              $("span.informations", item.el).text(),
+            ];
+            if (
+              !siteSettings.prevent_anons_from_downloading_files ||
+              User.current()
+            ) {
+              src.push(
+                '<a class="image-source-link" href="' +
+                  href +
+                  '">' +
+                  renderIcon("string", "download") +
+                  i18n("lightbox.download") +
+                  "</a>"
+              );
+            }
             src.push(
               '<a class="image-source-link" href="' +
-                href +
+                item.src +
                 '">' +
-                renderIcon("string", "download") +
-                i18n("lightbox.download") +
+                renderIcon("string", "image") +
+                i18n("lightbox.open") +
                 "</a>"
             );
-          }
-          src.push(
-            '<a class="image-source-link" href="' +
-              item.src +
-              '">' +
-              renderIcon("string", "image") +
-              i18n("lightbox.open") +
-              "</a>"
-          );
-          return src.join(" &middot; ");
+            return src.join(" &middot; ");
+          },
         },
-      },
-    });
-  });
+      });
+    }
+  );
 }

--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -88,6 +88,9 @@ describe "Admin About Config Area Page", type: :system do
       config_area.general_settings_section.banner_image_uploader.select_image(image_file.path)
       expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
+      config_area.general_settings_section.banner_image_uploader.toggle_lightbox_preview
+      expect(config_area.general_settings_section.banner_image_uploader).to have_lighbox_preview
+
       config_area.general_settings_section.submit
 
       expect(config_area.general_settings_section).to have_saved_successfully

--- a/spec/system/page_objects/components/uppy_image_uploader.rb
+++ b/spec/system/page_objects/components/uppy_image_uploader.rb
@@ -33,6 +33,14 @@ module PageObjects
         delete_button = @element.find(".btn-danger")
         delete_button.send_keys(:enter)
       end
+
+      def toggle_lightbox_preview
+        @element.find(".image-uploader-lightbox-btn").click
+      end
+
+      def has_lighbox_preview?
+        has_css?(".mfp-container", wait: 10)
+      end
     end
   end
 end


### PR DESCRIPTION
It is an old bug that preview is not working for newly uploaded images. To fix it, we need to preload lightbox on toggle and not when component is initialised.

Qunit test would be better but I struggled to properly simulate upload and therefore decided for system test.

<img width="1236" alt="Screenshot 2025-03-12 at 10 23 18 am" src="https://github.com/user-attachments/assets/77e80509-5205-4917-84c5-680bc90ebc65" />
