### PR TITLE
DEV: remove wrapping spans from #main-outlet plugin outlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
@@ -14,17 +14,15 @@ const Layout = <template>
     {{/if}}
   </div>
 
-  <span>
-    <PluginOutlet
-      @name="discovery-list-controls-above"
-      @connectorTagName="div"
-      @outletArgs={{hash
-        category=@model.category
-        tag=@model.tag
-        toggleTagInfo=@toggleTagInfo
-      }}
-    />
-  </span>
+  <PluginOutlet
+    @name="discovery-list-controls-above"
+    @connectorTagName="div"
+    @outletArgs={{hash
+      category=@model.category
+      tag=@model.tag
+      toggleTagInfo=@toggleTagInfo
+    }}
+  />
 
   <div class="list-controls">
     <PluginOutlet
@@ -83,12 +81,10 @@ const Layout = <template>
     </div>
   </div>
 
-  <span>
-    <PluginOutlet
-      @name="discovery-below"
-      @connectorTagName="div"
-      @outletArgs={{hash category=@model.category tag=@model.tag}}
-    />
-  </span>
+  <PluginOutlet
+    @name="discovery-below"
+    @connectorTagName="div"
+    @outletArgs={{hash category=@model.category tag=@model.tag}}
+  />
 </template>;
 export default Layout;


### PR DESCRIPTION
Even when these plugin outlets are unused we end up with empty spans in the layout, which can get in the way (especially for grid and flex layouts where empty containers are not collapsed). 

These are fairly hard to target without classes present anyway, they'd have to be picked up with `:has()` or something like `#main-outlet > span`. I did a quick spot check of themes/components that use these outlets in http://github.com/discourse and I didn't see any obvious cases where they were being targeted. 

In any cases where the removal does cause issue, the theme can be updated to target a container added by it, or a wrapping `span` can be added there. 