### PR TITLE
FIX: redirect user activity drafts route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
@@ -4,6 +4,7 @@ import { i18n } from "discourse-i18n";
 
 export default class UserActivityDrafts extends DiscourseRoute {
   @service router;
+  @service currentUser;
 
   templateName = "user/stream";
 

--- a/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
@@ -1,8 +1,20 @@
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
 export default class UserActivityDrafts extends DiscourseRoute {
+  @service router;
+
   templateName = "user/stream";
+
+  beforeModel() {
+    if (!this.currentUser) {
+      return this.router.transitionTo("discovery.latest");
+    }
+    if (!this.isCurrentUser(this.modelFor("user"))) {
+      return this.router.transitionTo("userActivity.drafts", this.currentUser);
+    }
+  }
 
   async model() {
     const user = this.modelFor("user");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-drafts-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "../helpers/qunit-helpers";
 
@@ -16,5 +16,26 @@ acceptance("User Activity / Drafts - empty state", function (needs) {
   test("It renders the empty state panel", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
     assert.dom("div.empty-state").exists();
+  });
+});
+
+acceptance("User Activity / Drafts - visiting another user", function (needs) {
+  const currentUser = "eviltrout";
+  const anotherUser = "charlie";
+
+  needs.user();
+
+  test("redirects to the current user drafts page", async function (assert) {
+    await visit(`/u/${anotherUser}/activity/drafts`);
+
+    assert.strictEqual(currentURL(), `/u/${currentUser}/activity/drafts`);
+  });
+});
+
+acceptance("User Activity / Drafts - not signed in", function () {
+  test("redirects to the login page", async function (assert) {
+    await visit("/u/eviltrout/activity/drafts");
+
+    assert.strictEqual(currentURL(), "/latest");
   });
 });


### PR DESCRIPTION
When logged in and visiting another user's drafts page, we should redirect back to the current user drafts page.

For non auth users, we can redirect back to the forum `/latest` page.

Internal ref: /t/150250