### PR TITLE
FIX: prevents d-menu trigger/untrigger propagation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -113,6 +113,7 @@ export default class NotificationsTracking extends Component {
         "notifications-tracking-trigger-btn"
         @triggerClass
       }}
+      @contentClass={{@contentClass}}
       @onRegisterApi={{this.registerDmenuApi}}
       @title={{@title}}
       @autofocus={{false}}

--- a/app/assets/javascripts/discourse/app/components/topic-notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-notifications-tracking.gjs
@@ -19,6 +19,7 @@ export default class TopicNotificationsTracking extends Component {
       class="topic-notifications-tracking"
       @levels={{topicLevels}}
       @suffix={{this.suffix}}
+      @contentClass={{@contentClass}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -669,7 +669,11 @@ export default class TopicTimelineScrollArea extends Component {
         {{/if}}
 
         {{#if (and this.currentUser this.site.desktopView)}}
-          <TopicNotificationsButton @topic={{@model}} @expanded={{false}} />
+          <TopicNotificationsButton
+            @contentClass="topic-timeline-notifications-tracking-content"
+            @topic={{@model}}
+            @expanded={{false}}
+          />
         {{/if}}
 
         <PluginOutlet

--- a/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
+++ b/app/assets/javascripts/float-kit/addon/lib/d-menu-instance.js
@@ -110,13 +110,17 @@ export default class DMenuInstance extends FloatKitInstance {
   }
 
   @action
-  async onTrigger() {
+  async onTrigger(event) {
+    event.stopPropagation();
+
     await this.options.beforeTrigger?.(this);
     await this.show();
   }
 
   @action
-  async onUntrigger() {
+  async onUntrigger(event) {
+    event.stopPropagation();
+
     await this.close();
   }
 

--- a/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/topic-notifications-button.gjs
@@ -122,6 +122,7 @@ export default class TopicNotificationsButton extends Component {
           @showFullTitle={{@expanded}}
           @showCaret={{@expanded}}
           @topic={{@topic}}
+          @contentClass={{@contentClass}}
         />
 
         {{#if @expanded}}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -6,6 +6,8 @@
 @import "common/whcm";
 @import "common/foundation/helpers";
 @import "common/foundation/base";
+@import "common/form-kit/_index";
+@import "common/float-kit/_index";
 @import "common/select-kit/_index";
 @import "common/components/_index";
 @import "common/modal/_index";
@@ -17,9 +19,7 @@
 @import "common/software-update-prompt";
 @import "common/topic-timeline";
 @import "common/loading-slider";
-@import "common/float-kit/_index";
 @import "common/rich-editor";
 @import "common/login/_index";
 @import "common/table-builder/_index";
 @import "common/post-action-feedback";
-@import "common/form-kit/_index";

--- a/app/assets/stylesheets/common/components/notifications-tracking.scss
+++ b/app/assets/stylesheets/common/components/notifications-tracking.scss
@@ -38,6 +38,6 @@
   }
 }
 
-.notifications-tracking-content {
+.topic-timeline-notifications-tracking-content {
   z-index: z("fullscreen") + 1;
 }

--- a/app/assets/stylesheets/common/components/notifications-tracking.scss
+++ b/app/assets/stylesheets/common/components/notifications-tracking.scss
@@ -37,3 +37,7 @@
     text-align: left;
   }
 }
+
+.notifications-tracking-content {
+  z-index: z("fullscreen") + 1;
+}


### PR DESCRIPTION
Before this fix a click on a d-menu trigger would fire a click on the parent element, which could have undesired consequences.

This also fixes two things:
- moves float-kit/form-kit css files higher in the chain, so it's easier to override
- increases the z-index of the notifications-tracking menu content or it would be behind the timeline control