### PR TITLE
FIX: category badge style missing data attr

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
@@ -109,13 +109,13 @@ export function decorateHashtags(element, site) {
         icon: site.hashtag_icons[hashtagType],
         id: hashtagEl.dataset.id,
         slug: hashtagEl.dataset.slug,
-        style_type: hashtagEl.dataset.styleType,
+        style_type: hashtagEl.dataset.styleType || "square",
       };
 
-      if (hashtagEl.dataset.styleType === "icon") {
+      if (opts.style_type === "icon") {
         opts.icon = hashtagEl.dataset.icon;
       }
-      if (hashtagEl.dataset.styleType === "emoji") {
+      if (opts.style_type === "emoji") {
         opts.emoji = hashtagEl.dataset.emoji;
       }
 


### PR DESCRIPTION
The style type data attribute is missing for cooked posts prior to #31795 which meant that older posts with category hashtags were not displaying correctly. We already have a default style type at the database level, but for hashtag styling it is handled based on stored markup at the point in time when the post was last cooked.

Simply rebuilding html solves this but a good workaround is to set a proper default when the data attr is missing.

### Before (old post)

<img width="429" alt="Screenshot 2025-04-10 at 12 19 04 PM" src="https://github.com/user-attachments/assets/b75cee30-2f60-4339-a34b-a0b19e268f77" />


### After (old post)

<img width="430" alt="Screenshot 2025-04-10 at 12 19 18 PM" src="https://github.com/user-attachments/assets/9663d9ba-a768-4c4c-933f-47d591c4e7d3" />

Internal ref: /t/151514