### PR TITLE
DEV: Add value transformer to `post-text-selection`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -11,6 +11,7 @@ import { INPUT_DELAY } from "discourse/lib/environment";
 import escapeRegExp from "discourse/lib/escape-regexp";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import toMarkdown from "discourse/lib/to-markdown";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import {
   getElement,
   selectedNode,
@@ -49,6 +50,10 @@ export default class PostTextSelection extends Component {
   @service menu;
 
   @tracked isSelecting = false;
+  @tracked preventClose = applyValueTransformer(
+    "post-text-selection-prevent-close",
+    false
+  );
 
   prevSelectedText;
 
@@ -93,6 +98,9 @@ export default class PostTextSelection extends Component {
 
   @bind
   async hideToolbar() {
+    if (this.preventClose) {
+      return;
+    }
     this.args.quoteState.clear();
     await this.menuInstance?.close();
   }

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -32,6 +32,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "parent-category-row-class-mobile",
   "post-menu-buttons",
   "post-menu-collapsed",
+  "post-text-selection-prevent-close",
   "small-user-attrs",
   "tag-separator",
   "topic-list-class",


### PR DESCRIPTION
This update adds a new value transformer to the `PostTextSelection` component. This allows for dynamically setting a `preventClose` property. This is useful to prevent the `onSelectionChange` listener from firing a toolbar close. In particular, we want to use this in Discourse AI to prevent the selection change from closing the toolbar when selecting new text inside the explain popup (https://github.com/discourse/discourse-ai/pull/1221)