### PR TITLE
FEATURE: prioritize the user who is getting the reply in the autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -1005,6 +1005,7 @@ export default class ComposerEditor extends Component {
         @outletArgs={{hash composer=this.composer.model editorType="composer"}}
         @topicId={{this.composer.model.topic.id}}
         @categoryId={{this.composer.model.category.id}}
+        @replyingToPostNumber={{this.composer.model.post.post_number}}
         @onSetup={{this.setupEditor}}
         @disableSubmit={{this.composer.disableSubmit}}
       >

--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -1005,7 +1005,7 @@ export default class ComposerEditor extends Component {
         @outletArgs={{hash composer=this.composer.model editorType="composer"}}
         @topicId={{this.composer.model.topic.id}}
         @categoryId={{this.composer.model.category.id}}
-        @replyingToPostNumber={{this.composer.model.post.post_number}}
+        @replyingToUser={{this.composer.replyingToUser}}
         @onSetup={{this.setupEditor}}
         @disableSubmit={{this.composer.disableSubmit}}
       >

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -635,6 +635,8 @@ export default class DEditor extends Component {
 
   @action
   async toggleRichEditor() {
+    // The ProsemirrorEditor component is loaded here, adding this comment because
+    // otherwise it's hard to find where the component is rendered by name.
     this.editorComponent = this.isRichEditorEnabled
       ? TextareaEditor
       : await loadRichEditor();

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -449,7 +449,7 @@ export default class DEditor extends Component {
           topicId: this.topicId,
           categoryId: this.categoryId,
           includeGroups: true,
-          userId: this.replyingToUser?.id,
+          prioritizedUserId: this.replyingToUser?.id,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);
           return result;

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -66,7 +66,6 @@ export default class DEditor extends Component {
   @service emojiStore;
   @service modal;
   @service menu;
-  @service composer;
 
   @tracked editorComponent;
   /** @type {TextManipulation} */
@@ -450,7 +449,7 @@ export default class DEditor extends Component {
           topicId: this.topicId,
           categoryId: this.categoryId,
           includeGroups: true,
-          replyingToPostNumber: this.composer.model.post?.post_number,
+          replyingToPostNumber: this.replyingToPostNumber,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);
           return result;
@@ -636,8 +635,6 @@ export default class DEditor extends Component {
 
   @action
   async toggleRichEditor() {
-    // The ProsemirrorEditor component is loaded here, adding this comment because
-    // otherwise it's hard to find where the component is rendered by name.
     this.editorComponent = this.isRichEditorEnabled
       ? TextareaEditor
       : await loadRichEditor();

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -66,6 +66,7 @@ export default class DEditor extends Component {
   @service emojiStore;
   @service modal;
   @service menu;
+  @service composer;
 
   @tracked editorComponent;
   /** @type {TextManipulation} */
@@ -449,6 +450,7 @@ export default class DEditor extends Component {
           topicId: this.topicId,
           categoryId: this.categoryId,
           includeGroups: true,
+          replyingToPostNumber: this.composer.model.post?.post_number,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);
           return result;

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -449,7 +449,7 @@ export default class DEditor extends Component {
           topicId: this.topicId,
           categoryId: this.categoryId,
           includeGroups: true,
-          replyingToPostNumber: this.replyingToPostNumber,
+          userId: this.replyingToUser?.id,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);
           return result;

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -35,7 +35,7 @@ function performSearch(
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
-  replyingToPostNumber,
+  userId,
   limit,
   resultsFn
 ) {
@@ -65,7 +65,7 @@ function performSearch(
     topic_allowed_users: allowedUsers,
     include_staged_users: includeStagedUsers,
     last_seen_users: lastSeenUsers,
-    replying_to_post_number: replyingToPostNumber,
+    user_id: userId,
     limit,
   };
 
@@ -121,7 +121,7 @@ let debouncedSearch = function (
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
-  replyingToPostNumber,
+  userId,
   limit,
   resultsFn
 ) {
@@ -139,7 +139,7 @@ let debouncedSearch = function (
     groupMembersOf,
     includeStagedUsers,
     lastSeenUsers,
-    replyingToPostNumber,
+    userId,
     limit,
     resultsFn,
     300
@@ -251,7 +251,7 @@ export default function userSearch(options) {
     groupMembersOf = options.groupMembersOf,
     includeStagedUsers = options.includeStagedUsers,
     lastSeenUsers = options.lastSeenUsers,
-    replyingToPostNumber = options.replyingToPostNumber,
+    userId = options.userId,
     limit = options.limit || 6;
 
   if (oldSearch) {
@@ -292,7 +292,7 @@ export default function userSearch(options) {
       groupMembersOf,
       includeStagedUsers,
       lastSeenUsers,
-      replyingToPostNumber,
+      userId,
       limit,
       function (r) {
         cancel(clearPromise);

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -35,6 +35,7 @@ function performSearch(
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
+  replyingToPostNumber,
   limit,
   resultsFn
 ) {
@@ -64,6 +65,7 @@ function performSearch(
     topic_allowed_users: allowedUsers,
     include_staged_users: includeStagedUsers,
     last_seen_users: lastSeenUsers,
+    replying_to_post_number: replyingToPostNumber,
     limit,
   };
 
@@ -119,6 +121,7 @@ let debouncedSearch = function (
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
+  replyingToPostNumber,
   limit,
   resultsFn
 ) {
@@ -136,6 +139,7 @@ let debouncedSearch = function (
     groupMembersOf,
     includeStagedUsers,
     lastSeenUsers,
+    replyingToPostNumber,
     limit,
     resultsFn,
     300
@@ -247,6 +251,7 @@ export default function userSearch(options) {
     groupMembersOf = options.groupMembersOf,
     includeStagedUsers = options.includeStagedUsers,
     lastSeenUsers = options.lastSeenUsers,
+    replyingToPostNumber = options.replyingToPostNumber,
     limit = options.limit || 6;
 
   if (oldSearch) {
@@ -287,6 +292,7 @@ export default function userSearch(options) {
       groupMembersOf,
       includeStagedUsers,
       lastSeenUsers,
+      replyingToPostNumber,
       limit,
       function (r) {
         cancel(clearPromise);

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -35,7 +35,7 @@ function performSearch(
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
-  userId,
+  prioritizedUserId,
   limit,
   resultsFn
 ) {
@@ -65,7 +65,7 @@ function performSearch(
     topic_allowed_users: allowedUsers,
     include_staged_users: includeStagedUsers,
     last_seen_users: lastSeenUsers,
-    user_id: userId,
+    prioritized_user_id: prioritizedUserId,
     limit,
   };
 
@@ -121,7 +121,7 @@ let debouncedSearch = function (
   groupMembersOf,
   includeStagedUsers,
   lastSeenUsers,
-  userId,
+  prioritizedUserId,
   limit,
   resultsFn
 ) {
@@ -139,7 +139,7 @@ let debouncedSearch = function (
     groupMembersOf,
     includeStagedUsers,
     lastSeenUsers,
-    userId,
+    prioritizedUserId,
     limit,
     resultsFn,
     300
@@ -251,7 +251,7 @@ export default function userSearch(options) {
     groupMembersOf = options.groupMembersOf,
     includeStagedUsers = options.includeStagedUsers,
     lastSeenUsers = options.lastSeenUsers,
-    userId = options.userId,
+    prioritizedUserId = options.prioritizedUserId,
     limit = options.limit || 6;
 
   if (oldSearch) {
@@ -292,7 +292,7 @@ export default function userSearch(options) {
       groupMembersOf,
       includeStagedUsers,
       lastSeenUsers,
-      userId,
+      prioritizedUserId,
       limit,
       function (r) {
         cancel(clearPromise);

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -195,6 +195,17 @@ export default class ComposerService extends Service {
     );
   }
 
+  get replyingToUser() {
+    if (this.get("model.editingPost")) {
+      const user = this.get("model.post.reply_to_user");
+      if (user) {
+        return user;
+      }
+    }
+
+    return this.get("model.post.user");
+  }
+
   get formTemplateInitialValues() {
     return this._formTemplateInitialValues;
   }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1235,6 +1235,9 @@ class UsersController < ApplicationController
 
     topic_id = params[:topic_id].to_i if params[:topic_id].present?
     category_id = params[:category_id].to_i if params[:category_id].present?
+    replying_to_post_number = params[:replying_to_post_number].to_i if params[
+      :replying_to_post_number
+    ].present?
 
     topic_allowed_users = params[:topic_allowed_users] || false
 
@@ -1259,6 +1262,7 @@ class UsersController < ApplicationController
 
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
+    options[:replying_to_post_number] = replying_to_post_number if replying_to_post_number
 
     results =
       if usernames.blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1235,7 +1235,7 @@ class UsersController < ApplicationController
 
     topic_id = params[:topic_id].to_i if params[:topic_id].present?
     category_id = params[:category_id].to_i if params[:category_id].present?
-    user_id = params[:user_id].to_i if params[:user_id].present?
+    prioritized_user_id = params[:prioritized_user_id].to_i if params[:prioritized_user_id].present?
 
     topic_allowed_users = params[:topic_allowed_users] || false
 
@@ -1260,7 +1260,7 @@ class UsersController < ApplicationController
 
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
-    options[:user_id] = user_id if user_id
+    options[:prioritized_user_id] = prioritized_user_id if prioritized_user_id
 
     results =
       if usernames.blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1235,9 +1235,7 @@ class UsersController < ApplicationController
 
     topic_id = params[:topic_id].to_i if params[:topic_id].present?
     category_id = params[:category_id].to_i if params[:category_id].present?
-    replying_to_post_number = params[:replying_to_post_number].to_i if params[
-      :replying_to_post_number
-    ].present?
+    user_id = params[:user_id].to_i if params[:user_id].present?
 
     topic_allowed_users = params[:topic_allowed_users] || false
 
@@ -1262,7 +1260,7 @@ class UsersController < ApplicationController
 
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
-    options[:replying_to_post_number] = replying_to_post_number if replying_to_post_number
+    options[:user_id] = user_id if user_id
 
     results =
       if usernames.blank?

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -8,6 +8,7 @@ class UserSearch
     @term_like = @term.gsub("_", "\\_") + "%"
     @topic_id = opts[:topic_id]
     @category_id = opts[:category_id]
+    # user_id is only used for ordering within the topic, it will prioritize this user
     @user_id = opts[:user_id]
     @topic_allowed_users = opts[:topic_allowed_users]
     @searching_user = opts[:searching_user]

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -8,7 +8,7 @@ class UserSearch
     @term_like = @term.gsub("_", "\\_") + "%"
     @topic_id = opts[:topic_id]
     @category_id = opts[:category_id]
-    @replying_to_post_number = opts[:replying_to_post_number]
+    @user_id = opts[:user_id]
     @topic_allowed_users = opts[:topic_allowed_users]
     @searching_user = opts[:searching_user]
     @include_staged_users = opts[:include_staged_users] || false
@@ -18,9 +18,7 @@ class UserSearch
 
     @topic = Topic.find(@topic_id) if @topic_id
     @category = Category.find(@category_id) if @category_id
-    if @topic && @replying_to_post_number
-      @replying_to_post = @topic.posts.find_by_post_number(@replying_to_post_number)
-    end
+    @replying_to_user = User.find_by_id(@user_id) if @user_id
 
     @guardian = Guardian.new(@searching_user)
     @guardian.ensure_can_see_groups_members!(@groups) if @groups
@@ -82,11 +80,11 @@ class UserSearch
     return users.to_a if users.size >= @limit
 
     # 2. if replying to a post, add the user who created the post but respect the usernames matching
-    if @replying_to_post_number && @replying_to_post
-      user_id = @replying_to_post.user_id
+    if @replying_to_user
+      user_id = @replying_to_user.id
 
       if user_id.present? && !users.include?(user_id) &&
-           (@term.blank? || @replying_to_post.user.username.include?(@term))
+           (@term.blank? || @replying_to_user.username.include?(@term))
         users << user_id
       end
     end

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -18,7 +18,6 @@ class UserSearch
 
     @topic = Topic.find(@topic_id) if @topic_id
     @category = Category.find(@category_id) if @category_id
-    @replying_to_user = User.find_by_id(@user_id) if @user_id
 
     @guardian = Guardian.new(@searching_user)
     @guardian.ensure_can_see_groups_members!(@groups) if @groups
@@ -90,11 +89,9 @@ class UserSearch
 
       in_topic = in_topic.where("users.id <> ?", @searching_user.id) if @searching_user.present?
 
-      if @replying_to_user
+      if @user_id
         in_topic =
-          in_topic.order(
-            DB.sql_fragment("CASE WHEN users.id = ? THEN 0 ELSE 1 END", @replying_to_user.id),
-          )
+          in_topic.order(DB.sql_fragment("CASE WHEN users.id = ? THEN 0 ELSE 1 END", @user_id))
       end
 
       in_topic

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -8,8 +8,8 @@ class UserSearch
     @term_like = @term.gsub("_", "\\_") + "%"
     @topic_id = opts[:topic_id]
     @category_id = opts[:category_id]
-    # user_id is only used for ordering within the topic, it will prioritize this user
-    @user_id = opts[:user_id]
+    # prioritized_user_id is only used for ordering within the topic, it will prioritize this user
+    @prioritized_user_id = opts[:prioritized_user_id]
     @topic_allowed_users = opts[:topic_allowed_users]
     @searching_user = opts[:searching_user]
     @include_staged_users = opts[:include_staged_users] || false
@@ -90,9 +90,11 @@ class UserSearch
 
       in_topic = in_topic.where("users.id <> ?", @searching_user.id) if @searching_user.present?
 
-      if @user_id
+      if @prioritized_user_id
         in_topic =
-          in_topic.order(DB.sql_fragment("CASE WHEN users.id = ? THEN 0 ELSE 1 END", @user_id))
+          in_topic.order(
+            DB.sql_fragment("CASE WHEN users.id = ? THEN 0 ELSE 1 END", @prioritized_user_id),
+          )
       end
 
       in_topic

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -298,6 +298,7 @@ class PostSerializer < BasicPostSerializer
 
   def reply_to_user
     {
+      id: object.reply_to_user.id,
       username: object.reply_to_user.username,
       name: object.reply_to_user.name,
       avatar_template: object.reply_to_user.avatar_template,

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -180,42 +180,32 @@ RSpec.describe UserSearch do
     end
 
     it "prioritises the replying to user" do
-      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post1.post_number)
+      results = search_for("mr", topic_id: topic.id, user_id: post1.user_id)
       expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post3.post_number)
+      results = search_for("mr", topic_id: topic.id, user_id: post3.user_id)
       expect(results).to eq [mr_orange, mr_pink, mr_b, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post4.post_number)
+      results = search_for("mr", topic_id: topic.id, user_id: post4.user_id)
       expect(results).to eq [mr_pink, mr_orange, mr_b, mr_brown, mr_blue].map(&:username)
     end
 
     it "returns the replying to user if the term includes the username" do
-      results =
-        search_for(mr_blue.username, topic_id: topic.id, replying_to_post_number: post1.post_number)
+      results = search_for(mr_blue.username, topic_id: topic.id, user_id: post1.user_id)
       expect(results).to eq [mr_blue].map(&:username)
-      results =
-        search_for(mr_blue.username, topic_id: topic.id, replying_to_post_number: post3.post_number)
+      results = search_for(mr_blue.username, topic_id: topic.id, user_id: post3.user_id)
       expect(results).to eq [mr_blue].map(&:username)
     end
 
     it "returns firstly the replying to user if the term is blank" do
-      results = search_for("", topic_id: topic.id, replying_to_post_number: post1.post_number)
+      results = search_for("", topic_id: topic.id, user_id: post1.user_id)
       expect(results).to eq [mr_b, mr_pink, mr_orange].map(&:username)
 
-      results = search_for("", topic_id: topic.id, replying_to_post_number: post3.post_number)
+      results = search_for("", topic_id: topic.id, user_id: post3.user_id)
       expect(results).to eq [mr_orange, mr_pink, mr_b].map(&:username)
 
-      results = search_for("", topic_id: topic.id, replying_to_post_number: post4.post_number)
+      results = search_for("", topic_id: topic.id, user_id: post4.user_id)
       expect(results).to eq [mr_pink, mr_orange, mr_b].map(&:username)
-    end
-
-    it "requires `topic_id` for `replying_to_post_number`" do
-      results = search_for("mr", replying_to_post_number: post1.post_number)
-      expect(results).to eq [mr_brown, mr_pink, mr_orange, mr_blue, mr_b].map(&:username)
-
-      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post1.post_number)
-      expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
     end
 
     it "does not reveal whisper users" do

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -179,6 +179,45 @@ RSpec.describe UserSearch do
       expect(results).to eq [mr_b, mr_brown, mr_blue].map(&:username)
     end
 
+    it "prioritises the replying to user" do
+      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post1.post_number)
+      expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
+
+      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post3.post_number)
+      expect(results).to eq [mr_orange, mr_pink, mr_b, mr_brown, mr_blue].map(&:username)
+
+      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post4.post_number)
+      expect(results).to eq [mr_pink, mr_orange, mr_b, mr_brown, mr_blue].map(&:username)
+    end
+
+    it "returns the replying to user if the term includes the username" do
+      results =
+        search_for(mr_blue.username, topic_id: topic.id, replying_to_post_number: post1.post_number)
+      expect(results).to eq [mr_blue].map(&:username)
+      results =
+        search_for(mr_blue.username, topic_id: topic.id, replying_to_post_number: post3.post_number)
+      expect(results).to eq [mr_blue].map(&:username)
+    end
+
+    it "returns firstly the replying to user if the term is blank" do
+      results = search_for("", topic_id: topic.id, replying_to_post_number: post1.post_number)
+      expect(results).to eq [mr_b, mr_pink, mr_orange].map(&:username)
+
+      results = search_for("", topic_id: topic.id, replying_to_post_number: post3.post_number)
+      expect(results).to eq [mr_orange, mr_pink, mr_b].map(&:username)
+
+      results = search_for("", topic_id: topic.id, replying_to_post_number: post4.post_number)
+      expect(results).to eq [mr_pink, mr_orange, mr_b].map(&:username)
+    end
+
+    it "requires `topic_id` for `replying_to_post_number`" do
+      results = search_for("mr", replying_to_post_number: post1.post_number)
+      expect(results).to eq [mr_brown, mr_pink, mr_orange, mr_blue, mr_b].map(&:username)
+
+      results = search_for("mr", topic_id: topic.id, replying_to_post_number: post1.post_number)
+      expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
+    end
+
     it "does not reveal whisper users" do
       results = search_for("", topic_id: topic2.id)
       expect(results).to eq [mr_blue.username]

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe UserSearch do
       expect(results).to eq [mr_b, mr_brown, mr_blue].map(&:username)
     end
 
-    it "prioritises the replying to user" do
+    it "prioritises the replying to user within a topic" do
       results = search_for("mr", topic_id: topic.id, user_id: mr_b.id)
       expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
 

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -180,13 +180,13 @@ RSpec.describe UserSearch do
     end
 
     it "prioritises the replying to user" do
-      results = search_for("mr", topic_id: topic.id, user_id: post1.user_id)
+      results = search_for("mr", topic_id: topic.id, user_id: mr_b.id)
       expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, user_id: post3.user_id)
+      results = search_for("mr", topic_id: topic.id, user_id: mr_orange.id)
       expect(results).to eq [mr_orange, mr_pink, mr_b, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, user_id: post4.user_id)
+      results = search_for("mr", topic_id: topic.id, user_id: mr_pink.id)
       expect(results).to eq [mr_pink, mr_orange, mr_b, mr_brown, mr_blue].map(&:username)
     end
 

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -180,31 +180,31 @@ RSpec.describe UserSearch do
     end
 
     it "prioritises the replying to user within a topic" do
-      results = search_for("mr", topic_id: topic.id, user_id: mr_b.id)
+      results = search_for("mr", topic_id: topic.id, prioritized_user_id: mr_b.id)
       expect(results).to eq [mr_b, mr_pink, mr_orange, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, user_id: mr_orange.id)
+      results = search_for("mr", topic_id: topic.id, prioritized_user_id: mr_orange.id)
       expect(results).to eq [mr_orange, mr_pink, mr_b, mr_brown, mr_blue].map(&:username)
 
-      results = search_for("mr", topic_id: topic.id, user_id: mr_pink.id)
+      results = search_for("mr", topic_id: topic.id, prioritized_user_id: mr_pink.id)
       expect(results).to eq [mr_pink, mr_orange, mr_b, mr_brown, mr_blue].map(&:username)
     end
 
     it "returns the replying to user if the term includes the username" do
-      results = search_for(mr_blue.username, topic_id: topic.id, user_id: post1.user_id)
+      results = search_for(mr_blue.username, topic_id: topic.id, prioritized_user_id: post1.user_id)
       expect(results).to eq [mr_blue].map(&:username)
-      results = search_for(mr_blue.username, topic_id: topic.id, user_id: post3.user_id)
+      results = search_for(mr_blue.username, topic_id: topic.id, prioritized_user_id: post3.user_id)
       expect(results).to eq [mr_blue].map(&:username)
     end
 
     it "returns firstly the replying to user if the term is blank" do
-      results = search_for("", topic_id: topic.id, user_id: post1.user_id)
+      results = search_for("", topic_id: topic.id, prioritized_user_id: post1.user_id)
       expect(results).to eq [mr_b, mr_pink, mr_orange].map(&:username)
 
-      results = search_for("", topic_id: topic.id, user_id: post3.user_id)
+      results = search_for("", topic_id: topic.id, prioritized_user_id: post3.user_id)
       expect(results).to eq [mr_orange, mr_pink, mr_b].map(&:username)
 
-      results = search_for("", topic_id: topic.id, user_id: post4.user_id)
+      results = search_for("", topic_id: topic.id, prioritized_user_id: post4.user_id)
       expect(results).to eq [mr_pink, mr_orange, mr_b].map(&:username)
     end
 

--- a/spec/requests/api/schemas/json/post_replies_response.json
+++ b/spec/requests/api/schemas/json/post_replies_response.json
@@ -138,6 +138,9 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "id": {
+            "type": "integer"
+          },
           "username": {
             "type": "string"
           },

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5227,12 +5227,7 @@ RSpec.describe UsersController do
     end
 
     it "brings first the replied to user" do
-      get "/u/search/users.json",
-          params: {
-            term: "",
-            topic_id: topic.id,
-            replying_to_post_number: post1.post_number,
-          }
+      get "/u/search/users.json", params: { term: "", topic_id: topic.id, user_id: post1.user_id }
 
       expect(response.status).to eq(200)
       json = response.parsed_body
@@ -5246,7 +5241,7 @@ RSpec.describe UsersController do
           params: {
             term: other_user.username,
             topic_id: topic.id,
-            replying_to_post_number: post1.post_number,
+            user_id: post1.user_id,
           }
 
       expect(response.status).to eq(200)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5226,6 +5226,35 @@ RSpec.describe UsersController do
       expect(json["users"].map { |u| u["username"] }).to include(user.username)
     end
 
+    it "brings first the replied to user" do
+      get "/u/search/users.json",
+          params: {
+            term: "",
+            topic_id: topic.id,
+            replying_to_post_number: post1.post_number,
+          }
+
+      expect(response.status).to eq(200)
+      json = response.parsed_body
+      expect(json["users"].map { |u| u["username"] }).to include(user.username)
+      expect(json["users"].first["username"]).to eq(user.username)
+    end
+
+    it "respects the term when replying to a post" do
+      other_user = Fabricate(:user, username: "other_user")
+      get "/u/search/users.json",
+          params: {
+            term: other_user.username,
+            topic_id: topic.id,
+            replying_to_post_number: post1.post_number,
+          }
+
+      expect(response.status).to eq(200)
+      json = response.parsed_body
+      expect(json["users"].map { |u| u["username"] }).to include(other_user.username)
+      expect(json["users"].first["username"]).to eq(other_user.username)
+    end
+
     it "searches only for users who have access to private topic" do
       searching_user = Fabricate(:user)
       privileged_user =

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5228,7 +5228,12 @@ RSpec.describe UsersController do
 
     context "in a topic" do
       it "brings first the replied to user" do
-        get "/u/search/users.json", params: { term: "", topic_id: topic.id, user_id: post1.user_id }
+        get "/u/search/users.json",
+            params: {
+              term: "",
+              topic_id: topic.id,
+              prioritized_user_id: post1.user_id,
+            }
 
         expect(response.status).to eq(200)
         json = response.parsed_body
@@ -5242,7 +5247,7 @@ RSpec.describe UsersController do
             params: {
               term: other_user.username,
               topic_id: topic.id,
-              user_id: post1.user_id,
+              prioritized_user_id: post1.user_id,
             }
 
         expect(response.status).to eq(200)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5226,28 +5226,30 @@ RSpec.describe UsersController do
       expect(json["users"].map { |u| u["username"] }).to include(user.username)
     end
 
-    it "brings first the replied to user" do
-      get "/u/search/users.json", params: { term: "", topic_id: topic.id, user_id: post1.user_id }
+    context "in a topic" do
+      it "brings first the replied to user" do
+        get "/u/search/users.json", params: { term: "", topic_id: topic.id, user_id: post1.user_id }
 
-      expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["users"].map { |u| u["username"] }).to include(user.username)
-      expect(json["users"].first["username"]).to eq(user.username)
-    end
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["users"].map { |u| u["username"] }).to include(user.username)
+        expect(json["users"].first["username"]).to eq(user.username)
+      end
 
-    it "respects the term when replying to a post" do
-      other_user = Fabricate(:user, username: "other_user")
-      get "/u/search/users.json",
-          params: {
-            term: other_user.username,
-            topic_id: topic.id,
-            user_id: post1.user_id,
-          }
+      it "respects the term when replying to a post" do
+        other_user = Fabricate(:user, username: "other_user")
+        get "/u/search/users.json",
+            params: {
+              term: other_user.username,
+              topic_id: topic.id,
+              user_id: post1.user_id,
+            }
 
-      expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["users"].map { |u| u["username"] }).to include(other_user.username)
-      expect(json["users"].first["username"]).to eq(other_user.username)
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["users"].map { |u| u["username"] }).to include(other_user.username)
+        expect(json["users"].first["username"]).to eq(other_user.username)
+      end
     end
 
     it "searches only for users who have access to private topic" do


### PR DESCRIPTION
When replying to a post, the user who is getting the reply should be prioritized in the autocomplete

- Added in composer a getter for getting `.replyingToUser`
- Added in d-editor the reference to the user that is getting the reply(`this.composer.replyingToUser`)
- Passed along the reference to the user that is getting the reply to the user-search service as `replyingToUser`
- Controller `users_controller.rb` was modified to accept the `user_id` parameter and pass it to the `UserSearch` model
- The `UserSearch` model was modified to accept the `user_id` parameter and use it to prioritize the user that is getting the reply in the autocomplete on the first time you call the autocomplete service and while the username is included in the searched term
- Had to update the serializer to pass the id of the `replyingToUser` from the post
