### PR TITLE
UX: Adjust code editor height when maximized

### DIFF
--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -112,6 +112,8 @@
     background-color: var(--tertiary-low);
     padding: 10px;
     margin: 10px 0;
+    white-space: nowrap;
+    overflow-x: auto;
   }
 
   .admin-container {
@@ -632,7 +634,11 @@
     }
 
     .ace-wrapper {
-      height: calc(100vh - 200px);
+      height: calc(100vh - 270px);
+    }
+
+    .edit-main-nav ~ .ace-wrapper {
+      height: calc(100vh - 315px);
     }
 
     .wrapper {


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/issue-with-custom-css-save-button-on-smaller-screens/358505

With the editor maximized, this PR adjusts the height by considering the new info banner (#31561) and the navbar with `Show advanced` enabled (even without banner, the height needed adjustments).

The info banner is forced to scroll to contain the height, especially on mobile.

Before:
![IiOWqPj3eO](https://github.com/user-attachments/assets/723aee77-d10b-4ec6-87e1-95984039b6a0)
![KmJA54V2H8](https://github.com/user-attachments/assets/568dc6ad-3dba-4829-87c9-0283bd685862)

After:
![d3GlykKDLE](https://github.com/user-attachments/assets/3955a094-91f7-4a11-a463-567e6f168897)
![cwzKPVc294](https://github.com/user-attachments/assets/b23fa5a6-97d1-468a-8f4a-e0bbb03b8a87)
