### PR TITLE
DEV: Improve `PageObjects::Pages::UserPreferencesSecurity#visit_second_factor`

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -83,7 +83,7 @@ describe "Changing email", type: :system do
     authenticator = page.driver.browser.add_virtual_authenticator(options)
 
     user_preferences_security_page.visit(user)
-    user_preferences_security_page.visit_second_factor(password)
+    user_preferences_security_page.visit_second_factor(user, password)
 
     find(".security-key .new-security-key").click
     expect(user_preferences_security_page).to have_css("input#security-key-name")

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -27,7 +27,7 @@ shared_examples "forgot password scenarios" do
     sign_in(user)
 
     user_preferences_security_page.visit(user)
-    user_preferences_security_page.visit_second_factor("supersecurepassword")
+    user_preferences_security_page.visit_second_factor(user, "supersecurepassword")
 
     find(".security-key .new-security-key").click
     expect(user_preferences_security_page).to have_css("input#security-key-name")

--- a/spec/system/page_objects/pages/user_preferences_security.rb
+++ b/spec/system/page_objects/pages/user_preferences_security.rb
@@ -8,11 +8,11 @@ module PageObjects
         self
       end
 
-      def visit_second_factor(password)
+      def visit_second_factor(user, password)
         click_button "Manage Two-Factor Authentication"
         find(".confirm-session input#password").fill_in(with: password)
         find(".confirm-session .btn-primary:not([disabled])").click
-        has_no_css?(".confirm-session")
+        expect(page).to have_current_path("/u/#{user.username}/preferences/second-factor")
         self
       end
     end

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -24,7 +24,7 @@ describe "User preferences | Security", type: :system do
       authenticator = page.driver.browser.add_virtual_authenticator(options)
 
       user_preferences_security_page.visit(user)
-      user_preferences_security_page.visit_second_factor(password)
+      user_preferences_security_page.visit_second_factor(user, password)
 
       find(".security-key .new-security-key").click
       expect(user_preferences_security_page).to have_css("input#security-key-name")


### PR DESCRIPTION
This commit improves said method to ensure that user is redirected to
the right page before returning.

### Reviewer notes

Example of test flakiness: https://github.com/discourse/discourse/actions/runs/14081653020/job/39435797236

```
Failure/Error: raise capybara_timeout_error

CapybaraTimeoutExtension::CapybaraTimedOut:
  This spec passed, but capybara waited for the full wait duration (10s) at least once. This will slow down the test suite. Beware of negating the result of selenium's RSpec matchers.

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_user_resetting_password_when_desktop_when_user_has_multi_factor_authentication_configured_when_user_has_security_key_and_backup_codes_configured_should_allow_a_user_to_reset_pass_261.png

~~~~~~~ JS LOGS ~~~~~~~
~~~~~ END JS LOGS ~~~~~

Shared Example Group: "forgot password scenarios" called from ./spec/system/forgot_password_spec.rb:213

./spec/rails_helper.rb:426:in `block (3 levels) in <top (required)>'
./spec/rails_helper.rb:619:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/benchmark-0.4.0/lib/benchmark.rb:304:in `measure'
./spec/rails_helper.rb:619:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:580:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
./spec/rails_helper.rb:570:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:527:in `block (2 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```