### PR TITLE
DEV: Add env var to silence SASS deprecation warnings

### DIFF
--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -63,6 +63,7 @@ module Stylesheet
           source_map_contents: true,
           load_paths: load_paths,
           silence_deprecations: %w[color-functions import global-builtin],
+          quiet: ENV["QUIET_SASS_DEPRECATIONS"] == "1",
         )
 
       result = engine.render


### PR DESCRIPTION
SASS deprecation warnings are quite noisy, especially when
running specs, here is an example:

```
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
52  │ ┌     @media screen and (max-width: 1048px) {
53  │ │       right: 0;
54  │ │     }
    │ └─── nested rule
... │
56  │       background: var(--secondary);
    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    theme-entrypoint/desktop.scss 56:5         @import
    /home/mb/repos/discourse/desktop.scss 3:9  root stylesheet
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
```

This commit adds an env var (`QUIET_SASS_DEPRECATIONS`) to control
turning them off.
