### PR TITLE
FIX: Refresh disabled state when switching between site texts

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-text-edit.js
@@ -24,7 +24,7 @@ export default class AdminSiteTextEdit extends Controller {
     });
   }
 
-  @discourseComputed("buffered.value")
+  @discourseComputed("buffered.value", "siteText.value")
   saveDisabled(value) {
     return this.siteText.value === value;
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -62,4 +62,18 @@ acceptance("Admin - Site Texts", function (needs) {
     assert.dom(".saved").doesNotExist();
     assert.dom(".revert-site-text").doesNotExist();
   });
+
+  test("save button disabled state", async function (assert) {
+    await visit("/admin/customize/site_texts");
+
+    await click('[data-site-text-id="site.test"] .site-text-edit');
+
+    await click(".go-back");
+
+    await click('[data-site-text-id="site.overridden"] .site-text-edit');
+    assert.dom(".save-changes").hasAttribute("disabled");
+
+    await fillIn(".site-text-value", "Some new value");
+    assert.dom(".save-changes").doesNotHaveAttribute("disabled");
+  });
 });


### PR DESCRIPTION
Repro steps:

1. Go to `/admin/customize/site_texts`
2. Click edit on any translation
3. Go back by clicking on "Back to search"
4. Click edit on another translation
5. Change the text field in any way

Expected results:

The disabled state on the "Save changes" button is removed and you're able to click it

Actual results:

The "Save changes" button remains disabled

This happens because the computed property for the button's disabled state doesn't get re-evaluated when navigating between translation strings because it doesn't include on the `siteText` property in its dependent properties, so changing the site text doesn't invalidate the old value for the disabled state and it always stays the same.

Meta topic: https://meta.discourse.org/t/i-cant-save-edit-on-site-texts/360990?u=osama