### PR TITLE
DEV: Fix mixed-decls Sass deprecation warning

### DIFF
--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -248,8 +248,10 @@
             max-width: 100%;
           }
 
-          // px muse be used because there is different font size inside each button
-          height: 45px;
+          & {
+            // px muse be used because there is different font size inside each button
+            height: 45px;
+          }
 
           &.smallest {
             font-size: var(--base-font-size-smallest);

--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -243,14 +243,12 @@
           flex: 0 0 19%;
           max-width: 19%;
 
+          // px must be used because there is different font size inside each button
+          height: 45px;
+
           @media (max-width: $mobile-breakpoint) {
             flex: 0 0 100%;
             max-width: 100%;
-          }
-
-          & {
-            // px muse be used because there is different font size inside each button
-            height: 45px;
           }
 
           &.smallest {


### PR DESCRIPTION
When running specs I noticed this mixed-decls Sass deprecation warning:

> Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
> rules will be changing to match the behavior specified by CSS in an upcoming
> version. To keep the existing behavior, move the declaration above the nested
> rule. To opt into the new behavior, wrap the declaration in & {}.
>
> More info: https://sass-lang.com/d/mixed-decls

This change address that issue.

Follow up to: 928f9175f05413289c45d3fd6424f62956ea0944
