### PR TITLE
DEV: Remove span tag from outlet

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/dashboard.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.hbs
@@ -1,6 +1,4 @@
-<span>
-  <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
-</span>
+<PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
 
 <DPageHeader @hideTabs={{true}}>
   <:breadcrumbs>


### PR DESCRIPTION
This PR removes the span wrapper from the admin dashboard plugin outlet.