### PR TITLE
FIX: twitter_summary_large_image is renamed to x

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -283,20 +283,18 @@ module ApplicationHelper
     end
 
     if opts[:image].blank?
-      twitter_summary_large_image_url = SiteSetting.site_twitter_summary_large_image_url
+      x_summary_large_image_url = SiteSetting.site_x_summary_large_image_url
 
-      if twitter_summary_large_image_url.present?
-        opts[:twitter_summary_large_image] = twitter_summary_large_image_url
-      end
+      opts[:x_summary_large_image] = x_summary_large_image_url if x_summary_large_image_url.present?
 
       opts[:image] = SiteSetting.site_opengraph_image_url
     end
 
     # Use the correct scheme for opengraph/twitter image
     opts[:image] = get_absolute_image_url(opts[:image]) if opts[:image].present?
-    opts[:twitter_summary_large_image] = get_absolute_image_url(
-      opts[:twitter_summary_large_image],
-    ) if opts[:twitter_summary_large_image].present?
+    opts[:x_summary_large_image] = get_absolute_image_url(opts[:x_summary_large_image]) if opts[
+      :x_summary_large_image
+    ].present?
 
     result = []
     result << tag(:meta, property: "og:site_name", content: opts[:site_name] || SiteSetting.title)
@@ -342,8 +340,8 @@ module ApplicationHelper
   private def generate_twitter_card_metadata(result, opts)
     img_url =
       (
-        if opts[:twitter_summary_large_image].present?
-          opts[:twitter_summary_large_image]
+        if opts[:x_summary_large_image].present?
+          opts[:x_summary_large_image]
         else
           opts[:image]
         end
@@ -354,7 +352,7 @@ module ApplicationHelper
       img_url = SiteSetting.site_logo_url.ends_with?(".svg") ? nil : SiteSetting.site_logo_url
     end
 
-    if opts[:twitter_summary_large_image].present? && img_url.present?
+    if opts[:x_summary_large_image].present? && img_url.present?
       result << tag(:meta, name: "twitter:card", content: "summary_large_image")
       result << tag(:meta, name: "twitter:image", content: img_url)
     elsif opts[:image].present? && img_url.present?

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -251,7 +251,7 @@ class SiteSetting < ActiveRecord::Base
     manifest_icon
     favicon
     apple_touch_icon
-    twitter_summary_large_image
+    x_summary_large_image
     opengraph_image
     push_notifications_icon
   ].each do |setting_name|

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -45,6 +45,7 @@ module SiteSettings::DeprecatedSettings
       false,
       "3.3",
     ],
+    ["min_first_post_typing_time", "fast_typing_threshold", false, "3.4"],
     ["twitter_summary_large_image", "x_summary_large_image", false, "3.4"],
   ]
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe ApplicationHelper do
       it "returns the correct image" do
         SiteSetting.opengraph_image = Fabricate(:upload, url: "/images/og-image.png")
 
-        SiteSetting.twitter_summary_large_image = Fabricate(:upload, url: "/images/twitter.png")
+        SiteSetting.x_summary_large_image = Fabricate(:upload, url: "/images/twitter.png")
 
         SiteSetting.large_icon = Fabricate(:upload, url: "/images/large_icon.png")
 
@@ -641,11 +641,9 @@ RSpec.describe ApplicationHelper do
 
         SiteSetting.opengraph_image = nil
 
-        expect(helper.crawlable_meta_data).to include(
-          SiteSetting.site_twitter_summary_large_image_url,
-        )
+        expect(helper.crawlable_meta_data).to include(SiteSetting.site_x_summary_large_image_url)
 
-        SiteSetting.twitter_summary_large_image = nil
+        SiteSetting.x_summary_large_image = nil
 
         expect(helper.crawlable_meta_data).to include(SiteSetting.site_large_icon_url)
 
@@ -675,13 +673,13 @@ RSpec.describe ApplicationHelper do
         <meta name=\"twitter:image\" content=\"#{SiteSetting.site_logo_url}\" />
         HTML
 
-        SiteSetting.twitter_summary_large_image = Fabricate(:upload, url: "/images/twitter.png")
+        SiteSetting.x_summary_large_image = Fabricate(:upload, url: "/images/twitter.png")
 
         expect(helper.crawlable_meta_data).to include(<<~HTML)
-        <meta name=\"twitter:image\" content=\"#{SiteSetting.site_twitter_summary_large_image_url}\" />
+        <meta name=\"twitter:image\" content=\"#{SiteSetting.site_x_summary_large_image_url}\" />
         HTML
 
-        SiteSetting.twitter_summary_large_image = Fabricate(:upload, url: "/images/twitter.svg")
+        SiteSetting.x_summary_large_image = Fabricate(:upload, url: "/images/twitter.svg")
 
         expect(helper.crawlable_meta_data).to include(<<~HTML)
         <meta name=\"twitter:image\" content=\"#{SiteSetting.site_logo_url}\" />

--- a/spec/jobs/clean_up_uploads_spec.rb
+++ b/spec/jobs/clean_up_uploads_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Jobs::CleanUpUploads do
       mobile_logo_upload = fabricate_upload
       large_icon_upload = fabricate_upload
       opengraph_image_upload = fabricate_upload
-      twitter_summary_large_image_upload = fabricate_upload
+      x_summary_large_image_upload = fabricate_upload
       favicon_upload = fabricate_upload
       apple_touch_icon_upload = fabricate_upload
 
@@ -129,7 +129,7 @@ RSpec.describe Jobs::CleanUpUploads do
       SiteSetting.large_icon = large_icon_upload
       SiteSetting.opengraph_image = opengraph_image_upload
 
-      SiteSetting.twitter_summary_large_image = twitter_summary_large_image_upload
+      SiteSetting.x_summary_large_image = x_summary_large_image_upload
 
       SiteSetting.favicon = favicon_upload
       SiteSetting.apple_touch_icon = apple_touch_icon_upload
@@ -143,7 +143,7 @@ RSpec.describe Jobs::CleanUpUploads do
         mobile_logo_upload,
         large_icon_upload,
         opengraph_image_upload,
-        twitter_summary_large_image_upload,
+        x_summary_large_image_upload,
         favicon_upload,
         apple_touch_icon_upload,
         system_upload,


### PR DESCRIPTION
In this PR x_summary_large_image was introduced but now updated in all places.

Also `min_first_post_typing_time` deprecation should not be removed.