### PR TITLE
UX: adjust border radius for reply-where buttons

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -265,6 +265,7 @@
     margin-right: 0;
     overflow: hidden;
     width: 100%;
+    border-radius: var(--d-border-radius);
 
     &.dialog-close {
       display: none;


### PR DESCRIPTION
These are *technically* buttons, but are much larger and have multi-line content, so if you apply a border-radius via `--d-button-border-radius` that tries to make rounded buttons... it doesn't work great here. 

A case where normal buttons are fine (6rem radius) 

![image](https://github.com/user-attachments/assets/914170c3-3751-4939-841a-24e6a445cbb5)

but these big buttons have too much content to pull it off well, the same border radius is too extreme

![image](https://github.com/user-attachments/assets/e00d076d-c555-42c1-9b15-0fa462bc5eaa)

the border radius variable we have for more general content areas (`--d-border-radius`) generally doesn't work with a fully round radius, so it should work better here most of the time: 

![image](https://github.com/user-attachments/assets/9b2f509d-d0ef-46d9-898a-9b4bdf34f1a2)

