### PR TITLE
FIX: remove abandon draft dialog

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -6,7 +6,6 @@ import deprecated from "discourse/lib/deprecated";
 import Composer, {
   addComposerSaveErrorCallback,
   clearComposerSaveErrorCallback,
-  toggleCheckDraftPopup,
 } from "discourse/services/composer";
 
 // TODO add deprecation
@@ -32,5 +31,4 @@ export {
   clearComposerSaveErrorCallback,
   clearPopupMenuOptions,
   clearPopupMenuOptionsCallback,
-  toggleCheckDraftPopup,
 };

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1384,19 +1384,6 @@ export default class ComposerService extends Service {
       }
 
       await this._setModel(composerModel, opts);
-
-      // otherwise, do the draft check async
-      // if (!opts.draft) {
-      // console.log("composer without opts.draft, draftKey:", opts.draftKey);
-      // let data = await Draft.get(opts.draftKey);
-      // data = await this.confirmDraftAbandon(data);
-
-      // if (data.draft) {
-      //   opts.draft = data.draft;
-      //   opts.draftSequence = data.draft_sequence;
-      //   await this.open(opts);
-      // }
-      // }
     } finally {
       this.skipAutoSave = false;
       this.appEvents.trigger("composer:open", { model: this.model });

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -19,7 +19,6 @@ import { customPopupMenuOptions } from "discourse/lib/composer/custom-popup-menu
 import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
-import { isTesting } from "discourse/lib/environment";
 import prepareFormTemplateData, {
   getFormTemplateObject,
 } from "discourse/lib/form-template-validation";
@@ -79,12 +78,6 @@ async function loadDraft(store, opts = {}) {
 }
 
 const _composerSaveErrorCallbacks = [];
-
-let _checkDraftPopup = !isTesting();
-
-export function toggleCheckDraftPopup(enabled) {
-  _checkDraftPopup = enabled;
-}
 
 export function clearComposerSaveErrorCallback() {
   _composerSaveErrorCallbacks.length = 0;
@@ -1393,16 +1386,17 @@ export default class ComposerService extends Service {
       await this._setModel(composerModel, opts);
 
       // otherwise, do the draft check async
-      if (!opts.draft) {
-        let data = await Draft.get(opts.draftKey);
-        data = await this.confirmDraftAbandon(data);
+      // if (!opts.draft) {
+      // console.log("composer without opts.draft, draftKey:", opts.draftKey);
+      // let data = await Draft.get(opts.draftKey);
+      // data = await this.confirmDraftAbandon(data);
 
-        if (data.draft) {
-          opts.draft = data.draft;
-          opts.draftSequence = data.draft_sequence;
-          await this.open(opts);
-        }
-      }
+      // if (data.draft) {
+      //   opts.draft = data.draft;
+      //   opts.draftSequence = data.draft_sequence;
+      //   await this.open(opts);
+      // }
+      // }
     } finally {
       this.skipAutoSave = false;
       this.appEvents.trigger("composer:open", { model: this.model });
@@ -1551,48 +1545,6 @@ export default class ComposerService extends Service {
     const sequence = draftSequence || this.get("model.draftSequence");
     await Draft.clear(key, sequence);
     this.appEvents.trigger("draft:destroyed", key);
-  }
-
-  confirmDraftAbandon(data) {
-    if (!data.draft) {
-      return data;
-    }
-
-    // do not show abandon dialog if old draft is clean
-    const draft = JSON.parse(data.draft);
-    if (draft.reply === draft.originalText) {
-      data.draft = null;
-      return data;
-    }
-
-    if (!_checkDraftPopup) {
-      data.draft = null;
-      return data;
-    }
-
-    return new Promise((resolve) => {
-      this.dialog.alert({
-        message: i18n("drafts.abandon.confirm"),
-        buttons: [
-          {
-            label: i18n("drafts.abandon.yes_value"),
-            class: "btn-danger",
-            icon: "trash-can",
-            action: () => {
-              this.destroyDraft(data.draft_sequence).finally(() => {
-                data.draft = null;
-                resolve(data);
-              });
-            },
-          },
-          {
-            label: i18n("drafts.abandon.no_value"),
-            class: "btn-resume-editing",
-            action: () => resolve(data),
-          },
-        ],
-      });
-    });
   }
 
   cancelComposer(opts = {}) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -3,7 +3,6 @@ import { test } from "qunit";
 import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
 import Draft from "discourse/models/draft";
-import { toggleCheckDraftPopup } from "discourse/services/composer";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import {
   acceptance,
@@ -382,12 +381,9 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     can_tag_topics: true,
   });
 
-  needs.hooks.afterEach(() => toggleCheckDraftPopup(false));
-
   test("shared draft", async function (assert) {
     updateCurrentUser({ draft_count: 1 });
     stubDraftResponse();
-    toggleCheckDraftPopup(true);
 
     await visit("/");
     await click("button.topic-drafts-menu-trigger");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-form-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-form-template-test.js
@@ -1,7 +1,6 @@
 import { click, fillIn, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
-import { toggleCheckDraftPopup } from "discourse/services/composer";
 import TopicFixtures from "discourse/tests/fixtures/topic";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -113,8 +112,6 @@ acceptance("Composer Form Template", function (needs) {
       return helper.response(topicList);
     });
   });
-
-  needs.hooks.afterEach(() => toggleCheckDraftPopup(false));
 
   test("Composer Form Template is shrank and reopened", async function (assert) {
     await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -844,6 +844,7 @@ acceptance("Composer", function (needs) {
 
     assert.dom(".dialog-body").doesNotExist("does not open the dialog");
     assert.dom(".d-editor-input").exists("the composer input is visible");
+    assert.dom(".d-editor-input").hasValue(/^Any plans to support/);
   });
 
   test("Can switch states without abandon popup", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -18,7 +18,6 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { translateModKey } from "discourse/lib/utilities";
 import Composer, { CREATE_TOPIC } from "discourse/models/composer";
 import Draft from "discourse/models/draft";
-import { toggleCheckDraftPopup } from "discourse/services/composer";
 import TopicFixtures from "discourse/tests/fixtures/topic";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import {
@@ -80,8 +79,6 @@ acceptance("Composer", function (needs) {
       return helper.response(topicList);
     });
   });
-
-  needs.hooks.afterEach(() => toggleCheckDraftPopup(false));
 
   test("Composer is opened", async function (assert) {
     await visit("/");
@@ -839,22 +836,17 @@ acceptance("Composer", function (needs) {
     assert.dom(".d-editor-input").hasNoValue("clears the composer input");
   });
 
-  test("Checks for existing draft", async function (assert) {
-    toggleCheckDraftPopup(true);
-
+  test("Does not check for existing draft", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
     await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".topic-post:nth-of-type(1) button.edit");
 
-    assert.dom(".dialog-body").hasText(i18n("drafts.abandon.confirm"));
-
-    await click(".dialog-footer .btn-resume-editing");
+    assert.dom(".dialog-body").doesNotExist("does not open the dialog");
+    assert.dom(".d-editor-input").exists("the composer input is visible");
   });
 
   test("Can switch states without abandon popup", async function (assert) {
-    toggleCheckDraftPopup(true);
-
     await visit("/t/internationalization-localization/280");
 
     const longText = "a".repeat(256);
@@ -889,9 +881,7 @@ acceptance("Composer", function (needs) {
       .doesNotExist("mode should have changed");
   });
 
-  test("Loading draft also replaces the recipients", async function (assert) {
-    toggleCheckDraftPopup(true);
-
+  test("Does not replace recipient when another draft exists", async function (assert) {
     sinon.stub(Draft, "get").resolves({
       draft:
         '{"reply":"hello","action":"privateMessage","title":"hello","categoryId":null,"archetypeId":"private_message","metaData":null,"recipients":"codinghorror","composerTime":9159,"typingTime":2500}',
@@ -900,10 +890,12 @@ acceptance("Composer", function (needs) {
 
     await visit("/u/charlie");
     await click("button.compose-pm");
-    await click(".dialog-footer .btn-resume-editing");
 
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.strictEqual(privateMessageUsers.header().value(), "codinghorror");
+    assert.strictEqual(privateMessageUsers.header().value(), "charlie");
+
+    await click(".submit-panel .cancel");
+    assert.dom(".d-editor-input").doesNotExist();
   });
 
   test("Deleting the text content of the first post in a private message", async function (assert) {

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -321,6 +321,7 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
 
   _replyAsNewTopicSelect(options) {
     options.action = CREATE_TOPIC;
+    options.draftKey = this.composer.topicDraftKey;
     options.categoryId = this.get("composerModel.topic.category.id");
     options.disableScopedCategory = true;
     this._replyFromExisting(options, _postSnapshot, _topicSnapshot);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -494,10 +494,6 @@ en:
       new_topic: "New topic draft"
       new_private_message: "New personal message draft"
       edit_topic: "Edit topic draft"
-      abandon:
-        confirm: "You already have a draft in progress. What would you like to do with it?"
-        yes_value: "Discard"
-        no_value: "Resume editing"
       dropdown:
         title: "Open the latest drafts menu"
         untitled: "Untitled draft"


### PR DESCRIPTION
Now that we support multiple drafts, we can avoid the extra draft check within composer when creating a new topic or reply. For posts, we already autoload the existing draft into composer when the user tries to create a new reply, so there is no longer a need for the abandon draft dialog.

Drafts can still be deleted by closing the composer (using a different dialog) or manually via the User Drafts page.

This change also correctly sets the draft key within composer actions when switching from a post reply to a linked topic.

Internal ref: /t/148325