### PR TITLE
UX: Welcome bannner and search tweaks for mobile

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -14,18 +14,8 @@
 $search-pad-vertical: 0.25em;
 $search-pad-horizontal: 0.5em;
 
-.search-menu,
-.search-menu-container {
-  .menu-panel .panel-body-contents {
-    overflow-y: auto;
-  }
-
+.search-menu.glimmer-search-menu {
   .search-input-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.25rem;
-
     @include breakpoint("mobile-extra-large") {
       --search-input-wrapper-padding: 0.5rem;
       position: fixed;
@@ -37,6 +27,20 @@ $search-pad-horizontal: 0.5em;
       background-color: var(--secondary);
       z-index: z("base");
     }
+  }
+}
+
+.search-menu,
+.search-menu-container {
+  .menu-panel .panel-body-contents {
+    overflow-y: auto;
+  }
+
+  .search-input-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.25rem;
   }
 
   .search-input {

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -35,6 +35,12 @@
       margin-top: 0.5em;
     }
 
+    @include breakpoint("mobile-extra-large") {
+      display: block;
+      padding: 0.5em;
+      margin-top: 0;
+    }
+
     > div {
       margin: 0 auto;
       max-width: 600px;
@@ -43,6 +49,10 @@
     .search-menu {
       display: flex;
       position: relative;
+
+      @include breakpoint("mobile-extra-large") {
+        display: none;
+      }
 
       .search-menu-container {
         width: 100%;
@@ -71,6 +81,10 @@
 
       @include breakpoint(tablet) {
         font-size: var(--font-up-4);
+      }
+
+      @include breakpoint("mobile-extra-large") {
+        font-size: var(--font-up-2);
       }
     }
 

--- a/app/assets/stylesheets/mobile/components/welcome-banner.scss
+++ b/app/assets/stylesheets/mobile/components/welcome-banner.scss
@@ -7,19 +7,3 @@
     width: 100%;
   }
 }
-
-.welcome-banner__wrap .search-menu {
-  @include breakpoint("mobile-extra-large") {
-    display: none;
-  }
-}
-
-.welcome-banner .welcome-banner__wrap {
-  display: block;
-  padding: 0.5em;
-  margin-top: 0;
-
-  h1 {
-    font-size: var(--font-up-2);
-  }
-}

--- a/app/assets/stylesheets/mobile/components/welcome-banner.scss
+++ b/app/assets/stylesheets/mobile/components/welcome-banner.scss
@@ -7,3 +7,19 @@
     width: 100%;
   }
 }
+
+.welcome-banner__wrap .search-menu {
+  @include breakpoint("mobile-extra-large") {
+    display: none;
+  }
+}
+
+.welcome-banner .welcome-banner__wrap {
+  display: block;
+  padding: 0.5em;
+  margin-top: 0;
+
+  h1 {
+    font-size: var(--font-up-2);
+  }
+}


### PR DESCRIPTION
* Hides the welcome banner search in mobile, it's not necessary
  since there is the header search
* Fix an issue where the positioning of the search input for
  the header on mobile was affecting welcome banner search
* Make the welcome font a bit smaller and with less padding so
  it takes up less room on mobile

![image](https://github.com/user-attachments/assets/630fcf8d-f8e1-488a-80a0-2d9e23dcf360)
