### PR TITLE
DEV: Add Content admin config page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-content-categories-and-tags.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-content-categories-and-tags.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigContentCategoriesAndTagsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-config-content-posts-and-topics.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-content-posts-and-topics.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigContentPostsAndTopicsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-config-content-sharing.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-content-sharing.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigContentSharingController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-config-content-stats-and-thresholds.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-content-stats-and-thresholds.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigContentPostsAndTopicsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-content-categories-and-tags.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-content-categories-and-tags.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigContentCategoriesAndTagsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.content.sub_pages.categories_and_tags.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-content-posts-and-topics.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-content-posts-and-topics.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigContentPostsAndTopicsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.content.sub_pages.posts_and_topics.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-content-sharing.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-content-sharing.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigContentSharingRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.content.sub_pages.sharing.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-content-stats-and-thresholds.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-content-stats-and-thresholds.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigContentStatsAndThresholdsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.content.sub_pages.stats_and_thresholds.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -238,6 +238,12 @@ export default function () {
             });
           }
         );
+        this.route("content", function () {
+          this.route("categoriesAndTags", { path: "/" });
+          this.route("sharing");
+          this.route("postsAndTopics", { path: "/posts-and-topics" });
+          this.route("statsAndThresholds", { path: "/stats-and-thresholds" });
+        });
         this.route("localization", function () {
           this.route("settings", {
             path: "/",

--- a/app/assets/javascripts/admin/addon/templates/config-content-categories-and-tags.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-content-categories-and-tags.gjs
@@ -1,0 +1,14 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @area="categories_and_tags"
+      @path="/admin/config/content/categories-and-tags"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      @showBreadcrumb={{false}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/config-content-posts-and-topics.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-content-posts-and-topics.gjs
@@ -1,0 +1,14 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @area="posts_and_topics"
+      @path="/admin/config/content/posts-and-topics"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      @showBreadcrumb={{false}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/config-content-sharing.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-content-sharing.gjs
@@ -1,0 +1,14 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @area="sharing"
+      @path="/admin/config/content/sharing"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      @showBreadcrumb={{false}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/config-content-stats-and-thresholds.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-content-stats-and-thresholds.gjs
@@ -1,0 +1,14 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @area="stats_and_thresholds"
+      @path="/admin/config/content/stats-and-thresholds"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      @showBreadcrumb={{false}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/config-content.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-content.gjs
@@ -1,0 +1,44 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import NavItem from "discourse/components/nav-item";
+import { i18n } from "discourse-i18n";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @titleLabel={{i18n "admin.config.content.title"}}
+      @descriptionLabel={{i18n "admin.config.content.header_description"}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/config/content"
+          @label={{i18n "admin.config.content.title"}}
+        />
+      </:breadcrumbs>
+      <:tabs>
+        <NavItem
+          @route="adminConfig.content.categoriesAndTags"
+          @label="admin.config.content.sub_pages.categories_and_tags.title"
+        />
+        <NavItem
+          @route="adminConfig.content.sharing"
+          @label="admin.config.content.sub_pages.sharing.title"
+        />
+        <NavItem
+          @route="adminConfig.content.postsAndTopics"
+          @label="admin.config.content.sub_pages.posts_and_topics.title"
+        />
+        <NavItem
+          @route="adminConfig.content.statsAndThresholds"
+          @label="admin.config.content.sub_pages.stats_and_thresholds.title"
+        />
+      </:tabs>
+    </DPageHeader>
+
+    <div class="admin-config-page__main-area">
+      {{outlet}}
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -115,6 +115,16 @@ export const ADMIN_NAV_MAP = [
         settings_area: "about",
       },
       {
+        name: "admin_content",
+        route: "adminConfig.content",
+        label: "admin.config.content.title",
+        description: "admin.config.content.header_description",
+        keywords: "admin.config.content.keywords",
+        icon: "pencil",
+        settings_area: "categories_and_tags",
+        multi_tabbed: true,
+      },
+      {
         name: "admin_badges",
         route: "adminBadges",
         label: "admin.config.badges.title",

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -4,6 +4,7 @@ class SiteSetting < ActiveRecord::Base
   VALID_AREAS = %w[
     about
     analytics
+    categories_and_tags
     email
     embedding
     emojis
@@ -17,8 +18,11 @@ class SiteSetting < ActiveRecord::Base
     notifications
     permalinks
     reports
+    posts_and_topics
     user_defaults
+    sharing
     site_admin
+    stats_and_thresholds
     trust_levels
   ]
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5420,6 +5420,19 @@ en:
           title: "Interface & layout"
           header_description: "Customize details of your site’s general layout and user interface"
           keywords: "splash"
+        content:
+          title: "Content"
+          header_description: "Configure how your topics and posts are managed, and customize the content creation experience for your members"
+          keywords: "topics|posts|categories|tags"
+          sub_pages:
+            categories_and_tags:
+              title: "Categories & tags"
+            sharing:
+              title: "Sharing"
+            posts_and_topics:
+              title: "Posts & topics"
+            stats_and_thresholds:
+              title: "Stats & thresholds"
         permalinks:
           title: "Permalinks"
           header_description: "Redirections to apply for URLs not known by the forum"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,10 @@ Discourse::Application.routes.draw do
       namespace :config, constraints: StaffConstraint.new do
         resources :site_settings, only: %i[index]
         get "analytics-and-seo" => "site_settings#index"
+        get "content" => "site_settings#index"
+        get "content/sharing" => "site_settings#index"
+        get "content/posts-and-topics" => "site_settings#index"
+        get "content/stats-and-thresholds" => "site_settings#index"
         get "developer" => "site_settings#index"
         get "files" => "site_settings#index"
         get "interface" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -190,16 +190,20 @@ basic:
     client: true
     default: 5
     max: 2000
+    area: "posts_and_topics"
   limit_suggested_to_category:
     default: false
+    area: "posts_and_topics"
   suggested_topics_unread_max_days_old:
     default: 90
     min: 0
     max: 36500
+    area: "posts_and_topics"
   suggested_topics_max_days_old:
     default: 365
     min: 7
     max: 36500
+    area: "posts_and_topics"
   ga_version:
     type: enum
     default: v4_gtag
@@ -265,6 +269,7 @@ basic:
       - bookmark
       - admin
       - reply
+    area: "posts_and_topics"
   post_menu_hidden_items:
     client: true
     type: list
@@ -280,6 +285,7 @@ basic:
       - bookmark
       - admin
       - reply
+    area: "posts_and_topics"
   share_links:
     client: true
     type: list
@@ -290,9 +296,11 @@ basic:
       - twitter
       - facebook
       - email
+    area: "sharing"
   allow_username_in_share_links:
     client: true
     default: true
+    area: "sharing"
   share_quote_visibility:
     client: true
     type: enum
@@ -301,6 +309,7 @@ basic:
       - none
       - anonymous
       - all
+    area: "sharing"
   share_quote_buttons:
     client: true
     type: list
@@ -311,6 +320,7 @@ basic:
       - twitter
       - facebook
       - email
+    area: "sharing"
   desktop_category_page_style:
     client: true
     enum: "CategoryPageStyle"
@@ -355,12 +365,15 @@ basic:
   relative_date_duration:
     client: true
     default: 30
+    area: "posts_and_topics"
   topics_per_period_in_top_summary:
     default: 20
     min: 1
+    area: "posts_and_topics"
   topics_per_period_in_top_page:
     default: 50
     min: 1
+    area: "posts_and_topics"
   top_page_default_timeframe:
     client: true
     default: "yearly"
@@ -372,6 +385,7 @@ basic:
       - monthly
       - weekly
       - daily
+    area: "posts_and_topics"
   fixed_category_positions:
     client: true
     default: false
@@ -942,6 +956,7 @@ posting:
       ja: 8
       zh_CN: 8
       zh_TW: 8
+    area: "posts_and_topics"
   min_first_post_length:
     client: true
     min: 1
@@ -950,9 +965,11 @@ posting:
       ja: 8
       zh_CN: 8
       zh_TW: 8
+    area: "posts_and_topics"
   prevent_uploads_only_posts:
     client: true
     default: false
+    area: "posts_and_topics"
   min_personal_message_post_length:
     client: true
     min: 1
@@ -961,22 +978,27 @@ posting:
       ja: 3
       zh_CN: 3
       zh_TW: 3
+    area: "posts_and_topics"
   max_post_length:
     client: true
     default: 32000
     max: 150000
+    area: "posts_and_topics"
   topic_featured_link_enabled:
     client: true
     default: true
+    area: "posts_and_topics"
   body_min_entropy:
     default: 7
     locale_default:
       ja: 3
       zh_CN: 3
       zh_TW: 3
+    area: "posts_and_topics"
   min_topic_views_for_delete_confirm:
     client: true
     default: 5000
+    area: "posts_and_topics"
   min_topic_title_length:
     client: true
     default: 15
@@ -985,42 +1007,53 @@ posting:
       ja: 6
       zh_CN: 6
       zh_TW: 6
+    area: "posts_and_topics"
   max_topic_title_length:
     client: true
     default: 255
     min: 5
     max: 255
+    area: "posts_and_topics"
   title_min_entropy:
     default: 10
     locale_default:
       ja: 3
       zh_CN: 3
       zh_TW: 3
+    area: "posts_and_topics"
   allow_uppercase_posts:
     default: false
     locale_default:
       ja: true
+    area: "posts_and_topics"
   max_consecutive_replies:
     default: 3
+    area: "posts_and_topics"
   enable_filtered_replies_view:
     default: false
     client: true
+    area: "posts_and_topics"
   title_prettify:
     default: true
     locale_default:
       ja: false
       zh_CN: false
       zh_TW: false
+    area: "posts_and_topics"
   title_remove_extraneous_space:
     default: false
     locale_default:
       en: true
       en_GB: true
-  title_fancy_entities: true
+    area: "posts_and_topics"
+  title_fancy_entities:
+    default: true
+    area: "posts_and_topics"
   min_personal_message_title_length:
     client: true
     default: 2
     min: 1
+    area: "posts_and_topics"
   max_emojis_in_title:
     default: 1
     area: "emojis"
@@ -1028,12 +1061,18 @@ posting:
     type: emoji_list
     default: +1|heart|tada
     client: true
+    area: "posts_and_topics"
   allow_uncategorized_topics:
     client: true
     default: false
     refresh: true
-  allow_duplicate_topic_titles: false
-  allow_duplicate_topic_titles_category: false
+    area: "posts_and_topics"
+  allow_duplicate_topic_titles:
+    default: false
+    area: "posts_and_topics"
+  allow_duplicate_topic_titles_category:
+    default: false
+    area: "posts_and_topics"
   min_title_similar_length:
     client: true
     default: 10
@@ -1041,8 +1080,10 @@ posting:
       ja: 4
       zh_CN: 4
       zh_TW: 4
+    area: "posts_and_topics"
   enable_system_message_replies:
     default: true
+    area: "posts_and_topics"
   personal_message_enabled_groups:
     default: "1|2|11" # auto group admins, moderators, trust_level_1
     mandatory_values: "1|2" # auto group admins, moderators
@@ -1050,13 +1091,22 @@ posting:
     allow_any: false
     refresh: true
     area: "group_permissions"
-  editing_grace_period: 300
-  editing_grace_period_max_diff: 100
-  editing_grace_period_max_diff_high_trust: 400
-  staff_edit_locks_post: false
+  editing_grace_period:
+    default: 300
+    area: "posts_and_topics"
+  editing_grace_period_max_diff:
+    default: 100
+    area: "posts_and_topics"
+  editing_grace_period_max_diff_high_trust:
+    default: 400
+    area: "posts_and_topics"
+  staff_edit_locks_post:
+    default: false
+    area: "posts_and_topics"
   shared_drafts_category:
     type: category
     default: ""
+    area: "posts_and_topics"
   shared_drafts_min_trust_level:
     default: "staff"
     enum: "TrustLevelAndStaffSetting"
@@ -1071,33 +1121,42 @@ posting:
   post_edit_time_limit:
     default: 1440
     max: 10080
+    area: "posts_and_topics"
   tl2_post_edit_time_limit:
     default: 43200
     max: 525600
+    area: "posts_and_topics"
   edit_history_visible_to_public:
     client: true
     default: true
+    area: "posts_and_topics"
   delete_removed_posts_after:
     client: true
     default: 24
     max: 876000
+    area: "posts_and_topics"
   notify_users_after_responses_deleted_on_flagged_post:
     default: false
+    area: "posts_and_topics"
   traditional_markdown_linebreaks:
     client: true
     default: false
+    area: "posts_and_topics"
   enable_markdown_typographer:
     client: true
     default: true
+    area: "posts_and_topics"
   enable_markdown_linkify:
     client: true
     default: true
+    area: "posts_and_topics"
   markdown_linkify_tlds:
     client: true
     type: list
     default: "com|net|org|io|onion|co|tv|ru|cn|us|uk|me|de|fr|fi|gov"
     list_type: compact
     validator: "MarkdownLinkifyTldsValidator"
+    area: "posts_and_topics"
   markdown_typographer_quotation_marks:
     client: true
     type: list
@@ -1107,23 +1166,32 @@ posting:
     locale_default:
       de: "„|“|‚|‘"
       fr: "«\xA0|\xA0»|‹\xA0|\xA0›"
+    area: "posts_and_topics"
   suppress_reply_directly_below:
     client: true
     default: true
+    area: "posts_and_topics"
   suppress_reply_directly_above:
     client: true
     default: true
+    area: "posts_and_topics"
   suppress_reply_when_quoting:
     default: true
+    area: "posts_and_topics"
   remove_full_quote:
     default: true
+    area: "posts_and_topics"
   max_reply_history:
     default: 1
     client: true
-  post_undo_action_window_mins: 10
+    area: "posts_and_topics"
+  post_undo_action_window_mins:
+    default: 10
+    area: "posts_and_topics"
   enable_mentions:
     default: true
     client: true
+    area: "posts_and_topics"
   max_mentions_per_post:
     default: 10
     area: "notifications"
@@ -1131,7 +1199,9 @@ posting:
     default: 100
     client: true
     area: "notifications"
-  newuser_max_replies_per_topic: 3
+  newuser_max_replies_per_topic:
+    default: 3
+    area: "posts_and_topics"
   newuser_max_mentions_per_post:
     default: 2
     area: "notifications"
@@ -1139,7 +1209,10 @@ posting:
     default: "here"
     validator: "NotUsernameValidator"
     client: true
-  max_here_mentioned: 10
+    area: "posts_and_topics"
+  max_here_mentioned:
+    default: 10
+    area: "posts_and_topics"
   min_trust_level_for_here_mention:
     default: "2"
     enum: "TrustLevelAndStaffSetting"
@@ -1158,16 +1231,22 @@ posting:
       ko: 50
       zh_CN: 50
       zh_TW: 50
+    area: "posts_and_topics"
   allowed_link_domains:
     default: ""
     type: list
-  newuser_max_links: 2
+    area: "posts_and_topics"
+  newuser_max_links:
+    default: 2
+    area: "posts_and_topics"
   newuser_max_embedded_media:
     client: true
     default: 1
+    area: "posts_and_topics"
   newuser_max_attachments:
     client: true
     default: 0
+    area: "posts_and_topics"
   post_excerpt_maxlength:
     default: 300
     max: 1000
@@ -1175,6 +1254,7 @@ posting:
       ja: 120
       zh_CN: 120
       zh_TW: 120
+    area: "posts_and_topics"
   topic_excerpt_maxlength:
     default: 220
     max: 1000
@@ -1182,44 +1262,58 @@ posting:
       ja: 120
       zh_CN: 120
       zh_TW: 120
+    area: "posts_and_topics"
   default_subcategory_on_read_only_category:
     client: true
     default: false
+    area: "posts_and_topics"
   show_pinned_excerpt_mobile:
     client: true
     default: true
+    area: "posts_and_topics"
   show_pinned_excerpt_desktop:
     client: true
     default: true
+    area: "posts_and_topics"
   display_name_on_posts:
     client: true
     default: false
+    area: "posts_and_topics"
   show_time_gap_days:
     default: 7
     max: 36500
     client: true
+    area: "posts_and_topics"
   short_progress_text_threshold:
     client: true
     default: 10000
     max: 99000
+    area: "posts_and_topics"
   default_code_lang:
     client: true
     default: "auto"
-  warn_reviving_old_topic_age: 180
+    area: "posts_and_topics"
+  warn_reviving_old_topic_age:
+    default: 180
+    area: "posts_and_topics"
   autohighlight_all_code:
     client: true
     default: false
+    area: "posts_and_topics"
   highlighted_languages:
     default: "bash|c|cpp|csharp|css|diff|go|graphql|ini|java|javascript|json|kotlin|lua|makefile|markdown|objectivec|perl|php|php-template|plaintext|python|python-repl|r|ruby|rust|scss|shell|sql|swift|typescript|xml|yaml|wasm"
     choices: "HighlightJs.languages"
     type: list
     client: true
     list_type: compact
+    area: "posts_and_topics"
   show_copy_button_on_codeblocks:
     client: true
     default: true
     hidden: true
-  delete_old_hidden_posts: true
+  delete_old_hidden_posts:
+    default: true
+    area: "posts_and_topics"
   enable_emoji:
     default: true
     client: true
@@ -1256,6 +1350,7 @@ posting:
     area: "emojis"
   approve_post_count:
     default: 0
+    area: "posts_and_topics"
   approve_unless_trust_level:
     default: 0
     enum: "TrustLevelSetting"
@@ -1280,8 +1375,10 @@ posting:
     area: "group_permissions"
   approve_suspect_users:
     default: true
+    area: "posts_and_topics"
   approve_unless_staged:
     default: false
+    area: "posts_and_topics"
   notify_about_queued_posts_after:
     type: float
     default: 24
@@ -1293,6 +1390,7 @@ posting:
     default: 10000
   auto_close_topics_create_linked_topic:
     default: true
+    area: "posts_and_topics"
   code_formatting_style:
     client: true
     type: enum
@@ -1300,6 +1398,7 @@ posting:
     choices:
       - code-fences
       - 4-spaces-indent
+    area: "posts_and_topics"
   embed_any_origin:
     default: false
     area: "embedding"
@@ -1329,9 +1428,11 @@ posting:
     default: ""
     type: list
     list_type: compact
+    area: "posts_and_topics"
   max_allowed_message_recipients:
     default: 30
     min: 1
+    area: "posts_and_topics"
   disable_watched_word_checking_in_user_fields:
     hidden: true
     default: false
@@ -1341,19 +1442,24 @@ posting:
   enable_fast_edit:
     default: true
     client: true
+    area: "posts_and_topics"
   old_post_notice_days:
     default: 14
     max: 36500
     client: true
+    area: "posts_and_topics"
   new_user_notice_tl:
     default: 2
     enum: "TrustLevelSetting"
+    area: "posts_and_topics"
   returning_user_notice_tl:
     default: 2
     enum: "TrustLevelSetting"
+    area: "posts_and_topics"
   returning_users_days:
     default: 120
     max: 36500
+    area: "posts_and_topics"
   review_media_unless_trust_level:
     default: 0
     enum: "TrustLevelSetting"
@@ -1368,13 +1474,19 @@ posting:
   blur_tl0_flagged_posts_media:
     default: true
     client: true
+    area: "posts_and_topics"
   enable_page_publishing:
     default: false
+    area: "posts_and_topics"
   show_published_pages_login_required:
     default: false
-  skip_auto_delete_reply_likes: 5
+    area: "posts_and_topics"
+  skip_auto_delete_reply_likes:
+    default: 5
+    area: "posts_and_topics"
   review_every_post:
     default: false
+    area: "posts_and_topics"
   max_draft_length:
     default: 400_000
     hidden: true
@@ -1385,9 +1497,11 @@ posting:
     default: 100
     min: 5
     max: 255
+    area: "posts_and_topics"
   max_form_template_content_length:
     default: 5000
     max: 150000
+    area: "posts_and_topics"
   group_pm_user_limit:
     default: 1000
     type: integer
@@ -2964,6 +3078,7 @@ uncategorized:
   suppress_uncategorized_badge:
     client: true
     default: true
+    area: "categories_and_tags"
 
   header_dropdown_category_count:
     client: true
@@ -2986,79 +3101,120 @@ uncategorized:
     validator: "RegexpListValidator"
     area: "permalinks"
 
-  max_similar_results: 5
-  minimum_topics_similar: 50
+  max_similar_results:
+    default: 5
+    area: "posts_and_topics"
+  minimum_topics_similar:
+    default: 50
+    area: "posts_and_topics"
 
   previous_visit_timeout_hours: 1
   staff_like_weight: 3
-  topic_view_duration_hours: 8
-  user_profile_view_duration_hours: 8
+  topic_view_duration_hours:
+    default: 8
+    area: "stats_and_thresholds"
+  user_profile_view_duration_hours:
+    default: 8
+    area: "stats_and_thresholds"
 
   # Summary mode
-  summary_score_threshold: 15
-  summary_posts_required: 50
-  summary_likes_required: 1
-  summary_percent_filter: 20
-  summary_max_results: 100
+  summary_score_threshold:
+    default: 15
+    area: "posts_and_topics"
+  summary_posts_required:
+    default: 50
+    area: "posts_and_topics"
+  summary_likes_required:
+    default: 1
+    area: "posts_and_topics"
+  summary_percent_filter:
+    default: 20
+    area: "posts_and_topics"
+  summary_max_results:
+    default: 100
+    area: "posts_and_topics"
   summary_timeline_button:
     client: true
     default: false
+    area: "posts_and_topics"
 
-  automatic_topic_heat_values: true
+  automatic_topic_heat_values:
+    default: true
+    area: "stats_and_thresholds"
 
   # View heat thresholds
   topic_views_heat_low:
     client: true
     default: 1000
+    area: "stats_and_thresholds"
   topic_views_heat_medium:
     client: true
     default: 2000
+    area: "stats_and_thresholds"
   topic_views_heat_high:
     client: true
     default: 3500
+    area: "stats_and_thresholds"
 
   # Post/Like heat thresholds
   topic_post_like_heat_low:
     client: true
     default: 0.5
+    area: "stats_and_thresholds"
   topic_post_like_heat_medium:
     client: true
     default: 1.0
+    area: "stats_and_thresholds"
   topic_post_like_heat_high:
     client: true
     default: 2.0
+    area: "stats_and_thresholds"
 
   # History edit heat thresholds
   history_hours_low:
     client: true
     default: 12
+    area: "stats_and_thresholds"
   history_hours_medium:
     client: true
     default: 24
+    area: "stats_and_thresholds"
   history_hours_high:
     client: true
     default: 48
+    area: "stats_and_thresholds"
 
   # Cold map thresholds
   cold_age_days_low:
     default: 14
     max: 36500
     client: true
+    area: "stats_and_thresholds"
   cold_age_days_medium:
     default: 90
     max: 36500
     client: true
+    area: "stats_and_thresholds"
   cold_age_days_high:
     default: 180
     max: 36500
     client: true
+    area: "stats_and_thresholds"
 
   # Warnings
   educate_until_posts: 2
-  sequential_replies_threshold: 2
-  get_a_room_threshold: 3
-  dont_feed_the_trolls_threshold: 2
-  dominating_topic_minimum_percent: 40
+  sequential_replies_threshold:
+    default: 2
+    area: "stats_and_thresholds"
+  get_a_room_threshold:
+    default: 3
+    area: "stats_and_thresholds"
+  dont_feed_the_trolls_threshold:
+    default: 2
+    area: "stats_and_thresholds"
+  dominating_topic_minimum_percent:
+    default: 40
+    area: "stats_and_thresholds"
   disable_avatar_education_message: false
   pm_warn_user_last_seen_months_ago: 24
 
@@ -3095,6 +3251,7 @@ uncategorized:
     type: category
     default: ""
     validator: "DefaultComposerCategoryValidator"
+    area: "posts_and_topics"
 
   notify_about_reviewable_item_after:
     type: float
@@ -3138,10 +3295,12 @@ uncategorized:
   delete_drafts_older_than_n_days:
     default: 180
     max: 36500
+    area: "posts_and_topics"
 
   delete_merged_stub_topics_after_days:
     default: 7
     min: -1
+    area: "posts_and_topics"
 
   backup_drafts_to_pm_length:
     default: 0
@@ -3183,6 +3342,7 @@ uncategorized:
   automatically_unpin_topics:
     default: true
     client: true
+    area: "posts_and_topics"
 
   read_time_word_count:
     default: 500
@@ -3191,10 +3351,12 @@ uncategorized:
       ja: 350
       zh_CN: 350
       zh_TW: 350
+    area: "posts_and_topics"
 
   topic_page_title_includes_category:
     default: true
     client: true
+    area: "posts_and_topics"
 
   native_app_install_banner_ios:
     default: false
@@ -3285,6 +3447,7 @@ uncategorized:
 
   create_revision_on_bulk_topic_moves:
     default: true
+    area: "posts_and_topics"
 
   allow_changing_staged_user_tracking: false
 
@@ -3304,10 +3467,12 @@ uncategorized:
   show_bottom_topic_map:
     client: true
     default: true
+    area: "posts_and_topics"
 
   show_topic_map_in_topics_without_replies:
     client: true
     default: true
+    area: "posts_and_topics"
 
   enable_welcome_banner:
     client: true
@@ -3530,6 +3695,7 @@ tags:
     client: true
     default: true
     refresh: true
+    area: "categories_and_tags"
   tag_style:
     client: true
     type: enum
@@ -3539,19 +3705,24 @@ tags:
       - bullet
       - box
     preview: '<div class="discourse-tags"><span class="discourse-tag {{value}}">tag1</span><span class="discourse-tag {{value}}">tag2</span></div>'
+    area: "categories_and_tags"
   max_tags_per_topic:
     default: 5
     client: true
+    area: "categories_and_tags"
   enable_max_tags_per_email_subject:
     default: false
     client: true
+    area: "categories_and_tags"
   max_tags_per_email_subject:
     default: 5
     client: true
     min: 0
+    area: "categories_and_tags"
   max_tag_length:
     default: 20
     client: true
+    area: "categories_and_tags"
   min_trust_to_create_tag:
     default: "3"
     type: enum
@@ -3581,18 +3752,22 @@ tags:
     client: true
     default: 5
     min: 1
+    area: "categories_and_tags"
   max_tags_in_filter_list:
     client: true
     default: 30
     min: 1
     refresh: true
+    area: "categories_and_tags"
   tags_sort_alphabetically:
     client: true
     default: false
     refresh: true
+    area: "categories_and_tags"
   tags_listed_by_group:
     client: true
     default: false
+    area: "categories_and_tags"
   pm_tags_allowed_for_groups:
     type: group_list
     list_type: compact
@@ -3603,22 +3778,28 @@ tags:
   suppress_overlapping_tags_in_list:
     default: false
     client: true
+    area: "categories_and_tags"
   remove_muted_tags_from_latest:
     client: true
     type: enum
     default: always
     enum: RemoveMutedTagsFromLatestSiteSetting
+    area: "categories_and_tags"
   watched_precedence_over_muted:
     client: true
     default: false
+    area: "categories_and_tags"
 
   force_lowercase_tags:
     default: true
     client: true
+    area: "categories_and_tags"
   create_post_for_category_and_tag_changes:
     default: false
+    area: "categories_and_tags"
   automatically_clean_unused_tags:
     default: false
+    area: "categories_and_tags"
 
 dashboard:
   dashboard_hidden_reports:

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -93,6 +93,7 @@ describe "Admin | Sidebar Navigation", type: :system do
     links = page.all(".sidebar-section-link-content-text")
     expect(links.map(&:text)).to eq(
       [
+        I18n.t("admin_js.admin.config.content.title"),
         I18n.t("admin_js.admin.config.user_fields.title"),
         I18n.t("admin_js.admin.config.flags.title"),
         I18n.t("admin_js.admin.config.email.title"),
@@ -192,6 +193,7 @@ describe "Admin | Sidebar Navigation", type: :system do
     links = page.all(".sidebar-section-link-content-text")
     expect(links.map(&:text)).to eq(
       [
+        I18n.t("admin_js.admin.config.content.title"),
         I18n.t("admin_js.admin.config.user_fields.title"),
         I18n.t("admin_js.admin.config.flags.title"),
         I18n.t("admin_js.admin.config.email.title"),


### PR DESCRIPTION
### What is this change?

This PR adds a dedicated page for Content related site settings. It has four different site setting tabs:

<img width="448" alt="Screenshot 2025-04-09 at 4 52 18 PM" src="https://github.com/user-attachments/assets/e2d66b38-3b8d-4594-840b-8007721c7e61" />
