### PR TITLE
DEV: Split 2fa logic from account activation

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -160,7 +160,10 @@ class Users::OmniauthCallbacksController < ApplicationController
       @auth_result.email = user.email
       return
     end
+    handle_account_activation(user)
+  end
 
+  def handle_account_activation(user)
     # automatically activate any account if a provider marked the email valid
     if @auth_result.email_valid && @auth_result.email == user.email
       if !user.active || !user.email_confirmed?


### PR DESCRIPTION
- This change separates the logic that handles 2fa flow, from the one that deals with the user after it is authenticated.