### PR TITLE
UX: only toggle rich editor details on caret click

### DIFF
--- a/plugins/discourse-details/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/discourse-details/assets/javascripts/lib/rich-editor-extension.js
@@ -69,15 +69,17 @@ const extension = {
   plugins: {
     props: {
       handleClickOn(view, pos, node, nodePos) {
-        if (node.type.name === "summary") {
-          const details = view.state.doc.nodeAt(nodePos - 1);
-          view.dispatch(
-            view.state.tr.setNodeMarkup(nodePos - 1, null, {
-              open: !details.attrs.open,
-            })
-          );
-          return true;
+        if (pos > 2 || node.type.name !== "summary") {
+          return false;
         }
+
+        const details = view.state.doc.nodeAt(nodePos - 1);
+        view.dispatch(
+          view.state.tr.setNodeMarkup(nodePos - 1, null, {
+            open: !details.attrs.open,
+          })
+        );
+        return true;
       },
     },
   },


### PR DESCRIPTION
Currently, all clicks on the `summary` node toggles the `details` `open` state.

With this change, only clicks on the caret ▶️  `::before` element will be used to toggle it.