### PR TITLE
FIX: Move CORE_SVG_SPRITES constant to a method

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -264,8 +264,6 @@ module SvgSprite
       ],
     )
 
-  CORE_SVG_SPRITES = Dir.glob("#{Rails.root}/vendor/assets/svg-icons/**/*.svg")
-
   THEME_SPRITE_VAR_NAME = "icons-sprite"
 
   MAX_THEME_SPRITE_SIZE = 1024.kilobytes
@@ -293,9 +291,13 @@ module SvgSprite
       .to_h
   end
 
+  def self.core_svgs_files
+    @svg_files ||= Dir.glob("#{Rails.root}/vendor/assets/svg-icons/**/*.svg")
+  end
+
   def self.core_svgs
     @core_svgs ||=
-      CORE_SVG_SPRITES.reduce({}) do |symbols, path|
+      core_svgs_files.reduce({}) do |symbols, path|
         symbols.merge!(symbols_for(File.basename(path, ".svg"), File.read(path), strict: true))
       end
   end


### PR DESCRIPTION
Changing the `CORE_SVG_SPRITES` constant to a method enables us to detect SVG files that are written to the vendor directory during plugin initialization (as done by the [FontAwesome pro plugin](https://github.com/discourse/discourse-fontawesome-pro/blob/79a8d39fb46d0f28543680a45acf988fd7b87194/plugin.rb#L31)) which happens after all the ruby classes/files are read and loaded into memory.

Internal topic: t/151476.