### PR TITLE
DEV: adds support for primitive collections in form-kit

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
@@ -148,6 +148,16 @@ export default class AdminConfigAreasApiKeysNew extends Component {
     });
   }
 
+  @action
+  scopesKeys(scopesData) {
+    return Object.keys(scopesData);
+  }
+
+  @action
+  paramsKeys(paramsData) {
+    return Object.keys(paramsData);
+  }
+
   async #loadScopes() {
     try {
       this.loadingScopes = true;
@@ -265,59 +275,68 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                       </tr>
                     </thead>
                     <tbody>
-                      <form.Object @name="scopes" as |scopesObject scopeName|>
-                        <tr class="scope-resource-name">
-                          <td><b>{{scopeName}}</b></td>
-                          <td></td>
-                          <td></td>
-                          <td></td>
-                        </tr>
+                      <form.Object @name="scopes" as |scopesObject scopesData|>
+                        {{#each (this.scopesKeys scopesData) as |scopeKey|}}
+                          <tr class="scope-resource-name">
+                            <td><b>{{scopeKey}}</b></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                          </tr>
 
-                        <scopesObject.Collection
-                          @name={{scopeName}}
-                          @tagName="tr"
-                          as |topicsCollection index collectionData|
-                        >
-                          <td>
-                            <topicsCollection.Field
-                              @name="enabled"
-                              @title={{collectionData.key}}
-                              @tooltip={{i18n
-                                (concat
-                                  "admin.api.scopes.descriptions."
-                                  scopeName
-                                  "."
-                                  collectionData.key
-                                )
-                              }}
-                              as |field|
-                            >
-                              <field.Checkbox />
-                            </topicsCollection.Field>
-                          </td>
-                          <td>
-                            <DButton
-                              @icon="link"
-                              @action={{fn this.showURLs collectionData.urls}}
-                              class="btn-info"
-                            />
-                          </td>
-                          <td>
-                            <topicsCollection.Object
-                              @name="params"
-                              as |paramsObject name|
-                            >
-                              <paramsObject.Field
-                                @name={{name}}
-                                @title={{name}}
-                                @showTitle={{false}}
-                                as |field|
-                              >
-                                <field.Input placeholder={{name}} />
-                              </paramsObject.Field>
-                            </topicsCollection.Object>
-                          </td>
-                        </scopesObject.Collection>
+                          <scopesObject.Collection
+                            @name={{scopeKey}}
+                            @tagName="div"
+                            as |topicsCollection index collectionData|
+                          >
+                            <tr>
+                              <td>
+                                <topicsCollection.Field
+                                  @name="enabled"
+                                  @title={{collectionData.key}}
+                                  @tooltip={{i18n
+                                    (concat
+                                      "admin.api.scopes.descriptions."
+                                      scopeKey
+                                      "."
+                                      collectionData.key
+                                    )
+                                  }}
+                                  as |field|
+                                >
+                                  <field.Checkbox />
+                                </topicsCollection.Field>
+                              </td>
+                              <td>
+                                <DButton
+                                  @icon="link"
+                                  @action={{fn
+                                    this.showURLs
+                                    collectionData.urls
+                                  }}
+                                  class="btn-info"
+                                />
+                              </td>
+                              <td>
+                                <topicsCollection.Object
+                                  @name="params"
+                                  as |paramsObject data|
+                                >
+                                  {{#each (this.paramsKeys data) as |name|}}
+                                    <paramsObject.Field
+                                      @name={{name}}
+                                      @title={{name}}
+                                      @showTitle={{false}}
+                                      as |field|
+                                    >
+                                      <field.Input placeholder={{name}} />
+                                    </paramsObject.Field>
+                                  {{/each}}
+                                </topicsCollection.Object>
+                              </td>
+                            </tr>
+                          </scopesObject.Collection>
+                        {{/each}}
                       </form.Object>
                     </tbody>
                   </table>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
@@ -148,16 +148,6 @@ export default class AdminConfigAreasApiKeysNew extends Component {
     });
   }
 
-  @action
-  scopesKeys(scopesData) {
-    return Object.keys(scopesData);
-  }
-
-  @action
-  paramsKeys(paramsData) {
-    return Object.keys(paramsData);
-  }
-
   async #loadScopes() {
     try {
       this.loadingScopes = true;
@@ -276,7 +266,7 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                     </thead>
                     <tbody>
                       <form.Object @name="scopes" as |scopesObject scopesData|>
-                        {{#each (this.scopesKeys scopesData) as |scopeKey|}}
+                        {{#each-in scopesData as |scopeKey|}}
                           <tr class="scope-resource-name">
                             <td><b>{{scopeKey}}</b></td>
                             <td></td>
@@ -320,9 +310,9 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                               <td>
                                 <topicsCollection.Object
                                   @name="params"
-                                  as |paramsObject data|
+                                  as |paramsObject paramsObjectData|
                                 >
-                                  {{#each (this.paramsKeys data) as |name|}}
+                                  {{#each-in paramsObjectData as |name|}}
                                     <paramsObject.Field
                                       @name={{name}}
                                       @title={{name}}
@@ -331,12 +321,12 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                                     >
                                       <field.Input placeholder={{name}} />
                                     </paramsObject.Field>
-                                  {{/each}}
+                                  {{/each-in}}
                                 </topicsCollection.Object>
                               </td>
                             </tr>
                           </scopesObject.Collection>
-                        {{/each}}
+                        {{/each-in}}
                       </form.Object>
                     </tbody>
                   </table>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/collection.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/collection.gjs
@@ -16,9 +16,11 @@ export default class FKCollection extends Component {
   }
 
   get name() {
-    return this.args.parentName
-      ? `${this.args.parentName}.${this.args.name}`
-      : this.args.name;
+    return this.args.name
+      ? `${this.args.parentName ? this.args.parentName + "." : ""}${
+          this.args.name
+        }`
+      : this.args.parentName;
   }
 
   get tagName() {
@@ -27,8 +29,8 @@ export default class FKCollection extends Component {
 
   <template>
     {{#let (element this.tagName) as |Wrapper|}}
-      {{#each this.collectionData key="index" as |data index|}}
-        <Wrapper class="form-kit__collection">
+      <Wrapper class="form-kit__collection">
+        {{#each this.collectionData key="index" as |data index|}}
           {{yield
             (hash
               Field=(component
@@ -53,6 +55,7 @@ export default class FKCollection extends Component {
                 unregisterField=@unregisterField
                 triggerRevalidationFor=@triggerRevalidationFor
                 parentName=(concat this.name "." index)
+                remove=@remove
               )
               Collection=(component
                 FKCollection
@@ -71,8 +74,8 @@ export default class FKCollection extends Component {
             index
             (get this.collectionData index)
           }}
-        </Wrapper>
-      {{/each}}
+        {{/each}}
+      </Wrapper>
     {{/let}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/field-data.gjs
@@ -167,21 +167,21 @@ export default class FKFieldData extends Component {
    * @throws {Error} If `name` is not a string or contains invalid characters.
    */
   get name() {
-    if (typeof this.args.name !== "string") {
-      throw new Error(
-        "@name is required and must be a string on `<form.Field />`."
-      );
+    if (!this.args.name && this.args.parentName) {
+      return this.args.parentName;
     }
 
-    if (this.args.name.includes(".") || this.args.name.includes("-")) {
+    const name = this.args.name.toString();
+
+    if (name?.includes(".") || name?.includes("-")) {
       throw new Error("@name can't include `.` or `-`.");
     }
 
     if (this.args.parentName) {
-      return `${this.args.parentName}.${this.args.name}`;
+      return `${this.args.parentName}.${name}`;
     }
 
-    return this.args.name;
+    return name;
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/object.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/object.gjs
@@ -9,65 +9,55 @@ export default class FKObject extends Component {
   }
 
   get name() {
-    return this.args.parentName
-      ? `${this.args.parentName}.${this.args.name}`
-      : this.args.name;
-  }
-
-  get keys() {
-    return Object.keys(this.objectData).map((name) => {
-      return { name };
-    });
-  }
-
-  entryData(name) {
-    return this.objectData[name];
+    return this.args.name
+      ? `${this.args.parentName ? this.args.parentName + "." : ""}${
+          this.args.name
+        }`
+      : this.args.parentName;
   }
 
   <template>
     <div class="form-kit__object">
-      {{#each this.keys key="name" as |key|}}
-        {{yield
-          (hash
-            Field=(component
-              FKField
-              errors=@errors
-              addError=@addError
-              data=@data
-              set=@set
-              registerField=@registerField
-              unregisterField=@unregisterField
-              triggerRevalidationFor=@triggerRevalidationFor
-              parentName=this.name
-            )
-            Object=(component
-              FKObject
-              errors=@errors
-              addError=@addError
-              data=@data
-              set=@set
-              registerField=@registerField
-              unregisterField=@unregisterField
-              triggerRevalidationFor=@triggerRevalidationFor
-              parentName=this.name
-            )
-            Collection=(component
-              FKCollection
-              errors=@errors
-              addError=@addError
-              data=@data
-              set=@set
-              registerField=@registerField
-              unregisterField=@unregisterField
-              triggerRevalidationFor=@triggerRevalidationFor
-              parentName=this.name
-              remove=@remove
-            )
+      {{yield
+        (hash
+          Field=(component
+            FKField
+            errors=@errors
+            addError=@addError
+            data=@data
+            set=@set
+            registerField=@registerField
+            unregisterField=@unregisterField
+            triggerRevalidationFor=@triggerRevalidationFor
+            parentName=this.name
           )
-          key.name
-          (this.entryData key.name)
-        }}
-      {{/each}}
+          Object=(component
+            FKObject
+            errors=@errors
+            addError=@addError
+            data=@data
+            set=@set
+            registerField=@registerField
+            unregisterField=@unregisterField
+            triggerRevalidationFor=@triggerRevalidationFor
+            parentName=this.name
+            remove=@remove
+          )
+          Collection=(component
+            FKCollection
+            errors=@errors
+            addError=@addError
+            data=@data
+            set=@set
+            registerField=@registerField
+            unregisterField=@unregisterField
+            triggerRevalidationFor=@triggerRevalidationFor
+            parentName=this.name
+            remove=@remove
+          )
+        )
+        this.objectData
+      }}
     </div>
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/collection-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/collection-test.gjs
@@ -25,9 +25,11 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
       <template>
         <Form @data={{hash foo=(array (hash bar=1) (hash bar=2))}} as |form|>
           <form.Collection @name="foo" as |collection|>
-            <collection.Field @name="bar" @title="Bar" as |field|>
-              <field.Input />
-            </collection.Field>
+            <collection.Object as |object|>
+              <object.Field @name="bar" @title="Bar" as |field|>
+                <field.Input />
+              </object.Field>
+            </collection.Object>
           </form.Collection>
         </Form>
       </template>
@@ -35,6 +37,21 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
 
     assert.form().field("foo.0.bar").hasValue("1");
     assert.form().field("foo.1.bar").hasValue("2");
+
+    await render(
+      <template>
+        <Form @data={{hash foo=(array 1 2)}} as |form|>
+          <form.Collection @name="foo" as |collection|>
+            <collection.Field @title="Bar" as |field|>
+              <field.Input />
+            </collection.Field>
+          </form.Collection>
+        </Form>
+      </template>
+    );
+
+    assert.form().field("foo.0").hasValue("1");
+    assert.form().field("foo.1").hasValue("2");
   });
 
   test("remove", async function (assert) {
@@ -42,13 +59,16 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
       <template>
         <Form @data={{hash foo=(array (hash bar=1) (hash bar=2))}} as |form|>
           <form.Collection @name="foo" as |collection index|>
-            <collection.Field @name="bar" @title="Bar" as |field|>
-              <field.Input />
+            <collection.Object as |object|>
+              <object.Field @name="bar" @title="Bar" as |field|>
+                <field.Input />
+              </object.Field>
+
               <form.Button
                 class={{concat "remove-" index}}
                 @action={{fn collection.remove index}}
               >Remove</form.Button>
-            </collection.Field>
+            </collection.Object>
           </form.Collection>
         </Form>
       </template>
@@ -76,11 +96,12 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
             <collection.Object @name="bar" as |object|>
               <object.Field @name="baz" @title="Baz" as |field|>
                 <field.Input />
-                <form.Button
-                  class={{concat "remove-" index}}
-                  @action={{fn collection.remove index}}
-                >Remove</form.Button>
               </object.Field>
+
+              <form.Button
+                class={{concat "remove-" index}}
+                @action={{fn collection.remove index}}
+              >Remove</form.Button>
             </collection.Object>
           </form.Collection>
         </Form>
@@ -112,24 +133,31 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
           as |form|
         >
           <form.Collection @name="one" as |first firstIndex|>
-            <first.Collection @name="two" as |second secondIndex|>
-              <second.Collection @name="three" as |third thirdIndex|>
-                <third.Field @name="foo" @title="Foo" as |field|>
-                  <field.Input />
-                  <form.Button
-                    class={{concat
-                      "remove-"
-                      firstIndex
-                      "-"
-                      secondIndex
-                      "-"
-                      thirdIndex
-                    }}
-                    @action={{fn third.remove thirdIndex}}
-                  >Remove</form.Button>
-                </third.Field>
+            <first.Object @name="two" as |second|>
+              <second.Collection as |third secondIndex|>
+                <third.Object @name="three" as |fourth|>
+                  <fourth.Collection as |fifth thirdIndex|>
+                    <fifth.Object as |sixth|>
+                      <sixth.Field @name="foo" @title="Foo" as |field|>
+                        <field.Input />
+                      </sixth.Field>
+                    </fifth.Object>
+
+                    <form.Button
+                      class={{concat
+                        "remove-"
+                        firstIndex
+                        "-"
+                        secondIndex
+                        "-"
+                        thirdIndex
+                      }}
+                      @action={{fn fifth.remove thirdIndex}}
+                    >Remove</form.Button>
+                  </fourth.Collection>
+                </third.Object>
               </second.Collection>
-            </first.Collection>
+            </first.Object>
           </form.Collection>
         </Form>
       </template>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/object-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/object-test.gjs
@@ -12,8 +12,11 @@ module("Integration | Component | FormKit | Object", function (hooks) {
     await render(
       <template>
         <Form @data={{hash foo=(hash bar=1 baz=2)}} as |form|>
-          <form.Object @name="foo" as |object name|>
-            <object.Field @name={{name}} @title={{name}} as |field|>
+          <form.Object @name="foo" as |object|>
+            <object.Field @name="bar" @title="bar" as |field|>
+              <field.Input />
+            </object.Field>
+            <object.Field @name="baz" @title="baz" as |field|>
               <field.Input />
             </object.Field>
           </form.Object>
@@ -34,8 +37,11 @@ module("Integration | Component | FormKit | Object", function (hooks) {
         >
           <form.Object @name="one" as |one|>
             <one.Object @name="two" as |two|>
-              <two.Object @name="three" as |three name|>
-                <three.Field @name={{name}} @title={{name}} as |field|>
+              <two.Object @name="three" as |three|>
+                <three.Field @name="foo" @title="foo" as |field|>
+                  <field.Input />
+                </three.Field>
+                <three.Field @name="bar" @title="bar" as |field|>
                   <field.Input />
                 </three.Field>
               </two.Object>

--- a/app/assets/stylesheets/admin/api.scss
+++ b/app/assets/stylesheets/admin/api.scss
@@ -28,6 +28,10 @@
     display: none;
   }
 
+  .form-kit__collection {
+    display: contents;
+  }
+
   .api-key-show {
     .form-element,
     .form-element-desc {

--- a/app/assets/stylesheets/common/form-kit/_collection.scss
+++ b/app/assets/stylesheets/common/form-kit/_collection.scss
@@ -1,7 +1,5 @@
 .form-kit__collection {
-  &div {
-    display: flex;
-    flex-direction: column;
-    gap: var(--form-kit-gutter-y);
-  }
+  display: flex;
+  flex-direction: column;
+  gap: var(--form-kit-gutter-y);
 }


### PR DESCRIPTION
Before this commit form-kit couldn't represent this shape of data: `[1,2,3]`, it could only represent: `[{value: 1}, {value: 2}]`.

The above data can now be expressed with this form:

```gjs
<Form @data={{hash foo=(array 1 2 3)}} as |form|>
  <form.Collection @name="foo" as |collection|>
    <collection.Field @title="time" as |field|>
      <field.Input @type="number" />
    </collection.Field>
  </form.Collection>
</Form>
```