### PR TITLE
DEV: duplicate scroll-top util function to lib and replace current usage with new path

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
@@ -1,7 +1,7 @@
 import { action } from "@ember/object";
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
-import { scrollTop } from "discourse/mixins/scroll-top";
+import { scrollTop } from "discourse/lib/scroll-top";
 import { i18n } from "discourse-i18n";
 import { COMPONENTS, THEMES } from "admin/models/theme";
 

--- a/app/assets/javascripts/admin/addon/routes/admin-dashboard.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-dashboard.js
@@ -1,4 +1,4 @@
-import { scrollTop } from "discourse/mixins/scroll-top";
+import { scrollTop } from "discourse/lib/scroll-top";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 

--- a/app/assets/javascripts/admin/addon/routes/admin-email-templates-edit.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-email-templates-edit.js
@@ -1,5 +1,5 @@
 import Route from "@ember/routing/route";
-import { scrollTop } from "discourse/mixins/scroll-top";
+import { scrollTop } from "discourse/lib/scroll-top";
 
 export default class AdminEmailTemplatesEditRoute extends Route {
   model(params) {

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -9,7 +9,7 @@ import { and, eq, not, or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import DAG from "discourse/lib/dag";
 import scrollLock from "discourse/lib/scroll-lock";
-import { scrollTop } from "discourse/mixins/scroll-top";
+import { scrollTop } from "discourse/lib/scroll-top";
 import delayedDestroy from "discourse/modifiers/delayed-destroy";
 import AuthButtons from "./header/auth-buttons";
 import Contents from "./header/contents";

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -10,6 +10,7 @@ import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { search as searchCategoryTag } from "discourse/lib/category-tag-search";
 import discourseComputed, { bind } from "discourse/lib/decorators";
 import { setTransient } from "discourse/lib/page-tracker";
+import { scrollTop } from "discourse/lib/scroll-top";
 import {
   getSearchKey,
   isValidSearchTerm,
@@ -22,7 +23,6 @@ import {
 import { applyBehaviorTransformer } from "discourse/lib/transformer";
 import userSearch from "discourse/lib/user-search";
 import { escapeExpression } from "discourse/lib/utilities";
-import { scrollTop } from "discourse/mixins/scroll-top";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";

--- a/app/assets/javascripts/discourse/app/lib/scroll-top.js
+++ b/app/assets/javascripts/discourse/app/lib/scroll-top.js
@@ -1,0 +1,21 @@
+import { scheduleOnce } from "@ember/runloop";
+import { isTesting } from "discourse/lib/environment";
+import DiscourseURL from "discourse/lib/url";
+
+const context = {
+  _scrollTop() {
+    if (isTesting()) {
+      return;
+    }
+    document.documentElement.scrollTop = 0;
+  },
+};
+
+function scrollTop() {
+  if (DiscourseURL.isJumpScheduled()) {
+    return;
+  }
+  scheduleOnce("afterRender", context, context._scrollTop);
+}
+
+export { scrollTop };

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -1,8 +1,8 @@
 import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { scrollTop } from "discourse/lib/scroll-top";
 import { defaultHomepage } from "discourse/lib/utilities";
-import { scrollTop } from "discourse/mixins/scroll-top";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";


### PR DESCRIPTION
This was refactored from an actual Mixin some time back. This PR moves the function to the lib folder and keeps the same logic/interface otherwise.

We'll remove the mixin file once all non-core repos change to use the new file.