### PR TITLE
PERF: Reuse existing core JS build where possible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Ember Build
         run: script/assemble_ember_build.rb
 
-      - name: status
-        run: git status
-
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
@@ -274,10 +271,6 @@ jobs:
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
         run: bin/rake plugin:turbo_spec['*','--verbose --format=documentation --use-runtime-info --profile=50']
-
-
-      - name: status
-        run: git status
 
       - name: Fetch ember build cache
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,44 +26,12 @@ permissions:
   contents: read
 
 jobs:
-  precompile_assets:
-    if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
-    name: "Precompile Assets"
-    runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
-    container: discourse/discourse_test:release
-    timeout-minutes: 20
-    env: 
-      EMBER_ENV: development
-      CHEAP_SOURCE_MAPS: "1"
-
-    steps:
-      - name: Set working directory owner
-        run: chown root:root .
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
-
-      - name: Setup ember build cache
-        uses: actions/cache@v4
-        id: ember-build-cache
-        with:
-          path: app/assets/javascripts/discourse/dist
-          key: ember-build-${{ github.run_id }}
-
-      - name: Ember Build
-        run: script/assemble_ember_build.rb
-
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
     container: discourse/discourse_test:release
     timeout-minutes: 20
-    needs: precompile_assets
 
     env:
       RAILS_ENV: test
@@ -77,7 +45,6 @@ jobs:
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
-      EMBER_ENV: development
 
     strategy:
       fail-fast: false
@@ -272,31 +239,19 @@ jobs:
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
         run: bin/rake plugin:turbo_spec['*','--verbose --format=documentation --use-runtime-info --profile=50']
 
-      - name: Fetch ember build cache
-        uses: actions/cache@v4
-        id: ember-build-cache
-        if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
-        with:
-          path: app/assets/javascripts/discourse/dist
-          key: ember-build-${{ github.run_id }}
-
-      - name: Ember Build
-        if: matrix.build_type == 'asset_precompile' || matrix.build_type == 'system' || matrix.build_type == 'frontend'
-        run: script/assemble_ember_build.rb
-
       - name: Core QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'core'
-        run: QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_BUILD=0 bin/rake qunit:test
+        run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake qunit:test
         timeout-minutes: 30
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
-        run: QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_BUILD=0 bin/rake plugin:qunit['*']
+        run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake plugin:qunit['*']
         timeout-minutes: 30
 
       - name: Theme QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'themes'
-        run: DISCOURSE_DEV_DB=discourse_test QUNIT_BUILD=0 bin/rake themes:qunit_all_official
+        run: DISCOURSE_DEV_DB=discourse_test bin/rake themes:qunit_all_official
         timeout-minutes: 10
 
       - uses: actions/upload-artifact@v4
@@ -304,6 +259,10 @@ jobs:
         with:
           name: ember-exam-execution-${{ matrix.target }}-${{ matrix.browser }}-frontend-${{ hashFiles('./app/assets/javascripts/discourse/test-execution-*.json') }}
           path: ./app/assets/javascripts/discourse/test-execution-*.json
+
+      - name: Ember Build for System Tests
+        if: matrix.build_type == 'system'
+        run: bin/ember-cli --build
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Ember Build
         run: script/assemble_ember_build.rb
 
+      - name: status
+        run: git status
+
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
@@ -271,6 +274,10 @@ jobs:
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
         run: bin/rake plugin:turbo_spec['*','--verbose --format=documentation --use-runtime-info --profile=50']
+
+
+      - name: status
+        run: git status
 
       - name: Fetch ember build cache
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
+      EMBER_ENV: development
 
     strategy:
       fail-fast: false
@@ -262,7 +263,7 @@ jobs:
 
       - name: Ember Build for System Tests
         if: matrix.build_type == 'system'
-        run: bin/ember-cli --build
+        run: script/assemble_ember_build.rb
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,44 @@ permissions:
   contents: read
 
 jobs:
+  precompile_assets:
+    if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
+    name: "Precompile Assets"
+    runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
+    container: discourse/discourse_test:release
+    timeout-minutes: 20
+    env: 
+      EMBER_ENV: development
+      CHEAP_SOURCE_MAPS: "1"
+
+    steps:
+      - name: Set working directory owner
+        run: chown root:root .
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup ember build cache
+        uses: actions/cache@v4
+        id: ember-build-cache
+        with:
+          path: app/assets/javascripts/discourse/dist
+          key: ember-build-${{ github.run_id }}
+
+      - name: Ember Build
+        run: script/assemble_ember_build.rb
+
   build:
     if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
     container: discourse/discourse_test:release
     timeout-minutes: 20
+    needs: precompile_assets
 
     env:
       RAILS_ENV: test
@@ -45,6 +77,7 @@ jobs:
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
       TESTEM_BROWSER: ${{ (startsWith(matrix.browser, 'Firefox') && 'Firefox') || matrix.browser }}
       TESTEM_FIREFOX_PATH: ${{ (matrix.browser == 'Firefox Evergreen') && '/opt/firefox-evergreen/firefox' }}
+      EMBER_ENV: development
 
     strategy:
       fail-fast: false
