### PR TITLE
DEV: adds declarative options to object/container

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-new.gjs
@@ -275,7 +275,11 @@ export default class AdminConfigAreasApiKeysNew extends Component {
                       </tr>
                     </thead>
                     <tbody>
-                      <form.Object @name="scopes" as |scopesObject scopesData|>
+                      <form.Object
+                        @name="scopes"
+                        class="scopes-table__object"
+                        as |scopesObject scopesData|
+                      >
                         {{#each (this.scopesDataKeys scopesData) as |scopeKey|}}
                           <tr class="scope-resource-name">
                             <td><b>{{scopeKey}}</b></td>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/container.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/container.gjs
@@ -1,8 +1,16 @@
+import { concat } from "@ember/helper";
 import FormText from "discourse/form-kit/components/fk/text";
 import concatClass from "discourse/helpers/concat-class";
 
 const FKContainer = <template>
-  <div class={{concatClass "form-kit__container" @class}} ...attributes>
+  <div
+    class={{concatClass
+      "form-kit__container"
+      @class
+      (if @direction (concat "--" @direction))
+    }}
+    ...attributes
+  >
     {{#if @title}}
       <span class="form-kit__container-title">
         {{@title}}
@@ -13,7 +21,12 @@ const FKContainer = <template>
       <FormText class="form-kit__container-subtitle">{{@subtitle}}</FormText>
     {{/if}}
 
-    <div class="form-kit__container-content">
+    <div
+      class={{concatClass
+        "form-kit__container-content"
+        (if @format (concat "--" @format))
+      }}
+    >
       {{yield}}
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/object.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/object.gjs
@@ -17,7 +17,7 @@ export default class FKObject extends Component {
   }
 
   <template>
-    <div class="form-kit__object">
+    <div class="form-kit__object" ...attributes>
       {{yield
         (hash
           Field=(component

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/container-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/container-test.gjs
@@ -49,5 +49,31 @@ module(
         .dom(".form-kit__container .form-kit__container-subtitle")
         .hasText("Subtitle");
     });
+
+    test("@format", async function (assert) {
+      await render(
+        <template>
+          <Form as |form|>
+            <form.Container @format="large">Test</form.Container>
+          </Form>
+        </template>
+      );
+
+      assert
+        .dom(".form-kit__container .form-kit__container-content.--large")
+        .exists();
+    });
+
+    test("@direction", async function (assert) {
+      await render(
+        <template>
+          <Form as |form|>
+            <form.Container @direction="column">Test</form.Container>
+          </Form>
+        </template>
+      );
+
+      assert.dom(".form-kit__container.--column").exists();
+    });
   }
 );

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/object-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/object-test.gjs
@@ -28,6 +28,18 @@ module("Integration | Component | FormKit | Object", function (hooks) {
     assert.form().field("foo.baz").hasValue("2");
   });
 
+  test("...attributes", async function (assert) {
+    await render(
+      <template>
+        <Form as |form|>
+          <form.Object class="test" />
+        </Form>
+      </template>
+    );
+
+    assert.dom(".form-kit__object.test").exists();
+  });
+
   test("nested object", async function (assert) {
     await render(
       <template>

--- a/app/assets/stylesheets/admin/api.scss
+++ b/app/assets/stylesheets/admin/api.scss
@@ -28,6 +28,10 @@
     display: none;
   }
 
+  .scopes-table__object {
+    display: contents;
+  }
+
   .form-kit__collection {
     display: contents;
   }

--- a/app/assets/stylesheets/common/form-kit/_container.scss
+++ b/app/assets/stylesheets/common/form-kit/_container.scss
@@ -4,6 +4,12 @@
   flex-direction: column;
   align-items: flex-start;
 
+  &.--column {
+    .form-kit__container-content {
+      flex-direction: column;
+    }
+  }
+
   &-title {
     display: inline;
     gap: 0.25em;
@@ -36,5 +42,21 @@
     flex-direction: row;
     align-items: flex-start;
     max-width: 100%;
+
+    &.--small {
+      width: var(--form-kit-small-input) !important;
+    }
+
+    &.--medium {
+      width: var(--form-kit-medium-input);
+    }
+
+    &.--large {
+      width: var(--form-kit-large-input);
+    }
+
+    &.--full {
+      width: 100% !important;
+    }
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_object.scss
+++ b/app/assets/stylesheets/common/form-kit/_object.scss
@@ -1,3 +1,6 @@
 .form-kit__object {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  gap: var(--form-kit-gutter-y);
+  width: 100%;
 }


### PR DESCRIPTION
We often need to be able to change the format of a container and to change the flex-direction, this is now possible through two properties:

`<form.Container @format="large">`
`<form.Container @direction="column">`

On top of this `Object` has now a similar behavior to `Collection`. It will be displayed as flex, add gap between children and accepts `...attributes`.