### PR TITLE
DEV: Fix flaky search system tests

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -216,4 +216,8 @@ module SystemHelpers
   def click_logo
     PageObjects::Components::Logo.click
   end
+
+  def is_mobile?
+    !!RSpec.current_example.metadata[:mobile]
+  end
 end

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -22,8 +22,12 @@ module PageObjects
         self
       end
 
-      def heading_text
-        find("h1.search-page-heading").text
+      def has_heading_text?(text)
+        has_selector?("h1.search-page-heading", text: text)
+      end
+
+      def has_no_heading_text?(text)
+        has_no_selector?("h1.search-page-heading", text: text)
       end
 
       def click_search_button
@@ -32,6 +36,8 @@ module PageObjects
 
       def click_search_icon
         find(".d-header #search-button").click
+        has_css?(is_mobile? ? ".search-container" : ".search-menu-container")
+        self
       end
 
       def click_in_posts_by_user

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -26,7 +26,7 @@ describe "Search", type: :system do
       search_page.click_search_button
 
       expect(search_page).to have_search_result
-      expect(search_page.heading_text).not_to eq("Search")
+      expect(search_page).to have_no_heading_text("Search")
 
       click_logo
       expect(search_page).to be_not_active
@@ -39,7 +39,7 @@ describe "Search", type: :system do
       search_page.click_search_icon
 
       expect(search_page).to have_no_search_result
-      expect(search_page.heading_text).to eq("Search")
+      expect(search_page).to have_heading_text("Search")
     end
 
     it "navigates search results using J/K keys" do


### PR DESCRIPTION
After clicking on the search icon, we should ensure that the
`.search-container` has been rendered before moving on. Also update assertions to properly rely on Capybara's autowait.

### Reviewer Notes

Example of flaky tests: https://github.com/discourse/discourse/actions/runs/14057379759/job/39359791607