### PR TITLE
FEATURE: when rich editor is enabled markdown is in monospace

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -730,7 +730,13 @@ export default class DEditor extends Component {
   }
 
   <template>
-    <div class="d-editor-container">
+    <div
+      class="d-editor-container
+        {{if
+          this.siteSettings.rich_editor
+          'd-editor-container--rich-editor-enabled'
+        }}"
+    >
       <div class="d-editor-textarea-column">
         {{yield}}
 

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -2,6 +2,10 @@
   display: flex;
   flex-grow: 1;
   max-width: 100%;
+
+  &--rich-editor-enabled .d-editor-textarea-wrapper textarea.d-editor-input {
+    font-family: var(--d-font-family--monospace);
+  }
 }
 
 .d-editor {


### PR DESCRIPTION
- adds .d-editor-container--rich-editor-enabled to d-editor-container
- conditionally swaps textarea to monospace when siteSettings.rich_editor is enabled

