### PR TITLE
WIP: Fix inline spoilers when using toolbar Blur Spoiler

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -103,11 +103,26 @@ export default class ProsemirrorTextManipulation {
       return;
     }
 
-    const text = head + i18n(`composer.${exampleKey}`) + tail;
-    const doc = this.convertFromMarkdown(text);
+    let text;
+    if (this.view.state.selection.empty) {
+      text = head + i18n(`composer.${exampleKey}`) + tail;
+    } else {
+      // NOTE: We need to add IGNORE here otherwise the convertFromMarkdown
+      // markdown parser will parse the text as a block instead of inline.
+      text =
+        "IGNORE " +
+        head +
+        this.view.state.doc.textBetween(sel.start, sel.end) +
+        tail;
+    }
 
+    const doc = this.convertFromMarkdown(text);
     this.view.dispatch(
-      this.view.state.tr.replaceWith(sel.start, sel.end, doc.content.firstChild)
+      this.view.state.tr.replaceRangeWith(
+        sel.start,
+        sel.end,
+        doc.content.firstChild.content.lastChild
+      )
     );
   }
 

--- a/plugins/spoiler-alert/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/spoiler-alert/test/javascripts/integration/rich-editor-extension-test.js
@@ -31,6 +31,11 @@ module(
         '<p>hey</p><div class="spoiled"><blockquote><p>did you know the good guys die</p></blockquote></div><p>in the end?</p>',
         "hey\n\n[spoiler]\n> did you know the good guys die\n\n[/spoiler]\n\nin the end?",
       ],
+      "inline spoiler without surrounding text": [
+        "[spoiler]did you know the good guys die[/spoiler]",
+        '<p><span class="spoiled">did you know the good guys die</span></p>',
+        "[spoiler]did you know the good guys die[/spoiler]",
+      ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
       test(name, async function (assert) {
         await testMarkdown(assert, markdown, html, expectedMarkdown);


### PR DESCRIPTION
When we do `applySurround`, if we have an active ProseMirror
selection via this.view.state.selection, then we should not use
the "example text" when attempting to add [spoiler] bbcode.

In addition to this, when we call `convertFromMarkdown` we must
add an additional bit of text at the beginning otherwise the
parser will always parse e.g. `[spoiler]test[/spoiler]` as
a spoiler block bbcode rather than inline bbcode
