### PR TITLE
Revert "DEV: remove singleton mixin (#31823)"

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/singleton.js
+++ b/app/assets/javascripts/discourse/app/mixins/singleton.js
@@ -1,0 +1,102 @@
+/**
+ This mixin allows a class to return a singleton, as well as a method to quickly
+ read/write attributes on the singleton.
+
+
+ Example usage:
+
+ ```javascript
+
+ // Define your class and apply the Mixin
+ User = EmberObject.extend({});
+ User.reopenClass(Singleton);
+
+ // Retrieve the current instance:
+ var instance = User.current();
+
+ ```
+
+ Commonly you want to read or write a property on the singleton. There's a
+ helper method which is a little nicer than `.current().get()`:
+
+ ```javascript
+
+ // Sets the age to 34
+ User.currentProp('age', 34);
+
+ console.log(User.currentProp('age')); // 34
+
+ ```
+
+ If you want to customize how the singleton is created, redefine the `createCurrent`
+ method:
+
+ ```javascript
+
+ // Define your class and apply the Mixin
+ Foot = EmberObject.extend({});
+ Foot.reopenClass(Singleton, {
+ createCurrent() {
+ return Foot.create({ toes: 5 });
+ }
+ });
+
+ console.log(Foot.currentProp('toes')); // 5
+
+ ```
+ **/
+import Mixin from "@ember/object/mixin";
+import deprecated from "discourse/lib/deprecated";
+
+const Singleton = Mixin.create({
+  init() {
+    this._super(...arguments);
+
+    deprecated(
+      "Singleton mixin is deprecated. Use the singleton class decorator from discourse/lib/singleton instead.",
+      {
+        id: "discourse.singleton-mixin",
+        since: "v3.4.0.beta4-dev",
+      }
+    );
+  },
+
+  current() {
+    if (!this._current) {
+      this._current = this.createCurrent();
+    }
+    return this._current;
+  },
+
+  /**
+   How the singleton instance is created. This can be overridden
+   with logic for creating (or even returning null) your instance.
+
+   By default it just calls `create` with an empty object.
+   **/
+  createCurrent() {
+    return this.create({});
+  },
+
+  // Returns OR sets a property on the singleton instance.
+  currentProp(property, value) {
+    let instance = this.current();
+    if (!instance) {
+      return;
+    }
+
+    if (typeof value !== "undefined") {
+      instance.set(property, value);
+      return value;
+    } else {
+      return instance.get(property);
+    }
+  },
+
+  resetCurrent(val) {
+    this._current = val;
+    return val;
+  },
+});
+
+export default Singleton;

--- a/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
@@ -1,0 +1,104 @@
+import EmberObject from "@ember/object";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import Singleton from "discourse/mixins/singleton";
+
+module("Unit | Mixin | singleton", function (hooks) {
+  setupTest(hooks);
+
+  test("current", function (assert) {
+    let DummyModel = class extends EmberObject {};
+    DummyModel.reopenClass(Singleton);
+
+    let current = DummyModel.current();
+    assert.present(current, "current returns the current instance");
+    assert.strictEqual(
+      current,
+      DummyModel.current(),
+      "calling it again returns the same instance"
+    );
+    assert.notStrictEqual(
+      current,
+      DummyModel.create({}),
+      "we can create other instances that are not the same as current"
+    );
+  });
+
+  test("currentProp reading", function (assert) {
+    let DummyModel = class extends EmberObject {};
+    DummyModel.reopenClass(Singleton);
+    let current = DummyModel.current();
+
+    assert.blank(
+      DummyModel.currentProp("evil"),
+      "by default attributes are blank"
+    );
+    current.set("evil", "trout");
+    assert.strictEqual(
+      DummyModel.currentProp("evil"),
+      "trout",
+      "after changing the instance, the value is set"
+    );
+  });
+
+  test("currentProp writing", function (assert) {
+    let DummyModel = class extends EmberObject {};
+    DummyModel.reopenClass(Singleton);
+
+    assert.blank(
+      DummyModel.currentProp("adventure"),
+      "by default attributes are blank"
+    );
+    let result = DummyModel.currentProp("adventure", "time");
+    assert.strictEqual(result, "time", "it returns the new value");
+    assert.strictEqual(
+      DummyModel.currentProp("adventure"),
+      "time",
+      "after calling currentProp the value is set"
+    );
+
+    DummyModel.currentProp("count", 0);
+    assert.strictEqual(
+      DummyModel.currentProp("count"),
+      0,
+      "we can set the value to 0"
+    );
+
+    DummyModel.currentProp("adventure", null);
+    assert.strictEqual(
+      DummyModel.currentProp("adventure"),
+      null,
+      "we can set the value to null"
+    );
+  });
+
+  test("createCurrent", function (assert) {
+    let Shoe = class extends EmberObject {};
+    Shoe.reopenClass(Singleton, {
+      createCurrent: function () {
+        return Shoe.create({ toes: 5 });
+      },
+    });
+
+    assert.strictEqual(
+      Shoe.currentProp("toes"),
+      5,
+      "it created the class using `createCurrent`"
+    );
+  });
+
+  test("createCurrent that returns null", function (assert) {
+    let Missing = class extends EmberObject {};
+    Missing.reopenClass(Singleton, {
+      createCurrent: function () {
+        return null;
+      },
+    });
+
+    assert.blank(Missing.current(), "it doesn't return an instance");
+    assert.blank(
+      Missing.currentProp("madeup"),
+      "it won't raise an error asking for a property. Will just return null."
+    );
+  });
+});


### PR DESCRIPTION
This reverts commit 992bdf173ad8ad25764c0a89132bc35df4c81f12.

This change was causing issues in a [third party plugin](https://meta.discourse.org/t/events-plugin): https://meta.discourse.org/t/events-plugin/69776/869

```
Uncaught Error: Could not find module `discourse/mixins/singleton` imported from `discourse/plugins/discourse-events/discourse/models/provider`
    at loader.js:247:1
    at h (loader.js:258:1)
    at u.findDeps (loader.js:168:1)
    at h (loader.js:262:1)
    at u.findDeps (loader.js:168:1)
    at h (loader.js:262:1)
    at requireModule (loader.js:24:1)
    at y (app.js:170:18)
    at b (app.js:193:19)
    at app.js:156:29
    at g.start (app.js:167:1)
    at HTMLDocument.<anonymous> (start-app.js:5:7)
    at discourse-boot.js:13:12
    at discourse-boot.js:1:1
```

