### PR TITLE
FIX: Wizard logo step JS error

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/image-previews/logo.js
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/image-previews/logo.js
@@ -45,6 +45,6 @@ export default class Logo extends PreviewBaseComponent {
       imageHeight
     );
 
-    this.drawPills(colors, font, height / 2);
+    this.drawPills(colors, font, height / 2, { homepageStyle: "hot" });
   }
 }


### PR DESCRIPTION
### What is the problem?

`PreviewBase#drawPills` expects a `homepageStyle` option, but on the logo wizard page we weren't passing any.

<img width="316" alt="Screenshot 2025-04-15 at 10 36 29 AM" src="https://github.com/user-attachments/assets/6c64678f-f621-4793-9064-0681498e474e" />

### How does this fix it?

Pass one of the possible values. I chose `hot` (because why not?)

### Screenshots

**Before:**

_Note how the navigation isn't rendered._

<img width="249" alt="Screenshot 2025-04-15 at 10 36 17 AM" src="https://github.com/user-attachments/assets/4d3d80fa-1ce6-437d-9097-13f7b5ed63ae" />

**After:**

<img width="253" alt="Screenshot 2025-04-15 at 10 36 04 AM" src="https://github.com/user-attachments/assets/7a50b390-c649-43d4-a94c-903fde0d277f" />
