### PR TITLE
DEV: Resolve flaky test due to regexp match

### DIFF
--- a/spec/system/user_activity_posts_spec.rb
+++ b/spec/system/user_activity_posts_spec.rb
@@ -20,7 +20,7 @@ describe "User activity posts", type: :system do
 
     expect(page).to have_css(".stream-topic-title .title", count: 2)
 
-    title_element = find(".stream-topic-title .title a[href*='/#{topic1.id}']")
+    title_element = find(".stream-topic-title .title a[href*='/#{topic1.id}/']")
     expect(title_element).to have_text("Title with &amp; characters and emoji")
     expect(title_element).to have_css("img.emoji[title='wave']")
   end


### PR DESCRIPTION
The test being fixed in this commit was flaking with the following
error:

```
Capybara::Ambiguous:
  Ambiguous match, found 2 elements matching visible css ".stream-topic-title .title a[href*='/2']"
```

The regexp match on the `href` attribute has the potential to match
multiple elements if both urls contain the `/#{topic.id}` substring. For
example, both `/t/-/2/2` and `/t/-/1/2` will satisfy the regexp.
