### PR TITLE
UX: Remove Ctrl+F search shortcut

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -12,7 +12,6 @@ import {
 import DiscourseURL from "discourse/lib/url";
 import Composer from "discourse/models/composer";
 import { capabilities } from "discourse/services/capabilities";
-import { i18n } from "discourse-i18n";
 
 let disabledBindings = [];
 export function disableDefaultKeyboardShortcuts(bindings) {
@@ -61,8 +60,6 @@ const DEFAULT_BINDINGS = {
   b: { handler: "toggleBookmark" },
   c: { handler: "createTopic" },
   "shift+c": { handler: "focusComposer" },
-  "ctrl+f": { handler: "maybeShowSearchTip", anonymous: true },
-  "command+f": { handler: "maybeShowSearchTip", anonymous: true },
   "command+left": { handler: "webviewKeyboardBack", anonymous: true },
   "command+[": { handler: "webviewKeyboardBack", anonymous: true },
   "command+right": { handler: "webviewKeyboardForward", anonymous: true },
@@ -457,26 +454,6 @@ export default {
         type: "page-search",
         event,
       });
-    });
-  },
-
-  maybeShowSearchTip() {
-    // TODO (martin) only do this if the user hasn't said never do this again
-    const toasts = getOwner(this).lookup("service:toasts");
-    toasts.info({
-      data: {
-        message: i18n("keyboard_shortcuts_help.search_ctrl_f_tip"),
-        actions: [
-          {
-            label: i18n("user_tips.dont_show_again"),
-            action: () => {
-              // TODO (martin) set the user pref here
-            },
-          },
-        ],
-        isHtmlMessage: true,
-      },
-      duration: 10000,
     });
   },
 

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -60,8 +60,6 @@ const DEFAULT_BINDINGS = {
   b: { handler: "toggleBookmark" },
   c: { handler: "createTopic" },
   "shift+c": { handler: "focusComposer" },
-  "ctrl+f": { handler: "showPageSearch", anonymous: true },
-  "command+f": { handler: "showPageSearch", anonymous: true },
   "command+left": { handler: "webviewKeyboardBack", anonymous: true },
   "command+[": { handler: "webviewKeyboardBack", anonymous: true },
   "command+right": { handler: "webviewKeyboardForward", anonymous: true },

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -12,6 +12,7 @@ import {
 import DiscourseURL from "discourse/lib/url";
 import Composer from "discourse/models/composer";
 import { capabilities } from "discourse/services/capabilities";
+import { i18n } from "discourse-i18n";
 
 let disabledBindings = [];
 export function disableDefaultKeyboardShortcuts(bindings) {
@@ -60,6 +61,8 @@ const DEFAULT_BINDINGS = {
   b: { handler: "toggleBookmark" },
   c: { handler: "createTopic" },
   "shift+c": { handler: "focusComposer" },
+  "ctrl+f": { handler: "maybeShowSearchTip", anonymous: true },
+  "command+f": { handler: "maybeShowSearchTip", anonymous: true },
   "command+left": { handler: "webviewKeyboardBack", anonymous: true },
   "command+[": { handler: "webviewKeyboardBack", anonymous: true },
   "command+right": { handler: "webviewKeyboardForward", anonymous: true },
@@ -454,6 +457,26 @@ export default {
         type: "page-search",
         event,
       });
+    });
+  },
+
+  maybeShowSearchTip() {
+    // TODO (martin) only do this if the user hasn't said never do this again
+    const toasts = getOwner(this).lookup("service:toasts");
+    toasts.info({
+      data: {
+        message: i18n("keyboard_shortcuts_help.search_ctrl_f_tip"),
+        actions: [
+          {
+            label: i18n("user_tips.dont_show_again"),
+            action: () => {
+              // TODO (martin) set the user pref here
+            },
+          },
+        ],
+        isHtmlMessage: true,
+      },
+      duration: 10000,
     });
   },
 

--- a/app/assets/javascripts/float-kit/addon/components/d-default-toast.gjs
+++ b/app/assets/javascripts/float-kit/addon/components/d-default-toast.gjs
@@ -1,5 +1,6 @@
 import { concat, fn, hash } from "@ember/helper";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
