### PR TITLE
DEV: Dump all threads for some flaky system tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -406,17 +406,12 @@ RSpec.configure do |config|
               # Store timeout for later, we'll only raise it if the test otherwise passes
               RSpec.current_example.metadata[:_capybara_timeout_exception] ||= timeout_error
 
-              RSpec.current_example.metadata[:_capybara_server_threads_backtraces] = Thread
-                .list
-                .reduce([]) do |array, thread|
-                  if thread.backtrace.any? { |line| line.include?("puma") }
-                    app_backtraces = thread.backtrace.filter { |line| !line.match?(%r{/gems/}) }
-                    array << app_backtraces if app_backtraces.any?
-                  end
-
-                  array
-                end
-                .uniq
+              if RSpec.current_example.metadata[:dump_threads_on_failure]
+                RSpec.current_example.metadata[:_capybara_server_threads_backtraces] = Thread
+                  .list
+                  .reduce([]) { |array, thread| array << thread.backtrace }
+                  .uniq
+              end
 
               raise # re-raise original error
             else

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -51,7 +51,7 @@ describe "Changing email", type: :system do
     try_until_success { expect(user.reload.primary_email.email).to eq(new_email) }
   end
 
-  it "works when user has totp 2fa" do
+  it "works when user has totp 2fa", dump_threads_on_failure: true do
     SiteSetting.hide_email_address_taken = false
 
     second_factor = Fabricate(:user_second_factor_totp, user: user)

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -208,7 +208,7 @@ shared_examples "forgot password scenarios" do
   end
 end
 
-describe "User resetting password", type: :system do
+describe "User resetting password", type: :system, dump_threads_on_failure: true do
   describe "when desktop" do
     include_examples "forgot password scenarios"
   end


### PR DESCRIPTION
This is to provide diagnostic information for some flaky system tests
which we are currently investigating. The previous attempt in
6f92f42eb83fea61b2712aaaefcc124e4939365d only dumped threads that
contains the `puma` gem in the backtrace but that is not enough. Since I
am now printing all thread backtraces, I added the `dump_threads_on_failure` metadata
which will be used to determine if all the thread backtraces should be
printed out in the spec's failure output.
