### PR TITLE
DEV: Pluralize email domain count string

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -639,7 +639,9 @@ en:
         one: "Maximum %{count} user can be added at once"
         other: "Maximum %{count} users can be added at once"
       usernames_or_emails_required: "Usernames or emails must be present"
-      counting_too_many_email_domains: "Maximum %{count} email domains can be counted at once"
+      counting_too_many_email_domains:
+        one: "Maximum %{count} email domain can be counted at once"
+        other: "Maximum %{count} email domains can be counted at once"
       no_invites_with_discourse_connect: "You can invite only registered users when DiscourseConnect is enabled"
       no_invites_without_local_logins: "You can invite only registered users when local logins are disabled"
     default_names:


### PR DESCRIPTION
The string introduced in https://github.com/discourse/discourse/pull/31854 included a count but was not pluralized. Even though the singular form may not be used in English, proper pluralization is necessary for other languages. Some languages have different plural forms depending on the number, so explicitly defining pluralization ensures accurate translations.