### PR TITLE
FIX: allows to resize textarea

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control-wrapper.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { concat, fn } from "@ember/helper";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
@@ -11,6 +12,8 @@ import FKTooltip from "discourse/form-kit/components/fk/tooltip";
 import concatClass from "discourse/helpers/concat-class";
 
 export default class FKControlWrapper extends Component {
+  @tracked controlWidth = "auto";
+
   constructor() {
     super(...arguments);
 
@@ -105,6 +108,7 @@ export default class FKControlWrapper extends Component {
           @expandedDatePickerOnDesktop={{@expandedDatePickerOnDesktop}}
           @selection={{@selection}}
           @includeNone={{@includeNone}}
+          @onControlWidthChange={{fn (mut this.controlWidth)}}
           id={{@field.id}}
           name={{@field.name}}
           aria-invalid={{if this.error "true"}}
@@ -121,7 +125,11 @@ export default class FKControlWrapper extends Component {
           >{{@field.helpText}}</FKText>
         {{/if}}
 
-        <FKMeta @field={{@field}} @error={{this.error}} />
+        <FKMeta
+          @field={{@field}}
+          @error={{this.error}}
+          @controlWidth={{this.controlWidth}}
+        />
       </div>
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -2,10 +2,23 @@ import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";
+import { modifier as modifierFn } from "ember-modifier";
 import { escapeExpression } from "discourse/lib/utilities";
 
 export default class FKControlTextarea extends Component {
   static controlType = "textarea";
+
+  resizeObserver = modifierFn((element) => {
+    const observer = new ResizeObserver(() => {
+      this.args.onControlWidthChange?.(element.offsetWidth);
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  });
 
   @action
   handleInput(event) {
@@ -26,6 +39,7 @@ export default class FKControlTextarea extends Component {
       style={{this.style}}
       disabled={{@field.disabled}}
       ...attributes
+      {{this.resizeObserver}}
       {{on "input" this.handleInput}}
     >{{@field.value}}</textarea>
   </template>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/meta.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/meta.gjs
@@ -1,4 +1,6 @@
 import Component from "@glimmer/component";
+import { concat } from "@ember/helper";
+import { htmlSafe } from "@ember/template";
 import FKCharCounter from "discourse/form-kit/components/fk/char-counter";
 import FKErrors from "discourse/form-kit/components/fk/errors";
 
@@ -15,9 +17,16 @@ export default class FKMeta extends Component {
     return this.args.showMeta ?? true;
   }
 
+  get width() {
+    return this.args.controlWidth ? `${this.args.controlWidth}px` : "auto";
+  }
+
   <template>
     {{#if this.shouldRenderMeta}}
-      <div class="form-kit__meta">
+      <div
+        class="form-kit__meta"
+        style={{htmlSafe (concat "width: " this.width)}}
+      >
         {{#if @error}}
           <FKErrors @id={{@field.errorId}} @error={{@error}} />
         {{/if}}

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -6,6 +6,7 @@ import {
   resetOnerror,
   settled,
   setupOnerror,
+  waitFor,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
@@ -370,7 +371,9 @@ module("Integration | Component | FormKit | Field", function (hooks) {
 
     query(".form-kit__control-textarea").style.width = "100px";
 
-    await settled();
+    await waitFor(".form-kit__meta[style]", {
+      timeout: 5000,
+    });
 
     assert.deepEqual(
       query(".form-kit__meta").style.width,

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -6,14 +6,12 @@ import {
   resetOnerror,
   settled,
   setupOnerror,
-  waitFor,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
-import { query } from "discourse/tests/helpers/qunit-helpers";
 import DTooltip from "float-kit/components/d-tooltip";
 
 module("Integration | Component | FormKit | Field", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -352,33 +352,4 @@ module("Integration | Component | FormKit | Field", function (hooks) {
 
     assert.dom(".fk-d-tooltip__inner-content").hasText("component");
   });
-
-  test("control width", async function (assert) {
-    await render(
-      <template>
-        <Form as |form|>
-          <form.Field
-            @name="foo"
-            @title="Foo"
-            @validation="length:1,100"
-            as |field|
-          >
-            <field.Textarea />
-          </form.Field>
-        </Form>
-      </template>
-    );
-
-    query(".form-kit__control-textarea").style.width = "100px";
-
-    await waitFor(".form-kit__meta[style]", {
-      timeout: 5000,
-    });
-
-    assert.deepEqual(
-      query(".form-kit__meta").style.width,
-      "100px",
-      "it also sets the width of the meta"
-    );
-  });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -12,6 +12,7 @@ import sinon from "sinon";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+import { query } from "discourse/tests/helpers/qunit-helpers";
 import DTooltip from "float-kit/components/d-tooltip";
 
 module("Integration | Component | FormKit | Field", function (hooks) {
@@ -349,5 +350,32 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     await click(".fk-d-tooltip__trigger");
 
     assert.dom(".fk-d-tooltip__inner-content").hasText("component");
+  });
+
+  test("control width", async function (assert) {
+    await render(
+      <template>
+        <Form as |form|>
+          <form.Field
+            @name="foo"
+            @title="Foo"
+            @validation="length:1,100"
+            as |field|
+          >
+            <field.Textarea />
+          </form.Field>
+        </Form>
+      </template>
+    );
+
+    query(".form-kit__control-textarea").style.width = "100px";
+
+    await settled();
+
+    assert.deepEqual(
+      query(".form-kit__meta").style.width,
+      "100px",
+      "it also sets the width of the meta"
+    );
   });
 });

--- a/app/assets/stylesheets/common/form-kit/_control-textarea.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-textarea.scss
@@ -4,7 +4,7 @@
 
   @include default-input {
     // reset textarea styles
-    height: 150px !important;
+    height: 150px;
     min-width: auto !important;
     padding: 0.5em !important;
   }

--- a/app/assets/stylesheets/common/form-kit/_default-input-mixin.scss
+++ b/app/assets/stylesheets/common/form-kit/_default-input-mixin.scss
@@ -1,5 +1,5 @@
 @mixin default-input {
-  width: 100% !important;
+  width: 100%;
   height: 2em;
   background: var(--secondary);
   border: 1px solid var(--primary-low-mid) !important;


### PR DESCRIPTION
This commit also ensures meta will resize with the textarea to avoid meta being badly positioned.

I couldn't easily write a test working on all platforms.

