### PR TITLE
DEV: Double default capybara wait time for certain flaky tests take 2

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -53,7 +53,7 @@ describe "Changing email", type: :system do
 
   it "works when user has totp 2fa", dump_threads_on_failure: true do
     # Tests is flaky so trying with a longer wait time as a workaround
-    using_wait_time(Capybara.default_max_wait_time * 2) do
+    Capybara.using_wait_time(Capybara.default_max_wait_time * 2) do
       SiteSetting.hide_email_address_taken = false
 
       second_factor = Fabricate(:user_second_factor_totp, user: user)

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -209,7 +209,8 @@ shared_examples "forgot password scenarios" do
 end
 
 describe "User resetting password", type: :system, dump_threads_on_failure: true do
-  around { |example| using_wait_time(Capybara.default_max_wait_time * 2) { example.run } }
+  # Tests are flaky so trying with a longer wait time as a workaround
+  around { |example| Capybara.using_wait_time(Capybara.default_max_wait_time * 2) { example.run } }
 
   describe "when desktop" do
     include_examples "forgot password scenarios"


### PR DESCRIPTION
The `using_wait_time` DSL did not work when used in the `around` context as the Capybara's session has not been initialized.

Follow-up to afde7cc1727a751e4d87be2ceee17f2d82edf89c
