### PR TITLE
DEV: Automatically reload dev when symlinked plugins change

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -11,6 +11,12 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
     "#{Rails.root}/plugins",
   ]
 
+  # Find symlinked plugins, and add their real paths to the watch list.
+  paths +=
+    Dir["#{Rails.root}/plugins/*"]
+      .select { |path| File.symlink? path }
+      .map { |path| File.expand_path(File.readlink(path), File.dirname(path)) }
+
   if Listen::Adapter::Linux.usable?
     # The Listen gem watches recursively, which has a cost per-file on Linux (via rb-inotify)
     # Skip a bunch of unnecessary directories to reduce the cost


### PR DESCRIPTION
## ✨ What's This?

In a development environment, the server auto-restarter can't watch symlinked paths, which means that any symlinked plugins won't reload if their non-autoloaded files change.

This change does a simple resolve of the symlink for any symlinked plugins, and adds the real plugin path to those that it will auto-restart for.