### PR TITLE
PERF: Set `cluster_concurrency 1` for `Jobs::BackfillBadge`

### DIFF
--- a/app/jobs/regular/backfill_badge.rb
+++ b/app/jobs/regular/backfill_badge.rb
@@ -3,6 +3,8 @@
 module Jobs
   class BackfillBadge < ::Jobs::Base
     sidekiq_options queue: "low"
+    # The queries executed by this job can be expensive so limit the concurrency to 1 per cluster
+    cluster_concurrency 1
 
     def execute(args)
       return unless SiteSetting.enable_badges


### PR DESCRIPTION
Since 3e4eac0fed05daedcdea50d6275e143469d55eda, the daily `Jobs::BadgeGrant` scheduled job enqueues one `Jobs::BackfillBadge`
job per enabled badge. This can become problematic on large sites that
have alot of enabled badges as the long running queries executed by each
`Jobs::BackfillBadge` job may end up exhausting all available
database connections in a short span of time. To combat this, we are
limiting the `cluster_concurrency` of the `Jobs::BackfillBadge` job to
`1`.
