### PR TITLE
DEV: Improve color-definition stylesheet failure mode

### DIFF
--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -53,10 +53,10 @@ class Stylesheet::Manager::Builder
         if Stylesheet::Importer::THEME_TARGETS.include?(@target.to_s)
           # no special errors for theme, handled in theme editor
           ["", nil]
-        elsif @target.to_s == Stylesheet::Manager::COLOR_SCHEME_STYLESHEET
+        elsif @target.to_s == Stylesheet::Manager::COLOR_SCHEME_STYLESHEET && Rails.env.production?
           # log error but do not crash for errors in color definitions SCSS
           Rails.logger.error "SCSS compilation error: #{e.message}"
-          ["", nil]
+          ["/* SCSS compilation error: #{e.message} */", nil]
         else
           raise Discourse::ScssError, e.message
         end


### PR DESCRIPTION
- Raise exception in dev/test environments
- Include a clue about the failure via a comment in production mode