### PR TITLE
DEV: refactor usage of buffered-content mixin

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.js
+++ b/app/assets/javascripts/admin/addon/components/site-setting.js
@@ -1,16 +1,26 @@
+import { cached, tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { readOnly } from "@ember/object/computed";
-import BufferedContent from "discourse/mixins/buffered-content";
+import BufferedProxy from "ember-buffered-proxy/proxy";
 import SettingComponent from "admin/mixins/setting-component";
 import SiteSetting from "admin/models/site-setting";
 
 export default class SiteSettingComponent extends Component.extend(
-  BufferedContent,
   SettingComponent
 ) {
+  @tracked setting = null;
   updateExistingUsers = null;
 
   @readOnly("setting.staffLogFilter") staffLogFilter;
+
+  @cached
+  @dependentKeyCompat
+  get buffered() {
+    return BufferedProxy.create({
+      content: this.setting,
+    });
+  }
 
   _save() {
     const setting = this.buffered;

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-robots-txt.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-robots-txt.js
@@ -1,11 +1,14 @@
+import { cached, tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
-import { action, computed } from "@ember/object";
+import { action } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { not } from "@ember/object/computed";
 import BufferedProxy from "ember-buffered-proxy/proxy";
 import { ajax } from "discourse/lib/ajax";
 import { propertyEqual } from "discourse/lib/computed";
 
 export default class AdminCustomizeRobotsTxtController extends Controller {
+  @tracked model;
   saved = false;
   isSaving = false;
 
@@ -13,10 +16,11 @@ export default class AdminCustomizeRobotsTxtController extends Controller {
 
   @not("model.overridden") resetDisabled;
 
-  @computed("model")
+  @cached
+  @dependentKeyCompat
   get buffered() {
     return BufferedProxy.create({
-      content: this.get("model"),
+      content: this.model,
     });
   }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
@@ -1,18 +1,28 @@
+import { cached, tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { service } from "@ember/service";
+import BufferedProxy from "ember-buffered-proxy/proxy";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse/lib/decorators";
-import { bufferedProperty } from "discourse/mixins/buffered-content";
 import { i18n } from "discourse-i18n";
 
-export default class AdminSiteTextEdit extends Controller.extend(
-  bufferedProperty("siteText")
-) {
+export default class AdminSiteTextEdit extends Controller {
   @service dialog;
+
+  @tracked siteText;
 
   saved = false;
   queryParams = ["locale"];
+
+  @cached
+  @dependentKeyCompat
+  get buffered() {
+    return BufferedProxy.create({
+      content: this.siteText,
+    });
+  }
 
   @discourseComputed("buffered.value")
   saveDisabled(value) {
@@ -32,7 +42,7 @@ export default class AdminSiteTextEdit extends Controller.extend(
     this.siteText
       .save(attrs)
       .then(() => {
-        this.commitBuffer();
+        this.buffered.applyChanges();
         this.set("saved", true);
       })
       .catch(popupAjaxError);
@@ -50,7 +60,7 @@ export default class AdminSiteTextEdit extends Controller.extend(
           .then((props) => {
             const buffered = this.buffered;
             buffered.setProperties(props);
-            this.commitBuffer();
+            this.buffered.applyChanges();
           })
           .catch(popupAjaxError);
       },

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -91,7 +91,6 @@ export default Mixin.create({
   attributeBindings: ["setting.setting:data-setting"],
   classNameBindings: [":row", ":setting", "overridden", "typeClass"],
   validationMessage: null,
-  setting: null,
 
   content: alias("setting"),
   isSecret: oneWay("setting.secret"),
@@ -310,7 +309,7 @@ export default Mixin.create({
       await this._save();
 
       this.set("validationMessage", null);
-      this.commitBuffer();
+      this.buffered.applyChanges();
       if (AUTO_REFRESH_ON_SAVE.includes(this.setting.setting)) {
         this.afterSave();
       }
@@ -339,7 +338,7 @@ export default Mixin.create({
   }),
 
   cancel: action(function () {
-    this.rollbackBuffer();
+    this.buffered.discardChanges();
     this.set("validationMessage", null);
   }),
 

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1,10 +1,13 @@
+import { cached, tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import EmberObject, { action } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { alias, and, not, or } from "@ember/object/computed";
 import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isEmpty, isPresent } from "@ember/utils";
 import { observes } from "@ember-decorators/object";
+import BufferedProxy from "ember-buffered-proxy/proxy";
 import { Promise } from "rsvp";
 import {
   CLOSE_INITIATED_BY_BUTTON,
@@ -31,7 +34,6 @@ import QuoteState from "discourse/lib/quote-state";
 import { extractLinkMeta } from "discourse/lib/render-topic-featured-link";
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import { escapeExpression } from "discourse/lib/utilities";
-import { bufferedProperty } from "discourse/mixins/buffered-content";
 import Bookmark, { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
@@ -57,9 +59,7 @@ export function registerCustomPostMessageCallback(type, callback) {
   customPostMessageCallbacks[type] = callback;
 }
 
-export default class TopicController extends Controller.extend(
-  bufferedProperty("model")
-) {
+export default class TopicController extends Controller {
   @service composer;
   @service dialog;
   @service documentTitle;
@@ -70,6 +70,8 @@ export default class TopicController extends Controller.extend(
   @service siteSettings;
   @service site;
   @service appEvents;
+
+  @tracked model;
 
   queryParams = ["filter", "username_filters", "replies_to_post_number"];
 
@@ -117,6 +119,14 @@ export default class TopicController extends Controller.extend(
   willDestroy() {
     super.willDestroy(...arguments);
     this.appEvents.off("post:show-revision", this, "_showRevision");
+  }
+
+  @cached
+  @dependentKeyCompat
+  get buffered() {
+    return BufferedProxy.create({
+      content: this.model,
+    });
   }
 
   updateQueryParams() {
@@ -1075,7 +1085,7 @@ export default class TopicController extends Controller.extend(
   @action
   cancelEditingTopic() {
     this.set("editingTopic", false);
-    this.rollbackBuffer();
+    this.buffered.discardChanges();
   }
 
   @action
@@ -1090,7 +1100,7 @@ export default class TopicController extends Controller.extend(
     Topic.update(this.model, props, { fastEdit: true })
       .then(() => {
         // We roll back on success here because `update` saves the properties to the topic
-        this.rollbackBuffer();
+        this.buffered.discardChanges();
         this.set("editingTopic", false);
       })
       .catch(popupAjaxError);


### PR DESCRIPTION
Refactors the use of the buffered-content mixin to native getters on the dependent classes. 

This mixin previously provided a cached wrapper around an instance of BufferedProxy and added 2 convenience methods aliasing BufferedProxy methods.

### Main changes:
* Use of the`@cached` decorator to maintain parity with the previous version of `this.buffered` to make sure we only refresh the buffered proxy if the dependent property changes. 
  * _Not entirely sure if @cached + @dependentCompat is more performant than just using `@computed`_

* Use of the`@dependentCompat` decorator to ensure backwards compatibility of the getter with computed properties - we will leave refactoring of those somewhere down the road as that would greatly increase the scope of this PR

* `applyChanges` / `discardChanges` are the same as `applyBufferedChanges` / `discardBufferedChanges` for BufferedProxy
 