### PR TITLE
DEV: Optionally include everyone groups when searching

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -675,12 +675,12 @@ class GroupsController < ApplicationController
   end
 
   def search
+    include_everyone = params[:include_everyone] == "true"
+    order = ["name"]
     groups =
-      Group
-        .visible_groups(current_user)
-        .where("groups.id <> ?", Group::AUTO_GROUPS[:everyone])
-        .includes(:flair_upload)
-        .order(:name)
+      Group.visible_groups(current_user, order, include_everyone: include_everyone).includes(
+        :flair_upload,
+      )
 
     if (term = params[:term]).present?
       groups =

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -820,6 +820,32 @@ RSpec.describe Group do
       Group.visible_groups(user).where(id: group.id).exists?
     end
 
+    it "includes everyone group when option is present" do
+      expect(
+        Group
+          .visible_groups(admin, [], include_everyone: true)
+          .where(id: Group::AUTO_GROUPS[:everyone])
+          .exists?,
+      ).to eq(true)
+    end
+
+    it "doesn't include everyones group by default" do
+      expect(
+        Group
+          .visible_groups(admin, [], include_everyone: false)
+          .where(id: Group::AUTO_GROUPS[:everyone])
+          .exists?,
+      ).to eq(false)
+
+      expect(
+        Group.visible_groups(admin, [], nil).where(id: Group::AUTO_GROUPS[:everyone]).exists?,
+      ).to eq(false)
+
+      expect(
+        Group.visible_groups(admin, [], {}).where(id: Group::AUTO_GROUPS[:everyone]).exists?,
+      ).to eq(false)
+    end
+
     it "correctly restricts group visibility" do
       group = Fabricate.build(:group, visibility_level: Group.visibility_levels[:owners])
       logged_on_user = Fabricate(:user)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2641,6 +2641,19 @@ RSpec.describe GroupsController do
         expect(groups.length).to eq(2)
 
         expect(groups.map { |group| group["id"] }).to contain_exactly(group.id, hidden_group.id)
+
+        get "/groups/search.json?include_everyone=true"
+
+        expect(response.status).to eq(200)
+        groups = response.parsed_body
+
+        automatic_ids = Group::AUTO_GROUPS.map { |name, id| id }
+
+        expect(groups.map { |group| group["id"] }).to contain_exactly(
+          group.id,
+          hidden_group.id,
+          *automatic_ids,
+        )
       end
     end
 


### PR DESCRIPTION
`GroupsController#search` now accepts an `include_everyone` parameter to include the "everyone" group in the results. discourse-ai relies on this
 endpoint for configuring personas' allowed groups and needs this group
 to be present. You still need to be able to see the group.