### PR TITLE
DEV: Add modifier for meta_data_content in ApplicationHelper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -307,6 +307,8 @@ module ApplicationHelper
     %i[url title description].each do |property|
       if opts[property].present?
         content = (property == :url ? opts[property] : gsub_emoji_to_unicode(opts[property]))
+        content =
+          DiscoursePluginRegistry.apply_modifier(:meta_data_content, content, property, opts)
         result << tag(:meta, { property: "og:#{property}", content: content }, nil, true)
         result << tag(:meta, { name: "twitter:#{property}", content: content }, nil, true)
       end


### PR DESCRIPTION
I've considered some _very_ generic, like:

  ```rb
DiscoursePluginRegistry.apply_modifier(:"meta_data_content_for_#{property}", content, property, opts)
```


But, I think for now, we can use this one and rely on the plugin to do the filtering (`if property == :title`)