### PR TITLE
FIX: relax automation restrictions

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
@@ -13,6 +13,7 @@ export default class TagsField extends BaseField {
         <div class="controls">
           <TagChooser
             @tags={{@field.metadata.value}}
+            @everyTag={{true}}
             @options={{hash allowAny=false disabled=@field.isDisabled}}
           />
 

--- a/plugins/automation/lib/discourse_automation/scriptable.rb
+++ b/plugins/automation/lib/discourse_automation/scriptable.rb
@@ -254,7 +254,6 @@ module DiscourseAutomation
 
           if pm[:target_usernames].empty? && pm[:target_group_names].empty? &&
                pm[:target_emails].empty?
-            Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames, groups or emails"
             return
           end
 
@@ -300,6 +299,7 @@ module DiscourseAutomation
 
           post_created = EncryptedPostCreator.new(sender, pm).create if prefers_encrypt
 
+          pm[:acting_user] = Discourse.system_user
           PostCreator.new(sender, pm).create! if !post_created
         end
       end

--- a/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
@@ -16,6 +16,11 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::AUTO_TAG_TOPIC
 
     tags = fields.dig("tags", "value")
 
-    DiscourseTagging.tag_topic_by_names(topic, Guardian.new(post.user), tags, append: true)
+    DiscourseTagging.tag_topic_by_names(
+      topic,
+      Guardian.new(Discourse.system_user),
+      tags,
+      append: true,
+    )
   end
 end


### PR DESCRIPTION
Relaxed restrictions:
- Automation posts are not validated for similarity. This was causing error when PMs were created by regular user with same content and sent to different users.
- Don't create warning logs when PM target does not exist anymore. When for example spammer was deleted, delayed PM is not sent, but it is correct behaviour;
- Allow tags to be applied even if an automation user is not allowed to tag;
- Restricted category tags should be visible in configuration UI. Still, they will be applied only when specific topic belongs to correct category.