### PR TITLE
FIX: tag revisions need an empty wrapper

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
@@ -100,19 +100,23 @@ export default class Revisions extends Component {
       {{/if}}
       {{#if @model.tags_changes}}
         <div class="row -tag-revisions">
-          {{discourseTags
-            this.fakePreviousTagsTopic
-            tagClasses=this.previousTagClassesMap
-          }}
+          <span class="tag-revision__wrapper">
+            {{discourseTags
+              this.fakePreviousTagsTopic
+              tagClasses=this.previousTagClassesMap
+            }}
+          </span>
 
           {{#if (or @mobileView (eq @viewMode "inline"))}}
             &rarr;&nbsp;
           {{/if}}
 
-          {{discourseTags
-            this.fakeCurrentTagsTopic
-            tagClasses=this.currentTagClassesMap
-          }}
+          <span class="tag-revision__wrapper">
+            {{discourseTags
+              this.fakeCurrentTagsTopic
+              tagClasses=this.currentTagClassesMap
+            }}
+          </span>
         </div>
       {{/if}}
       {{#if @model.featured_link_changes}}

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -111,7 +111,7 @@
   }
 
   &:not(.--mode-inline) {
-    .-tag-revisions .discourse-tags {
+    .-tag-revisions .tag-revision__wrapper {
       flex: 0 1 50%;
       min-width: 0;
       align-self: start;


### PR DESCRIPTION
follow-up to b4f9626984667133a2a1f656109d154214dbe47a

the previous commit removed an intentionally empty wrapper, which aligned the diff when there's only an addition


Before (tag aligned to the left, associated with the wrong version):
![image](https://github.com/user-attachments/assets/cacf5fc0-8020-460b-a596-e65acab31c27)


After (tag aligned right, associated with the new revision):
![image](https://github.com/user-attachments/assets/3ea14fd1-d871-493b-acec-60ad8c3d530d)
