### PR TITLE
FIX: Ensure uploaded watched word CSVs are converted to utf-8.

### DIFF
--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -56,7 +56,9 @@ class Admin::WatchedWordsController < Admin::StaffController
 
     Scheduler::Defer.later("Upload watched words") do
       begin
-        CSV.foreach(file.tempfile, encoding: "bom|utf-8") do |row|
+        content = Encodings.to_utf8(File.read(file.tempfile, mode: "rb"))
+
+        CSV.parse(content) do |row|
           if row[0].present? && (!has_replacement || row[1].present?)
             watched_word =
               WatchedWord.create_or_update_word(

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -232,6 +232,24 @@ RSpec.describe Admin::WatchedWordsController do
           ["test", false],
         )
       end
+
+      it "handles files with invalid UTF-8 sequences" do
+        # Create a file with Windows-1250 encoded characters
+        temp_file = Tempfile.new(%w[test .csv])
+        # Write Windows-1250 encoded content
+        content = String.new("h\xE9llo\nworld\x99").force_encoding("Windows-1250")
+        temp_file.write(content)
+        temp_file.rewind
+
+        post "/admin/customize/watched_words/upload.json",
+             params: {
+               action_key: "flag",
+               file: Rack::Test::UploadedFile.new(temp_file.path, "text/csv"),
+             }
+
+        expect(response.status).to eq(200)
+        expect(WatchedWord.pluck(:word)).to contain_exactly("héllo", "world™")
+      end
     end
   end
 

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -234,17 +234,12 @@ RSpec.describe Admin::WatchedWordsController do
       end
 
       it "handles files with invalid UTF-8 sequences" do
-        # Create a file with Windows-1250 encoded characters
-        temp_file = Tempfile.new(%w[test .csv])
-        # Write Windows-1250 encoded content
         content = String.new("h\xE9llo\nworld\x99").force_encoding("Windows-1250")
-        temp_file.write(content)
-        temp_file.rewind
 
         post "/admin/customize/watched_words/upload.json",
              params: {
                action_key: "flag",
-               file: Rack::Test::UploadedFile.new(temp_file.path, "text/csv"),
+               file: Rack::Test::UploadedFile.new(file_from_contents(content, "words.csv")),
              }
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
## ✨ What's This?

When a watched words CSV file is uploaded, we assume it's utf-8 encoded, but that's not always going to be the case. This change loads the CSV and converts it to utf-8 before processing it.