### PR TITLE
UX: emoji styling adjustments

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -46,13 +46,17 @@
 
       .d-icon,
       .emoji {
-        width: 1em;
-        height: 1em;
+        width: 0.74em;
+        height: 0.74em;
       }
     }
 
     &.--style-icon .d-icon {
       color: var(--category-badge-color);
+    }
+
+    &.--style-icon .d-icon + .d-icon {
+      color: var(--primary-medium);
     }
 
     &__name {

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -107,12 +107,21 @@ a.hashtag {
       margin-right: 0.25em;
     }
 
-    .hashtag-category-square {
+    .hashtag-category-square,
+    .hashtag-category-icon,
+    .hashtag-category-emoji {
       flex: 0 0 auto;
       width: 15px;
       height: 15px;
       margin-right: 5px;
       display: inline-block;
+    }
+
+    .hashtag-category-icon .svg-icon,
+    .hashtag-category-emoji .emoji {
+      width: 15px;
+      height: 15px;
+      vertical-align: top;
     }
   }
 


### PR DESCRIPTION
Small alignment and sizing improvements for emojis/icons added to categories.

We are also fixing the private category locked icon to retain the grey color.

### Before:

Private category lock color:
<img width="342" alt="Screenshot 2025-03-27 at 11 56 39 AM" src="https://github.com/user-attachments/assets/8bc559a3-59a2-479e-a011-491438c83156" />

Emoji sizing was too big:
<img width="259" alt="Screenshot 2025-03-27 at 12 44 35 PM" src="https://github.com/user-attachments/assets/040c6b9f-2cf7-453c-a274-2782eafe2197" />


### After:

Private category lock color:
<img width="341" alt="Screenshot 2025-03-27 at 12 06 26 PM" src="https://github.com/user-attachments/assets/6731c6c9-68b7-49ff-b8e0-e741282018fa" />

Emoji sizing now matches squares:

<img width="242" alt="Screenshot 2025-03-27 at 12 44 58 PM" src="https://github.com/user-attachments/assets/744310d2-7fbc-45ad-b6b0-8bec7d902ba5" />

And here too:
<img width="351" alt="Screenshot 2025-03-27 at 12 43 18 PM" src="https://github.com/user-attachments/assets/7b656ad9-34a0-432d-b65c-cd18ead8d413" />

And within the header:

<img width="358" alt="Screenshot 2025-03-27 at 12 07 19 PM" src="https://github.com/user-attachments/assets/785f9eca-051e-420e-8bf9-85f9ea208445" />
