### PR TITLE
DEV: Add `@tracked` to RestModel `__state`

### DIFF
--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -33,6 +33,8 @@ export default class RestModel extends EmberObject {
   @equal("__state", "new") isNew;
   @equal("__state", "created") isCreated;
 
+  @tracked __state;
+
   beforeCreate() {}
   afterCreate() {}
 


### PR DESCRIPTION
This property is used for the `isNew` and `isCreated` computed properties, which are then used in templates. To make that work correctly, we need to use `.set` or `@tracked`.