### PR TITLE
DEV: remove list-controls wrapper on tags index

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.gjs
@@ -15,13 +15,11 @@ export default RouteTemplate(
 
     <div class="container tags-index">
 
-      <div class="list-controls">
-        <div class="container tags-controls">
-          {{#if @controller.canAdminTags}}
-            <TagsAdminDropdown @actionsMapping={{@controller.actionsMapping}} />
-          {{/if}}
-          <h2>{{i18n "tagging.tags"}}</h2>
-        </div>
+      <div class="container tags-controls">
+        {{#if @controller.canAdminTags}}
+          <TagsAdminDropdown @actionsMapping={{@controller.actionsMapping}} />
+        {{/if}}
+        <h2>{{i18n "tagging.tags"}}</h2>
       </div>
 
       <div>


### PR DESCRIPTION
This `.list-controls` wrapper on the tags index has no specific styles applied, and can easily pick up styles of the actual `.list-controls` container on topic lists when the class is used in themes... so it's more harmful than helpful (it's also not a list?).

Before:
![image](https://github.com/user-attachments/assets/ac32d4b2-e0be-422e-90f4-d4066304eb00)
![image](https://github.com/user-attachments/assets/4157d7d8-b4f1-4bde-acde-f08f544a23ea)


After (no visual changes):
![image](https://github.com/user-attachments/assets/7cbc9ce3-82b7-46c7-9c47-3b4086f84bae)
![image](https://github.com/user-attachments/assets/ec040df8-8b99-4c6b-95ff-01319c194931)



