### PR TITLE
DEV: Maintain activerecord relation when filtering visible tags

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2112,7 +2112,7 @@ class Topic < ActiveRecord::Base
   end
 
   def visible_tags(guardian)
-    tags.reject { |tag| guardian.hidden_tag_names.include?(tag[:name]) }
+    tags.where.not(name: guardian.hidden_tag_names)
   end
 
   def self.editable_custom_fields(guardian)


### PR DESCRIPTION
This PR updates Topic `visible_tags` method to use ActiveRecord's query interface instead of Ruby's `reject` method. This change:

- Preserves the `ActiveRecord::Associations::CollectionProxy` type in the return value
- Performs filtering at the database level for better performance
- Maintains chainability with other ActiveRecord methods

Before this change, the method was returning a plain Ruby array, which lost ActiveRecord's relation capabilities.