### PR TITLE
FIX: Admin search page shortcut

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/search-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/search-index.gjs
@@ -10,7 +10,7 @@ export default RouteTemplate(
       @titleLabel={{i18n "admin.config.search_everything.title"}}
       @descriptionLabel={{i18n
         "admin.config.search_everything.header_description"
-        shortcutHTML=this.shortcutHTML
+        shortcutHTML=@controller.shortcutHTML
       }}
       @shouldDisplay={{true}}
     >


### PR DESCRIPTION
Fixes "[missing %{shortcutHTML} value]" on standalone
admin search page.

**Before**

![image](https://github.com/user-attachments/assets/532bc0af-95b0-411c-abde-9dd412dd42e8)

**After**

![image](https://github.com/user-attachments/assets/6ed7e491-f346-4b82-9caf-79feb2f36366)
