### PR TITLE
DEV: Disable site setting save/discard buttons while saving

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -109,6 +109,7 @@ export default class SiteSettingComponent extends Component.extend(
         <DButton
           @action={{this.cancel}}
           @icon="xmark"
+          @disabled={{this.disableUndoButton}}
           @ariaLabel="admin.settings.cancel"
           class="cancel setting-controls__cancel"
         />

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -91,6 +91,7 @@ export default Mixin.create({
   attributeBindings: ["setting.setting:data-setting"],
   classNameBindings: [":row", ":setting", "overridden", "typeClass"],
   validationMessage: null,
+  isSaving: false,
 
   content: alias("setting"),
   isSecret: oneWay("setting.secret"),
@@ -216,8 +217,12 @@ export default Mixin.create({
     }
   }),
 
-  disableSaveButton: computed("validationMessage", function () {
-    return !!this.validationMessage;
+  disableSaveButton: computed("isSaving", "validationMessage", function () {
+    return !!this.validationMessage || this.isSaving;
+  }),
+
+  disableUndoButton: computed("isSaving", function () {
+    return !!this.isSaving;
   }),
 
   confirmChanges(settingKey) {
@@ -306,6 +311,8 @@ export default Mixin.create({
 
   save: action(async function () {
     try {
+      this.set("isSaving", true);
+
       await this._save();
 
       this.set("validationMessage", null);
@@ -326,6 +333,8 @@ export default Mixin.create({
       } else {
         this.set("validationMessage", i18n("generic_error"));
       }
+    } finally {
+      this.set("isSaving", false);
     }
   }),
 


### PR DESCRIPTION
### What is this change?

This change disables the save and undo buttons for site settings while the setting is being saved. This gives some visual indication that saving is underway, and prevents unnecessarily sending more than one request (which will be no-ops anyway.)

Here's a screen recording with a heavily throttled response time for demonstration purposes:

![disable-buttons-on-save](https://github.com/user-attachments/assets/6d3b8dfe-4407-4379-98a6-65df722dc232)
