### PR TITLE
PERF: Optimize topic-tracking-state subcategory calculation

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -545,18 +545,15 @@ export default class TopicTrackingState extends EmberObject {
   }
 
   getSubCategoryIds(categoryId) {
-    const result = [categoryId];
-    const categories = Category.list();
-
-    for (let i = 0; i < result.length; ++i) {
-      for (let j = 0; j < categories.length; ++j) {
-        if (result[i] === categories[j].parent_category_id) {
-          result[result.length] = categories[j].id;
-        }
-      }
+    if (!categoryId) {
+      return [];
     }
 
-    return new Set(result);
+    const descendants = Category.findById(categoryId).descendants.map(
+      (c) => c.id
+    );
+
+    return new Set([categoryId, ...descendants]);
   }
 
   countCategoryByState({

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -6,7 +6,6 @@ import { module, test } from "qunit";
 import sinon from "sinon";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import DiscourseURL from "discourse/lib/url";
-import Category from "discourse/models/category";
 import User from "discourse/models/user";
 import {
   fakeTime,
@@ -685,7 +684,9 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
       slug: "baz",
       parent_category_id: bar.id,
     });
-    sinon.stub(Category, "list").returns([foo, bar, baz]);
+
+    const site = getOwner(this).lookup("service:site");
+    site.set("categories", [foo, bar, baz]);
 
     const trackingState = this.store.createRecord("topic-tracking-state");
     assert.deepEqual(Array.from(trackingState.getSubCategoryIds(1)), [1, 2, 3]);
@@ -713,7 +714,9 @@ module("Unit | Model | topic-tracking-state", function (hooks) {
       id: 4,
       slug: "qux",
     });
-    sinon.stub(Category, "list").returns([foo, bar, baz, qux]);
+
+    const site = getOwner(this).lookup("service:site");
+    site.set("categories", [foo, bar, baz, qux]);
 
     let currentUser = this.store.createRecord("user", {
       username: "chuck",


### PR DESCRIPTION
When opening the sidebar on a site with thousands of categories, `getSubCategoryIds` is called repeatedly and the nested loops burn a lot of CPU time.

The `Category.descendants` logic is similar in efficiency, but crucially it is cached so it only needs to be calculated once per category. So this change should make a big difference to sidebar performance on sites with lots of categories.