### PR TITLE
DEV: Make group auto e-mail domain limit configurable

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -630,6 +630,7 @@ en:
         one: "'%{username}' is already a member of this group."
         other: "The following users are already members of this group: %{username}"
       invalid_domain: "'%{domain}' is not a valid domain."
+      too_many_domains: "Too many domains. Maximum of %{max}."
       invalid_incoming_email: "'%{email}' is not a valid email address."
       email_already_used_in_group: "'%{email}' is already used by the group '%{group_name}'."
       email_already_used_in_category: "'%{email}' is already used by the category '%{category_name}'."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -912,6 +912,9 @@ groups:
   enable_category_group_moderation:
     client: true
     default: false
+  max_automatic_membership_email_domains:
+    default: 50
+    hidden: true
 
 posting:
   min_post_length:

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Group do
   it_behaves_like "it has custom fields"
 
   describe "Validations" do
-    it { is_expected.to allow_value("#{"a" * 996}.com").for(:automatic_membership_email_domains) }
-    it do
-      is_expected.not_to allow_value("#{"a" * 997}.com").for(:automatic_membership_email_domains)
-    end
     it { is_expected.to validate_length_of(:bio_raw).is_at_most(3000) }
     it { is_expected.to validate_length_of(:membership_request_template).is_at_most(5000) }
     it { is_expected.to validate_length_of(:full_name).is_at_most(100) }
@@ -174,6 +170,17 @@ RSpec.describe Group do
     it "is valid for proper domains" do
       group.automatic_membership_email_domains = "discourse.org|wikipedia.org"
       expect(group.valid?).to eq true
+    end
+
+    it "is invalid for too many domains" do
+      SiteSetting.max_automatic_membership_email_domains = 1
+      group.automatic_membership_email_domains = "discourse.org|wikipedia.org"
+      expect(group).not_to be_valid
+    end
+
+    it "is invalid for too abnormally long domains" do
+      group.automatic_membership_email_domains = "#{"d" * 253}.org"
+      expect(group).not_to be_valid
     end
 
     it "is valid for newer TLDs" do


### PR DESCRIPTION
### What is this change?

We currently limit the number of characters in the bar-separated list of auto-membership e-mail domains. We want to make this configurable through site settings.

After this change, we limit the length of each individual domain, and enable the number of domains to be configured through a hidden site setting.

The original limit is there to prevent DoS, since a `TEXT` column can take up to 1Gb. With this new limit we're still at a maximum of around 10kb.