### PR TITLE
FIX: invite_link_max_redemptions_limit min 1

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2518,12 +2518,12 @@ rate_limits:
     min: 0
     default: 10
   invite_link_max_redemptions_limit:
-    min: 2
+    min: 1
     max: 1000000
     default: 5000
     client: true
   invite_link_max_redemptions_limit_users:
-    min: 2
+    min: 1
     max: 1000000
     default: 10
     client: true


### PR DESCRIPTION
When the feature was designed in 2020, it had two options: invite a single user or generate a link.

https://github.com/discourse/discourse/pull/9813

With simplified interface, it makes sense to allow to send a link to just 1 user.

Meta: https://meta.discourse.org/t/unable-to-restrict-invite-link-to-one-person/359872