### PR TITLE
FEATURE: Ctrl+M to toggle between rich/markdown editor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -156,8 +156,9 @@ export default class DEditor extends Component {
 
     keymap["tab"] = () => this.textManipulation.indentSelection("right");
     keymap["shift+tab"] = () => this.textManipulation.indentSelection("left");
-    keymap["ctrl+m"] = () =>
-      this.siteSettings.rich_editor && this.toggleRichEditor();
+    if (this.siteSettings.rich_editor) {
+      keymap["ctrl+m"] = () => this.toggleRichEditor();
+    }
 
     return keymap;
   }

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -156,6 +156,8 @@ export default class DEditor extends Component {
 
     keymap["tab"] = () => this.textManipulation.indentSelection("right");
     keymap["shift+tab"] = () => this.textManipulation.indentSelection("left");
+    keymap["ctrl+m"] = () =>
+      this.siteSettings.rich_editor && this.toggleRichEditor();
 
     return keymap;
   }

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -474,6 +474,25 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("ol li", text: "Item 1")
       expect(rich).to have_css("ol li", text: "Item 2Item 3")
     end
+
+    it "supports Ctrl + M to toggle between rich and markdown editors" do
+      open_composer_and_toggle_rich_editor
+
+      composer.type_content("> This is a test")
+
+      expect(composer).to have_value(nil)
+      expect(rich).to have_css("blockquote", text: "This is a test")
+
+      composer.send_keys([:control, "m"])
+
+      expect(composer).to have_value("> This is a test")
+      expect(composer).to have_no_rich_editor
+
+      composer.send_keys([:control, "m"])
+
+      expect(composer).to have_value(nil)
+      expect(rich).to have_css("blockquote", text: "This is a test")
+    end
   end
 
   describe "pasting content" do

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -7,9 +7,18 @@ module PageObjects
       AUTOCOMPLETE_MENU = ".autocomplete.ac-emoji"
       HASHTAG_MENU = ".autocomplete.hashtag-autocomplete"
       MENTION_MENU = ".autocomplete.ac-user"
+      RICH_EDITOR = ".d-editor-input.ProseMirror"
 
       def rich_editor
-        find(".d-editor-input.ProseMirror")
+        find(RICH_EDITOR)
+      end
+
+      def has_rich_editor?
+        page.has_css?(RICH_EDITOR)
+      end
+
+      def has_no_rich_editor?
+        page.has_no_css?(RICH_EDITOR)
       end
 
       def opened?


### PR DESCRIPTION
Adds a ctrl+m shortcut to d-editor to toggle between rich and markdown editor when the `rich_editor` site setting is enabled.