### PR TITLE
FIX: flaky admin_branding_spec fonts section

### DIFF
--- a/spec/system/page_objects/components/admin-branding-fonts-form.rb
+++ b/spec/system/page_objects/components/admin-branding-fonts-form.rb
@@ -11,6 +11,7 @@ module PageObjects
 
       def select_default_text_size(size)
         find(".admin-fonts-form__button-option.#{size}").click
+        page.has_css?(".admin-fonts-form__button-option.#{size}.active")
       end
 
       def active_font(section)


### PR DESCRIPTION
Wait for state to be updated before submit fonts form to avoid random failures.

Form was submitted too quickly 
![lucky-luke-shadow](https://github.com/user-attachments/assets/3cf05b5d-7048-49a8-aab3-9f237408552b)
