### PR TITLE
UX: header search mobile support - follow up

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -116,6 +116,7 @@ export default class GlimmerHeader extends Component {
   handleAnimationComplete() {
     this.hasClosingAnimation = false;
     this.search.visible = false;
+    this.toggleBodyScrolling(false);
   }
 
   @action
@@ -172,6 +173,7 @@ export default class GlimmerHeader extends Component {
       this.hasClosingAnimation = true;
     } else {
       this.search.visible = !this.search.visible;
+      this.toggleBodyScrolling(true);
     }
 
     if (!this.search.visible) {

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -170,6 +170,7 @@ export default class GlimmerHeader extends Component {
     }
 
     if (this.site.mobileView && this.search.visible) {
+      // hide is delayed for the duration of `search-slide-out` animation
       this.hasClosingAnimation = true;
     } else {
       this.search.visible = !this.search.visible;

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -472,7 +472,7 @@ export default class SearchMenu extends Component {
             @action={{this.cancelMobileSearch}}
             @translatedLabel={{i18n "cancel_value"}}
             class="btn-flat btn-cancel-mobile-search"
-            data-test-button="cancel-search-mobile"
+            data-test-button="cancel-mobile-search"
           />
         {{/if}}
       </div>

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -188,9 +188,7 @@ export default class SearchMenu extends Component {
   }
 
   @bind
-  clearSearch(e) {
-    e.stopPropagation();
-    e.preventDefault();
+  clearSearch() {
     this.search.activeGlobalSearchTerm = "";
     this.search.focusSearchInput();
     this.triggerSearch();

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -471,7 +471,7 @@ export default class SearchMenu extends Component {
           <DButton
             @action={{this.cancelMobileSearch}}
             @translatedLabel={{i18n "cancel_value"}}
-            class="btn-flat"
+            class="btn-flat btn-cancel-mobile-search"
             data-test-button="cancel-search-mobile"
           />
         {{/if}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/advanced-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/advanced-button.gjs
@@ -3,7 +3,7 @@ import { i18n } from "discourse-i18n";
 
 <template>
   <DButton
-    class="show-advanced-search btn-transparent"
+    class="btn-transparent show-advanced-search"
     data-test-button="show-advanced-search"
     title={{i18n "search.open_advanced"}}
     @action={{@openAdvancedSearch}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/clear-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/clear-button.gjs
@@ -1,16 +1,13 @@
-import { on } from "@ember/modifier";
-import icon from "discourse/helpers/d-icon";
+import DButton from "discourse/components/d-button";
 import { i18n } from "discourse-i18n";
 
 <template>
-  <a
-    class="clear-search"
-    data-test-anchor="clear-search-input"
+  <DButton
+    class="btn-transparent clear-search"
+    data-test-button="clear-search-input"
     aria-label="clear_input"
     title={{i18n "search.clear_search"}}
-    href
-    {{on "click" @clearSearch}}
-  >
-    {{icon "xmark"}}
-  </a>
+    @action={{@clearSearch}}
+    @icon="xmark"
+  />
 </template>

--- a/app/assets/javascripts/discourse/app/modifiers/delayed-destroy.js
+++ b/app/assets/javascripts/discourse/app/modifiers/delayed-destroy.js
@@ -15,7 +15,7 @@ export default modifier(
   (
     element,
     posArgs,
-    { animate = false, onComplete = () => {}, elementSelector, delay = 300 }
+    { animate = false, onComplete = () => {}, elementSelector, delay = 200 }
   ) => {
     if (animate) {
       const targetEl = elementSelector

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -64,7 +64,7 @@ acceptance("Search - Mobile", function (needs) {
     test("with empty input search", async function (assert) {
       await visit("/");
       await click("#search-button");
-      await click('[data-test-button="cancel-search-mobile"]');
+      await click('[data-test-button="cancel-mobile-search"]');
 
       assert
         .dom('[data-test-selector="menu-panel"]')
@@ -82,7 +82,7 @@ acceptance("Search - Mobile", function (needs) {
         "search results are listed on search value present"
       );
 
-      await click('[data-test-button="cancel-search-mobile"]');
+      await click('[data-test-button="cancel-mobile-search"]');
       await click("#search-button");
 
       assert.dom('[data-test-input="search-term"]').hasNoValue();

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -52,7 +52,7 @@ acceptance("Search - Mobile", function (needs) {
         "search results are listed on search value present"
       );
 
-      await click('[data-test-anchor="clear-search-input"]');
+      await click('[data-test-button="clear-search-input"]');
 
       assert
         .dom('[data-test-selector="search-menu-results"]')

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -243,11 +243,11 @@
       width: 100vw;
       max-width: 100vw;
       padding: 0.5rem 0.5rem 0;
-      transform-origin: 68%;
+      transform-origin: 66%;
+      transition: height 0.2s ease-in;
 
       &.empty-panel {
-        height: auto;
-        padding-bottom: 0.5rem;
+        height: 4rem;
       }
 
       &.slide-in {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -242,6 +242,7 @@
     &.search-menu-panel {
       width: 100vw;
       max-width: 100vw;
+      padding: 0.75rem;
       transform-origin: 68%;
 
       &.empty-panel {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -274,6 +274,10 @@
           transform: scaleX(0);
         }
       }
+
+      .btn-cancel-mobile-search {
+        padding: 1rem 0.625rem;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -247,6 +247,7 @@
 
       &.empty-panel {
         height: auto;
+        min-height: 3.66em; // must be equal to `.d-header` height
       }
 
       &.slide-in {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -242,7 +242,7 @@
     &.search-menu-panel {
       width: 100vw;
       max-width: 100vw;
-      padding: 0.75rem;
+      padding: 0.5rem 0.5rem 0;
       transform-origin: 68%;
 
       &.empty-panel {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -242,34 +242,36 @@
     &.search-menu-panel {
       width: 100vw;
       max-width: 100vw;
+      transform-origin: 68%;
 
       &.empty-panel {
         height: auto;
       }
 
       &.slide-in {
-        animation: search-slidein 0.3s ease-out forwards;
+        animation: search-slide-in 0.2s ease-out forwards;
       }
 
       &.is-destroying {
-        animation: search-slideout 0.3s ease-in forwards;
+        animation: search-slide-out 0.2s ease-in forwards;
       }
 
-      @keyframes search-slidein {
+      @keyframes search-slide-in {
         from {
           opacity: 0;
-          transform: translateY(-100%);
+          transform: scaleX(0);
         }
       }
 
-      @keyframes search-slideout {
-        80% {
+      @keyframes search-slide-out {
+        from {
+          transform: scaleX(1);
           opacity: 1;
         }
 
-        100% {
+        to {
           opacity: 0;
-          transform: translateY(-100%);
+          transform: scaleX(0);
         }
       }
     }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -247,7 +247,7 @@
 
       &.empty-panel {
         height: auto;
-        min-height: 3.66em; // must be equal to `.d-header` height
+        padding-bottom: 0.5rem;
       }
 
       &.slide-in {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -423,18 +423,14 @@ $search-pad-horizontal: 0.5em;
     align-items: center;
 
     .spinner {
-      width: 12px;
-      height: 12px;
-      border-width: 2px;
-      margin: 0 0.5em 0.25em 0;
-      margin-top: 2px;
+      width: 0.75rem; // 12px
+      height: 0.75rem; // 12px
+      border-width: 0.125rem; // 2px
+      margin: 0 $hpad 0 0;
     }
 
     .show-advanced-search,
-    a.clear-search {
-      display: inline-block;
-      background-color: transparent;
-
+    .clear-search {
       .d-icon {
         color: var(--primary-medium);
       }
@@ -447,8 +443,12 @@ $search-pad-horizontal: 0.5em;
       }
     }
 
-    a.clear-search {
-      margin-right: 3px;
+    .clear-search {
+      padding-right: 0.25rem; // 4px
+    }
+
+    .show-advanced-search {
+      padding-left: 0.375rem; // 6px
     }
   }
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -35,7 +35,7 @@ $search-pad-horizontal: 0.5em;
       width: calc(100dvw - calc(var(--search-input-wrapper-padding) * 2));
       padding-bottom: var(--search-input-wrapper-padding);
       background-color: var(--secondary);
-      z-index: 1;
+      z-index: z("base");
     }
   }
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -25,6 +25,18 @@ $search-pad-horizontal: 0.5em;
     align-items: center;
     justify-content: space-between;
     gap: 0.25rem;
+
+    @include breakpoint("mobile-extra-large") {
+      --search-input-wrapper-padding: 0.5rem;
+      position: fixed;
+      left: var(--search-input-wrapper-padding);
+      right: var(--search-input-wrapper-padding);
+      top: var(--search-input-wrapper-padding);
+      width: calc(100dvw - calc(var(--search-input-wrapper-padding) * 2));
+      padding-bottom: var(--search-input-wrapper-padding);
+      background-color: var(--secondary);
+      z-index: 1;
+    }
   }
 
   .search-input {
@@ -112,6 +124,13 @@ $search-pad-horizontal: 0.5em;
 
     &.with-search-term {
       padding-top: $search-pad-vertical;
+    }
+
+    @include breakpoint("mobile-extra-large") {
+      &,
+      &.with-search-term {
+        padding-top: 3rem;
+      }
     }
 
     .list {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -24,6 +24,7 @@ $search-pad-horizontal: 0.5em;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 0.25rem;
   }
 
   .search-input {

--- a/app/assets/stylesheets/desktop/components/header-search.scss
+++ b/app/assets/stylesheets/desktop/components/header-search.scss
@@ -72,7 +72,7 @@
             justify-content: flex-end;
 
             .show-advanced-search,
-            a.clear-search {
+            .clear-search {
               display: inline-flex;
               align-items: center;
             }


### PR DESCRIPTION
Follows up [my initial PR](https://github.com/discourse/discourse/pull/31711) on mobile search in header improvements.

### Changes made

#### Styling
1. added `4px` spacing between search input and cancel button
2. increased cancel button size (with padding) to match input height
3. decreased search panel padding by 1/2 from 16px to 8px
4. animation show/hide changed (from vertical to horizontal) and made it quicker (300ms->200ms)
5. set html unscrollable when search panel is open

#### Dev
1. changed `data-test-` value to be consistent with other element's attrs values
2. clear search action tag changed from `<a>` to `<DButton>`