### PR TITLE
DEV: add plugin outlet to desktop & mobile Topic List Item after badges

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -344,6 +344,10 @@ export default class Item extends Component {
                       class="badge-notification new-topic"
                     ></span></span>
                 {{~/if~}}
+                <PluginOutlet
+                  @name="topic-list-after-badges"
+                  @outletArgs={{hash topic=@topic}}
+                />
                 {{~#if this.expandPinned~}}
                   <TopicExcerpt @topic={{@topic}} />
                 {{~/if~}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
@@ -93,6 +93,10 @@ export default class TopicCell extends Component {
               @url={{@topic.lastUnreadUrl}}
             />
           {{~/if~}}
+          <PluginOutlet
+            @name="topic-list-after-badges"
+            @outletArgs={{hash topic=@topic}}
+          />
         </PluginOutlet>
       </span>
 


### PR DESCRIPTION
There is no current plugin outlet on the Topic List which allows one attach additional UI after the title without messing up the badge display.

We can’t use `topic-list-after-title` because that will render before the badge which looks untid:


![](https://d11a6trkgmumsb.cloudfront.net/original/4X/b/2/9/b29d5add404ea9c91f533acab580abb0fc7f3041.png)

... and we can’t use`topic-list-before-category` because that’s not always rendered when we drill into a Category.

The solution is a new plugin outlet located after the badge is rendered.  This needs to be on both the desktop and mobile flavours.

See discussion here: https://meta.discourse.org/t/locations-plugin/69742/1144?u=merefield