### PR TITLE
UX: improve hashtag emoji alignment

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -33,12 +33,13 @@ a.hashtag {
   .hashtag-icon-placeholder {
     font-size: var(--font-down-1);
     margin: 0;
+    vertical-align: baseline;
   }
 
   img.emoji {
     width: 15px;
     height: 15px;
-    vertical-align: text-bottom;
+    vertical-align: text-top;
   }
 
   svg {

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -33,7 +33,6 @@ a.hashtag {
   .hashtag-icon-placeholder {
     font-size: var(--font-down-1);
     margin: 0;
-    vertical-align: baseline;
   }
 
   img.emoji {


### PR DESCRIPTION
Improves alignment of emojis within hashtags.

### Before

Emojis:

<img width="504" alt="Screenshot 2025-03-26 at 7 07 20 PM" src="https://github.com/user-attachments/assets/5203ce16-6541-4fac-aa71-411c227a1e35" />

### After

Emojis:

<img width="518" alt="Screenshot 2025-03-26 at 7 07 02 PM" src="https://github.com/user-attachments/assets/e3531daa-2d42-412c-89c7-4c0384c0a3a3" />
