### PR TITLE
DEV: add d-chat-border-radius and d-chat-message-inset variables

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -11,7 +11,7 @@
   background-color: var(--primary-very-low);
   margin: 4px 0 -2px calc(var(--message-left-width) - 0.25rem);
   padding: 0.5rem;
-  border-radius: var(--d-border-radius-large);
+  border-radius: var(--d-chat-border-radius, 0);
   color: var(--primary);
 
   > * {

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -189,7 +189,9 @@
 
 .chat-message-container {
   background-color: var(--d-content-background, var(--secondary));
-  width: 100%;
+  border-radius: var(--d-chat-border-radius, 0);
+  width: calc(100% - var(--d-chat-message-inset, 0) * 2);
+  margin-left: var(--d-chat-message-inset, 0);
 
   &.-errored {
     color: var(--primary-medium);


### PR DESCRIPTION
This adds two optional variables for chat that can be used by theme developers 

`--d-chat-border-radius` and `--d-chat-message-inset`

When used together these can be used to indent and round chat messages: 

![image](https://github.com/user-attachments/assets/b23f1f34-5c38-4910-b8c4-e36462150c5b)

Until assigned, these have no effect: 

![image](https://github.com/user-attachments/assets/ff25b21f-484e-4155-8b46-2b302b8f0f6b)

