### PR TITLE
FIX: Fallback to #search-menu for search input

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -33,7 +33,6 @@ import userSearch from "discourse/lib/user-search";
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
 const SUGGESTIONS_REGEXP = /(in:|status:|order:|:)([a-zA-Z]*)$/gi;
-export const SEARCH_INPUT_ID = "icon-search-input";
 export const MODIFIER_REGEXP = /.*(\#|\@|:).*$/gi;
 export const DEFAULT_TYPE_FILTER = "exclude_topics";
 
@@ -52,6 +51,7 @@ export default class SearchMenu extends Component {
   @tracked invalidTerm = false;
   @tracked menuPanelOpen = false;
 
+  searchInputId = this.args.searchInputId ?? "search-term";
   _debouncer = null;
   _activeSearch = null;
 
@@ -130,7 +130,7 @@ export default class SearchMenu extends Component {
 
     // We want to blur the search input when in stand-alone mode
     // so that when we focus on the search input again, the menu panel pops up
-    document.getElementById(this.args.searchInputId || SEARCH_INPUT_ID)?.blur();
+    document.getElementById(this.searchInputId)?.blur();
     this.menuPanelOpen = false;
   }
 
@@ -428,7 +428,7 @@ export default class SearchMenu extends Component {
           @closeSearchMenu={{this.close}}
           @openSearchMenu={{this.open}}
           @autofocus={{@autofocusInput}}
-          @inputId={{@searchInputId}}
+          @inputId={{this.searchInputId}}
         />
 
         {{#if this.loading}}
@@ -448,7 +448,7 @@ export default class SearchMenu extends Component {
 
       {{#if @inlineResults}}
         <Results
-          @searchInputId={{@searchInputId}}
+          @searchInputId={{this.searchInputId}}
           @loading={{this.loading}}
           @invalidTerm={{this.invalidTerm}}
           @suggestionKeyword={{this.suggestionKeyword}}
@@ -464,7 +464,7 @@ export default class SearchMenu extends Component {
       {{else if this.displayMenuPanelResults}}
         <MenuPanel @panelClass="search-menu-panel">
           <Results
-            @searchInputId={{@searchInputId}}
+            @searchInputId={{this.searchInputId}}
             @loading={{this.loading}}
             @invalidTerm={{this.invalidTerm}}
             @suggestionKeyword={{this.suggestionKeyword}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
@@ -4,10 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
-import {
-  DEFAULT_TYPE_FILTER,
-  SEARCH_INPUT_ID,
-} from "discourse/components/search-menu";
+import { DEFAULT_TYPE_FILTER } from "discourse/components/search-menu";
 import { isiPad } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 
@@ -28,11 +25,6 @@ export default class SearchTerm extends Component {
 
   @tracked lastEnterTimestamp = null;
   @tracked searchCleared = !this.search.activeGlobalSearchTerm;
-
-  // make constant available in template
-  get inputId() {
-    return this.args.inputId || SEARCH_INPUT_ID;
-  }
 
   @action
   updateSearchTerm(input) {
@@ -120,7 +112,7 @@ export default class SearchTerm extends Component {
 
   <template>
     <input
-      id={{this.inputId}}
+      id={{@inputId}}
       class="search-term__input"
       type="search"
       autocomplete="off"

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
@@ -98,4 +98,12 @@ module("Integration | Component | search-menu", function (hooks) {
       .dom(".menu-panel .search-menu-initial-options")
       .doesNotExist("Menu panel is hidden");
   });
+
+  test("rendering without a searchInputId provided", async function (assert) {
+    await render(<template><SearchMenu @location="test" /></template>);
+
+    assert
+      .dom("#search-term.search-term__input")
+      .exists("input defaults to id of search-term");
+  });
 });


### PR DESCRIPTION
Followup c4d971ea2c7677d893e0d6fdcec5d7d93d9c964e

There are some customizations still relying on #search-menu
for an ID, this provides a fallback to that ID if no
@searchInputId arg is provided while we work through the
customizations.
