### PR TITLE
DEV: Add `guardian` argument to `TopicsFilter` plugin callback

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -276,8 +276,8 @@ class Plugin::Instance
   # Ensure proper input sanitization before using it in a query.
   #
   # Example usage:
-  #   add_filter_custom_filter("word_count") do |scope, value|
-  #     scope.where(word_count: value)
+  #   add_filter_custom_filter("word_count") do |scope, value, guardian|
+  #     scope.where(word_count: value) if guardian.admin?
   #   end
   def add_filter_custom_filter(name, &block)
     DiscoursePluginRegistry.register_custom_filter_mapping({ name => block }, self)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -85,7 +85,7 @@ class TopicsFilter
       else
         if custom_filter =
              DiscoursePluginRegistry.custom_filter_mappings.find { |hash| hash.key?(filter) }
-          @scope = instance_exec(@scope, filter_values, &custom_filter[filter]) || @scope
+          @scope = custom_filter[filter].call(@scope, filter_values, @guardian) || @scope
         end
       end
     end
@@ -563,7 +563,7 @@ class TopicsFilter
         if custom_match =
              DiscoursePluginRegistry.custom_filter_mappings.find { |hash| hash.key?(key) }
           dir = match_data[:asc] ? "ASC" : "DESC"
-          @scope = instance_exec(@scope, dir, &custom_match[key]) || @scope
+          @scope = custom_match[key].call(@scope, dir, @guardian) || @scope
         end
       end
     end

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -85,7 +85,7 @@ class TopicsFilter
       else
         if custom_filter =
              DiscoursePluginRegistry.custom_filter_mappings.find { |hash| hash.key?(filter) }
-          @scope = custom_filter[filter].call(@scope, filter_values)
+          @scope = instance_exec(@scope, filter_values, &custom_filter[filter]) || @scope
         end
       end
     end
@@ -562,7 +562,8 @@ class TopicsFilter
         key = "order:#{match_data[:column]}"
         if custom_match =
              DiscoursePluginRegistry.custom_filter_mappings.find { |hash| hash.key?(key) }
-          @scope = custom_match[key].call(@scope, match_data[:asc].nil? ? "DESC" : "ASC")
+          dir = match_data[:asc] ? "ASC" : "DESC"
+          @scope = instance_exec(@scope, dir, &custom_match[key]) || @scope
         end
       end
     end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1551,7 +1551,7 @@ RSpec.describe TopicsFilter do
         )
       end
 
-      it "has access to @guardian and other instance variables" do
+      it "can guard against the current user" do
         expect(
           TopicsFilter.new(guardian: Guardian.new).filter_from_query_string("foo:bar").pluck(:id),
         ).to be_empty

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1540,5 +1540,29 @@ RSpec.describe TopicsFilter do
         end
       end
     end
+
+    describe "with a custom filter" do
+      fab!(:topic)
+
+      before do
+        Plugin::Instance.new.add_filter_custom_filter(
+          "foo",
+          &->(scope, value) { @guardian.is_admin? ? scope : scope.where("1=0") }
+        )
+      end
+
+      it "has access to @guardian and other instance variables" do
+        expect(
+          TopicsFilter.new(guardian: Guardian.new).filter_from_query_string("foo:bar").pluck(:id),
+        ).to be_empty
+
+        expect(
+          TopicsFilter
+            .new(guardian: Guardian.new(admin))
+            .filter_from_query_string("foo:bar")
+            .pluck(:id),
+        ).to contain_exactly(topic.id)
+      end
+    end
   end
 end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1516,7 +1516,7 @@ RSpec.describe TopicsFilter do
           before_all do
             Plugin::Instance.new.add_filter_custom_filter(
               "order:bumped",
-              &->(scope, value) { scope.order("bumped_at #{value}") }
+              &->(scope, value, _guardian) { scope.order("bumped_at #{value}") }
             )
           end
 
@@ -1547,7 +1547,7 @@ RSpec.describe TopicsFilter do
       before do
         Plugin::Instance.new.add_filter_custom_filter(
           "foo",
-          &->(scope, value) { @guardian.is_admin? ? scope : scope.where("1=0") }
+          &->(scope, value, guardian) { guardian.is_admin? ? scope : scope.where("1=0") }
         )
       end
 


### PR DESCRIPTION
This adds the `guardian` argument to the `TopicsFilter` plugin callback so that plugin can guard their topics filter based on the current user.