### PR TITLE
DEV: Attempt to fix flaky search system test

### DIFF
--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe "Chat channel", type: :system do
         ".chat-message-actions-container .secondary-actions .select-kit-body",
       )
 
-      PageObjects::Components::Logo.hover
+      PageObjects::Components::Logo.new.hover
       expect(page).to have_css(
         ".chat-message-actions-container .secondary-actions .select-kit-body",
       )

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -174,7 +174,7 @@ module PageObjects
         # and that the message actions menu is closed.
         # This check is essential because the message actions menu might partially
         # overlap with the header, making certain buttons inaccessible.
-        PageObjects::Components::Logo.hover
+        PageObjects::Components::Logo.new.hover
       end
     end
   end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -214,7 +214,7 @@ module SystemHelpers
   end
 
   def click_logo
-    PageObjects::Components::Logo.click
+    PageObjects::Components::Logo.new.click
   end
 
   def is_mobile?

--- a/spec/system/page_objects/components/logo.rb
+++ b/spec/system/page_objects/components/logo.rb
@@ -5,12 +5,12 @@ module PageObjects
     class Logo < PageObjects::Pages::Base
       SELECTOR = "#site-logo"
 
-      def self.click
-        new.find(SELECTOR).click
+      def click
+        find(SELECTOR).click
       end
 
-      def self.hover
-        new.find(SELECTOR).hover
+      def hover
+        find(SELECTOR).hover
       end
     end
   end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -29,6 +29,7 @@ describe "Search", type: :system do
       expect(search_page).to have_no_heading_text("Search")
 
       click_logo
+      expect(page).to have_current_path("/")
       expect(search_page).to be_not_active
 
       page.go_back
@@ -36,6 +37,8 @@ describe "Search", type: :system do
       expect(search_page).to have_search_result
 
       click_logo
+      expect(page).to have_current_path("/")
+
       search_page.click_search_icon
 
       expect(search_page).to have_no_search_result


### PR DESCRIPTION
A system test in `system/search_spec.rb` was failing with the following
error frequently on CI:

```
Failure/Error: expect(search_page).to have_heading_text("Search")
  expected `#<PageObjects::Pages::Search:0x00007fb9fcd3f028>.has_heading_text?("Search")` to be truthy, got false

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_search_when_using_full_page_search_on_mobile_works_and_clears_search_page_state_912.png

~~~~~~~ JS LOGS ~~~~~~~
(no logs)
~~~~~ END JS LOGS ~~~~~

./spec/system/search_spec.rb:42:in `block (3 levels) in <main>'
./spec/rails_helper.rb:619:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/benchmark-0.4.0/lib/benchmark.rb:304:in `measure'
./spec/rails_helper.rb:619:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:580:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
./spec/rails_helper.rb:570:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:527:in `block (2 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

The failure screenshot shows that the "user" is on the homepage even
though we have already clicked the search icon and ensured that the user
can see the search container. I suspect there is some sort of race
condition here since Capybara executes clicks in quick sucession where
we clicked on both the homepage logo and the search icon. It may be
possible that Ember redirected the user to the search page first
before the browser was able to finish navigating the user to the `/`
href.

### Reviewer notes

Test flaked in https://github.com/discourse/discourse/actions/runs/14085443789/job/39448197089 with the following failure screenshot: 

![image](https://github.com/user-attachments/assets/55a2834f-9357-460d-adeb-dc9a2fa475e8)
