### PR TITLE
DEV: Double default capybara max wait time for certain tests take 3

### DIFF
--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -70,40 +70,45 @@ describe "Changing email", type: :system do
   end
 
   it "works when user has webauthn 2fa" do
-    # enforced 2FA flow needs a user created > 5 minutes ago
-    user.created_at = 6.minutes.ago
-    user.save!
+    # Tests is flaky so trying with a longer wait time as a workaround
+    Capybara.using_wait_time(Capybara.default_max_wait_time * 2) do
+      begin
+        # enforced 2FA flow needs a user created > 5 minutes ago
+        user.created_at = 6.minutes.ago
+        user.save!
 
-    sign_in user
+        sign_in user
 
-    DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
-    options =
-      ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
-        user_verification: true,
-        user_verified: true,
-        resident_key: true,
-      )
-    authenticator = page.driver.browser.add_virtual_authenticator(options)
+        DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+        options =
+          ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
+            user_verification: true,
+            user_verified: true,
+            resident_key: true,
+          )
+        authenticator = page.driver.browser.add_virtual_authenticator(options)
 
-    user_preferences_security_page.visit(user)
-    user_preferences_security_page.visit_second_factor(user, password)
+        user_preferences_security_page.visit(user)
+        user_preferences_security_page.visit_second_factor(user, password)
 
-    find(".security-key .new-security-key").click
-    expect(user_preferences_security_page).to have_css("input#security-key-name")
+        find(".security-key .new-security-key").click
+        expect(user_preferences_security_page).to have_css("input#security-key-name")
 
-    find(".d-modal__body input#security-key-name").fill_in(with: "First Key")
-    find(".add-security-key").click
+        find(".d-modal__body input#security-key-name").fill_in(with: "First Key")
+        find(".add-security-key").click
 
-    expect(user_preferences_security_page).to have_css(".security-key .second-factor-item")
+        expect(user_preferences_security_page).to have_css(".security-key .second-factor-item")
 
-    visit generate_confirm_link
+        visit generate_confirm_link
 
-    find(".confirm-new-email .btn-primary").click
-    find("#security-key-authenticate-button").click
+        find(".confirm-new-email .btn-primary").click
+        find("#security-key-authenticate-button").click
 
-    try_until_success { expect(user.reload.primary_email.email).to eq(new_email) }
-  ensure
-    authenticator&.remove!
+        try_until_success { expect(user.reload.primary_email.email).to eq(new_email) }
+      ensure
+        authenticator&.remove!
+      end
+    end
   end
 
   it "does not require login to confirm email change" do


### PR DESCRIPTION
This is a follow up to 59edec46a3de105e720bd2c716ae34d636794044

Test is flaky and seems to require more time to complete on CI so we
double the max wait time for now to see if it reduces the test's
flakiness.
