### PR TITLE
FIX: Set X-Robots-Tag header to prevent indexing of /safe-mode

### DIFF
--- a/app/controllers/safe_mode_controller.rb
+++ b/app/controllers/safe_mode_controller.rb
@@ -8,6 +8,7 @@ class SafeModeController < ApplicationController
   skip_before_action :preload_json, :check_xhr
 
   def index
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
   end
 
   def enter

--- a/spec/requests/safe_mode_controller_spec.rb
+++ b/spec/requests/safe_mode_controller_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe SafeModeController do
       expect(response.body).not_to include("My Custom Header")
       expect(response.body).not_to include("data-theme-id=\"#{theme.id}\"")
     end
+
+    it "sets the robots header" do
+      get "/safe-mode"
+      expect(response.headers["X-Robots-Tag"]).to eq("noindex, nofollow")
+    end
   end
 
   describe "enter" do


### PR DESCRIPTION
## ✨ What's This?

The `/safe-mode` route doesn't really need to be indexed by search engines. Notably, it results in meta's safe-mode page appearing before safe mode documentation in Google.

<img width="879" alt="" src="https://github.com/user-attachments/assets/c237c806-b4fd-4cbf-b2ea-d1a096577e00" />

This change adds the `X-Robots-Tag` header to the `/safe-mode` response, discouraging search engines from including the page in their index.
