### PR TITLE
UX: rich editor html_block without escaping and avoiding \n\n

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-block.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-block.js
@@ -26,10 +26,39 @@ const extension = {
   },
   serializeNode: {
     html_block: (state, node) => {
-      state.renderContent(node);
+      state.text(node.textContent, false);
       state.write("\n\n");
     },
   },
+  plugins: ({ pmState: { Plugin }, utils: { changedDescendants } }) =>
+    // When cooking the markdown, a html block is auto-closed when a \n\n
+    // is found, so here we make sure there's at most one \n in the block
+    new Plugin({
+      appendTransaction(transactions, prevState, state) {
+        if (!transactions.some((tr) => tr.docChanged)) {
+          return null;
+        }
+
+        const { tr } = state;
+        changedDescendants(prevState.doc, state.doc, (node, pos) => {
+          if (node.type.name === "html_block") {
+            const content = node.textContent;
+            const normalized = content.replace(/\n{2,}/g, "\n");
+
+            if (content !== normalized) {
+              const textNode = node.content.firstChild;
+              tr.replaceWith(
+                pos + 1,
+                pos + 1 + textNode.nodeSize,
+                state.schema.text(normalized)
+              );
+            }
+          }
+        });
+
+        return tr;
+      },
+    }),
 };
 
 export default extension;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/plugin-utils.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/plugin-utils.js
@@ -86,3 +86,26 @@ export function atBlockStart(state, view) {
   }
   return $cursor;
 }
+
+// https://github.com/discourse/discourse/pull/31933#discussion_r2019739410
+export function changedDescendants(old, cur, f, offset = 0) {
+  const oldSize = old.childCount,
+    curSize = cur.childCount;
+  outer: for (let i = 0, j = 0; i < curSize; i++) {
+    const child = cur.child(i);
+    for (let scan = j, e = Math.min(oldSize, i + 5); scan < e; scan++) {
+      if (old.child(scan) === child) {
+        j = scan + 1;
+        offset += child.nodeSize;
+        continue outer;
+      }
+    }
+    f(child, offset);
+    if (j < oldSize && old.child(j).sameMarkup(child)) {
+      changedDescendants(old.child(j), child, f, offset + 1);
+    } else {
+      child.nodesBetween(0, child.content.size, f, offset + 1);
+    }
+    offset += child.nodeSize;
+  }
+}

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/html-block-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/html-block-test.js
@@ -28,6 +28,11 @@ module(
         '<pre class="html-block"><code>&lt;div&gt;1&lt;/div&gt;</code></pre><p>A</p><pre class="html-block"><code>&lt;div&gt;2&lt;/div&gt;</code></pre>',
         "<div>1</div>\n\nA\n\n<div>2</div>\n\n",
       ],
+      "html block with formatting that would be escaped outside it": [
+        "<div>A **bold** or *italic* text</div>",
+        '<pre class="html-block"><code>&lt;div&gt;A **bold** or *italic* text&lt;/div&gt;</code></pre>',
+        "<div>A **bold** or *italic* text</div>\n\n",
+      ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {
       test(name, async function (assert) {
         this.siteSettings.rich_editor = true;


### PR DESCRIPTION
When using a html block within the rich editor (currently only possible after parsing it from Markdown), it would get serialized with the default escape=true processing.

Additionally, html blocks are a continuous block, if a `\n\n` is seen during cooking the block is closed, so we make sure at most one continuous `\n` is seen in the html block node on the  ProseMirror doc.

EDIT: It turns out, it's not so simple. I'm merging this as is, but it's important to link the actual behavior to close a paragraph from markdown-it:

https://github.com/markdown-it/markdown-it/blob/0fe7ccb4b7f30236fb05f623be6924961d296d3d/lib/rules_block/html_block.mjs#L6-L17