### PR TITLE
UX: Append '+' to link count if above threshold in topic map

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -22,6 +22,7 @@ import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
 const TRUNCATED_LINKS_LIMIT = 5;
+const LINKS_THRESHOLD = 50;
 const MIN_POST_READ_TIME_MINUTES = 4;
 const MIN_READ_TIME_MINUTES = 3;
 const MIN_LIKES_COUNT = 5;
@@ -339,7 +340,7 @@ export default class TopicMapSummary extends Component {
           @inline={{true}}
         >
           <:trigger>
-            {{number this.linksCount noTitle="true"}}
+            {{number this.linksCount maxDisplay=LINKS_THRESHOLD noTitle="true"}}
             <span class="topic-map__stat-label">
               {{i18n "links_lowercase" count=this.linksCount}}
             </span>

--- a/app/assets/javascripts/discourse/app/helpers/number.js
+++ b/app/assets/javascripts/discourse/app/helpers/number.js
@@ -29,7 +29,7 @@ export default function number(orig, params = {}) {
   let addTitle = params.noTitle ? false : true;
 
   // Round off the thousands to one decimal place
-  const n = numberFormatter(orig);
+  const n = numberFormatter(orig, { maxDisplay: params.maxDisplay });
   if (n.toString() !== title.toString() && addTitle) {
     result += " title='" + escapeExpression(title) + "'";
   }

--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -374,7 +374,8 @@ export function relativeAge(date, options) {
   return "UNKNOWN FORMAT";
 }
 
-export function number(val) {
+export function number(val, options) {
+  options = options || {};
   let formattedNumber;
 
   val = Math.round(parseFloat(val));
@@ -382,17 +383,36 @@ export function number(val) {
     val = 0;
   }
 
+  const shouldAppendPlus =
+    typeof options?.maxDisplay === "number" &&
+    options.maxDisplay > 0 &&
+    val > 0 &&
+    val > options.maxDisplay;
+
+  if (shouldAppendPlus) {
+    val = options.maxDisplay;
+  }
+
+  let output;
+
   if (val > 999999) {
     formattedNumber = I18n.toNumber(val / 1000000, { precision: 1 });
-    return i18n("number.short.millions", { number: formattedNumber });
+    output = i18n("number.short.millions", { number: formattedNumber });
   } else if (val > 99999) {
     formattedNumber = I18n.toNumber(Math.floor(val / 1000), { precision: 0 });
-    return i18n("number.short.thousands", { number: formattedNumber });
+    output = i18n("number.short.thousands", { number: formattedNumber });
   } else if (val > 999) {
     formattedNumber = I18n.toNumber(val / 1000, { precision: 1 });
-    return i18n("number.short.thousands", { number: formattedNumber });
+    output = i18n("number.short.thousands", { number: formattedNumber });
+  } else {
+    output = val.toString();
   }
-  return val.toString();
+
+  if (shouldAppendPlus) {
+    output += "+";
+  }
+
+  return output;
 }
 
 export function ensureJSON(json) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -319,6 +319,32 @@ module("Unit | Utility | formatter", function (hooks) {
       "13",
       "it returns a string float rounded to an integer as a string"
     );
+
+    assert.strictEqual(
+      number(100, { maxDisplay: 50 }),
+      "50+",
+      "it appends + when value exceeds maxDisplay"
+    );
+    assert.strictEqual(
+      number(50, { maxDisplay: 50 }),
+      "50",
+      "it does not append + when value equals maxDisplay"
+    );
+    assert.strictEqual(
+      number(49, { maxDisplay: 50 }),
+      "49",
+      "it does not append + when value is below maxDisplay"
+    );
+    assert.strictEqual(
+      number(3333, { maxDisplay: 1000 }),
+      "1.0k+",
+      "it abbreviates thousands and appends +"
+    );
+    assert.strictEqual(
+      number(2499999, { maxDisplay: 1000000 }),
+      "1.0M+",
+      "it abbreviates millions and appends +"
+    );
   });
 
   test("durationTiny", function (assert) {

--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -51,7 +51,7 @@ class TopicLink < ActiveRecord::Base
       /*where*/
       GROUP BY ftl.url, ft.title, ftl.title, ftl.link_topic_id, ftl.reflection, ftl.internal, ftl.domain
       ORDER BY clicks DESC, count(*) DESC
-      LIMIT 50
+      LIMIT 51
     SQL
 
     builder.where("ftl.topic_id = :topic_id", topic_id: topic_id)


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/suggestion-for-fixing-the-inaccurate-link-counter-value/359527

The link count in the topic map summary is limited to 50 on the backend. 
However, the frontend displays exactly 50, even when more links exist. 
This can be misleading as users might assume there are no additional links.

This PR updates the logic by fetching one extra link from the database and appending a `+` to the count when there are more than 50 links.

Before:
![image](https://github.com/user-attachments/assets/a741d984-1eb0-41f0-9f58-1a52574fc9bc)

After:
![image](https://github.com/user-attachments/assets/8b1e589a-f85f-4c06-a2ac-dd2b34a41b46)
