### PR TITLE
FIX: Double wait timeout for mail deliver in email_change_spec.rb

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -20,7 +20,9 @@ describe "Changing email", type: :system do
 
     find(".save-button button").click
 
-    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 1 }
+    wait_for(timeout: Capybara.default_max_wait_time * 2) do
+      ActionMailer::Base.deliveries.count === 1
+    end
 
     if user.admin?
       get_link_from_email(:old)
@@ -141,7 +143,10 @@ describe "Changing email", type: :system do
     find(".dialog-footer .btn-primary").click
 
     # Confirm new email
-    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 2 }
+    wait_for(timeout: Capybara.default_max_wait_time * 2) do
+      ActionMailer::Base.deliveries.count === 2
+    end
+
     confirm_new_link = get_link_from_email(:new)
 
     visit confirm_new_link
@@ -172,7 +177,10 @@ describe "Changing email", type: :system do
     find(".dialog-footer .btn-primary").click
 
     # Confirm new email
-    wait_for(timeout: Capybara.default_max_wait_time) { ActionMailer::Base.deliveries.count === 2 }
+    wait_for(timeout: Capybara.default_max_wait_time * 2) do
+      ActionMailer::Base.deliveries.count === 2
+    end
+
     confirm_new_link = get_link_from_email(:new)
 
     visit confirm_new_link


### PR DESCRIPTION
The tests have been flaky on CI so just double the timeouts for now.
We will investigate further if it continues to flake with the doubled
timeout.
