### PR TITLE
FIX: Ensure discovery queryParams do not persist invisibly

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag/show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag/show.js
@@ -1,0 +1,1 @@
+export { default } from "../discovery/list";

--- a/app/assets/javascripts/discourse/app/initializers/dynamic-route-builders.js
+++ b/app/assets/javascripts/discourse/app/initializers/dynamic-route-builders.js
@@ -1,4 +1,5 @@
 import { dasherize } from "@ember/string";
+import DiscoveryListController from "discourse/controllers/discovery/list";
 import Site from "discourse/models/site";
 import buildCategoryRoute from "discourse/routes/build-category-route";
 import buildTopicRoute from "discourse/routes/build-topic-route";
@@ -12,14 +13,17 @@ export default {
       "route:discovery.category",
       buildCategoryRoute({ filter: "default" })
     );
+    app.register("controller:discovery.category", DiscoveryListController);
     app.register(
       "route:discovery.category-none",
       buildCategoryRoute({ filter: "default", no_subcategories: true })
     );
+    app.register("controller:discovery.category-none", DiscoveryListController);
     app.register(
       "route:discovery.category-all",
       buildCategoryRoute({ filter: "default", no_subcategories: false })
     );
+    app.register("controller:discovery.category-all", DiscoveryListController);
 
     const site = Site.current();
     site.get("filters").forEach((filter) => {
@@ -29,30 +33,45 @@ export default {
         `route:discovery.${filterDasherized}`,
         buildTopicRoute(filter)
       );
+      app.register(
+        `controller:discovery.${filterDasherized}`,
+        DiscoveryListController
+      );
 
       app.register(
         `route:discovery.${filterDasherized}-category`,
         buildCategoryRoute({ filter })
       );
       app.register(
+        `controller:discovery.${filterDasherized}-category`,
+        DiscoveryListController
+      );
+      app.register(
         `route:discovery.${filterDasherized}-category-none`,
         buildCategoryRoute({ filter, no_subcategories: true })
+      );
+      app.register(
+        `controller:discovery.${filterDasherized}-category-none`,
+        DiscoveryListController
       );
     });
 
     app.register("route:tags.show-category", buildTagRoute());
+    app.register("controller:tags.show-category", DiscoveryListController);
     app.register(
       "route:tags.show-category-none",
       buildTagRoute({
         noSubcategories: true,
       })
     );
+    app.register("controller:tags.show-category-none", DiscoveryListController);
     app.register(
       "route:tags.show-category-all",
       buildTagRoute({
         noSubcategories: false,
       })
     );
+    app.register("controller:tags.show-category-all", DiscoveryListController);
 
     site.get("filters").forEach(function (filter) {
       const filterDasherized = dasherize(filter);
@@ -64,16 +83,32 @@ export default {
         })
       );
       app.register(
+        `controller:tag.show-${filterDasherized}`,
+        DiscoveryListController
+      );
+      app.register(
         `route:tags.show-category-${filterDasherized}`,
         buildTagRoute({ navMode: filter })
+      );
+      app.register(
+        `controller:tags.show-category-${filterDasherized}`,
+        DiscoveryListController
       );
       app.register(
         `route:tags.show-category-none-${filterDasherized}`,
         buildTagRoute({ navMode: filter, noSubcategories: true })
       );
       app.register(
+        `controller:tags.show-category-none-${filterDasherized}`,
+        DiscoveryListController
+      );
+      app.register(
         `route:tags.show-category-all-${filterDasherized}`,
         buildTagRoute({ navMode: filter, noSubcategories: false })
+      );
+      app.register(
+        `controller:tags.show-category-all-${filterDasherized}`,
+        DiscoveryListController
       );
     });
   },

--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -27,7 +27,6 @@ class AbstractCategoryRoute extends DiscourseRoute {
   queryParams = queryParams;
 
   templateName = "discovery/list";
-  controllerName = "discovery/list";
 
   async model(params, transition) {
     const category = this.site.lazy_load_categories

--- a/app/assets/javascripts/discourse/app/routes/build-topic-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-topic-route.js
@@ -92,7 +92,6 @@ class AbstractTopicRoute extends DiscourseRoute {
 
   queryParams = queryParams;
   templateName = "discovery/list";
-  controllerName = "discovery/list";
 
   async model(data) {
     // attempt to stop early cause we need this to be called before .sync

--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -29,7 +29,6 @@ export default class TagShowRoute extends DiscourseRoute {
   @service historyStore;
 
   queryParams = queryParams;
-  controllerName = "discovery/list";
   templateName = "discovery/list";
   routeConfig = {};
 

--- a/spec/system/discovery_list_spec.rb
+++ b/spec/system/discovery_list_spec.rb
@@ -61,4 +61,16 @@ describe "Discovery list", type: :system do
       expect(page).to have_no_css("button.bulk-select")
     end
   end
+
+  it "doesn't preserve query parameters when navigating" do
+    category = Fabricate(:category)
+    topics.each { |t| t.update(category_id: category.id) }
+    topics.last.update(closed: true)
+
+    visit "/latest?status=closed"
+    expect(discovery.topic_list).to have_topics(count: 1)
+    discovery.category_drop.select_row_by_value(category.id)
+    expect(discovery.topic_list).to have_topics(count: 10)
+    expect(page).to have_current_path("/c/#{category.slug}/#{category.id}")
+  end
 end


### PR DESCRIPTION
Sharing a controller seems to make query params behave more weirdly than normal. This change lets Ember create a separate controller instance for each route, even though they will still share the same class.