### PR TITLE
UX: add flex to mentions mixin + update units

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1280,9 +1280,8 @@ a.mention-group {
 }
 
 .mention .emoji {
-  margin-left: 0.3em;
-  width: 15px;
-  height: 15px;
+  width: 0.93em;
+  height: 0.93em;
 }
 
 span.mention {

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -36,9 +36,9 @@ a.hashtag {
   }
 
   img.emoji {
-    width: 15px;
-    height: 15px;
-    vertical-align: text-top;
+    width: 0.93em;
+    height: 0.93em;
+    vertical-align: middle;
   }
 
   svg {
@@ -56,7 +56,6 @@ a.hashtag {
 
   .hashtag-category-icon,
   .hashtag-category-emoji {
-    margin-right: 0.25em;
     display: inline-block;
   }
 }
@@ -111,8 +110,8 @@ a.hashtag {
     .hashtag-category-icon,
     .hashtag-category-emoji {
       flex: 0 0 auto;
-      width: 15px;
-      height: 15px;
+      width: 1em;
+      height: 1em;
       margin-right: 5px;
       display: inline-block;
     }
@@ -121,7 +120,7 @@ a.hashtag {
     .hashtag-category-emoji .emoji {
       width: 15px;
       height: 15px;
-      vertical-align: top;
+      vertical-align: middle;
     }
   }
 

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -110,16 +110,16 @@ a.hashtag {
     .hashtag-category-icon,
     .hashtag-category-emoji {
       flex: 0 0 auto;
-      width: 1em;
-      height: 1em;
+      width: 0.93em;
+      height: 0.93em;
       margin-right: 5px;
       display: inline-block;
     }
 
     .hashtag-category-icon .svg-icon,
     .hashtag-category-emoji .emoji {
-      width: 15px;
-      height: 15px;
+      width: 0.93em;
+      height: 0.93em;
       vertical-align: middle;
     }
   }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -235,15 +235,18 @@ $hpad: 0.65em;
 }
 
 @mixin mention() {
-  display: inline;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
   font-size: 0.93em;
   font-weight: normal;
   color: var(--primary);
-  padding: 0.14em 0.34em 0.19em;
+  padding: 0.2em 0.34em;
   background: var(--primary-low);
   border-radius: 0.6em;
   text-decoration: none;
   text-wrap: nowrap;
+  line-height: 1;
 
   &.--bot {
     background: var(--success-low);

--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe "Channel - Info - Members page", type: :system do
       chat_page.find(".add-to-channel").click
 
       expect(chat_page).to have_current_path("/chat/c/#{channel_1.slug}/#{channel_1.id}")
-      expect(chat_page).to have_content(
+      expect(chat_page).to have_text(
+        :all,
         I18n.t(
           "chat.channel.users_invited_to_channel",
           invited_users: "@#{new_user.username}",
@@ -144,7 +145,8 @@ RSpec.describe "Channel - Info - Members page", type: :system do
       chat_page.find(".add-to-channel").click
 
       expect(chat_page).to have_current_path("/chat/c/#{channel_1.slug}/#{channel_1.id}")
-      expect(chat_page).to have_content(
+      expect(chat_page).to have_text(
+        :all,
         I18n.t(
           "chat.channel.users_invited_to_channel",
           invited_users: "@#{new_user.username}",


### PR DESCRIPTION
Fixing hashtag text glued to the icon
![CleanShot 2025-04-01 at 14 14 39](https://github.com/user-attachments/assets/237a0d54-dc08-438d-b935-94d3e670fd09)

And updated some related properties to using better units

| Before | After |
|--------|--------|
| ![CleanShot 2025-04-01 at 14 25 32@2x](https://github.com/user-attachments/assets/818d763d-900d-4a68-9115-381173b0c0a3) | ![CleanShot 2025-04-01 at 14 15 37@2x](https://github.com/user-attachments/assets/abbe9167-6fa1-41ff-999d-e12a779f6a0e) |
