### PR TITLE
FIX: replace positive lookbehind on checklist inputrule

### DIFF
--- a/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
@@ -33,12 +33,12 @@ const extension = {
 
   inputRules: [
     {
-      match: /(?<=^|\s)\[(x? ?)]$/,
+      match: /(^|\s)\[(x? ?)]$/,
       handler: (state, match, start, end) =>
         state.tr.replaceWith(
-          start,
+          start + match[1].length,
           end,
-          state.schema.nodes.check.create({ checked: match[1] === "x" })
+          state.schema.nodes.check.create({ checked: match[2] === "x" })
         ),
       options: { undoable: false },
     },


### PR DESCRIPTION
Not supported on iOS Safari <= 16.3