### PR TITLE
DEV: Skip flaky test

### DIFF
--- a/plugins/chat/spec/system/chat_composer_draft_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_draft_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Chat composer draft", type: :system do
       sign_in(current_user)
     end
 
-    it "loads the draft" do
+    xit "loads the draft" do
       chat_page.visit_channel(channel_1)
 
       expect(channel_page.composer).to have_value("draft")


### PR DESCRIPTION
The test has been flaking in CI with the following message:

```
Failure/Error: measurement = Benchmark.measure { example.run }

  expected: "draft"
       got: ""

  (compared using ==)

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_chat_composer_draft_when_loading_a_channel_with_a_draft_loads_the_draft_458.png

~~~~~~~ JS LOGS ~~~~~~~
~~~~~ END JS LOGS ~~~~~

./plugins/chat/spec/system/chat_composer_draft_spec.rb:31:in `block (3 levels) in <main>'
```
