### PR TITLE
FEATURE: allow adding members to new 1-1 DM channels

### DIFF
--- a/plugins/chat/app/services/chat/add_users_to_channel.rb
+++ b/plugins/chat/app/services/chat/add_users_to_channel.rb
@@ -57,8 +57,9 @@ module Chat
     end
 
     def can_add_users_to_channel(guardian:, channel:)
-      (guardian.user.admin? || channel.joined_by?(guardian.user)) &&
-        channel.direct_message_channel? && channel.chatable.group
+      return false if !guardian.user.admin? && !channel.joined_by?(guardian.user)
+
+      channel.direct_message_channel? && (channel.chatable.group || channel.messages_count == 0)
     end
 
     def fetch_target_users(params:, channel:)

--- a/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/routes/channel-info-members.gjs
@@ -142,6 +142,17 @@ export default class ChatRouteChannelInfoMembers extends Component {
     return MODES.add_members;
   }
 
+  get canAddMembers() {
+    if (!this.args.channel.isDirectMessageChannel) {
+      return false;
+    }
+
+    return (
+      this.args.channel.chatable.group ||
+      this.args.channel.messagesManager.messages.length === 0
+    );
+  }
+
   <template>
     <div class="c-routes --channel-info-members">
       {{#if this.site.mobileView}}
@@ -172,7 +183,7 @@ export default class ChatRouteChannelInfoMembers extends Component {
           />
 
           <ul class="c-channel-members__list" {{this.fill}}>
-            {{#if @channel.chatable.group}}
+            {{#if this.canAddMembers}}
               <li
                 class="c-channel-members__list-item -add-member"
                 role="button"

--- a/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe Chat::Api::ChannelsMembershipsController do
     end
 
     context "when users can't be added" do
-      before { channel_1.chatable.update(group: false) }
+      before do
+        channel_1.chatable.update(group: false)
+        channel_1.update(messages_count: 1)
+      end
 
       it "returns a 422" do
         post "/chat/api/channels/#{channel_1.id}/memberships",

--- a/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
@@ -114,8 +114,11 @@ RSpec.describe Chat::AddUsersToChannel do
       it { is_expected.to fail_a_policy(:can_add_users_to_channel) }
     end
 
-    context "when channel is not a group" do
-      before { direct_message.update!(group: false) }
+    context "when channel is not a group and has activity" do
+      before do
+        direct_message.update!(group: false)
+        channel.update!(messages_count: 1)
+      end
 
       it { is_expected.to fail_a_policy(:can_add_users_to_channel) }
     end

--- a/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
@@ -114,13 +114,19 @@ RSpec.describe Chat::AddUsersToChannel do
       it { is_expected.to fail_a_policy(:can_add_users_to_channel) }
     end
 
-    context "when channel is not a group and has activity" do
-      before do
-        direct_message.update!(group: false)
-        channel.update!(messages_count: 1)
+    context "when channel is not a group" do
+      before { direct_message.update!(group: false) }
+
+      it "allows adding members when there are no channel messages" do
+        expect { result }.to change { Chat::UserChatChannelMembership.count }.by(users.count + 1) # +1 for system user
+        expect(result).to be_a_success
       end
 
-      it { is_expected.to fail_a_policy(:can_add_users_to_channel) }
+      context "when there are messages in the channel" do
+        before { channel.update!(messages_count: 1) }
+
+        it { is_expected.to fail_a_policy(:can_add_users_to_channel) }
+      end
     end
 
     context "when channel is not a direct message channel" do

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -122,6 +122,42 @@ RSpec.describe "Channel - Info - Members page", type: :system do
     end
   end
 
+  context "when 1:1 DM channel" do
+    fab!(:channel_1) do
+      Fabricate(
+        :direct_message_channel,
+        slug: "test-channel",
+        users: [current_user, Fabricate(:user)],
+        group: false,
+      )
+    end
+
+    it "allows to add members when there are no channel messages" do
+      new_user = Fabricate(:user)
+
+      chat_page.visit_channel_members(channel_1)
+      expect(chat_page).to have_add_member_button
+
+      chat_page.find(".c-channel-members__list-item.-add-member").click
+      chat_page.find(".chat-message-creator__members-input").fill_in(with: new_user.username)
+      chat_page.find(".chat-message-creator__list-item").click
+      chat_page.find(".add-to-channel").click
+
+      expect(chat_page).to have_current_path("/chat/c/#{channel_1.slug}/#{channel_1.id}")
+      expect(chat_page).to have_content(
+        I18n.t(
+          "chat.channel.users_invited_to_channel",
+          invited_users: "@#{new_user.username}",
+          inviting_user: "@#{current_user.username}",
+          count: 1,
+        ),
+      )
+
+      chat_page.visit_channel_members(channel_1)
+      expect(chat_page).to have_no_add_member_button
+    end
+  end
+
   describe "removing members" do
     fab!(:current_user) { Fabricate(:admin) }
 

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -138,6 +138,14 @@ module PageObjects
         has_css?(".direct-message-channels-section")
       end
 
+      def has_add_member_button?
+        has_css?(".c-channel-members__list-item.-add-member")
+      end
+
+      def has_no_add_member_button?
+        has_no_css?(".c-channel-members__list-item.-add-member")
+      end
+
       private
 
       def drawer?(expectation:, channel_id: nil, expanded: true)


### PR DESCRIPTION
This change allows more flexibility when starting a 1-1 direct message with another user. If there are no messages in the new DM channel then we should still allow them to add additional users.

Internal ref: /t/148525