### PR TITLE
FIX: flaky admin_branding_spec

### DIFF
--- a/spec/system/page_objects/components/uppy_image_uploader.rb
+++ b/spec/system/page_objects/components/uppy_image_uploader.rb
@@ -27,6 +27,7 @@ module PageObjects
 
       def remove_image
         @element.find(".btn-danger").click
+        @element.has_no_css?(".btn-danger")
       end
 
       def remove_image_with_keyboard


### PR DESCRIPTION
When remove image, ensure that state is updated before saving form.

We know that state is updated when remove button is no longer available.