### PR TITLE
FIX: Stop non-rgb header background colors crashing DiscourseHub

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -441,9 +441,17 @@ export function prefersReducedMotion() {
 }
 
 export function postRNWebviewMessage(prop, value) {
-  if (window.ReactNativeWebView !== undefined) {
-    window.ReactNativeWebView.postMessage(JSON.stringify({ [prop]: value }));
+  if (window.ReactNativeWebView === undefined) {
+    return;
   }
+
+  if (prop === "headerBg" && !value.startsWith("rgb(")) {
+    // eslint-disable-next-line no-console
+    console.warn("Skipping unsupported headerBg value:", value);
+    return;
+  }
+
+  window.ReactNativeWebView.postMessage(JSON.stringify({ [prop]: value }));
 }
 
 function pickMarker(text) {


### PR DESCRIPTION
Ideally we would add support for color spaces like okclh to the app, or have some method for converting them to rgb automatically. But for now, this will stop the app crashing completely.