### PR TITLE
DEV: add value transformer to allow bulk select in nav controls

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -27,7 +27,7 @@
 {{/unless}}
 
 <div class="navigation-controls">
-  {{#if (and this.notCategoriesRoute this.site.mobileView @canBulkSelect)}}
+  {{#if this.showBulkSelectInNavControls}}
     <BulkSelectToggle @bulkSelectHelper={{@bulkSelectHelper}} />
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -9,12 +9,14 @@ import { setting } from "discourse/lib/computed";
 import discourseComputed from "discourse/lib/decorators";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import { NotificationLevels } from "discourse/lib/notification-levels";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import NavItem from "discourse/models/nav-item";
 
 @tagName("")
 export default class DNavigation extends Component {
   @service router;
   @service dialog;
+  @service site;
 
   @tracked filterMode;
 
@@ -22,6 +24,20 @@ export default class DNavigation extends Component {
 
   get createTopicLabel() {
     return this.site.desktopView ? "topic.create" : "";
+  }
+
+  get showBulkSelectInNavControls() {
+    const mobileViewRequired = applyValueTransformer(
+      "bulk-select-in-nav-controls",
+      true,
+      { site: this.site }
+    );
+
+    return (
+      (mobileViewRequired ? this.site.mobileView : true) &&
+      this.notCategoriesRoute &&
+      this.canBulkSelect
+    );
   }
 
   @dependentKeyCompat

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -27,14 +27,14 @@ export default class DNavigation extends Component {
   }
 
   get showBulkSelectInNavControls() {
-    const mobileViewRequired = applyValueTransformer(
+    const enableOnDesktop = applyValueTransformer(
       "bulk-select-in-nav-controls",
-      true,
+      false,
       { site: this.site }
     );
 
     return (
-      (mobileViewRequired ? this.site.mobileView : true) &&
+      (this.site.mobileView || enableOnDesktop) &&
       this.notCategoriesRoute &&
       this.canBulkSelect
     );

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -11,6 +11,7 @@ export const BEHAVIOR_TRANSFORMERS = Object.freeze([
 export const VALUE_TRANSFORMERS = Object.freeze([
   // use only lowercase names
   "admin-reports-show-query-params",
+  "bulk-select-in-nav-controls",
   "category-available-views",
   "category-description-text",
   "category-display-name",


### PR DESCRIPTION
It's somewhat common for a theme to remove our topic list header: 
![image](https://github.com/user-attachments/assets/28fbe764-0944-4d96-b84e-00fd68fda385)

One issue with this is that it eliminates the bulk select button. 

Fortunately, we already have a solution for this on mobile... show it in the navigation-controls: 

![image](https://github.com/user-attachments/assets/17d0b20a-2948-4f3e-8615-7f8577adba3d)


This PR adds the `showBulkSelectInNavControls` value transformer — so we can optionally allow this on desktop as well: 

![image](https://github.com/user-attachments/assets/883975ec-95ed-44b4-85cc-6c9aa53142cd)

This provides an easy way to keep the bulk select controls without the topic list header. 

```js
  api.registerValueTransformer("bulk-select-in-nav-controls", () => {
    return true;
  });
 ```