### PR TITLE
DEV: Print puma threads backtraces when Capybara's helpers time out

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -405,6 +405,19 @@ RSpec.configure do |config|
             if RSpec.current_example
               # Store timeout for later, we'll only raise it if the test otherwise passes
               RSpec.current_example.metadata[:_capybara_timeout_exception] ||= timeout_error
+
+              RSpec.current_example.metadata[:_capybara_server_threads_backtraces] = Thread
+                .list
+                .reduce([]) do |array, thread|
+                  if thread.backtrace.any? { |line| line.include?("puma") }
+                    app_backtraces = thread.backtrace.filter { |line| !line.match?(%r{/gems/}) }
+                    array << app_backtraces if app_backtraces.any?
+                  end
+
+                  array
+                end
+                .uniq
+
               raise # re-raise original error
             else
               # Outside an example... maybe a `before(:all)` hook?
@@ -734,6 +747,21 @@ RSpec.configure do |config|
 
   config.after(:each, type: :system) do |example|
     lines = RSpec.current_example.metadata[:extra_failure_lines]
+
+    if example.exception &&
+         (
+           backtraces = RSpec.current_example.metadata[:_capybara_server_threads_backtraces]
+         ).present?
+      lines << "~~~~~~~ SERVER THREADS BACKTRACES ~~~~~~~"
+
+      backtraces.each_with_index do |backtrace, index|
+        lines << "\n" if index != 0
+        backtrace.each { |line| lines << line }
+      end
+
+      lines << "~~~~~~~ END SERVER THREADS BACKTRACES ~~~~~~~"
+      lines << "\n"
+    end
 
     # This is disabled by default because it is super verbose,
     # if you really need to dig into how selenium is communicating


### PR DESCRIPTION
When a Capybara helper times out after hitting `Capybara.default_max_wait_time`, we will now
dump the puma server threads backtraces. This information will help us
diagnose test failures due to requests not completing within `Capybara.default_max_wait_time`.

Example test failure output:

```
Failures:

  1) User resetting password when desktop when user has multi-factor authentication configured when user has TOTP, security key and backup codes configured should allow a user to toggle from security key to TOTP and between TOTP and backup codes
     Failure/Error: expect(page).to have_current_path("/u/#{user.username}/preferences/second-factor")
       expected `#<Capybara::Session>.has_current_path?("/u/john/preferences/second-factor")` to be truthy, got false

     [Screenshot Image]: /Users/tgxworld/work/discourse/tmp/capybara/failures_r_spec_example_groups_user_resetting_password_when_desktop_when_user_has_multi_factor_authentication_configured_when_user_has_totp_security_key_and_backup_codes_configured_should_allow_a_user_to_toggl_874.png

     ~~~~~~~ SERVER THREADS BACKTRACES ~~~~~~~
     /Users/tgxworld/work/discourse/app/controllers/users_controller.rb:2216:in 'Kernel#sleep'
     /Users/tgxworld/work/discourse/app/controllers/users_controller.rb:2216:in 'UsersController#confirm_secure_session'
     /Users/tgxworld/work/discourse/app/controllers/users_controller.rb:1543:in 'UsersController#confirm_session'
     /Users/tgxworld/work/discourse/app/controllers/application_controller.rb:427:in 'block in ApplicationController#with_resolved_locale'
     /Users/tgxworld/work/discourse/app/controllers/application_controller.rb:427:in 'ApplicationController#with_resolved_locale'
     /Users/tgxworld/work/discourse/lib/middleware/omniauth_bypass_middleware.rb:35:in 'Middleware::OmniauthBypassMiddleware#call'
     /Users/tgxworld/work/discourse/lib/content_security_policy/middleware.rb:12:in 'ContentSecurityPolicy::Middleware#call'
     /Users/tgxworld/work/discourse/lib/middleware/anonymous_cache.rb:368:in 'Middleware::AnonymousCache#call'
     /Users/tgxworld/work/discourse/lib/middleware/csp_script_nonce_injector.rb:12:in 'Middleware::CspScriptNonceInjector#call'
     /Users/tgxworld/work/discourse/spec/rails_helper.rb:48:in 'RspecErrorTracker#call'
     /Users/tgxworld/work/discourse/config/initializers/008-rack-cors.rb:14:in 'Discourse::Cors#call'
     /Users/tgxworld/work/discourse/lib/middleware/default_headers.rb:13:in 'Middleware::DefaultHeaders#call'
     /Users/tgxworld/work/discourse/config/initializers/100-quiet_logger.rb:20:in 'DiscourseRackQuietAssetsLogger#call'
     /Users/tgxworld/work/discourse/config/initializers/100-silence_logger.rb:29:in 'SilenceLogger#call'
     /Users/tgxworld/work/discourse/lib/middleware/enforce_hostname.rb:24:in 'Middleware::EnforceHostname#call'
     /Users/tgxworld/work/discourse/lib/middleware/processing_request.rb:12:in 'Middleware::ProcessingRequest#call'
     /Users/tgxworld/work/discourse/lib/middleware/request_tracker.rb:385:in 'Middleware::RequestTracker#call'
     /Users/tgxworld/work/discourse/config/initializers/200-first_middlewares.rb:30:in 'TestMultisiteMiddleware#call'
     /Users/tgxworld/work/discourse/config/initializers/200-first_middlewares.rb:77:in 'BlockRequestsMiddleware#call'
     ~~~~~~~ END SERVER THREADS BACKTRACES ~~~~~~~

     ~~~~~~~ JS LOGS ~~~~~~~
     (no logs)
     ~~~~~ END JS LOGS ~~~~~
```


### Reviewer notes

In this [flaky test example](https://github.com/discourse/discourse/actions/runs/14087382392/job/39454911943), the test failed because a capybara assertion did not pass within `Capybara.default_max_wait_time`. From the screenshot below, we see that the submit button is still loading which indicates that the request is still being processed by the server. However, we need to know why the server is taking more than 10 seconds to generate a response.


```
Failure/Error: expect(page).to have_current_path("/u/#{user.username}/preferences/second-factor")
  expected `#<Capybara::Session>.has_current_path?("/u/john/preferences/second-factor")` to be truthy, got false

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_user_resetting_password_when_desktop_when_user_has_multi_factor_authentication_configured_when_user_only_has_security_key_configured_should_allow_a_user_to_reset_password_with_a__75.png

~~~~~~~ JS LOGS ~~~~~~~
(no logs)
~~~~~ END JS LOGS ~~~~~

Shared Example Group: "forgot password scenarios" called from ./spec/system/forgot_password_spec.rb:213

./spec/system/page_objects/pages/user_preferences_security.rb:15:in `visit_second_factor'
./spec/system/forgot_password_spec.rb:30:in `create_user_security_key'
./spec/system/forgot_password_spec.rb:79:in `block (4 levels) in <main>'
./spec/rails_helper.rb:619:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/benchmark-0.4.0/lib/benchmark.rb:304:in `measure'
./spec/rails_helper.rb:619:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:580:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
./spec/rails_helper.rb:570:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:527:in `block (2 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

![image](https://github.com/user-attachments/assets/9a6b4c91-1d17-4c23-9239-f4440fe7fb07)






