### PR TITLE
UX: Add separator for "Learn more..." on admin pages

### DIFF
--- a/app/assets/stylesheets/common/components/d-page-header.scss
+++ b/app/assets/stylesheets/common/components/d-page-header.scss
@@ -90,3 +90,9 @@ $mobile-breakpoint: 700px;
     color: var(--primary);
   }
 }
+
+.d-page-header__learn-more {
+  &::before {
+    content: "• ";
+  }
+}


### PR DESCRIPTION
We have this rule in
https://meta.discourse.org/t/formatting-text-in-discourse-documentation-and-uis/324637:

> Do not use a period for the following:
>
> Tooltips, image captions, or other UI elements with only one sentence

However, this looks strange on some admin pages because we also show
a "Learn more..." link after the header description, which kind of
runs on into the link.

This commit adds a separator after the link to address this issue.

**Before**

![image](https://github.com/user-attachments/assets/fe6461c0-a01a-4ab2-a449-e236ec840a5a)

**After**

![image](https://github.com/user-attachments/assets/f7eb7743-66b4-4486-8fbf-e8bc337d9284)

