### PR TITLE
DEV: normalize tag text color assignment

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -130,16 +130,13 @@
 .topic-list-item.visited .topic-list-data,
 .latest-topic-list-item.visited,
 .category-topic-link.visited {
+  --tag-text-color: var(--primary-medium);
+
   a.title:not(.badge-notification) {
     color: var(--primary-medium);
   }
 
   .badge-category {
-    color: var(--primary-medium);
-  }
-
-  .discourse-tag,
-  .discourse-tag:visited {
     color: var(--primary-medium);
   }
 }

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -388,7 +388,6 @@
 
     .discourse-tags {
       display: inline;
-      color: var(--header_primary-high);
 
       @include ellipsis;
 

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -1,3 +1,11 @@
+:root {
+  --tag-text-color: var(--primary-high);
+}
+
+.extra-info-wrapper {
+  --tag-text-color: var(--header_primary-high);
+}
+
 .container.tags-index {
   background: var(--d-content-background);
 }
@@ -59,19 +67,15 @@
 .discourse-tag {
   max-width: 14em;
   display: inline-block;
-
-  @include ellipsis;
   vertical-align: middle;
   margin: 0;
-  color: var(--primary-medium);
+  color: var(--tag-text-color);
+
+  @include ellipsis;
 
   &:visited,
   &:hover {
-    color: var(--primary-medium);
-  }
-
-  .extra-info-wrapper & {
-    color: var(--header_primary-high) !important;
+    color: var(--tag-text-color);
   }
 
   &.large {
@@ -80,19 +84,11 @@
 
   &.box {
     background-color: var(--primary-low);
-    color: var(--primary-high);
     padding: 2px 8px;
 
     .extra-info-wrapper & {
       background-color: var(--header_primary-low);
-      color: var(--header_primary-medium);
     }
-  }
-
-  &.simple,
-  &.simple:visited,
-  &.simple:hover {
-    color: var(--primary-high);
   }
 
   &.bullet {
@@ -130,6 +126,7 @@
 
   &__tag-separator {
     margin-right: 0.25em;
+    color: var(--tag-text-color);
   }
 
   .box,
@@ -149,10 +146,6 @@
     font-weight: normal;
     font-size: var(--font-down-1);
   }
-}
-
-header .discourse-tag {
-  color: var(--primary-medium);
 }
 
 .list-tags {

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -243,12 +243,6 @@
       background: var(--d-hover);
     }
 
-    .discourse-tag,
-    .discourse-tag:visited,
-    .discourse-tag:hover {
-      color: var(--primary-high);
-    }
-
     &.create-color-row {
       border-left-style: solid;
       border-left-width: 5px;


### PR DESCRIPTION
This reduces some duplicate color assignment to tags and rolls them up under a common css var

```css
:root {
  --tag-text-color: var(--primary-high);
}

.extra-info-wrapper {
  --tag-text-color: var(--header_primary-high);
}
```

This also makes the tag separator color consistent with the tag color, by setting it to `--tag-text-color`

Ultimately we have 3 tag text color states (this appeared to be consistent across all tag styles):
* Default: primary-high
* Header: header__primary-high
* Visited topic in the topic list: primary-medium 