### PR TITLE
DEV: show no icon if icon name is missing and log at error level

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -1,7 +1,11 @@
 import { h } from "virtual-dom";
 import attributeHook from "discourse/lib/attribute-hook";
 import deprecated from "discourse/lib/deprecated";
-import { isDevelopment } from "discourse/lib/environment";
+import {
+  isDevelopment,
+  isRailsTesting,
+  isTesting,
+} from "discourse/lib/environment";
 import escape from "discourse/lib/escape";
 import { i18n } from "discourse-i18n";
 
@@ -142,10 +146,14 @@ function handleDeprecatedIcon(id) {
   newId = remapFromFA5(newId);
 
   if (newId !== id) {
+    const error_msg = `Missing icon error: The icon name "${id}" has been removed and should be updated to "${newId}" in your code. More info at https://meta.discourse.org/t/325349.`;
+
     // eslint-disable-next-line no-console
-    console.error(
-      `Missing icon error: The icon name "${id}" has been removed and should be updated to "${newId}" in your code. More info at https://meta.discourse.org/t/325349.`
-    );
+    console.error(error_msg);
+
+    if (isRailsTesting() || isTesting()) {
+      throw error_msg;
+    }
   }
 
   return id;

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -1,11 +1,7 @@
 import { h } from "virtual-dom";
 import attributeHook from "discourse/lib/attribute-hook";
 import deprecated from "discourse/lib/deprecated";
-import {
-  isDevelopment,
-  isRailsTesting,
-  isTesting,
-} from "discourse/lib/environment";
+import { isDevelopment } from "discourse/lib/environment";
 import escape from "discourse/lib/escape";
 import { i18n } from "discourse-i18n";
 
@@ -146,13 +142,11 @@ function handleDeprecatedIcon(id) {
   newId = remapFromFA5(newId);
 
   if (newId !== id) {
-    deprecated(
-      `The icon name "${id}" has been updated to "${newId}". Please use the new name in your code. Old names have been removed as of Q2 2025.`,
-      {
-        id: "discourse.fontawesome-6-upgrade",
-        url: "https://meta.discourse.org/t/325349",
-        raiseError: isTesting() || isRailsTesting(),
-      }
+    //TODO maybe add consolePrefix
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `Missing icon error: The icon name "${id}" has been removed and should be updated to "${newId}" in your code. More info at https://meta.discourse.org/t/325349.`
     );
   }
 

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -147,7 +147,7 @@ function handleDeprecatedIcon(id) {
 
   if (newId !== id) {
     deprecated(
-      `The icon name "${id}" has been updated to "${newId}". Please use the new name in your code. Old names will be removed in Q2 2025.`,
+      `The icon name "${id}" has been updated to "${newId}". Please use the new name in your code. Old names have been removed as of Q2 2025.`,
       {
         id: "discourse.fontawesome-6-upgrade",
         url: "https://meta.discourse.org/t/325349",
@@ -156,7 +156,7 @@ function handleDeprecatedIcon(id) {
     );
   }
 
-  return newId;
+  return id;
 }
 
 function warnIfMissing(id) {

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -1,11 +1,7 @@
 import { h } from "virtual-dom";
 import attributeHook from "discourse/lib/attribute-hook";
 import deprecated from "discourse/lib/deprecated";
-import {
-  isDevelopment,
-  isRailsTesting,
-  isTesting,
-} from "discourse/lib/environment";
+import { isDevelopment } from "discourse/lib/environment";
 import escape from "discourse/lib/escape";
 import { i18n } from "discourse-i18n";
 
@@ -150,10 +146,6 @@ function handleDeprecatedIcon(id) {
 
     // eslint-disable-next-line no-console
     console.error(error_msg);
-
-    if (isRailsTesting() || isTesting()) {
-      throw error_msg;
-    }
   }
 
   return id;

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -142,8 +142,6 @@ function handleDeprecatedIcon(id) {
   newId = remapFromFA5(newId);
 
   if (newId !== id) {
-    //TODO maybe add consolePrefix
-
     // eslint-disable-next-line no-console
     console.error(
       `Missing icon error: The icon name "${id}" has been removed and should be updated to "${newId}" in your code. More info at https://meta.discourse.org/t/325349.`

--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -19,7 +19,6 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.header-widget-overrides",
   "discourse.plugin-outlet-tag-name",
   "discourse.post-menu-widget-overrides",
-  "discourse.fontawesome-6-upgrade",
   "discourse.add-flag-property",
   "discourse.breadcrumbs.childCategories",
   "discourse.breadcrumbs.firstCategory",

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -55,10 +55,7 @@ module("Unit | Utility | icon-library", function (hooks) {
     withSilencedDeprecations("discourse.fontawesome-6-upgrade", () => {
       const adjustIcon = iconHTML("adjust");
       assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
-      assert.true(
-        adjustIcon.includes('href="#circle-half-stroke"'),
-        "has remapped icon"
-      );
+      assert.true(adjustIcon.includes('href="#adjust"'), "has original icon");
 
       const farIcon = iconHTML("far-dot-circle");
       assert.true(
@@ -66,8 +63,8 @@ module("Unit | Utility | icon-library", function (hooks) {
         "class is maintained"
       );
       assert.true(
-        farIcon.includes('href="#far-circle-dot"'),
-        "has remapped icon"
+        farIcon.includes('href="#far-dot-circle"'),
+        "has original icon"
       );
     });
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -1,11 +1,9 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
-import sinon from "sinon";
 import {
   convertIconClass,
   iconHTML,
   iconNode,
-  isTesting,
 } from "discourse/lib/icon-library";
 
 module("Unit | Utility | icon-library", function (hooks) {
@@ -49,43 +47,18 @@ module("Unit | Utility | icon-library", function (hooks) {
   });
 
   test("fa5 remaps", function (assert) {
-    const stub = sinon.stub(isTesting);
-    stub.returns(false);
+    const adjustIcon = iconHTML("adjust");
+    assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
+    assert.true(adjustIcon.includes('href="#adjust"'), "keeps original icon");
 
-    try {
-      const adjustIcon = iconHTML("adjust");
-      assert.true(adjustIcon.includes("d-icon-adjust"), "class is maintained");
-      assert.true(adjustIcon.includes('href="#adjust"'), "keeps original icon");
-
-      const farIcon = iconHTML("far-dot-circle");
-      assert.true(
-        farIcon.includes("d-icon-far-dot-circle"),
-        "class is maintained"
-      );
-      assert.true(
-        farIcon.includes('href="#far-dot-circle"'),
-        "keeps original icon"
-      );
-    } finally {
-      stub.restore();
-    }
-  });
-
-  test("fa remaps throws error", function (assert) {
-    assert.throws(
-      () => {
-        iconHTML("adjust");
-      },
-      `Missing icon error: The icon name "adjust" has been removed and should be updated to "circle-half-stroke" in your code. More info at https://meta.discourse.org/t/325349.`,
-      "throws an error if icon name is deprecated"
+    const farIcon = iconHTML("far-dot-circle");
+    assert.true(
+      farIcon.includes("d-icon-far-dot-circle"),
+      "class is maintained"
     );
-
-    assert.throws(
-      () => {
-        iconHTML("far-dot-circle");
-      },
-      `Missing icon error: The icon name "far-dot-circle" has been removed and should be updated to "far-circle-dot" in your code. More info at https://meta.discourse.org/t/325349.`,
-      "throws an error if icon name is deprecated"
+    assert.true(
+      farIcon.includes('href="#far-dot-circle"'),
+      "keeps original icon"
     );
   });
 });

--- a/lib/deprecated_icon_handler.rb
+++ b/lib/deprecated_icon_handler.rb
@@ -687,9 +687,8 @@ module DeprecatedIconHandler
     new_name = remap_from_fa5(new_name)
 
     if icon_name != new_name
-      Discourse.deprecate(
-        "The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.",
-        raise_error: Rails.env.test?,
+      Rails.logger.error(
+        `Missing icon error: The icon name "#{icon_name}" has been removed and should be updated to "#{new_name}" in your code. More info at https://meta.discourse.org/t/325349.`,
       )
     end
 

--- a/lib/deprecated_icon_handler.rb
+++ b/lib/deprecated_icon_handler.rb
@@ -691,7 +691,6 @@ module DeprecatedIconHandler
         "The icon `#{icon_name}` is deprecated. Use `#{new_name}` instead.",
         raise_error: Rails.env.test?,
       )
-      return new_name
     end
 
     icon_name

--- a/lib/deprecated_icon_handler.rb
+++ b/lib/deprecated_icon_handler.rb
@@ -687,9 +687,12 @@ module DeprecatedIconHandler
     new_name = remap_from_fa5(new_name)
 
     if icon_name != new_name
-      Rails.logger.error(
-        `Missing icon error: The icon name "#{icon_name}" has been removed and should be updated to "#{new_name}" in your code. More info at https://meta.discourse.org/t/325349.`,
-      )
+      error_msg =
+        `Missing icon error: The icon name "#{icon_name}" has been removed and should be updated to "#{new_name}" in your code. More info at https://meta.discourse.org/t/325349.`
+
+      Rails.logger.error(error_msg)
+
+      raise Discourse::MissingIconError.new(error_msg) if Rails.env.test?
     end
 
     icon_name

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -117,6 +117,7 @@ module Discourse
 
     class CommandError < RuntimeError
       attr_reader :status, :stdout, :stderr
+
       def initialize(message, status: nil, stdout: nil, stderr: nil)
         super(message)
         @status = status
@@ -303,6 +304,9 @@ module Discourse
   end
 
   class Deprecation < StandardError
+  end
+
+  class MissingIconError < StandardError
   end
 
   class ScssError < StandardError

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe SvgSprite do
 
   it "raises an error in test for deprecated icons" do
     allow(Rails.env).to receive(:test?).and_return(true)
-    expect { SvgSprite.search("fa-gamepad") }.to raise_error(Discourse::Deprecation)
+    expect { SvgSprite.search("fa-gamepad") }.to raise_error(Discourse::MissingIconError)
   end
 
   it "includes icons defined in theme settings" do

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -88,13 +88,13 @@ RSpec.describe SvgSprite do
 
   it "strips whitespace when processing icons" do
     Fabricate(:badge, name: "Custom Icon Badge", icon: "  fab fa-facebook-messenger  ")
-    expect(SvgSprite.all_icons).to include("fab-facebook-messenger")
-    expect(SvgSprite.all_icons).not_to include("  fab-facebook-messenger  ")
+    expect(SvgSprite.all_icons).to include("fab fa-facebook-messenger")
+    expect(SvgSprite.all_icons).not_to include("  fab fa-facebook-messenger  ")
   end
 
-  it "includes Font Awesome 5 icons from badges" do
+  it "includes icons from badges" do
     Fabricate(:badge, name: "Custom Icon Badge", icon: "far fa-building")
-    expect(SvgSprite.all_icons).to include("far-building")
+    expect(SvgSprite.all_icons).to include("far fa-building")
   end
 
   it "raises an error in test for deprecated icons" do
@@ -127,7 +127,7 @@ RSpec.describe SvgSprite do
     # FA5 syntax
     theme.update_setting(:custom_icon, "fab fa-bandcamp")
     theme.save!
-    expect(SvgSprite.all_icons(theme.id)).to include("fab-bandcamp")
+    expect(SvgSprite.all_icons(theme.id)).to include("fab fa-bandcamp")
 
     # Internal Discourse syntax + multiple icons
     theme.update_setting(:custom_icon, "fab-android|dragon")
@@ -227,7 +227,7 @@ RSpec.describe SvgSprite do
     DiscoursePluginRegistry.register_svg_icon "fab fa-bandcamp"
 
     expect(SvgSprite.all_icons).to include("blender")
-    expect(SvgSprite.all_icons).to include("fab-bandcamp")
+    expect(SvgSprite.all_icons).to include("fab fa-bandcamp")
   end
 
   it "includes Font Awesome icon from groups" do


### PR DESCRIPTION
On 1st April, we'll start showing no icons if the icon name used is a deprecated one and therefore no longer part of the svg set.

We'll continue showing the messages with the correct icon name to aid correction of these names. 

Console logging will now be done at an error level for such icons.

We retain the behaviour of raising an error for such icons in plugins from svg_sprite.rb in test environments, but removed this from icon-library.js as it's harder to test the actual expected behaviour of returning the original icon now that it's not part of the deprecation workflow. (sinon.stub doesn't work well here for `isTesting` - the alternative would be to override the environment.js module with `proxyquire`) In any case, once we remove the mapping logic, we won't be raising errors in test environment either for this scenario.

Example with the Discourse AI header icon (or lack thereof):
<img width="897" alt="error logs" src="https://github.com/user-attachments/assets/ac916285-d16d-463b-94ac-d24b77c12ef6" />

