### PR TITLE
FIX: Don't error out after destroying first post with webhook configured

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -85,7 +85,7 @@ class PostDestroyer
       UserActionManager.topic_destroyed(@topic)
       DiscourseEvent.trigger(:topic_destroyed, @topic, @user)
       if WebHook.active_web_hooks(:topic_destroyed).exists?
-        topic_view = TopicView.new(@topic.id, Discourse.system_user, skip_staff_action: true)
+        topic_view = TopicView.new(@topic, Discourse.system_user, skip_staff_action: true)
         topic_payload = WebHook.generate_payload(:topic, topic_view, WebHookTopicViewSerializer)
         WebHook.enqueue_topic_hooks(:topic_destroyed, @topic, topic_payload)
       end

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1142,6 +1142,8 @@ RSpec.describe PostDestroyer do
     end
 
     it "destroys the post when force_destroy is true for soft deleted topics" do
+      Fabricate(:topic_web_hook)
+
       post = Fabricate(:post)
       topic = post.topic
 


### PR DESCRIPTION
### What is the problem?

When hard deleting a first post by passing `force_destroy: true` as an option to `PostDestroyer`, the post/topic is correctly deleted, and the staff record is created, but the app then errors out.

This only happens on sites with a `topic_destroyed` webhook setup.

### Why is this happening?

After deleting the record, we pass the topic's ID to `TopicView`, which then raises an error because it can not load it from the DB.

### How does this fix it?

`TopicView` supports being initialized with either an ID or an already instantiated record. Since we still have the record in memory after deleting, we can pass that to `TopicView`.