### PR TITLE
UX: convert emdash+hyphen to a horizontal rule on rich editor

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/core/inputrules.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/core/inputrules.js
@@ -33,9 +33,11 @@ export function buildInputRules(extensions, params, includeDefault = true) {
       markInputRule(/(?:^|(?<!\*))\*([^*]+)\*$/, schema.marks.em),
       markInputRule(/(?<=^|\s)_([^_]+)_$/, schema.marks.em),
       markInputRule(/`([^`]+)`$/, schema.marks.code),
-      new InputRule(/^(\u2013-|___\s|\*\*\*\s)$/, horizontalRuleHandler, {
-        inCodeMark: false,
-      })
+      new InputRule(
+        /^(\u2013-|\u2014-|___\s|\*\*\*\s)$/,
+        horizontalRuleHandler,
+        { inCodeMark: false }
+      )
     );
   }
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -163,11 +163,11 @@ describe "Composer - ProseMirror editor", type: :system do
       )
     end
 
-    it "supports ---, *** or ___ to create a horizontal rule" do
+    it "supports ---, ***, ___, en-dash+hyphen, em-dash+hyphen to create a horizontal rule" do
       open_composer_and_toggle_rich_editor
-      composer.type_content("Hey\n---\nThere\n*** Friend\n___ ")
+      composer.type_content("Hey\n---There\n*** Friend\n___ How\n\u2013-are\n\u2014-you")
 
-      expect(rich).to have_css("hr", count: 3)
+      expect(rich).to have_css("hr", count: 5)
     end
   end
 


### PR DESCRIPTION
iOS is automatically converting a double-hyphen (--) to an em-dash (–).

It may get in the way when we're trying to create an horizontal rule with a ---, so this PR adds the "em-dash + hyphen" case to our input rule regex.