### PR TITLE
DEV: Change device-screenshots stub job condition

### DIFF
--- a/.github/workflows/device-screenshots.yml
+++ b/.github/workflows/device-screenshots.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sanitize:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'thenonexistentguy'
+    if: github.event_name == "noop"
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Followup https://github.com/discourse/discourse/commit/0af0087c77a46f92662b5072190aa3823638d6f0

Change the condition so it doesn't rely on a user,
all we want is a noop here and people could register this user.

This job is just a stub anyway at this point, so not too
dangerous.
