### PR TITLE
DEV: Move dialog DOM handling from service to component

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/components/dialog-holder.gjs
+++ b/app/assets/javascripts/dialog-holder/addon/components/dialog-holder.gjs
@@ -3,11 +3,27 @@ import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import A11yDialog from "a11y-dialog";
+import { modifier } from "ember-modifier";
 import { notEq, or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 
 export default class DialogHolder extends Component {
   @service dialog;
+
+  setupDialog = modifier((element) => {
+    const dialogInstance = new A11yDialog(element);
+    dialogInstance.show();
+
+    dialogInstance.on("hide", () => {
+      this.dialog.hide();
+    });
+
+    () => {
+      dialogInstance.hide();
+      dialogInstance.destroy();
+    };
+  });
 
   @action
   async handleButtonAction(btn) {
@@ -19,69 +35,72 @@ export default class DialogHolder extends Component {
   }
 
   <template>
-    <div
-      aria-labelledby={{this.dialog.titleElementId}}
-      aria-hidden="true"
-      id="dialog-holder"
-      class="dialog-container {{this.dialog.class}}"
-    >
-      <div class="dialog-overlay" data-a11y-dialog-hide></div>
+    {{#if this.dialog.show}}
+      <div
+        aria-labelledby={{this.dialog.titleElementId}}
+        id="dialog-holder"
+        aria-hidden="true"
+        class="dialog-container {{this.dialog.class}}"
+        {{this.setupDialog}}
+      >
+        <div class="dialog-overlay" data-a11y-dialog-hide></div>
 
-      {{#if this.dialog.type}}
-        <div class="dialog-content" role="document">
-          {{#if this.dialog.title}}
-            <div class="dialog-header">
-              <h3 id={{this.dialog.titleElementId}}>{{this.dialog.title}}</h3>
-              <DButton
-                @action={{this.dialog.cancel}}
-                @title="modal.close"
-                @icon="xmark"
-                class="btn-flat dialog-close close"
-              />
-            </div>
-          {{/if}}
-
-          {{#if (or this.dialog.message this.dialog.bodyComponent)}}
-            <div class="dialog-body">
-              {{#if this.dialog.bodyComponent}}
-                <this.dialog.bodyComponent
-                  @model={{this.dialog.bodyComponentModel}}
-                />
-              {{else if this.dialog.message}}
-                <p>{{htmlSafe this.dialog.message}}</p>
-              {{/if}}
-            </div>
-          {{/if}}
-
-          {{#if (notEq this.dialog.type "notice")}}
-            <div class="dialog-footer">
-              {{#each this.dialog.buttons as |button|}}
+        {{#if this.dialog.type}}
+          <div class="dialog-content" role="document">
+            {{#if this.dialog.title}}
+              <div class="dialog-header">
+                <h3 id={{this.dialog.titleElementId}}>{{this.dialog.title}}</h3>
                 <DButton
-                  @action={{fn this.handleButtonAction button}}
-                  @translatedLabel={{button.label}}
-                  @icon={{button.icon}}
-                  class={{button.class}}
+                  @action={{this.dialog.cancel}}
+                  @title="modal.close"
+                  @icon="xmark"
+                  class="btn-flat dialog-close close"
                 />
-              {{else}}
-                <DButton
-                  @action={{this.dialog.didConfirmWrapped}}
-                  @icon={{this.dialog.confirmButtonIcon}}
-                  @label={{this.dialog.confirmButtonLabel}}
-                  @disabled={{this.dialog.confirmButtonDisabled}}
-                  class={{this.dialog.confirmButtonClass}}
-                />
-                {{#if this.dialog.shouldDisplayCancel}}
-                  <DButton
-                    @action={{this.dialog.cancel}}
-                    @label={{this.dialog.cancelButtonLabel}}
-                    class={{this.dialog.cancelButtonClass}}
+              </div>
+            {{/if}}
+
+            {{#if (or this.dialog.message this.dialog.bodyComponent)}}
+              <div class="dialog-body">
+                {{#if this.dialog.bodyComponent}}
+                  <this.dialog.bodyComponent
+                    @model={{this.dialog.bodyComponentModel}}
                   />
+                {{else if this.dialog.message}}
+                  <p>{{htmlSafe this.dialog.message}}</p>
                 {{/if}}
-              {{/each}}
-            </div>
-          {{/if}}
-        </div>
-      {{/if}}
-    </div>
+              </div>
+            {{/if}}
+
+            {{#if (notEq this.dialog.type "notice")}}
+              <div class="dialog-footer">
+                {{#each this.dialog.buttons as |button|}}
+                  <DButton
+                    @action={{fn this.handleButtonAction button}}
+                    @translatedLabel={{button.label}}
+                    @icon={{button.icon}}
+                    class={{button.class}}
+                  />
+                {{else}}
+                  <DButton
+                    @action={{this.dialog.didConfirmWrapped}}
+                    @icon={{this.dialog.confirmButtonIcon}}
+                    @label={{this.dialog.confirmButtonLabel}}
+                    @disabled={{this.dialog.confirmButtonDisabled}}
+                    class={{this.dialog.confirmButtonClass}}
+                  />
+                  {{#if this.dialog.shouldDisplayCancel}}
+                    <DButton
+                      @action={{this.dialog.cancel}}
+                      @label={{this.dialog.cancelButtonLabel}}
+                      class={{this.dialog.cancelButtonClass}}
+                    />
+                  {{/if}}
+                {{/each}}
+              </div>
+            {{/if}}
+          </div>
+        {{/if}}
+      </div>
+    {{/if}}
   </template>
 }

--- a/app/assets/javascripts/dialog-holder/addon/services/dialog.js
+++ b/app/assets/javascripts/dialog-holder/addon/services/dialog.js
@@ -1,6 +1,4 @@
-import { schedule } from "@ember/runloop";
 import Service from "@ember/service";
-import A11yDialog from "a11y-dialog";
 import { bind } from "discourse/lib/decorators";
 
 export default class DialogService extends Service {
@@ -27,11 +25,6 @@ export default class DialogService extends Service {
   class = null;
   _confirming = false;
 
-  willDestroy() {
-    this.dialogInstance?.destroy();
-    this.reset();
-  }
-
   async dialog(params) {
     const {
       message,
@@ -55,6 +48,8 @@ export default class DialogService extends Service {
     } = params;
 
     this.setProperties({
+      show: true,
+
       message,
       bodyComponent,
       bodyComponentModel,
@@ -76,28 +71,6 @@ export default class DialogService extends Service {
       didCancel,
       buttons,
       class: params.class,
-    });
-
-    await new Promise((resolve) => schedule("afterRender", resolve));
-    const element = document.getElementById("dialog-holder");
-
-    if (!element) {
-      const msg =
-        "dialog-holder wrapper element not found. Unable to render dialog";
-      // eslint-disable-next-line no-console
-      console.error(msg, params);
-      throw new Error(msg);
-    }
-
-    this.dialogInstance = new A11yDialog(element);
-    this.dialogInstance.show();
-
-    this.dialogInstance.on("hide", () => {
-      if (!this._confirming && this.didCancel) {
-        this.didCancel();
-      }
-
-      this.reset();
     });
   }
 
@@ -149,7 +122,13 @@ export default class DialogService extends Service {
   }
 
   reset() {
+    if (!this._confirming && this.didCancel) {
+      this.didCancel();
+    }
+
     this.setProperties({
+      show: false,
+
       message: null,
       bodyComponent: null,
       bodyComponentModel: null,
@@ -182,16 +161,21 @@ export default class DialogService extends Service {
       this.didConfirm();
     }
     this._confirming = true;
-    this.dialogInstance.hide();
+    this.reset();
   }
 
   @bind
   cancel() {
-    this.dialogInstance.hide();
+    this.reset();
   }
 
   @bind
   enableConfirmButton() {
     this.set("confirmButtonDisabled", false);
+  }
+
+  @bind
+  hide() {
+    this.reset();
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/dialog-holder-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/dialog-holder-test.gjs
@@ -22,8 +22,9 @@ module("Integration | Component | dialog-holder", function (hooks) {
 
   test("basics", async function (assert) {
     await render(<template><DialogHolder /></template>);
-    assert.dom("#dialog-holder").exists("element is in DOM");
-    assert.dom("#dialog-holder").hasNoText("dialog is empty by default");
+    assert
+      .dom("#dialog-holder")
+      .doesNotExist("element is not in DOM by default");
 
     this.dialog.alert({
       message: "This is an error",
@@ -38,18 +39,14 @@ module("Integration | Component | dialog-holder", function (hooks) {
     // dismiss by clicking on overlay
     await click(".dialog-overlay");
 
-    assert.dom("#dialog-holder").exists("element is still in DOM");
-    assert
-      .dom(".dialog-overlay")
-      .hasProperty("offsetWidth", 0, "overlay is not visible");
-    assert.dom("#dialog-holder").hasNoText("dialog is empty");
+    assert.dom("#dialog-holder").doesNotExist("element removed from DOM");
+    assert.dom(".dialog-overlay").doesNotExist("overlay removed from DOM");
   });
 
   test("basics - dismiss using Esc", async function (assert) {
     let cancelCallbackCalled = false;
     await render(<template><DialogHolder /></template>);
-    assert.dom("#dialog-holder").exists("element is in DOM");
-    assert.dom("#dialog-holder").hasNoText("dialog is empty by default");
+    assert.dom("#dialog-holder").doesNotExist("element is not in DOM");
 
     this.dialog.alert({
       message: "This is an error",
@@ -68,13 +65,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
     await triggerKeyEvent(document.activeElement, "keydown", "Escape");
 
     assert.true(cancelCallbackCalled, "cancel callback called");
-    assert.dom("#dialog-holder").exists("element is still in DOM");
-
-    assert
-      .dom(".dialog-overlay")
-      .hasProperty("offsetWidth", 0, "overlay is not visible");
-
-    assert.dom("#dialog-holder").hasNoText("dialog is empty");
+    assert.dom("#dialog-holder").doesNotExist("dialog closed");
   });
 
   test("alert with title", async function (assert) {
@@ -101,11 +92,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
 
     await click(".dialog-close");
 
-    assert.dom("#dialog-holder").exists("element is still in DOM");
-    assert
-      .dom(".dialog-overlay")
-      .hasProperty("offsetWidth", 0, "overlay is not visible");
-    assert.dom("#dialog-holder").hasNoText("dialog is empty");
+    assert.dom("#dialog-holder").doesNotExist("element removed from DOM");
   });
 
   test("alert with a string parameter", async function (assert) {
@@ -155,7 +142,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
     assert.true(confirmCallbackCalled, "confirm callback called");
     assert.false(cancelCallbackCalled, "cancel callback NOT called");
 
-    assert.dom("#dialog-holder").hasNoText("dialog is empty");
+    assert.dom("#dialog-holder").doesNotExist("dialog hidden");
   });
 
   test("cancel callback", async function (assert) {
@@ -183,7 +170,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
     assert.false(confirmCallbackCalled, "confirm callback NOT called");
     assert.true(cancelCallbackCalled, "cancel callback called");
 
-    assert.dom("#dialog-holder").hasNoText("dialog has been dismissed");
+    assert.dom("#dialog-holder").doesNotExist("dialog has been dismissed");
   });
 
   test("yes/no confirm", async function (assert) {
@@ -245,7 +232,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
     await click(".dialog-footer .btn-danger");
     assert.true(customCallbackTriggered, "custom action was triggered");
 
-    assert.dom("#dialog-holder").hasNoText("dialog has been dismissed");
+    assert.dom("#dialog-holder").doesNotExist();
   });
 
   test("alert with custom classes", async function (assert) {
@@ -267,19 +254,7 @@ module("Integration | Component | dialog-holder", function (hooks) {
 
     await click(".dialog-footer .btn-primary");
 
-    assert
-      .dom("#dialog-holder")
-      .doesNotHaveClass(
-        "dialog-special",
-        "additional class removed on dismissal"
-      );
-
-    assert
-      .dom("#dialog-holder")
-      .doesNotHaveClass(
-        "dialog-super",
-        "additional class removed on dismissal"
-      );
+    assert.dom("#dialog-holder").doesNotExist("dialog is hidden");
   });
 
   test("notice", async function (assert) {


### PR DESCRIPTION
Accessing a component-rendered DOM element from a service is not ideal, and can lead to timing issues. We've attempted to work around this using `afterRender`, but it's still not ideal.

This commit moves the `A11YDialog` setup into a modifier. Now the service only stores state, and the component renders things based on that state. This is much more in line with Ember norms, and should be much more robust.

Test adjustments are because the dialog element is now only rendered on-demand, rather than being present in the DOM all the time. This brings dialog inline with our Modal system.