### PR TITLE
UX: keep the whisper editor font/color style consistent between editors

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -99,9 +99,12 @@
   overflow: auto;
 }
 
-.composing-whisper .d-editor-preview {
-  font-style: italic;
-  color: var(--primary-medium) !important;
+.composing-whisper {
+  .d-editor-preview,
+  .d-editor-input {
+    font-style: italic;
+    color: var(--primary-medium) !important;
+  }
 }
 
 .hide-preview .d-editor-preview-wrapper {

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -130,11 +130,6 @@
     padding-top: 0.2rem;
   }
 
-  .composing-whisper & {
-    font-style: italic;
-    color: var(--primary-medium);
-  }
-
   .onebox-wrapper {
     white-space: normal;
   }


### PR DESCRIPTION
Adds the whisper styling to the Markdown editor as well, keeping it consistent with the preview and the rich editor.