### PR TITLE
DEV: Fix a flaky system test by doubling timeout

### DIFF
--- a/plugins/chat/spec/system/thread_list/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_list/full_page_spec.rb
@@ -188,7 +188,9 @@ describe "Thread list in side panel | full page", type: :system do
 
         restore_message!(thread_1.original_message, user: other_user)
 
-        expect(thread_list_page).to have_thread(thread_1)
+        try_until_success(timeout: Capybara.default_max_wait_time * 2) do
+          expect(thread_list_page).to have_thread(thread_1)
+        end
       end
     end
 


### PR DESCRIPTION
The system test relies on a MessageBus message being published and
received by the client. As we currently don't have a reliable way to
ensure that we run an assertion after the client has received all
MessageBus messages, we will just double the timeout for now.

### Reviewer notes

Example of flaky test: https://github.com/discourse/discourse/actions/runs/14192287309/job/39759467138

