### PR TITLE
FIX: always allow edit category bg color

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -277,34 +277,32 @@ export default class EditCategoryGeneral extends Component {
           </@form.Field>
         {{/if}}
 
-        {{#unless (eq @transientData.style_type "emoji")}}
-          <@form.Field
-            @name="color"
-            @title={{i18n "category.background_color"}}
-            @format="full"
-            as |field|
-          >
-            <field.Custom>
-              <div class="category-color-editor">
-                <div class="colorpicker-wrapper edit-background-color">
-                  <ColorInput
-                    @hexValue={{readonly field.value}}
-                    @valid={{@category.colorValid}}
-                    @ariaLabelledby="background-color-label"
-                    @onChangeColor={{fn this.updateColor field}}
-                  />
-                  <ColorPicker
-                    @colors={{this.backgroundColors}}
-                    @usedColors={{this.usedBackgroundColors}}
-                    @value={{readonly field.value}}
-                    @ariaLabel={{i18n "category.predefined_colors"}}
-                    @onSelectColor={{fn this.updateColor field}}
-                  />
-                </div>
+        <@form.Field
+          @name="color"
+          @title={{i18n "category.background_color"}}
+          @format="full"
+          as |field|
+        >
+          <field.Custom>
+            <div class="category-color-editor">
+              <div class="colorpicker-wrapper edit-background-color">
+                <ColorInput
+                  @hexValue={{readonly field.value}}
+                  @valid={{@category.colorValid}}
+                  @ariaLabelledby="background-color-label"
+                  @onChangeColor={{fn this.updateColor field}}
+                />
+                <ColorPicker
+                  @colors={{this.backgroundColors}}
+                  @usedColors={{this.usedBackgroundColors}}
+                  @value={{readonly field.value}}
+                  @ariaLabel={{i18n "category.predefined_colors"}}
+                  @onSelectColor={{fn this.updateColor field}}
+                />
               </div>
-            </field.Custom>
-          </@form.Field>
-        {{/unless}}
+            </div>
+          </field.Custom>
+        </@form.Field>
       </@form.Section>
     </div>
   </template>


### PR DESCRIPTION
Some themes make use of the category background color even when using emojis or icons as the category style.

Therefore we should always allow the color selector to be visible when editing the category.

Internal ref: /t/150539