### PR TITLE
UX: Admin Dashboard title

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/dashboard.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.gjs
@@ -14,7 +14,8 @@ export default RouteTemplate(
     <DPageHeader
       @titleLabel={{i18n "admin.dashboard.title"}}
       @descriptionLabel={{i18n "admin.dashboard.header_description"}}
-      @hideTabs={{true}}>
+      @hideTabs={{true}}
+    >
       <:breadcrumbs>
         <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
         <DBreadcrumbsItem

--- a/app/assets/javascripts/admin/addon/templates/dashboard.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.gjs
@@ -12,10 +12,9 @@ export default RouteTemplate(
     <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
 
     <DPageHeader
-      @titleLabel="Dashboard"
-      @descriptionLabel="Probably should have a description to break up headings 'Dashboard' and 'Version'?"
-      @hideTabs={{true}}
-    >
+      @titleLabel={{i18n "admin.dashboard.title"}}
+      @descriptionLabel={{i18n "admin.dashboard.header_description"}}
+      @hideTabs={{true}}>
       <:breadcrumbs>
         <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
         <DBreadcrumbsItem

--- a/app/assets/javascripts/admin/addon/templates/dashboard.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.gjs
@@ -14,7 +14,8 @@ export default RouteTemplate(
     <DPageHeader
       @titleLabel="Dashboard"
       @descriptionLabel="Probably should have a description to break up headings 'Dashboard' and 'Version'?"
-      @hideTabs={{true}}>
+      @hideTabs={{true}}
+    >
       <:breadcrumbs>
         <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
         <DBreadcrumbsItem
@@ -24,7 +25,10 @@ export default RouteTemplate(
       </:breadcrumbs>
     </DPageHeader>
 
-    <PluginOutlet @name="admin-dashboard-after-header" @connectorTagName="div" />
+    <PluginOutlet
+      @name="admin-dashboard-after-header"
+      @connectorTagName="div"
+    />
 
     {{#if @controller.showVersionChecks}}
       <div class="section-top">

--- a/app/assets/javascripts/admin/addon/templates/dashboard.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.gjs
@@ -11,14 +11,20 @@ export default RouteTemplate(
   <template>
     <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
 
-    <DPageHeader @hideTabs={{true}}>
+    <DPageHeader
+      @titleLabel="Dashboard"
+      @descriptionLabel="Probably should have a description to break up headings 'Dashboard' and 'Version'?"
+      @hideTabs={{true}}>
       <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
         <DBreadcrumbsItem
           @path="/admin"
           @label={{i18n "admin.dashboard.title"}}
         />
       </:breadcrumbs>
     </DPageHeader>
+
+    <PluginOutlet @name="admin-dashboard-after-header" @connectorTagName="div" />
 
     {{#if @controller.showVersionChecks}}
       <div class="section-top">

--- a/app/assets/javascripts/admin/addon/templates/dashboard.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.gjs
@@ -13,7 +13,7 @@ export default RouteTemplate(
 
     <DPageHeader
       @titleLabel={{i18n "admin.dashboard.title"}}
-      @descriptionLabel={{i18n "admin.dashboard.header_description"}}
+      @descriptionLabel={{i18n "admin.config.dashboard.header_description"}}
       @hideTabs={{true}}
     >
       <:breadcrumbs>


### PR DESCRIPTION
This adds a title to the admin dashboard to match other admin pages.
Adds a description to the admin dashboard.
Adds a plugin outlet after the header

BEFORE:
![CleanShot 2025-03-26 at 11 16 13@2x](https://github.com/user-attachments/assets/ebac6005-61b3-44ab-a97f-581e58e89eaf)


AFTER:
![CleanShot 2025-03-27 at 08 22 13@2x](https://github.com/user-attachments/assets/e64b1dae-8403-4545-9d6d-ac898e59a8bc)

