### PR TITLE
UX: Align tag separator properly when viewing search in full-page mode

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -347,6 +347,7 @@
     flex-wrap: wrap;
     margin-top: 0.25em;
     gap: 0 0.5em;
+    align-items: center;
 
     .badge-category__wrapper {
       max-width: 100%;
@@ -357,6 +358,7 @@
     flex-wrap: wrap;
     display: inline-flex;
     font-weight: normal;
+    align-items: center;
 
     .discourse-tag.simple {
       font-size: var(--font-down-1);


### PR DESCRIPTION
Better alignment with the  `,` separator

### Before
<img width="205" alt="image" src="https://github.com/user-attachments/assets/5d834e72-8e55-4d4b-923a-e5d088fb0102" />

### After
<img width="207" alt="image" src="https://github.com/user-attachments/assets/7d85a0ff-1804-451e-aea4-3fb9844e5b8e" />
