### PR TITLE
UX: re-hide hidden upload field

### DIFF
--- a/app/assets/stylesheets/common/base/upload.scss
+++ b/app/assets/stylesheets/common/base/upload.scss
@@ -122,3 +122,8 @@
     top: 0%;
   }
 }
+
+.hidden-upload-field {
+  visibility: hidden;
+  position: absolute;
+}


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse/commit/6d92165ae77bf78935b9b54a22e517ebc75701f9, rehides this: 


before:

![image](https://github.com/user-attachments/assets/34f07b8c-a547-476f-bfc4-ba92bd6f056e)


after: 

![image](https://github.com/user-attachments/assets/d2f18305-75e0-47f2-9ef9-d3a3a31d43d6)
