### PR TITLE
DEV: Add Analytics and SEO admin config page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-analytics-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-analytics-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigAnalyticsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-analytics.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-analytics.js
@@ -1,0 +1,8 @@
+import { i18n } from "discourse-i18n";
+import AdminConfigWithSettingsRoute from "./admin-config-with-settings-route";
+
+export default class AdminAnalyticsRoute extends AdminConfigWithSettingsRoute {
+  titleToken() {
+    return i18n("admin.config.analytics.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -281,6 +281,15 @@ export default function () {
           this.route("components");
         });
         this.route(
+          "adminAnalytics",
+          { path: "/analytics-and-seo", resetNamespace: true },
+          function () {
+            this.route("settings", {
+              path: "/",
+            });
+          }
+        );
+        this.route(
           "adminPermalinks",
           { path: "/permalinks", resetNamespace: true },
           function () {

--- a/app/assets/javascripts/admin/addon/templates/analytics-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/analytics-settings.gjs
@@ -1,0 +1,33 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @hideTabs={{true}}
+      @titleLabel={{i18n "admin.config.analytics.title"}}
+      @descriptionLabel={{i18n "admin.config.analytics.header_description"}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/config/analytics-and-seo"
+          @label={{i18n "admin.config.analytics.title"}}
+        />
+      </:breadcrumbs>
+    </DPageHeader>
+
+    <div class="admin-config-page__main-area">
+      <AdminAreaSettings
+        @showBreadcrumb={{false}}
+        @area="analytics"
+        @path="/admin/config/analytics-and-seo"
+        @filter={{@controller.filter}}
+        @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      />
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -137,6 +137,16 @@ export const ADMIN_NAV_MAP = [
         settings_area: "localization",
       },
       {
+        name: "admin_analytics",
+        route: "adminAnalytics",
+        label: "admin.config.analytics.title",
+        description: "admin.config.analytics.header_description",
+        icon: "chart-pie",
+        settings_area: "analytics",
+        keywords: "admin.config.analytics.keywords",
+        multi_tabbed: false,
+      },
+      {
         name: "admin_permalinks",
         route: "adminPermalinks",
         label: "admin.config.permalinks.title",

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -3,6 +3,7 @@
 class SiteSetting < ActiveRecord::Base
   VALID_AREAS = %w[
     about
+    analytics
     embedding
     emojis
     flags

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5391,6 +5391,10 @@ en:
         badges:
           title: "Badges"
           header_description: "Badges reward users for their activities, contributions, and achievements to recognize, validate, and encourage positive behavior and engagement within the community"
+        analytics:
+          title: "Analytics & SEO"
+          header_description: "Improve your site’s visibility to search engines and configure how you track site visitors"
+          keywords: "search|google|sitemap"
         permalinks:
           title: "Permalinks"
           header_description: "Redirections to apply for URLs not known by the forum"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,7 @@ Discourse::Application.routes.draw do
 
       namespace :config, constraints: StaffConstraint.new do
         resources :site_settings, only: %i[index]
+        get "analytics-and-seo" => "site_settings#index"
         get "developer" => "site_settings#index"
         get "fonts" => "site_settings#index"
         get "files" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -80,6 +80,7 @@ required:
     default: ""
     type: list
     list_type: simple
+    area: "analytics"
   company_name:
     default: ""
     area: "about|legal"
@@ -204,21 +205,26 @@ basic:
     choices:
       - v3_analytics
       - v4_gtag
+    area: "analytics"
   ga_universal_tracking_code:
     client: true
     default: ""
     regex: "^(UA|G)-[\\w-]+"
+    area: "analytics"
   ga_universal_domain_name:
     client: true
     default: "auto"
+    area: "analytics"
   ga_universal_auto_link_domains:
     default: ""
     type: list
     list_type: simple
+    area: "analytics"
   gtm_container_id:
     client: true
     default: ""
     regex: "^GTM-"
+    area: "analytics"
   top_menu:
     client: true
     refresh: true
@@ -449,8 +455,10 @@ basic:
     allow_any: false
   enable_sitemap:
     default: true
+    area: "analytics"
   sitemap_page_size:
     default: 10000
+    area: "analytics"
   enable_user_tips:
     client: true
     default: true
@@ -473,6 +481,7 @@ basic:
   adobe_analytics_tags_url:
     default: ""
     regex: "assets.adobedtm.com"
+    area: "analytics"
   extended_site_description:
     default: ""
     max: 10_000


### PR DESCRIPTION
### What is this change?

This PR adds a dedicated page for Analytics and SEO related site settings:

<img width="532" alt="Screenshot 2025-04-07 at 1 54 00 PM" src="https://github.com/user-attachments/assets/ee9b3504-3711-4e5b-b6a4-20d16c92b38a" />
