### PR TITLE
FIX: safari bug on rich editor's list item

### DIFF
--- a/app/assets/stylesheets/common/modal/login-modal.scss
+++ b/app/assets/stylesheets/common/modal/login-modal.scss
@@ -207,7 +207,7 @@
 }
 
 .invites-show {
-  #account-email-validation:not(:has(*)) {
+  #account-email-validation:not(:has(svg)) {
     display: none;
   }
 }


### PR DESCRIPTION
This fixes a bug on Safari where, for some reason, it was leaking to affect the rich editor list item rendering. When typing, the current list item was breaking to a next line:

![image](https://github.com/user-attachments/assets/038be450-2096-441c-ac3c-bb765b16d634)

With this change, it doesn't happen anymore, and the more specific `svg` target will serve the same purpose as it's currently defined on `InputTip`.