### PR TITLE
FIX: Disable composer editor switch when uploading

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -43,7 +43,7 @@
     @topicId={{this.composer.model.topic.id}}
     @categoryId={{this.composer.model.category.id}}
     @onSetup={{this.setupEditor}}
-    @isUploading={{this.composer.disableSubmit}}
+    @disableSubmit={{this.composer.disableSubmit}}
   >
     {{yield}}
   </DEditor>

--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -43,6 +43,7 @@
     @topicId={{this.composer.model.topic.id}}
     @categoryId={{this.composer.model.category.id}}
     @onSetup={{this.setupEditor}}
+    @isUploading={{this.composer.disableSubmit}}
   >
     {{yield}}
   </DEditor>

--- a/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
@@ -30,6 +30,7 @@ export default class ComposerToggleSwitch extends Component {
       }}
       type="button"
       role="switch"
+      disabled={{@disabled}}
       aria-checked={{if @state "true" "false"}}
       aria-label={{this.label}}
       title={{this.label}}

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -11,6 +11,7 @@
         {{#if this.siteSettings.rich_editor}}
           <Composer::ToggleSwitch
             @preventFocus={{true}}
+            @disabled={{@isUploading}}
             @state={{this.isRichEditorEnabled}}
             {{on "click" this.toggleRichEditor}}
           />

--- a/app/assets/javascripts/discourse/app/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.hbs
@@ -11,7 +11,7 @@
         {{#if this.siteSettings.rich_editor}}
           <Composer::ToggleSwitch
             @preventFocus={{true}}
-            @disabled={{@isUploading}}
+            @disabled={{@disableSubmit}}
             @state={{this.isRichEditorEnabled}}
             {{on "click" this.toggleRichEditor}}
           />

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -443,4 +443,20 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("p", count: 2) # New paragraph inserted after the ruler
     end
   end
+
+  describe "uploads" do
+    it "handles uploads and disables the editor toggle while uploading" do
+      open_composer_and_toggle_rich_editor
+
+      file_path = file_from_fixtures("logo.png", "images").path
+      cdp.with_slow_upload do
+        attach_file(file_path) { composer.click_toolbar_button("upload") }
+        expect(composer).to have_in_progress_uploads
+        expect(composer.editor_toggle_switch).to be_disabled
+      end
+
+      expect(composer).to have_no_in_progress_uploads
+      expect(rich).to have_css("img", count: 1)
+    end
+  end
 end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -297,8 +297,12 @@ module PageObjects
       end
 
       def toggle_rich_editor
-        find("#{COMPOSER_ID} .composer-toggle-switch").click
+        editor_toggle_switch.click
         self
+      end
+
+      def editor_toggle_switch
+        find("#{COMPOSER_ID} .composer-toggle-switch")
       end
 
       private


### PR DESCRIPTION
When you are uploading, it just causes weird problems
when you switch between markdown/rich editors, and it's
not something we really want to support. This commit
disables the Composer::ToggleSwitch while uploading.
