### PR TITLE
UX: Add tooltip for markdown toggle shortcut

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import { translateModKey } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 
 export default class ComposerToggleSwitch extends Component {
@@ -14,10 +15,11 @@ export default class ComposerToggleSwitch extends Component {
   }
 
   get label() {
+    const keyboardShortcut = `${translateModKey("ctrl")}+M`;
     if (this.args.state) {
-      return i18n("composer.switch_to_markdown");
+      return i18n("composer.switch_to_markdown", { keyboardShortcut });
     } else {
-      return i18n("composer.switch_to_rich_text");
+      return i18n("composer.switch_to_rich_text", { keyboardShortcut });
     }
   }
 

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -504,6 +504,7 @@ export function translateModKey(string) {
       .replace("shift", "\u21E7")
       .replace("meta", "\u2318")
       .replace("alt", "\u2325")
+      .replace("ctrl", "\u2303")
       .replace(/\+/g, "");
   } else {
     string = string

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2770,8 +2770,8 @@ en:
       show_preview: "show preview"
       hide_preview: "hide preview"
 
-      switch_to_markdown: "Switch to standard Markdown editor"
-      switch_to_rich_text: "Switch to new rich text editor"
+      switch_to_markdown: "Switch to standard Markdown editor (%{keyboardShortcut})"
+      switch_to_rich_text: "Switch to new rich text editor (%{keyboardShortcut})"
       quote_post_title: "Quote whole post"
       bold_label: "B"
       bold_title: "Strong"


### PR DESCRIPTION
Followup 198dc813750d7a0de98cc94372dea1222b97743b

Indicate the shortcut in the tooltip for the rich/markdown
editor toggle, and also add the control translation for mac
in `translateModKey`