### PR TITLE
DEV: apply pm border radius to topic map

### DIFF
--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -74,6 +74,14 @@
       border: none;
       background: var(--primary-very-low);
       padding-inline: var(--pm-padding);
+
+      &:first-of-type {
+        border-radius: var(--pm-border-radius) var(--pm-border-radius) 0 0;
+      }
+
+      &:last-of-type {
+        border-radius: 0 0 var(--pm-border-radius) var(--pm-border-radius);
+      }
     }
 
     .map {


### PR DESCRIPTION
This applies the pm border radius (optional theme variable) to the pm topic map as well 

before:

![image](https://github.com/user-attachments/assets/b62b8791-b8d7-49c5-b4f8-03614b7187dc)


after: 

![image](https://github.com/user-attachments/assets/0d0dcf62-f43a-4409-8504-9ecc937775c6)
