### PR TITLE
FIX: Selecting a parent category shouldn't clear other form fields

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -199,10 +199,10 @@ export default class EditCategoryGeneral extends Component {
         >
           <field.Custom>
             <CategoryChooser
-              @value={{@category.parent_category_id}}
+              @value={{@transientData.parent_category_id}}
               @allowSubCategories={{true}}
               @allowRestrictedCategories={{true}}
-              @onChange={{fn (mut @category.parent_category_id)}}
+              @onChange={{field.set}}
               @options={{hash
                 allowUncategorized=false
                 excludeCategoryId=@category.id

--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.gjs
@@ -34,9 +34,13 @@ export default class EditCategorySettings extends buildCategoryPanel(
   showSubcategoryListStyle;
   @empty("category.sort_order") isDefaultSortOrder;
 
-  @discourseComputed("category.isParent", "category.parent_category_id")
-  isParentCategory(isParent, parentCategoryId) {
-    return isParent || !parentCategoryId;
+  @discourseComputed(
+    "category.isParent",
+    "category.parent_category_id",
+    "transientData.parent_category_id"
+  )
+  isParentCategory(isParent, parentCategoryId, transientParentCategoryId) {
+    return isParent || !(parentCategoryId || transientParentCategoryId);
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -99,6 +99,21 @@ acceptance("Category New", function (needs) {
       "back routing works"
     );
   });
+
+  test("Specifying a parent category", async function (assert) {
+    await visit("/new-category");
+
+    await fillIn("input.category-name", "testing");
+
+    const categorySelector = selectKit(".category-chooser");
+    await categorySelector.expand();
+    await categorySelector.selectRowByValue(6); // 6 is support category's id
+
+    assert
+      .dom("input.category-name")
+      .hasValue("testing", "it doesn't clear out the rest of the form fields");
+    assert.strictEqual(categorySelector.header().value(), "6");
+  });
 });
 
 acceptance("Category text color", function (needs) {


### PR DESCRIPTION
This PR fixes a bug where, if you're editing or creating a category, selecting a parent category for the category that's being edited/created causes the rest of the fields in the category edit/create form to be cleared out.

Internal topic: t/151232.