### PR TITLE
DEV: Add polyfill for CSS relative color syntax

### DIFF
--- a/app/assets/javascripts/theme-transpiler/package.json
+++ b/app/assets/javascripts/theme-transpiler/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/standalone": "^7.26.10",
     "@csstools/postcss-light-dark-function": "^2.0.7",
+    "@csstools/postcss-relative-color-syntax": "^3.0.8",
     "@zxing/text-encoding": "^0.9.0",
     "autoprefixer": "^10.4.21",
     "babel-plugin-ember-template-compilation": "^2.3.0",

--- a/app/assets/javascripts/theme-transpiler/postcss.js
+++ b/app/assets/javascripts/theme-transpiler/postcss.js
@@ -1,5 +1,6 @@
 import "core-js/actual/url";
 import postcssLightDark from "@csstools/postcss-light-dark-function";
+import postcssRelativeColor from "@csstools/postcss-relative-color-syntax";
 import autoprefixer from "autoprefixer";
 import postcss from "postcss";
 import minmax from "postcss-media-minmax";
@@ -12,6 +13,7 @@ const postCssProcessor = postcss([
   }),
   minmax(),
   postcssLightDark,
+  postcssRelativeColor(),
   postcssVariablePrefixer(),
 ]);
 let lastPostcssError, lastPostcssResult;

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -8,7 +8,7 @@ end
 
 class Stylesheet::Manager
   # Bump this number to invalidate all stylesheet caches (e.g. if you change something inside the compiler)
-  BASE_COMPILER_VERSION = 4
+  BASE_COMPILER_VERSION = 5
 
   # Add any dependencies here which should automatically cause a global cache invalidation.
   BASE_CACHE_KEY = "#{BASE_COMPILER_VERSION}::#{DiscourseFonts::VERSION}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1018,6 +1018,9 @@ importers:
       '@csstools/postcss-light-dark-function':
         specifier: ^2.0.7
         version: 2.0.7(postcss@8.5.3)
+      '@csstools/postcss-relative-color-syntax':
+        specifier: ^3.0.8
+        version: 3.0.8(postcss@8.5.3)
       '@zxing/text-encoding':
         specifier: ^0.9.0
         version: 0.9.0
@@ -1723,6 +1726,12 @@ packages:
 
   '@csstools/postcss-progressive-custom-properties@4.0.0':
     resolution: {integrity: sha512-XQPtROaQjomnvLUSy/bALTR5VCtTVUFwYs1SblvYgLSeTo2a/bMNwUwo2piXw5rTv/FEYiy5yPSXBqg9OKUx7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/postcss-relative-color-syntax@3.0.8':
+    resolution: {integrity: sha512-eGE31oLnJDoUysDdjS9MLxNZdtqqSxjDXMdISpLh80QMaYrKs7VINpid34tWQ+iU23Wg5x76qAzf1Q/SLLbZVg==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
@@ -9585,6 +9594,15 @@ snapshots:
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
+
+  '@csstools/postcss-relative-color-syntax@3.0.8(postcss@8.5.3)':
+    dependencies:
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.3)
+      '@csstools/utilities': 2.0.0(postcss@8.5.3)
+      postcss: 8.5.3
 
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.0)':
     dependencies:


### PR DESCRIPTION
This polyfill only works with static color values, which means it will NOT work on things like `olclh(from var(--primary) ...`.

Therefore, we must only use it in color_definition stylesheets, and use scss variables as the source color. Like `okclh(from #{$primary}`.

Once we drop iOS 15, we'll be able to drop this polyfill, and use the syntax anywhere with `var()`