### PR TITLE
DEV: Drop 'cache_onebox_response_body' feature

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2349,16 +2349,6 @@ onebox:
     secret: true
   block_onebox_on_redirect:
     default: false
-  cache_onebox_response_body:
-    default: false
-    hidden: true
-  cache_onebox_response_body_domains:
-    default: ""
-    type: list
-    hidden: true
-  cache_onebox_user_agent:
-    default: ""
-    hidden: true
   github_onebox_access_tokens:
     default: ""
     type: list

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -236,11 +236,6 @@ class FinalDestination
       end
     end
 
-    if Oneboxer.cached_response_body_exists?(@uri.to_s)
-      @status = :resolved
-      return @uri
-    end
-
     headers = request_headers
     middlewares = Excon.defaults[:middlewares].dup
     middlewares << Excon::Middleware::Decompress if @http_verb == :get
@@ -294,13 +289,6 @@ class FinalDestination
 
     case response.status
     when 200
-      # Cache body of successful `get` requests
-      if @http_verb == :get
-        if Oneboxer.cache_response_body?(@uri)
-          Oneboxer.cache_response_body(@uri.to_s, response_body)
-        end
-      end
-
       if @follow_canonical
         next_url = fetch_canonical_url(response_body)
 

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -18,13 +18,6 @@ module Onebox
       def url
         @raw ||= nil
 
-        # If possible, fetch the cached HTML body immediately so we can
-        # try to grab the canonical URL from that document,
-        # rather than guess at the best URL structure to use
-        if !@raw && has_cached_body
-          @raw = Onebox::Helpers.fetch_html_doc(@url, http_params, body_cacher)
-        end
-
         if @raw
           canonical_link = @raw.at('//link[@rel="canonical"]/@href')
           return canonical_link.to_s if canonical_link
@@ -80,12 +73,6 @@ module Onebox
       end
 
       private
-
-      def has_cached_body
-        body_cacher.respond_to?("cache_response_body?") &&
-          body_cacher.cache_response_body?(uri.to_s) &&
-          body_cacher.cached_response_body_exists?(uri.to_s)
-      end
 
       def match
         @match ||= @url.match(%r{(?:d|g)p/(?:product/|video/detail/)?(?<id>[A-Z0-9]+)(?:/|\?|$)}mi)

--- a/lib/onebox/engine/html.rb
+++ b/lib/onebox/engine/html.rb
@@ -11,11 +11,7 @@ module Onebox
       end
 
       def raw
-        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params, body_cacher)
-      end
-
-      def body_cacher
-        self.options&.[](:body_cacher)
+        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params)
       end
 
       def html?

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -63,11 +63,6 @@ module Oneboxer
   def self.force_get_hosts
     hosts = []
     hosts += SiteSetting.force_get_hosts.split("|").collect { |domain| "https://#{domain}" }
-    hosts +=
-      SiteSetting
-        .cache_onebox_response_body_domains
-        .split("|")
-        .collect { |domain| "https://www.#{domain}" }
     hosts += amazon_domains
 
     hosts.uniq
@@ -124,36 +119,6 @@ module Oneboxer
   def self.invalidate(url)
     Discourse.cache.delete(onebox_cache_key(url))
     Discourse.cache.delete(onebox_failed_cache_key(url))
-  end
-
-  def self.cache_response_body?(uri)
-    uri = URI.parse(uri) if uri.is_a?(String)
-
-    if SiteSetting.cache_onebox_response_body?
-      SiteSetting
-        .cache_onebox_response_body_domains
-        .split("|")
-        .any? { |domain| uri.hostname.ends_with?(domain) }
-    end
-  end
-
-  def self.cache_response_body(uri, response)
-    key = redis_cached_response_body_key(uri)
-    Discourse.redis.without_namespace.setex(key, 1.minutes.to_i, response)
-  end
-
-  def self.cached_response_body_exists?(uri)
-    key = redis_cached_response_body_key(uri)
-    Discourse.redis.without_namespace.exists(key).to_i > 0
-  end
-
-  def self.fetch_cached_response_body(uri)
-    key = redis_cached_response_body_key(uri)
-    Discourse.redis.without_namespace.get(key)
-  end
-
-  def self.redis_cached_response_body_key(uri)
-    "CACHED_RESPONSE_#{onebox_locale}_#{uri}"
   end
 
   # Parse URLs out of HTML, returning the document when finished.
@@ -557,15 +522,11 @@ module Oneboxer
           hostname: GlobalSetting.hostname,
           facebook_app_access_token: SiteSetting.facebook_app_access_token,
           disable_media_download_controls: SiteSetting.disable_onebox_media_download_controls,
