### PR TITLE
Add a plugin outlet to the login splash screen

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/login.gjs
+++ b/app/assets/javascripts/discourse/app/templates/login.gjs
@@ -219,6 +219,11 @@ export default RouteTemplate(
                   class="btn-primary login-button"
                 />
               </div>
+              
+              <PluginOutlet
+                @name="below-login-buttons"
+                @outletArgs={{hash model=@controller.model}}
+              />
             </div>
           </div>
         </section>


### PR DESCRIPTION
Adds a plugin outlet below the login buttons in the login-required splash screen.

Use case: adding a custom footer to the splash screen with links to tos and privacy policy.


![example case](https://github.com/user-attachments/assets/85bd4b57-9bcd-48ee-8f12-7af54a7259c8)
