### PR TITLE
DEV: Preserve ids/classes in emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -400,7 +400,6 @@ module Email
       # needs to be before class + id strip because we need to style redacted
       # media and also not double-redact already redacted from lower levels
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
-      strip_classes_and_ids
       replace_relative_urls
       deduplicate_styles
 
@@ -545,15 +544,6 @@ module Email
             end
           return
           # rubocop:enable Lint/NonLocalExitFromIterator
-        end
-    end
-
-    def strip_classes_and_ids
-      @fragment
-        .css("*")
-        .each do |element|
-          element.delete("class")
-          element.delete("id")
         end
     end
 

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -397,8 +397,6 @@ module Email
     end
 
     def to_html
-      # needs to be before class + id strip because we need to style redacted
-      # media and also not double-redact already redacted from lower levels
       replace_secure_uploads_urls if SiteSetting.secure_uploads?
       replace_relative_urls
       deduplicate_styles

--- a/spec/integration/email_style_spec.rb
+++ b/spec/integration/email_style_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe EmailStyle do
         SiteSetting.default_email_in_reply_to = true
 
         expect(mail_html.scan('<h1 style="color:red">FOR YOU</h1>').count).to eq(1)
-        matches = mail_html.match(/<div style="([^"]+)" dm=\"body\">#{post.raw}/)
+        matches = mail_html.match(/<div class="body" style="([^"]+)" dm=\"body\">#{post.raw}/)
         expect(matches[1]).to include("color:#FAB") # custom
         expect(matches[1]).to include("padding-top:5px") # div.body
       end

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -592,7 +592,7 @@ RSpec.describe Email::Sender do
       reply.rebake!
       Email::Sender.new(message, :valid_type).send
       expected = <<~HTML
-      <a href=\"#{Discourse.base_url}#{category.url}\" data-type=\"category\" data-slug=\"dev\" data-id=\"#{category.id}\" data-style-type=\"square\" style=\"text-decoration:none;font-weight:bold;color:#006699\"><span>#dev</span>
+      <a class="hashtag-cooked" href=\"#{Discourse.base_url}#{category.url}\" data-type=\"category\" data-slug=\"dev\" data-id=\"#{category.id}\" data-style-type=\"square\" style=\"text-decoration:none;font-weight:bold;color:#006699\"><span>#dev</span>
       HTML
       expect(message.html_part.body.to_s).to include(expected.chomp)
     end

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe Email::Styles do
       expect(frag.at("img")["src"]).to eq("#{Discourse.base_url}/some-image.png")
     end
 
-    it "strips classes and ids" do
-      frag = basic_fragment("<div class='foo' id='bar'><div class='foo' id='bar'></div></div>")
-      expect(frag.to_html).to eq("<div><div></div></div>")
+    it "preserves classes and ids" do
+      raw = '<div class="foo" id="bar"><div class="foo" id="bar"></div></div>'
+      frag = basic_fragment(raw)
+      expect(frag.to_html).to eq(raw)
     end
   end
 


### PR DESCRIPTION
These aren't technically needed in the output, since we inline all styles. However, there's no harm in including them, and having them visible will improve the developer experience when restyling emails.