### PR TITLE
FIX: hide search field on invites page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -43,7 +43,7 @@ export default class Contents extends Component {
   get showHeaderSearch() {
     if (
       this.site.mobileView ||
-      this.router.currentURL?.match(/\/(signup|login|invites)/)
+      this.router.currentURL?.match(/\/(signup|login|invites|activate-account)/)
     ) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -43,7 +43,7 @@ export default class Contents extends Component {
   get showHeaderSearch() {
     if (
       this.site.mobileView ||
-      this.router.currentURL?.match(/\/(signup|login)/)
+      this.router.currentURL?.match(/\/(signup|login|invites)/)
     ) {
       return false;
     }

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -145,8 +145,6 @@ describe "Search", type: :system do
     end
 
     describe "with search field in header" do
-      fab!(:invite)
-
       before { SiteSetting.search_experience = "search_field" }
 
       it "displays the correct search mode" do
@@ -168,7 +166,7 @@ describe "Search", type: :system do
         expect(search_page).to have_no_search_icon
       end
 
-      it "does not display on login, signup or invite pages" do
+      it "does not display on login, signup or activate account pages" do
         visit("/login")
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
@@ -177,9 +175,20 @@ describe "Search", type: :system do
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
 
-        visit("/invites/#{invite.invite_key}")
+        email_token = Fabricate(:email_token, user: Fabricate(:user, active: false))
+        visit("/u/activate-account/#{email_token.token}")
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
+      end
+
+      describe "with invites" do
+        fab!(:invite)
+
+        it "does not display search field" do
+          visit("/invites/#{invite.invite_key}")
+          expect(search_page).to have_no_search_icon
+          expect(search_page).to have_no_search_field
+        end
       end
     end
   end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -145,6 +145,8 @@ describe "Search", type: :system do
     end
 
     describe "with search field in header" do
+      fab!(:invite)
+
       before { SiteSetting.search_experience = "search_field" }
 
       it "displays the correct search mode" do
@@ -166,12 +168,16 @@ describe "Search", type: :system do
         expect(search_page).to have_no_search_icon
       end
 
-      it "does not display on login and signup pages" do
+      it "does not display on login, signup or invite pages" do
         visit("/login")
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
 
         visit("/signup")
+        expect(search_page).to have_no_search_icon
+        expect(search_page).to have_no_search_field
+
+        visit("/invites/#{invite.invite_key}")
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
       end


### PR DESCRIPTION
Prevents rendering the search field on the invites page.

Internal ref: /t/150011

