### PR TITLE
PERF: Set `JOBS=1` for low-memory build environments

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -23,10 +23,10 @@ task "assets:precompile:build" do
 
     if heap_size_limit < 2048
       STDERR.puts "Node.js heap_size_limit (#{heap_size_limit}) is less than 2048MB. Setting --max-old-space-size=2048 and CHEAP_SOURCE_MAPS=1"
-      jobs_env_count = 0
+      jobs_env_count = 1
 
       compile_command =
-        "CI=1 NODE_OPTIONS='--max-old-space-size=2048' CHEAP_SOURCE_MAPS=1 #{compile_command}"
+        "NODE_OPTIONS='--max-old-space-size=2048' CHEAP_SOURCE_MAPS=1 #{compile_command}"
     end
 
     ember_env = ENV["EMBER_ENV"] || "production"


### PR DESCRIPTION
Recent testing has shown that this config requires significantly less memory for a successful build, which should improve the situation for people running Discourse on low-memory servers.