### PR TITLE
FIX: “Input data should be a string” error in ProseMirror

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -634,6 +634,8 @@ export default class DEditor extends Component {
 
   @action
   async toggleRichEditor() {
+    // The ProsemirrorEditor component is loaded here, adding this comment because
+    // otherwise it's hard to find where the component is rendered by name.
     this.editorComponent = this.isRichEditorEnabled
       ? TextareaEditor
       : await loadRichEditor();

--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -154,7 +154,7 @@ export default class ProsemirrorEditor extends Component {
     this.view = new EditorView(container, {
       state,
       nodeViews: extractNodeViews(this.extensions),
-      attributes: { class: this.args.class },
+      attributes: { class: this.args.class ?? "" },
       editable: () => this.args.disabled !== true,
       dispatchTransaction: (tr) => {
         this.view.updateState(this.view.state.apply(tr));
@@ -209,12 +209,14 @@ export default class ProsemirrorEditor extends Component {
 
   @bind
   convertFromValue() {
+    const value = this.args.value ?? "";
+
     // Ignore the markdown we just serialized
-    if (this.args.value === this.#lastSerialized) {
+    if (value === this.#lastSerialized) {
       return;
     }
 
-    const doc = this.convertFromMarkdown(this.args.value);
+    const doc = this.convertFromMarkdown(value);
 
     const tr = this.view.state.tr;
     tr.replaceWith(0, this.view.state.doc.content.size, doc.content).setMeta(

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
@@ -20,6 +20,28 @@ module("Integration | Component | prosemirror-editor", function (hooks) {
     assert.dom(".ProseMirror").exists("it renders the ProseMirror editor");
   });
 
+  test("renders the editor with a null initial value", async function (assert) {
+    await render(<template><ProsemirrorEditor @value={{null}} /></template>);
+    assert.dom(".ProseMirror").exists("it renders the ProseMirror editor");
+  });
+
+  test("renders the editor with a markdown initial value", async function (assert) {
+    await render(
+      <template>
+        <ProsemirrorEditor
+          @value="the **chickens** have come home to roost _bobby boucher_!"
+        />
+      </template>
+    );
+    assert.dom(".ProseMirror").exists("it renders the ProseMirror editor");
+    assert
+      .dom(".ProseMirror em")
+      .exists("it renders the italic markdown as HTML");
+    assert
+      .dom(".ProseMirror strong")
+      .exists("it renders the strong markdown as HTML");
+  });
+
   test("renders the editor with minimum extensions", async function (assert) {
     const minimumExtensions = [
       { nodeSpec: { doc: { content: "inline*" }, text: { group: "inline" } } },


### PR DESCRIPTION
When passing our ProsemirrorEditor component an initial value,
we were sometimes passing `null`, which causes the error in
the title of this commit. The fix here is to handle `null`
gracefully as string.

We originally found this on the category edit page, since
we have a `<DEditor />` in the form template form for the
category.
