### PR TITLE
DEV: Simplify showing dialog in afterRender Ember runloop queue

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/services/dialog.js
+++ b/app/assets/javascripts/dialog-holder/addon/services/dialog.js
@@ -32,7 +32,7 @@ export default class DialogService extends Service {
     this.reset();
   }
 
-  async dialog(params) {
+  dialog(params) {
     const {
       message,
       bodyComponent,
@@ -78,26 +78,27 @@ export default class DialogService extends Service {
       class: params.class,
     });
 
-    await new Promise((resolve) => schedule("afterRender", resolve));
-    const element = document.getElementById("dialog-holder");
+    schedule("afterRender", () => {
+      const element = document.getElementById("dialog-holder");
 
-    if (!element) {
-      const msg =
-        "dialog-holder wrapper element not found. Unable to render dialog";
-      // eslint-disable-next-line no-console
-      console.error(msg, params);
-      throw new Error(msg);
-    }
-
-    this.dialogInstance = new A11yDialog(element);
-    this.dialogInstance.show();
-
-    this.dialogInstance.on("hide", () => {
-      if (!this._confirming && this.didCancel) {
-        this.didCancel();
+      if (!element) {
+        const msg =
+          "dialog-holder wrapper element not found. Unable to render dialog";
+        // eslint-disable-next-line no-console
+        console.error(msg, params);
+        throw new Error(msg);
       }
 
-      this.reset();
+      this.dialogInstance = new A11yDialog(element);
+      this.dialogInstance.show();
+
+      this.dialogInstance.on("hide", () => {
+        if (!this._confirming && this.didCancel) {
+          this.didCancel();
+        }
+
+        this.reset();
+      });
     });
   }
 


### PR DESCRIPTION
No need to deal with promises here when we can just schedule the dialog
code to run directly in the afterRender queue. We [don't call `await` on the async function](https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/app/assets/javascripts/discourse/app/lib/ajax-error.js#L97-L100) anyway. 

### Reviewer notes

I suspect this is related to test flakiness in system tests whenever we assert for dialogs:

```
Failure/Error: measurement = Benchmark.measure { example.run }
  expected to find text "You are not permitted to view the requested resource." in "Topics\nMy Posts\nMore\nCATEGORIES\nAmazing Category 0\nAmazing Category 1\nAmazing Category 3\nUncategorized\nAll categories\nMESSAGES\nInbox\nMy Threads\nCHANNELS\nDMS\nbruce3\nChannels\nAll\nOpen\nClosed\nRandom 0\nJoin". (However, it was found 1 time including non-visible text.)

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_visit_channel_when_chat_enabled_when_regular_user_when_category_channel_is_read_only_shows_an_error_759.png

~~~~~~~ JS LOGS ~~~~~~~
http://localhost:31338/chat/api/channels/10000000005 - Failed to load resource: the server responded with a status of 403 (Forbidden)
http://localhost:31338/assets/chunk.f94534295fbf61464215.d41d8cd9.js 70194:14 "dialog-holder wrapper element not found. Unable to render dialog" Object
http://localhost:31338/assets/chunk.f94534295fbf61464215.d41d8cd9.js 70195:12 Uncaught Error: dialog-holder wrapper element not found. Unable to render dialog
http://localhost:31338/assets/chunk.f94534295fbf61464215.d41d8cd9.js 122174:14 Uncaught Error: TransitionAborted
~~~~~ END JS LOGS ~~~~~

./plugins/chat/spec/system/visit_channel_spec.rb:119:in `block (5 levels) in <main>'
```

`chat-channel-decorator` fetches the `model`

https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/plugins/chat/assets/javascripts/discourse/routes/chat-channel-decorator.js#L10

which calls `find`

https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js#L28-L37

which then calls `#find`

https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js#L161-L168

`popupAjaxError` is not an `async` function and we don't return the promise at all

https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/app/assets/javascripts/discourse/app/lib/ajax-error.js#L93-L102

Therefore, I'm not sure if the following line in `DialogService#dialog` even works:

https://github.com/discourse/discourse/blob/7f9a0bb2a75217731de3a0168302b66453152c09/app/assets/javascripts/dialog-holder/addon/services/dialog.js#L81
