### PR TITLE
UX: Add missing border-radius variable

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -89,6 +89,7 @@ $search-pad-horizontal: 0.5em;
     display: flex;
     flex-direction: column;
     padding-top: $search-pad-vertical;
+    border-radius: var(--d-border-radius);
 
     .list {
       min-width: 100px;


### PR DESCRIPTION
The search result panel didn't have the new-ish border-radius variable attached yet.