### PR TITLE
UX: strip partial :emoji when adding emoji from picker

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -191,13 +191,27 @@ export default class ProsemirrorTextManipulation {
     command?.(this.view.state, this.view.dispatch);
   }
 
-  @bind
   emojiSelected(code) {
+    let index = 0;
+
+    const lastIndex = this.autocompleteHandler.getValue().lastIndexOf(":");
+    if (lastIndex !== -1) {
+      index = this.autocompleteHandler.getValue().length - lastIndex;
+    }
+
+    const { from, to } = this.view.state.selection;
+
     this.view.dispatch(
       this.view.state.tr
-        .replaceSelectionWith(this.schema.nodes.emoji.create({ code }))
+        .replaceRangeWith(
+          from - index,
+          to,
+          this.schema.nodes.emoji.create({ code })
+        )
         .insertText(" ")
     );
+
+    next(() => this.focus());
   }
 
   @bind
@@ -336,8 +350,6 @@ class ProsemirrorAutocompleteHandler {
 
   /**
    * Replaces the term between start-end in the currently selected text block
-   *
-   * It uses input rules to convert it to a node if possible
    *
    * @param {number} start
    * @param {number} end

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -194,9 +194,10 @@ export default class ProsemirrorTextManipulation {
   emojiSelected(code) {
     let index = 0;
 
-    const match = this.autocompleteHandler.getValue().match(/\B:(\w*)$/);
+    const value = this.autocompleteHandler.getValue();
+    const match = value.match(/\B:(\w*)$/);
     if (match) {
-      index = this.autocompleteHandler.getValue().length - match.index;
+      index = value.length - match.index;
     }
 
     const { from, to } = this.view.state.selection;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -194,9 +194,9 @@ export default class ProsemirrorTextManipulation {
   emojiSelected(code) {
     let index = 0;
 
-    const lastIndex = this.autocompleteHandler.getValue().lastIndexOf(":");
-    if (lastIndex !== -1) {
-      index = this.autocompleteHandler.getValue().length - lastIndex;
+    const match = this.autocompleteHandler.getValue().match(/\B:(\w*)$/);
+    if (match) {
+      index = this.autocompleteHandler.getValue().length - match.index;
     }
 
     const { from, to } = this.view.state.selection;

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -51,6 +51,22 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(composer).to have_emoji_autocomplete
     end
+
+    it "strips partially written emoji when using 'more' emoji modal" do
+      open_composer_and_toggle_rich_editor
+      composer.type_content("Why :repeat_single")
+
+      expect(composer).to have_emoji_autocomplete
+
+      # "more" emoji picker
+      composer.send_keys(:arrow_down, :enter)
+
+      find("img[data-emoji='repeat_single_button']").click
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("Why :repeat_single_button: ")
+    end
   end
 
   context "with inputRules" do


### PR DESCRIPTION
When a user typed `:emoji` using the autocomplete on the rich editor, but then used the "more" option to open the emoji picker and picked an emoji from there, we were leaving the dangling `:emoji` there and just added the emoji node after it.

We now check if there's a partial emoji exactly at the caret position, and replace it too.