### PR TITLE
UX: Apply changes live when editing currently active palette

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -20,6 +20,7 @@ export default class AdminConfigAreasColorPalette extends Component {
   @tracked editingName = false;
   @tracked editorMode = LIGHT;
   @tracked hasUnsavedChanges = false;
+  @tracked saving = false;
   hasChangedColors = false;
 
   @cached
@@ -55,6 +56,7 @@ export default class AdminConfigAreasColorPalette extends Component {
 
   @action
   async handleSubmit(data) {
+    this.saving = true;
     this.args.colorPalette.name = data.name;
     this.args.colorPalette.user_selectable = data.user_selectable;
 
@@ -68,7 +70,7 @@ export default class AdminConfigAreasColorPalette extends Component {
         },
       });
       if (this.hasChangedColors) {
-        this.applyColorChangesIfPossible();
+        await this.applyColorChangesIfPossible();
         this.hasChangedColors = false;
       }
     } catch (error) {
@@ -78,6 +80,8 @@ export default class AdminConfigAreasColorPalette extends Component {
           message: extractError(error),
         },
       });
+    } finally {
+      this.saving = false;
     }
   }
 
@@ -141,7 +145,7 @@ export default class AdminConfigAreasColorPalette extends Component {
     try {
       const data = await ajax(`/color-scheme-stylesheet/${id}.json`, {
         data: {
-          request_dark: !!darkTag,
+          include_dark_scheme: !!darkTag,
         },
       });
       if (data?.new_href && lightTag) {
@@ -265,6 +269,7 @@ export default class AdminConfigAreasColorPalette extends Component {
                   </span>
                 {{/if}}
                 <form.Submit
+                  @disabled={{this.saving}}
                   @label="admin.config_areas.color_palettes.save_changes"
                 />
               </div>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -269,7 +269,7 @@ export default class AdminConfigAreasColorPalette extends Component {
                   </span>
                 {{/if}}
                 <form.Submit
-                  @disabled={{this.saving}}
+                  @isLoading={{this.saving}}
                   @label="admin.config_areas.color_palettes.save_changes"
                 />
               </div>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
@@ -14,6 +14,7 @@ export default class FKSubmit extends Component {
       class="btn-primary form-kit__button"
       type="submit"
       @isLoading={{@isLoading}}
+      @disabled={{@disabled}}
       ...attributes
     />
   </template>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
@@ -14,7 +14,6 @@ export default class FKSubmit extends Component {
       class="btn-primary form-kit__button"
       type="submit"
       @isLoading={{@isLoading}}
-      @disabled={{@disabled}}
       ...attributes
     />
   </template>

--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -23,23 +23,15 @@ class StylesheetsController < ApplicationController
   def color_scheme
     params.require("id")
     params.permit("theme_id")
-    params.permit("request_dark")
+    params.permit("include_dark_scheme")
 
     manager = Stylesheet::Manager.new(theme_id: params[:theme_id])
-    stylesheet = manager.color_scheme_stylesheet_details(params[:id], fallback_to_base: true)
-
-    if params[:request_dark]
-      dark_href =
-        manager.color_scheme_stylesheet_link_tag_href(
-          params[:id],
-          dark: true,
-          fallback_to_base: false,
-        )
-      if dark_href
-        stylesheet = stylesheet.dup
-        stylesheet[:new_dark_href] = dark_href
-      end
-    end
+    stylesheet =
+      manager.color_scheme_stylesheet_details(
+        params[:id],
+        fallback_to_base: true,
+        include_dark_scheme: !!params[:include_dark_scheme],
+      )
 
     render json: stylesheet
   end

--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -23,9 +23,24 @@ class StylesheetsController < ApplicationController
   def color_scheme
     params.require("id")
     params.permit("theme_id")
+    params.permit("request_dark")
 
     manager = Stylesheet::Manager.new(theme_id: params[:theme_id])
     stylesheet = manager.color_scheme_stylesheet_details(params[:id], fallback_to_base: true)
+
+    if params[:request_dark]
+      dark_href =
+        manager.color_scheme_stylesheet_link_tag_href(
+          params[:id],
+          dark: true,
+          fallback_to_base: false,
+        )
+      if dark_href
+        stylesheet = stylesheet.dup
+        stylesheet[:new_dark_href] = dark_href
+      end
+    end
+
     render json: stylesheet
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -676,14 +676,16 @@ module ApplicationHelper
         light_href,
         light_elements_media_query,
         "light-scheme",
+        scheme_id,
       )
       result << color_scheme_stylesheet_link_tag(
         dark_href,
         dark_elements_media_query,
         "dark-scheme",
+        dark_scheme_id,
       )
     else
-      result << color_scheme_stylesheet_link_tag(light_href, "all", "light-scheme")
+      result << color_scheme_stylesheet_link_tag(light_href, "all", "light-scheme", scheme_id)
     end
     result.html_safe
   end
@@ -859,7 +861,7 @@ module ApplicationHelper
       end
   end
 
-  def color_scheme_stylesheet_link_tag(href, media, css_class)
-    %[<link href="#{href}" media="#{media}" rel="stylesheet" class="#{css_class}"/>]
+  def color_scheme_stylesheet_link_tag(href, media, css_class, scheme_id)
+    %[<link href="#{href}" media="#{media}" rel="stylesheet" class="#{css_class}"#{scheme_id && scheme_id != -1 ? %[ data-scheme-id="#{scheme_id}"] : ""}/>]
   end
 end

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -341,7 +341,12 @@ class Stylesheet::Manager
     end
   end
 
-  def color_scheme_stylesheet_details(color_scheme_id = nil, dark: false, fallback_to_base: true)
+  def color_scheme_stylesheet_details(
+    color_scheme_id = nil,
+    dark: false,
+    fallback_to_base: true,
+    include_dark_scheme: false
+  )
     theme_id = @theme_id || SiteSetting.default_theme_id
 
     color_scheme = ColorScheme.find_by(id: color_scheme_id)
@@ -373,6 +378,18 @@ class Stylesheet::Manager
 
       href = builder.stylesheet_absolute_url
       stylesheet[:new_href] = href
+
+      if include_dark_scheme
+        dark_href =
+          self.color_scheme_stylesheet_link_tag_href(
+            color_scheme_id,
+            dark: true,
+            fallback_to_base: false,
+          )
+
+        stylesheet[:new_dark_href] = dark_href if dark_href
+      end
+
       stylesheet.freeze
     end
   end


### PR DESCRIPTION
When editing a color palette via the new page introduced in https://github.com/discourse/discourse/pull/31742, it should apply the color changes for the admin making the change automatically upon save.

Internal topic: t/148628/12.