### PR TITLE
DEV: Convert groups page to components

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-card.gjs
@@ -1,6 +1,5 @@
 import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
-import Component from "@glimmer/component";
 import AvatarFlair from "discourse/components/avatar-flair";
 import GroupInfo from "discourse/components/group-info";
 import GroupMembershipButton from "discourse/components/group-membership-button";
@@ -10,79 +9,77 @@ import htmlSafe from "discourse/helpers/html-safe";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
-export default class GroupCard extends Component {
-  <template>
-    <LinkTo
-      @route="group.members"
-      @model={{@group.name}}
-      class="group-box"
-      data-group-name={{@group.name}}
-    >
-      <div class="group-box-inner">
-        <div class="group-info-wrapper">
-          {{#if @group.flair_url}}
-            <span class="group-avatar-flair">
-              <AvatarFlair
-                @flairName={{@group.name}}
-                @flairUrl={{@group.flair_url}}
-                @flairBgColor={{@group.flair_bg_color}}
-                @flairColor={{@group.flair_color}}
-              />
-            </span>
-          {{/if}}
-
-          <span class="group-info">
-            <GroupInfo @group={{@group}} />
-            <div class="group-user-count">{{icon
-                "user"
-              }}{{@group.user_count}}</div>
-          </span>
-        </div>
-
-        <div class="group-description">{{htmlSafe
-            @group.bio_excerpt
-          }}</div>
-
-        <div class="group-membership">
-          <GroupMembershipButton
-            @tagName=""
-            @model={{@group}}
-            @showLogin={{routeAction "showLogin"}}
-          >
-            {{#if @group.is_group_owner}}
-              <span class="is-group-owner">
-                {{icon "shield-halved"}}
-                {{i18n "groups.index.is_group_owner"}}
-              </span>
-            {{else if @group.is_group_user}}
-              <span class="is-group-member">
-                {{icon "check"}}
-                {{i18n "groups.index.is_group_user"}}
-              </span>
-            {{else if @group.public_admission}}
-              {{i18n "groups.index.public"}}
-            {{else if @group.isPrivate}}
-              {{icon "far-eye-slash"}}
-              {{i18n "groups.index.private"}}
-            {{else}}
-              {{#if @group.automatic}}
-                {{i18n "groups.index.automatic"}}
-              {{else}}
-                {{icon "ban"}}
-                {{i18n "groups.index.closed"}}
-              {{/if}}
-            {{/if}}
-          </GroupMembershipButton>
-
-          <span>
-            <PluginOutlet
-              @name="group-index-box-after"
-              @connectorTagName="div"
-              @outletArgs={{hash model=@group}}
+const GroupCard = <template>
+  <LinkTo
+    @route="group.members"
+    @model={{@group.name}}
+    class="group-box"
+    data-group-name={{@group.name}}
+  >
+    <div class="group-box-inner">
+      <div class="group-info-wrapper">
+        {{#if @group.flair_url}}
+          <span class="group-avatar-flair">
+            <AvatarFlair
+              @flairName={{@group.name}}
+              @flairUrl={{@group.flair_url}}
+              @flairBgColor={{@group.flair_bg_color}}
+              @flairColor={{@group.flair_color}}
             />
           </span>
-        </div>
+        {{/if}}
+
+        <span class="group-info">
+          <GroupInfo @group={{@group}} />
+          <div class="group-user-count">{{icon
+              "user"
+            }}{{@group.user_count}}</div>
+        </span>
       </div>
-    </LinkTo>
-  </template>
-}
+
+      <div class="group-description">{{htmlSafe @group.bio_excerpt}}</div>
+
+      <div class="group-membership">
+        <GroupMembershipButton
+          @tagName=""
+          @model={{@group}}
+          @showLogin={{routeAction "showLogin"}}
+        >
+          {{#if @group.is_group_owner}}
+            <span class="is-group-owner">
+              {{icon "shield-halved"}}
+              {{i18n "groups.index.is_group_owner"}}
+            </span>
+          {{else if @group.is_group_user}}
+            <span class="is-group-member">
+              {{icon "check"}}
+              {{i18n "groups.index.is_group_user"}}
+            </span>
+          {{else if @group.public_admission}}
+            {{i18n "groups.index.public"}}
+          {{else if @group.isPrivate}}
+            {{icon "far-eye-slash"}}
+            {{i18n "groups.index.private"}}
+          {{else}}
+            {{#if @group.automatic}}
+              {{i18n "groups.index.automatic"}}
+            {{else}}
+              {{icon "ban"}}
+              {{i18n "groups.index.closed"}}
+            {{/if}}
+          {{/if}}
+        </GroupMembershipButton>
+
+        <span>
+          <PluginOutlet
+            @name="group-index-box-after"
+            @connectorTagName="div"
+            @outletArgs={{hash model=@group}}
+          />
+        </span>
+      </div>
+    </div>
+  </LinkTo>
+</template>;
+
+export default GroupCard;

--- a/app/assets/javascripts/discourse/app/components/group-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-card.gjs
@@ -1,0 +1,88 @@
+import { hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
+import Component from "@glimmer/component";
+import AvatarFlair from "discourse/components/avatar-flair";
+import GroupInfo from "discourse/components/group-info";
+import GroupMembershipButton from "discourse/components/group-membership-button";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import icon from "discourse/helpers/d-icon";
+import htmlSafe from "discourse/helpers/html-safe";
+import routeAction from "discourse/helpers/route-action";
+import { i18n } from "discourse-i18n";
+
+export default class GroupCard extends Component {
+  <template>
+    <LinkTo
+      @route="group.members"
+      @model={{@group.name}}
+      class="group-box"
+      data-group-name={{@group.name}}
+    >
+      <div class="group-box-inner">
+        <div class="group-info-wrapper">
+          {{#if @group.flair_url}}
+            <span class="group-avatar-flair">
+              <AvatarFlair
+                @flairName={{@group.name}}
+                @flairUrl={{@group.flair_url}}
+                @flairBgColor={{@group.flair_bg_color}}
+                @flairColor={{@group.flair_color}}
+              />
+            </span>
+          {{/if}}
+
+          <span class="group-info">
+            <GroupInfo @group={{@group}} />
+            <div class="group-user-count">{{icon
+                "user"
+              }}{{@group.user_count}}</div>
+          </span>
+        </div>
+
+        <div class="group-description">{{htmlSafe
+            @group.bio_excerpt
+          }}</div>
+
+        <div class="group-membership">
+          <GroupMembershipButton
+            @tagName=""
+            @model={{@group}}
+            @showLogin={{routeAction "showLogin"}}
+          >
+            {{#if @group.is_group_owner}}
+              <span class="is-group-owner">
+                {{icon "shield-halved"}}
+                {{i18n "groups.index.is_group_owner"}}
+              </span>
+            {{else if @group.is_group_user}}
+              <span class="is-group-member">
+                {{icon "check"}}
+                {{i18n "groups.index.is_group_user"}}
+              </span>
+            {{else if @group.public_admission}}
+              {{i18n "groups.index.public"}}
+            {{else if @group.isPrivate}}
+              {{icon "far-eye-slash"}}
+              {{i18n "groups.index.private"}}
+            {{else}}
+              {{#if @group.automatic}}
+                {{i18n "groups.index.automatic"}}
+              {{else}}
+                {{icon "ban"}}
+                {{i18n "groups.index.closed"}}
+              {{/if}}
+            {{/if}}
+          </GroupMembershipButton>
+
+          <span>
+            <PluginOutlet
+              @name="group-index-box-after"
+              @connectorTagName="div"
+              @outletArgs={{hash model=@group}}
+            />
+          </span>
+        </div>
+      </div>
+    </LinkTo>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/group-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-list.gjs
@@ -68,7 +68,7 @@ export default class GroupList extends Component {
 
         <div class="groups-header-filters">
           <Input
-            @value={{readonly @filter}}
+            @value={{@filter}}
             placeholder={{i18n "groups.index.all"}}
             class="groups-header-filters-name no-blur"
             {{on "input" (withEventValue @onFilterChanged)}}

--- a/app/assets/javascripts/discourse/app/components/group-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-list.gjs
@@ -1,0 +1,82 @@
+import Component from "@glimmer/component";
+import { Input } from "@ember/component";
+import { fn, hash } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { or } from "truth-helpers";
+import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import DButton from "discourse/components/d-button";
+import GroupCard from "discourse/components/group-card";
+import LoadMore from "discourse/components/load-more";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import bodyClass from "discourse/helpers/body-class";
+import hideApplicationFooter from "discourse/helpers/hide-application-footer";
+import withEventValue from "discourse/helpers/with-event-value";
+import { i18n } from "discourse-i18n";
+import ComboBox from "select-kit/components/combo-box";
+
+export default class GroupList extends Component {
+  <template>
+    {{#if (or @controller.loading @controller.groups.canLoadMore)}}
+      {{hideApplicationFooter}}
+    {{/if}}
+
+    {{bodyClass "groups-page"}}
+
+    <PluginOutlet
+      @name="before-groups-index-container"
+      @connectorTagName="div"
+    />
+
+    <section class="container groups-index">
+      <div class="groups-header">
+        {{#if @controller.currentUser.can_create_group}}
+          <DButton
+            @action={{@controller.new}}
+            @icon="plus"
+            @label="admin.groups.new.title"
+            class="btn-default groups-header-new pull-right"
+          />
+        {{/if}}
+
+        <div class="groups-header-filters">
+          <Input
+            @value={{readonly @controller.filter}}
+            placeholder={{i18n "groups.index.all"}}
+            class="groups-header-filters-name no-blur"
+            {{on "input" (withEventValue @controller.onFilterChanged)}}
+            @type="search"
+            aria-description={{i18n "groups.index.search_results"}}
+          />
+
+          <ComboBox
+            @value={{@controller.type}}
+            @content={{@controller.types}}
+            @onChange={{fn (mut @controller.type)}}
+            @options={{hash clearable=true none="groups.index.filter"}}
+            class="groups-header-filters-type"
+          />
+        </div>
+      </div>
+
+      {{#if @controller.groups}}
+        <LoadMore
+          @selector=".groups-boxes .group-box"
+          @action={{@controller.loadMore}}
+        >
+          <div class="container">
+            <div class="groups-boxes">
+              {{#each @controller.groups as |group|}}
+                <GroupCard @group={{group}} />
+              {{/each}}
+            </div>
+          </div>
+        </LoadMore>
+        <ConditionalLoadingSpinner
+          @condition={{@controller.groups.loadingMore}}
+        />
+      {{else}}
+        <p role="status">{{i18n "groups.index.empty"}}</p>
+      {{/if}}
+    </section>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/controllers/groups-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/groups-index.js
@@ -1,48 +1,24 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
-import { service } from "@ember/service";
 import discourseDebounce from "discourse/lib/debounce";
-import discourseComputed from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
-import { i18n } from "discourse-i18n";
 
 export default class GroupsIndexController extends Controller {
-  @service router;
-
   queryParams = ["order", "asc", "filter", "type"];
   order = null;
   asc = null;
   filter = "";
   type = null;
   groups = null;
-  isLoading = false;
 
-  @discourseComputed("groups.extras.type_filters")
-  types(typeFilters) {
-    const types = [];
-
-    if (typeFilters) {
-      typeFilters.forEach((type) =>
-        types.push({ id: type, name: i18n(`groups.index.${type}_groups`) })
-      );
-    }
-
-    return types;
+  @action
+  onTypeChanged(type) {
+    this.set("type", type);
   }
 
   @action
   onFilterChanged(filter) {
     discourseDebounce(this, this._debouncedFilter, filter, INPUT_DELAY);
-  }
-
-  @action
-  loadMore() {
-    this.groups && this.groups.loadMore();
-  }
-
-  @action
-  new() {
-    this.router.transitionTo("groups.new");
   }
 
   _debouncedFilter(filter) {

--- a/app/assets/javascripts/discourse/app/templates/groups/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.gjs
@@ -4,7 +4,14 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 
 export default RouteTemplate(
   <template>
-    <GroupList @controller={{@controller}} />
+    <GroupList
+      @controller={{@controller}}
+      @groups={{@model.groups}}
+      @type={{@controller.type}}
+      @filter={{@controller.filter}}
+      @onTypeChanged={{@controller.onTypeChanged}}
+      @onFilterChanged={{@controller.onFilterChanged}}
+    />
 
     <PluginOutlet
       @name="after-groups-index-container"

--- a/app/assets/javascripts/discourse/app/templates/groups/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.gjs
@@ -1,83 +1,10 @@
-import { Input } from "@ember/component";
-import { fn, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
-import { or } from "truth-helpers";
-import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
-import DButton from "discourse/components/d-button";
-import GroupCard from "discourse/components/group-card";
-import LoadMore from "discourse/components/load-more";
+import GroupList from "discourse/components/group-list";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import bodyClass from "discourse/helpers/body-class";
-import hideApplicationFooter from "discourse/helpers/hide-application-footer";
-import withEventValue from "discourse/helpers/with-event-value";
-import { i18n } from "discourse-i18n";
-import ComboBox from "select-kit/components/combo-box";
 
 export default RouteTemplate(
   <template>
-    {{#if (or @controller.loading @controller.groups.canLoadMore)}}
-      {{hideApplicationFooter}}
-    {{/if}}
-
-    {{bodyClass "groups-page"}}
-
-    <PluginOutlet
-      @name="before-groups-index-container"
-      @connectorTagName="div"
-    />
-
-    <section class="container groups-index">
-      <div class="groups-header">
-        {{#if @controller.currentUser.can_create_group}}
-          <DButton
-            @action={{@controller.new}}
-            @icon="plus"
-            @label="admin.groups.new.title"
-            class="btn-default groups-header-new pull-right"
-          />
-        {{/if}}
-
-        <div class="groups-header-filters">
-          <Input
-            @value={{readonly @controller.filter}}
-            placeholder={{i18n "groups.index.all"}}
-            class="groups-header-filters-name no-blur"
-            {{on "input" (withEventValue @controller.onFilterChanged)}}
-            @type="search"
-            aria-description={{i18n "groups.index.search_results"}}
-          />
-
-          <ComboBox
-            @value={{@controller.type}}
-            @content={{@controller.types}}
-            @onChange={{fn (mut @controller.type)}}
-            @options={{hash clearable=true none="groups.index.filter"}}
-            class="groups-header-filters-type"
-          />
-        </div>
-      </div>
-
-      {{#if @controller.groups}}
-        <LoadMore
-          @selector=".groups-boxes .group-box"
-          @action={{@controller.loadMore}}
-        >
-          <div class="container">
-            <div class="groups-boxes">
-              {{#each @controller.groups as |group|}}
-                <GroupCard @group={{group}} />
-              {{/each}}
-            </div>
-          </div>
-        </LoadMore>
-        <ConditionalLoadingSpinner
-          @condition={{@controller.groups.loadingMore}}
-        />
-      {{else}}
-        <p role="status">{{i18n "groups.index.empty"}}</p>
-      {{/if}}
-    </section>
+    <GroupList @controller={{@controller}} />
 
     <PluginOutlet
       @name="after-groups-index-container"

--- a/app/assets/javascripts/discourse/app/templates/groups/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.gjs
@@ -1,21 +1,15 @@
 import { Input } from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
-import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import { or } from "truth-helpers";
-import AvatarFlair from "discourse/components/avatar-flair";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
-import GroupInfo from "discourse/components/group-info";
-import GroupMembershipButton from "discourse/components/group-membership-button";
+import GroupCard from "discourse/components/group-card";
 import LoadMore from "discourse/components/load-more";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
-import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
-import htmlSafe from "discourse/helpers/html-safe";
-import routeAction from "discourse/helpers/route-action";
 import withEventValue from "discourse/helpers/with-event-value";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -72,78 +66,7 @@ export default RouteTemplate(
           <div class="container">
             <div class="groups-boxes">
               {{#each @controller.groups as |group|}}
-                <LinkTo
-                  @route="group.members"
-                  @model={{group.name}}
-                  class="group-box"
-                  data-group-name={{group.name}}
-                >
-                  <div class="group-box-inner">
-                    <div class="group-info-wrapper">
-                      {{#if group.flair_url}}
-                        <span class="group-avatar-flair">
-                          <AvatarFlair
-                            @flairName={{group.name}}
-                            @flairUrl={{group.flair_url}}
-                            @flairBgColor={{group.flair_bg_color}}
-                            @flairColor={{group.flair_color}}
-                          />
-                        </span>
-                      {{/if}}
-
-                      <span class="group-info">
-                        <GroupInfo @group={{group}} />
-                        <div class="group-user-count">{{icon
-                            "user"
-                          }}{{group.user_count}}</div>
-                      </span>
-                    </div>
-
-                    <div class="group-description">{{htmlSafe
-                        group.bio_excerpt
-                      }}</div>
-
-                    <div class="group-membership">
-                      <GroupMembershipButton
-                        @tagName=""
-                        @model={{group}}
-                        @showLogin={{routeAction "showLogin"}}
-                      >
-                        {{#if group.is_group_owner}}
-                          <span class="is-group-owner">
-                            {{icon "shield-halved"}}
-                            {{i18n "groups.index.is_group_owner"}}
-                          </span>
-                        {{else if group.is_group_user}}
-                          <span class="is-group-member">
-                            {{icon "check"}}
-                            {{i18n "groups.index.is_group_user"}}
-                          </span>
-                        {{else if group.public_admission}}
-                          {{i18n "groups.index.public"}}
-                        {{else if group.isPrivate}}
-                          {{icon "far-eye-slash"}}
-                          {{i18n "groups.index.private"}}
-                        {{else}}
-                          {{#if group.automatic}}
-                            {{i18n "groups.index.automatic"}}
-                          {{else}}
-                            {{icon "ban"}}
-                            {{i18n "groups.index.closed"}}
-                          {{/if}}
-                        {{/if}}
-                      </GroupMembershipButton>
-
-                      <span>
-                        <PluginOutlet
-                          @name="group-index-box-after"
-                          @connectorTagName="div"
-                          @outletArgs={{hash model=group}}
-                        />
-                      </span>
-                    </div>
-                  </div>
-                </LinkTo>
+                <GroupCard @group={{group}} />
               {{/each}}
             </div>
           </div>

--- a/app/assets/javascripts/discourse/app/templates/groups/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.gjs
@@ -5,7 +5,6 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 export default RouteTemplate(
   <template>
     <GroupList
-      @controller={{@controller}}
       @groups={{@model.groups}}
       @type={{@controller.type}}
       @filter={{@controller.filter}}


### PR DESCRIPTION
### What is this change?

We need to reuse some of the groups UI in the admin dashboard. This is currently a bit hairy because it's using the old controller + routes + template style design.

This PR extracts to components, `GroupCard`, and `GroupList`, and shifts the logic in there.

Below is a screenshot of a list with twelve cards:

<img width="542" alt="Screenshot 2025-04-15 at 9 54 32 AM" src="https://github.com/user-attachments/assets/a02e8e13-3edb-4e54-88ee-ffa397c16ef9" />
