### PR TITLE
FIX: bugs with refresh page after save fonts

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-fonts-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-fonts-form.gjs
@@ -11,9 +11,14 @@ import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 import AdminFontChooser from "admin/components/admin-font-chooser";
-import { DEFAULT_TEXT_SIZES } from "admin/lib/constants";
+import {
+  DEFAULT_TEXT_SIZES,
+  MAIN_FONTS,
+  MORE_FONTS,
+} from "admin/lib/constants";
 import eq from "truth-helpers/helpers/eq";
 
+const ALL_FONTS = [...MAIN_FONTS, ...MORE_FONTS];
 export default class AdminFontsForm extends Component {
   @service siteSettings;
   @service siteSettingChangeTracker;
@@ -82,7 +87,12 @@ export default class AdminFontsForm extends Component {
           message: i18n("admin.config.logo_and_fonts.fonts.form.saved"),
         },
       });
-      this.siteSettingChangeTracker.refreshPage();
+      this.siteSettingChangeTracker.refreshPage({
+        base_font: ALL_FONTS.find((font) => font.key === data.base_font).name,
+        heading_font: ALL_FONTS.find((font) => font.key === data.heading_font)
+          .name,
+        default_text_size: data.default_text_size,
+      });
     } catch (err) {
       this.toasts.error({
         duration: 3000,

--- a/app/assets/javascripts/admin/addon/components/admin-logo-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-logo-form.gjs
@@ -82,7 +82,7 @@ export default class AdminLogoForm extends Component {
           message: i18n("admin.config.logo_and_fonts.logo.form.saved"),
         },
       });
-      this.siteSettingChangeTracker.refreshPage();
+      this.siteSettingChangeTracker.refreshPage(data);
     } catch (err) {
       this.toasts.error({
         duration: 3000,

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -211,7 +211,9 @@ export default Mixin.create({
       this.buffered.applyChanges();
 
       if (this.setting.requiresReload) {
-        this.siteSettingChangeTracker.refreshPage();
+        this.siteSettingChangeTracker.refreshPage({
+          [this.setting.setting]: this.setting.value,
+        });
       }
     } catch (e) {
       const json = e.jqXHR?.responseJSON;

--- a/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
+++ b/app/assets/javascripts/admin/addon/services/site-setting-change-tracker.js
@@ -185,21 +185,28 @@ export default class SiteSettingChangeTracker extends Service {
     });
   }
 
-  refreshPage() {
-    document.documentElement.style.setProperty(
-      "--font-family",
-      this.siteSettings.base_font
-    );
-    document.documentElement.style.setProperty(
-      "--heading-font-family",
-      this.siteSettings.heading_font
-    );
-    DEFAULT_TEXT_SIZES.forEach((size) => {
-      document.documentElement.classList.remove(`text-size-${size}`);
-    });
-    document.documentElement.classList.add(
-      `text-size-${this.siteSettings.default_text_size}`
-    );
+  refreshPage(params) {
+    if (params.base_font) {
+      document.documentElement.style.setProperty(
+        "--font-family",
+        params.base_font
+      );
+    }
+    if (params.heading_font) {
+      document.documentElement.style.setProperty(
+        "--heading-font-family",
+        params.heading_font
+      );
+    }
+    if (params.default_text_size) {
+      DEFAULT_TEXT_SIZES.forEach((size) => {
+        document.documentElement.classList.remove(`text-size-${size}`);
+      });
+      document.documentElement.classList.add(
+        `text-size-${params.default_text_size}`
+      );
+    }
+
     let logo;
 
     if (this.site.mobileView) {
@@ -207,18 +214,18 @@ export default class SiteSettingChangeTracker extends Service {
         this.session.defaultColorSchemeIsDark ||
         this.session.darkModeAvailable
       ) {
-        logo = this.siteSettings.mobile_logo_dark;
+        logo = params.mobile_logo_dark;
       } else {
-        logo = this.siteSettings.mobile_logo;
+        logo = params.mobile_logo;
       }
     }
 
     if (!logo && this.session.defaultColorSchemeIsDark) {
-      logo = this.siteSettings.logo_dark;
+      logo = params.logo_dark;
     }
 
     if (!logo) {
-      logo = this.siteSettings.logo;
+      logo = params.logo;
     }
 
     // Force reload when switching from text logo to image logo and vice versa
@@ -227,7 +234,7 @@ export default class SiteSettingChangeTracker extends Service {
       (this.siteSettings.logo && !document.getElementById("site-logo"))
     ) {
       window.location.reload();
-    } else {
+    } else if (logo) {
       document.getElementById("site-logo").setAttribute("src", logo);
     }
   }

--- a/spec/system/admin_logo_and_fonts_spec.rb
+++ b/spec/system/admin_logo_and_fonts_spec.rb
@@ -225,16 +225,22 @@ describe "Admin Logo and Fonts Page", type: :system do
       logo_and_fonts_page.visit
       logo_and_fonts_page.fonts_form.select_font("base", "helvetica")
 
-      expect(logo_and_fonts_page.fonts_form).to have_no_font("heading", "Oswald")
+      expect(logo_and_fonts_page.fonts_form).to have_no_font("heading", "JetBrains Mono")
       logo_and_fonts_page.fonts_form.show_more_fonts("heading")
-      logo_and_fonts_page.fonts_form.select_font("heading", "oswald")
+      logo_and_fonts_page.fonts_form.select_font("heading", "jet-brains-mono")
 
       logo_and_fonts_page.fonts_form.submit
       expect(logo_and_fonts_page.fonts_form).to have_saved_successfully
 
+      expect(page.find("html")["style"]).to include(
+        "font-family: Helvetica; --heading-font-family: JetBrains Mono",
+      )
+
       logo_and_fonts_page.visit
       expect(logo_and_fonts_page.fonts_form.active_font("base")).to eq("Helvetica")
-      expect(logo_and_fonts_page.fonts_form.active_font("heading")).to eq("Oswald")
+
+      logo_and_fonts_page.visit
+      expect(logo_and_fonts_page.fonts_form.active_font("heading")).to eq("JetBrains Mono")
     end
 
     it "allows an admin to change default text size and does not update existing users preferences" do
@@ -251,6 +257,8 @@ describe "Admin Logo and Fonts Page", type: :system do
       modal.close
       expect(modal).to be_closed
       expect(logo_and_fonts_page.fonts_form).to have_saved_successfully
+
+      expect(page.find("html")["class"]).to include("text-size-larger")
 
       visit "/"
       expect(page).to have_css("html.text-size-normal")

--- a/spec/system/page_objects/components/admin_fonts_form.rb
+++ b/spec/system/page_objects/components/admin_fonts_form.rb
@@ -7,6 +7,9 @@ module PageObjects
         find(
           "[data-name='#{section}_font'] .admin-fonts-form__button-option.body-font-#{font}",
         ).click
+        page.has_css?(
+          "[data-name='#{section}_font'] .admin-fonts-form__button-option.body-font-#{font}.active",
+        )
       end
 
       def select_default_text_size(size)


### PR DESCRIPTION
It takes a moment to sync site settings. Therefore, it is better to pass new values to  `refreshPage` function.

Also, it was not working for some fonts like `JetBrains Mono`. SiteSetting key is `jet_brains_mono` but font family value should be `JetBrains Mono`.