### PR TITLE
DEV: Attempt to fix flaky system tests around email confirmation

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/confirm-new-email.js
+++ b/app/assets/javascripts/discourse/app/controllers/confirm-new-email.js
@@ -7,6 +7,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 
 export default class ConfirmNewEmailController extends Controller {
+  @service currentUser;
   @service dialog;
   @service router;
 
@@ -41,6 +42,8 @@ export default class ConfirmNewEmailController extends Controller {
       })
     );
 
-    this.router.transitionTo("/my/preferences/account");
+    this.router.transitionTo(
+      `/u/${this.currentUser.username_lower}/preferences/account`
+    );
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/confirm-old-email.js
+++ b/app/assets/javascripts/discourse/app/controllers/confirm-old-email.js
@@ -7,6 +7,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 
 export default class ConfirmOldEmailController extends Controller {
+  @service currentUser;
   @service dialog;
   @service router;
 
@@ -34,6 +35,8 @@ export default class ConfirmOldEmailController extends Controller {
       })
     );
 
-    this.router.transitionTo("/my/preferences/account");
+    this.router.transitionTo(
+      `/u/${this.currentUser.username_lower}/preferences/account`
+    );
   }
 }

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -38,7 +38,7 @@ describe "Changing email", type: :system do
     mail.body.to_s[%r{/u/confirm-#{type}-email/\S+}, 0]
   end
 
-  xit "allows regular user to change their email" do
+  it "allows regular user to change their email" do
     sign_in user
 
     visit generate_confirm_link
@@ -52,7 +52,7 @@ describe "Changing email", type: :system do
     expect(user_preferences_page).to have_primary_email(new_email)
   end
 
-  xit "works when user has totp 2fa" do
+  it "works when user has totp 2fa" do
     SiteSetting.hide_email_address_taken = false
 
     second_factor = Fabricate(:user_second_factor_totp, user: user)


### PR DESCRIPTION
Both tests being unskipped here failed previosly with the following
error:

```
Failure/Error: expect(page).to have_current_path("/u/#{user.username}/preferences/account")
  expected "/u/confirm-new-email/f42a416fcbca40d66788d65a8837ad49" to equal "/u/bruce306/preferences/account"

./spec/system/email_change_spec.rb:49:in `block (2 levels) in <main>'
```

The error indicates that the transition was not successful and I
suspect that it may be due to the use of the `/my` route prefix which
is just a nice to have and not necessary.
