### PR TITLE
DEV: Add User defaults admin config page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-user-defaults-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-user-defaults-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigUserDefaultsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-user-defaults-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-user-defaults-settings.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigUserDefaultsSettingsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.user_defaults.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -271,6 +271,11 @@ export default function () {
             });
           }
         );
+        this.route("userDefaults", { path: "user-defaults" }, function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route("trustLevels", { path: "/trust-levels" }, function () {
           this.route("settings", {
             path: "/",

--- a/app/assets/javascripts/admin/addon/templates/config-user-defaults-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-user-defaults-settings.gjs
@@ -1,0 +1,33 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @hideTabs={{true}}
+      @titleLabel={{i18n "admin.config.user_defaults.title"}}
+      @descriptionLabel={{i18n "admin.config.user_defaults.header_description"}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/config/user-defaults"
+          @label={{i18n "admin.config.user_defaults.title"}}
+        />
+      </:breadcrumbs>
+    </DPageHeader>
+
+    <div class="admin-config-page__main-area">
+      <AdminAreaSettings
+        @showBreadcrumb={{false}}
+        @area="user_defaults"
+        @path="/admin/config/user-defaults"
+        @filter={{@controller.filter}}
+        @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      />
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -156,6 +156,16 @@ export const ADMIN_NAV_MAP = [
         multi_tabbed: true,
       },
       {
+        name: "admin_user_defaults",
+        route: "adminConfig.userDefaults.settings",
+        label: "admin.config.user_defaults.title",
+        description: "admin.config.user_defaults.header_description",
+        keywords: "admin.config.user_defaults.keywords",
+        icon: "circle-user",
+        settings_area: "user_defaults",
+        multi_tabbed: false,
+      },
+      {
         name: "admin_trust_levels",
         route: "adminConfig.trustLevels.settings",
         label: "admin.config.trust_levels.title",

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -14,6 +14,7 @@ class SiteSetting < ActiveRecord::Base
     navigation
     notifications
     permalinks
+    user_defaults
     trust_levels
   ]
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5414,6 +5414,10 @@ en:
         permalinks:
           title: "Permalinks"
           header_description: "Redirections to apply for URLs not known by the forum"
+        user_defaults:
+          title: "User defaults"
+          header_description: "Set default values for settings that impact your users, configuring their onboarding experience"
+          keywords: "users|onboarding|new"
         user_fields:
           title: "User fields"
           header_description: "Create custom user fields to collect extra details about your community members. You can choose what information is required during sign-up, what shows on profiles, and what users can update."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -408,6 +408,7 @@ Discourse::Application.routes.draw do
         get "security" => "site_settings#index"
         get "spam" => "site_settings#index"
         get "user-api" => "site_settings#index"
+        get "user-defaults" => "site_settings#index"
         get "experimental" => "site_settings#index"
         get "trust-levels" => "site_settings#index"
         get "group-permissions" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3211,45 +3211,72 @@ user_preferences:
   default_email_digest_frequency:
     enum: "DigestEmailSiteSetting"
     default: 10080
-  default_include_tl0_in_digests: false
+    area: "user_defaults"
+  default_include_tl0_in_digests:
+    default: false
+    area: "user_defaults"
   default_email_level:
     enum: "EmailLevelSiteSetting"
     default: 1
+    area: "user_defaults"
   default_email_messages_level:
     enum: "EmailLevelSiteSetting"
     default: 0
-  default_email_mailing_list_mode: false
+    area: "user_defaults"
+  default_email_mailing_list_mode:
+    default: false
+    area: "user_defaults"
   default_email_mailing_list_mode_frequency:
     enum: "MailingListModeSiteSetting"
     default: 1
+    area: "user_defaults"
   disable_mailing_list_mode:
     default: true
     client: true
+    area: "user_defaults"
   default_email_previous_replies:
     enum: "PreviousRepliesSiteSetting"
     default: 2
+    area: "user_defaults"
   default_email_in_reply_to:
     default: false
+    area: "user_defaults"
   default_hide_profile:
     default: false
+    area: "user_defaults"
   default_hide_presence:
     default: false
+    area: "user_defaults"
   default_other_new_topic_duration_minutes:
     enum: "NewTopicDurationSiteSetting"
     default: 2880
+    area: "user_defaults"
   default_other_auto_track_topics_after_msecs:
     enum: "AutoTrackDurationSiteSetting"
     default: 300000
+    area: "user_defaults"
   default_other_notification_level_when_replying:
     enum: "NotificationLevelWhenReplyingSiteSetting"
     default: 2
     area: "notifications"
-  default_other_external_links_in_new_tab: false
-  default_other_enable_quoting: true
-  default_other_enable_defer: false
-  default_other_enable_smart_lists: true
-  default_other_dynamic_favicon: false
-  default_other_skip_new_user_tips: false
+  default_other_external_links_in_new_tab:
+    default: false
+    area: "user_defaults"
+  default_other_enable_quoting:
+    default: true
+    area: "user_defaults"
+  default_other_enable_defer:
+    default: false
+    area: "user_defaults"
+  default_other_enable_smart_lists:
+    default: true
+    area: "user_defaults"
+  default_other_dynamic_favicon:
+    default: false
+    area: "user_defaults"
+  default_other_skip_new_user_tips:
+    default: false
+    area: "user_defaults"
   default_other_like_notification_frequency:
     enum: "LikeNotificationFrequencySiteSetting"
     default: 1
@@ -3258,38 +3285,49 @@ user_preferences:
   default_topics_automatic_unpin:
     default: true
     client: true
+    area: "user_defaults"
 
   default_categories_watching:
     type: category_list
     default: ""
+    area: "user_defaults"
   default_categories_tracking:
     type: category_list
     default: ""
+    area: "user_defaults"
   default_categories_muted:
     type: category_list
     default: ""
+    area: "user_defaults"
   default_categories_watching_first_post:
     type: category_list
     default: ""
+    area: "user_defaults"
   default_categories_normal:
     type: category_list
     default: ""
+    area: "user_defaults"
   mute_all_categories_by_default:
     default: false
     client: true
+    area: "user_defaults"
 
   default_tags_watching:
     type: tag_list
     default: ""
+    area: "user_defaults"
   default_tags_tracking:
     type: tag_list
     default: ""
+    area: "user_defaults"
   default_tags_muted:
     type: tag_list
     default: ""
+    area: "user_defaults"
   default_tags_watching_first_post:
     type: tag_list
     default: ""
+    area: "user_defaults"
 
   default_text_size:
     type: enum
@@ -3304,9 +3342,11 @@ user_preferences:
     choices:
       - notifications
       - contextual
+    area: "user_defaults"
   enable_offline_indicator:
     default: false
     client: true
+    area: "user_defaults"
   default_sidebar_link_to_filtered_list:
     default: false
     area: "navigation"

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -65,6 +65,7 @@ module SvgSprite
         circle-minus
         circle-plus
         circle-question
+        circle-user
         circle-xmark
         clock
         clock-rotate-left


### PR DESCRIPTION
### What is this change?

This PR adds a dedicated admin config page for User defaults related site settings.

<img width="545" alt="Screenshot 2025-04-07 at 4 43 17 PM" src="https://github.com/user-attachments/assets/bbf77d48-4f96-4b52-baba-1276580f7d12" />
