### PR TITLE
FIX: Make dark mobile logo fallback to dark desktop logo

### DIFF
--- a/lib/site_icon_manager.rb
+++ b/lib/site_icon_manager.rb
@@ -22,6 +22,13 @@ module SiteIconManager
       fallback_to_sketch: false,
       resize_required: false,
     },
+    mobile_logo_dark: {
+      width: nil,
+      height: nil,
+      settings: %i[mobile_logo_dark logo_dark],
+      fallback_to_sketch: false,
+      resize_required: false,
+    },
     large_icon: {
       width: nil,
       height: nil,

--- a/spec/lib/site_icon_manager_spec.rb
+++ b/spec/lib/site_icon_manager_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
-class GlobalPathInstance
-  extend GlobalPath
-end
-
 RSpec.describe SiteIconManager do
+  fab!(:mobile_logo_image) { Fabricate(:image_upload, color: "black", width: 400, height: 120) }
+  fab!(:mobile_logo_dark_image) do
+    Fabricate(:image_upload, color: "white", width: 400, height: 120)
+  end
+
+  fab!(:logo_image) { Fabricate(:image_upload, color: "black", width: 600, height: 80) }
+  fab!(:logo_dark_image) { Fabricate(:image_upload, color: "white", width: 600, height: 80) }
+
   before { SiteIconManager.enable }
 
   let(:upload) do
@@ -41,6 +45,42 @@ RSpec.describe SiteIconManager do
 
     # Site Setting integration
     expect(SiteSetting.manifest_icon).to eq(nil)
-    expect(SiteSetting.site_manifest_icon_url).to eq(GlobalPathInstance.full_cdn_url(manifest.url))
+    expect(SiteSetting.site_manifest_icon_url).to eq(GlobalPath.full_cdn_url(manifest.url))
+  end
+
+  describe ".mobile_logo_url" do
+    before do
+      SiteSetting.logo = logo_image
+      SiteSetting.mobile_logo = mobile_logo_image
+    end
+
+    it "returns the upload URL for the mobile_logo site setting" do
+      expect(SiteIconManager.mobile_logo_url).to eq(GlobalPath.full_cdn_url(mobile_logo_image.url))
+    end
+
+    it "returns the upload URL for the logo site setting when the mobile_logo setting isn't set" do
+      SiteSetting.mobile_logo = nil
+      expect(SiteIconManager.mobile_logo_url).to eq(GlobalPath.full_cdn_url(logo_image.url))
+    end
+  end
+
+  describe ".mobile_logo_dark_url" do
+    before do
+      SiteSetting.logo_dark = logo_dark_image
+      SiteSetting.mobile_logo_dark = mobile_logo_dark_image
+    end
+
+    it "returns the upload URL for the mobile_logo_dark site setting" do
+      expect(SiteIconManager.mobile_logo_dark_url).to eq(
+        GlobalPath.full_cdn_url(mobile_logo_dark_image.url),
+      )
+    end
+
+    it "returns the upload URL for the logo_dark site setting when the mobile_logo_dark setting isn't set" do
+      SiteSetting.mobile_logo_dark = nil
+      expect(SiteIconManager.mobile_logo_dark_url).to eq(
+        GlobalPath.full_cdn_url(logo_dark_image.url),
+      )
+    end
   end
 end


### PR DESCRIPTION
Currently, the light version of mobile logo falls back to the desktop version if the mobile version isn't set. It makes sense to have the same fallback rule for the dark version as well, i.e. if there's no dark mobile logo, use the dark desktop logo.

Internal topic: t/150316.