### PR TITLE
FIX: avoid double base path on push notification

### DIFF
--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -26,7 +26,7 @@ class PushNotificationPusher
         icon: notification_icon,
         tag: payload[:tag] || "#{Discourse.current_hostname}-#{payload[:topic_id]}",
         base_url: Discourse.base_url,
-        url: payload[:post_url],
+        url: payload[:post_url]&.sub(/\A#{Discourse.base_path}/, ""),
       }
 
       subscriptions(user).each { |subscription| send_notification(user, subscription, message) }

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe PushNotificationPusher do
   context "with user" do
     fab!(:user)
     let(:topic_title) { "Topic" }
-    let(:post_url) { "https://example.com/t/1/2" }
+    let(:base_url) { Discourse.base_url }
+    let(:post_url) { "/base/t/1/2" }
     let(:username) { "system" }
+
+    before { Discourse.stubs(base_path: "/base") }
 
     def create_subscription
       data = <<~JSON
@@ -39,6 +42,7 @@ RSpec.describe PushNotificationPusher do
           username: username,
           excerpt: "description",
           topic_id: 1,
+          base_url: base_url,
           post_url: post_url,
           notification_type: notification_type,
           post_number: post_number,
@@ -83,6 +87,17 @@ RSpec.describe PushNotificationPusher do
       expect(pn_sent_event[:event_name]).to eq(:push_notification_sent)
       expect(pn_sent_event[:params].first).to eq(user)
       expect(pn_sent_event[:params].second[:url]).to eq(post_url)
+    end
+
+    it "triggers a DiscourseEvent with base_path stripped from the url when present" do
+      WebPush.expects(:payload_send)
+      create_subscription
+      pn_sent_event = DiscourseEvent.track_events { message = execute_push }.first
+
+      expect(pn_sent_event[:event_name]).to eq(:push_notification_sent)
+      expect(pn_sent_event[:params].first).to eq(user)
+      expect(pn_sent_event[:params].second[:url]).to eq("/t/1/2")
+      expect(pn_sent_event[:params].second[:base_url]).to eq(base_url)
     end
 
     it "deletes subscriptions which are erroring regularly" do

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe PushNotificationPusher do
 
       expect(pn_sent_event[:event_name]).to eq(:push_notification_sent)
       expect(pn_sent_event[:params].first).to eq(user)
-      expect(pn_sent_event[:params].second[:url]).to eq(post_url)
+      expect(pn_sent_event[:params].second[:url]).to eq("/t/1/2")
     end
 
     it "triggers a DiscourseEvent with base_path stripped from the url when present" do


### PR DESCRIPTION
Our service worker concatenates `baseUrl` with `url` coming from the payload:

https://github.com/discourse/discourse/blob/e8f4433872f075db6400ab53c94d8d117422b93b/app/views/static/service-worker.js.erb#L96

This PRs strips the base path before sending `url` to the push notification to avoid having a URL with the base path duplicated, causing a 404.
