### PR TITLE
FIX: Make the 'Keep Message Deleted' reviewable option work

### DIFF
--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -114,6 +114,10 @@ module Chat
       ignore { chat_message.trash!(performed_by) }
     end
 
+    def perform_agree_and_keep_deleted(performed_by, args)
+      agree
+    end
+
     private
 
     def agree

--- a/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat/reviewable_chat_message_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe Chat::ReviewableMessage, type: :model do
     expect(chat_message.reload.deleted_at).not_to be_present
   end
 
+  it "agree_and_keep_deleted agrees with the flag and keeps the message deleted" do
+    chat_message.trash!(user)
+    reviewable.perform(moderator, :agree_and_keep_deleted)
+    expect(reviewable).to be_approved
+    expect(chat_message.reload.deleted_at).to be_present
+  end
+
   it "agree_and_delete agrees with the flag and deletes the message" do
     chat_message_id = chat_message.id
     reviewable.perform(moderator, :agree_and_delete)


### PR DESCRIPTION
When a flagged chat message has already been deleted, we offer an option in the review queue to agree with the flag and keep the message deleted. However, this option is currently broken due to a missing implementation for the option.

Internal topic: t/152203.