### PR TITLE
FEATURE: Dynamic size for hot topic IDs cache

### DIFF
--- a/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/spec/serializers/topic_list_item_serializer_spec.rb
@@ -210,10 +210,11 @@ RSpec.describe TopicListItemSerializer do
 
   describe "#is_hot" do
     describe "including the attr based on theme modifier or plugin registry" do
-      fab!(:hot_topic) { Fabricate(:topic, like_count: 10) }
+      fab!(:hot_topic) { Fabricate(:topic) }
 
-      before { TopicHotScore.update_scores }
-      after { TopicHotScore.hot_topic_ids_cache.clear }
+      # Caching this directly to workaround the limit heuristic.
+      before { Discourse.cache.write(TopicHotScore::CACHE_KEY, Set.new([hot_topic.id])) }
+      after { Discourse.cache.delete(TopicHotScore::CACHE_KEY) }
 
       context "without opt-in" do
         before do


### PR DESCRIPTION
This change makes the cache size either 100, or the 10% of topics with activity since the hot topic days cutoff, whatever is lower.

We observed that in sites with a small number of topics, everything is flagged as hot, which while true, defeats the purpose of the feature.