### PR TITLE
FIX: Do not `@import` `.css` assets for plugins

### DIFF
--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -24,7 +24,11 @@ module Stylesheet
 
         plugin_assets.each do |src|
           options[:load_paths] << File.expand_path(File.dirname(src))
-          file += "@import \"#{src}\";\n"
+          if src.end_with?(".scss")
+            file += "@import \"#{src}\";\n"
+          else
+            file += File.read(src)
+          end
         end
       else # Core asset
         file += "@import \"#{asset}\";\n"

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -8,7 +8,7 @@ end
 
 class Stylesheet::Manager
   # Bump this number to invalidate all stylesheet caches (e.g. if you change something inside the compiler)
-  BASE_COMPILER_VERSION = 4
+  BASE_COMPILER_VERSION = 5
 
   # Add any dependencies here which should automatically cause a global cache invalidation.
   BASE_CACHE_KEY = "#{BASE_COMPILER_VERSION}::#{DiscourseFonts::VERSION}"

--- a/spec/fixtures/plugins/scss_plugin/assets/stylesheets/simple.css
+++ b/spec/fixtures/plugins/scss_plugin/assets/stylesheets/simple.css
@@ -1,0 +1,3 @@
+body {
+  --simple-css-color: red;
+}

--- a/spec/fixtures/plugins/scss_plugin/plugin.rb
+++ b/spec/fixtures/plugins/scss_plugin/plugin.rb
@@ -5,3 +5,4 @@
 # version: 1.0
 
 register_asset "stylesheets/common/common.scss"
+register_asset "stylesheets/simple.css"

--- a/spec/lib/stylesheet/compiler_spec.rb
+++ b/spec/lib/stylesheet/compiler_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Stylesheet::Compiler do
         expect(css).to include("fill:green")
         expect(css).to include("line-height:1.2em")
         expect(css).to include("border-color:#c00")
+        expect(css).to include("--simple-css-color: red")
       end
     end
   end


### PR DESCRIPTION
b1924c35 switched our compiler to use `@import` internally for scss entrypoints. This logic also applied to `.css` files, but unfortunately sass doesn't do anything with `@import` of CSS files, so they'll be left intact all the way to the browser. Continue using the old concatenation approach for them in the compiler.

Followup to b1924c352487ab2c85ae50af45c5b3e098589014