### PR TITLE
DEV: Attempt at stabilizing components listing page system spec

### DIFF
--- a/spec/system/admin_customize_components_config_area_spec.rb
+++ b/spec/system/admin_customize_components_config_area_spec.rb
@@ -84,21 +84,21 @@ describe "Admin Customize Themes Config Area Page", type: :system do
       config_area.visit
 
       config_area.status_selector.select("used")
-      expect(config_area).to be_loading
+      config_area.wait_until_done_loading
       expect(config_area.components_shown).to contain_exactly(
         enabled_component.id,
         remote_component.id,
       )
 
       config_area.status_selector.select("unused")
-      expect(config_area).to be_loading
+      config_area.wait_until_done_loading
       expect(config_area.components_shown).to contain_exactly(
         disabled_component.id,
         remote_component_with_update.id,
       )
 
       config_area.status_selector.select("updates_available")
-      expect(config_area).to be_loading
+      config_area.wait_until_done_loading
       expect(config_area.components_shown).to contain_exactly(remote_component_with_update.id)
     end
 
@@ -107,7 +107,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
       config_area.name_filter_input.fill_in(with: "glo")
 
-      expect(config_area).to be_loading
+      config_area.wait_until_done_loading
       expect(config_area.components_shown).to contain_exactly(
         enabled_component.id,
         disabled_component.id,
@@ -341,7 +341,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
           page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
 
-          expect(config_area).to be_loading
+          config_area.wait_until_done_loading
           expect(config_area).to have_component(enabled_component.id)
 
           expect(config_area.components_shown.size).to eq(8)

--- a/spec/system/page_objects/pages/admin_customize_components_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_components_config_area.rb
@@ -119,8 +119,8 @@ module PageObjects
         page.visit("/admin/config/customize/components")
       end
 
-      def loading?
-        has_css?(".loading-container.visible")
+      def wait_until_done_loading
+        try_until_success { has_no_css?(".loading-container.visible") }
       end
 
       def component(id)


### PR DESCRIPTION
We've seen random failures in these specs at the `expect(config_area).to be_loading` assertions. A race condition can happen here where by the time the test reaches the assertion line, the page will have already loaded the new components list and done loading, causing the assertion to fail.

Replacing the assertion with a loop that waits until the loading state is finished (with a timeout) should help stabilizing the specs.