### PR TITLE
UX: keep content on rich editor footnote inputrule

### DIFF
--- a/plugins/footnote/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/footnote/assets/javascripts/lib/rich-editor-extension.js
@@ -235,10 +235,10 @@ const extension = {
     {
       match: /\^\[(.*?)]$/,
       handler: (state, match, start, end) => {
-        const footnote = state.schema.nodes.footnote.create(
-          null,
-          state.schema.nodes.paragraph.create(null, state.schema.text(match[1]))
-        );
+        const content = state.doc.slice(start + 2, end).content;
+        const paragraph = state.schema.nodes.paragraph.create(null, content);
+        const footnote = state.schema.nodes.footnote.create(null, paragraph);
+
         return state.tr.replaceWith(start, end, footnote);
       },
     },


### PR DESCRIPTION
Instead of using the matched string, this PR uses the actual sliced content from the ProseMirror document range as the content when creating the footnote node.