### PR TITLE
UX: Wrap participants in pm topic item

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -303,6 +303,8 @@
     .participant-group-wrapper {
       display: flex;
       margin-left: 0.5em;
+      flex-wrap: wrap;
+      gap: 0.5em;
 
       .participant-group {
         padding: 0 5px;


### PR DESCRIPTION
This PR allows group participant tags to wrap in the topic list.