### PR TITLE
FIX: Prioritize !important CSS in emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -381,7 +381,11 @@ module Email
         .split(";")
         .select(&:present?)
         .map { _1.split(":", 2).map(&:strip) }
-        .each { |k, v| styles[k] = v if k.present? && v.present? }
+        .each do |k, v|
+          next if k.blank? || v.blank?
+          next if styles[k]&.end_with?("!important") && !v.end_with?("!important")
+          styles[k] = v
+        end
 
       styles.map { |k, v| "#{k}:#{v}" }.join(";")
     end

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe Email::Styles do
       styled = Nokogiri::HTML5.fragment(styled)
       expect(styled.at("test")["style"]).to eq("color:red;background:yellow")
     end
+    it "respects !important" do
+      frag = "<test style='color:yellow !important;color:green !important;color:red'>hello</test>"
+
+      styler = Email::Styles.new(frag)
+      styled = styler.to_html
+      styled = Nokogiri::HTML5.fragment(styled)
+      expect(styled.at("test")["style"]).to eq("color:green !important")
+    end
   end
 
   describe "dark mode emails" do

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe Email::Styles do
       styled = Nokogiri::HTML5.fragment(styled)
       expect(styled.at("test")["style"]).to eq("color:red")
     end
+
     it "handles whitespace correctly" do
       frag =
         "<test style=' color :  green ; ; ;   color :    red; background:white;  background:yellow '>hello</test>"
@@ -185,6 +186,7 @@ RSpec.describe Email::Styles do
       styled = Nokogiri::HTML5.fragment(styled)
       expect(styled.at("test")["style"]).to eq("color:red;background:yellow")
     end
+
     it "respects !important" do
       frag = "<test style='color:yellow !important;color:green !important;color:red'>hello</test>"
 


### PR DESCRIPTION
7d587937 introduced css property deduplication in emails to workaround bugs in some email clients. However, this didn't account for admin-supplied customizations which were overriding core rules using `!important`. This commit ensures that the deduplicator will always prioritise `!important` rules, just like a browser.