### PR TITLE
FIX: Bookmark search input can't be cleared with backspace with `?q=` present

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -30,7 +30,7 @@ export default class UserActivityBookmarksController extends Controller {
 
   @computed("q")
   get searchTerm() {
-    return this._searchTerm || this.q;
+    return this._searchTerm !== undefined ? this._searchTerm : this.q;
   }
 
   set searchTerm(value) {

--- a/spec/system/page_objects/pages/user_activity_bookmarks.rb
+++ b/spec/system/page_objects/pages/user_activity_bookmarks.rb
@@ -20,9 +20,22 @@ module PageObjects
         self
       end
 
+      def clear_query_with_backspace
+        search_element.value.length.times { search_element.send_keys(:backspace) }
+        self
+      end
+
       def fill_in_search(query)
         fill_in("bookmark-search", with: query)
         self
+      end
+
+      def search_element
+        find_by_id("bookmark-search")
+      end
+
+      def has_empty_search?
+        search_element.value == ""
       end
 
       def has_topic?(topic)

--- a/spec/system/user_activity_bookmarks_spec.rb
+++ b/spec/system/user_activity_bookmarks_spec.rb
@@ -58,4 +58,10 @@ describe "User activity bookmarks", type: :system do
     expect(user_activity_bookmarks).to have_topic(bookmark_1.bookmarkable.topic)
     expect(user_activity_bookmarks).to have_topic(bookmark_2.bookmarkable.topic)
   end
+
+  it "can clear the query with backspace" do
+    user_activity_bookmarks.visit(current_user, q: "dog")
+    user_activity_bookmarks.clear_query_with_backspace
+    expect(user_activity_bookmarks.has_empty_search?).to eq(true)
+  end
 end

--- a/spec/system/user_activity_bookmarks_spec.rb
+++ b/spec/system/user_activity_bookmarks_spec.rb
@@ -62,6 +62,6 @@ describe "User activity bookmarks", type: :system do
   it "can clear the query with backspace" do
     user_activity_bookmarks.visit(current_user, q: "dog")
     user_activity_bookmarks.clear_query_with_backspace
-    expect(user_activity_bookmarks.has_empty_search?).to eq(true)
+    expect(user_activity_bookmarks).to have_empty_search
   end
 end


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/cant-erase-the-bookmark-search-input/357861/4

> When we fill in the bookmark search input and send the request, then we can’t delete the input’s content.

After removing the last character, the `searchTerm` getter is called. At this point, `_searchTerm` is empty.
However,  `this._searchTerm || this.q` will treat the empty string as _falsy_, and the `q` value is displayed instead.
It makes it impossible to clear the input.

To fix this, we check specifically on the initial state of `_searchTerm,` which is _undefined_, to include an empty string as a valid value.

Note: because of `@computed`, the issue is not triggered when the content is selected and deleted. 