### PR TITLE
FIX: Add helpers for title and content for `application.html.erb` and `crawler.html.erb`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -270,7 +270,7 @@ module ApplicationHelper
     (request ? I18n.locale.to_s : SiteSetting.default_locale).sub("_", "-")
   end
 
-  def crawlable_title_content
+  def title_content
     DiscoursePluginRegistry.apply_modifier(
       :meta_data_content,
       content_for(:title) || SiteSetting.title,
@@ -279,7 +279,7 @@ module ApplicationHelper
     )
   end
 
-  def crawlable_description_content
+  def description_content
     DiscoursePluginRegistry.apply_modifier(
       :meta_data_content,
       @description_meta || SiteSetting.site_description,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html lang="<%= html_lang %>" class="<%= html_classes %>">
   <head>
     <meta charset="utf-8">
-    <title><%= content_for?(:title) ? yield(:title) : SiteSetting.title %></title>
-    <meta name="description" content="<%= @description_meta || SiteSetting.site_description %>">
+    <title><%= title_content %></title>
+    <meta name="description" content="<%= description_content %>">
     <meta name="discourse_theme_id" content="<%= theme_id %>">
     <meta name="discourse_current_homepage" content="<%= current_homepage %>">
 

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -2,8 +2,8 @@
 <html lang="<%= html_lang %>">
   <head>
     <meta charset="utf-8">
-    <title><%= crawlable_title_content %></title>
-    <meta name="description" content="<%= crawlable_description_content %>">
+    <title><%= title_content %></title>
+    <meta name="description" content="<%= description_content %>">
     <%= render partial: "layouts/head" %>
     <%= render partial: "common/discourse_stylesheet" %>
     <%= theme_lookup("head_tag") %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -745,10 +745,10 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe "#crawlable_title_content" do
+  describe "#title_content" do
     it "returns the correct title" do
       SiteSetting.title = "Test Title"
-      result = helper.crawlable_title_content
+      result = helper.title_content
 
       expect(result).to include("Test Title")
     end
@@ -757,16 +757,16 @@ RSpec.describe ApplicationHelper do
       helper.stubs(:content_for?).with(:title).returns(true)
       helper.stubs(:content_for).with(:title).returns("Custom Title")
 
-      result = helper.crawlable_title_content
+      result = helper.title_content
 
       expect(result).to include("Custom Title")
     end
   end
 
-  describe "#crawlable_description_content" do
+  describe "#description_content" do
     it "returns the correct description" do
       SiteSetting.site_description = "Test Description"
-      result = helper.crawlable_description_content
+      result = helper.description_content
 
       expect(result).to include("Test Description")
     end
@@ -774,7 +774,7 @@ RSpec.describe ApplicationHelper do
     it "accepts a content argument" do
       @description_meta = "Custom Description"
 
-      result = helper.crawlable_description_content
+      result = helper.description_content
 
       expect(result).to include("Custom Description")
     end
@@ -810,7 +810,7 @@ RSpec.describe ApplicationHelper do
     it "modifies the title tag" do
       plugin.register_modifier(:meta_data_content, &block)
 
-      title = helper.crawlable_title_content
+      title = helper.title_content
 
       expect(title).to include("BIG TITLE")
     end
@@ -818,7 +818,7 @@ RSpec.describe ApplicationHelper do
     it "modifies the description tag" do
       plugin.register_modifier(:meta_data_content, &block)
 
-      description = helper.crawlable_description_content
+      description = helper.description_content
 
       expect(description).to include(" - modified by plugin")
     end


### PR DESCRIPTION


Previously, there was only those helpers in `crawler.html.erb` as we added it in https://github.com/discourse/discourse/pull/32259

However, to keep it consistent, we need to add it in `application.html.erb` as well.