### PR TITLE
DEV: remove unnecessary use of buffered mixin in share-topic modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
@@ -14,13 +14,10 @@ import discourseComputed, { afterRender } from "discourse/lib/decorators";
 import { longDateNoYear } from "discourse/lib/formatter";
 import { getAbsoluteURL } from "discourse/lib/get-url";
 import Sharing from "discourse/lib/sharing";
-import { bufferedProperty } from "discourse/mixins/buffered-content";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
 
-export default class ShareTopicModal extends Component.extend(
-  bufferedProperty("invite")
-) {
+export default class ShareTopicModal extends Component {
   @service modal;
 
   @readOnly("model.topic") topic;


### PR DESCRIPTION
Use of the buffer API within this component was removed back in https://github.com/discourse/discourse/pull/23940. 