### PR TITLE
UX: Adjust spacing between simple tags in the site settings preview

### DIFF
--- a/app/assets/stylesheets/admin/settings.scss
+++ b/app/assets/stylesheets/admin/settings.scss
@@ -173,4 +173,12 @@
     margin-top: 0.5em;
     margin-bottom: 0.2em;
   }
+
+  .discourse-tags {
+    gap: var(--space-1);
+
+    .simple {
+      margin-right: var(--space-1);
+    }
+  }
 }


### PR DESCRIPTION
### Before
![image](https://github.com/user-attachments/assets/27afb534-cac3-4573-9be7-a5608f1dc498)


### After
<img width="635" alt="image" src="https://github.com/user-attachments/assets/999aca40-5488-41f0-8887-01584ce425a4" />
