### PR TITLE
UX: only check for toolbar-visible class in mobileView

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -474,9 +474,11 @@ html.composer-open {
     flex-grow: 1;
     min-height: 0;
 
-    &:not(.toolbar-visible) {
-      .d-editor-button-bar {
-        display: none;
+    .mobile-view & {
+      &:not(.toolbar-visible) {
+        .d-editor-button-bar {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
Follow-up to bbea7c3b11054b8e7faeee85a0336ecc45b84890

This behavior should only be applied to mobile view, otherwise there are some scenarios (Android tablets) where the composer toolbar will become inaccessible. 