### PR TITLE
DEV: Move setting deprecation check to SiteSetting::Update service

### DIFF
--- a/app/controllers/admin/config/about_controller.rb
+++ b/app/controllers/admin/config/about_controller.rb
@@ -51,6 +51,9 @@ class Admin::Config::AboutController < Admin::AdminController
       },
     ) do
       on_success { render json: success_json }
+      on_failed_policy(:settings_are_not_deprecated) do |policy|
+        raise Discourse::InvalidParameters, policy.reason
+      end
       on_failed_policy(:settings_are_visible) do |policy|
         raise Discourse::InvalidParameters, policy.reason
       end

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -21,25 +21,10 @@ class Admin::SiteSettingsController < Admin::AdminController
     params.require(:id)
     id = params[:id]
     update_existing_users = params[:update_existing_user].present?
-    value = params[id]
-
-    new_setting_name =
-      SiteSettings::DeprecatedSettings::SETTINGS.find do |old_name, new_name, override, _|
-        if old_name == id
-          if !override
-            raise Discourse::InvalidParameters,
-                  "You cannot change this site setting because it is deprecated, use #{new_name} instead."
-          end
-
-          break new_name
-        end
-      end
-
-    id = new_setting_name if new_setting_name
 
     previous_value = value_or_default(SiteSetting.get(id)) if update_existing_users
 
-    SiteSetting::Update.call(params: { settings: { id => value } }, guardian:) do
+    SiteSetting::Update.call(params: { settings: { id => params[id] } }, guardian:) do
       on_success do |params:|
         if update_existing_users
           params.settings.to_a.each do |setting_name, setting_value|
@@ -47,6 +32,9 @@ class Admin::SiteSettingsController < Admin::AdminController
           end
         end
         render body: nil
+      end
+      on_failed_policy(:settings_are_not_deprecated) do |policy|
+        raise Discourse::InvalidParameters, policy.reason
       end
       on_failed_policy(:settings_are_visible) do |policy|
         raise Discourse::InvalidParameters, policy.reason

--- a/app/services/site_setting/policy/settings_are_not_deprecated.rb
+++ b/app/services/site_setting/policy/settings_are_not_deprecated.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SiteSetting::Policy::SettingsAreNotDeprecated < Service::PolicyBase
+  delegate :options, :params, to: :context
+
+  def call
+    params.settings.keys.each do |id|
+      SiteSettings::DeprecatedSettings::SETTINGS.find do |old_name, new_name, override, _|
+        if old_name.to_sym == id
+          if override
+            options.overridden_setting_names[old_name.to_sym] = new_name
+            break
+          else
+            @old_name = old_name
+            @new_name = new_name
+            return false
+          end
+        end
+      end
+    end
+
+    true
+  end
+
+  def reason
+    I18n.t(
+      "errors.site_settings.site_settings_are_deprecated",
+      old_name: @old_name,
+      new_name: @new_name,
+    )
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -341,7 +341,7 @@ en:
     site_settings:
       invalid_site_setting: "No setting named '%{name}' exists"
       invalid_category_id: "You specified a category that does not exist"
-      site_settings_are_deprecated: "You cannot change %{old_name} because it is deprecated, use %{new_name} instead"
+      site_settings_are_deprecated: "The following settings are deprecated: %{old_names}. Use %{new_names} instead"
       site_settings_are_hidden: "You are not allowed to change hidden settings: %{setting_names}"
       site_settings_are_shadowed_globally: "You cannot change those settings because they are globally configured: %{setting_names}"
       site_settings_are_unconfigurable: "You are not allowed to change unconfigurable settings: %{setting_names}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -341,6 +341,7 @@ en:
     site_settings:
       invalid_site_setting: "No setting named '%{name}' exists"
       invalid_category_id: "You specified a category that does not exist"
+      site_settings_are_deprecated: "You cannot change %{old_name} because it is deprecated, use %{new_name} instead"
       site_settings_are_hidden: "You are not allowed to change hidden settings: %{setting_names}"
       site_settings_are_shadowed_globally: "You cannot change those settings because they are globally configured: %{setting_names}"
       site_settings_are_unconfigurable: "You are not allowed to change unconfigurable settings: %{setting_names}"

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -235,7 +235,18 @@ RSpec.describe Admin::SiteSettingsController do
         expect(SiteSetting.title).to eq("hello")
       end
 
-      it "works for deprecated settings" do
+      it "throws an error for hard deprecated settings" do
+        stub_deprecated_settings!(override: false) do
+          put "/admin/site_settings/old_one.json", params: { old_one: true }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            "You cannot change old_one because it is deprecated, use new_one instead",
+          )
+        end
+      end
+
+      it "works for soft deprecated settings" do
         stub_deprecated_settings!(override: true) do
           put "/admin/site_settings/old_one.json", params: { old_one: true }
 

--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Admin::SiteSettingsController do
 
           expect(response.status).to eq(422)
           expect(response.parsed_body["errors"]).to contain_exactly(
-            "You cannot change old_one because it is deprecated, use new_one instead",
+            "The following settings are deprecated: old_one. Use new_one instead",
           )
         end
       end


### PR DESCRIPTION
### What is this change?

This PR moves the logic that checks if a site setting we're trying to update has been deprecated from one of the controllers into a policy of the `SiteSetting::Update` service.

It also gives us the opportunity to shift the error message into a locale file.