### PR TITLE
DEV: Grant all anniversary badges during imports

### DIFF
--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -101,6 +101,7 @@ class BulkImport::Generic < BulkImport::Base
     import_badges
     import_user_badges
     import_anniversary_user_badges
+    update_badge_grant_counts
 
     import_optimized_images
 
@@ -2410,6 +2411,11 @@ class BulkImport::Generic < BulkImport::Base
   end
 
   def import_anniversary_user_badges
+    unless SiteSetting.enable_badges?
+      puts "", "Skipping anniversary user badges because badges are not enabled."
+      return
+    end
+
     puts "", "Importing anniversary user badges..."
 
     start_time = Time.now
@@ -2474,7 +2480,9 @@ class BulkImport::Generic < BulkImport::Base
     UserBadge.update_featured_ranks!
 
     puts "  Anniversary user badges imported in #{(Time.now - start_time).to_i} seconds."
+  end
 
+  def update_badge_grant_counts
     puts "", "Updating badge grant counts..."
     start_time = Time.now
 

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -2407,24 +2407,6 @@ class BulkImport::Generic < BulkImport::Base
     end
 
     user_badges.close
-
-    puts "", "Updating badge grant counts..."
-    start_time = Time.now
-
-    DB.exec(<<~SQL)
-        WITH
-          grants AS (
-                      SELECT badge_id, COUNT(*) AS grant_count FROM user_badges GROUP BY badge_id
-                    )
-
-      UPDATE badges
-         SET grant_count = grants.grant_count
-        FROM grants
-       WHERE badges.id = grants.badge_id
-         AND badges.grant_count <> grants.grant_count
-    SQL
-
-    puts "  Update took #{(Time.now - start_time).to_i} seconds."
   end
 
   def import_anniversary_user_badges
@@ -2492,6 +2474,24 @@ class BulkImport::Generic < BulkImport::Base
     UserBadge.update_featured_ranks!
 
     puts "  Anniversary user badges imported in #{(Time.now - start_time).to_i} seconds."
+
+    puts "", "Updating badge grant counts..."
+    start_time = Time.now
+
+    DB.exec(<<~SQL)
+        WITH
+          grants AS (
+                      SELECT badge_id, COUNT(*) AS grant_count FROM user_badges GROUP BY badge_id
+                    )
+
+      UPDATE badges
+         SET grant_count = grants.grant_count
+        FROM grants
+       WHERE badges.id = grants.badge_id
+         AND badges.grant_count <> grants.grant_count
+    SQL
+
+    puts "  Update took #{(Time.now - start_time).to_i} seconds."
   end
 
   def import_permalink_normalizations

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -100,6 +100,7 @@ class BulkImport::Generic < BulkImport::Base
     import_badge_groupings
     import_badges
     import_user_badges
+    import_anniversary_user_badges
 
     import_optimized_images
 
@@ -2424,6 +2425,73 @@ class BulkImport::Generic < BulkImport::Base
     SQL
 
     puts "  Update took #{(Time.now - start_time).to_i} seconds."
+  end
+
+  def import_anniversary_user_badges
+    puts "", "Importing anniversary user badges..."
+
+    start_time = Time.now
+
+    DB.exec(<<~SQL)
+      WITH
+        eligible_users AS (
+                            SELECT u.id, u.created_at
+                            FROM users u
+                            WHERE u.active
+                              AND NOT u.staged
+                              AND u.id > 0
+                              AND (u.silenced_till IS NULL OR u.silenced_till < CURRENT_TIMESTAMP)
+                              AND (u.suspended_till IS NULL OR u.suspended_till < CURRENT_TIMESTAMP)
+                              AND NOT EXISTS (SELECT 1 FROM anonymous_users AS au WHERE au.user_id = u.id)
+                          ),
+        anniversary_dates AS ( -- Series of anniversary dates starting from the user's created_at + 1 year up to the current year
+                               SELECT
+                                 eu.id AS user_id,
+                                 (
+                                   eu.created_at +
+                                   ((year_num - EXTRACT(YEAR FROM eu.created_at)) || ' years')::interval
+                                 )::timestamp AS anniversary_date
+                               FROM eligible_users eu,
+                                    generate_series(
+                                      EXTRACT(YEAR FROM eu.created_at)::int + 1,
+                                      EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::int
+                                    ) AS year_num
+                                WHERE
+                                  (
+                                    eu.created_at +
+                                    ((year_num - EXTRACT(YEAR FROM eu.created_at)) || ' years')::interval
+                                  ) < CURRENT_TIMESTAMP
+                             )
+      INSERT INTO user_badges (granted_at, created_at, granted_by_id, user_id, badge_id, seq)
+      SELECT a.anniversary_date,
+             CURRENT_TIMESTAMP,
+             #{Discourse.system_user.id},
+             a.user_id,
+             #{Badge::Anniversary},
+             (ROW_NUMBER() OVER (PARTITION BY a.user_id ORDER BY a.anniversary_date) - 1) AS seq
+      FROM anniversary_dates a
+           JOIN eligible_users u ON a.user_id = u.id
+           JOIN posts AS p ON p.user_id = u.id
+           JOIN topics AS t ON p.topic_id = t.id
+      WHERE p.deleted_at IS NULL
+        AND NOT p.hidden
+        AND p.created_at BETWEEN a.anniversary_date - '1 year'::interval AND a.anniversary_date
+        AND t.visible
+        AND t.archetype <> 'private_message'
+        AND t.deleted_at IS NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM user_badges AS ub
+            WHERE ub.user_id = u.id
+            AND ub.badge_id = #{Badge::Anniversary}
+            AND ub.granted_at BETWEEN a.anniversary_date - '1 year'::interval AND a.anniversary_date
+        )
+      GROUP BY a.user_id, a.anniversary_date
+    SQL
+
+    UserBadge.update_featured_ranks!
+
+    puts "  Anniversary user badges imported in #{(Time.now - start_time).to_i} seconds."
   end
 
   def import_permalink_normalizations


### PR DESCRIPTION
This change adds an import step to retroactively grant anniversary badges to users.