### PR TITLE
FIX: Escape regex symbols when replaceText is called for ProseMirror

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -6,6 +6,7 @@ import { lift, setBlockType, toggleMark, wrapIn } from "prosemirror-commands";
 import { liftListItem, sinkListItem } from "prosemirror-schema-list";
 import { TextSelection } from "prosemirror-state";
 import { bind } from "discourse/lib/decorators";
+import escapeRegExp from "discourse/lib/escape-regexp";
 import { i18n } from "discourse-i18n";
 
 /**
@@ -276,7 +277,7 @@ export default class ProsemirrorTextManipulation {
 
     const markdown = this.convertToMarkdown(this.view.state.doc);
 
-    const regex = opts.regex || new RegExp(oldValue, "g");
+    const regex = opts.regex || new RegExp(escapeRegExp(oldValue), "g");
     const index = opts.index || 0;
     let matchCount = 0;
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.gjs
@@ -1314,3 +1314,35 @@ third line`
     }
   })();
 });
+
+module("Integration | Component | d-editor | rich editor", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("replaceText escapes markdown symbols that could be regexp symbols", async function (assert) {
+    this.siteSettings.rich_editor = true;
+
+    const initialValue = "Hello\n\n* world\n* am am here $";
+
+    withPluginApi("2.1.0", (api) => {
+      api.onToolbarCreate((toolbar) => {
+        toolbar.addButton({
+          id: "replace-text",
+          icon: "xmark",
+          group: "extras",
+          action: () => {
+            toolbar.context
+              .newToolbarEvent()
+              .replaceText(initialValue, "goodbye");
+          },
+          condition: () => true,
+        });
+      });
+    });
+
+    await render(<template><DEditor @value={{initialValue}} /></template>);
+    await click(".composer-toggle-switch");
+    await click("button.replace-text");
+
+    assert.dom(".ProseMirror p").hasText("goodbye");
+  });
+});


### PR DESCRIPTION
When we do replaceText in the ProseMirror TextManipulation lib,
we are creating a regex for the provided markdown. However this markdown
can have things like * (which is valid for a markdown list), which also
doubles as a regex symbol. We can escape the markdown provided to
the regex first to fix the issue.
