### PR TITLE
FEATURE: Release admin search for all sites

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -22,15 +22,13 @@ export default class AdminRoute extends DiscourseRoute {
   }
 
   activate() {
-    if (this.currentUser.use_experimental_admin_search) {
-      KeyboardShortcuts.addShortcut(
-        `${PLATFORM_KEY_MODIFIER}+/`,
-        (event) => this.showAdminSearchModal(event),
-        {
-          global: true,
-        }
-      );
-    }
+    KeyboardShortcuts.addShortcut(
+      `${PLATFORM_KEY_MODIFIER}+/`,
+      (event) => this.showAdminSearchModal(event),
+      {
+        global: true,
+      }
+    );
 
     this.adminSidebarStateManager.maybeForceAdminSidebar({
       onlyIfAlreadyActive: false,
@@ -44,11 +42,9 @@ export default class AdminRoute extends DiscourseRoute {
   deactivate(transition) {
     this.controllerFor("application").set("showTop", true);
 
-    if (this.currentUser.use_experimental_admin_search) {
-      KeyboardShortcuts.unbind({
-        [`${PLATFORM_KEY_MODIFIER}+/`]: this.showAdminSearchModal,
-      });
-    }
+    KeyboardShortcuts.unbind({
+      [`${PLATFORM_KEY_MODIFIER}+/`]: this.showAdminSearchModal,
+    });
 
     if (!transition?.to.name.startsWith("admin")) {
       this.adminSidebarStateManager.stopForcingAdminSidebar();

--- a/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/keyboard-shortcuts-help.gjs
@@ -269,24 +269,22 @@ export default class KeyboardShortcutsHelp extends Component {
       },
     };
 
-    if (this.currentUser?.use_experimental_admin_search) {
-      shortcuts.admin = {
-        shortcuts: {
-          admin_search_open: buildShortcut("admin.search_open", {
-            keys1: [META, "/"],
-            keysDelimiter: PLUS,
-          }),
-          admin_search_prev_next: buildShortcut("admin.search_prev_next", {
-            keys1: ["&uarr;"],
-            keys2: ["&darr;"],
-            shortcutsDelimiter: "slash",
-          }),
-          admin_search_full_page: buildShortcut("admin.search_full_page", {
-            keys1: ["Enter"],
-          }),
-        },
-      };
-    }
+    shortcuts.admin = {
+      shortcuts: {
+        admin_search_open: buildShortcut("admin.search_open", {
+          keys1: [META, "/"],
+          keysDelimiter: PLUS,
+        }),
+        admin_search_prev_next: buildShortcut("admin.search_prev_next", {
+          keys1: ["&uarr;"],
+          keys2: ["&darr;"],
+          shortcutsDelimiter: "slash",
+        }),
+        admin_search_full_page: buildShortcut("admin.search_full_page", {
+          keys1: ["Enter"],
+        }),
+      },
+    };
 
     this._buildExtraShortcuts(shortcuts);
     this._addCountsToShortcutCategories(shortcuts);

--- a/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/filter.gjs
@@ -3,7 +3,6 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
-import { translateModKey } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 
 export default class Filter extends Component {
@@ -48,27 +47,8 @@ export default class Filter extends Component {
     document.querySelector(".sidebar-filter__input").focus();
   }
 
-  get showShortcutCombo() {
-    // Very specific to admin pages, but we don't hook this shortcut
-    // anywhere else, so it's not right to show it in other places.
-    if (!this.router.currentRouteName.startsWith("admin")) {
-      return false;
-    }
-    return (
-      !this.displayClearFilter &&
-      !this.currentUser?.use_experimental_admin_search
-    );
-  }
-
-  get sidebarShortcutCombo() {
-    return `${translateModKey("Meta")}+/`;
-  }
-
   get filterPlaceholder() {
-    if (
-      this.currentUser?.staff &&
-      this.currentUser?.use_experimental_admin_search
-    ) {
+    if (this.currentUser?.staff) {
       return i18n("sidebar.filter_links");
     }
     return i18n("sidebar.filter");
@@ -87,11 +67,6 @@ export default class Filter extends Component {
             enterkeyhint="done"
             class="sidebar-filter__input"
           />
-          {{#if this.showShortcutCombo}}
-            <span
-              class="sidebar-filter__shortcut-hint"
-            >{{this.sidebarShortcutCombo}}</span>
-          {{/if}}
 
           {{#if this.displayClearFilter}}
             <DButton

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -500,10 +500,6 @@ export default {
 
     if (filterInput) {
       this._scrollTo(0);
-
-      if (!this.currentUser.use_experimental_admin_search) {
-        filterInput.focus();
-      }
     }
   },
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -415,35 +415,15 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
   }
 
   filterNoResultsDescription(filter) {
-    const currentUser = getOwnerWithFallback(this).lookup(
-      "service:current-user"
-    );
-
     const escapedFilter = escapeExpression(filter);
 
-    const params = {
-      filter: escapedFilter,
-      settings_filter_url: getURL(
-        `/admin/site_settings/category/all_results?filter=${encodeURIComponent(
-          filter
-        )}`
-      ),
-      user_list_filter_url: getURL(
-        `/admin/users/list/active?username=${encodeURIComponent(filter)}`
-      ),
-    };
-
-    if (currentUser?.use_experimental_admin_search) {
-      return htmlSafe(
-        i18n("sidebar.no_results.description_admin_search", {
-          filter: escapedFilter,
-          admin_search_url: getURL(
-            `/admin/search?filter=${encodeURIComponent(filter)}`
-          ),
-        })
-      );
-    }
-
-    return htmlSafe(i18n("sidebar.no_results.description", params));
+    return htmlSafe(
+      i18n("sidebar.no_results.description_admin_search", {
+        filter: escapedFilter,
+        admin_search_url: getURL(
+          `/admin/search?filter=${encodeURIComponent(filter)}`
+        ),
+      })
+    );
   }
 }

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -72,7 +72,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :sidebar_category_ids,
              :sidebar_sections,
              :new_new_view_enabled?,
-             :use_experimental_admin_search,
              :can_view_raw_email,
              :login_method,
              :has_unseen_features,
@@ -132,10 +131,6 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def can_send_private_messages
     scope.can_send_private_messages?
-  end
-
-  def use_experimental_admin_search
-    object.staff? && object.in_any_groups?(SiteSetting.experimental_admin_search_enabled_groups_map)
   end
 
   def has_unseen_features

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5077,7 +5077,6 @@ en:
       clear_filter: "Clear filter"
       no_results:
         title: "No results"
-        description: 'We couldn’t find anything matching ‘%{filter}’.<br><br>Did you want to <a class="sidebar-additional-filter-settings" href="%{settings_filter_url}">search site settings</a> or the <a class="sidebar-additional-filter-users" href="%{user_list_filter_url}">admin user list?</a>'
         description_admin_search: 'We couldn’t find anything matching ‘%{filter}’.<br><br>Try <a class="sidebar-additional-filter-admin-search" href="%{admin_search_url}">searching the entire admin interface</a>.'
       footer:
         interface_color_selector:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2762,7 +2762,6 @@ en:
     experimental_form_templates: "Enable the form templates feature. Manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."
     experimental_auto_grid_images: "Automatically wraps images in [grid] tags when 3 or more images are uploaded in the composer."
-    experimental_admin_search_enabled_groups: "Enable the new admin search for users in these groups. This will enable the use of the keyboard shortcut to open the admin search, as well as visiting <a href='%{base_path}/admin/search'>the full page search</a>."
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     about_page_hidden_groups: "Do not show members of specific groups on the /about page."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3933,14 +3933,6 @@ experimental:
     allow_any: false
     refresh: true
     area: "group_permissions|navigation"
-  experimental_admin_search_enabled_groups:
-    client: true
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true
-    area: "group_permissions"
   glimmer_post_stream_mode_auto_groups:
     client: true
     type: group_list

--- a/db/migrate/20250416012407_remove_experimental_admin_search_enabled_groups_setting.rb
+++ b/db/migrate/20250416012407_remove_experimental_admin_search_enabled_groups_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveExperimentalAdminSearchEnabledGroupsSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'experimental_admin_search_enabled_groups'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-describe "Admin User Page", type: :system do
+describe "Admin Search", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:search_modal) { PageObjects::Modals::AdminSearch.new }
 
-  before do
-    SiteSetting.experimental_admin_search_enabled_groups = Group::AUTO_GROUPS[:admins]
-    sign_in(current_user)
-  end
+  before { sign_in(current_user) }
 
   def open_search_modal
     send_keys([SystemHelpers::PLATFORM_KEY_MODIFIER, "/"])

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -141,37 +141,11 @@ describe "Admin | Sidebar Navigation", type: :system do
 
     no_results_description = page.find(".sidebar-no-results__description")
     expect(no_results_description.text).to eq(
-      "We couldn’t find anything matching ‘ieeee’.\n\nDid you want to search site settings or the admin user list?",
-    )
-    expect(no_results_description).to have_link(
-      "search site settings",
-      href: "/admin/site_settings/category/all_results?filter=ieeee",
-    )
-    expect(no_results_description).to have_link(
-      "admin user list?",
-      href: "/admin/users/list/active?username=ieeee",
-    )
-  end
-
-  it "encodes the url param in the links when the filter has no results" do
-    visit("/admin")
-
-    unknown_filter = "blahblah"
-    filter.filter(unknown_filter)
-    expect(page).to have_no_css(".sidebar-section-link-content-text")
-    expect(page).to have_css(".sidebar-no-results")
-
-    no_results_description = page.find(".sidebar-no-results__description")
-    expect(no_results_description.text).to eq(
-      "We couldn’t find anything matching ‘#{unknown_filter}’.\n\nDid you want to search site settings or the admin user list?",
-    )
-    expect(no_results_description).to have_link(
-      "search site settings",
-      href: "/admin/site_settings/category/all_results?filter=#{unknown_filter}",
-    )
-    expect(no_results_description).to have_link(
-      "admin user list?",
-      href: "/admin/users/list/active?username=#{unknown_filter}",
+      I18n.t(
+        "js.sidebar.no_results.description_admin_search",
+        filter: "ieeee",
+        admin_search_url: "/admin/search",
+      ),
     )
   end
 
@@ -212,36 +186,6 @@ describe "Admin | Sidebar Navigation", type: :system do
         I18n.t("admin_js.admin.config.whats_new.title"),
       ],
     )
-  end
-
-  it "allows further filtering of site settings or users if links do not show results" do
-    user_1 = Fabricate(:user, username: "moltisanti", name: "Christopher Moltisanti")
-    user_2 = Fabricate(:user, username: "bevelaqua", name: "Matthew Bevelaqua")
-
-    visit("/admin")
-    filter.filter("user locale")
-    find(".sidebar-additional-filter-settings").click
-    expect(page).to have_current_path(
-      "/admin/site_settings/category/all_results?filter=user%20locale",
-    )
-    expect(page).to have_content(I18n.t("site_settings.allow_user_locale"))
-
-    filter.filter("log_search_queries")
-    find(".sidebar-additional-filter-settings").click
-    expect(page).to have_current_path(
-      "/admin/site_settings/category/all_results?filter=log_search_queries",
-    )
-    expect(page).to have_content(I18n.t("site_settings.log_search_queries"))
-
-    filter.filter("bevelaqua")
-    find(".sidebar-additional-filter-users").click
-    expect(page).to have_current_path("/admin/users/list/active?username=bevelaqua")
-    expect(find(".users-list-container")).to have_content("bevelaqua")
-
-    filter.filter("moltisanti")
-    find(".sidebar-additional-filter-users").click
-    expect(page).to have_current_path("/admin/users/list/active?username=moltisanti")
-    expect(find(".users-list-container")).to have_content("moltisanti")
   end
 
   it "allows sections to be expanded" do

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -141,11 +141,7 @@ describe "Admin | Sidebar Navigation", type: :system do
 
     no_results_description = page.find(".sidebar-no-results__description")
     expect(no_results_description.text).to eq(
-      I18n.t(
-        "js.sidebar.no_results.description_admin_search",
-        filter: "ieeee",
-        admin_search_url: "/admin/search",
-      ),
+      "We couldn’t find anything matching ‘ieeee’.\n\nTry searching the entire admin interface.",
     )
   end
 


### PR DESCRIPTION
This commit removes the experimental setting controlling
admin search and releases it for all admins. This search
can be triggered with Ctrl+/ or Cmd+/

For more information see https://meta.discourse.org/t/introducing-comprehensive-admin-search/360157
