### PR TITLE
UX: improve input rules for rich editor autolink/linkify

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/core/inputrules.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/core/inputrules.js
@@ -64,7 +64,7 @@ function processInputRule(inputRule, params) {
   }
 
   if (inputRule instanceof Function) {
-    inputRule = inputRule(params);
+    return processInputRule(inputRule(params));
   }
 
   if (inputRule instanceof InputRule) {

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -199,8 +199,11 @@ const extension = {
             to = Math.min(to + 1, state.doc.nodeSize - 2);
           }
 
+          // stores the nodes visited ahead, skipping a node if already seen in nodeAfter
+          const visited = new Set();
           state.doc.nodesBetween(from, to, (node, pos) => {
             if (
+              visited.has(node) ||
               !node.isText ||
               node.marks.some(
                 (mark) =>
@@ -241,11 +244,10 @@ const extension = {
                 nodeBefore.text[nodeBefore.text.length - 1]
               ) &&
               !utils.isWhiteSpace(text[0]) &&
-              nodeBefore.text[nodeBefore.text.length - 1] !== "`" &&
               nodeBefore.marks.length === 1 &&
-              nodeBefore.marks.some(
+              !nodeBefore.marks.some(
                 (mark) =>
-                  mark.type.name === "link" && mark.attrs.markup === "linkify"
+                  mark.type.name === "link" && mark.attrs.markup !== "linkify"
               )
             ) {
               textBefore = nodeBefore.text;
@@ -265,6 +267,7 @@ const extension = {
               )
             ) {
               textAfter = nodeAfter.text;
+              visited.add(nodeAfter);
             }
 
             const fullText = textBefore + textSlice + textAfter;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -129,7 +129,7 @@ const extension = {
       }
     ),
   ],
-  plugins: ({ pmState: { Plugin }, utils }) => [
+  plugins: ({ pmState: { Plugin }, utils }) =>
     new Plugin({
       props: {
         // Auto-linkify plain-text pasted URLs over a selection
@@ -140,7 +140,7 @@ const extension = {
 
           return addLinkMark(view, text, utils);
         },
-        // Auto-linkify rich content with a single text node that is a URL over a selection
+        // Auto-linkify pasted rich content with a single text node that is a URL over a selection
         transformPasted(slice, view) {
           if (view.state.selection.empty) {
             return slice;
@@ -173,9 +173,8 @@ const extension = {
           return addLinkMark(view, node.text, utils);
         },
       },
-    }),
-    // plugin for auto-linking while typing
-    new Plugin({
+
+      // Automatically adds and removes link marks when typing
       appendTransaction(transactions, prevState, state) {
         const transaction = prevState.tr;
         transactions
@@ -308,7 +307,6 @@ const extension = {
         return tr;
       },
     }),
-  ],
 };
 
 function addLinkMark(view, text, utils) {

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -42,7 +42,7 @@ const extension = {
             title: node.attrs.title,
             class: node.attrs.attachment ? "attachment" : undefined,
             "data-orig-href": node.attrs["data-orig-href"],
-            "data-markup": node.attrs.markup,
+            "data-markup": node.attrs.markup || undefined,
           },
           0,
         ];

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -29,6 +29,7 @@ const extension = {
               title: dom.getAttribute("title"),
               attachment: dom.classList.contains("attachment"),
               "data-orig-href": dom.getAttribute("data-orig-href"),
+              markup: dom.getAttribute("data-markup"),
             };
           },
         },
@@ -41,6 +42,7 @@ const extension = {
             title: node.attrs.title,
             class: node.attrs.attachment ? "attachment" : undefined,
             "data-orig-href": node.attrs["data-orig-href"],
+            "data-markup": node.attrs.markup,
           },
           0,
         ];
@@ -243,7 +245,6 @@ const extension = {
                 nodeBefore.text[nodeBefore.text.length - 1]
               ) &&
               !utils.isWhiteSpace(text[0]) &&
-              nodeBefore.marks.length === 1 &&
               !nodeBefore.marks.some(
                 (mark) =>
                   mark.type.name === "link" && mark.attrs.markup !== "linkify"

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/link-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/link-test.js
@@ -20,7 +20,7 @@ module(
       ],
       autolink: [
         "<https://example.com>",
-        '<p><a href="https://example.com">https://example.com</a></p>',
+        '<p><a href="https://example.com" data-markup="autolink">https://example.com</a></p>',
         "<https://example.com>",
       ],
       "attachment link": [

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -185,6 +185,17 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(rich).to have_css("hr", count: 5)
     end
+
+    it "supports <http://example.com> to create an 'autolink'" do
+      open_composer_and_toggle_rich_editor
+      composer.type_content("<http://example.com>")
+
+      expect(rich).to have_css("a", text: "http://example.com")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("<http://example.com>")
+    end
   end
 
   context "with oneboxing" do
@@ -623,7 +634,7 @@ describe "Composer - ProseMirror editor", type: :system do
     end
   end
 
-  describe "auto-linking/unlinking" do
+  describe "auto-linking/unlinking while typing" do
     it "auto-links non-protocol URLs and removes the link when no longer a URL" do
       open_composer_and_toggle_rich_editor
 
@@ -671,6 +682,19 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(rich).to have_css("code", text: "code mark https://example.com")
       expect(rich).to have_no_css("a", text: "https://example.com")
+    end
+
+    it "doesn't continue a <https://url> markup='autolink'" do
+      open_composer_and_toggle_rich_editor
+
+      composer.type_content("<https://example.com>.de")
+
+      expect(rich).to have_css("a", text: "https://example.com")
+      expect(rich).to have_no_css("a", text: "https://example.com.de")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("<https://example.com>.de")
     end
   end
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -549,7 +549,7 @@ describe "Composer - ProseMirror editor", type: :system do
       )
     end
 
-    it "respects existing marks when pasting a url to make a link" do
+    it "respects existing marks when pasting a url over a selection" do
       cdp.allow_clipboard
       open_composer_and_toggle_rich_editor
       cdp.copy_paste("not selected `code`**bold**not*italic* not selected")
@@ -568,7 +568,7 @@ describe "Composer - ProseMirror editor", type: :system do
       )
     end
 
-    it "auto-links pasted URLs from text/html" do
+    it "auto-links pasted URLs from text/html over a selection" do
       cdp.allow_clipboard
       open_composer_and_toggle_rich_editor
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -638,17 +638,19 @@ describe "Composer - ProseMirror editor", type: :system do
     it "auto-links non-protocol URLs and removes the link when no longer a URL" do
       open_composer_and_toggle_rich_editor
 
-      composer.type_content("www.example.com")
+      composer.type_content("www.example.com and also mid-paragraph www.example2.com")
 
       expect(rich).to have_css("a", text: "www.example.com")
+      expect(rich).to have_css("a", text: "www.example2.com")
+      expect(rich).to have_css("a", count: 2)
 
       composer.send_keys(%i[backspace backspace])
 
-      expect(rich).to have_no_css("a")
+      expect(rich).to have_css("a", count: 1)
 
       composer.type_content("om")
 
-      expect(rich).to have_css("a", text: "www.example.com")
+      expect(rich).to have_css("a", text: "www.example2.com")
     end
 
     it "auto-links protocol URLs" do


### PR DESCRIPTION
Adds support to creating an "autolink" by explicitly typing the `<https://link>`.

Changes linkification while typing to only act when `markup` is `linkify` (so, not a `[normal](link)` nor an `<autolink>`), and adds a test to make sure `<http://auto.links>` won't convert to a `linkify` while typing.

Avoids linkifying within code when pasting `text/html`.

Removes the `markup: "linkify"` when pasting a URL over a selection, as that will create a `[normal](link)` instead.

Fixes the case on Firefox when you're typing an `example.com` URL mid-paragraph and it stopped the link mark before the last letter, leaving an un-linked dangling `m`.

Also uses a `linkify.test()` call before `linkify.match()` for "best speed" as per https://markdown-it.github.io/linkify-it/doc/#LinkifyIt.prototype.match.