### PR TITLE
DEV: Fix flaky system tests due to select kit

### DIFF
--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -26,7 +26,7 @@ module PageObjects
       end
 
       def expanded_component
-        expand_if_needed
+        return expand if is_collapsed?
         find(@context + ".is-expanded", wait: 5)
       end
 
@@ -98,10 +98,6 @@ module PageObjects
 
       def select_row_by_index(index)
         expanded_component.find(".select-kit-row[data-index='#{index}']").click
-      end
-
-      def expand_if_needed
-        expand if is_collapsed?
       end
     end
   end


### PR DESCRIPTION
The "Tag synonyms when visiting edit tag page allows an admin to create a new tag as synonym when tag does not exist" system
test was flaky with the following error:

```
Failure/Error: super

Capybara::ElementNotFound:
  Unable to find css "#add-synonyms.is-expanded"
```

Backtrace points to the following location:

```
...
./spec/system/page_objects/components/select_kit.rb:30:in `expanded_component'
./spec/system/page_objects/components/select_kit.rb:88:in `search'
...
```

What I noticed is that
`PageObjects::Components::SelectKit#expanded_component` has already
found the expanded element when it calls `#expand`. Therefore, there is
no need for us to search for it again.
