### PR TITLE
FIX: paste url on rich editor with partial paragraph selected

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -2,7 +2,6 @@
 const extension = {
   markSpec: {
     link: {
-      before: "em",
       attrs: {
         href: {},
         title: { default: null },

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -2,6 +2,7 @@
 const extension = {
   markSpec: {
     link: {
+      before: "em",
       attrs: {
         href: {},
         title: { default: null },
@@ -126,40 +127,36 @@ const extension = {
 
         // Auto-linkify rich content with a single text node that is a URL
         transformPasted(paste, view) {
-          let textContent = null;
+          let node = null;
 
           if (paste.content.childCount === 1) {
             if (paste.content.firstChild.isText) {
-              // Direct text node
-              textContent = paste.content.firstChild.text;
+              node = paste.content.firstChild;
             } else if (
               paste.content.firstChild.type.name === "paragraph" &&
               paste.content.firstChild.childCount === 1 &&
               paste.content.firstChild.firstChild.isText
             ) {
-              // Text inside paragraph
-              textContent = paste.content.firstChild.firstChild.text;
+              node = paste.content.firstChild.firstChild;
             }
           }
 
           if (
-            !textContent ||
-            paste.content.firstChild.firstChild.marks.some(
-              (mark) => mark.type.name === "link"
-            )
+            !node?.text ||
+            node?.marks.some((mark) => mark.type.name === "link")
           ) {
             return paste;
           }
 
-          const matches = utils.getLinkify().match(textContent);
+          const matches = utils.getLinkify().match(node.text);
           const isFullMatch =
-            matches && matches.length === 1 && matches[0].raw === textContent;
+            matches && matches.length === 1 && matches[0].raw === node.text;
 
           if (!isFullMatch) {
             return paste;
           }
 
-          return addLinkMark(view, textContent);
+          return addLinkMark(view, node.text);
         },
       },
     }),

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -490,7 +490,7 @@ describe "Composer - ProseMirror editor", type: :system do
       cdp.allow_clipboard
       open_composer_and_toggle_rich_editor
 
-      cdp.write_clipboard("not selected **bold**not not selected")
+      cdp.write_clipboard("not selected **bold** not selected")
       page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
       rich.find("strong").double_click
 
@@ -499,7 +499,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.toggle_rich_editor
 
-      expect(composer).to have_value("not selected [**bold**not](www.example.com) not selected")
+      expect(composer).to have_value("not selected **[bold](www.example.com)** not selected")
     end
   end
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -468,10 +468,11 @@ describe "Composer - ProseMirror editor", type: :system do
     it "respects existing marks when pasting a url to make a link" do
       cdp.allow_clipboard
       open_composer_and_toggle_rich_editor
-      cdp.write_clipboard("`code` **bold** *italic*")
+      cdp.write_clipboard("not selected `code`**bold**not*italic* not selected")
       page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
-      page.execute_script("document.execCommand('selectAll',false,null)")
-      cdp.write_clipboard("www.google.com")
+      rich.find("strong").double_click
+
+      cdp.write_clipboard("www.example.com")
       page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
 
       expect(rich).to have_css("code", text: "code")
@@ -480,7 +481,25 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.toggle_rich_editor
 
-      expect(composer).to have_value("[`code` **bold** *italic*](www.google.com)")
+      expect(composer).to have_value(
+        "not selected [`code`**bold**not*italic*](www.example.com) not selected",
+      )
+    end
+
+    it "auto-links pasted URLs from text/html" do
+      cdp.allow_clipboard
+      open_composer_and_toggle_rich_editor
+
+      cdp.write_clipboard("not selected **bold**not not selected")
+      page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
+      rich.find("strong").double_click
+
+      cdp.write_clipboard("<p>www.example.com</p>", html: true)
+      page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("not selected [**bold**not](www.example.com) not selected")
     end
   end
 


### PR DESCRIPTION
Fixes an incorrect logic on `transformPasted` that was causing a `TypeError: Cannot read properties of null (reading 'marks')` when only part of a paragraph was selected.

Adds tests