### PR TITLE
FEATURE: Add setting to prevent anonymous users from using chat

### DIFF
--- a/plugins/chat/app/validators/chat/allow_chat_in_anonymous_mode_validator.rb
+++ b/plugins/chat/app/validators/chat/allow_chat_in_anonymous_mode_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Chat
+  class AllowChatInAnonymousModeValidator
+    def initialize(opts = {})
+      @opts = opts
+    end
+
+    def valid_value?(val)
+      return true if val == "f"
+      return true if SiteSetting.allow_anonymous_mode
+
+      false
+    end
+
+    def error_message
+      I18n.t("site_settings.errors.allow_chat_in_anonymous_mode_invalid")
+    end
+  end
+end

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -29,6 +29,7 @@ en:
       chat_default_channel: "The default chat channel must be a public channel."
       direct_message_enabled_groups_invalid: "You must specify at least one group for this setting. If you do not want anyone except staff to send direct messages, choose the staff group."
       chat_upload_not_allowed_secure_uploads: "Chat uploads are not allowed when secure uploads site setting is enabled."
+      allow_chat_in_anonymous_mode_invalid: "This setting requires the 'allow anonymous mode' setting to be enabled first."
   system_messages:
     private_channel_title: "Channel %{id}"
     chat_channel_archive_complete:

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -24,6 +24,7 @@ en:
     chat_editing_grace_period_max_diff_low_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 0 and 1)."
     chat_editing_grace_period_max_diff_high_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 2 and up)."
     chat_preferred_index: "Preferred tab when loading /chat."
+    allow_chat_in_anonymous_mode: "Enable this setting to allow users who are browsing your site anonymously to use chat. This setting requires the `allow anonymous mode` setting to be enabled."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
       direct_message_enabled_groups_invalid: "You must specify at least one group for this setting. If you do not want anyone except staff to send direct messages, choose the staff group."

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -147,3 +147,4 @@ chat:
       - my_threads
   allow_chat_in_anonymous_mode:
     default: false
+    validator: "Chat::AllowChatInAnonymousModeValidator"

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -145,3 +145,5 @@ chat:
       - channels
       - direct_messages
       - my_threads
+  allow_chat_in_anonymous_mode:
+    default: false

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -13,7 +13,13 @@ module Chat
 
     def can_chat?
       return false if anonymous?
-      @user.bot? || @user.in_any_groups?(Chat.allowed_group_ids)
+      return true if @user.bot?
+
+      if @user.anonymous?
+        SiteSetting.allow_chat_in_anonymous_mode
+      else
+        @user.in_any_groups?(Chat.allowed_group_ids)
+      end
     end
 
     def can_direct_message?

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -16,7 +16,8 @@ module Chat
       return true if @user.bot?
 
       if @user.anonymous?
-        SiteSetting.allow_chat_in_anonymous_mode
+        SiteSetting.allow_chat_in_anonymous_mode &&
+          AnonymousShadowCreator.get_master(@user)&.guardian&.can_chat?
       else
         @user.in_any_groups?(Chat.allowed_group_ids)
       end

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -740,7 +740,7 @@ RSpec.describe Chat::GuardianExtensions do
   end
 
   describe "#recipient_can_chat?" do
-    fab!(:other_user) { Fabricate(:user) }
+    fab!(:other_user) { Fabricate(:user, groups: [chatters]) }
     fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user, other_user]) }
     alias_matcher :be_able_to_chat, :be_recipient_can_chat
 

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe Chat::GuardianExtensions do
       end
     end
 
+    context "when user is a shadow account" do
+      fab!(:anonymous)
+
+      before { SiteSetting.allow_anonymous_mode = true }
+
+      context "when allow_chat_in_anonymous_mode is true" do
+        before { SiteSetting.allow_chat_in_anonymous_mode = true }
+
+        it "can chat" do
+          expect(Guardian.new(anonymous).can_chat?).to eq(true)
+        end
+      end
+
+      context "when allow_chat_in_anonymous_mode is false" do
+        before { SiteSetting.allow_chat_in_anonymous_mode = false }
+
+        it "can not chat" do
+          expect(Guardian.new(anonymous).can_chat?).to eq(false)
+        end
+      end
+    end
+
     it "allows TL1 to chat by default and by extension higher trust levels" do
       expect(guardian.can_chat?).to eq(true)
       user.change_trust_level!(TrustLevel[3])

--- a/plugins/chat/spec/validators/allow_chat_in_anonymous_mode_validator_spec.rb
+++ b/plugins/chat/spec/validators/allow_chat_in_anonymous_mode_validator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::AllowChatInAnonymousModeValidator do
+  context "when anonymous mode is disabled" do
+    before { SiteSetting.allow_anonymous_mode = false }
+
+    it "does not allow the allow_chat_in_anonymous_mode setting to be enabled" do
+      expect { SiteSetting.allow_chat_in_anonymous_mode = true }.to raise_error(
+        Discourse::InvalidParameters,
+        "allow_chat_in_anonymous_mode: #{I18n.t("site_settings.errors.allow_chat_in_anonymous_mode_invalid")}",
+      )
+    end
+
+    it "allows the setting to be disabled" do
+      SiteSetting.allow_anonymous_mode = true
+      SiteSetting.allow_chat_in_anonymous_mode = true
+
+      SiteSetting.allow_anonymous_mode = false
+      expect { SiteSetting.allow_likes_in_anonymous_mode = false }.not_to raise_error
+    end
+  end
+
+  context "when anonymous mode is enabled" do
+    before { SiteSetting.allow_anonymous_mode = true }
+
+    it "allows the setting to be enabled" do
+      expect { SiteSetting.allow_likes_in_anonymous_mode = true }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Currently, anonymous/shadow users go through the same permission checks for chat as normal users do. This means that if a site has chat enabled for all users, anonymous users also get access to chat. This may be undesirable for some communities, so we're adding a new site setting `allow_chat_in_anonymous_mode` to block access to chat for anonymous users.

Internal topic: t/148088.