### PR TITLE
FIX: Add value transformers for welcome banner and search

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -18,7 +18,7 @@ import Icons from "./header/icons";
 import SearchMenuWrapper from "./header/search-menu-wrapper";
 import UserMenuWrapper from "./header/user-menu-wrapper";
 
-const SEARCH_BUTTON_ID = "search-button";
+export const SEARCH_BUTTON_ID = "search-button";
 const USER_BUTTON_ID = "toggle-current-user";
 const HAMBURGER_BUTTON_ID = "toggle-hamburger-menu";
 const PANEL_SELECTOR = ".panel-body";

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -44,7 +44,7 @@ export default class Contents extends Component {
     }
 
     const searchExperience = applyValueTransformer(
-      "search-experience",
+      "site-setting-search-experience",
       this.siteSettings.search_experience
     );
 

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -43,10 +43,12 @@ export default class Contents extends Component {
       return false;
     }
 
-    return (
-      this.siteSettings.search_experience === "search_field" &&
-      !this.args.topicInfoVisible
+    const searchExperience = applyValueTransformer(
+      "search-experience",
+      this.siteSettings.search_experience
     );
+
+    return searchExperience === "search_field" && !this.args.topicInfoVisible;
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -61,7 +61,7 @@ export default class Icons extends Component {
     }
 
     const searchExperience = applyValueTransformer(
-      "search-experience",
+      "site-setting-search-experience",
       this.siteSettings.search_experience
     );
 

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -5,6 +5,7 @@ import { eq } from "truth-helpers";
 import InterfaceColorSelector from "discourse/components/interface-color-selector";
 import DAG from "discourse/lib/dag";
 import getURL from "discourse/lib/get-url";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import Dropdown from "./dropdown";
 import UserDropdown from "./user-dropdown";
 
@@ -59,9 +60,14 @@ export default class Icons extends Component {
       return false;
     }
 
+    const searchExperience = applyValueTransformer(
+      "search-experience",
+      this.siteSettings.search_experience
+    );
+
     return (
       this.site.mobileView ||
-      this.siteSettings.search_experience === "search_icon" ||
+      searchExperience === "search_icon" ||
       this.args.topicInfoVisible
     );
   }

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -8,6 +8,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import SearchMenu from "discourse/components/search-menu";
 import bodyClass from "discourse/helpers/body-class";
 import { prioritizeNameFallback } from "discourse/lib/settings";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 
 export default class WelcomeBanner extends Component {
@@ -54,7 +55,12 @@ export default class WelcomeBanner extends Component {
   }
 
   get shouldDisplay() {
-    if (!this.siteSettings.enable_welcome_banner) {
+    const enabled = applyValueTransformer(
+      "enable-welcome-banner",
+      this.siteSettings.enable_welcome_banner
+    );
+
+    if (!enabled) {
       return false;
     }
 

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -56,7 +56,7 @@ export default class WelcomeBanner extends Component {
 
   get shouldDisplay() {
     const enabled = applyValueTransformer(
-      "enable-welcome-banner",
+      "site-setting-enable-welcome-banner",
       this.siteSettings.enable_welcome_banner
     );
 

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -41,6 +41,6 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "topic-list-item-expand-pinned",
   "topic-list-item-mobile-layout",
   "topic-list-item-style",
-  "enable-welcome-banner",
-  "search-experience",
+  "site-setting-enable-welcome-banner",
+  "site-setting-search-experience",
 ]);

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -41,4 +41,6 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "topic-list-item-expand-pinned",
   "topic-list-item-mobile-layout",
   "topic-list-item-style",
+  "enable-welcome-banner",
+  "search-experience",
 ]);

--- a/app/assets/javascripts/discourse/tests/integration/components/header-contents-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/header-contents-test.gjs
@@ -1,0 +1,91 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import Contents from "discourse/components/header/contents";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Header | Contents", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("showHeaderSearch", async function (assert) {
+    const site = getOwner(this).lookup("service:site");
+    const toggleNavigationMenu = () => {};
+    this.siteSettings.search_experience = "search_icon";
+
+    await render(
+      <template>
+        <Contents
+          @sidebarEnabled={{true}}
+          @toggleNavigationMenu={{toggleNavigationMenu}}
+          @showSidebar={{true}}
+        >test</Contents>
+      </template>
+    );
+
+    assert
+      .dom(".floating-search-input-wrapper")
+      .doesNotExist(
+        "it does not display when the search_experience setting is search_icon"
+      );
+
+    this.siteSettings.search_experience = "search_field";
+
+    await render(
+      <template>
+        <Contents
+          @sidebarEnabled={{true}}
+          @toggleNavigationMenu={{toggleNavigationMenu}}
+          @showSidebar={{true}}
+        >test</Contents>
+      </template>
+    );
+
+    assert
+      .dom(".floating-search-input-wrapper")
+      .exists(
+        "it does display when the search_experience setting is search_field"
+      );
+
+    sinon.stub(site, "mobileView").value(true);
+
+    await render(
+      <template>
+        <Contents
+          @sidebarEnabled={{true}}
+          @toggleNavigationMenu={{toggleNavigationMenu}}
+          @showSidebar={{true}}
+        >test</Contents>
+      </template>
+    );
+
+    assert
+      .dom(".floating-search-input-wrapper")
+      .doesNotExist("it does not display when the site is in mobile view");
+
+    sinon.stub(site, "mobileView").value(false);
+
+    withPluginApi("1.37.1", (api) => {
+      api.registerValueTransformer("site-setting-search-experience", () => {
+        return "search_icon";
+      });
+    });
+
+    await render(
+      <template>
+        <Contents
+          @sidebarEnabled={{true}}
+          @toggleNavigationMenu={{toggleNavigationMenu}}
+          @showSidebar={{true}}
+        >test</Contents>
+      </template>
+    );
+
+    assert
+      .dom(".floating-search-input-wrapper")
+      .doesNotExist(
+        "it does not display when the value transformer is not search_field"
+      );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
@@ -1,0 +1,104 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { SEARCH_BUTTON_ID } from "discourse/components/header";
+import Icons from "discourse/components/header/icons";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Header | Icons", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("showSearchButton", async function (assert) {
+    const site = getOwner(this).lookup("service:site");
+    const noop = () => {};
+    this.siteSettings.search_experience = "search_field";
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".search-dropdown")
+      .doesNotExist(
+        "it does not display when the search_experience setting is search_field"
+      );
+
+    this.siteSettings.search_experience = "search_icon";
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".search-dropdown")
+      .exists(
+        "it does display when the search_experience setting is search_icon"
+      );
+
+    sinon.stub(site, "mobileView").value(true);
+    this.siteSettings.search_experience = "search_field";
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".search-dropdown")
+      .exists(
+        "it does display when the site is in mobile view even if search_experience setting is search_field"
+      );
+
+    sinon.stub(site, "mobileView").value(false);
+    this.siteSettings.search_experience = "search_icon";
+
+    withPluginApi("1.37.1", (api) => {
+      api.registerValueTransformer("site-setting-search-experience", () => {
+        return "search_field";
+      });
+    });
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".search-dropdown")
+      .doesNotExist(
+        "it does not display when the value transformer is not search_icon"
+      );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/integration/components/welcome-banner-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/welcome-banner-test.gjs
@@ -1,0 +1,50 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import WelcomeBanner from "discourse/components/welcome-banner";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | WelcomeBanner", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("shouldDisplay", async function (assert) {
+    const router = getOwner(this).lookup("service:router");
+
+    await render(<template><WelcomeBanner /></template>);
+    assert
+      .dom(".welcome-banner")
+      .doesNotExist("it does not display when the site setting is disabled");
+
+    this.siteSettings.enable_welcome_banner = true;
+
+    await render(<template><WelcomeBanner /></template>);
+    assert
+      .dom(".welcome-banner")
+      .doesNotExist(
+        "it does not dispaly when the site setting is enabled but the route is not correct"
+      );
+
+    sinon.stub(router, "currentRouteName").value("discovery.latest");
+    await render(<template><WelcomeBanner /></template>);
+    assert
+      .dom(".welcome-banner")
+      .exists(
+        "it does dispaly when the site setting is enabled and the route is correct from top_menu"
+      );
+
+    withPluginApi("1.37.1", (api) => {
+      api.registerValueTransformer("site-setting-enable-welcome-banner", () => {
+        return false;
+      });
+    });
+
+    await render(<template><WelcomeBanner /></template>);
+    assert
+      .dom(".welcome-banner")
+      .doesNotExist(
+        "it does not display when the value transformer returns a different value from the site setting"
+      );
+  });
+});


### PR DESCRIPTION
We want to give some themes more control over
the default experience in core. To this end, this
commit adds value transformers for these
site settings:

* enable_welcome_banner
* search_experience

This way, themes can give a different value to
what has been set in core.

This can be potentially confusing, a follow up PR
may refactor this a bit so there is a more direct
correlation between the setting and the transformer
so we could show a warning in the site setting page
for example.
