### PR TITLE
UX: rename Twitter login button to X

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2516,9 +2516,9 @@ en:
         title: "Sign in with Google"
         sr_title: "Sign in with Google"
       twitter:
-        name: "Twitter"
-        title: "Sign in with Twitter"
-        sr_title: "Sign in with Twitter"
+        name: "X"
+        title: "Sign in with X"
+        sr_title: "Sign in with X"
       instagram:
         name: "Instagram"
         title: "Log in with Instagram"
@@ -7514,7 +7514,7 @@ en:
         unmask: "unmask input"
         not_found: "Settings could not be found"
       site_settings:
-        title: "Site settings" 
+        title: "Site settings"
         description: "Configure the settings for your Discourse site to customize its appearance, functionality, and user experience."
         discard: "Discard changes"
         save: "Save all changes"

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -489,7 +489,7 @@ module Discourse
       frame_height: 500,
     ), # Custom icon implemented in client
     Auth::AuthProvider.new(authenticator: Auth::GithubAuthenticator.new, icon: "fab-github"),
-    Auth::AuthProvider.new(authenticator: Auth::TwitterAuthenticator.new, icon: "fab-twitter"),
+    Auth::AuthProvider.new(authenticator: Auth::TwitterAuthenticator.new, icon: "fab-x-twitter"),
     Auth::AuthProvider.new(authenticator: Auth::DiscordAuthenticator.new, icon: "fab-discord"),
     Auth::AuthProvider.new(
       authenticator: Auth::LinkedInOidcAuthenticator.new,


### PR DESCRIPTION
Before:

<img width="234" alt="Screenshot 2025-04-02 at 1 15 25 PM" src="https://github.com/user-attachments/assets/1f852543-38d7-45d3-96d3-df6a8a7e3623" />

After:

<img width="184" alt="Screenshot 2025-04-02 at 1 20 41 PM" src="https://github.com/user-attachments/assets/6bf9428f-2152-45a1-8215-ae006ce4f356" />
