### PR TITLE
FEATURE: add override for crawler title and description tags

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -270,6 +270,30 @@ module ApplicationHelper
     (request ? I18n.locale.to_s : SiteSetting.default_locale).sub("_", "-")
   end
 
+  def crawlable_title_content
+    content = content_for?(:title) ? content_for(:title) : SiteSetting.title
+    content =
+      DiscoursePluginRegistry.apply_modifier(
+        :meta_data_content,
+        content,
+        :title,
+        { url: request.fullpath },
+      )
+    content
+  end
+
+  def crawlable_description_content
+    content = @description_meta || SiteSetting.site_description
+    content =
+      DiscoursePluginRegistry.apply_modifier(
+        :meta_data_content,
+        content,
+        :description,
+        { url: request.fullpath },
+      )
+    content
+  end
+
   # Creates open graph and twitter card meta data
   def crawlable_meta_data(opts = nil)
     opts ||= {}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -271,27 +271,21 @@ module ApplicationHelper
   end
 
   def crawlable_title_content
-    content = content_for?(:title) ? content_for(:title) : SiteSetting.title
-    content =
-      DiscoursePluginRegistry.apply_modifier(
-        :meta_data_content,
-        content,
-        :title,
-        { url: request.fullpath },
-      )
-    content
+    DiscoursePluginRegistry.apply_modifier(
+      :meta_data_content,
+      content_for(:title) || SiteSetting.title,
+      :title,
+      { url: request.fullpath },
+    )
   end
 
   def crawlable_description_content
-    content = @description_meta || SiteSetting.site_description
-    content =
-      DiscoursePluginRegistry.apply_modifier(
-        :meta_data_content,
-        content,
-        :description,
-        { url: request.fullpath },
-      )
-    content
+    DiscoursePluginRegistry.apply_modifier(
+      :meta_data_content,
+      @description_meta || SiteSetting.site_description,
+      :description,
+      { url: request.fullpath },
+    )
   end
 
   # Creates open graph and twitter card meta data

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -2,8 +2,8 @@
 <html lang="<%= html_lang %>">
   <head>
     <meta charset="utf-8">
-    <title><%= content_for?(:title) ? yield(:title) : SiteSetting.title %></title>
-    <meta name="description" content="<%= @description_meta || SiteSetting.site_description %>">
+    <title><%= crawlable_title_content %></title>
+    <meta name="description" content="<%= crawlable_description_content %>">
     <%= render partial: "layouts/head" %>
     <%= render partial: "common/discourse_stylesheet" %>
     <%= theme_lookup("head_tag") %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -743,33 +743,84 @@ RSpec.describe ApplicationHelper do
         )
       end
     end
+  end
 
-    describe "when a plugin registers the :meta_data_content modifier" do
-      let!(:plugin) { Plugin::Instance.new }
-      let!(:block) do
-        ->(content, property, opts) do
-          content << " - modified by plugin" if property == :description
-          content = "BIG TITLE" if property == :title
-          content
-        end
+  describe "#crawlable_title_content" do
+    it "returns the correct title" do
+      SiteSetting.title = "Test Title"
+      result = helper.crawlable_title_content
+
+      expect(result).to include("Test Title")
+    end
+
+    it "accepts a content argument" do
+      helper.stubs(:content_for?).with(:title).returns(true)
+      helper.stubs(:content_for).with(:title).returns("Custom Title")
+
+      result = helper.crawlable_title_content
+
+      expect(result).to include("Custom Title")
+    end
+  end
+
+  describe "#crawlable_description_content" do
+    it "returns the correct description" do
+      SiteSetting.site_description = "Test Description"
+      result = helper.crawlable_description_content
+
+      expect(result).to include("Test Description")
+    end
+
+    it "accepts a content argument" do
+      @description_meta = "Custom Description"
+
+      result = helper.crawlable_description_content
+
+      expect(result).to include("Custom Description")
+    end
+  end
+
+  describe "when a plugin registers the :meta_data_content modifier" do
+    let!(:plugin) { Plugin::Instance.new }
+    let!(:block) do
+      ->(content, property, opts) do
+        content << " - modified by plugin" if property == :description
+        content = "BIG TITLE" if property == :title
+        content
       end
+    end
 
-      after { DiscoursePluginRegistry.unregister_modifier(plugin, :meta_data_content, &block) }
+    after { DiscoursePluginRegistry.unregister_modifier(plugin, :meta_data_content, &block) }
 
-      it "allows the plugin to modify the meta tags" do
-        plugin.register_modifier(:meta_data_content, &block)
+    it "allows the plugin to modify the meta tags" do
+      plugin.register_modifier(:meta_data_content, &block)
 
-        result =
-          helper.crawlable_meta_data(
-            description: "This is a test description",
-            title: "to be overridden",
-          )
-
-        expect(result).to include(
-          "<meta property=\"og:description\" content=\"This is a test description - modified by plugin\" />",
+      result =
+        helper.crawlable_meta_data(
+          description: "This is a test description",
+          title: "to be overridden",
         )
-        expect(result).to include("<meta property=\"og:title\" content=\"BIG TITLE\" />")
-      end
+
+      expect(result).to include(
+        "<meta property=\"og:description\" content=\"This is a test description - modified by plugin\" />",
+      )
+      expect(result).to include("<meta property=\"og:title\" content=\"BIG TITLE\" />")
+    end
+
+    it "modifies the title tag" do
+      plugin.register_modifier(:meta_data_content, &block)
+
+      title = helper.crawlable_title_content
+
+      expect(title).to include("BIG TITLE")
+    end
+
+    it "modifies the description tag" do
+      plugin.register_modifier(:meta_data_content, &block)
+
+      description = helper.crawlable_description_content
+
+      expect(description).to include(" - modified by plugin")
     end
   end
 


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/32159 we overrode the `og:` and `twitter:` title and description but for some crawlers, we need to override the `title` and `description` meta tag as well.