### PR TITLE
UX: whisper color and font-style on rich editor

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -130,6 +130,11 @@
     padding-top: 0.2rem;
   }
 
+  .composing-whisper & {
+    font-style: italic;
+    color: var(--primary-medium);
+  }
+
   .onebox-wrapper {
     white-space: normal;
   }


### PR DESCRIPTION
Respects the same styling from the preview for font-style and color for the ProseMirror editor when we're composing a whisper.