### PR TITLE
DEV: Add Dashboard settings tab to Reports page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-reports-dashboard-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports-dashboard-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminReportsDashboardSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-reports.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports.js
@@ -1,0 +1,10 @@
+import Controller from "@ember/controller";
+import { service } from "@ember/service";
+
+export default class AdminReportsController extends Controller {
+  @service router;
+
+  get hideTabs() {
+    return ["adminReports.show"].includes(this.router.currentRouteName);
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-reports-dashboard-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports-dashboard-settings.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminReportsDashboardSettingsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("settings");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -161,6 +161,7 @@ export default function () {
       function () {
         this.route("index", { path: "/" });
         this.route("show", { path: ":type" });
+        this.route("dashboardSettings", { path: "dashboard-settings" });
       }
     );
 

--- a/app/assets/javascripts/admin/addon/templates/reports-dashboard-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/reports-dashboard-settings.gjs
@@ -1,0 +1,13 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @area="reports"
+      @path="/admin/reports/dashboard-settings"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/reports-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/reports-index.gjs
@@ -1,30 +1,10 @@
 import RouteTemplate from "ember-route-template";
-import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
-import DPageHeader from "discourse/components/d-page-header";
-import { i18n } from "discourse-i18n";
 import AdminReports from "admin/components/admin-reports";
 
 export default RouteTemplate(
   <template>
-    <DPageHeader
-      @titleLabel={{i18n "admin.config.reports.title"}}
-      @descriptionLabel={{i18n "admin.config.reports.header_description"}}
-      @learnMoreUrl="https://meta.discourse.org/t/-/240233"
-      @hideTabs={{true}}
-    >
-      <:breadcrumbs>
-        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
-        <DBreadcrumbsItem
-          @path="/admin.config.reports"
-          @label={{i18n "admin.config.reports.title"}}
-        />
-      </:breadcrumbs>
-    </DPageHeader>
-
-    <div class="admin-container admin-config-page__main-area">
-      <div class="admin-config-area__full-width">
-        <AdminReports />
-      </div>
+    <div class="admin-config-area__full-width">
+      <AdminReports />
     </div>
   </template>
 );

--- a/app/assets/javascripts/admin/addon/templates/reports.gjs
+++ b/app/assets/javascripts/admin/addon/templates/reports.gjs
@@ -1,0 +1,38 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import NavItem from "discourse/components/nav-item";
+import { i18n } from "discourse-i18n";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @titleLabel={{i18n "admin.config.reports.title"}}
+      @descriptionLabel={{i18n "admin.config.reports.header_description"}}
+      @learnMoreUrl="https://meta.discourse.org/t/-/240233"
+      @hideTabs={{@controller.hideTabs}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin.config.reports"
+          @label={{i18n "admin.config.reports.title"}}
+        />
+      </:breadcrumbs>
+      <:tabs>
+        <NavItem
+          @route="adminReports.dashboardSettings"
+          @label="admin.config.reports.sub_pages.settings.title"
+        />
+        <NavItem
+          @route="adminReports.index"
+          @label="admin.config.reports.title"
+        />
+      </:tabs>
+    </DPageHeader>
+
+    <div class="admin-container admin-config-page__main-area">
+      {{outlet}}
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -84,11 +84,21 @@ export const ADMIN_NAV_MAP = [
     links: [
       {
         name: "admin_all_reports",
-        route: "adminReports.index",
+        route: "adminReports",
         label: "admin.config.reports.title",
         description: "admin.config.reports.header_description",
         icon: "chart-bar",
         moderator: true,
+        links: [
+          {
+            name: "admin_reports_settings",
+            route: "adminReports.dashboardSettings",
+            label: "settings",
+            description: "admin.config.reports.header_description",
+            icon: "gear",
+            settings_area: "reports",
+          },
+        ],
       },
     ],
   },

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -16,6 +16,7 @@ class SiteSetting < ActiveRecord::Base
     navigation
     notifications
     permalinks
+    reports
     user_defaults
     site_admin
     trust_levels

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5404,6 +5404,9 @@ en:
         reports:
           title: "Reports"
           header_description: "Reports are a powerful tool to help you understand what’s happening on your site. They can help you identify trends, spot problems, and make decisions based on data."
+          sub_pages:
+            settings:
+              title: "Dashboard settings"
         badges:
           title: "Badges"
           header_description: "Badges reward users for their activities, contributions, and achievements to recognize, validate, and encourage positive behavior and engagement within the community"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3627,6 +3627,7 @@ dashboard:
     list_type: compact
     default: ""
     allow_any: true
+    area: "reports"
   dashboard_visible_tabs:
     client: true
     type: list
@@ -3638,6 +3639,7 @@ dashboard:
       - security
       - reports
       - features
+    area: "reports"
   dashboard_general_tab_activity_metrics:
     client: true
     type: list
@@ -3652,6 +3654,7 @@ dashboard:
       - flags
       - user_to_user_private_messages_with_replies
       - signups
+    area: "reports"
   verbose_user_stat_count_logging:
     hidden: true
     default: false


### PR DESCRIPTION
### What is this change?

This change adds a `Dashboard settings` tab to the `Reports` page:

<img width="323" alt="Screenshot 2025-04-09 at 1 11 38 PM" src="https://github.com/user-attachments/assets/f1a2e875-6f96-4d78-81ae-253c8bb95254" />