@@ -239,19 +272,31 @@ jobs:
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
         run: bin/rake plugin:turbo_spec['*','--verbose --format=documentation --use-runtime-info --profile=50']
 
+      - name: Fetch ember build cache
+        uses: actions/cache@v4
+        id: ember-build-cache
+        if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
+        with:
+          path: app/assets/javascripts/discourse/dist
+          key: ember-build-${{ github.run_id }}
+
+      - name: Ember Build
+        if: matrix.build_type == 'asset_precompile' || matrix.build_type == 'system' || matrix.build_type == 'frontend'
+        run: script/assemble_ember_build.rb
+
       - name: Core QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'core'
-        run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake qunit:test
+        run: QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_BUILD=0 bin/rake qunit:test
         timeout-minutes: 30
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
-        run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake plugin:qunit['*']
+        run: QUNIT_WRITE_EXECUTION_FILE=1 QUNIT_BUILD=0 bin/rake plugin:qunit['*']
         timeout-minutes: 30
 
       - name: Theme QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'themes'
-        run: DISCOURSE_DEV_DB=discourse_test bin/rake themes:qunit_all_official
+        run: DISCOURSE_DEV_DB=discourse_test QUNIT_BUILD=0 bin/rake themes:qunit_all_official
         timeout-minutes: 10
 
       - uses: actions/upload-artifact@v4
@@ -259,10 +304,6 @@ jobs:
         with:
           name: ember-exam-execution-${{ matrix.target }}-${{ matrix.browser }}-frontend-${{ hashFiles('./app/assets/javascripts/discourse/test-execution-*.json') }}
           path: ./app/assets/javascripts/discourse/test-execution-*.json
-
-      - name: Ember Build for System Tests
-        if: matrix.build_type == 'system'
-        run: bin/ember-cli --build
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@
 
 /spec/fixtures/plugins/my_plugin/auto_generated
 
