### PR TITLE
FIX: prevent duplicate category icons

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/combo-box.js
+++ b/app/assets/javascripts/select-kit/addon/components/combo-box.js
@@ -11,6 +11,7 @@ import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
   autoFilterable: "autoFilterable",
   clearable: false,
   headerComponent: "combo-box/combo-box-header",
+  shouldDisplayIcon: false,
 })
 export default class ComboBox extends SingleSelectComponent {
   @gte("content.length", 10) autoFilterable;


### PR DESCRIPTION
Follow up fix to #31795 to prevent duplicate icons in category chooser.

This change prevents duplicate icons or icon and emoji combinations.

### Before

<img width="668" alt="Screenshot 2025-04-01 at 1 23 29 PM" src="https://github.com/user-attachments/assets/5bf91a55-a7ae-4d6b-bd07-546e34c75eaf" />

### After

<img width="609" alt="Screenshot 2025-04-01 at 1 23 13 PM" src="https://github.com/user-attachments/assets/6cc5677b-fd6a-4ba5-89af-7665b64d3c6f" />


Relevant meta topic:
https://meta.discourse.org/t/duplicated-icon-in-composers-category-dropdown/359474