### PR TITLE
FIX: Make SmallUserList change backwards compatible

### DIFF
--- a/app/assets/javascripts/discourse/app/components/small-user-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/small-user-list.gjs
@@ -43,7 +43,7 @@ export default class SmallUserList extends Component {
   }
 
   get shouldShow() {
-    return this.users.length && this.args.isVisible;
+    return this.users.length && (this.args.isVisible ?? true);
   }
 
   <template>


### PR DESCRIPTION
### What is this change?

We made some changes to the `SmallUserList` widget in #31549. This accidentally broke at least one plugin (`discourse-topic-voting`) which uses it.

This fixes that by defaulting `isVisible` to `true` (old behaviour) when the argument is missing.

**Before:**

<img width="425" alt="Screenshot 2025-03-13 at 2 11 24 PM" src="https://github.com/user-attachments/assets/b6ef611d-f5f1-4850-abc1-c5075f6258ea" />

**After:**

<img width="431" alt="Screenshot 2025-03-13 at 2 11 09 PM" src="https://github.com/user-attachments/assets/99633337-4bcf-43ad-bbfe-6adc806d56eb" />
