### PR TITLE
FIX: Archiving messages from group inbox

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -151,14 +151,22 @@ export default class BulkTopicActions extends Component {
         break;
       case "archive_messages":
       case "move_messages_to_inbox":
+        let params = { type: this.model.action };
+
         let userPrivateMessages = getOwner(this).lookup(
           "controller:user-private-messages"
         );
 
-        let params = { type: this.model.action };
-
         if (userPrivateMessages.isGroup) {
           params.group = userPrivateMessages.groupFilter;
+        }
+
+        let groupPrivateMessages = getOwner(this).lookup(
+          "controller:group-messages"
+        );
+
+        if (groupPrivateMessages.isGroup) {
+          params.group = groupPrivateMessages.model.name;
         }
 
         this.performAndRefresh(params);

--- a/app/assets/javascripts/discourse/app/controllers/group-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-messages.js
@@ -1,3 +1,10 @@
 import Controller from "@ember/controller";
+import { service } from "@ember/service";
 
-export default class GroupMessagesController extends Controller {}
+export default class GroupMessagesController extends Controller {
+  @service router;
+
+  get isGroup() {
+    return this.router.currentRoute.parent.name === "group.messages";
+  }
+}

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -356,6 +356,17 @@ describe "Topic bulk select", type: :system do
       expect(page).to have_content(group_private_message.title)
     end
 
+    it "allows archiving group private messages from the group inbox page" do
+      sign_in(admin)
+      visit("/g/#{group.name}/messages/inbox")
+      expect(page).to have_content(group_private_message.title)
+      open_bulk_actions_modal([group_private_message], "archive-messages")
+      topic_bulk_actions_modal.click_bulk_topics_confirm
+      expect(page).to have_content(I18n.t("js.topics.bulk.completed"))
+      visit("/g/#{group.name}/messages/archive")
+      expect(page).to have_content(group_private_message.title)
+    end
+
     it "allows moving group private messages to the scoped group Inbox" do
       GroupArchivedMessage.create!(group: group, topic: group_private_message)
       sign_in(admin)


### PR DESCRIPTION
### What is the problem?

Bulk archiving group messages can be done from two places: a) from the user's view (`/u/ted/messages/group/swedes`) and b) from the group's view (`/g/swedes/messages/inbox`). Only the former is currently working. From the latter view, the action looks like a success, but is actually a no-op.

### Why is this happening?

When using the group view, the `operation[group]` parameter is missing from the request.

### How does this fix it?

Copy the logic of the user view for the group view to make sure the `group` parameter is included.