### PR TITLE
FIX: remote_theme_spec run on local machine

### DIFF
--- a/spec/support/mock_git_importer.rb
+++ b/spec/support/mock_git_importer.rb
@@ -53,4 +53,27 @@ class MockGitImporter < ThemeStore::GitImporter
 
     Discourse::Utils.execute_command("git", "clone", path, @temp_folder)
   end
+
+  def version
+    Discourse::Utils.execute_command("git", "-C", @temp_folder, "rev-parse", "HEAD").strip
+  end
+
+  def commits_since(hash)
+    commit_hash, commits_behind = nil
+    commits_behind =
+      begin
+        Discourse::Utils.execute_command(
+          "git",
+          "-C",
+          @temp_folder,
+          "rev-list",
+          "#{hash}..HEAD",
+          "--count",
+        ).strip
+      rescue StandardError
+        -1
+      end
+
+    [version, commits_behind]
+  end
 end


### PR DESCRIPTION
Mock `version` and `commits_since` methods in `MockGitImporter`.

Error without fix

![Screenshot 2025-04-16 at 12 14 07 pm](https://github.com/user-attachments/assets/ef316d2b-c510-46c4-8da5-e8477f1f16f6)
