### PR TITLE
DEV: Drop wasm type override in nginx config

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -1,7 +1,6 @@
 # Additional MIME types that you'd like nginx to handle go in here
 types {
   text/csv csv;
-  application/wasm wasm;
   font/ttf ttf;
   font/otf otf;
 }


### PR DESCRIPTION
This is already included in nginx's default set, and is currently causing this message to be printed:

> nginx: [warn] duplicate extension "wasm", content type: "application/wasm", previous content type: "application/wasm" in /etc/nginx/conf.d/discourse.conf:4