### PR TITLE
DEV: Fix FA icon deprecation 'smile' -> 'face-smile'

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -64,7 +64,7 @@ class ChatSetupInit {
           label: "chat.emoji",
           id: "emoji",
           class: "chat-emoji-btn",
-          icon: "smile",
+          icon: "face-smile",
           position: "dropdown",
           displayed: owner.lookup("service:site").mobileView,
           action(context) {


### PR DESCRIPTION
Over the last few weeks, I have occasionally seen a deprecation warning on my smartphone. Unfortunately, there was no corresponding entry in /logs, and I never had the browser console available at the time.

I have now found the steps to reproduce the issue: the warning is triggered by the emoji selection button in the chat.

https://github.com/user-attachments/assets/fbda7ee2-6967-48af-aa00-d081466e6aea

The icon used in the button was 'smile' instead of 'face-smile'. With this fix, the warning no longer appears. 

Otherwise, the icon will be missing once https://github.com/discourse/discourse/pull/31866 is merged.
![After_1_April](https://github.com/user-attachments/assets/eed141e4-abd8-42c3-a27c-6dad7c4467f9)
