### PR TITLE
DEV: Skip a flaky test

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -87,7 +87,7 @@ describe "Admin Customize Themes", type: :system do
       expect(theme_translations_settings_editor.get_input_value).to have_content("Hello World")
     end
 
-    it "should allow admin to edit and save the theme translations from other languages" do
+    xit "should allow admin to edit and save the theme translations from other languages" do
       theme.set_field(
         target: :translations,
         name: "en",


### PR DESCRIPTION
Test is flaking in CI with:

```
Failure/Error: expect(theme_translations_settings_editor.get_input_value).to have_content("Bonjour!")
  expected to find text "Bonjour!" in "Hello there!"

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_admin_customize_themes_when_editing_theme_translations_should_allow_admin_to_edit_and_save_the_theme_translations_from_other_languages_797.png

~~~~~~~ JS LOGS ~~~~~~~
(no logs)
~~~~~ END JS LOGS ~~~~~

./spec/system/admin_customize_themes_spec.rb:158:in `block (3 levels) in <main>'
```
