### PR TITLE
FIX: copy image from cooked to rich editor

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -39,7 +39,11 @@ const extension = {
               alt: dom.getAttribute("alt"),
               width: dom.getAttribute("width"),
               height: dom.getAttribute("height"),
-              originalSrc: dom.dataset.origSrc,
+              originalSrc:
+                dom.dataset.origSrc ??
+                (dom.dataset.base62Sha1
+                  ? `upload://${dom.dataset.base62Sha1}`
+                  : undefined),
               extras: dom.hasAttribute("data-thumbnail")
                 ? "thumbnail"
                 : undefined,

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -426,6 +426,25 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("pre code", wait: 1)
       expect(rich).to have_css("select.code-language-select", wait: 1)
     end
+
+    it "parses images copied from cooked with base62-sha1" do
+      cdp.allow_clipboard
+      open_composer_and_toggle_rich_editor
+
+      cdp.write_clipboard(
+        '<img src="image.png" alt="alt text" data-base62-sha1="1234567890">',
+        html: true,
+      )
+      page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
+
+      within(rich) do
+        image = find("img")
+
+        expect(image[:src]).to end_with("image.png")
+        expect(image[:alt]).to eq("alt text")
+        expect(image["data-orig-src"]).to eq("upload://1234567890")
+      end
+    end
   end
 
   describe "trailing paragraph" do

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -437,13 +437,9 @@ describe "Composer - ProseMirror editor", type: :system do
       )
       page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
 
-      within(rich) do
-        image = find("img")
-
-        expect(image[:src]).to end_with("image.png")
-        expect(image[:alt]).to eq("alt text")
-        expect(image["data-orig-src"]).to eq("upload://1234567890")
-      end
+      expect(page).to have_css(
+        "img[src$='image.png'][alt='alt text'][data-orig-src='upload://1234567890']",
+      )
     end
   end
 

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -30,11 +30,23 @@ module PageObjects
       page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
     end
 
-    def write_clipboard(text)
-      page.evaluate_async_script(
-        "navigator.clipboard.writeText(arguments[0]).then(arguments[1])",
-        text,
-      )
+    def write_clipboard(content, html: false)
+      if html
+        page.evaluate_async_script(
+          "navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([arguments[0]], { type: 'text/html' }),
+          'text/plain': new Blob([arguments[0]], { type: 'text/plain' })
+        })
+      ]).then(arguments[1])",
+          content,
+        )
+      else
+        page.evaluate_async_script(
+          "navigator.clipboard.writeText(arguments[0]).then(arguments[1])",
+          content,
+        )
+      end
     end
 
     def clipboard_has_text?(text, chomp: false, strict: true)


### PR DESCRIPTION
When copying images from cooked, we have a `data-base62-sha1` attribute instead of a `data-orig-src` that we were expecting.

This PR fixes it and adds a system test.