### PR TITLE
UX: Fix banner search losing focus after selecting a result

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -37,7 +37,8 @@ export const SEARCH_INPUT_ID = "search-term";
 export const MODIFIER_REGEXP = /.*(\#|\@|:).*$/gi;
 export const DEFAULT_TYPE_FILTER = "exclude_topics";
 
-export function focusSearchInput(inputId = SEARCH_INPUT_ID) {
+export function focusSearchInput(inputId) {
+  inputId = inputId || SEARCH_INPUT_ID;
   document.getElementById(inputId).focus();
 }
 
@@ -189,7 +190,7 @@ export default class SearchMenu extends Component {
     e.stopPropagation();
     e.preventDefault();
     this.search.activeGlobalSearchTerm = "";
-    focusSearchInput();
+    focusSearchInput(this.args.searchInputId);
     this.triggerSearch();
   }
 
@@ -463,6 +464,7 @@ export default class SearchMenu extends Component {
           @closeSearchMenu={{this.close}}
           @searchTermChanged={{this.searchTermChanged}}
           @clearSearch={{this.clearSearch}}
+          @inputId={{@searchInputId}}
         />
       {{else if this.displayMenuPanelResults}}
         <MenuPanel @panelClass="search-menu-panel">
@@ -478,6 +480,7 @@ export default class SearchMenu extends Component {
             @closeSearchMenu={{this.close}}
             @searchTermChanged={{this.searchTermChanged}}
             @clearSearch={{this.clearSearch}}
+            @inputId={{@searchInputId}}
           />
         </MenuPanel>
       {{/if}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
@@ -86,6 +86,7 @@ export default class Results extends Component {
               @results={{@suggestionResults}}
               @closeSearchMenu={{@closeSearchMenu}}
               @searchTermChanged={{@searchTermChanged}}
+              @inputId={{@inputId}}
             />
           {{else if this.termTooShort}}
             <div class="no-results">{{i18n "search.too_short"}}</div>
@@ -95,6 +96,7 @@ export default class Results extends Component {
             <InitialOptions
               @closeSearchMenu={{@closeSearchMenu}}
               @searchTermChanged={{@searchTermChanged}}
+              @inputId={{@inputId}}
             />
           {{else}}
             {{#if (and (not @searchTopics) (not @inPMInboxContext))}}
@@ -102,6 +104,7 @@ export default class Results extends Component {
               <InitialOptions
                 @closeSearchMenu={{@closeSearchMenu}}
                 @searchTermChanged={{@searchTermChanged}}
+                @inputId={{@inputId}}
               />
             {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -128,7 +128,7 @@ export default class AssistantItem extends Component {
       ...(inTopicContext &&
         !this.args.searchAllTopics && { setTopicContext: true }),
     });
-    focusSearchInput();
+    focusSearchInput(this.args.inputId);
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
@@ -171,6 +171,7 @@ export default class InitialOptions extends Component {
             @closeSearchMenu={{@closeSearchMenu}}
             @searchTermChanged={{@searchTermChanged}}
             @suggestionKeyword={{this.contextTypeKeyword}}
+            @inputId={{@inputId}}
           />
         {{else}}
           {{#if
@@ -184,6 +185,7 @@ export default class InitialOptions extends Component {
                 @extraHint={{true}}
                 @searchTermChanged={{@searchTermChanged}}
                 @suggestionKeyword={{this.contextTypeKeyword}}
+                @inputId={{@inputId}}
               />
             {{/if}}
 
@@ -197,6 +199,7 @@ export default class InitialOptions extends Component {
                 @label={{this.label}}
                 @closeSearchMenu={{@closeSearchMenu}}
                 @searchTermChanged={{@searchTermChanged}}
+                @inputId={{@inputId}}
               />
 
               {{#if
@@ -209,6 +212,7 @@ export default class InitialOptions extends Component {
                 <RecentSearches
                   @closeSearchMenu={{@closeSearchMenu}}
                   @searchTermChanged={{@searchTermChanged}}
+                  @inputId={{@inputId}}
                 />
               {{/if}}
             {{/if}}
@@ -218,6 +222,7 @@ export default class InitialOptions extends Component {
               <RecentSearches
                 @closeSearchMenu={{@closeSearchMenu}}
                 @searchTermChanged={{@searchTermChanged}}
+                @inputId={{@inputId}}
               />
             {{/if}}
           {{/if}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/recent-searches.gjs
@@ -70,6 +70,7 @@ export default class RecentSearches extends Component {
             @searchTermChanged={{@searchTermChanged}}
             @usage="recent-search"
             @concatSlug={{true}}
+            @inputId={{@inputId}}
           />
         {{/each}}
       </div>

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -8,6 +8,11 @@ module PageObjects
         self
       end
 
+      def type_in_banner_search(input)
+        find("input.search-term__input").send_keys(input)
+        self
+      end
+
       def type_in_search_menu(input)
         find(".search-input--header input").send_keys(input)
         self

--- a/spec/system/search_welcome_banner_spec.rb
+++ b/spec/system/search_welcome_banner_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe "Search | Welcome banner", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+
+  let(:welcome_banner) { PageObjects::Components::WelcomeBanner.new }
+  let(:search_page) { PageObjects::Pages::Search.new }
+
+  before { sign_in(current_user) }
+
+  context "when search_experience is search_icon" do
+    before do
+      SiteSetting.enable_welcome_banner = true
+      SiteSetting.search_experience = "search_icon"
+    end
+
+    it "focuses input after selecting a result" do
+      visit("/")
+      expect(welcome_banner).to be_visible
+      search_page.type_in_banner_search("text")
+      page.send_keys(:arrow_down)
+      page.send_keys(:enter)
+      expect(page).to have_field("welcome-banner-search-term", focused: true)
+      expect(current_active_element[:id]).to eq("welcome-banner-search-term")
+    end
+
+    it "focuses input after clearing" do
+      visit("/")
+      expect(welcome_banner).to be_visible
+      search_page.type_in_banner_search("text")
+      find(".clear-search").click
+      expect(current_active_element[:id]).to eq("welcome-banner-search-term")
+    end
+  end
+end


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/the-welcome-banner-search-input-loses-focus-after-selecting-a-result/359934
Followup https://github.com/discourse/discourse/commit/832ed8ce748982311e5ed654a9110fc608a03bf8

With `Search experience` set to icon search, if you enter a search in the welcome banner, the input field loses focus after selecting a suggested result. This problem also occurs when using the clear button.

Instead, it throws the following error in the console:

![image](https://github.com/user-attachments/assets/11e20db8-bd15-4742-9023-fb238a1e759c)


This PR correctly passes the search banner input ID to the child components so it can be used when `focusSearchInput` is called.

<details><summary>Before</summary>

https://github.com/user-attachments/assets/8545544d-8549-46cb-8022-ee9211755f70
</details> 

<details><summary>After</summary>

https://github.com/user-attachments/assets/c30659cb-ef7d-43ac-ac55-f35c19ac31c1
</details> 
