### PR TITLE
DEV: Try fix composer rich text transcript spec

### DIFF
--- a/plugins/chat/spec/system/rich_editor_extension_transcript_spec.rb
+++ b/plugins/chat/spec/system/rich_editor_extension_transcript_spec.rb
@@ -31,7 +31,10 @@ describe "chat transcripts in rich editor", type: :system do
         messages_or_ids: [message_1],
       ).generate_markdown
 
-    cdp.copy_paste(markdown)
+    cdp.copy_paste(
+      markdown,
+      css_selector: PageObjects::Components::Composer::COMPOSER_INPUT_SELECTOR,
+    )
 
     expect(rich).to have_css(".chat-transcript", text: channel.name)
     expect(rich).to have_css(
@@ -54,7 +57,10 @@ describe "chat transcripts in rich editor", type: :system do
         messages_or_ids: [message_1, message_2],
       ).generate_markdown
 
-    cdp.copy_paste(markdown)
+    cdp.copy_paste(
+      markdown,
+      css_selector: PageObjects::Components::Composer::COMPOSER_INPUT_SELECTOR,
+    )
 
     expect(rich).to have_css(".chat-transcript.chat-transcript-chained", count: 2)
     expect(rich).to have_css(

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -70,14 +70,18 @@ module PageObjects
       end
     end
 
-    def copy_paste(text, html: false)
+    def copy_paste(text, html: false, css_selector: nil)
       allow_clipboard
       write_clipboard(text, html: html)
-      paste
+      paste(css_selector:)
     end
 
-    def paste
-      page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
+    def paste(css_selector: nil)
+      if css_selector
+        find(css_selector).send_keys([PLATFORM_KEY_MODIFIER, "v"])
+      else
+        page.send_keys([PLATFORM_KEY_MODIFIER, "v"])
+      end
     end
 
     def with_network_disconnected


### PR DESCRIPTION
This is to try fix this error by sending the keys
on the element itself:

```
Failure/Error: page.send_keys([PLATFORM_KEY_MODIFIER, "v"])

Selenium::WebDriver::Error::StaleElementReferenceError:
  stale element reference: stale element not found in the current frame
    (Session info: chrome=135.0.7049.84); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#stale-element-reference-exception
```
