### PR TITLE
UX: improve nav fade css

### DIFF
--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -78,6 +78,11 @@
     }
   }
 
+  [class*="horizontal-overflow-nav__scroll-"] {
+    --fade-color: var(--d-content-background, var(--secondary));
+    background-color: var(--d-content-background, var(--secondary));
+  }
+
   .user-navigation-secondary {
     position: relative;
     display: flex;

--- a/app/assets/stylesheets/common/components/horizontal-overflow-nav.scss
+++ b/app/assets/stylesheets/common/components/horizontal-overflow-nav.scss
@@ -31,7 +31,7 @@
 .horizontal-overflow-nav__scroll-right,
 .horizontal-overflow-nav__scroll-left {
   --fade-width: 1.5em;
-  --fade-color: var(--secondary-rgb); // must be RGB for gradient
+  --fade-color: var(--secondary);
   opacity: 1;
   position: absolute;
   z-index: 2;
@@ -63,11 +63,7 @@
     margin-left: calc(var(--fade-width) * -1);
     height: 100%;
     width: var(--fade-width);
-    background: linear-gradient(
-      to left,
-      rgba(var(--fade-color), 1),
-      rgba(var(--fade-color), 0)
-    );
+    background: linear-gradient(to left, var(--fade-color), transparent);
   }
 }
 
@@ -79,10 +75,6 @@
     margin-right: calc(var(--fade-width) * -1);
     height: 100%;
     width: var(--fade-width);
-    background: linear-gradient(
-      to right,
-      rgba(var(--fade-color), 1),
-      rgba(var(--fade-color), 0)
-    );
+    background: linear-gradient(to right, var(--fade-color), transparent);
   }
 }


### PR DESCRIPTION
Concerns this little fading scroll affordance in the horizontal overflow nav: 

![image](https://github.com/user-attachments/assets/3d59896c-faf4-4550-9fcb-62ce4e31cecd)

The parent container of the user nav has an optional `--d-content-background` variable applied, and adding this for the nav means that if a theme author uses `--d-content-background` the nav will match automatically. When `--d-content-background` is not set, we fall back to `--secondary` which is the default background. 

I also realized that we don't need RGB values here since we're simply fading from a solid color to transparent. 