### PR TITLE
DEV: Skip a flaky test

### DIFF
--- a/spec/requests/admin/site_settings_controller_spec.rb
+++ b/spec/requests/admin/site_settings_controller_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Admin::SiteSettingsController do
         expect(SiteSetting.selectable_avatars).to eq([])
       end
 
-      it "sanitizes integer values" do
+      xit "sanitizes integer values" do
         put "/admin/site_settings/suggested_topics.json", params: { suggested_topics: "1,000" }
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
Has been assigned for investigation soon

```
1) Admin::SiteSettingsController#update when logged in as an admin sanitizes integer values
    Failure/Error: expect(SiteSetting.suggested_topics).to eq(1000)

      expected: 1000
          got: 5

      (compared using ==)
    # ./spec/requests/admin/site_settings_controller_spec.rb:318:in `block (4 levels) in <main>'
    # ./spec/rails_helper.rb:588:in `block (3 levels) in <top (required)>'
    # ./vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
    # ./vendor/bundle/ruby/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
    # ./spec/rails_helper.rb:578:in `block (2 levels) in <top (required)>'
    # ./spec/rails_helper.rb:535:in `block (2 levels) in <top (required)>'
    # ./vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```
