### PR TITLE
FIX: create UserHistory only when setting changed

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -525,6 +525,7 @@ module SiteSettingExtension
   def set_and_log(name, value, user = Discourse.system_user, detailed_message = nil)
     if has_setting?(name)
       prev_value = public_send(name)
+      return if prev_value == value
       set(name, value)
       # Logging via the rails console is already handled in add_override!
       log(name, value, prev_value, user, detailed_message) unless defined?(Rails::Console)

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -601,6 +601,10 @@ RSpec.describe SiteSettingExtension do
       expect(UserHistory.last.new_value).to eq("Discourse v2")
     end
 
+    it "does not create an entry in the staff action logs when new value is the same" do
+      expect { settings.set_and_log("title", "Discourse v1") }.not_to change { UserHistory.count }
+    end
+
     context "when a detailed message is provided" do
       let(:message) { "We really need to do this, see https://meta.discourse.org/t/123" }
 


### PR DESCRIPTION
Do not create UserHistory when new value is same as the old one. It is even more important now, when we have bulk save option.