-/vendor/bundle/*
+/vendor/bundle
 /vendor/data/GeoLite2-City.mmdb
 /vendor/data/GeoLite2-ASN.mmdb
 

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -89,6 +89,12 @@ module.exports = function (defaults) {
   const terserPlugin = app.project.findAddonByName("ember-cli-terser");
   const applyTerser = (tree) => terserPlugin.postprocessTree("all", tree);
 
+  const pluginTrees = applyTerser(discoursePluginsTree);
+
+  if (process.env.SKIP_CORE_BUILD) {
+    return pluginTrees;
+  }
+
   let extraPublicTrees = [
     parsePluginClientSettings(discourseRoot, vendorJs, app),
     funnel(`${discourseRoot}/public/javascripts`, { destDir: "javascripts" }),
@@ -99,7 +105,7 @@ module.exports = function (defaults) {
       })
     ),
     applyTerser(generateScriptsTree(app)),
-    applyTerser(discoursePluginsTree),
+    pluginTrees,
   ];
 
   const assetCachebuster = process.env["DISCOURSE_ASSET_URL_SALT"] || "";

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -107,16 +107,13 @@ task "qunit:test", %i[qunit_path filter] do |_, args|
     if qunit_path
       # Bypass `ember test` - it only works properly for the `/tests` path.
       # We have to trigger a `build` manually so that JS is available for rails to serve.
-
-      if ENV["QUNIT_BUILD"] != "0"
-        system(
-          "pnpm",
-          "ember",
-          "build",
-          chdir: "#{Rails.root}/app/assets/javascripts/discourse",
-          exception: true,
-        )
-      end
+      system(
+        "pnpm",
+        "ember",
+        "build",
+        chdir: "#{Rails.root}/app/assets/javascripts/discourse",
+        exception: true,
+      )
 
       env["THEME_TEST_PAGES"] = if ENV["THEME_IDS"]
         ENV["THEME_IDS"]
@@ -135,7 +132,6 @@ task "qunit:test", %i[qunit_path filter] do |_, args|
       cmd += ["--load-balance", "--parallel", parallel] if parallel
       cmd += ["--filter", filter] if filter
       cmd << "--write-execution-file" if ENV["QUNIT_WRITE_EXECUTION_FILE"]
-      cmd << "--path" << "dist" if ENV["QUNIT_BUILD"] == "0"
     end
 
     # Print out all env for debugging purposes

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -107,13 +107,16 @@ task "qunit:test", %i[qunit_path filter] do |_, args|
     if qunit_path
       # Bypass `ember test` - it only works properly for the `/tests` path.
       # We have to trigger a `build` manually so that JS is available for rails to serve.
-      system(
-        "pnpm",
-        "ember",
-        "build",
-        chdir: "#{Rails.root}/app/assets/javascripts/discourse",
-        exception: true,
-      )
+
+      if ENV["QUNIT_BUILD"] != "0"
+        system(
+          "pnpm",
+          "ember",
+          "build",
+          chdir: "#{Rails.root}/app/assets/javascripts/discourse",
+          exception: true,
+        )
+      end
 
       env["THEME_TEST_PAGES"] = if ENV["THEME_IDS"]
         ENV["THEME_IDS"]
@@ -132,6 +135,7 @@ task "qunit:test", %i[qunit_path filter] do |_, args|
       cmd += ["--load-balance", "--parallel", parallel] if parallel
       cmd += ["--filter", filter] if filter
       cmd << "--write-execution-file" if ENV["QUNIT_WRITE_EXECUTION_FILE"]
+      cmd << "--path" << "dist" if ENV["QUNIT_BUILD"] == "0"
     end
 
     # Print out all env for debugging purposes

--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -96,6 +96,7 @@ if existing_core_build_usable?
   ensure
     FileUtils.rm_rf("dist/_plugin_only_build")
   end
+  STDERR.puts "Plugin build successfully integrated into dist"
 else
   STDERR.puts "Running full core build..."
   system(build_env, *build_cmd, exception: true)

--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# rubocop:disable Discourse/NoChdir
+
+require "fileutils"
+require "tempfile"
+require "open3"
+require "json"
+
+BUILD_INFO_FILE = "dist/BUILD_INFO.json"
+
+Dir.chdir("#{__dir__}/../app/assets/javascripts/discourse")
+
+def capture(*args)
+  output, status = Open3.capture2(*args)
+  raise "Command failed: #{args.inspect}" if status != 0
+  output
+end
+
+# Returns a git tree-hash representing the current state of Discourse core.
+# If the working directory is clean, it will match the tree hash (note: different to the commit hash) of the HEAD commit.
+def core_tree_hash
+  Tempfile.create do |f|
+    f.close
+
+    git_dir = capture("git", "rev-parse", "--git-dir").strip
+    FileUtils.cp "#{git_dir}/index", f.path
+
+    env = { "GIT_INDEX_FILE" => f.path }
+    system(env, "git", "add", "-A", exception: true)
+    return capture(env, "git", "write-tree").strip
+  end
+end
+
+def node_heap_size_limit
+  capture("node", "-e", "console.log(v8.getHeapStatistics().heap_size_limit/1024/1024)").to_f
+end
+
+def low_memory_environment?
+  node_heap_size_limit < 2048
+end
+
+def resolved_ember_env
+  ENV["EMBER_ENV"] || "production"
+end
+
+def build_info
+  { "ember_env" => resolved_ember_env, "core_tree_hash" => core_tree_hash }
+end
+
+def existing_core_build_usable?
+  return false if !File.exist?(BUILD_INFO_FILE)
+  JSON.parse(File.read(BUILD_INFO_FILE)) == build_info
+end
+
+build_cmd = %w[pnpm ember build]
+build_env = { "CI" => "1" }
+
+if Etc.nprocessors > 2
+  # Anything more than 2 doesn't seem to improve build times
+  build_env["JOBS"] ||= "2"
+end
+
+if low_memory_environment?
+  STDERR.puts "Node.js heap_size_limit is less than 2048MB. Setting --max-old-space-size=2048 and CHEAP_SOURCE_MAPS=1"
+  build_env["NODE_OPTIONS"] = "--max_old_space_size=2048"
+  build_env["CHEAP_SOURCE_MAPS"] = "1"
+end
+
+build_cmd << "-prod" if resolved_ember_env == "production"
+
+if existing_core_build_usable?
+  STDERR.puts "Reusing existing core ember build. Only building plugins..."
+  build_env["SKIP_CORE_BUILD"] = "1"
+  build_cmd << "-o" << "dist/_plugin_only_build"
+  begin
+    system(build_env, *build_cmd, exception: true)
+    FileUtils.rm_rf("dist/assets/plugins")
+    FileUtils.mv("dist/_plugin_only_build/assets/plugins", "dist/assets/plugins")
+  ensure
+    FileUtils.rm_rf("dist/_plugin_only_build")
+  end
+else
+  STDERR.puts "Running full core build..."
+  system(build_env, *build_cmd, exception: true)
+  File.write(BUILD_INFO_FILE, JSON.pretty_generate(build_info))
+end

--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -49,8 +49,24 @@ def build_info
 end
 
 def existing_core_build_usable?
-  return false if !File.exist?(BUILD_INFO_FILE)
-  JSON.parse(File.read(BUILD_INFO_FILE)) == build_info
+  if !File.exist?(BUILD_INFO_FILE)
+    STDERR.puts "No existing build info file found."
+    return false
+  end
+
+  existing = JSON.parse(File.read(BUILD_INFO_FILE))
+  expected = build_info
+
+  if existing == expected
+    true
+  else
+    STDERR.puts <<~MSG
+      Existing build is not reusable.
+      - Existing: #{existing.inspect}
+      - Current: #{expected.inspect}
+    MSG
+    false
+  end
 end
 
 build_cmd = %w[pnpm ember build]


### PR DESCRIPTION
Building the Discourse JS app is very resource-intensive. This commit introduces an `assemble_ember_build` script which will check the existing content of the `dist/` directory and re-use the core build if possible. Plugins will always be rebuilt.

For now, this functionality is only useful for multi-stage (i.e. non-standard) Discourse deployments. But in future, this script may be extended to pull the contents of the `dist/` directory from a remote location.