### PR TITLE
DEV: Fix flaky automation system test

### DIFF
--- a/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
+++ b/plugins/automation/spec/system/page_objects/discourse_automation/automation.rb
@@ -9,7 +9,7 @@ module PageObjects
       end
 
       def set_name(name)
-        form.find('input[name="automation-name"]').set("aaaaa")
+        form.find('input[name="automation-name"]').set(name)
         self
       end
 
@@ -29,7 +29,7 @@ module PageObjects
       end
 
       def update
-        form.find(".update-automation").click
+        form.find(".update-automation:not([disabled])").click
         self
       end
 


### PR DESCRIPTION
This commit updates `PageObjects::Pages::Automation#update` to check
that the button is not disabled before clicking the button.

### Reviewer notes

Instances of flakiness:
1. https://github.com/discourse/discourse/actions/runs/13864294630/job/38801362996
2. https://github.com/discourse/discourse/actions/runs/13392214535/job/37402368070