### PR TITLE
FIX: Incorrect chat DM group user count

### DIFF
--- a/plugins/chat/app/serializers/chat/chatable_group_serializer.rb
+++ b/plugins/chat/app/serializers/chat/chatable_group_serializer.rb
@@ -9,7 +9,7 @@ module Chat
     end
 
     def chat_enabled_user_count
-      object.users.count { |user| user.user_option&.chat_enabled }
+      object.human_users.count { |user| user.user_option&.chat_enabled }
     end
 
     def can_chat

--- a/plugins/chat/spec/serializer/chat/chatable_group_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chatable_group_serializer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+RSpec.describe Chat::ChatableGroupSerializer do
+  fab!(:group)
+  fab!(:user_1) { Fabricate(:user) }
+  fab!(:user_2) { Fabricate(:user) }
+  fab!(:bot_user) { Fabricate(:bot) }
+
+  subject(:serializer) { described_class.new(group, scope: Fabricate(:user).guardian, root: false) }
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_max_direct_message_users = 3
+
+    group.add(user_1)
+    group.add(user_2)
+    group.add(bot_user)
+
+    user_1.user_option.update!(chat_enabled: true)
+    user_2.user_option.update!(chat_enabled: true)
+    bot_user.user_option.update!(chat_enabled: true)
+  end
+
+  it "gets the correct chat_enabled_user_count, excluding bot users" do
+    expect(serializer.chat_enabled_user_count).to eq(2)
+  end
+
+  it "gets correct can_chat based on chat_enabled_user_count and chat_max_direct_message_users" do
+    expect(serializer.can_chat).to eq(true)
+    SiteSetting.chat_max_direct_message_users = 2
+    expect(serializer.can_chat).to eq(false)
+  end
+end


### PR DESCRIPTION
When creating a DM to a group in chat, we show
a count of users for that group if the number of
users exceeds SiteSetting.chat_max_direct_message_users.

However, we were also counting bot users here, we should
only be counting human users, this led to confusion because
the chat group count was different from the one on
e.g. /g/:group_name
