### PR TITLE
DEV: Double default capybara wait time for certain flaky tests

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -52,18 +52,21 @@ describe "Changing email", type: :system do
   end
 
   it "works when user has totp 2fa", dump_threads_on_failure: true do
-    SiteSetting.hide_email_address_taken = false
+    # Tests is flaky so trying with a longer wait time as a workaround
+    using_wait_time(Capybara.default_max_wait_time * 2) do
+      SiteSetting.hide_email_address_taken = false
 
-    second_factor = Fabricate(:user_second_factor_totp, user: user)
-    sign_in user
+      second_factor = Fabricate(:user_second_factor_totp, user: user)
+      sign_in user
 
-    visit generate_confirm_link
+      visit generate_confirm_link
 
-    find(".confirm-new-email .btn-primary").click
-    find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
-    find("button[type=submit]").click
+      find(".confirm-new-email .btn-primary").click
+      find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
+      find("button[type=submit]").click
 
-    try_until_success { expect(user.reload.primary_email.email).to eq(new_email) }
+      try_until_success { expect(user.reload.primary_email.email).to eq(new_email) }
+    end
   end
 
   it "works when user has webauthn 2fa" do

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -209,6 +209,8 @@ shared_examples "forgot password scenarios" do
 end
 
 describe "User resetting password", type: :system, dump_threads_on_failure: true do
+  around { |example| using_wait_time(Capybara.default_max_wait_time * 2) { example.run } }
+
   describe "when desktop" do
     include_examples "forgot password scenarios"
   end


### PR DESCRIPTION
I'm not sure what is causing the tests to be flaky so I need more
information to determine where the problem is. For now, I'm doubling the
wait time to rule out any server side problem.
