### PR TITLE
UX: don't decrease composer monospace font on mobile

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .d-editor-container {
   display: flex;
   flex-grow: 1;
@@ -5,8 +7,11 @@
 
   &--rich-editor-enabled .d-editor-textarea-wrapper textarea.d-editor-input {
     font-family: var(--d-font-family--monospace);
-    font-size: var(--font-down-1);
     font-variant-ligatures: none;
+
+    @include viewport.from(sm) {
+      font-size: var(--font-down-1);
+    }
   }
 }
 


### PR DESCRIPTION
I think this is causing iOS to zoom in on the composer in some scenarios, and we don't want that:

![image](https://github.com/user-attachments/assets/b4b22d25-c3f8-4da5-91d0-1b1940150a89)
