### PR TITLE
DEV: skip watch word when message is created by bots

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -118,7 +118,7 @@ module Chat
 
     validate :validate_message
     def validate_message
-      WatchedWordsValidator.new(attributes: [:message]).validate(self)
+      WatchedWordsValidator.new(attributes: [:message]).validate(self) if !user&.bot?
 
       if self.new_record? || self.changed.include?("message")
         Chat::DuplicateMessageValidator.new(self).validate

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -131,6 +131,36 @@ describe Chat::Message do
         )
       end
     end
+
+    context "with watched words" do
+      fab!(:watched_word) do
+        Fabricate(:watched_word, word: "badword", action: WatchedWord.actions[:block])
+      end
+
+      let(:text) { "this message contains badword and should be blocked" }
+
+      it "validates watched words for regular users" do
+        regular_user = Fabricate(:user)
+        message =
+          Chat::Message.new(
+            chat_channel: Fabricate(:chat_channel),
+            user: regular_user,
+            message: text,
+          )
+
+        expect(message).not_to be_valid
+      end
+
+      it "skips watched words validation for bot users" do
+        bot_user = Fabricate(:user, id: -999)
+        message =
+          Chat::Message.new(chat_channel: Fabricate(:chat_channel), user: bot_user, message: text)
+
+        message.validate_message
+
+        expect(message).to be_valid
+      end
+    end
   end
 
   describe ".in_thread?" do

--- a/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
@@ -48,18 +48,6 @@ RSpec.describe Chat::IncomingWebhooksController do
       expect(chat_webhook_event.chat_message_id).to eq(Chat::Message.last.id)
     end
 
-    it "handles create message failures gracefully and does not create the chat message" do
-      watched_word = Fabricate(:watched_word, action: WatchedWord.actions[:block])
-
-      expect {
-        post "/chat/hooks/#{webhook.key}.json", params: { text: "hey #{watched_word.word}" }
-      }.not_to change { Chat::Message.where(chat_channel: chat_channel).count }
-      expect(response.status).to eq(422)
-      expect(response.parsed_body["errors"]).to include(
-        "Sorry, you can't post the word '#{watched_word.word}'; it's not allowed.",
-      )
-    end
-
     it "handles create message failures gracefully if the channel is read only" do
       chat_channel.update!(status: :read_only)
       expect {


### PR DESCRIPTION
Especially with AI we have no exact control on the words and this could create and endless loop of errors.