### PR TITLE
DEV: Fix a flaky chat system test

### DIFF
--- a/plugins/chat/spec/system/chat_new_message_spec.rb
+++ b/plugins/chat/spec/system/chat_new_message_spec.rb
@@ -54,9 +54,11 @@ RSpec.describe "Chat New Message from params", type: :system do
     end
 
     it "creates a dm channel when none exists" do
-      expect { chat_page.visit_new_message([user_1, user_3]) }.to change { Chat::Channel.count }.by(
-        1,
-      )
+      original_channel_count = Chat::Channel.count
+
+      chat_page.visit_new_message([user_1, user_3])
+
+      try_until_success { expect(Chat::Channel.count - original_channel_count).to eq(1) }
 
       expect(page).to have_current_path(
         %r{/chat/c/#{group_slug([user_1, user_3])}/#{Chat::Channel.last.id}},


### PR DESCRIPTION
We are not waiting for asynchronous operations to complete before executing our assertions.

### Reviewer notes

Example test failure: https://github.com/discourse/discourse/actions/runs/14100970402/job/39496976787

```
Failure/Error: measurement = Benchmark.measure { example.run }
  expected `Chat::Channel.count` to have changed by 1, but was changed by 0

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_chat_new_message_from_params_with_multiple_users_creates_a_dm_channel_when_none_exists_626.png

~~~~~~~ JS LOGS ~~~~~~~
~~~~~ END JS LOGS ~~~~~

./plugins/chat/spec/system/chat_new_message_spec.rb:57:in `block (3 levels) in <main>'
./spec/rails_helper.rb:619:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/benchmark-0.4.0/lib/benchmark.rb:304:in `measure'
./spec/rails_helper.rb:619:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:580:in `block (3 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
./spec/rails_helper.rb:570:in `block (2 levels) in <top (required)>'
./spec/rails_helper.rb:527:in `block (2 levels) in <top (required)>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```