### PR TITLE
DEV: Add protection for migrations that creates index concurrently

### DIFF
--- a/spec/fixtures/db/migrate/create_index_concurrently_safe/20230309014016_create_index_concurrently.rb
+++ b/spec/fixtures/db/migrate/create_index_concurrently_safe/20230309014016_create_index_concurrently.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateIndexConcurrently < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    DROP INDEX IF EXISTS some_notifications_index;
+    SQL
+
+    execute <<~SQL
+    CREATE INDEX CONCURRENTLY some_notifications_index ON notifications(user_id);
+    SQL
+
+    execute <<~SQL
+    DROP INDEX some_notifications_index;
+    SQL
+  end
+
+  def down
+    raise "not tested"
+  end
+end

--- a/spec/fixtures/db/migrate/create_index_concurrently_unsafe/20230309014015_create_index_concurrently.rb
+++ b/spec/fixtures/db/migrate/create_index_concurrently_unsafe/20230309014015_create_index_concurrently.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexConcurrently < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    DROP INDEX IF EXISTS some_wrong_index;
+    SQL
+
+    execute <<~SQL
+    CREATE INDEX CONCURRENTLY some_notifications_index ON notifications(user_id, id DESC, read, topic_id);
+    SQL
+  end
+
+  def down
+    raise "not tested"
+  end
+end


### PR DESCRIPTION
This commit updates `Migration::SafeMigrate` to protect against unsafe
ways of adding a Postgres index concurrently.

Per postgres documentation:

  If a problem arises while scanning the table, such as a deadlock or a uniqueness violation in a unique index,
  the CREATE INDEX command will fail but leave behind an "invalid" index. This index will be ignored for querying
  purposes because it might be incomplete; however it will still consume update overhead. The recommended recovery
  method in such cases is to drop the index and try again to perform CREATE INDEX CONCURRENTLY .

Therefore, the simplest way for us to ensure that migrations that create
indexes concurrently are idempotent is to follow postgres'
recommendation of dropping the index first before trying to create the
index concurrently.
