### PR TITLE
UX: Add loading state to button when confirming password

### DIFF
--- a/app/assets/javascripts/discourse/app/components/dialog-messages/confirm-session.gjs
+++ b/app/assets/javascripts/discourse/app/components/dialog-messages/confirm-session.gjs
@@ -20,6 +20,7 @@ export default class ConfirmSession extends Component {
 
   @tracked errorMessage;
   @tracked resetEmailSent = null;
+  @tracked isLoading = false;
 
   passwordLabel = i18n("user.password.title");
   instructions = i18n("user.confirm_access.instructions");
@@ -64,22 +65,28 @@ export default class ConfirmSession extends Component {
 
   @action
   async submit() {
-    this.errorMessage = this.password
-      ? null
-      : i18n("user.confirm_access.incorrect_password");
+    try {
+      this.isLoading = true;
 
-    const result = await ajax("/u/confirm-session.json", {
-      type: "POST",
-      data: {
-        password: this.password,
-      },
-    });
+      this.errorMessage = this.password
+        ? null
+        : i18n("user.confirm_access.incorrect_password");
 
-    if (result.success) {
-      this.errorMessage = null;
-      this.dialog.didConfirmWrapped();
-    } else {
-      this.errorMessage = i18n("user.confirm_access.incorrect_password");
+      const result = await ajax("/u/confirm-session.json", {
+        type: "POST",
+        data: {
+          password: this.password,
+        },
+      });
+
+      if (result.success) {
+        this.errorMessage = null;
+        this.dialog.didConfirmWrapped();
+      } else {
+        this.errorMessage = i18n("user.confirm_access.incorrect_password");
+      }
+    } finally {
+      this.isLoading = false;
     }
   }
 
@@ -140,6 +147,7 @@ export default class ConfirmSession extends Component {
               autofocus="autofocus"
             />
             <DButton
+              @isLoading={{this.isLoading}}
               class="btn-primary"
               @type="submit"
               @action={{this.submit}}

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -209,11 +209,11 @@ shared_examples "forgot password scenarios" do
 end
 
 describe "User resetting password", type: :system do
-  skip "when desktop" do
+  describe "when desktop" do
     include_examples "forgot password scenarios"
   end
 
-  skip "when mobile", mobile: true do
+  describe "when mobile", mobile: true do
     include_examples "forgot password scenarios"
   end
 end

--- a/spec/system/page_objects/pages/user_preferences_security.rb
+++ b/spec/system/page_objects/pages/user_preferences_security.rb
@@ -10,9 +10,10 @@ module PageObjects
 
       def visit_second_factor(password)
         click_button "Manage Two-Factor Authentication"
-
-        find(".dialog-body input#password").fill_in(with: password)
-        find(".dialog-body .btn-primary").click
+        find(".confirm-session input#password").fill_in(with: password)
+        find(".confirm-session .btn-primary:not([disabled])").click
+        has_no_css?(".confirm-session")
+        self
       end
     end
   end


### PR DESCRIPTION
This commit adds a loading state to the confirm button in
`confirm-session` dialog.

This also unskips the flaky system tests in
`spec/system/forgot_password_spec.rb` as this change will allow us to
gather more information about why the test is flaky. The screenshots
which we have gathered when the test flakes does not allow us to know if
the button has been clicked or not before the test times out.
