### PR TITLE
DEV: refactor CanCheckEmailsHelper to directly take model id

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -133,7 +133,7 @@ export default class AdminUserIndexController extends Controller {
   @computed("model.id", "currentUser.id")
   get canCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canCheckEmails;
@@ -142,7 +142,7 @@ export default class AdminUserIndexController extends Controller {
   @computed("model.id", "currentUser.id")
   get canAdminCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canAdminCheckEmails;

--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -66,7 +66,7 @@ export default class AdminUsersListShowController extends Controller {
   @computed("model.id", "currentUser.id")
   get canCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model?.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canCheckEmails;
@@ -75,7 +75,7 @@ export default class AdminUsersListShowController extends Controller {
   @computed("model.id", "currentUser.id")
   get canAdminCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model?.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canAdminCheckEmails;

--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -57,7 +57,7 @@ export default class AccountController extends Controller {
   @computed("model.id", "currentUser.id")
   get canCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canCheckEmails;

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -35,7 +35,7 @@ export default class SecurityController extends Controller {
   @computed("model.id", "currentUser.id")
   get canCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canCheckEmails;

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -196,7 +196,7 @@ export default class UserController extends Controller {
   @computed("model.id", "currentUser.id")
   get canCheckEmails() {
     return new CanCheckEmailsHelper(
-      this.model,
+      this.model.id,
       this.canModeratorsViewEmails,
       this.currentUser
     ).canCheckEmails;

--- a/app/assets/javascripts/discourse/app/lib/can-check-emails-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/can-check-emails-helper.js
@@ -1,6 +1,6 @@
 export default class CanCheckEmailsHelper {
-  constructor(model, can_moderators_view_emails, currentUser) {
-    this.model = model;
+  constructor(model_id, can_moderators_view_emails, currentUser) {
+    this.model_id = model_id;
     this.can_moderators_view_emails = can_moderators_view_emails;
     this.currentUser = currentUser;
   }
@@ -18,7 +18,7 @@ export default class CanCheckEmailsHelper {
     const canStaffCheckEmails =
       this.can_moderators_view_emails && this.currentUser.staff;
     return (
-      this.model?.id === this.currentUser.id ||
+      this.model_id === this.currentUser.id ||
       this.canAdminCheckEmails ||
       canStaffCheckEmails
     );


### PR DESCRIPTION
We only need the `model.id` input here, so this simplifies the arguments being passed into this helper.