### PR TITLE
FIX: update chat icon position on mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -168,7 +168,7 @@ class ChatSetupInit {
       if (this.chatService.userCanChat) {
         api.headerIcons.add("chat", ChatHeaderIcon, {
           after: "search",
-          before: "user-menu",
+          before: "hamburger",
         });
       }
 


### PR DESCRIPTION
The chat icon was repositioned in #31951 but we should also account for mobile, where it should appear before the hamburger icon.

### Before

Mobile/hub:

<img width="428" alt="Screenshot 2025-03-26 at 4 12 19 PM" src="https://github.com/user-attachments/assets/69e1564a-8b49-45a1-a5b4-070825efb92d" />


### After

Mobile/hub:

<img width="425" alt="Screenshot 2025-03-26 at 4 12 03 PM" src="https://github.com/user-attachments/assets/26c20ed9-55b9-422b-8865-9daedfc48617" />

Desktop:

<img width="165" alt="Screenshot 2025-03-26 at 4 13 21 PM" src="https://github.com/user-attachments/assets/bd3d857f-30ac-4e06-9ebd-425094cfa496" />

