### PR TITLE
DEV: Correct log level when logging in `Demon::Base`

### DIFF
--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -125,7 +125,9 @@ class Demon::Base
       if alive?
         log(
           "Process would not terminate cleanly, force quitting. pid: #{@pid} #{self.class}\n#{caller.join("\n")}",
+          level: :warn,
         )
+
         Process.kill("KILL", @pid)
       end
 
@@ -229,7 +231,7 @@ class Demon::Base
             Process.kill "KILL", Process.pid
           end
         rescue => e
-          log("URGENT monitoring thread had an exception #{e}")
+          log("URGENT monitoring thread had an exception #{e}", level: :error)
         end
         sleep 1
       end


### PR DESCRIPTION
This commit updates the log level for certain log messages to the
approporiate level for the severity of the message being logged.
