### PR TITLE
UX: Onebox & quote border radius

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -104,6 +104,7 @@ aside.onebox {
   padding: 1em;
   font-size: var(--font-0);
   background: var(--secondary);
+  border-radius: var(--d-border-radius);
 
   header {
     align-items: center;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -493,17 +493,21 @@ blockquote {
   padding: 12px;
 }
 
-aside.quote:has(.title) .title {
+aside.quote .title {
   border-top-right-radius: var(--d-border-radius);
   border-top-left-radius: var(--d-border-radius);
 }
 
-aside.quote:has(.title) blockquote {
-  border-bottom-right-radius: var(--d-border-radius);
-  border-bottom-left-radius: var(--d-border-radius);
+aside.quote blockquote {
+  border-radius: var(--d-border-radius);
 }
 
-aside.quote:not(:has(.title)) blockquote {
+aside.quote .title + blockquote {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.cooked blockquote {
   border-radius: var(--d-border-radius);
 }
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -493,6 +493,20 @@ blockquote {
   padding: 12px;
 }
 
+aside.quote:has(.title) .title {
+  border-top-right-radius: var(--d-border-radius);
+  border-top-left-radius: var(--d-border-radius);
+}
+
+aside.quote:has(.title) blockquote {
+  border-bottom-right-radius: var(--d-border-radius);
+  border-bottom-left-radius: var(--d-border-radius);
+}
+
+aside.quote:not(:has(.title)) blockquote {
+  border-radius: var(--d-border-radius);
+}
+
 /* quotes with attribution */
 .quote {
   & > blockquote {

--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -4,6 +4,7 @@
   min-height: 50px;
   padding: 12px;
   margin: 1rem 0;
+  border-radius: var(--d-border-radius);
 
   @include post-aside;
 


### PR DESCRIPTION
This PR causes oneboxes and quotes to inherit the border radius set by `var(--d-border-radius)`