### PR TITLE
DEV: Use `Capybara::Session#using_wait_time` instead (#32116)

### DIFF
--- a/app/jobs/regular/backfill_badge.rb
+++ b/app/jobs/regular/backfill_badge.rb
@@ -3,6 +3,8 @@
 module Jobs
   class BackfillBadge < ::Jobs::Base
     sidekiq_options queue: "low"
+    # The queries executed by this job can be expensive so limit the concurrency to 1 per cluster
+    cluster_concurrency 1
 
     def execute(args)
       return unless SiteSetting.enable_badges


### PR DESCRIPTION
When `Capybara.threadsafe` has been set to `true` as in our case, we
have to use `Capybara::Session#using_wait_time` instead of
`Capybara.using_wait_time`. The latter sets `default_max_wait_time` on
`Capybara.default_max_wait_time` while the former sets
`default_max_wait_time` on the session.
