### PR TITLE
FIX: Reapply 94ee3554

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -344,6 +344,10 @@ export default class Item extends Component {
                       class="badge-notification new-topic"
                     ></span></span>
                 {{~/if~}}
+                <PluginOutlet
+                  @name="topic-list-after-badges"
+                  @outletArgs={{hash topic=@topic}}
+                />
                 {{~#if this.expandPinned~}}
                   <TopicExcerpt @topic={{@topic}} />
                 {{~/if~}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
@@ -93,6 +93,10 @@ export default class TopicCell extends Component {
               @url={{@topic.lastUnreadUrl}}
             />
           {{~/if~}}
+          <PluginOutlet
+            @name="topic-list-after-badges"
+            @outletArgs={{hash topic=@topic}}
+          />
         </PluginOutlet>
       </span>
 


### PR DESCRIPTION
This was accidentally reverted as part of the rebasing/merging of the gjs conversions in b29e0b6e1b6001890ce92f96448258550f80132b