### PR TITLE
FIX: Ensure ordering is enforced in `PostsController#replies`

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -451,6 +451,7 @@ class PostsController < ApplicationController
         .replies
         .secured(guardian)
         .where(post_number: after + 1..)
+        .order(:post_number)
         .limit(MAX_POST_REPLIES)
         .pluck(:id)
 


### PR DESCRIPTION
This was picked up by the `PostsController#replies supports pagination`
requests spec as it was flaky from time to time.

Example of failing run: https://github.com/discourse/discourse/actions/runs/13824916594/job/38677991883
