### PR TITLE
DEV: Add Interface and layout admin config page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-interface-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-interface-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigInterfaceSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-interface-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-interface-settings.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminConfigInterfaceSettingsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.interface.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -262,6 +262,11 @@ export default function () {
             path: "/",
           });
         });
+        this.route("interface", function () {
+          this.route("settings", {
+            path: "/",
+          });
+        });
         this.route(
           "groupPermissions",
           { path: "/group-permissions" },

--- a/app/assets/javascripts/admin/addon/templates/config-interface-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-interface-settings.gjs
@@ -1,0 +1,33 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import { i18n } from "discourse-i18n";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @hideTabs={{true}}
+      @titleLabel={{i18n "admin.config.interface.title"}}
+      @descriptionLabel={{i18n "admin.config.interface.header_description"}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/config/interface"
+          @label={{i18n "admin.config.interface.title"}}
+        />
+      </:breadcrumbs>
+    </DPageHeader>
+
+    <div class="admin-config-page__main-area">
+      <AdminAreaSettings
+        @showBreadcrumb={{false}}
+        @area="interface"
+        @path="/admin/config/interface"
+        @filter={{@controller.filter}}
+        @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+      />
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -225,6 +225,16 @@ export const ADMIN_NAV_MAP = [
         icon: "palette",
       },
       {
+        name: "admin_interface",
+        route: "adminConfig.interface",
+        label: "admin.config.interface.title",
+        description: "admin.config.interface.header_description",
+        keywords: "admin.config.interface.keywords",
+        icon: "discourse-table",
+        settings_area: "interface",
+        multi_tabbed: false,
+      },
+      {
         name: "admin_emoji",
         route: "adminEmojis",
         label: "admin.config.emoji.title",

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -9,6 +9,7 @@ class SiteSetting < ActiveRecord::Base
     flags
     fonts
     group_permissions
+    interface
     legal
     localization
     navigation

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5411,6 +5411,10 @@ en:
           title: "Analytics & SEO"
           header_description: "Improve your site’s visibility to search engines and configure how you track site visitors"
           keywords: "search|google|sitemap"
+        interface:
+          title: "Interface & layout"
+          header_description: "Customize details of your site’s general layout and user interface"
+          keywords: "splash"
         permalinks:
           title: "Permalinks"
           header_description: "Redirections to apply for URLs not known by the forum"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -396,6 +396,7 @@ Discourse::Application.routes.draw do
         get "analytics-and-seo" => "site_settings#index"
         get "developer" => "site_settings#index"
         get "files" => "site_settings#index"
+        get "interface" => "site_settings#index"
         get "legal" => "site_settings#index"
         get "localization" => "site_settings#index"
         get "login-and-authentication" => "site_settings#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -185,6 +185,7 @@ basic:
   categories_topics:
     default: 20
     validator: "CategoriesTopicsValidator"
+    area: "interface"
   suggested_topics:
     client: true
     default: 5
@@ -325,6 +326,7 @@ basic:
     type: list
     list_type: compact
     default: "BF1E2E|F1592A|F7941D|9EB83B|3AB54A|12A89D|25AAE2|0E76BD|652D90|92278F|ED207B|8C6238|231F20|808281|B3B5B4|E45735"
+    area: "interface"
   max_category_nesting:
     client: true
     default: 2
@@ -373,9 +375,11 @@ basic:
   fixed_category_positions:
     client: true
     default: false
+    area: "interface"
   fixed_category_positions_on_create:
     client: true
     default: false
+    area: "interface"
   enable_badges:
     client: true
     default: true
@@ -476,6 +480,7 @@ basic:
   show_user_menu_avatars:
     client: true
     default: false
+    area: "interface"
   about_page_hidden_groups:
     default: ""
     type: group_list
@@ -511,6 +516,7 @@ basic:
     client: true
     enum: "InterfaceColorSelectorSetting"
     default: "disabled"
+    area: "interface"
 
 login:
   invite_only:
@@ -3190,6 +3196,7 @@ uncategorized:
 
   splash_screen:
     default: true
+    area: "interface"
 
   suggest_weekends_in_date_pickers:
     client: true


### PR DESCRIPTION
### What is this change?

This PR adds a dedicated admin settings page for Interface & layout related site settings:

<img width="565" alt="Screenshot 2025-04-07 at 5 30 48 PM" src="https://github.com/user-attachments/assets/ec735aa8-6e73-4bfd-b5a1-4f4802e31709" />
