### PR TITLE
FIX: ensure old email set correctly when updating email

### DIFF
--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -37,6 +37,8 @@ class EmailUpdater
       if secondary_emails_count >= SiteSetting.max_allowed_secondary_emails
         errors.add(:base, I18n.t("change_email.max_secondary_emails_error"))
       end
+      # else
+      #   old_email = @user.email
     end
 
     return if errors.present? || existing_user.present?
@@ -54,6 +56,11 @@ class EmailUpdater
         new_email: email,
       )
 
+    # if @change_req.new_record?
+    #   @change_req.requested_by = @guardian.user
+    #   @change_req.old_email = old_email
+    #   @change_req.new_email = email
+    # end
     @change_req.old_email = nil if add
     @change_req.requested_by = @guardian.user if @change_req.new_record?
 
@@ -94,6 +101,7 @@ class EmailUpdater
 
       email_token.update!(confirmed: true)
 
+      puts "Confirm for email_token.id: #{email_token.id}"
       @user = email_token.user
       @change_req =
         @user

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -37,8 +37,6 @@ class EmailUpdater
       if secondary_emails_count >= SiteSetting.max_allowed_secondary_emails
         errors.add(:base, I18n.t("change_email.max_secondary_emails_error"))
       end
-    else
-      old_email = @user.email
     end
 
     return if errors.present? || existing_user.present?
@@ -49,13 +47,15 @@ class EmailUpdater
       UserHistory.create!(action: UserHistory.actions[:add_email], acting_user_id: @user.id)
     end
 
-    @change_req = EmailChangeRequest.find_or_initialize_by(user_id: @user.id, new_email: email)
+    @change_req =
+      EmailChangeRequest.find_or_initialize_by(
+        user_id: @user.id,
+        old_email: @user.email,
+        new_email: email,
+      )
 
-    if @change_req.new_record?
-      @change_req.requested_by = @guardian.user
-      @change_req.old_email = old_email
-      @change_req.new_email = email
-    end
+    @change_req.old_email = nil if add
+    @change_req.requested_by = @guardian.user if @change_req.new_record?
 
     if @change_req.change_state.blank? ||
          @change_req.change_state == EmailChangeRequest.states[:complete]

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -37,8 +37,6 @@ class EmailUpdater
       if secondary_emails_count >= SiteSetting.max_allowed_secondary_emails
         errors.add(:base, I18n.t("change_email.max_secondary_emails_error"))
       end
-      # else
-      #   old_email = @user.email
     end
 
     return if errors.present? || existing_user.present?
@@ -56,11 +54,6 @@ class EmailUpdater
         new_email: email,
       )
 
-    # if @change_req.new_record?
-    #   @change_req.requested_by = @guardian.user
-    #   @change_req.old_email = old_email
-    #   @change_req.new_email = email
-    # end
     @change_req.old_email = nil if add
     @change_req.requested_by = @guardian.user if @change_req.new_record?
 

--- a/spec/lib/email_updater_spec.rb
+++ b/spec/lib/email_updater_spec.rb
@@ -438,26 +438,32 @@ RSpec.describe EmailUpdater do
   end
 
   context "when changing back to original email" do
-    let(:plus_email) { "new.email+123@example.com" }
+    let(:plus_email_1) { "new.email+11@example.com" }
+    let(:plus_email_2) { "new.email+22@example.com" }
     let(:user) { Fabricate(:user, email: old_email) }
     let(:updater) { EmailUpdater.new(guardian: user.guardian, user: user) }
 
     before do
       SiteSetting.normalize_emails = false
       SiteSetting.require_change_email_confirmation = true
-
-      updater.change_to(new_email)
-      updater.confirm(updater.change_req.old_email_token&.token)
-      updater.change_to(plus_email)
-      updater.confirm(updater.change_req.old_email_token&.token)
-      updater.change_to(old_email)
     end
 
     it "shows correct old email" do
-      expect(updater.change_req.old_email).to eq(plus_email)
-      expect(updater.change_req.new_email).to eq(old_email)
-      expect(updater.change_req.change_state).to eq(EmailChangeRequest.states[:authorizing_new])
-      expect(updater.change_req.old_email_token).to be_blank
+      updater.change_to(plus_email_1)
+      updater.confirm(updater.change_req.old_email_token&.token)
+      updater.confirm(updater.change_req.new_email_token&.token)
+
+      updater.change_to(old_email)
+      updater.confirm(updater.change_req.old_email_token&.token)
+      updater.confirm(updater.change_req.new_email_token&.token)
+
+      updater.change_to(plus_email_2)
+      updater.confirm(updater.change_req.old_email_token&.token)
+      updater.confirm(updater.change_req.new_email_token&.token)
+
+      updater.change_to(old_email)
+      expect(updater.change_req.old_email).to eq(plus_email_2)
+      expect(updater.change_req.old_email_token.email).to eq(plus_email_2)
     end
   end
 end


### PR DESCRIPTION
Previously when changing back to the same email (ie. change to new email, then change back again) we can easily end up showing the incorrect old email.  Passing the incorrect old email causes an error as it can't be found:

```
@user.user_emails.find_by(email: old_email).update!(email: new_email)
```

This is because we only searched for a combination of `user_id` and `new_email` which can load an older change from the database. By using the current email address when finding / initializing the `EmailChangeRequest` we can prevent this issue as we will be creating a new entry rather than loading an outdated one.