### PR TITLE
DEV: Make expanding select-kit more reliable in system tests

### DIFF
--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -27,7 +27,7 @@ module PageObjects
 
       def expanded_component
         return expand if is_collapsed?
-        find(@context + ".is-expanded", wait: 5)
+        find(@context + ".is-expanded")
       end
 
       def collapsed_component
@@ -39,7 +39,7 @@ module PageObjects
       end
 
       def is_collapsed?
-        has_css?(context + ":not(.is-expanded)", wait: 0)
+        has_css?(context) && has_css?("#{context}:not(.is-expanded)", wait: 0)
       end
 
       def is_not_disabled?
@@ -75,7 +75,7 @@ module PageObjects
       end
 
       def expand
-        collapsed_component.find(":not(.is-expanded) .select-kit-header", visible: :all).click
+        collapsed_component.find(".select-kit-header", visible: :all).click
         expanded_component
       end
 


### PR DESCRIPTION
Before this commit,
`PageObjects::Components::SelectKit#expanded_component` might not expand
the component if `is_collapsed?` returns true which can return true if
the method was called before the select-kit component appears on the
screen. When that happens, we end up not expanding the `select-kit`
because we think it is collapsed when in fact the select-kit component
is not rendered yet. This lead to system test failures with errors like:

```
Capybara::ElementNotFound:
  Unable to find css "#add-synonyms.is-expanded"
```

This commit updates `PageObjects::Components::SelectKit#is_collapsed?`
to check that the select-kit component has rendered first before
checking if the component is not expanded.
### Reviewer notes

Instances of test flakiness due to this bug:

1. https://github.com/discourse/discourse/actions/runs/13905226478/job/38906569777
2. https://github.com/discourse/discourse/actions/runs/13848357836/job/38751122333