### PR TITLE
DEV: generate identifier for collections

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/collection.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/collection.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { concat, hash } from "@ember/helper";
-import { action, get } from "@ember/object";
+import { action } from "@ember/object";
 import FKField from "discourse/form-kit/components/fk/field";
 import FKObject from "discourse/form-kit/components/fk/object";
 import element from "discourse/helpers/element";
@@ -12,7 +12,12 @@ export default class FKCollection extends Component {
   }
 
   get collectionData() {
-    return this.args.data.get(this.name);
+    return this.args.data.get(this.name).map((item, index) => {
+      return {
+        identifier: `${this.name}-${index}`,
+        item,
+      };
+    });
   }
 
   get name() {
@@ -30,7 +35,7 @@ export default class FKCollection extends Component {
   <template>
     {{#let (element this.tagName) as |Wrapper|}}
       <Wrapper class="form-kit__collection">
-        {{#each this.collectionData key="index" as |data index|}}
+        {{#each this.collectionData key="identifier" as |data index|}}
           {{yield
             (hash
               Field=(component
@@ -72,7 +77,7 @@ export default class FKCollection extends Component {
               remove=this.remove
             )
             index
-            (get this.collectionData index)
+            data.item
           }}
         {{/each}}
       </Wrapper>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/collection-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/collection-test.gjs
@@ -175,4 +175,34 @@ module("Integration | Component | FormKit | Collection", function (hooks) {
 
     assert.form().field("one.0.two.0.three.0.foo").hasValue("2");
   });
+
+  test("emptying a collection field", async function (assert) {
+    const onSubmit = (data) => {
+      assert.deepEqual(
+        data.animals,
+        ["souna", undefined],
+        "correctly makes the field undefined"
+      );
+    };
+
+    await render(
+      <template>
+        <Form
+          @data={{hash animals=(array "souna" "sissi")}}
+          @onSubmit={{onSubmit}}
+          as |form|
+        >
+          <form.Collection @name="animals" as |collection|>
+            <collection.Field @title="cat" as |field|>
+              <field.Input />
+            </collection.Field>
+          </form.Collection>
+          <form.Submit />
+        </Form>
+      </template>
+    );
+
+    await formKit().field("animals.1").fillIn("");
+    await formKit().submit();
+  });
 });


### PR DESCRIPTION
This is particularly important for array of primitives, eg: `["a", "b", "c"]` where ember will struggle to know it's re-rendering the same object.

The previous code was mostly working by chance as calling index on something almost works for anything in javascript. But since we introduced array of primitives  in collections, we could now end up with an `undefined` value for the items of the collection, and calling `index` on `undefined` would raise an error.

This commit create a more general and explicit solution to this problem.