### PR TITLE
UX: auto focus emoji picker input on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
@@ -460,7 +460,7 @@ export default class EmojiPicker extends Component {
           }}
         >
           <FilterInput
-            {{didInsert (if this.site.desktopView this.focusFilter (noop))}}
+            {{didInsert this.focusFilter}}
             {{didInsert this.registerFilterInput}}
             @value={{this.term}}
             @filterAction={{withEventValue this.didInputFilter}}


### PR DESCRIPTION
Previously this behavior was only on desktop.