### PR TITLE
DEV: Add workflow to check production build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,9 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
-    container: discourse/discourse_test:release
+    container:
+      image: discourse/discourse_test:release
+      options: -m 2000m
     timeout-minutes: 20
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,6 +304,12 @@ jobs:
           CHEAP_SOURCE_MAPS: 0 # We want real sourcemaps here
         run: ./script/check_reproducible_assets.rb
 
+      - uses: actions/upload-artifact@v4
+        if: always() && matrix.build_type == 'production-build'
+        with:
+          name: production-build
+          path: ./app/assets/javascripts/discourse
+
       - name: Check for failed system test screenshots
         id: check-failed-system-test-screenshots
         if: always() && matrix.build_type == 'system'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
-    container:
-      image: discourse/discourse_test:release
-      options: -m 2000m
+    container: discourse/discourse_test:release
     timeout-minutes: 20
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,8 @@ jobs:
           - build_type: frontend
             target: core
             browser: Firefox ESR
+          - build_type: production-build
+            target: core
 
     steps:
       - name: Set working directory owner
@@ -295,6 +297,12 @@ jobs:
           RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --profile=50 --verbose --format documentation tmp/themes/*/spec/system
         shell: bash
         timeout-minutes: 30
+
+      - name: Test production build
+        if: matrix.build_type == 'production-build'
+        env: 
+          CHEAP_SOURCE_MAPS: 0 # We want real sourcemaps here
+        run: ./script/check_reproducible_assets.rb
 
       - name: Check for failed system test screenshots
         id: check-failed-system-test-screenshots

--- a/script/check_reproducible_assets.rb
+++ b/script/check_reproducible_assets.rb
@@ -8,6 +8,7 @@
 require "digest"
 
 DIST_DIR = File.expand_path("#{__dir__}/../app/assets/javascripts/discourse/dist")
+DIST_1_DIR = File.expand_path("#{__dir__}/../app/assets/javascripts/discourse/dist1")
 
 def collect_asset_info
   files =
@@ -15,15 +16,28 @@ def collect_asset_info
   puts "Found #{files.length} files"
   raise "No files found" if files.empty?
   digests = files.map { |file| Digest::MD5.file("#{DIST_DIR}/#{file}").hexdigest }
-  { files: files, digests: digests }
+  sizes = files.map { |file| [file, File.size("#{DIST_DIR}/#{file}") / 8 / 1024] }.to_h
+  { files: files, digests: digests, sizes: sizes }
+end
+
+def print_details(files, size_dict)
+  files.each { |file| puts " - #{file} (#{size_dict[file]}kb)" }
 end
 
 puts "Running first build..."
-system "#{__dir__}/../bin/yarn-app ember build -prod", exception: true
+system "cd #{__dir__}/.. && pnpm ember build -prod", exception: true
 first_build_info = collect_asset_info
+system "rm", "-rf", DIST_1_DIR, exception: true
+system "mv", DIST_DIR, DIST_1_DIR, exception: true
 
 puts "Running second build..."
-system "#{__dir__}/../bin/yarn-app ember build -prod", exception: true
+Dir.chdir("#{__dir__}/../app/assets/javascripts/discourse") do # rubocop:disable Discourse/NoChdir
+  system "/bin/bash",
+         "-c",
+         "shopt -s nullglob; rm -rf $TMPDIR/embroider $TMPDIR/.broccoli-* node_modules/.embroider",
+         exception: true
+end
+system "cd #{__dir__}/.. && pnpm ember build -prod", exception: true
 second_build_info = collect_asset_info
 
 puts nil, nil, "Comparing builds...", nil, nil
@@ -32,10 +46,12 @@ if first_build_info[:files] != second_build_info[:files]
   puts "Set of files is different"
 
   new_assets = first_build_info[:files].difference(second_build_info[:files])
-  puts "Second build had additional assets: #{new_assets.inspect}"
+  puts "Second build had additional assets:"
+  print_details(new_assets, first_build_info[:sizes])
 
   missing_assets = second_build_info[:files].difference(first_build_info[:files])
-  puts "Second build was missing assets: #{missing_assets.inspect}"
+  puts "Second build was missing assets:"
+  print_details(missing_assets, second_build_info[:sizes])
 
   exit 1
 else


### PR DESCRIPTION
At the moment this just checks for the reproducibility of the production build. We may want to extend this workflow in future to check for things like bundle-size, and perhaps run a smoke test of a production-mode site.