### PR TITLE
PERF: Enable brotli in NGINX

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -54,6 +54,12 @@ server {
   gzip_types application/json text/css text/javascript application/x-javascript application/javascript image/svg+xml application/wasm font/ttf font/otf;
   gzip_proxied any;
 
+  brotli on;
+  brotli_min_length 1000;
+  brotli_comp_level 4;
+  brotli_types application/json text/css text/javascript application/x-javascript application/javascript image/svg+xml application/wasm font/ttf font/otf;
+  brotli_proxied any;
+
   server_name _;
   server_tokens off;
 


### PR DESCRIPTION
This enables on-the-fly brotli compression at level 4 for all responses which we currently gzip. This level should provide slightly improved file sizes when compared to gzip, as well as slightly faster processing times. This is the [level which Cloudflare use](https://blog.cloudflare.com/results-experimenting-brotli/) for dynamic responses.