### PR TITLE
UX: backspace rich editor keymap improvements

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/code-block.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/code-block.js
@@ -78,59 +78,21 @@ class CodeBlockWithLangSelectorNodeView {
 /** @type {RichEditorExtension} */
 const extension = {
   nodeViews: { code_block: CodeBlockWithLangSelectorNodeView },
-  plugins({ pmState: { Plugin }, getContext }) {
-    return [
-      async () =>
-        highlightPlugin(
-          (hljs = await ensureHighlightJs(
-            getContext().session.highlightJsPath
-          )),
-          ["code_block", "html_block"],
+  async plugins({ getContext }) {
+    return highlightPlugin(
+      (hljs = await ensureHighlightJs(getContext().session.highlightJsPath)),
+      ["code_block", "html_block"],
 
-          // NOTE: If the language has not been set with the code block, we default to plain
-          // text rather than autodetecting. This is to work around an infinite loop issue
-          // in prosemirror-highlightjs when autodetecting which hangs the browser sometimes
-          // for > 10 seconds, for example:
-          //
-          // https://github.com/b-kelly/prosemirror-highlightjs/issues/21
-          //
-          // We can remove this if we find some other workaround.
-          (node) => node.attrs.params || "text"
-        ),
-      new Plugin({
-        props: {
-          // Handles removal of the code_block when it's at the start of the document
-          handleKeyDown(view, event) {
-            if (
-              event.key === "Backspace" &&
-              view.state.selection.$from.parent.type ===
-                view.state.schema.nodes.code_block &&
-              view.state.selection.$from.start() === 1 &&
-              view.state.selection.$from.parentOffset === 0
-            ) {
-              const { tr } = view.state;
-
-              const codeBlock = view.state.selection.$from.parent;
-              const paragraph = view.state.schema.nodes.paragraph.create(
-                null,
-                codeBlock.content
-              );
-              tr.replaceWith(
-                view.state.selection.$from.before(),
-                view.state.selection.$from.after(),
-                paragraph
-              );
-              tr.setSelection(
-                new view.state.selection.constructor(tr.doc.resolve(1))
-              );
-
-              view.dispatch(tr);
-              return true;
-            }
-          },
-        },
-      }),
-    ];
+      // NOTE: If the language has not been set with the code block, we default to plain
+      // text rather than autodetecting. This is to work around an infinite loop issue
+      // in prosemirror-highlightjs when autodetecting which hangs the browser sometimes
+      // for > 10 seconds, for example:
+      //
+      // https://github.com/b-kelly/prosemirror-highlightjs/issues/21
+      //
+      // We can remove this if we find some other workaround.
+      (node) => node.attrs.params || "text"
+    );
   },
 };
 

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/plugin-utils.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/plugin-utils.js
@@ -74,3 +74,15 @@ export function getChangedRanges(tr) {
 
   return changes;
 }
+
+// from https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.ts
+export function atBlockStart(state, view) {
+  let { $cursor } = state.selection;
+  if (
+    !$cursor ||
+    (view ? !view.endOfTextblock("backward", state) : $cursor.parentOffset > 0)
+  ) {
+    return null;
+  }
+  return $cursor;
+}

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -438,6 +438,39 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(rich).to have_css("hr")
     end
+
+    it "supports Backspace to reset a heading" do
+      open_composer_and_toggle_rich_editor
+      composer.type_content("# With text")
+
+      expect(rich).to have_css("h1", text: "With text")
+
+      composer.send_keys(:home)
+      composer.send_keys(:backspace)
+
+      expect(rich).to have_css("p", text: "With text")
+    end
+
+    it "supports Backspace to reset a code_block" do
+      open_composer_and_toggle_rich_editor
+      composer.type_content("```code block")
+      composer.send_keys(:home)
+      composer.send_keys(%i[backspace])
+
+      expect(rich).to have_css("p", text: "code block")
+    end
+
+    it "doesn't add a new list item when backspacing from below a list" do
+      open_composer_and_toggle_rich_editor
+      composer.type_content("1. Item 1\nItem 2")
+      composer.send_keys(:down)
+      composer.type_content("Item 3")
+      composer.send_keys(:home)
+      composer.send_keys(:backspace)
+
+      expect(rich).to have_css("ol li", text: "Item 1")
+      expect(rich).to have_css("ol li", text: "Item 2Item 3")
+    end
   end
 
   describe "pasting content" do


### PR DESCRIPTION
Adds to the Backspace keymap - a custom `backspaceUnset`, which will set the node as `paragraph` if it's at a block start and the node type in `BACKSPACE_UNSET_NODES`, currently for `heading` and `code_block`.

Removes a `code_block`-specific plugin that did exactly the same.

Adds to the Backspace keymap - `joinTextblockBackward`, which will take precedence over `joinBackward`, and make the backward joining closer to the expectation e.g. backspacing to a list won't create a new list item