### PR TITLE
PERF: Remove caches from Category.subcategories & Category.descendents

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -503,12 +503,10 @@ export default class Category extends RestModel {
     this.set("parent_category_id", newParentCategory?.id);
   }
 
-  @computed("site.categoriesByParentId")
   get subcategories() {
     return this.site.categoriesByParentId.get(this.id) || [];
   }
 
-  @computed("subcategories")
   get unloadedSubcategoryCount() {
     return this.subcategory_count - this.subcategories.length;
   }
@@ -560,8 +558,7 @@ export default class Category extends RestModel {
     }
   }
 
-  @discourseComputed("subcategories")
-  descendants() {
+  get descendants() {
     const descendants = [this];
     for (let i = 0; i < descendants.length; i++) {
       if (descendants[i].subcategories) {


### PR DESCRIPTION
Since d2409f2964e85a4cb134f119d1bdddce54156175, these calculations are now incredibly cheap, and the caches introduced by `@computed` become the bottleneck. On a site with 5k+ categories, removing these caches results in a 4x render time improvement for their homepage (~2s -> ~0.5s).

Technically, this means these properties will no longer be reactive for places that depend on them using computed property syntax. However, they are still reactive for modern code with autotracking. Given that the set of categories doesn't change after initial load, I think this is acceptable. If we do run into any issues, then we can update the related code to use autotracking.

Note: `@dependentKeyCompat` has similar perf overheads to `@computed`, so that's why I haven't used that for backward-compat.