### PR TITLE
UX: Improve UX of 2FA token submission page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/second-factor-auth.gjs
+++ b/app/assets/javascripts/discourse/app/templates/second-factor-auth.gjs
@@ -1,7 +1,7 @@
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
-import { gt, or } from "truth-helpers";
+import { gt, not, or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import SecondFactorInput from "discourse/components/second-factor-input";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
@@ -43,7 +43,10 @@ export default RouteTemplate(
             @secondFactorMethod={{@controller.shownSecondFactorMethod}}
             value={{@controller.secondFactorToken}}
           />
+
           <DButton
+            @isLoading={{@controller.isLoading}}
+            @disabled={{not @controller.isSecondFactorTokenValid}}
             @action={{@controller.authenticateToken}}
             @label="submit"
             type="submit"

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -108,7 +108,7 @@ describe "Changing email", type: :system do
     authenticator&.remove!
   end
 
-  xit "does not require login to verify" do
+  it "does not require login to verify" do
     second_factor = Fabricate(:user_second_factor_totp, user: user)
     sign_in user
 
@@ -120,9 +120,8 @@ describe "Changing email", type: :system do
 
     find(".confirm-new-email .btn-primary").click
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
-    find("button[type=submit]").click
+    find("button[type=submit]:not([disabled])").click
 
-    expect(page).to have_content(I18n.t("js.second_factor_auth.redirect_after_success"))
     expect(page).to have_current_path("/latest")
     expect(user.reload.email).to eq(new_email)
   end


### PR DESCRIPTION
This commit updates the 2FA token submission page to disable the submit
button when the 2FA token is not valid and to also set the submit button
to be in the loading state after the submit button has been clicked.

The UX issues were discovered while I was investigating a flaky test
which has been unskipped in this commit as well. I am not sure if  this
will completely resolve the flakiness but we have to unskip it to know
if it continues to be flaky.
