### PR TITLE
DEV: Remove flaky system test and replace it with simpler unit test

### DIFF
--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe TopicsBulkAction do
 
       PostDestroyer.new(Fabricate(:admin), p).destroy
 
+      TopicTrackingState.expects(:publish_dismiss_new_posts).with(
+        post1.user_id,
+        topic_ids: [post1.topic_id],
+      )
+
       TopicsBulkAction.new(post1.user, [post1.topic_id], type: "dismiss_posts").perform!
 
       tu = TopicUser.find_by(user_id: post1.user_id, topic_id: post1.topic_id)

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -14,28 +14,6 @@ RSpec.describe "Dismissing New", type: :system do
     fab!(:post1) { create_post(user: user, topic: topic) }
     fab!(:post2) { create_post(topic: topic) }
 
-    it "should remove the unread post across sessions after the user dismisses it" do
-      sign_in(user)
-
-      visit("/unread")
-
-      expect(topic_list_controls).to have_unread(count: 1)
-
-      using_session(:tab_1) do
-        sign_in(user)
-
-        visit("/unread")
-
-        expect(topic_list_controls).to have_unread(count: 1)
-      end
-
-      topic_list_controls.dismiss_unread
-
-      expect(topic_list_controls).to have_unread(count: 0)
-
-      using_session(:tab_1) { expect(topic_list_controls).to have_unread(count: 0) }
-    end
-
     it "should untrack topics across sessions after the user dismisses it" do
       sign_in(user)
 


### PR DESCRIPTION
This commit removes a system test that has been flaky in Github's CI and
replaces it with a much simpler unit test that covers the fix introduced
in 48c8ed49d6eda40fbee0d926ea67a81f2851e641


### Reviewer notes

Example of multiple flakes in CI:
1. https://github.com/discourse/discourse/actions/runs/13888933997/job/38857572872
2. https://github.com/discourse/discourse/actions/runs/13793587465/job/38579530997