### PR TITLE
DEV: Skip meta_data_content specs

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -790,6 +790,8 @@ RSpec.describe ApplicationHelper do
       end
     end
 
+    before { skip "State is leaking" }
+
     after { DiscoursePluginRegistry.unregister_modifier(plugin, :meta_data_content, &block) }
 
     it "allows the plugin to modify the meta tags" do


### PR DESCRIPTION
State seems to be leaking into other specs. Minimal repro:

```
bin/rspec --order defined spec/helpers/application_helper_spec.rb:783 spec/lib/wizard/wizard_builder_spec.rb:38
```

```
Failures:

  1) Wizard::Builder introduction should not prefill default site setting values
     Failure/Error: expect(description_field.value).to eq("")

       expected: ""
            got: " - modified by plugin"
```