### PR TITLE
DEV: Move User API admin settings into API keys page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminApiKeysSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-api-keys.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-api-keys.js
@@ -1,3 +1,10 @@
 import Controller from "@ember/controller";
+import { service } from "@ember/service";
 
-export default class AdminApiKeysController extends Controller {}
+export default class AdminApiKeysController extends Controller {
+  @service router;
+
+  get hideTabs() {
+    return ["adminApiKeys.show"].includes(this.router.currentRouteName);
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-api-keys-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-api-keys-index.js
@@ -1,6 +1,11 @@
-import Route from "@ember/routing/route";
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
-export default class AdminApiKeysIndexRoute extends Route {
+export default class AdminApiKeysIndexRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("admin.config.api_keys.title");
+  }
+
   model() {
     return this.store.findAll("api-key");
   }

--- a/app/assets/javascripts/admin/addon/routes/admin-api-keys-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-api-keys-settings.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminApiKeysSettingsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("settings");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -130,6 +130,7 @@ export default function () {
         "adminApiKeys",
         { path: "/keys", resetNamespace: true },
         function () {
+          this.route("settings");
           this.route("show", { path: "/:api_key_id" });
           this.route("new");
         }
@@ -358,9 +359,6 @@ export default function () {
           this.route("settings", { path: "/" });
         });
         this.route("spam", function () {
-          this.route("settings", { path: "/" });
-        });
-        this.route("user-api", function () {
           this.route("settings", { path: "/" });
         });
 

--- a/app/assets/javascripts/admin/addon/templates/api-keys.gjs
+++ b/app/assets/javascripts/admin/addon/templates/api-keys.gjs
@@ -1,6 +1,7 @@
 import RouteTemplate from "ember-route-template";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DPageHeader from "discourse/components/d-page-header";
+import NavItem from "discourse/components/nav-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { i18n } from "discourse-i18n";
 
@@ -10,7 +11,7 @@ export default RouteTemplate(
       <DPageHeader
         @titleLabel={{i18n "admin.config.api_keys.title"}}
         @descriptionLabel={{i18n "admin.config.api_keys.header_description"}}
-        @hideTabs={{true}}
+        @hideTabs={{@controller.hideTabs}}
       >
         <:breadcrumbs>
           <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
@@ -25,6 +26,18 @@ export default RouteTemplate(
             @label="admin.api_keys.add"
           />
         </:actions>
+        <:tabs>
+          <NavItem
+            @route="adminApiKeys.settings"
+            @label="settings"
+            class="admin-api-keys-tabs__settings"
+          />
+          <NavItem
+            @route="adminApiKeys.index"
+            @label="admin.config.api_keys.title"
+            class="admin-api-keys-tabs__index"
+          />
+        </:tabs>
       </DPageHeader>
 
       <div class="admin-container admin-config-page__main-area">

--- a/app/assets/javascripts/admin/addon/templates/api-keys/settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/api-keys/settings.gjs
@@ -1,0 +1,13 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @categories="user_api"
+      @path="/admin/api/keys/settings"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -501,14 +501,6 @@ export const ADMIN_NAV_MAP = [
         settings_category: "rate_limits",
       },
       {
-        name: "admin_user_api",
-        route: "adminConfig.user-api.settings",
-        label: "admin.config.user_api.title",
-        description: "admin.config.user_api.header_description",
-        icon: "shuffle",
-        settings_category: "user_api",
-      },
-      {
         name: "admin_onebox",
         route: "adminConfig.onebox.settings",
         label: "admin.config.onebox.title",


### PR DESCRIPTION
### What is this change?

We used to have a `User API` admin page, which is just a page with the site settings. This PR moves that into a `Settings` tab under `API keys`:

<img width="460" alt="Screenshot 2025-04-09 at 11 08 13 AM" src="https://github.com/user-attachments/assets/1536b2ba-b2c9-4d1d-a656-7c4d93977408" />
