### PR TITLE
FIX: Update tag topic counts when bulk removing tags

### DIFF
--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -271,7 +271,7 @@ class TopicsBulkAction
   def remove_tags
     topics.each do |t|
       if guardian.can_edit?(t)
-        TopicTag.where(topic_id: t.id).delete_all
+        TopicTag.where(topic_id: t.id).in_batches.destroy_all
         @changed_ids << t.id
       end
     end

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -558,15 +558,18 @@ RSpec.describe TopicsBulkAction do
     before do
       SiteSetting.tagging_enabled = true
       SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
-      topic.tags = [tag1, tag2]
+      TopicTag.create!(topic: topic, tag: tag1)
+      TopicTag.create!(topic: topic, tag: tag2)
     end
 
     it "can remove all tags" do
+      expect(tag1.reload.staff_topic_count).to eq(1)
       tba = TopicsBulkAction.new(topic.user, [topic.id], type: "remove_tags")
       topic_ids = tba.perform!
       expect(topic_ids).to eq([topic.id])
       topic.reload
       expect(topic.tags.size).to eq(0)
+      expect(tag1.reload.staff_topic_count).to eq(0)
     end
 
     context "when user can't edit topic" do


### PR DESCRIPTION
### What is the problem?

When bulk removing tags, the tag topic count isn't updated. You have to wait for the daily "ensure consistency" job to run for it to update properly. This is causing downstream problems, like the inability to use the "remove unused tags" feature.

### Why is it happening?

The counter updating is handled on destroy by the join table model `TopicTag`. But we are calling `#delete_all` to perform the bulk tag removal, which bypasses callbacks.

### How does this fix it?

Change from `#delete_all` to `#destroy_all`, which invokes callbacks and updates the counters.