### PR TITLE
FIX: logs time even when automation raises

### DIFF
--- a/plugins/automation/app/models/discourse_automation/stat.rb
+++ b/plugins/automation/app/models/discourse_automation/stat.rb
@@ -7,12 +7,17 @@ module DiscourseAutomation
     def self.log(automation_id, run_time = nil)
       if block_given? && run_time.nil?
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        result = yield
-        run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-        result
+        begin
+          result = yield
+          run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+          result
+        rescue => e
+          run_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+          raise e
+        end
       end
     ensure
-      update_stats(automation_id, run_time)
+      update_stats(automation_id, run_time || 0)
     end
 
     def self.fetch_period_summaries

--- a/plugins/automation/spec/models/stat_spec.rb
+++ b/plugins/automation/spec/models/stat_spec.rb
@@ -159,6 +159,23 @@ RSpec.describe DiscourseAutomation::Stat do
         expect(stat.max_run_time).to eq(0.75)
         expect(stat.total_runs).to eq(1)
       end
+
+      context "when an error occurs" do
+        it "yields the correct error and records it" do
+          allow(Process).to receive(:clock_gettime).and_return(10, 10.75)
+
+          expect { DiscourseAutomation::Stat.log(automation_id) { raise } }.to raise_error(
+            RuntimeError,
+          )
+
+          stat = DiscourseAutomation::Stat.find_by(automation_id: automation_id)
+          expect(stat.total_time).to eq(0.75)
+          expect(stat.average_run_time).to eq(0.75)
+          expect(stat.min_run_time).to eq(0.75)
+          expect(stat.max_run_time).to eq(0.75)
+          expect(stat.total_runs).to eq(1)
+        end
+      end
     end
 
     context "with direct call form" do


### PR DESCRIPTION
The previous code could attempt to log a `nil` `run_time` if the block would raise an exception. This commit adds two safeguards:

- rescue any exception to still compute `run_time`
- defaults to `0` if we still don't have any `run_time`