### PR TITLE
UX: Set a delay after confirming 2FA token before redirecting

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/second-factor-auth.js
+++ b/app/assets/javascripts/discourse/app/controllers/second-factor-auth.js
@@ -175,43 +175,39 @@ export default class SecondFactorAuthController extends Controller {
     this.set("messageIsError", false);
   }
 
-  verifySecondFactor(data) {
+  async verifySecondFactor(data) {
     this.set("isLoading", true);
 
-    return ajax("/session/2fa", {
-      type: "POST",
-      data: {
-        ...data,
-        second_factor_method: this.shownSecondFactorMethod,
-        nonce: this.nonce,
-      },
-    })
-      .then((response) => {
-        this.displaySuccess(i18n("second_factor_auth.redirect_after_success"));
-
-        return ajax(response.callback_path, {
-          type: response.callback_method,
-          data: {
-            second_factor_nonce: this.nonce,
-            ...response.callback_params,
-          },
-        })
-          .then((callbackResponse) => {
-            const redirectUrl =
-              callbackResponse.redirect_url || response.redirect_url;
-            return DiscourseURL.routeTo(redirectUrl);
-          })
-          .catch((error) => this.displayError(extractError(error)))
-          .finally(() => {
-            this.set("isLoading", false);
-          });
-      })
-      .catch((error) => {
-        this.displayError(extractError(error));
-      })
-      .finally(() => {
-        this.set("isLoading", false);
+    try {
+      const response = await ajax("/session/2fa", {
+        type: "POST",
+        data: {
+          ...data,
+          second_factor_method: this.shownSecondFactorMethod,
+          nonce: this.nonce,
+        },
       });
+
+      const callbackResponse = await ajax(response.callback_path, {
+        type: response.callback_method,
+        data: {
+          second_factor_nonce: this.nonce,
+          ...response.callback_params,
+        },
+      });
+
+      this.displaySuccess(i18n("second_factor_auth.redirect_after_success"));
+
+      setTimeout(() => {
+        DiscourseURL.routeTo(
+          callbackResponse.redirect_url || response.redirect_url
+        );
+      }, 2500);
+    } catch (error) {
+      this.displayError(extractError(error));
+    } finally {
+      this.set("isLoading", false);
+    }
   }
 
   @action

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -64,11 +64,12 @@ describe "Changing email", type: :system do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]").click
 
+    expect(page).to have_content(I18n.t("js.second_factor_auth.redirect_after_success"))
     expect(page).to have_current_path("/u/#{user.username}/preferences/account")
     expect(user_preferences_page).to have_primary_email(new_email)
   end
 
-  xit "works when user has webauthn 2fa" do
+  it "works when user has webauthn 2fa" do
     # enforced 2FA flow needs a user created > 5 minutes ago
     user.created_at = 6.minutes.ago
     user.save!
@@ -107,7 +108,7 @@ describe "Changing email", type: :system do
     authenticator&.remove!
   end
 
-  xit "does not require login to verify" do
+  it "does not require login to verify" do
     second_factor = Fabricate(:user_second_factor_totp, user: user)
     sign_in user
 
@@ -121,6 +122,7 @@ describe "Changing email", type: :system do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]:not([disabled])").click
 
+    expect(page).to have_content(I18n.t("js.second_factor_auth.redirect_after_success"))
     expect(page).to have_current_path("/latest")
     expect(user.reload.email).to eq(new_email)
   end


### PR DESCRIPTION
Before this commit, the user was redirected immediately after confirming
their 2FA token. This means that the success message may not have been
seen by the user completely before the transition happens. This is
alittle adrupt so we want to introduce some delay for the success
message to be shown and read before redirecting.
