### PR TITLE
FIX: Updating a group without e-mail domains

### DIFF
--- a/app/assets/javascripts/discourse/app/services/group-automatic-members-dialog.js
+++ b/app/assets/javascripts/discourse/app/services/group-automatic-members-dialog.js
@@ -1,4 +1,5 @@
 import Service, { service } from "@ember/service";
+import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP } from "discourse/lib/constants";
@@ -8,11 +9,11 @@ export default class GroupAutomaticMembersDialog extends Service {
   @service dialog;
 
   async showConfirm(group_id, email_domains) {
-    const domainCount = email_domains?.split("|")?.length ?? 0;
-
-    if (domainCount === 0) {
+    if (isEmpty(email_domains)) {
       return Promise.resolve(true);
     }
+
+    const domainCount = email_domains.split("|").length;
 
     // On the back-end we compare every single user's e-mail to each e-mail
     // domain by regular expression. At some point this is a but much work

--- a/spec/system/groups/group_spec.rb
+++ b/spec/system/groups/group_spec.rb
@@ -63,6 +63,21 @@ describe "Group", type: :system do
     end
   end
 
+  describe "update a group" do
+    it "creates a new group" do
+      group_page.visit(group)
+
+      group_page.click_manage
+      group_page.click_membership
+
+      group_page.fill_in("title", with: "The Illuminati")
+
+      group_page.click_save
+
+      expect(group_page).to have_css(".group-manage-save-button span", text: "Saved!")
+    end
+  end
+
   describe "delete a group" do
     it "redirects to groups index page" do
       group_page.visit(group)

--- a/spec/system/page_objects/pages/group.rb
+++ b/spec/system/page_objects/pages/group.rb
@@ -33,6 +33,18 @@ module PageObjects
         page.find(".modal-container button.add.btn-primary").click
         self
       end
+
+      def click_manage
+        page.find(".user-primary-navigation .manage").click
+      end
+
+      def click_membership
+        page.find(".user-secondary-navigation li", text: "Membership").click
+      end
+
+      def click_save
+        page.find(".group-manage-save").click
+      end
     end
   end
 end


### PR DESCRIPTION
### What is the problem

The change made in #31854 introduced a regression when editing groups, preventing saving when no auto membership e-mail domains are entered.

This change fixes that and adds a system test.