### PR TITLE
DEV: removes code block enter edge case

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -359,12 +359,6 @@ export default class ChatComposer extends Component {
     }
 
     if (event.key === "Enter") {
-      // if we are inside a code block just insert newline
-      const { pre } = this.composer.textarea.getSelected({ lineVal: true });
-      if (this.composer.textarea.isInside(pre, /(^|\n)```/g)) {
-        return;
-      }
-
       const shortcutPreference =
         this.currentUser.user_option.chat_send_shortcut;
       const send =


### PR DESCRIPTION
This was causing some confusion and now that we have the chat preference to send with enter or metakey+enter it's even more confusing.

If your setting is send on enter, you need to use shift+enter for a new line, even in codeblocks. If your setting is meta+enter you need to use enter in the codeblock for a new line, meta+enter will send as expected.