### PR TITLE
UX: removing baseline alignment from topic title wrapper

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -318,7 +318,6 @@
       "title title"
       "categories extra";
     grid-template-columns: auto minmax(2em, 1fr); // min must be as wide as ellipsis
-    align-items: baseline;
     gap: 0 0.5em;
 
     .header-title {


### PR DESCRIPTION
This is causing misalignment with displayed metadata such as category, tags, assigned,… We don't remember why it was added in the first place.