### PR TITLE
FIX: ensures chat context is given to emoji picker

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/chat-composer-inline-buttons/emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/chat-composer-inline-buttons/emoji-picker.hbs
@@ -3,6 +3,7 @@
     @context={{concat "channel_" @outletArgs.channel.id}}
     @didSelectEmoji={{@outletArgs.composer.onSelectEmoji}}
     @btnClass="chat-composer-button btn-transparent -emoji"
+    @context="chat"
   />
 
   <Chat::Composer::Separator />

--- a/plugins/chat/assets/javascripts/discourse/connectors/chat-composer-inline-buttons/emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/chat-composer-inline-buttons/emoji-picker.hbs
@@ -1,6 +1,5 @@
 {{#if this.site.desktopView}}
   <EmojiPicker
-    @context={{concat "channel_" @outletArgs.channel.id}}
     @didSelectEmoji={{@outletArgs.composer.onSelectEmoji}}
     @btnClass="chat-composer-button btn-transparent -emoji"
     @context="chat"


### PR DESCRIPTION
This was preventing favorites emojis to work correctly as it was using topic context. No tests for now as it's a very specific behavior hard to test with acceptance test and a system spec seems heavy for this.