### PR TITLE
UX: Adjust spacing to prevent last setting from being hidden behind save all banner

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -860,7 +860,7 @@ $mobile-breakpoint: 700px;
   background-color: var(--secondary);
   margin-left: 0;
   border-left: solid 1px var(--primary-low);
-  padding: 30px 0 30px 30px;
+  padding: 30px 0 90px 30px;
   width: 82%;
   box-sizing: border-box;
 


### PR DESCRIPTION
This PR adjusts the bottom spacing in the site settings when scrolled to the bottom and the “Save all changes” banner is visible, ensuring that the setting controls and helper text are fully visible within the viewport.

### Before
<img width="954" alt="image" src="https://github.com/user-attachments/assets/69d8b1ad-e90e-4d94-9f32-4a8ae17ef725" />


### After
<img width="937" alt="image" src="https://github.com/user-attachments/assets/50365613-8553-4354-a8f3-71d834898583" />
