### PR TITLE
UX: improve mobile topic list tag layout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -380,12 +380,13 @@ export default class Item extends Component {
                       @outletArgs={{hash topic=@topic}}
                     />
                     {{categoryLink @topic.category}}
+                    {{~! no whitespace ~}}
                     <PluginOutlet
                       @name="topic-list-after-category"
                       @outletArgs={{hash topic=@topic}}
-                    />
+                    />{{~! no whitespace ~}}
                   {{/unless}}
-
+                  {{~! no whitespace ~}}
                   {{discourseTags @topic mode="list"}}
                 </span>
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -291,10 +291,6 @@
     align-items: center;
     gap: 0.5em;
 
-    .discourse-tags {
-      flex-wrap: wrap;
-    }
-
     a.discourse-tag.box {
       padding-top: 0;
       padding-bottom: 0;

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -108,10 +108,8 @@
       max-width: 160px;
     }
 
-    .num .d-icon,
-    a,
-    a:visited {
-      color: var(--primary-med-or-secondary-med);
+    .num .d-icon {
+      color: var(--primary-medium);
     }
   }
 
@@ -119,10 +117,6 @@
     margin-right: 0.5em;
     max-width: 90%;
     line-height: var(--line-height-medium);
-
-    .discourse-tags {
-      display: inline;
-    }
 
     .badge-category__wrapper {
       vertical-align: bottom;
@@ -136,8 +130,21 @@
       pointer-events: none;
     }
 
-    .discourse-tags .discourse-tag {
-      margin: 0;
+    .discourse-tags {
+      display: inline;
+
+      &__tag-separator {
+        position: absolute;
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: -0.5em;
+        margin-top: 0.25em;
+      }
+
+      .discourse-tag {
+        margin: 0;
+        margin-right: 0.5em;
+      }
     }
 
     .badge-wrapper {

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -142,8 +142,7 @@
       }
 
       .discourse-tag {
-        margin: 0;
-        margin-right: 0.5em;
+        margin: 0 0.5em 0 0;
       }
     }
 


### PR DESCRIPTION
* Prevents tag separators (commas by default) from wrapping separately by using absolute positioning so they don't impact the width (thus a comma can't wrap on its own, because a tag can't influence the width) 

* Removes some whitespace creating extra space between categories and tags (to better match desktop) 

* Removes a redundant `flex-wrap: wrap` as `.discourse-tags` already carries this 

* Improves vertical alignment of commas (they were too high on mobile, which is avoided on desktop with baseline alignment in flex) 

* Fixes an issue where tag and separator color could be mismatched because of a too-broad color being applied to all links 

Before:
![image](https://github.com/user-attachments/assets/bc4b0f52-5eff-467f-ae0d-95661bd57351)


After:
![image](https://github.com/user-attachments/assets/dcdf39a4-4f23-4b23-a7b5-5f6a60c1ca6f)
