### PR TITLE
DEV: pass post as an argument for additional member info

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
@@ -115,7 +115,7 @@ export default class PostListItemDetails extends Component {
 
           <PluginOutlet
             @name="post-list-additional-member-info"
-            @outletArgs={{hash user=@user}}
+            @outletArgs={{hash user=@user post=@post}}
           />
 
           {{!


### PR DESCRIPTION
- The user information passed currently is very limited and in some cases we need more info.