### PR TITLE
UX: reposition chat header icon

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -167,7 +167,8 @@ class ChatSetupInit {
 
       if (this.chatService.userCanChat) {
         api.headerIcons.add("chat", ChatHeaderIcon, {
-          before: "interface-color-selector",
+          after: "search",
+          before: "user-menu",
         });
       }
 


### PR DESCRIPTION
With header search we toggle the search icon when scrolling on topics, which can feel visually jarring when the search icon is in the middle.

Switching the position of the chat icon in the header reduces the impact of this.

Before:
<img width="154" alt="Screenshot 2025-03-26 at 10 34 53 AM" src="https://github.com/user-attachments/assets/f6983e4a-219e-4815-9263-d275f30f6b7d" />


After:
<img width="161" alt="Screenshot 2025-03-26 at 10 35 49 AM" src="https://github.com/user-attachments/assets/2dc109bd-9918-4ec4-9611-2476636a4efb" />

Internal ref: /t/150026/46