### PR TITLE
DEV: Remove flaky system test

### DIFF
--- a/plugins/chat/spec/system/kick_user_from_channel_spec.rb
+++ b/plugins/chat/spec/system/kick_user_from_channel_spec.rb
@@ -25,11 +25,6 @@ describe "Kick user from chat channel", type: :system do
   context "when the user is looking at the channel they are kicked from" do
     before { chat.visit_channel(channel_1) }
 
-    it "shows an alert" do
-      publish_kick
-      expect(dialog).to have_content(I18n.t("js.chat.kicked_from_channel"))
-    end
-
     context "when the user presses ok" do
       it "redirects them to the first other public channel they have" do
         publish_kick


### PR DESCRIPTION
This commit removes a flaky system test without replacement given that
the test isn't really testing something in the critical path or
something that happens often.

### Reviewer notes

Example of flakiness:

1. https://github.com/discourse/discourse/actions/runs/13901410315/job/38893877234
2. https://github.com/discourse/discourse/actions/runs/12362090310/job/34500684809