### PR TITLE
Added button to remove password from account

### DIFF
--- a/app/assets/javascripts/dialog-holder/addon/services/dialog.js
+++ b/app/assets/javascripts/dialog-holder/addon/services/dialog.js
@@ -157,11 +157,12 @@ export default class DialogService extends Service {
 
   @bind
   didConfirmWrapped() {
-    if (this.didConfirm) {
-      this.didConfirm();
-    }
+    let didConfirm = this.didConfirm;
     this._confirming = true;
     this.reset();
+    if (didConfirm) {
+      didConfirm();
+    }
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-passkeys.gjs
@@ -115,8 +115,12 @@ export default class UserPasskeys extends Component {
       this.dialog.deleteConfirm({
         title: i18n("user.passkeys.confirm_delete_passkey"),
         didConfirm: () => {
-          this.args.model.deletePasskey(id).then(() => {
-            this.router.refresh();
+          this.args.model.deletePasskey(id).then((response) => {
+            if (response.success) {
+              this.router.refresh();
+            } else {
+              this.dialog.alert(response.message);
+            }
           });
         },
       });

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -107,6 +107,89 @@ export default class SecurityController extends Controller {
     }
   }
 
+  @discourseComputed(
+    "model.is_anonymous",
+    "model.no_password",
+    "siteSettings",
+    "model.user_passkeys",
+    "model.associated_accounts"
+  )
+  canRemovePassword(
+    isAnonymous,
+    noPassword,
+    siteSettings,
+    userPasskeys,
+    associatedAccounts
+  ) {
+    if (
+      isAnonymous ||
+      noPassword ||
+      siteSettings.enable_discourse_connect ||
+      !siteSettings.enable_local_logins
+    ) {
+      return false;
+    }
+
+    return (
+      associatedAccounts?.length > 0 ||
+      (this.canUsePasskeys && userPasskeys?.length > 0)
+    );
+  }
+
+  @discourseComputed("model.associated_accounts")
+  associatedAccountsLoaded(associatedAccounts) {
+    return typeof associatedAccounts !== "undefined";
+  }
+
+  removePasswordConfirm() {
+    this.dialog.deleteConfirm({
+      title: i18n("user.change_password.remove"),
+      message: i18n("user.change_password.remove_detail"),
+      confirmButtonIcon: "trash-can",
+      didConfirm: () => {
+        this.set("removePasswordInProgress", true);
+
+        this.model
+          .removePassword()
+          .then((response) => {
+            this.set("removePasswordInProgress", false);
+            if (response.success) {
+              this.model.set("no_password", true);
+            }
+          })
+          .catch((error) => {
+            this.set("removePasswordInProgress", false);
+            popupAjaxError(error);
+          });
+      },
+    });
+  }
+
+  @action
+  async removePassword(event) {
+    event?.preventDefault();
+    if (this.removePasswordInProgress) {
+      return;
+    }
+
+    try {
+      const trustedSession = await this.model.trustedSession();
+
+      if (!trustedSession.success) {
+        this.dialog.dialog({
+          title: i18n("user.confirm_access.title"),
+          type: "notice",
+          bodyComponent: ConfirmSession,
+          didConfirm: () => this.removePasswordConfirm(),
+        });
+      } else {
+        this.removePasswordConfirm();
+      }
+    } catch (error) {
+      popupAjaxError(error);
+    }
+  }
+
   @action
   toggleShowAllAuthTokens(event) {
     event?.preventDefault();

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -2,6 +2,7 @@ import Controller from "@ember/controller";
 import { action, computed } from "@ember/object";
 import { gt } from "@ember/object/computed";
 import { service } from "@ember/service";
+import isNone from "@ember/utils/lib/is_none";
 import ConfirmSession from "discourse/components/dialog-messages/confirm-session";
 import AuthTokenModal from "discourse/components/modal/auth-token";
 import { ajax } from "discourse/lib/ajax";
@@ -138,7 +139,7 @@ export default class SecurityController extends Controller {
 
   @discourseComputed("model.associated_accounts")
   associatedAccountsLoaded(associatedAccounts) {
-    return typeof associatedAccounts !== "undefined";
+    return !isNone(associatedAccounts);
   }
 
   removePasswordConfirm() {

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -2,7 +2,7 @@ import Controller from "@ember/controller";
 import { action, computed } from "@ember/object";
 import { gt } from "@ember/object/computed";
 import { service } from "@ember/service";
-import isNone from "@ember/utils/lib/is_none";
+import typeOf from "@ember/utils/lib/type-of";
 import ConfirmSession from "discourse/components/dialog-messages/confirm-session";
 import AuthTokenModal from "discourse/components/modal/auth-token";
 import { ajax } from "discourse/lib/ajax";
@@ -139,7 +139,7 @@ export default class SecurityController extends Controller {
 
   @discourseComputed("model.associated_accounts")
   associatedAccountsLoaded(associatedAccounts) {
-    return !isNone(associatedAccounts);
+    return typeOf(associatedAccounts) !== "undefined";
   }
 
   removePasswordConfirm() {

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -591,6 +591,12 @@ export default class User extends RestModel.extend(Evented) {
     });
   }
 
+  async removePassword() {
+    return ajax(userPath(`${this.username}/remove-password`), {
+      type: "PUT",
+    });
+  }
+
   loadSecondFactorCodes() {
     return ajax("/u/second_factors.json", {
       type: "POST",

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -9,6 +9,7 @@ import UserApiKeys from "discourse/components/user-preferences/user-api-keys";
 import UserPasskeys from "discourse/components/user-preferences/user-passkeys";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
+import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -24,6 +25,7 @@ export default RouteTemplate(
             href
             {{on "click" @controller.changePassword}}
             class="btn btn-default"
+            id="change-password-button"
           >
             {{icon "envelope"}}
             {{#if @controller.model.no_password}}
@@ -35,6 +37,35 @@ export default RouteTemplate(
 
           {{@controller.passwordProgress}}
         </div>
+
+        {{#unless @controller.model.no_password}}
+          {{#if @controller.associatedAccountsLoaded}}
+            {{#if @controller.canRemovePassword}}
+              <div class="controls">
+                <DButton
+                  @action={{@controller.removePassword}}
+                  @icon="trash-can"
+                  @label="user.change_password.remove"
+                  class="btn-default"
+                  @isLoading={{@controller.removePasswordInProgress}}
+                  id="remove-password-button"
+                />
+              </div>
+              <div class="instructions">
+                {{i18n "user.change_password.remove_detail"}}
+              </div>
+            {{/if}}
+          {{else}}
+            <div class="controls">
+              <DButton
+                @action={{fn (routeAction "checkEmail") @controller.model}}
+                @title="admin.users.check_email.title"
+                @icon="envelope"
+                @label="admin.users.check_email.text"
+              />
+            </div>
+          {{/if}}
+        {{/unless}}
       </div>
 
       {{#if @controller.canUsePasskeys}}

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-security-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
@@ -20,6 +20,14 @@ acceptance("User Preferences - Security", function (needs) {
     });
 
     server.post("/session/forgot_password.json", () => {
+      return helper.response({ success: "Ok" });
+    });
+
+    server.post("/u/confirm-session.json", () => {
+      return helper.response({ success: "Ok" });
+    });
+
+    server.put("/u/eviltrout/remove-password", () => {
       return helper.response({ success: "Ok" });
     });
   });
@@ -219,5 +227,63 @@ acceptance("User Preferences - Security", function (needs) {
     assert
       .dom(".passkey-options-dropdown")
       .doesNotExist("does not show passkey options dropdown");
+  });
+
+  test("Remove Password availability", async function (assert) {
+    this.siteSettings.enable_passkeys = true;
+    await visit("/u/eviltrout/preferences/security");
+    // eviltrout starts with an entry in associated_accounts, can remove password
+    assert
+      .dom("#remove-password-button")
+      .exists("shows for user with associated account");
+
+    updateCurrentUser({
+      associated_accounts: null,
+    });
+
+    assert
+      .dom("#remove-password-button")
+      .doesNotExist(
+        "does not show for user with no associated account and no passkeys"
+      );
+
+    updateCurrentUser({
+      user_passkeys: [
+        {
+          id: 1,
+          name: "Password Manager",
+          last_used: "2023-10-09T20:03:20.986Z",
+          created_at: "2023-10-09T20:01:37.578Z",
+        },
+      ],
+    });
+    assert.dom("#remove-password-button").exists("shows for user with passkey");
+  });
+
+  test("Removing User Password", async function (assert) {
+    await visit("/u/eviltrout/preferences/security");
+    // eviltrout starts with an entry in associated_accounts, can remove password
+
+    await click("#remove-password-button");
+    assert
+      .dom(".dialog-body .confirm-session")
+      .exists(
+        "displays a dialog to confirm the user's identity before deleting password"
+      );
+    await fillIn(".confirm-session #password", "correct");
+    await click(".confirm-session .btn-primary");
+    assert
+      .dom(".dialog-body")
+      .hasText(i18n("user.change_password.remove_detail"));
+    await click(".dialog-footer .btn-danger");
+    assert
+      .dom("#remove-password-button")
+      .doesNotExist("hides remove password button once password is removed");
+    assert
+      .dom("#change-password-button")
+      .hasText(
+        i18n("user.change_password.set_password"),
+        "shows set password instead of change after password removed"
+      );
   });
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -870,11 +870,8 @@ class UsersController < ApplicationController
     raise Discourse::ReadOnly if staff_writes_only_mode? && !user.staff?
     raise Discourse::InvalidAccess if !secure_session_confirmed?
 
-    if user.associated_accounts.blank? && user.passkey_credential_ids.blank?
-      raise Discourse::InvalidAccess
-    end
-
     user.remove_password
+
     render json: success_json
   end
 
@@ -1697,8 +1694,7 @@ class UsersController < ApplicationController
 
     security_key = current_user.security_keys.find_by(id: params[:id].to_i)
 
-    if security_key&.factor_type == UserSecurityKey.factor_types[:first_factor] &&
-         current_user.passkey_credential_ids.length == 1
+    if security_key&.first_factor? && current_user.passkey_credential_ids.length == 1
       if !current_user.has_password? && current_user.associated_accounts.blank?
         return render json: { success: false, message: I18n.t("user.cannot_remove_all_auth") }
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -758,7 +758,7 @@ class UsersController < ApplicationController
 
     # just assign a password if we have an authenticator and no password
     # this is the case for Twitter
-    user.password = SecureRandom.hex if user.password.blank? &&
+    user.password = SecureRandom.hex if user.password_required? && user.password.blank? &&
       (authentication.has_authenticator? || associations.present?)
 
     if user.save
@@ -856,6 +856,26 @@ class UsersController < ApplicationController
                  security_params.merge(DiscourseWebauthn.allowed_credentials(@user, secure_session))
       end
     end
+  end
+
+  def remove_password
+    RateLimiter.new(nil, "remove-password-hr-#{request.remote_ip}", 6, 1.hour).performed!
+    RateLimiter.new(nil, "remove-password-min-#{request.remote_ip}", 3, 1.hour).performed!
+
+    user = fetch_user_from_params
+    guardian.ensure_can_edit!(user)
+    RateLimiter.new(nil, "remove-password-hr-#{user.username}", 6, 1.hour).performed!
+
+    raise Discourse::NotFound if !user || !user.user_password
+    raise Discourse::ReadOnly if staff_writes_only_mode? && !user.staff?
+    raise Discourse::InvalidAccess if !secure_session_confirmed?
+
+    if user.associated_accounts.blank? && user.passkey_credential_ids.blank?
+      raise Discourse::InvalidAccess
+    end
+
+    user.remove_password
+    render json: success_json
   end
 
   def password_reset_update
@@ -1675,7 +1695,16 @@ class UsersController < ApplicationController
   def delete_passkey
     raise Discourse::NotFound unless SiteSetting.enable_passkeys
 
-    current_user.security_keys.find_by(id: params[:id].to_i)&.destroy!
+    security_key = current_user.security_keys.find_by(id: params[:id].to_i)
+
+    if security_key&.factor_type == UserSecurityKey.factor_types[:first_factor] &&
+         current_user.passkey_credential_ids.length == 1
+      if !current_user.has_password? && current_user.associated_accounts.blank?
+        return render json: { success: false, message: I18n.t("user.cannot_remove_all_auth") }
+      end
+    end
+
+    security_key&.destroy!
 
     render json: success_json
   end
@@ -1797,6 +1826,12 @@ class UsersController < ApplicationController
     # revoke permissions even if the admin has temporarily disabled that type of login
     authenticator = Discourse.authenticators.find { |a| a.name == provider_name }
     raise Discourse::NotFound if authenticator.nil? || !authenticator.can_revoke?
+
+    if user.associated_accounts&.length == 1
+      if !user.has_password? && user.passkey_credential_ids.blank?
+        return render json: { success: false, message: I18n.t("user.cannot_remove_all_auth") }
+      end
+    end
 
     skip_remote = params.permit(:skip_remote)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -930,6 +930,10 @@ class User < ActiveRecord::Base
     @raw_password = pw # still required to maintain compatibility with usage of password-related User interface
   end
 
+  def remove_password()
+    user_password.destroy if user_password
+  end
+
   def password
     "" # so that validator doesn't complain that a password attribute doesn't exist
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -930,7 +930,9 @@ class User < ActiveRecord::Base
     @raw_password = pw # still required to maintain compatibility with usage of password-related User interface
   end
 
-  def remove_password()
+  def remove_password
+    raise Discourse::InvalidAccess if associated_accounts.blank? && passkey_credential_ids.blank?
+
     user_password.destroy if user_password
   end
 

--- a/app/models/user_security_key.rb
+++ b/app/models/user_security_key.rb
@@ -15,6 +15,10 @@ class UserSecurityKey < ActiveRecord::Base
     @factor_types ||= Enum.new(second_factor: 0, first_factor: 1, multi_factor: 2)
   end
 
+  def first_factor?
+    factor_type == self.class.factor_types[:first_factor]
+  end
+
   private
 
   def count_per_user_does_not_exceed_limit

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -20,7 +20,8 @@ class UserSerializer < UserCardSerializer
              :associated_accounts,
              :profile_background_upload_url,
              :can_upload_profile_header,
-             :can_upload_user_card_background
+             :can_upload_user_card_background,
+             :no_password
 
   has_one :invited_by, embed: :object, serializer: BasicUserSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
@@ -343,6 +344,14 @@ class UserSerializer < UserCardSerializer
 
   def can_pick_theme_with_custom_homepage
     ThemeModifierHelper.new(theme_ids: Theme.enabled_theme_and_component_ids).custom_homepage
+  end
+
+  def no_password
+    true
+  end
+
+  def include_no_password?
+    !object.has_password?
   end
 
   private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1616,6 +1616,8 @@ en:
         choose: "Choose a password"
         verify_identity: "To continue, please verify your identity."
         title: "Password Reset"
+        remove: "Remove Password"
+        remove_detail: "This completely erases your password. Your account will no longer be accessible by using your password to log in unless you reset it."
 
       second_factor_backup:
         title: "Two-Factor Backup Codes"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3100,6 +3100,7 @@ en:
       one: "User %{username} has %{count} post in a public topic or personal message, so they can't be deleted."
       other: "User %{username} has %{count} posts in public topics or personal messages, so they can't be deleted."
     cannot_bulk_delete: "One or more users cannot be deleted either because they're an admin, have too many posts or have a very old post."
+    cannot_remove_all_auth: "You must have at least one associated account, a passkey, or a password set."
 
   unsubscribe_mailer:
     title: "Unsubscribe Mailer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -934,6 +934,11 @@ Discourse::Application.routes.draw do
           :constraints => {
             username: RouteFormat.username,
           }
+      put "#{root_path}/:username/remove-password" => "users#remove_password",
+          :format => :json,
+          :constraints => {
+            username: RouteFormat.username,
+          }
     end
 
     get "user-badges/:username.json" => "user_badges#username",

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -208,6 +208,85 @@ RSpec.describe UsersController do
     end
   end
 
+  describe "#remove password" do
+    it "responds forbidden when not logged in" do
+      put "/u/#{user.username}/remove-password.json"
+      expect(response.status).to eq(403)
+    end
+
+    context "when logged in with no associated accout, no passkeys" do
+      before { sign_in(user) }
+
+      it "fails without a secure session" do
+        put "/u/#{user.username}/remove-password.json" #
+        expect(response.status).to eq(403)
+      end
+
+      it "fails with a secure session" do
+        stub_secure_session_confirmed
+        put "/u/#{user.username}/remove-password.json"
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when logged in and has a passkey" do
+      before do
+        SiteSetting.enable_passkeys = true
+        Fabricate(:passkey_with_random_credential, user: user)
+        sign_in(user)
+      end
+
+      it "fails without a secure session" do
+        put "/u/#{user.username}/remove-password.json" #
+        expect(response.status).to eq(403)
+      end
+
+      it "succeeds with a secure session" do
+        stub_secure_session_confirmed
+        put "/u/#{user.username}/remove-password.json"
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when logged in and has associated accout" do
+      let(:plugin_auth_provider) do
+        authenticator_class =
+          Class.new(Auth::ManagedAuthenticator) do
+            def name
+              "pluginauth"
+            end
+
+            def enabled?
+              true
+            end
+          end
+
+        provider = Auth::AuthProvider.new
+        provider.authenticator = authenticator_class.new
+        provider
+      end
+
+      before do
+        DiscoursePluginRegistry.register_auth_provider(plugin_auth_provider)
+        user.user_associated_accounts.create!(provider_name: "pluginauth", provider_uid: "foo")
+        sign_in(user)
+      end
+
+      it "fails without a secure session" do
+        put "/u/#{user.username}/remove-password.json" #
+        expect(response.status).to eq(403)
+      end
+
+      it "succeeds with a secure session" do
+        stub_secure_session_confirmed
+        put "/u/#{user.username}/remove-password.json"
+        expect(response.status).to eq(200)
+      end
+
+      after { DiscoursePluginRegistry.reset! }
+    end
+  end
+
   describe "#password_reset" do
     let(:token) { SecureRandom.hex }
 
@@ -6381,6 +6460,27 @@ RSpec.describe UsersController do
 
         expect(user1.passkey_credential_ids[0]).to eq(passkey.credential_id)
       end
+
+      context "with second passkey" do
+        fab!(:second_passkey) { Fabricate(:passkey_with_random_credential, user: user1) }
+        it "fails removing the last passkey if the user has neither password nor associated accounts" do
+          user1.user_password = nil
+          allow(user1).to receive(:associated_accounts).and_return([])
+
+          sign_in(user1)
+          expect(user1.passkey_credential_ids.length).to eq(2)
+
+          #succeeds removing the first passkey since there's still a second one
+          delete "/u/delete_passkey/#{passkey.id}.json"
+          expect(response.status).to eq(200)
+          expect(user1.passkey_credential_ids.length).to eq(1)
+
+          delete "/u/delete_passkey/#{second_passkey.id}.json"
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("user.cannot_remove_all_auth"))
+          expect(user1.passkey_credential_ids.length).to eq(1)
+        end
+      end
     end
   end
 
@@ -6535,6 +6635,55 @@ RSpec.describe UsersController do
                  provider_name: "testprovider",
                }
           expect(response.status).to eq(200)
+        end
+
+        context "with a second provider" do
+          let(:second_authenticator) do
+            Class
+              .new(Auth::ManagedAuthenticator) do
+                def name
+                  "testprovider2"
+                end
+
+                def enabled?
+                  true
+                end
+              end
+              .new
+          end
+
+          before do
+            DiscoursePluginRegistry.register_auth_provider(
+              Auth::AuthProvider.new(authenticator: second_authenticator),
+            )
+            authenticator.can_revoke = true
+            user1.user_password = nil
+            allow(user1).to receive(:passkey_credential_ids).and_return([])
+            user1.user_associated_accounts.create!(
+              provider_name: "testprovider2",
+              provider_uid: "foo",
+            )
+          end
+
+          it "fails removing the last associated account if the user has neither password nor passkey" do
+            expect(user1.associated_accounts.length).to eq(2)
+
+            #succeeds removing the first account since there's still a second one
+            post "/u/#{user1.username}/preferences/revoke-account.json",
+                 params: {
+                   provider_name: "testprovider2",
+                 }
+
+            expect(response.status).to eq(200)
+            expect(user1.associated_accounts.length).to eq(1)
+
+            post "/u/#{user1.username}/preferences/revoke-account.json",
+                 params: {
+                   provider_name: "testprovider",
+                 }
+            expect(response.parsed_body["message"]).to eq(I18n.t("user.cannot_remove_all_auth"))
+            expect(user1.associated_accounts.length).to eq(1)
+          end
         end
       end
     end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe UsersController do
       expect(response.status).to eq(403)
     end
 
-    context "when logged in with no associated accout, no passkeys" do
+    context "when logged in with no associated account, no passkeys" do
       before { sign_in(user) }
 
       it "fails without a secure session" do

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -54,7 +54,7 @@ describe "User preferences | Security", type: :system do
   shared_examples "passkeys" do
     before { SiteSetting.enable_passkeys = true }
 
-    it "adds a passkey and logs in with it" do
+    it "adds a passkey, removes user password, logs in with passkey" do
       options =
         ::Selenium::WebDriver::VirtualAuthenticatorOptions.new(
           user_verification: true,
@@ -94,6 +94,11 @@ describe "User preferences | Security", type: :system do
 
       # close the dialog (don't delete the key, we need it to login in the next step)
       find(".dialog-close").click
+
+      find("#remove-password-button").click
+      # already confirmed session for the passkey, so this will go straight for the confirmation dialog
+      find(".dialog-footer .btn-danger").click
+      expect(user_preferences_security_page).to have_no_css("#remove-password-button")
 
       user_menu.sign_out
 


### PR DESCRIPTION
Added button to remove password from account if user has a linked external account or passkey

The button only displays if the user has at least one associated account or a passkey set up. Uses the ConfirmSession dialog in addition to a warning about deleting the password.

Users can still reset their password via the Reset Password button (which will now display "Set Password" if they've removed it).

Also prevent user from removing their last remaining associated account or passkey if they have no password set.

Replaces PR #31489 from my personal repo, with some fixes for conflicts since then.