### PR TITLE
DEV: exposes parentName and name in onSet

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/field-data.gjs
@@ -68,6 +68,8 @@ export default class FKFieldData extends Component {
     if (this.args.onSet) {
       await this.args.onSet(value, {
         set: this.args.set,
+        name: this.name,
+        parentName: this.args.parentName,
         index: this.args.collectionIndex,
       });
     } else {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -288,22 +288,27 @@ module("Integration | Component | FormKit | Field", function (hooks) {
   test("@onSet", async function (assert) {
     const onSetWasCalled = assert.async();
 
-    const onSet = async (value, { set }) => {
-      assert.form().field("foo").hasValue("bar");
+    const onSet = async (value, { name, parentName, set }) => {
+      assert.deepEqual(name, "something.foo");
+      assert.deepEqual(parentName, "something");
 
-      await set("foo", "baz");
+      assert.form().field("something.foo").hasValue("bar");
+
+      await set("something.foo", "baz");
       await settled();
 
-      assert.form().field("foo").hasValue("baz");
+      assert.form().field("something.foo").hasValue("baz");
       onSetWasCalled();
     };
 
     await render(
       <template>
-        <Form as |form|>
-          <form.Field @name="foo" @title="Foo" @onSet={{onSet}} as |field|>
-            <field.Input />
-          </form.Field>
+        <Form @data={{hash something=(hash foo=1)}} as |form|>
+          <form.Object @name="something" as |object|>
+            <object.Field @name="foo" @title="Foo" @onSet={{onSet}} as |field|>
+              <field.Input />
+            </object.Field>
+          </form.Object>
         </Form>
       </template>
     );


### PR DESCRIPTION
This allows more flexibility for custom behaviours.

Example usage:

```gjs
@action
onSet(value, { set, name }) {
  set(name + ".0.baz", value * 2)
}

<form.Object @name="something" as |object|>
  <object.Field @name="foo" @title="Foo" @onSet={{onSet}} as |field|>
    <field.Input />
  </object.Field>
</form.Object>
```