### PR TITLE
FEATURE: allow searching for whispers and bots

### DIFF
--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -3035,8 +3035,7 @@ RSpec.describe Search do
   end
 
   describe "bot search" do
-    fab!(:bot) { Fabricate(:user, id: User.minimum(:id) - 1) }
-
+    fab!(:bot)
     fab!(:bot_topic) { Fabricate(:topic, title: "this is a topic by a bot") }
     fab!(:bot_post) do
       Fabricate(:post, user: bot, topic: bot_topic, raw: "this is a regular post by a bot")

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2990,7 +2990,6 @@ RSpec.describe Search do
 
   context "when max_duplicate_search_index_terms limits duplication" do
     before { SearchIndexer.enable }
-
     after { SearchIndexer.disable }
 
     it "correctly ranks topics" do
@@ -3032,6 +3031,93 @@ RSpec.describe Search do
       expect(search.term).to eq("hello")
       expect(sql).to include("ORDER BY posts.created_at DESC")
       expect(sql).to match(/where.*topics.closed/i)
+    end
+  end
+
+  describe "bot search" do
+    fab!(:bot) { Fabricate(:user, id: User.minimum(:id) - 1) }
+
+    fab!(:bot_topic) { Fabricate(:topic, title: "this is a topic by a bot") }
+    fab!(:bot_post) do
+      Fabricate(:post, user: bot, topic: bot_topic, raw: "this is a regular post by a bot")
+    end
+
+    fab!(:human_post) { Fabricate(:post, topic: topic, raw: "this is a regular post not by a bot") }
+
+    before do
+      SearchIndexer.enable
+      SearchIndexer.index(bot_post, force: true)
+      SearchIndexer.index(human_post, force: true)
+    end
+
+    it "works as expected" do
+      # include bot posts by default
+      results = Search.execute("bot", guardian: Guardian.new)
+      expect(results.posts).to contain_exactly(bot_post, human_post)
+
+      # bots only
+      results = Search.execute("bot in:bot", guardian: Guardian.new)
+      expect(results.posts).to contain_exactly(bot_post)
+
+      # allows searching for human only
+      results = Search.execute("bot in:human", guardian: Guardian.new)
+      expect(results.posts).to contain_exactly(human_post)
+    end
+  end
+
+  describe "whisper search" do
+    fab!(:topic2) { Fabricate(:topic) }
+    fab!(:user)
+    fab!(:whisperer) { Fabricate(:user) }
+    fab!(:whisperers_group) { Fabricate(:group) }
+    fab!(:regular_post) do
+      Fabricate(:post, topic: topic, raw: "this is a regular post with whisper content")
+    end
+    fab!(:whisper_post) do
+      Fabricate(
+        :post,
+        topic: topic2,
+        raw: "this is a whisper post",
+        post_type: Post.types[:whisper],
+      )
+    end
+
+    before do
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{whisperers_group.id}"
+      whisperers_group.add(whisperer)
+      SearchIndexer.enable
+      [regular_post, whisper_post].each { |post| SearchIndexer.index(post, force: true) }
+    end
+
+    it "works as expected" do
+      # note this is simple enough, saving up on all the reindexing over and over
+      # by running in a big batch
+
+      # anon
+      results = Search.execute("whisper", guardian: Guardian.new(user))
+      expect(results.posts).to contain_exactly(regular_post)
+
+      # staff
+      results = Search.execute("whisper", guardian: Guardian.new(admin))
+      expect(results.posts).to contain_exactly(regular_post, whisper_post)
+
+      # whisperer
+      results = Search.execute("whisper", guardian: Guardian.new(whisperer))
+      expect(results.posts).to contain_exactly(regular_post, whisper_post)
+
+      # in:whispers
+      results = Search.execute("whisper in:whispers", guardian: Guardian.new(admin))
+      expect(results.posts).to contain_exactly(whisper_post)
+
+      results = Search.execute("whisper in:whispers", guardian: Guardian.new(user))
+      expect(results.posts).to be_empty
+
+      # in:regular
+      results = Search.execute("whisper in:regular", guardian: Guardian.new(admin))
+      expect(results.posts).to contain_exactly(regular_post)
+
+      results = Search.execute("content in:regular", guardian: Guardian.new(admin))
+      expect(results.posts).to contain_exactly(regular_post)
     end
   end
 end


### PR DESCRIPTION
Add new advanced search filters for post types

- `in:bot` or `in:bots`: Filters for posts made by bot users (user_id < 0)
- `in:human` or `in:humans`: Filters for posts made by human users (user_id >= 0)
- `in:whisper` or `in:whispers`: Filters for whisper posts (respects permissions)
- `in:regular`: Filters for regular posts only

