### PR TITLE
FIX: Prioritize the author when replying to topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -1005,7 +1005,7 @@ export default class ComposerEditor extends Component {
         @outletArgs={{hash composer=this.composer.model editorType="composer"}}
         @topicId={{this.composer.model.topic.id}}
         @categoryId={{this.composer.model.category.id}}
-        @replyingToUser={{this.composer.replyingToUser}}
+        @replyingToUserId={{this.composer.replyingToUserId}}
         @onSetup={{this.setupEditor}}
         @disableSubmit={{this.composer.disableSubmit}}
       >

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -449,7 +449,7 @@ export default class DEditor extends Component {
           topicId: this.topicId,
           categoryId: this.categoryId,
           includeGroups: true,
-          prioritizedUserId: this.replyingToUser?.id,
+          prioritizedUserId: this.replyingToUserId,
         }).then((result) => {
           initUserStatusHtml(getOwner(this), result.users);
           return result;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -208,7 +208,6 @@ export default class ComposerService extends Service {
       return user.id;
     }
 
-    // it is replying to a topic, so return the topic owner
     return this.get("model.topic.user_id");
   }
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -195,15 +195,21 @@ export default class ComposerService extends Service {
     );
   }
 
-  get replyingToUser() {
+  get replyingToUserId() {
     if (this.get("model.editingPost")) {
       const user = this.get("model.post.reply_to_user");
       if (user) {
-        return user;
+        return user.id;
       }
     }
 
-    return this.get("model.post.user");
+    const user = this.get("model.post.user");
+    if (user) {
+      return user.id;
+    }
+
+    // it is replying to a topic, so return the topic owner
+    return this.get("model.topic.user_id");
   }
 
   get formTemplateInitialValues() {

--- a/spec/system/composer_spec.rb
+++ b/spec/system/composer_spec.rb
@@ -17,7 +17,7 @@ describe "Composer", type: :system do
     page.has_css?("#user-card")
   end
 
-  context "in a topic the autocomplete prioritizes" do
+  context "in a topic, the autocomplete prioritizes" do
     fab!(:topic_user) { Fabricate(:user) }
     fab!(:second_reply_user) { Fabricate(:user) }
 

--- a/spec/system/composer_spec.rb
+++ b/spec/system/composer_spec.rb
@@ -68,7 +68,7 @@ describe "Composer", type: :system do
 
       composer.fill_content("@")
       expect(composer.mention_menu_autocomplete_username_list).to eq(
-        [second_reply_user.username, topic_user.username, user.username],
+        [second_reply_user.username, user.username, topic_user.username],
       )
     end
   end

--- a/spec/system/composer_spec.rb
+++ b/spec/system/composer_spec.rb
@@ -16,4 +16,60 @@ describe "Composer", type: :system do
 
     page.has_css?("#user-card")
   end
+
+  context "in a topic the autocomplete prioritizes" do
+    fab!(:topic_user) { Fabricate(:user) }
+    fab!(:second_reply_user) { Fabricate(:user) }
+
+    fab!(:topic) { Fabricate(:topic, user: topic_user) }
+    fab!(:op) { Fabricate(:post, topic: topic, user: topic_user) }
+    let!(:op_post) { PageObjects::Components::Post.new(op.post_number) }
+
+    fab!(:second_reply) { Fabricate(:post, topic: topic, user: second_reply_user) }
+    let!(:second_reply_post) { PageObjects::Components::Post.new(second_reply.post_number) }
+
+    it "the topic owner if replying to topic" do
+      page.visit "/t/#{topic.id}"
+
+      op_post.reply
+      expect(composer).to be_opened
+
+      composer.fill_content("@")
+
+      expect(composer.mention_menu_autocomplete_username_list).to eq(
+        [op.username, second_reply_user.username], # must be first the topic owner
+      )
+    end
+
+    it "the recipient of the reply when replying" do
+      page.visit "/t/#{topic.id}"
+
+      second_reply_post.reply
+      expect(composer).to be_opened
+
+      composer.fill_content("@")
+
+      expect(composer.mention_menu_autocomplete_username_list).to eq(
+        [second_reply_user.username, topic_user.username], # must be first the reply user
+      )
+    end
+
+    it "the recipient of the reply when editing a reply" do
+      admin = Fabricate(:admin, refresh_auto_groups: true)
+      reply_to_second_post =
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: second_reply.post_number)
+      reply_post = PageObjects::Components::Post.new(reply_to_second_post.post_number)
+
+      sign_in(admin)
+      page.visit "/t/#{topic.id}"
+
+      reply_post.edit
+      expect(composer).to be_opened
+
+      composer.fill_content("@")
+      expect(composer.mention_menu_autocomplete_username_list).to eq(
+        [second_reply_user.username, topic_user.username, user.username],
+      )
+    end
+  end
 end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -136,6 +136,10 @@ module PageObjects
         has_css?(MENTION_MENU)
       end
 
+      def mention_menu_autocomplete_username_list
+        find(MENTION_MENU).all("a").map { |a| a.text }
+      end
+
       def has_emoji_autocomplete?
         has_css?(AUTOCOMPLETE_MENU)
       end

--- a/spec/system/page_objects/components/post.rb
+++ b/spec/system/page_objects/components/post.rb
@@ -7,8 +7,21 @@ module PageObjects
         @post_number = post_number
       end
 
+      def post
+        find("#post_#{@post_number}")
+      end
+
+      def reply
+        post.find(".reply.create").click
+      end
+
+      def edit
+        post.find(".show-more-actions").click
+        post.find("button.edit").click
+      end
+
       def show_replies
-        find("#post_#{@post_number} .show-replies").click
+        post.find(".show-replies").click
       end
 
       def load_more_replies
@@ -28,7 +41,7 @@ module PageObjects
       end
 
       def show_parent_posts
-        find("#post_#{@post_number} .reply-to-tab").click
+        post.find(".reply-to-tab").click
       end
 
       def has_parent_posts?(count: nil)


### PR DESCRIPTION
Added in https://github.com/discourse/discourse/pull/32086 this prioritization did not accounted for when the user was replying to the topic/OP.

Now when replying to the topic, the author will be prioritized in the list.

All other cases are the same as before.

Added testing for all cases and changed `replyingToUser` to `replyingToUserId` for clarity and consistency with API.