### PR TITLE
DEV: Allow specifying a condition when preloading topics for topic list

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -138,15 +138,13 @@ class TopicList
       { category: :parent_category },
     ]
 
-    DiscoursePluginRegistry.topic_preloader_associations.each do |assoc|
-      if assoc.is_a?(Symbol)
-        topic_preloader_associations << assoc
-      elsif assoc.is_a?(Hash)
-        if assoc.key?(:association) && assoc.key?(:condition)
-          topic_preloader_associations << assoc[:association] if assoc[:condition].call
-        else
-          topic_preloader_associations << assoc
-        end
+    DiscoursePluginRegistry.topic_preloader_associations.each do |a|
+      fields = a[:fields]
+      condition = a[:condition]
+      if condition.present?
+        topic_preloader_associations << fields if condition.present? && condition.call
+      else
+        topic_preloader_associations << fields
       end
     end
 

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1350,19 +1350,19 @@ class Plugin::Instance
   # This method allows plugins to preload topic associations when loading topics
   # that make use of topic_list.
   #
-  # @param fields [Array<Symbol>, Symbol, Hash] The topic associations to preload.
-  #   - :association` [Symbol] The association to preload.
-  #   - :condition` [Proc] A function that returns a boolean value indicating whether the association should be preloaded
+  # @param fields [Symbol, Array<Symbol>, Hash] The topic associations to preload.
   #
   # @example
-  #   register_topic_preloader_associations(%i[custom_association another_association])
-  #   register_topic_preloader_associations({
-  #     association: :linked_topic, condition: ->(topic) { topic.custom_field.present? }
-  #   })
+  #   register_topic_preloader_associations(:first_post)
+  #   register_topic_preloader_associations([:first_post, :topic_embeds])
+  #   register_topic_preloader_associations({ first_post: :uploads })
+  #   register_topic_preloader_associations({ first_post: :uploads }) do
+  #     SiteSetting.some_setting_enabled?
+  #   end
   #
   # @return [void]
-  def register_topic_preloader_associations(fields)
-    DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
+  def register_topic_preloader_associations(fields, &condition)
+    DiscoursePluginRegistry.register_topic_preloader_association({ fields:, condition: }, self)
   end
 
   protected

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1305,22 +1305,11 @@ RSpec.describe TopicQuery do
 
     context "when preloading associations" do
       it "preloads associations" do
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          :topic_embed,
-          Plugin::Instance.new,
-        )
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          { first_post: [:uploads] },
-          Plugin::Instance.new,
-        )
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          { association: :user_warning, condition: -> { true } },
-          Plugin::Instance.new,
-        )
-        DiscoursePluginRegistry.register_topic_preloader_association(
-          { association: :linked_topic, condition: -> { false } },
-          Plugin::Instance.new,
-        )
+        plugin = Plugin::Instance.new
+        plugin.register_topic_preloader_associations(:topic_embed)
+        plugin.register_topic_preloader_associations({ first_post: [:uploads] })
+        plugin.register_topic_preloader_associations(:user_warning) { true }
+        plugin.register_topic_preloader_associations(:linked_topic) { false }
 
         topic = Fabricate(:topic)
         Fabricate(:post, topic: topic)


### PR DESCRIPTION
Take 2 of https://github.com/discourse/discourse/pull/32079

> Currently when using `register_topic_preloader_associations`, we are not able to specify a condition that is evaluated at runtime.
>
This PR allows specifying a condition and also keeps backward compatibility.
>
```
   register_topic_preloader_associations({
     association: :linked_topic, condition: ->(topic) { topic.custom_field.present? }
   })
```

The earlier PR was reverted due to the case where a hash was defined and the condition not being available. e.g. the following is also valid

```
   register_topic_preloader_associations({
     first_post: [uploads]
   })
```