### PR TITLE
FEATURE: enable full page login by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -689,8 +689,9 @@ login:
     min: 1
     max: 175200
   full_page_login:
-    default: false
+    default: true
     client: true
+    hidden: true
   show_signup_form_email_instructions:
     client: true
     default: true


### PR DESCRIPTION
This switches the signup/login UI to the full page experience by default.

It also marks the setting as hidden. THe plan is to keep the setting for only a short period of time to allow for quickly reverting if there are any major issues. After that, the setting will be removed.