### PR TITLE
DEV: Support target in problem check problem constructor

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -188,18 +188,22 @@ class ProblemCheck
     [NO_TARGET]
   end
 
-  def problem(override_key: nil, override_data: {})
-    [
+  def problem(target = nil, override_key: nil, override_data: {})
+    problem =
       Problem.new(
         I18n.t(
           override_key || translation_key,
           base_path: Discourse.base_path,
-          **override_data.merge(translation_data).symbolize_keys,
+          **override_data.merge(
+            target.present? ? translation_data(target) : translation_data,
+          ).symbolize_keys,
         ),
         priority: self.config.priority,
         identifier:,
-      ),
-    ]
+        target: target&.id,
+      )
+
+    target.present? ? problem : [problem]
   end
 
   def no_problem
@@ -210,7 +214,7 @@ class ProblemCheck
     "dashboard.problem.#{identifier}"
   end
 
-  def translation_data
+  def translation_data(target = nil)
     {}
   end
 end

--- a/app/services/problem_check/problem.rb
+++ b/app/services/problem_check/problem.rb
@@ -18,7 +18,7 @@ class ProblemCheck::Problem
   end
 
   def to_h
-    { message: message, priority: priority, identifier: identifier }
+    { message:, priority:, identifier:, target: }
   end
   alias_method :attributes, :to_h
 
@@ -27,6 +27,6 @@ class ProblemCheck::Problem
 
     return if h[:message].blank?
 
-    new(h[:message], priority: h[:priority], identifier: h[:identifier])
+    new(h[:message], priority: h[:priority], identifier: h[:identifier], target: h[:target])
   end
 end

--- a/spec/services/problem_check/group_email_credentials_spec.rb
+++ b/spec/services/problem_check/group_email_credentials_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ProblemCheck::GroupEmailCredentials do
 
         expect(described_class.new.call).to contain_exactly(
           have_attributes(
-            identifier: "group_email_credentials",
+            identifier: :group_email_credentials,
             target: group2.id,
             priority: "high",
             message:
@@ -66,7 +66,7 @@ RSpec.describe ProblemCheck::GroupEmailCredentials do
 
         expect(described_class.new.call).to contain_exactly(
           have_attributes(
-            identifier: "group_email_credentials",
+            identifier: :group_email_credentials,
             target: group3.id,
             priority: "high",
             message:


### PR DESCRIPTION
### What is this change?

We didn't have support in the `#problem` constructor for multiple targets, forcing developers to manually construct a `Problem` instance. This involves a lot of details and is error prone.

This PR supports passing an optional `target` argument to the constructor. This will be passed on to the `translation_data` method to generate the correct message as well.