-          body_cacher: self,
           content_type: fd.content_type,
         }
 
         onebox_options[:cookie] = fd.cookie if fd.cookie
 
-        user_agent_override = SiteSetting.cache_onebox_user_agent if Oneboxer.cache_response_body?(
-          url,
-        ) && SiteSetting.cache_onebox_user_agent.present?
         onebox_options[:user_agent] = user_agent_override if user_agent_override
 
         preview_result = Onebox.preview(uri.to_s, onebox_options)
@@ -702,9 +663,6 @@ module Oneboxer
       fd_options[:force_custom_user_agent_hosts] = ["https://#{uri.hostname}"]
     end
 
-    user_agent_override = SiteSetting.cache_onebox_user_agent if Oneboxer.cache_response_body?(
-      url,
-    ) && SiteSetting.cache_onebox_user_agent.present?
     fd_options[:default_user_agent] = user_agent_override if user_agent_override
 
     fd_options

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -527,8 +527,6 @@ module Oneboxer
 
         onebox_options[:cookie] = fd.cookie if fd.cookie
 
-        onebox_options[:user_agent] = user_agent_override if user_agent_override
-
         preview_result = Onebox.preview(uri.to_s, onebox_options)
         result = {
           onebox: WordWatcher.censor(preview_result.to_s),
@@ -662,8 +660,6 @@ module Oneboxer
     if strategy && Oneboxer.strategies[strategy][:force_custom_user_agent_host]
       fd_options[:force_custom_user_agent_hosts] = ["https://#{uri.hostname}"]
     end
-
-    fd_options[:default_user_agent] = user_agent_override if user_agent_override
 
     fd_options
   end

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -906,16 +906,8 @@ RSpec.describe Oneboxer do
   end
 
   describe "#force_get_hosts" do
-    before do
-      SiteSetting.cache_onebox_response_body_domains = "example.net|example.com|example.org"
-    end
-
     it "includes Amazon sites" do
       expect(Oneboxer.force_get_hosts).to include("https://www.amazon.ca")
-    end
-
-    it "includes cache_onebox_response_body_domains" do
-      expect(Oneboxer.force_get_hosts).to include("https://www.example.com")
     end
   end
 
@@ -968,52 +960,6 @@ RSpec.describe Oneboxer do
 
         expect(Oneboxer.preferred_strategy(hostname)).not_to eq(:default)
       end
-    end
-  end
-
-  describe "cache_onebox_response_body" do
-    let(:html) { <<~HTML }
-        <html>
-        <body>
-           <p>cache me if you can</p>
-        </body>
-        <html>
-      HTML
-
-    let(:url) { "https://www.example.com/my/great/content" }
-    let(:url2) { "https://www.example2.com/my/great/content" }
-
-    before do
-      stub_request(:any, url).to_return(status: 200, body: html)
-      stub_request(:any, url2).to_return(status: 200, body: html)
-
-      SiteSetting.cache_onebox_response_body = true
-      SiteSetting.cache_onebox_response_body_domains = "example.net|example.com|example.org"
-    end
-
-    it "caches when domain matches" do
-      preview = Oneboxer.preview(url, invalidate_oneboxes: true)
-      expect(Oneboxer.cached_response_body_exists?(url)).to eq(true)
-      expect(Oneboxer.fetch_cached_response_body(url)).to eq(html)
-    end
-
-    it "ignores cache when domain not present" do
-      preview = Oneboxer.preview(url2, invalidate_oneboxes: true)
-      expect(Oneboxer.cached_response_body_exists?(url2)).to eq(false)
-    end
-
-    it "separates cache by default_locale" do
-      Oneboxer.preview(url, invalidate_oneboxes: true)
-      expect(Oneboxer.cached_response_body_exists?(url)).to eq(true)
-      SiteSetting.default_locale = "fr"
-      expect(Oneboxer.cached_response_body_exists?(url)).to eq(false)
-    end
-
-    it "separates cache by onebox_locale, when set" do
-      Oneboxer.preview(url, invalidate_oneboxes: true)
-      expect(Oneboxer.cached_response_body_exists?(url)).to eq(true)
-      SiteSetting.onebox_locale = "fr"
-      expect(Oneboxer.cached_response_body_exists?(url)).to eq(false)
     end
   end
 


### PR DESCRIPTION
This is a hidden site setting which has never been publicized, and is not recommended for use. If we decide to add a feature like this in future as a visible site setting, it would need many more safeguards to prevent misuse.