@@ -33,7 +34,11 @@ const DDefaultToast = <template>
         {{/if}}
         {{#if @data.message}}
           <div class="fk-d-default-toast__message">
-            {{@data.message}}
+            {{#if @data.isHtmlMessage}}
+              {{htmlSafe @data.message}}
+            {{else}}
+              {{@data.message}}
+            {{/if}}
           </div>
         {{/if}}
       </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2203,6 +2203,7 @@ en:
     user_tips:
       button: "Got it!"
       skip: "Skip tips"
+      dont_show_again: "Don't show this again"
 
       first_notification:
         title: "Your first notification!"
@@ -4564,6 +4565,7 @@ en:
       shortcut_delimiter_newline: "%{shortcut1}<br>%{shortcut2}"
       title: "Keyboard Shortcuts"
       short_title: "Shortcuts"
+      search_ctrl_f_tip: "To search across this entire forum, press <kbd>/</kbd>"
       jump_to:
         title: "Jump To"
         home: "%{shortcut} Home"

--- a/spec/system/search_shortcut_variation_spec.rb
+++ b/spec/system/search_shortcut_variation_spec.rb
@@ -8,6 +8,15 @@ describe "Search | Shortcuts for variations of search input", type: :system do
 
   before { sign_in(current_user) }
 
+  it "displays a one time toast telling the user that / should be used to search, not Ctrl+F, when Ctrl+F is pressed" do
+    visit("/")
+    search_page.browser_search_shortcut
+    expect(page).to have_content(I18n.t("js.keyboard_shortcuts_help.search_ctrl_f_tip"))
+    page.find(".fk-d-default-toast__actions .btn").click
+    search_page.browser_search_shortcut
+    expect(page).to have_no_content(I18n.t("js.keyboard_shortcuts_help.search_ctrl_f_tip"))
+  end
+
   context "when search_experience is search_field" do
     before { SiteSetting.search_experience = "search_field" }
 
@@ -24,29 +33,6 @@ describe "Search | Shortcuts for variations of search input", type: :system do
         expect(search_page).to have_no_search_menu_visible
       end
 
-      it "displays and focuses welcome banner search when Ctrl+F is pressed and hides it when Escape is pressed" do
-        visit("/")
-        expect(welcome_banner).to be_visible
-        search_page.browser_search_shortcut
-        expect(search_page).to have_search_menu
-        expect(current_active_element[:id]).to eq("welcome-banner-search-input")
-        page.send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
-      end
-
-      it "displays and focuses welcome banner search when Ctrl+F is pressed and blurs it when Ctrl+F is pressed" do
-        visit("/")
-        expect(welcome_banner).to be_visible
-        search_page.browser_search_shortcut
-        expect(search_page).to have_search_menu
-        expect(current_active_element[:id]).to eq("welcome-banner-search-input")
-        # NOTE: This does not work as expected because pressing Ctrl+F in the browser does
-        # not change the document acive element, leaving it here as a reminder to manually test
-        # this behavior.
-        # search_page.browser_search_shortcut
-        # expect(current_active_element[:id]).to eq(nil)
-      end
-
       context "when welcome banner is not in the viewport" do
         before do
           visit("/")
@@ -61,27 +47,6 @@ describe "Search | Shortcuts for variations of search input", type: :system do
           page.send_keys(:escape)
           expect(search_page).to have_no_search_menu_visible
         end
-
-        it "displays and focuses header search when Ctrl+F is pressed and hides it when Escape is pressed" do
-          expect(welcome_banner).to be_invisible
-          search_page.browser_search_shortcut
-          expect(search_page).to have_search_menu
-          expect(current_active_element[:id]).to eq("header-search-input")
-          page.send_keys(:escape)
-          expect(search_page).to have_no_search_menu_visible
-        end
-
-        it "displays and focuses welcome banner search when Ctrl+F is pressed and blurs it when Ctrl+F is pressed" do
-          expect(welcome_banner).to be_invisible
-          search_page.browser_search_shortcut
-          expect(search_page).to have_search_menu
-          expect(current_active_element[:id]).to eq("header-search-input")
-          # NOTE: This does not work as expected because pressing Ctrl+F in the browser does
-          # not change the document acive element, leaving it here as a reminder to manually test
-          # this behavior.
-          # search_page.browser_search_shortcut
-          # expect(current_active_element[:id]).to eq(nil)
-        end
       end
     end
 
@@ -92,16 +57,6 @@ describe "Search | Shortcuts for variations of search input", type: :system do
         visit("/")
         expect(welcome_banner).to be_hidden
         page.send_keys("/")
-        expect(search_page).to have_search_menu
-        expect(current_active_element[:id]).to eq("header-search-input")
-        page.send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
-      end
-
-      it "displays and focuses header search when Ctrl+F is pressed and hides it when Escape is pressed" do
-        visit("/")
-        expect(welcome_banner).to be_hidden
-        search_page.browser_search_shortcut
         expect(search_page).to have_search_menu
         expect(current_active_element[:id]).to eq("header-search-input")
         page.send_keys(:escape)
@@ -124,30 +79,6 @@ describe "Search | Shortcuts for variations of search input", type: :system do
         expect(current_active_element[:id]).to eq("welcome-banner-search-input")
         page.send_keys(:escape)
         expect(search_page).to have_no_search_menu_visible
-      end
-
-      it "displays and focuses welcome banner search when Ctrl+F is pressed and hides it when Escape is pressed" do
-        visit("/")
-        expect(welcome_banner).to be_visible
-        search_page.browser_search_shortcut
-        expect(search_page).to have_search_menu
-        expect(current_active_element[:id]).to eq("welcome-banner-search-input")
-        page.send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
-      end
-
-      it "displays and focuses welcome banner search when Ctrl+F is pressed and blurs it when Ctrl+F is pressed" do
-        visit("/")
-        expect(welcome_banner).to be_visible
-        search_page.browser_search_shortcut
-        expect(search_page).to have_search_menu
-        expect(current_active_element[:id]).to eq("welcome-banner-search-input")
-
-        # NOTE: This does not work as expected because pressing Ctrl+F in the browser does
-        # not change the document acive element, leaving it here as a reminder to manually test
-        # this behavior.
-        # search_page.browser_search_shortcut
-        # expect(current_active_element[:id]).to eq(nil)
       end
 
       context "when welcome banner is not in the viewport" do
@@ -186,16 +117,13 @@ describe "Search | Shortcuts for variations of search input", type: :system do
         fab!(:topic)
         fab!(:posts) { Fabricate.times(21, :post, topic: topic) }
 
-        it "opens search on first press of Ctrl+F, and closes on the second" do
+        it "opens search on first press of /, and closes when Escape is pressed" do
           visit "/t/#{topic.slug}/#{topic.id}"
-          search_page.browser_search_shortcut
-          expect(search_page).to have_search_menu_visible
+          page.send_keys("/")
+          expect(search_page).to have_search_menu
           expect(current_active_element[:id]).to eq("icon-search-input")
-          # NOTE: This does not work as expected because pressing Ctrl+F in the browser does
-          # not change the document acive element, leaving it here as a reminder to manually test
-          # this behavior.
-          # search_page.browser_search_shortcut
-          # expect(current_active_element[:id]).to eq(nil)
+          page.send_keys(:escape)
+          expect(search_page).to have_no_search_menu_visible
         end
       end
     end

--- a/spec/system/search_shortcut_variation_spec.rb
+++ b/spec/system/search_shortcut_variation_spec.rb
@@ -8,15 +8,6 @@ describe "Search | Shortcuts for variations of search input", type: :system do
 
   before { sign_in(current_user) }
 
-  it "displays a one time toast telling the user that / should be used to search, not Ctrl+F, when Ctrl+F is pressed" do
-    visit("/")
-    search_page.browser_search_shortcut
-    expect(page).to have_content(I18n.t("js.keyboard_shortcuts_help.search_ctrl_f_tip"))
-    page.find(".fk-d-default-toast__actions .btn").click
-    search_page.browser_search_shortcut
-    expect(page).to have_no_content(I18n.t("js.keyboard_shortcuts_help.search_ctrl_f_tip"))
-  end
-
   context "when search_experience is search_field" do
     before { SiteSetting.search_experience = "search_field" }
 


### PR DESCRIPTION
This commit removes the Ctrl+F search shortcut, which hijacks the
browser search shortcut in Discourse. We are doing this because there
has been many years of complaints around this behaviour, and now that
we have the new header search it has become even more annoying.

We originally added this because we lazy load posts in a topic, and it
might not have been immediately clear to users that they are not searching
all the posts in the topic when pressing Ctrl+F. However, that was 10+ years
ago, most people are very familiar with lazy loading now, it doesn't make sense
to keep this additional hijack for this one topic use case.

Search is still accessible by pressing the `/` shortcut.