### PR TITLE
DEV: Allow loading topic associations on /categories

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -106,7 +106,10 @@ class CategoryList
           )
     end
 
-    @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user).includes(:last_poster)
+    inclusions = [:last_poster]
+    preload = DiscoursePluginRegistry.category_list_topics_preloader_associations
+    inclusions.concat(preload) if preload.present?
+    @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user).includes(inclusions)
   end
 
   def find_relevant_topics

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -91,6 +91,7 @@ class DiscoursePluginRegistry
 
   define_filtered_register :topic_thumbnail_sizes
   define_filtered_register :topic_preloader_associations
+  define_filtered_register :category_list_topics_preloader_associations
 
   define_filtered_register :api_parameter_routes
   define_filtered_register :api_key_scope_mappings

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1442,6 +1442,12 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
   end
 
+  # When loading /categories with topics, preload topic associations
+  # using register_category_list_topics_preloader_associations(:association_name)
+  def register_category_list_topics_preloader_associations(fields)
+    DiscoursePluginRegistry.register_category_list_topics_preloader_association(fields, self)
+  end
+
   private
 
   def setting_category


### PR DESCRIPTION
`/categories` sometimes returns accompanying topics under certain site settings. The `CategoryList` currently allows preloading for topic custom fields via `preloaded_topic_custom_fields`, but not for topics themselves.

This addition is required for https://github.com/discourse/discourse-solved/pull/342.