### PR TITLE
PERF: Prevent N+1 queries when loading theme/component descriptions

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -87,14 +87,21 @@ class Theme < ActiveRecord::Base
             :child_themes,
             :theme_settings,
             :settings_field,
-            :locale_fields,
             :color_scheme,
-            :theme_translation_overrides,
             theme_fields: %i[upload theme_settings_migration],
           )
         end
 
-  scope :include_basic_relations, -> { includes(:parent_themes, :remote_theme, :user) }
+  scope :include_basic_relations,
+        -> do
+          includes(
+            :remote_theme,
+            :user,
+            :locale_fields,
+            :theme_translation_overrides,
+            parent_themes: %i[locale_fields theme_translation_overrides],
+          )
+        end
 
   delegate :remote_url, to: :remote_theme, private: true, allow_nil: true
 


### PR DESCRIPTION
Theme/component description is fetched via the `locale_fields` and `theme_translation_overrides` associations on the `Theme` model. We're currently not preloading these associations when serializing themes/components, which causes an N+1 performance issue when accessing the themes/components listing pages.