### PR TITLE
FIX: prevents fields in Object to re-render

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
@@ -164,6 +164,16 @@ export default class AdminConfigAreasApiKeysNew extends Component {
     }
   }
 
+  @action
+  paramsObjectKeys(paramsObjectData) {
+    return Object.keys(paramsObjectData);
+  }
+
+  @action
+  scopesDataKeys(scopesData) {
+    return Object.keys(scopesData);
+  }
+
   <template>
     <BackButton @route="adminApiKeys.index" @label="admin.api_keys.back" />
 
@@ -266,7 +276,7 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                     </thead>
                     <tbody>
                       <form.Object @name="scopes" as |scopesObject scopesData|>
-                        {{#each-in scopesData as |scopeKey|}}
+                        {{#each (this.scopesDataKeys scopesData) as |scopeKey|}}
                           <tr class="scope-resource-name">
                             <td><b>{{scopeKey}}</b></td>
                             <td></td>
@@ -312,7 +322,10 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                                   @name="params"
                                   as |paramsObject paramsObjectData|
                                 >
-                                  {{#each-in paramsObjectData as |name|}}
+                                  {{#each
+                                    (this.paramsObjectKeys paramsObjectData)
+                                    as |name|
+                                  }}
                                     <paramsObject.Field
                                       @name={{name}}
                                       @title={{name}}
@@ -321,12 +334,12 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                                     >
                                       <field.Input placeholder={{name}} />
                                     </paramsObject.Field>
-                                  {{/each-in}}
+                                  {{/each}}
                                 </topicsCollection.Object>
                               </td>
                             </tr>
                           </scopesObject.Collection>
-                        {{/each-in}}
+                        {{/each}}
                       </form.Object>
                     </tbody>
                   </table>


### PR DESCRIPTION
This is a temporary fix while we make this codepath of FormKit to correctly follow Data down action up pattern, re-rendering a component shouldn't be an issue.