### PR TITLE
PERF: Skip lazy-loading images in composer preview

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -5,9 +5,13 @@ function isLoaded(img) {
 }
 
 export function nativeLazyLoading(api) {
-  api.decorateCookedElement((post) =>
-    post.querySelectorAll("img").forEach((img) => (img.loading = "lazy"))
-  );
+  api.decorateCookedElement((element, helper) => {
+    if (helper.getModel()) {
+      // We only want to lazy load images in the post-stream, not the composer
+      // (Safari in particular is very bad at re-rendering lazy-loaded images smoothly)
+      element.querySelectorAll("img").forEach((img) => (img.loading = "lazy"));
+    }
+  });
 
   api.decorateCookedElement(
     (post) => {


### PR DESCRIPTION
Safari does not reload lazy images smoothly, which causes a lot of flickering in the composer preview while typing.