### PR TITLE
DEV: Fix flaky system test

### DIFF
--- a/spec/system/page_objects/components/ace_editor.rb
+++ b/spec/system/page_objects/components/ace_editor.rb
@@ -9,10 +9,10 @@ module PageObjects
       end
 
       def fill_input(content)
-        # Clear the input before filling it in because capybara's fill_in method doesn't seem to replace existing content
-        # unless the content is a blank string.
-        editor_input.fill_in(with: "")
-        editor_input.fill_in(with: content)
+        # Can't rely on capybara here because ace editor is not a normal input.
+        page.evaluate_script(
+          "ace.edit(document.getElementsByClassName('ace')[0]).setValue(#{content.to_json})",
+        )
         self
       end
 

--- a/spec/system/page_objects/components/admin_theme_settings_editor.rb
+++ b/spec/system/page_objects/components/admin_theme_settings_editor.rb
@@ -3,6 +3,11 @@
 module PageObjects
   module Components
     class AdminThemeSettingsEditor < Base
+      def opened?
+        page.has_css?(".ace_editor")
+        self
+      end
+
       def fill_in(settings)
         editor.fill_input(settings)
         self

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -90,7 +90,7 @@ module PageObjects
 
       def click_theme_settings_editor_button
         click_button(I18n.t("admin_js.admin.customize.theme.settings_editor"))
-        PageObjects::Components::AdminThemeSettingsEditor.new
+        PageObjects::Components::AdminThemeSettingsEditor.new.opened?
       end
 
       def switch_to_components


### PR DESCRIPTION
The "Admin editing objects type theme setting when editing a theme setting of objects type allows an admin to edit a theme setting of objects type via the settings editor"
system test was flaky because of the way we were filling in content into
AceEditor. It is not a normal input and does not seem to function like a
normal input. Using Capybara's `fill_in` method was not reliable so we
will just use AceEditor's API directly to update its input.
