### PR TITLE
DEV: Stop using sprockets to compile service-worker js

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -220,23 +220,7 @@ class StaticController < ApplicationController
         # Maximum cache that the service worker will respect is 24 hours.
         # However, ensure that these may be cached and served for longer on servers.
         immutable_for 1.year
-
-        if Rails.application.assets_manifest.assets["service-worker.js"]
-          path =
-            File.expand_path(
-              Rails.root +
-                "public/assets/#{Rails.application.assets_manifest.assets["service-worker.js"]}",
-            )
-          response.headers["Last-Modified"] = File.ctime(path).httpdate
-        end
-        content = Rails.application.assets_manifest.find_sources("service-worker.js").first
-
-        base_url = File.dirname(helpers.script_asset_path("service-worker"))
-        content =
-          content.sub(%r{^//# sourceMappingURL=(service-worker-.+\.map)$}) do
-            "//# sourceMappingURL=#{base_url}/#{Regexp.last_match(1)}"
-          end
-        render(plain: content, content_type: "application/javascript")
+        render "service-worker"
       end
     end
   end

--- a/app/views/static/service-worker.js.erb
+++ b/app/views/static/service-worker.js.erb
@@ -1,7 +1,7 @@
 'use strict';
 
 var chatRegex = /\/chat\/channel\/(\d+)\//;
-var inlineReplyIcon = "<%= UrlHelper.absolute("/images/push-notifications/inline_reply.png") %>";
+var inlineReplyIcon = "<%= ::UrlHelper.absolute("/images/push-notifications/inline_reply.png") %>";
 
 function showNotification(title, body, icon, badge, tag, baseUrl, url) {
   var notificationOptions = {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -25,7 +25,6 @@ Rails.application.config.assets.precompile += [
 
 Rails.application.config.assets.precompile += %w[
   break_string.js
-  service-worker.js
   locales/i18n.js
   scripts/discourse-test-listen-boot
 ]

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe StaticController do
     it "works" do
       get "/service-worker.js"
       expect(response.status).to eq(200)
-      expect(response.content_type).to start_with("application/javascript")
+      expect(response.content_type).to start_with("text/javascript")
       expect(response.body).to include("addEventListener")
     end
   end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -342,40 +342,5 @@ RSpec.describe StaticController do
       expect(response.content_type).to start_with("application/javascript")
       expect(response.body).to include("addEventListener")
     end
-
-    it "replaces sourcemap URL" do
-      Rails
-        .application
-        .assets_manifest
-        .stubs(:find_sources)
-        .with("service-worker.js")
-        .returns([<<~JS])
-          someFakeServiceWorkerSource();
-          //# sourceMappingURL=service-worker-abcde.js.map
-        JS
-
-      {
-        "/assets/service-worker.js" => "/assets/service-worker-abcde.js.map",
-        "/assets/service-worker.js.br" => "/assets/service-worker-abcde.js.map",
-        "/assets/service-worker.br.js" => "/assets/service-worker-abcde.js.map",
-        "/assets/service-worker.js.gz" => "/assets/service-worker-abcde.js.map",
-        "/assets/service-worker.gz.js" => "/assets/service-worker-abcde.js.map",
-        "https://example.com/assets/service-worker.js" =>
-          "https://example.com/assets/service-worker-abcde.js.map",
-        "https://example.com/subfolder/assets/service-worker.js" =>
-          "https://example.com/subfolder/assets/service-worker-abcde.js.map",
-      }.each do |asset_path, expected_map_url|
-        ActionController::Base
-          .helpers
-          .stubs(:asset_path)
-          .with("service-worker.js")
-          .returns(asset_path)
-
-        get "/service-worker.js"
-        expect(response.status).to eq(200)
-        expect(response.content_type).to start_with("application/javascript")
-        expect(response.body).to include("sourceMappingURL=#{expected_map_url}\n")
-      end
-    end
   end
 end


### PR DESCRIPTION
The service worker isn't served via normal asset paths or the CDN. Instead, the ERB was being compiled by sprockets, fished out of the `public/` directory by the static_controller, and then the sprockets-specific stuff like `sourceMappingUrl` was being removed.

Instead, we can put the ERB under `views/static/`, and have it evaluate at runtime. There are only a couple of super-cheap interpolations, plus the route is cached in nginx, so there is no performance concern.

This takes us one step closer to removing sprockets.