### PR TITLE
DEV: Preserve unsaved site settings

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-site-settings-changes-banner.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-site-settings-changes-banner.gjs
@@ -41,23 +41,37 @@ export default class AdminSiteSettingsChangesBanner extends Component {
     });
   }
 
+  get saveLabel() {
+    return i18n("admin.site_settings.save", {
+      count: this.dirtyCount,
+    });
+  }
+
+  get discardLabel() {
+    return i18n("admin.site_settings.discard", {
+      count: this.dirtyCount,
+    });
+  }
+
   <template>
     {{#if this.showBanner}}
       <div class="admin-site-settings__changes-banner">
         <span>{{htmlSafe this.bannerLabel}}</span>
         <div class="controls">
           <DButton
-            @label="admin.site_settings.discard"
             @action={{this.discard}}
             @disabled={{this.isSaving}}
             class="btn-secondary btn-small"
-          />
+          >
+            {{this.discardLabel}}
+          </DButton>
           <DButton
-            @label="admin.site_settings.save"
             @action={{this.save}}
             @isLoading={{this.isSaving}}
             class="btn-primary btn-small"
-          />
+          >
+            {{this.saveLabel}}
+          </DButton>
         </div>
       </div>
     {{/if}}

--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -98,14 +98,14 @@ export default class SiteSettingComponent extends Component.extend(
         <DButton
           @action={{this.update}}
           @icon="check"
-          @disabled={{this.disableControls}}
+          @isLoading={{this.disableControls}}
           @ariaLabel="admin.settings.save"
           class="ok setting-controls__ok"
         />
         <DButton
           @action={{this.cancel}}
           @icon="xmark"
-          @disabled={{this.disableControls}}
+          @isLoading={{this.disableControls}}
           @ariaLabel="admin.settings.cancel"
           class="cancel setting-controls__cancel"
         />

--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -98,14 +98,14 @@ export default class SiteSettingComponent extends Component.extend(
         <DButton
           @action={{this.update}}
           @icon="check"
-          @disabled={{this.disableSaveButton}}
+          @disabled={{this.disableControls}}
           @ariaLabel="admin.settings.save"
           class="ok setting-controls__ok"
         />
         <DButton
           @action={{this.cancel}}
           @icon="xmark"
-          @disabled={{this.disableUndoButton}}
+          @disabled={{this.disableControls}}
           @ariaLabel="admin.settings.cancel"
           class="cancel setting-controls__cancel"
         />

--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -1,11 +1,10 @@
-import { cached, tracked } from "@glimmer/tracking";
+import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { readOnly } from "@ember/object/computed";
 import { getOwner } from "@ember/owner";
 import { LinkTo } from "@ember/routing";
-import BufferedProxy from "ember-buffered-proxy/proxy";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -28,18 +27,15 @@ export default class SiteSettingComponent extends Component.extend(
     );
   }
 
-  @cached
   @dependentKeyCompat
   get buffered() {
-    return BufferedProxy.create({
-      content: this.setting,
-    });
+    return this.setting.buffered;
   }
 
   _save() {
     const setting = this.buffered;
     return SiteSetting.update(setting.get("setting"), setting.get("value"), {
-      updateExistingUsers: this.updateExistingUsers,
+      updateExistingUsers: this.setting.updateExistingUsers,
     });
   }
 
@@ -90,7 +86,7 @@ export default class SiteSettingComponent extends Component.extend(
           @changeValueCallback={{this.changeValueCallback}}
           @setValidationMessage={{this.setValidationMessage}}
         />
-        <SettingValidationMessage @message={{this.validationMessage}} />
+        <SettingValidationMessage @message={{this.setting.validationMessage}} />
         {{#if this.displayDescription}}
           <Description @description={{this.setting.description}} />
         {{/if}}

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -1,5 +1,5 @@
 import Controller from "@ember/controller";
-import EmberObject, { action } from "@ember/object";
+import { action } from "@ember/object";
 import {
   empty,
   filterBy,
@@ -16,6 +16,7 @@ import discourseComputed from "discourse/lib/decorators";
 import { makeArray } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
 import ThemeSettingsEditor from "admin/components/theme-settings-editor";
+import SiteSetting from "admin/models/site-setting";
 import { COMPONENTS, THEMES } from "admin/models/theme";
 import ThemeSettings from "admin/models/theme-settings";
 import ThemeUploadAddModal from "../components/theme-upload-add";
@@ -91,11 +92,11 @@ export default class AdminCustomizeThemesShowController extends Controller {
 
   @discourseComputed("model.parentThemes.[]")
   relativesSelectorSettingsForComponent() {
-    return EmberObject.create({
+    return SiteSetting.create({
       list_type: "compact",
       type: "list",
       preview: null,
-      anyValue: false,
+      allow_any: false,
       setting: "parent_theme_ids",
       label: i18n("admin.customize.theme.component_on_themes"),
       choices: this.availableThemesNames,
@@ -109,11 +110,11 @@ export default class AdminCustomizeThemesShowController extends Controller {
 
   @discourseComputed("model.parentThemes.[]")
   relativesSelectorSettingsForTheme() {
-    return EmberObject.create({
+    return SiteSetting.create({
       list_type: "compact",
       type: "list",
       preview: null,
-      anyValue: false,
+      allow_any: false,
       setting: "child_theme_ids",
       label: i18n("admin.customize.theme.included_components"),
       choices: this.availableComponentsNames,

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -67,7 +67,7 @@ export default Mixin.create({
   }),
 
   dirty: computed("buffered.value", "setting.value", function () {
-    let bufferVal = this.get("buffered.value");
+    let bufferVal = this.buffered.get("value");
     let settingVal = this.setting?.value;
 
     if (isNone(bufferVal)) {
@@ -91,7 +91,7 @@ export default Mixin.create({
 
   preview: computed("setting", "buffered.value", function () {
     const setting = this.setting;
-    const value = this.get("buffered.value");
+    const value = this.buffered.get("value");
     const preview = setting.preview;
     if (preview) {
       const escapedValue = preview.replace(/\{\{value\}\}/g, value);
@@ -128,7 +128,7 @@ export default Mixin.create({
   }),
 
   bufferedValues: computed("buffered.value", function () {
-    const value = this.get("buffered.value");
+    const value = this.buffered.get("value");
     return splitString(value, "|");
   }),
 
@@ -203,11 +203,11 @@ export default Mixin.create({
 
   save: action(async function () {
     try {
-      this.setting.set("isSaving", true);
+      this.setting.isSaving = true;
 
       await this._save();
 
-      this.setting.set("validationMessage", null);
+      this.setting.validationMessage = null;
       this.buffered.applyChanges();
       if (this.setting.requiresReload) {
         this.afterSave();
@@ -221,31 +221,31 @@ export default Mixin.create({
           errorString = htmlSafe(errorString);
         }
 
-        this.setting.set("validationMessage", errorString);
+        this.setting.validationMessage = errorString;
       } else {
-        this.setting.set("validationMessage", i18n("generic_error"));
+        this.setting.validationMessage = i18n("generic_error");
       }
     } finally {
-      this.setting.set("isSaving", false);
+      this.setting.isSaving = false;
     }
   }),
 
   changeValueCallback: action(function (value) {
-    this.set("buffered.value", value);
+    this.buffered.set("value", value);
   }),
 
   setValidationMessage: action(function (message) {
-    this.setting.set("validationMessage", message);
+    this.setting.validationMessage = message;
   }),
 
   cancel: action(function () {
     this.buffered.discardChanges();
-    this.setting.set("validationMessage", null);
+    this.setting.validationMessage = null;
   }),
 
   resetDefault: action(function () {
-    this.setting.set("buffered.value", this.setting.default);
-    this.setting.set("validationMessage", null);
+    this.buggered.set("value", this.setting.default);
+    this.setting.validationMessage = null;
   }),
 
   toggleSecret: action(function () {
@@ -253,11 +253,11 @@ export default Mixin.create({
   }),
 
   setDefaultValues: action(function () {
-    this.set(
-      "buffered.value",
+    this.buffered.set(
+      "value",
       this.bufferedValues.concat(this.defaultValues).uniq().join("|")
     );
-    this.setting.set("validationMessage", null);
+    this.setting.validationMessage = null;
     return false;
   }),
 

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -244,7 +244,7 @@ export default Mixin.create({
   }),
 
   resetDefault: action(function () {
-    this.buggered.set("value", this.setting.default);
+    this.buffered.set("value", this.setting.default);
     this.setting.validationMessage = null;
   }),
 

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -5,19 +5,12 @@ import Mixin from "@ember/object/mixin";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { isNone } from "@ember/utils";
-import { Promise } from "rsvp";
 import JsonSchemaEditorModal from "discourse/components/modal/json-schema-editor";
-import { ajax } from "discourse/lib/ajax";
 import { fmt, propertyNotEqual } from "discourse/lib/computed";
 import { deepEqual } from "discourse/lib/object";
 import { humanizedSettingName } from "discourse/lib/site-settings-utils";
 import { splitString } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
-import {
-  DEFAULT_USER_PREFERENCES,
-  SITE_SETTING_REQUIRES_CONFIRMATION_TYPES,
-} from "admin/lib/constants";
-import SiteSettingDefaultCategoriesModal from "../components/modal/site-setting-default-categories";
 
 const CUSTOM_TYPES = [
   "bool",
@@ -45,8 +38,6 @@ const CUSTOM_TYPES = [
   "font_list",
 ];
 
-const AUTO_REFRESH_ON_SAVE = ["logo", "logo_small", "large_icon"];
-
 export default Mixin.create({
   modal: service(),
   router: service(),
@@ -55,8 +46,6 @@ export default Mixin.create({
   siteSettingChangeTracker: service(),
   attributeBindings: ["setting.setting:data-setting"],
   classNameBindings: [":row", ":setting", "overridden", "typeClass"],
-  validationMessage: null,
-  isSaving: false,
 
   content: alias("setting"),
   isSecret: oneWay("setting.secret"),
@@ -70,7 +59,6 @@ export default Mixin.create({
 
   willDestroyElement() {
     this._super(...arguments);
-    this.siteSettingChangeTracker.remove(this);
     this.element.removeEventListener("keydown", this._handleKeydown);
   },
 
@@ -93,9 +81,9 @@ export default Mixin.create({
     const dirty = !deepEqual(bufferVal, settingVal);
 
     if (dirty) {
-      this.siteSettingChangeTracker.add(this);
+      this.siteSettingChangeTracker.add(this.setting);
     } else {
-      this.siteSettingChangeTracker.remove(this);
+      this.siteSettingChangeTracker.remove(this.setting);
     }
 
     return dirty;
@@ -191,120 +179,41 @@ export default Mixin.create({
     }
   }),
 
-  disableSaveButton: computed("isSaving", "validationMessage", function () {
-    return !!this.validationMessage || this.isSaving;
+  disableSaveButton: computed("setting.isSaving", function () {
+    return !!this.setting.isSaving;
   }),
 
-  disableUndoButton: computed("isSaving", function () {
-    return !!this.isSaving;
+  disableUndoButton: computed("setting.isSaving", function () {
+    return !!this.setting.isSaving;
   }),
-
-  requiresReload() {
-    return AUTO_REFRESH_ON_SAVE.includes(this.setting.setting);
-  },
-
-  requiresConfirmation() {
-    return (
-      this.buffered.get("requires_confirmation") ===
-      SITE_SETTING_REQUIRES_CONFIRMATION_TYPES.simple
-    );
-  },
-
-  affectsExistingUsers() {
-    return DEFAULT_USER_PREFERENCES.includes(this.buffered.get("setting"));
-  },
-
-  confirmChanges() {
-    const settingKey = this.buffered.get("setting");
-
-    return new Promise((resolve) => {
-      // Fallback is needed in case the setting does not have a custom confirmation
-      // prompt/confirm defined.
-      this.dialog.alert({
-        message: i18n(
-          `admin.site_settings.requires_confirmation_messages.${settingKey}.prompt`,
-          {
-            translatedFallback: i18n(
-              "admin.site_settings.requires_confirmation_messages.default.prompt"
-            ),
-          }
-        ),
-        buttons: [
-          {
-            label: i18n(
-              `admin.site_settings.requires_confirmation_messages.${settingKey}.confirm`,
-              {
-                translatedFallback: i18n(
-                  "admin.site_settings.requires_confirmation_messages.default.confirm"
-                ),
-              }
-            ),
-            class: "btn-primary",
-            action: () => resolve(true),
-          },
-          {
-            label: i18n("no_value"),
-            class: "btn-default",
-            action: () => resolve(false),
-          },
-        ],
-      });
-    });
-  },
-
-  async configureBackfill() {
-    const key = this.buffered.get("setting");
-
-    const data = {
-      [key]: this.buffered.get("value"),
-    };
-
-    const result = await ajax(`/admin/site_settings/${key}/user_count.json`, {
-      type: "PUT",
-      data,
-    });
-
-    const count = result.user_count;
-
-    if (count > 0) {
-      await this.modal.show(SiteSettingDefaultCategoriesModal, {
-        model: {
-          siteSetting: { count, key: key.replaceAll("_", " ") },
-          setUpdateExistingUsers: this.setUpdateExistingUsers,
-        },
-      });
-    }
-  },
 
   update: action(async function () {
-    if (this.requiresConfirmation()) {
-      const confirm = await this.confirmChanges();
+    if (this.setting.requiresConfirmation) {
+      const confirm = await this.siteSettingChangeTracker.confirmChanges(
+        this.setting
+      );
 
       if (!confirm) {
         return;
       }
     }
 
-    if (this.affectsExistingUsers()) {
-      await this.configureBackfill();
+    if (this.setting.affectsExistingUsers) {
+      await this.siteSettingChangeTracker.configureBackfill(this.setting);
     }
 
     await this.save();
   }),
 
-  setUpdateExistingUsers: action(function (value) {
-    this.updateExistingUsers = value;
-  }),
-
   save: action(async function () {
     try {
-      this.set("isSaving", true);
+      this.setting.set("isSaving", true);
 
       await this._save();
 
-      this.set("validationMessage", null);
+      this.setting.set("validationMessage", null);
       this.buffered.applyChanges();
-      if (this.requiresReload()) {
+      if (this.setting.requiresReload) {
         this.afterSave();
       }
     } catch (e) {
@@ -316,12 +225,12 @@ export default Mixin.create({
           errorString = htmlSafe(errorString);
         }
 
-        this.set("validationMessage", errorString);
+        this.setting.set("validationMessage", errorString);
       } else {
-        this.set("validationMessage", i18n("generic_error"));
+        this.setting.set("validationMessage", i18n("generic_error"));
       }
     } finally {
-      this.set("isSaving", false);
+      this.setting.set("isSaving", false);
     }
   }),
 
@@ -330,17 +239,17 @@ export default Mixin.create({
   }),
 
   setValidationMessage: action(function (message) {
-    this.set("validationMessage", message);
+    this.setting.set("validationMessage", message);
   }),
 
   cancel: action(function () {
     this.buffered.discardChanges();
-    this.set("validationMessage", null);
+    this.setting.set("validationMessage", null);
   }),
 
   resetDefault: action(function () {
-    this.set("buffered.value", this.setting.default);
-    this.set("validationMessage", null);
+    this.setting.set("buffered.value", this.setting.default);
+    this.setting.set("validationMessage", null);
   }),
 
   toggleSecret: action(function () {
@@ -352,7 +261,7 @@ export default Mixin.create({
       "buffered.value",
       this.bufferedValues.concat(this.defaultValues).uniq().join("|")
     );
-    this.set("validationMessage", null);
+    this.setting.set("validationMessage", null);
     return false;
   }),
 

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -179,11 +179,7 @@ export default Mixin.create({
     }
   }),
 
-  disableSaveButton: computed("setting.isSaving", function () {
-    return !!this.setting.isSaving;
-  }),
-
-  disableUndoButton: computed("setting.isSaving", function () {
+  disableControls: computed("setting.isSaving", function () {
     return !!this.setting.isSaving;
   }),
 

--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -3,12 +3,12 @@ import EmberObject from "@ember/object";
 import { alias } from "@ember/object/computed";
 import BufferedProxy from "ember-buffered-proxy/proxy";
 import { ajax } from "discourse/lib/ajax";
+import discourseComputed, { bind } from "discourse/lib/decorators";
+import { i18n } from "discourse-i18n";
 import {
   DEFAULT_USER_PREFERENCES,
   SITE_SETTING_REQUIRES_CONFIRMATION_TYPES,
-} from "discourse/lib/constants";
-import discourseComputed, { bind } from "discourse/lib/decorators";
-import { i18n } from "discourse-i18n";
+} from "admin/lib/constants";
 import SettingObjectHelper from "admin/lib/setting-object-helper";
 
 const AUTO_REFRESH_ON_SAVE = ["logo", "logo_small", "large_icon"];

--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -1,9 +1,17 @@
+import { tracked } from "@glimmer/tracking";
 import EmberObject from "@ember/object";
 import { alias } from "@ember/object/computed";
+import BufferedProxy from "ember-buffered-proxy/proxy";
 import { ajax } from "discourse/lib/ajax";
-import discourseComputed from "discourse/lib/decorators";
+import {
+  DEFAULT_USER_PREFERENCES,
+  SITE_SETTING_REQUIRES_CONFIRMATION_TYPES,
+} from "discourse/lib/constants";
+import discourseComputed, { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 import SettingObjectHelper from "admin/lib/setting-object-helper";
+
+const AUTO_REFRESH_ON_SAVE = ["logo", "logo_small", "large_icon"];
 
 export default class SiteSetting extends EmberObject {
   static findAll(params = {}) {
@@ -47,6 +55,10 @@ export default class SiteSetting extends EmberObject {
     });
   }
 
+  @tracked isSaving = false;
+  @tracked validationMessage = null;
+  updateExistingUsers = false;
+
   settingObjectHelper = new SettingObjectHelper(this);
 
   @alias("settingObjectHelper.overridden") overridden;
@@ -55,6 +67,11 @@ export default class SiteSetting extends EmberObject {
   @alias("settingObjectHelper.validValues") validValues;
   @alias("settingObjectHelper.allowsNone") allowsNone;
   @alias("settingObjectHelper.anyValue") anyValue;
+
+  constructor() {
+    super(...arguments);
+    this.buffered = BufferedProxy.create({ content: this });
+  }
 
   @discourseComputed("setting")
   staffLogFilter(setting) {
@@ -66,5 +83,25 @@ export default class SiteSetting extends EmberObject {
       subject: setting,
       action_name: "change_site_setting",
     };
+  }
+
+  get requiresConfirmation() {
+    return (
+      this.requires_confirmation ===
+      SITE_SETTING_REQUIRES_CONFIRMATION_TYPES.simple
+    );
+  }
+
+  get requiresReload() {
+    return AUTO_REFRESH_ON_SAVE.includes(this.setting);
+  }
+
+  get affectsExistingUsers() {
+    return DEFAULT_USER_PREFERENCES.includes(this.setting);
+  }
+
+  @bind
+  setUpdateExistingUsers(value) {
+    this.updateExistingUsers = value;
   }
 }

--- a/app/assets/javascripts/admin/addon/models/theme-settings.js
+++ b/app/assets/javascripts/admin/addon/models/theme-settings.js
@@ -1,19 +1,8 @@
-import EmberObject from "@ember/object";
-import { alias } from "@ember/object/computed";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import SettingObjectHelper from "admin/lib/setting-object-helper";
+import SiteSetting from "admin/models/site-setting";
 
-export default class ThemeSettings extends EmberObject {
-  settingObjectHelper = new SettingObjectHelper(this);
-
-  @alias("settingObjectHelper.overridden") overridden;
-  @alias("settingObjectHelper.computedValueProperty") computedValueProperty;
-  @alias("settingObjectHelper.computedNameProperty") computedNameProperty;
-  @alias("settingObjectHelper.validValues") validValues;
-  @alias("settingObjectHelper.allowsNone") allowsNone;
-  @alias("settingObjectHelper.anyValue") anyValue;
-
+export default class ThemeSettings extends SiteSetting {
   updateSetting(themeId, newValue) {
     if (this.objects_schema) {
       newValue = JSON.stringify(newValue);

--- a/app/assets/javascripts/admin/addon/routes/admin-config-with-settings-route.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-with-settings-route.js
@@ -1,13 +1,9 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 
 export default class AdminConfigWithSettingsRoute extends DiscourseRoute {
-  @service dialog;
   @service siteSettingChangeTracker;
-
-  _transitionConfirmed = true;
 
   resetController(controller, isExiting) {
     // Have to do this because this is the parent route. We don't want to have
@@ -26,23 +22,9 @@ export default class AdminConfigWithSettingsRoute extends DiscourseRoute {
     if (this.siteSettingChangeTracker.hasUnsavedChanges) {
       transition.abort();
 
-      await new Promise(() => {
-        this.dialog.confirm({
-          message: i18n("admin.site_settings.dirty_banner", {
-            count: this.siteSettingChangeTracker.count,
-          }),
-          confirmButtonLabel: "admin.site_settings.save",
-          cancelButtonLabel: "admin.site_settings.discard",
-          didConfirm: async () => {
-            await this.siteSettingChangeTracker.save();
-            transition.retry();
-          },
-          didCancel: () => {
-            this.siteSettingChangeTracker.discard();
-            transition.retry();
-          },
-        });
-      });
+      await this.siteSettingChangeTracker.confirmTransition();
+
+      transition.retry();
     }
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-config-with-settings-route.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-with-settings-route.js
@@ -1,6 +1,14 @@
+import { action } from "@ember/object";
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
 export default class AdminConfigWithSettingsRoute extends DiscourseRoute {
+  @service dialog;
+  @service siteSettingChangeTracker;
+
+  _transitionConfirmed = true;
+
   resetController(controller, isExiting) {
     // Have to do this because this is the parent route. We don't want to have
     // to make a controller for every single settings route when we can reset
@@ -10,6 +18,31 @@ export default class AdminConfigWithSettingsRoute extends DiscourseRoute {
     );
     if (isExiting) {
       settingsController.set("filter", "");
+    }
+  }
+
+  @action
+  async willTransition(transition) {
+    if (this.siteSettingChangeTracker.hasUnsavedChanges) {
+      transition.abort();
+
+      await new Promise(() => {
+        this.dialog.confirm({
+          message: i18n("admin.site_settings.dirty_banner", {
+            count: this.siteSettingChangeTracker.count,
+          }),
+          confirmButtonLabel: "admin.site_settings.save",
+          cancelButtonLabel: "admin.site_settings.discard",
+          didConfirm: async () => {
+            await this.siteSettingChangeTracker.save();
+            transition.retry();
+          },
+          didCancel: () => {
+            this.siteSettingChangeTracker.discard();
+            transition.retry();
+          },
+        });
+      });
     }
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -1,8 +1,13 @@
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
 
 export default class AdminSiteSettingsRoute extends DiscourseRoute {
+  @service dialog;
+  @service siteSettingChangeTracker;
+
   queryParams = {
     filter: { replace: true },
   };
@@ -16,6 +21,34 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
 
     if (!controller.get("visibleSiteSettings")) {
       controller.set("visibleSiteSettings", siteSettings);
+    }
+  }
+
+  @action
+  async willTransition(transition) {
+    if (
+      this.siteSettingChangeTracker.hasUnsavedChanges &&
+      transition.from.name !== transition.to.name
+    ) {
+      transition.abort();
+
+      await new Promise(() => {
+        this.dialog.confirm({
+          message: i18n("admin.site_settings.dirty_banner", {
+            count: this.siteSettingChangeTracker.count,
+          }),
+          confirmButtonLabel: "admin.site_settings.save",
+          cancelButtonLabel: "admin.site_settings.discard",
+          didConfirm: () => {
+            this.siteSettingChangeTracker.save();
+            transition.retry();
+          },
+          didCancel: () => {
+            this.siteSettingChangeTracker.discard();
+            transition.retry();
+          },
+        });
+      });
     }
   }
 

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -1,11 +1,9 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
 
 export default class AdminSiteSettingsRoute extends DiscourseRoute {
-  @service dialog;
   @service siteSettingChangeTracker;
 
   queryParams = {
@@ -32,23 +30,9 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
     ) {
       transition.abort();
 
-      await new Promise(() => {
-        this.dialog.confirm({
-          message: i18n("admin.site_settings.dirty_banner", {
-            count: this.siteSettingChangeTracker.count,
-          }),
-          confirmButtonLabel: "admin.site_settings.save",
-          cancelButtonLabel: "admin.site_settings.discard",
-          didConfirm: () => {
-            this.siteSettingChangeTracker.save();
-            transition.retry();
-          },
-          didCancel: () => {
-            this.siteSettingChangeTracker.discard();
-            transition.retry();
-          },
-        });
-      });
+      await this.siteSettingChangeTracker.confirmTransition();
+
+      transition.retry();
     }
   }
 

--- a/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
+++ b/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
@@ -131,8 +131,8 @@ export default class SiteSettingChangeTracker extends Service {
         message: i18n("admin.site_settings.dirty_banner", {
           count: this.count,
         }),
-        confirmButtonLabel: "admin.site_settings.save",
-        cancelButtonLabel: "admin.site_settings.discard",
+        confirmButtonLabel: this.saveLabel,
+        cancelButtonLabel: this.discardLabel,
         didConfirm: async () => {
           await this.save();
           resolve(true);
@@ -187,6 +187,18 @@ export default class SiteSettingChangeTracker extends Service {
 
   get hasUnsavedChanges() {
     return this.count > 0;
+  }
+
+  get saveLabel() {
+    const count = this.hasUnsavedChanges ? "other" : "one";
+
+    return `admin.site_settings.save.${count}`;
+  }
+
+  get discardLabel() {
+    const count = this.hasUnsavedChanges ? "other" : "one";
+
+    return `admin.site_settings.discard.${count}`;
   }
 
   get #requiresConfirmation() {

--- a/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
+++ b/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
@@ -124,6 +124,26 @@ export default class SiteSettingChangeTracker extends Service {
     });
   }
 
+  async confirmTransition() {
+    await new Promise((resolve) => {
+      this.dialog.confirm({
+        message: i18n("admin.site_settings.dirty_banner", {
+          count: this.count,
+        }),
+        confirmButtonLabel: "admin.site_settings.save",
+        cancelButtonLabel: "admin.site_settings.discard",
+        didConfirm: async () => {
+          await this.save();
+          resolve(true);
+        },
+        didCancel: () => {
+          this.discard();
+          resolve(false);
+        },
+      });
+    });
+  }
+
   async configureBackfill(setting) {
     const key = setting.buffered.get("setting");
 

--- a/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
+++ b/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
@@ -1,28 +1,30 @@
 import { tracked } from "@glimmer/tracking";
 import Service, { service } from "@ember/service";
 import { TrackedSet } from "@ember-compat/tracked-built-ins";
+import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
+import SiteSettingDefaultCategoriesModal from "../components/modal/site-setting-default-categories";
 
 export default class SiteSettingChangeTracker extends Service {
+  @service dialog;
   @service modal;
 
   @tracked dirtySiteSettings = new TrackedSet();
 
-  add(settingComponent) {
-    this.dirtySiteSettings.add(settingComponent);
+  add(setting) {
+    this.dirtySiteSettings.add(setting);
   }
 
-  remove(settingComponent) {
-    this.dirtySiteSettings.delete(settingComponent);
+  remove(setting) {
+    this.dirtySiteSettings.delete(setting);
   }
 
   async save() {
     const params = {};
 
-    this.dirtySiteSettings.forEach((setting) => {
-      setting.set("isSaving", true);
-    });
+    this.#startSaving();
 
     try {
       let reload = false;
@@ -31,11 +33,13 @@ export default class SiteSettingChangeTracker extends Service {
       // Settings with custom confirmation messages.
       if (this.#requiresConfirmation.length > 0) {
         for (let setting of this.#requiresConfirmation) {
-          confirm = await setting.confirmChanges();
-        }
+          confirm = await this.confirmChanges(setting);
 
-        if (!confirm) {
-          return;
+          if (!confirm) {
+            this.#stopSaving();
+
+            return;
+          }
         }
       }
 
@@ -43,7 +47,7 @@ export default class SiteSettingChangeTracker extends Service {
       // affect existing users.
       if (this.#affectsExistingUsers.length > 0) {
         for (let setting of this.#affectsExistingUsers) {
-          await setting.configureBackfill();
+          await this.configureBackfill(setting);
         }
       }
 
@@ -59,40 +63,120 @@ export default class SiteSettingChangeTracker extends Service {
       this.dirtySiteSettings.forEach((setting) => {
         setting.set("validationMessage", null);
         setting.buffered.applyChanges();
-        if (setting.requiresReload()) {
+        if (setting.requiresReload) {
           reload = setting.afterSave;
         }
       });
+
+      this.#stopSaving();
+      this.dirtySiteSettings.clear();
 
       if (reload) {
         reload();
       }
     } catch (error) {
       popupAjaxError(error);
-    } finally {
-      this.dirtySiteSettings.forEach((setting) =>
-        setting.set("isSaving", false)
-      );
     }
   }
 
   discard() {
-    this.dirtySiteSettings.forEach((siteSetting) => siteSetting.cancel());
+    this.dirtySiteSettings.forEach((setting) =>
+      setting.buffered.discardChanges()
+    );
+    this.dirtySiteSettings.clear();
+  }
+
+  async confirmChanges(setting) {
+    const settingKey = setting.buffered.get("setting");
+
+    return new Promise((resolve) => {
+      // Fallback is needed in case the setting does not have a custom confirmation
+      // prompt/confirm defined.
+      this.dialog.alert({
+        message: i18n(
+          `admin.site_settings.requires_confirmation_messages.${settingKey}.prompt`,
+          {
+            translatedFallback: i18n(
+              "admin.site_settings.requires_confirmation_messages.default.prompt"
+            ),
+          }
+        ),
+        buttons: [
+          {
+            label: i18n(
+              `admin.site_settings.requires_confirmation_messages.${settingKey}.confirm`,
+              {
+                translatedFallback: i18n(
+                  "admin.site_settings.requires_confirmation_messages.default.confirm"
+                ),
+              }
+            ),
+            class: "btn-primary",
+            action: () => resolve(true),
+          },
+          {
+            label: i18n("no_value"),
+            class: "btn-default",
+            action: () => resolve(false),
+          },
+        ],
+      });
+    });
+  }
+
+  async configureBackfill(setting) {
+    const key = setting.buffered.get("setting");
+
+    const data = {
+      [key]: setting.buffered.get("value"),
+    };
+
+    const result = await ajax(`/admin/site_settings/${key}/user_count.json`, {
+      type: "PUT",
+      data,
+    });
+
+    const count = result.user_count;
+
+    if (count > 0) {
+      await this.modal.show(SiteSettingDefaultCategoriesModal, {
+        model: {
+          siteSetting: { count, key: key.replaceAll("_", " ") },
+          setUpdateExistingUsers: setting.setUpdateExistingUsers,
+        },
+      });
+    }
+  }
+
+  #startSaving() {
+    this.dirtySiteSettings.forEach((setting) => {
+      setting.set("isSaving", true);
+    });
+  }
+
+  #stopSaving() {
+    this.dirtySiteSettings.forEach((setting) => {
+      setting.set("isSaving", false);
+    });
   }
 
   get count() {
     return this.dirtySiteSettings.size;
   }
 
+  get hasUnsavedChanges() {
+    return this.count > 0;
+  }
+
   get #requiresConfirmation() {
-    return [...this.dirtySiteSettings].filter((setting) =>
-      setting.requiresConfirmation()
+    return [...this.dirtySiteSettings].filter(
+      (setting) => setting.requiresConfirmation
     );
   }
 
   get #affectsExistingUsers() {
-    return [...this.dirtySiteSettings].filter((setting) =>
-      setting.affectsExistingUsers()
+    return [...this.dirtySiteSettings].filter(
+      (setting) => setting.affectsExistingUsers
     );
   }
 }

--- a/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
+++ b/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
@@ -61,7 +61,7 @@ export default class SiteSettingChangeTracker extends Service {
       await SiteSetting.bulkUpdate(params);
 
       this.dirtySiteSettings.forEach((setting) => {
-        setting.set("validationMessage", null);
+        setting.validationMessage = null;
         setting.buffered.applyChanges();
         if (setting.requiresReload) {
           reload = setting.afterSave;
@@ -75,6 +75,7 @@ export default class SiteSettingChangeTracker extends Service {
         reload();
       }
     } catch (error) {
+      this.#stopSaving();
       popupAjaxError(error);
     }
   }
@@ -170,13 +171,13 @@ export default class SiteSettingChangeTracker extends Service {
 
   #startSaving() {
     this.dirtySiteSettings.forEach((setting) => {
-      setting.set("isSaving", true);
+      setting.isSaving = true;
     });
   }
 
   #stopSaving() {
     this.dirtySiteSettings.forEach((setting) => {
-      setting.set("isSaving", false);
+      setting.isSaving = false;
     });
   }
 

--- a/app/assets/javascripts/discourse/tests/integration/components/compact-list-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/compact-list-test.gjs
@@ -1,9 +1,9 @@
-import EmberObject from "@ember/object";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import SiteSetting from "admin/components/site-setting";
+import SiteSettingComponent from "admin/components/site-setting";
+import SiteSetting from "admin/models/site-setting";
 
 module("Integration | Component | compact-list site-setting", function (hooks) {
   setupRenderingTest(hooks);
@@ -13,17 +13,14 @@ module("Integration | Component | compact-list site-setting", function (hooks) {
 
     this.set(
       "setting",
-      EmberObject.create({
-        allowsNone: undefined,
+      SiteSetting.create({
         category: "foo",
         description: "Choose setting",
-        overridden: false,
         placeholder: null,
         preview: null,
         secret: false,
         setting: "foo_bar",
         type: "compact_list",
-        validValues: undefined,
         default: "admin",
         mandatory_values: "admin",
         value: "admin|moderator",
@@ -31,7 +28,7 @@ module("Integration | Component | compact-list site-setting", function (hooks) {
     );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
 
     const subject = selectKit(".list-setting");

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.gjs
@@ -1,9 +1,9 @@
-import EmberObject from "@ember/object";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import SiteSetting from "admin/components/site-setting";
+import SiteSettingComponent from "admin/components/site-setting";
+import SiteSetting from "admin/models/site-setting";
 
 module("Integration | Component | group-list site-setting", function (hooks) {
   setupRenderingTest(hooks);
@@ -24,24 +24,21 @@ module("Integration | Component | group-list site-setting", function (hooks) {
 
     this.set(
       "setting",
-      EmberObject.create({
-        allowsNone: undefined,
+      SiteSetting.create({
         category: "foo",
         default: "",
         description: "Choose groups",
-        overridden: false,
         placeholder: null,
         preview: null,
         secret: false,
         setting: "foo_bar",
         type: "group_list",
-        validValues: undefined,
         value: "1",
       })
     );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
 
     const subject = selectKit(".list-setting");
@@ -78,25 +75,22 @@ module("Integration | Component | group-list site-setting", function (hooks) {
 
     this.set(
       "setting",
-      EmberObject.create({
-        allowsNone: undefined,
+      SiteSetting.create({
         category: "foo",
         default: "",
         description: "Choose groups",
-        overridden: false,
         placeholder: null,
         preview: null,
         secret: false,
         setting: "foo_bar",
         type: "group_list",
-        validValues: undefined,
         mandatory_values: "1",
         value: "1",
       })
     );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
 
     const subject = selectKit(".list-setting");

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
@@ -1,11 +1,11 @@
-import EmberObject from "@ember/object";
 import { click, fillIn, render, typeIn } from "@ember/test-helpers";
 import { module, skip, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
-import SiteSetting from "admin/components/site-setting";
+import SiteSettingComponent from "admin/components/site-setting";
+import SiteSetting from "admin/models/site-setting";
 
 module("Integration | Component | site-setting", function (hooks) {
   setupRenderingTest(hooks);
@@ -13,14 +13,17 @@ module("Integration | Component | site-setting", function (hooks) {
   test("displays host-list setting value", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "blocked_onebox_domains",
-      value: "a.com|b.com",
-      type: "host_list",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "blocked_onebox_domains",
+        value: "a.com|b.com",
+        type: "host_list",
+      })
+    );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
 
     assert.dom(".formatted-selection").hasText("a.com, b.com");
@@ -29,11 +32,14 @@ module("Integration | Component | site-setting", function (hooks) {
   test("Error response with html_message is rendered as HTML", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "test_setting",
-      value: "",
-      type: "input-setting-string",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "test_setting",
+        value: "",
+        type: "input-setting-string",
+      })
+    );
 
     const message = "<h1>Unable to update site settings</h1>";
 
@@ -42,7 +48,7 @@ module("Integration | Component | site-setting", function (hooks) {
     });
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
     await fillIn(".setting input", "value");
     await click(".setting .d-icon-check");
@@ -53,11 +59,14 @@ module("Integration | Component | site-setting", function (hooks) {
   test("Error response without html_message is not rendered as HTML", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "test_setting",
-      value: "",
-      type: "input-setting-string",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "test_setting",
+        value: "",
+        type: "input-setting-string",
+      })
+    );
 
     const message = "<h1>Unable to update site settings</h1>";
 
@@ -66,7 +75,7 @@ module("Integration | Component | site-setting", function (hooks) {
     });
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
     await fillIn(".setting input", "value");
     await click(".setting .d-icon-check");
@@ -77,14 +86,17 @@ module("Integration | Component | site-setting", function (hooks) {
   test("displays file types list setting", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "theme_authorized_extensions",
-      value: "jpg|jpeg|png",
-      type: "file_types_list",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "theme_authorized_extensions",
+        value: "jpg|jpeg|png",
+        type: "file_types_list",
+      })
+    );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
 
     assert.dom(".formatted-selection").hasText("jpg, jpeg, png");
@@ -106,14 +118,17 @@ module("Integration | Component | site-setting", function (hooks) {
   skip("prevents decimal in integer setting input", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "suggested_topics_unread_max_days_old",
-      value: "",
-      type: "integer",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "suggested_topics_unread_max_days_old",
+        value: "",
+        type: "integer",
+      })
+    );
 
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
     await typeIn(".input-setting-integer", "90,5", { delay: 1000 });
     assert.dom(".input-setting-integer").hasValue("905");
@@ -122,14 +137,17 @@ module("Integration | Component | site-setting", function (hooks) {
   test("does not consider an integer setting overridden if the value is the same as the default", async function (assert) {
     const self = this;
 
-    this.set("setting", {
-      setting: "suggested_topics_unread_max_days_old",
-      value: "99",
-      default: "99",
-      type: "integer",
-    });
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "suggested_topics_unread_max_days_old",
+        value: "99",
+        default: "99",
+        type: "integer",
+      })
+    );
     await render(
-      <template><SiteSetting @setting={{self.setting}} /></template>
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
     await fillIn(".input-setting-integer", "90");
     assert.dom(".input-setting-integer").hasValue("90");
@@ -148,17 +166,20 @@ module(
     test("shows the reset button when the value has been changed from the default", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "2048",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "2048",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       assert.dom(".setting-controls__undo").exists("reset button is shown");
     });
@@ -166,17 +187,20 @@ module(
     test("doesn't show the reset button when the value is the same as the default", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1024",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1024",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       assert
         .dom(".setting-controls__undo")
@@ -186,17 +210,20 @@ module(
     test("shows validation error when the value exceeds the max limit", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1024",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1024",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       await fillIn(".file-size-input", "5000");
 
@@ -207,24 +234,26 @@ module(
         }),
         "validation error message is shown"
       );
-      assert.dom(".setting-controls__ok").hasAttribute("disabled");
       assert.dom(".setting-controls__cancel").doesNotHaveAttribute("disabled");
     });
 
     test("shows validation error when the value is below the min limit", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1000",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1000",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       await fillIn(".file-size-input", "100");
 
@@ -235,24 +264,26 @@ module(
         }),
         "validation error message is shown"
       );
-      assert.dom(".setting-controls__ok").hasAttribute("disabled");
       assert.dom(".setting-controls__cancel").doesNotHaveAttribute("disabled");
     });
 
     test("cancelling pending changes resets the value and removes validation error", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1000",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1000",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
 
       await fillIn(".file-size-input", "100");
@@ -268,17 +299,20 @@ module(
     test("resetting to the default value changes the content of input field", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1000",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1000",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       assert
         .dom(".file-size-input")
@@ -301,15 +335,18 @@ module(
     test("resetting to the default value changes the content of checkbox field", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "test_setting",
-        value: "true",
-        default: "false",
-        type: "bool",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "test_setting",
+          value: "true",
+          default: "false",
+          type: "bool",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       assert
         .dom("input[type=checkbox]")
@@ -332,17 +369,20 @@ module(
     test("clearing the input field keeps the cancel button and the validation error shown", async function (assert) {
       const self = this;
 
-      this.set("setting", {
-        setting: "max_image_size_kb",
-        value: "1000",
-        default: "1024",
-        min: 512,
-        max: 4096,
-        type: "file_size_restriction",
-      });
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "max_image_size_kb",
+          value: "1000",
+          default: "1024",
+          min: 512,
+          max: 4096,
+          type: "file_size_restriction",
+        })
+      );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
 
       await fillIn(".file-size-input", "100");
@@ -351,7 +391,6 @@ module(
       await fillIn(".file-size-input", "");
       assert.dom(".validation-error").hasNoClass("hidden");
       assert.dom(".setting-controls__ok").exists("the save button is shown");
-      assert.dom(".setting-controls__ok").hasAttribute("disabled");
       assert
         .dom(".setting-controls__cancel")
         .exists("the cancel button is shown");
@@ -385,25 +424,22 @@ module(
 
       this.set(
         "setting",
-        EmberObject.create({
-          allowsNone: undefined,
+        SiteSetting.create({
           category: "",
           choices: fonts,
           default: "",
           description: "Base font",
-          overridden: false,
           placeholder: null,
           preview: null,
           secret: false,
           setting: "base_font",
           type: "font_list",
-          validValues: undefined,
           value: "arial",
         })
       );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       const fontSelector = selectKit(".font-selector");
       await fontSelector.expand();
@@ -422,25 +458,22 @@ module(
 
       this.set(
         "setting",
-        EmberObject.create({
-          allowsNone: undefined,
+        SiteSetting.create({
           category: "",
           choices: fonts,
           default: "",
           description: "Heading font",
-          overridden: false,
           placeholder: null,
           preview: null,
           secret: false,
           setting: "heading_font",
           type: "font_list",
-          validValues: undefined,
           value: "arial",
         })
       );
 
       await render(
-        <template><SiteSetting @setting={{self.setting}} /></template>
+        <template><SiteSettingComponent @setting={{self.setting}} /></template>
       );
       const fontSelector = selectKit(".font-selector");
       await fontSelector.expand();

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7519,8 +7519,8 @@ en:
         discard: "Discard changes"
         save: "Save all changes"
         dirty_banner:
-          one: "You have <em>%{count}</em> unsaved change"
-          other: "You have <em>%{count}</em> unsaved changes"
+          one: "You have <b>%{count}</b> unsaved change"
+          other: "You have <b>%{count}</b> unsaved changes"
         emoji_list:
           invalid_input: "Emoji list should only contain valid emoji names, eg: hugs"
           add_emoji_button:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7516,8 +7516,12 @@ en:
       site_settings:
         title: "Site settings"
         description: "Configure the settings for your Discourse site to customize its appearance, functionality, and user experience."
-        discard: "Discard changes"
-        save: "Save all changes"
+        discard:
+          one: "Discard change"
+          other: "Discard changes"
+        save:
+          one: "Save change"
+          other: "Save all changes"
         dirty_banner:
           one: "You have <b>%{count}</b> unsaved change"
           other: "You have <b>%{count}</b> unsaved changes"

--- a/spec/system/admin_site_setting_bulk_action_spec.rb
+++ b/spec/system/admin_site_setting_bulk_action_spec.rb
@@ -85,4 +85,48 @@ describe "Admin Site Setting Bulk Action", type: :system do
     expect(banner).to be_visible
     expect(banner.element).to have_text("You have 2 unsaved changes")
   end
+
+  it "persists unsaved settings when browsing categories" do
+    settings_page.visit
+
+    settings_page.fill_setting("title", "The Shell")
+    settings_page.fill_setting("site_description", "A cool place")
+
+    expect(banner).to be_visible
+    expect(banner.element).to have_text("You have 2 unsaved changes")
+
+    settings_page.navigate_to_category(:branding)
+
+    expect(banner).to be_visible
+    expect(banner.element).to have_text("You have 2 unsaved changes")
+
+    settings_page.navigate_to_category(:required)
+
+    expect(banner).to be_visible
+    expect(banner.element).to have_text("You have 2 unsaved changes")
+
+    expect(settings_page).to have_overridden_setting("title", value: "The Shell")
+    expect(settings_page).to have_overridden_setting("site_description", value: "A cool place")
+  end
+
+  it "prompts about unsaved settings when navigating away" do
+    settings_page.visit
+
+    settings_page.fill_setting("title", "The Shell")
+    settings_page.fill_setting("site_description", "A cool place")
+
+    expect(banner).to be_visible
+    expect(banner.element).to have_text("You have 2 unsaved changes")
+
+    settings_page.find(".admin-sidebar-nav-link", text: "Dashboard").click
+
+    expect(settings_page).to have_current_path("/admin/site_settings/category/required")
+
+    expect(dialog).to be_open
+    expect(dialog).to have_content("You have 2 unsaved changes")
+
+    dialog.click_no
+
+    expect(settings_page).to have_current_path("/admin")
+  end
 end

--- a/spec/system/admin_site_setting_category_bulk_action_spec.rb
+++ b/spec/system/admin_site_setting_category_bulk_action_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe "Admin Site Setting Category Bulk Action", type: :system do
+  let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+  let(:banner) { PageObjects::Components::AdminSiteSettingBulkBanner.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
+
+  fab!(:admin)
+
+  before { sign_in(admin) }
+
+  it "prompts about unsaved settings when navigating away" do
+    page.visit("/admin/config/notifications")
+
+    settings_page.fill_setting("max_mentions_per_post", 2)
+
+    expect(banner).to be_visible
+    expect(banner.element).to have_text("You have 1 unsaved change")
+
+    settings_page.find(".admin-sidebar-nav-link", text: "Login & authentication").click
+
+    expect(settings_page).to have_current_path("/admin/config/notifications")
+
+    expect(dialog).to be_open
+    expect(dialog).to have_content("You have 1 unsaved change")
+
+    dialog.click_no
+
+    expect(settings_page).to have_current_path("/admin/config/login-and-authentication")
+  end
+end

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -22,6 +22,11 @@ module PageObjects
         self
       end
 
+      def navigate_to_category(category)
+        page.find("a.#{category}").click
+        self
+      end
+
       def setting_row_selector(setting_name)
         ".row.setting[data-setting='#{setting_name}']"
       end


### PR DESCRIPTION
### What is this change?

This builds onto #32013 in two major ways:

1. Unsaved changes are now persisted when you browse categories inside "All site settings".
2. If you're about to navigate away (and lose edits) you will be prompted if you want to save or discard changes. (This applies to individual category site setting pages as well.

### Demonstration

**All site settings:**

![settings-persistence](https://github.com/user-attachments/assets/23d85df9-51fe-4d04-b30c-3c1861d8c95d)

**Site setting category:**

![settings-persistence-category](https://github.com/user-attachments/assets/1c1ab10f-a201-4ad9-9d16-1a988b00e60e)

### Implementation details

The original problem is that we kept a lot of the state in the components themselves. Because of Ember's component lifecycle, these were destroyed when switching categories, losing the state.

Most of this change is shifting state and behaviour around between three actors:

- `SiteSettingChangeTracker` service.
- `SiteSettingComponent` component (and its `SettingComponent` mixin).
- `SiteSetting` model.

In particular:

- The relevant state (buffered proxy and some predicate methods) are moved from the component to the model. This allows us to track model instances, which aren't destroyed when switching categories, instead of component instances in `SiteSettingChangeTracker`.
- The functionality for requesting confirmation, whether when clicking the button, or when navigating away, has been moved to `SiteSettingChangeTracker`.

There are also a couple child classes of `SiteSettingComponent`. These were passed plain `EmberObject` instances instead of the `SiteSetting` model, so that has also been addressed.