### PR TITLE
FIX: remove newline from rich editor's pasted img title/alt

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -35,8 +35,8 @@ const extension = {
           getAttrs(dom) {
             return {
               src: dom.getAttribute("src"),
-              title: dom.getAttribute("title"),
-              alt: dom.getAttribute("alt"),
+              title: dom.getAttribute("title")?.replace(/\n/g, " "),
+              alt: dom.getAttribute("alt")?.replace(/\n/g, " "),
               width: dom.getAttribute("width"),
               height: dom.getAttribute("height"),
               originalSrc:

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -570,6 +570,27 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(composer).to have_value("not selected **[bold](www.example.com)** not selected")
     end
+
+    it "removes newlines from alt/title in pasted image" do
+      cdp.allow_clipboard
+      open_composer_and_toggle_rich_editor
+
+      cdp.copy_paste(<<~HTML, html: true)
+          <img src="https://example.com/image.png" alt="alt
+          with new
+          lines" title="title
+          with new
+          lines">
+        HTML
+
+      expect(page).to have_css("img[alt='alt with new lines'][title='title with new lines']")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value(
+        '![alt with new lines](https://example.com/image.png "title with new lines")',
+      )
+    end
   end
 
   describe "trailing paragraph" do


### PR DESCRIPTION
New lines on `alt`/`title` embedded media are not allowed, causing an invalid serialized Markdown which is not supposed to contain new lines for these attributes.

This PR removes them during HTML parsing – we are not creating this new line scenario otherwise.