### PR TITLE
UX: only-emoji consistency between rich editor and cooked

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/table.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/table.js
@@ -22,7 +22,7 @@ const extension = {
       draggable: true,
       parseDOM: [{ tag: "table" }],
       toDOM() {
-        return ["table", 0];
+        return ["table", { class: "md-table" }, 0];
       },
     },
     table_head: {

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/table-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/table-test.js
@@ -10,17 +10,17 @@ module(
     Object.entries({
       "basic table": [
         "| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |",
-        `<table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>`,
+        `<table class="md-table"><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table>`,
         `| Header 1 | Header 2 |\n|----|----|\n| Cell 1 | Cell 2 |\n\n`,
       ],
       "table with alignment": [
         `| Left | Center | Right |\n| :--- | :---: | ---: |\n| A | B | C |`,
-        `<table><thead><tr><th style="text-align: left">Left</th><th style="text-align: center">Center</th><th style="text-align: right">Right</th></tr></thead><tbody><tr><td style="text-align: left">A</td><td style="text-align: center">B</td><td style="text-align: right">C</td></tr></tbody></table>`,
+        `<table class="md-table"><thead><tr><th style="text-align: left">Left</th><th style="text-align: center">Center</th><th style="text-align: right">Right</th></tr></thead><tbody><tr><td style="text-align: left">A</td><td style="text-align: center">B</td><td style="text-align: right">C</td></tr></tbody></table>`,
         `| Left | Center | Right |\n|:---|:---:|---:|\n| A | B | C |\n\n`,
       ],
       "table within quotes": [
         `> \n> | Header 1 | Header 2 |\n> | --- | --- |\n> | Cell 1 | Cell 2 |\n`,
-        `<blockquote><table><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table></blockquote>`,
+        `<blockquote><table class="md-table"><thead><tr><th>Header 1</th><th>Header 2</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td></tr></tbody></table></blockquote>`,
         `> \n> | Header 1 | Header 2 |\n> |----|----|\n> | Cell 1 | Cell 2 |\n\n`,
       ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {

--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -21,7 +21,8 @@ img.emoji.only-emoji {
 
 a,
 .md-table,
-.poll {
+.poll,
+li {
   img.emoji.only-emoji {
     width: 20px;
     height: 20px;


### PR DESCRIPTION
Adds the `md-table` to rich editor tables for consistency with cooked.

Keeps `only-emoji` with their regular size when they happen within a `li`.