### PR TITLE
FIX: hide search field on auth pages

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -16,6 +16,7 @@ export default class Contents extends Component {
   @service currentUser;
   @service siteSettings;
   @service header;
+  @service router;
   @service sidebarState;
 
   get sidebarIcon() {
@@ -39,7 +40,10 @@ export default class Contents extends Component {
   }
 
   get showHeaderSearch() {
-    if (this.site.mobileView) {
+    if (
+      this.site.mobileView ||
+      this.router.currentURL.match(/\/(signup|login)/)
+    ) {
       return false;
     }
 

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -42,7 +42,7 @@ export default class Contents extends Component {
   get showHeaderSearch() {
     if (
       this.site.mobileView ||
-      this.router.currentURL.match(/\/(signup|login)/)
+      this.router.currentURL?.match(/\/(signup|login)/)
     ) {
       return false;
     }

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -165,6 +165,16 @@ describe "Search", type: :system do
         find(".timeline-date-wrapper:first-child a").click
         expect(search_page).to have_no_search_icon
       end
+
+      it "does not display on login and signup pages" do
+        visit("/login")
+        expect(search_page).to have_no_search_icon
+        expect(search_page).to have_no_search_field
+
+        visit("/signup")
+        expect(search_page).to have_no_search_icon
+        expect(search_page).to have_no_search_field
+      end
     end
   end
 


### PR DESCRIPTION
This change prevents rendering the search field on login and sign up pages.

Internal ref: /t/150011