### PR TITLE
DEV: Pass full model for tag to sidebar serializer

### DIFF
--- a/app/serializers/concerns/navigation_menu_tags_mixin.rb
+++ b/app/serializers/concerns/navigation_menu_tags_mixin.rb
@@ -5,7 +5,6 @@ module NavigationMenuTagsMixin
     topic_count_column = Tag.topic_count_column(scope)
 
     tags
-      .select(:name, topic_count_column, :pm_topic_count, :description)
       .order(topic_count_column => :desc)
       .map { |tag| SidebarTagSerializer.new(tag, scope: scope, root: false).as_json }
   end


### PR DESCRIPTION
We are currently only passing a few attributes of a tag when serializing sidebar tags.

This PR passes the `Tag` into the serializer instead.