### PR TITLE
Revert "DEV: Allow specifying a condition when preloading topics for …

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -138,13 +138,7 @@ class TopicList
       { category: :parent_category },
     ]
 
-    DiscoursePluginRegistry.topic_preloader_associations.each do |assoc|
-      if assoc.is_a?(Symbol)
-        topic_preloader_associations << assoc
-      elsif assoc.is_a?(Hash) && assoc[:condition].call
-        topic_preloader_associations << assoc[:association]
-      end
-    end
+    topic_preloader_associations.concat(DiscoursePluginRegistry.topic_preloader_associations.to_a)
 
     ActiveRecord::Associations::Preloader.new(
       records: @topics,

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1347,24 +1347,6 @@ class Plugin::Instance
     end
   end
 
-  # This method allows plugins to preload topic associations when loading topics
-  # that make use of topic_list.
-  #
-  # @param fields [Array<Symbol>, Symbol, Hash] The topic associations to preload.
-  #   - :association` [Symbol] The association to preload.
-  #   - :condition` [Proc] A function that returns a boolean value indicating whether the association should be preloaded
-  #
-  # @example
-  #   register_topic_preloader_associations(%i[custom_association another_association])
-  #   register_topic_preloader_associations({
-  #     association: :linked_topic, condition: ->(topic) { topic.custom_field.present? }
-  #   })
-  #
-  # @return [void]
-  def register_topic_preloader_associations(fields)
-    DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
-  end
-
   protected
 
   def self.js_path
@@ -1457,6 +1439,10 @@ class Plugin::Instance
 
   def allow_new_queued_post_payload_attribute(attribute_name)
     reloadable_patch { NewPostManager.add_plugin_payload_attribute(attribute_name) }
+  end
+
+  def register_topic_preloader_associations(fields)
+    DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
   end
 
   ##

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1309,14 +1309,6 @@ RSpec.describe TopicQuery do
           :first_post,
           Plugin::Instance.new,
         )
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          { association: :user_warning, condition: -> { true } },
-          Plugin::Instance.new,
-        )
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          { association: :linked_topic, condition: -> { false } },
-          Plugin::Instance.new,
-        )
 
         topic = Fabricate(:topic)
         Fabricate(:post, topic: topic)
@@ -1324,8 +1316,6 @@ RSpec.describe TopicQuery do
         new_topic = topic_query.list_new.topics.first
         expect(new_topic.association(:image_upload).loaded?).to eq(true) # Preloaded by default
         expect(new_topic.association(:first_post).loaded?).to eq(true) # Testing a user-defined preloaded association
-        expect(new_topic.association(:user_warning).loaded?).to eq(true) # Conditionally loaded
-        expect(new_topic.association(:linked_topic).loaded?).to eq(false) # Failed condition
         expect(new_topic.association(:user).loaded?).to eq(false) # Testing the negative
 
         DiscoursePluginRegistry.reset_register!(:topic_preloader_associations)


### PR DESCRIPTION
…topic list (#32079)"

This reverts commit 70887351d7962947184e8351fea5745ee2b3a974.

This was causing errors:

```
NoMethodError (undefined method `call' for nil)
app/models/topic_list.rb:144:in `block in load_topics'
app/models/topic_list.rb:141:in `each'
app/models/topic_list.rb:141:in `load_topics'
app/models/topic_list.rb:75:in `topics'
app/serializers/suggested_topics_mixin.rb:15:in `include_suggested_topics?'
```
