### PR TITLE
DEV: Update mailgun pricing

### DIFF
--- a/docs/INSTALL-email.md
+++ b/docs/INSTALL-email.md
@@ -17,7 +17,7 @@ Enter these values when prompted by `./discourse-setup` per the [install guide](
     SMTP password?       [SMTP credentials for your domain under [SMTP-Key tab](https://app.brevo.com/settings/keys/smtp)]
     Port:                587
     
-#### [Mailgun][gun] &mdash; 5k emails/month on a 3 month trial
+#### [Mailgun][gun] &mdash; 50k emails/month on a 30 day trial OR 10k emails/month with no trial
 
     SMTP server address? smtp.mailgun.org
     SMTP user name?      [SMTP credentials for your domain under domains tab]


### PR DESCRIPTION
mailgun no longer offers a 5k/3 month trial. it offers a 50k/30 day trial. the "Basic" level for $15/mo with 10k emails has no ability to trial it for any time.