### PR TITLE
UX: Add missing admin config page titles

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-api-keys.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-api-keys.js
@@ -1,3 +1,0 @@
-import Route from "@ember/routing/route";
-
-export default class AdminApiKeysRoute extends Route {}

--- a/app/assets/javascripts/admin/addon/routes/admin-badges.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges.js
@@ -12,6 +12,10 @@ export default class AdminBadgesRoute extends DiscourseRoute {
 
   _json = null;
 
+  titleToken() {
+    return i18n("admin.config.badges.title");
+  }
+
   async model() {
     let json = await ajax("/admin/badges.json");
     this._json = json;

--- a/app/assets/javascripts/admin/addon/routes/admin-dashboard.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-dashboard.js
@@ -1,7 +1,12 @@
 import { scrollTop } from "discourse/mixins/scroll-top";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
 export default class AdminDashboardRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.dashboard.title");
+  }
+
   activate() {
     this.controllerFor("admin-dashboard").fetchProblems();
     this.controllerFor("admin-dashboard").fetchDashboard();

--- a/app/assets/javascripts/admin/addon/routes/admin-email.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-email.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminEmailRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.email.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminLogsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.staff_action_logs.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-permalinks.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-permalinks.js
@@ -1,7 +1,12 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 import Permalink from "admin/models/permalink";
 
 export default class AdminPermalinksRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.permalinks.title");
+  }
+
   model() {
     return Permalink.findAll();
   }

--- a/app/assets/javascripts/admin/addon/routes/admin-reports.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminReportsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.reports.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -1,6 +1,7 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
 
 export default class AdminSiteSettingsRoute extends DiscourseRoute {
@@ -9,6 +10,10 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
   queryParams = {
     filter: { replace: true },
   };
+
+  titleToken() {
+    return i18n("admin.config.site_settings.title");
+  }
 
   model() {
     return SiteSetting.findAll();

--- a/app/assets/javascripts/admin/addon/routes/admin-site-text.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-text.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminSiteTextRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.site_texts.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-users.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminUsersRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.users.title");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-watched-words.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-watched-words.js
@@ -1,10 +1,15 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 import WatchedWord from "admin/models/watched-word";
 
 export default class AdminWatchedWordsRoute extends DiscourseRoute {
   queryParams = {
     filter: { replace: true },
   };
+
+  titleToken() {
+    return i18n("admin.config.watched_words.title");
+  }
 
   model() {
     return WatchedWord.findAll();

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -46,7 +46,7 @@ describe "Admin User Page", type: :system do
 
     it "displays username in the title" do
       expect(page).to have_css(".display-row.username")
-      expect(page.title).to eq("#{user.username} - Admin - Discourse")
+      expect(page.title).to eq("#{user.username} - Users - Admin - Discourse")
     end
 
     describe "the suspend user modal" do


### PR DESCRIPTION
### What is this change?

A number of admin config pages are missing a page title. This PR adds them in.

For example:

<img width="204" alt="Screenshot 2025-04-07 at 8 16 45 PM" src="https://github.com/user-attachments/assets/b56edc60-4b33-4f40-8acf-229687fede74" />
