### PR TITLE
DEV: Bump up max num of puma threads when running system tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' || matrix.build_type == 'system' }}
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
+      CAPYBARA_PUMA_SERVER_MAX_THREADS: 20
       MINIO_RUNNER_LOG_LEVEL: DEBUG
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && '1' }}
       CHEAP_SOURCE_MAPS: "1"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -357,6 +357,16 @@ RSpec.configure do |config|
       Capybara.default_max_wait_time = 4
     end
 
+    puma_max_threads = (ENV["CAPYBARA_PUMA_SERVER_MAX_THREADS"].presence || 10).to_i
+
+    Capybara.server =
+      :puma,
+      {
+        Threads: "0:#{puma_max_threads}",
+        worker_timeout: Capybara.default_max_wait_time * 2 / 3,
+        Silent: true,
+      }
+
     Capybara.threadsafe = true
     Capybara.disable_animation = true
 
@@ -405,6 +415,7 @@ RSpec.configure do |config|
             if RSpec.current_example
               # Store timeout for later, we'll only raise it if the test otherwise passes
               RSpec.current_example.metadata[:_capybara_timeout_exception] ||= timeout_error
+
               raise # re-raise original error
             else
               # Outside an example... maybe a `before(:all)` hook?


### PR DESCRIPTION
More threads -> More throughput -> Less system tests stuck waiting on a
request to be processed.
