### PR TITLE
UX: Wrap edit category subcategories

### DIFF
--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -115,6 +115,10 @@ div.edit-category {
     .edit-category-tab.active {
       display: contents;
     }
+
+    .form-kit__container-content {
+      flex-wrap: wrap;
+    }
   }
 
   #list-area & h2 {


### PR DESCRIPTION
### Issue
In the **edit category settings**, if the category has a large amount of subcategories, the layout can spill outside the normal content area.
![image](https://github.com/user-attachments/assets/388d0f47-7054-4f6e-85cb-c648df126ee0)

### Solution
Add `flex-wrap: wrap` to form kit container content within edit category.
![image](https://github.com/user-attachments/assets/a2b51a64-cd6d-423d-9ac6-3230445ed8cf)
