### PR TITLE
FIX: add category badge style to category list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-title-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-link.gjs
@@ -2,19 +2,25 @@ import Component from "@ember/component";
 import { tagName } from "@ember-decorators/component";
 import CategoryLogo from "discourse/components/category-logo";
 import CategoryTitleBefore from "discourse/components/category-title-before";
-import icon from "discourse/helpers/d-icon";
+import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import dirSpan from "discourse/helpers/dir-span";
 
 @tagName("h3")
 export default class CategoryTitleLink extends Component {
+  get displayName() {
+    const categoryBadge = categoryBadgeHTML(this.category, {
+      allowUncategorized: true,
+      link: false,
+    });
+
+    return dirSpan(categoryBadge, { htmlSafe: "true" });
+  }
+
   <template>
     <a class="category-title-link" href={{this.category.url}}>
       <div class="category-text-title">
         <CategoryTitleBefore @category={{this.category}} />
-        {{#if this.category.read_restricted}}
-          {{icon this.lockIcon}}
-        {{/if}}
-        <span class="category-name">{{dirSpan this.category.displayName}}</span>
+        <span class="category-name">{{this.displayName}}</span>
       </div>
       {{#if this.category.uploaded_logo.url}}
         <CategoryLogo @category={{this.category}} />

--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -344,14 +344,6 @@
   h3,
   h4 {
     margin-bottom: 0;
-
-    .d-icon {
-      color: var(--primary-high);
-      height: 0.76em;
-      width: 0.76em;
-      vertical-align: baseline;
-      margin-right: 0.1em;
-    }
   }
 
   .category-description {


### PR DESCRIPTION
Adds support for category style headings (square, emojis and icons) to the all categories list.

### Before

<img width="565" alt="Screenshot 2025-04-01 at 5 33 56 PM" src="https://github.com/user-attachments/assets/e7990aa5-890c-4113-9ba3-96fe397c1c93" />

### After

<img width="575" alt="Screenshot 2025-04-01 at 5 32 35 PM" src="https://github.com/user-attachments/assets/0c53cc90-2237-4611-b79e-d3cc48ecc968" />

With RTL support:

<img width="546" alt="Screenshot 2025-04-01 at 5 45 46 PM" src="https://github.com/user-attachments/assets/7207e655-2ddf-4adf-8647-c41443858fd0" />

Internal ref: /t/150539