### PR TITLE
FEATURE: send email to deleted user

### DIFF
--- a/app/controllers/admin/email_templates_controller.rb
+++ b/app/controllers/admin/email_templates_controller.rb
@@ -80,6 +80,7 @@ class Admin::EmailTemplatesController < Admin::AdminController
       test_mailer
       unsubscribe_mailer
       user_notifications.account_created
+      user_notifications.account_deleted
       user_notifications.account_exists
       user_notifications.account_second_factor_disabled
       user_notifications.account_silenced

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -179,7 +179,9 @@ class UserNotifications < ActionMailer::Base
   end
 
   def account_deleted(email, reviewable)
-    post_action_type_id = reviewable.reviewable_scores.first.reviewable_score_type
+    post_action_type_id =
+      reviewable.reviewable_scores.first&.reviewable_score_type ||
+        PostActionTypeView.new.types[:spam]
     build_email(
       email,
       template: "user_notifications.account_deleted",

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -178,6 +178,15 @@ class UserNotifications < ActionMailer::Base
     end
   end
 
+  def account_deleted(email, reviewable)
+    post_action_type_id = reviewable.reviewable_scores.first.reviewable_score_type
+    build_email(
+      email,
+      template: "user_notifications.account_deleted",
+      flag_reason: I18n.t("flag_reasons.#{PostActionTypeView.new.types[post_action_type_id]}"),
+    )
+  end
+
   def account_suspended(user, opts = nil)
     opts ||= {}
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4318,6 +4318,18 @@ en:
 
         Reason - %{reason}
 
+    account_deleted:
+      title: "Account Deleted"
+      subject_template: "[%{email_prefix}] Your account has been deleted"
+      text_body_template: |
+        Hello,
+
+        This is an automated message from [%{site_name}](%{base_url}) to let you know that the user account associated with this email address has been deleted by a staff member.
+
+        %{flag_reason}
+
+        Please review our [community guidelines](%{base_url}/guidelines) for details.
+
     account_exists:
       title: "Account already exists"
       subject_template: "[%{email_prefix}] Account already exists"


### PR DESCRIPTION
When a user post is flag as spam and the moderator deletes the user, we should send email to the affected user.