### PR TITLE
FIX: incorrect flag message when en_GB language

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -2,7 +2,6 @@ import { isEmpty } from "@ember/utils";
 import getURL from "discourse/lib/get-url";
 import { userPath } from "discourse/lib/url";
 import Badge from "discourse/models/badge";
-import { i18n } from "discourse-i18n";
 
 const _additionalAttributes = new Set();
 
@@ -197,18 +196,12 @@ export default function transformPost(
         return a.actionType.name_key !== "like" && a.acted;
       })
       .map((a) => {
-        const action = a.actionType.name_key;
-
         return {
           id: a.id,
           postId: post.id,
-          action,
+          action: a.actionType.name_key,
           canUndo: a.can_undo,
-          description: i18n(`post.actions.by_you.${action}`, {
-            defaultValue: i18n(`post.actions.by_you.custom`, {
-              custom: a.actionType.name,
-            }),
-          }),
+          description: a.actionType.translatedDescription,
         };
       });
   }

--- a/app/assets/javascripts/discourse/app/models/post-action-type.js
+++ b/app/assets/javascripts/discourse/app/models/post-action-type.js
@@ -1,8 +1,20 @@
 import { equal } from "@ember/object/computed";
+import discourseComputed from "discourse/lib/decorators";
 import RestModel from "discourse/models/rest";
+import { i18n } from "discourse-i18n";
 
 export const MAX_MESSAGE_LENGTH = 500;
 
 export default class PostActionType extends RestModel {
   @equal("name_key", "illegal") isIllegal;
+
+  @discourseComputed()
+  translatedDescription() {
+    if (this.system) {
+      return i18n(`post.actions.by_you.${this.name_key}`);
+    }
+    return i18n(`post.actions.by_you.custom`, {
+      custom: this.name,
+    });
+  }
 }

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -744,18 +744,12 @@ export default class Post extends RestModel {
         return postAction.actionType.name_key !== "like" && postAction.acted;
       })
       ?.map((postAction) => {
-        const action = postAction.actionType.name_key;
-
         return {
           id: postAction.id,
           postId: this.id,
-          action,
+          action: postAction.actionType.name_key,
           canUndo: postAction.can_undo,
-          description: i18n(`post.actions.by_you.${action}`, {
-            defaultValue: i18n(`post.actions.by_you.custom`, {
-              custom: postAction.actionType.name,
-            }),
-          }),
+          description: postAction.translatedDescription,
         };
       });
   }

--- a/app/serializers/flag_serializer.rb
+++ b/app/serializers/flag_serializer.rb
@@ -13,7 +13,8 @@ class FlagSerializer < ApplicationSerializer
              :is_flag,
              :applies_to,
              :is_used,
-             :auto_action_type
+             :auto_action_type,
+             :system
 
   def i18n_prefix
     "#{@options[:target] || "post_action"}_types.#{object.name_key}"
@@ -46,5 +47,9 @@ class FlagSerializer < ApplicationSerializer
 
   def applies_to
     Array.wrap(object.applies_to)
+  end
+
+  def system
+    object.system?
   end
 end

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -377,6 +377,9 @@
             },
             "auto_action_type": {
               "type": "boolean"
+            },
+            "system": {
+              "type": "boolean"
             }
           },
           "required": [
@@ -435,6 +438,9 @@
               "type": "integer"
             },
             "auto_action_type": {
+              "type": "boolean"
+            },
+            "system": {
               "type": "boolean"
             }
           },

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -56,6 +56,27 @@ describe "Flagging post", type: :system do
     end
   end
 
+  describe "As send a message to user" do
+    before do
+      SiteSetting.allow_user_locale = true
+      current_user.update!(locale: "en_GB")
+      sign_in(current_user)
+    end
+
+    it do
+      topic_page.visit_topic(topic)
+      topic_page.expand_post_actions(post_to_flag)
+      topic_page.click_post_action_button(post_to_flag, :flag)
+      flag_modal.choose_type(:notify_user)
+
+      flag_modal.fill_message("This looks totally illegal to me.")
+
+      flag_modal.confirm_flag
+
+      expect(page).to have_content(I18n.t("js.post.actions.by_you.notify_user"))
+    end
+  end
+
   context "when tl0" do
     fab!(:tl0_user) { Fabricate(:user, trust_level: TrustLevel[0]) }
     before { sign_in(tl0_user) }


### PR DESCRIPTION
Currently, this is the order of i18n translate function:
1. Translation in required language;
2. Optional `defaultValue` provided;
3. Fallback to forum default language.

When admin set language as English GB, translation was not correctly displayed as it went to step 2 and displayed `defaultValue` instead of correct translation from default language.

Before
<img width="757" alt="Screenshot 2025-04-07 at 2 43 22 pm" src="https://github.com/user-attachments/assets/71bd9b3f-9bee-40ce-b560-fcbbd6b09b8f" />

After
<img width="760" alt="Screenshot 2025-04-07 at 2 42 41 pm" src="https://github.com/user-attachments/assets/6a7d4b81-0f15-4cbd-98ec-d8882aaec1ab" />
