### PR TITLE
FIX: error when trying to un-favorite badge

### DIFF
--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -135,14 +135,16 @@ class UserBadgesController < ApplicationController
 
     return render json: failed_json, status: 403 unless can_favorite_badge?(user_badge)
 
-    if !user_badge.is_favorite &&
+    is_favorite = user_badges.where(badge: user_badge.badge).pluck(:is_favorite).any?
+
+    if !is_favorite &&
          user_badges.select(:badge_id).distinct.where(is_favorite: true).count >=
            SiteSetting.max_favorite_badges
       return render json: failed_json, status: 400
     end
 
     UserBadge.where(user_id: user_badge.user_id, badge_id: user_badge.badge_id).update_all(
-      is_favorite: !user_badge.is_favorite,
+      is_favorite: !is_favorite,
     )
     UserBadge.update_featured_ranks!([user_badge.user_id])
   end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -155,6 +155,8 @@ class BadgeGranter
             self.class.send_notification(@user.id, @user.username, @user.effective_locale, @badge)
           user_badge.update!(notification_id: notification.id)
         end
+        is_favorite = @user.user_badges.where(badge: @badge).pluck(:is_favorite).any?
+        user_badge.update!(is_favorite: true) if is_favorite
       end
     end
 

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -480,6 +480,21 @@ RSpec.describe UserBadgesController do
       put "/user_badges/#{other_user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(204)
       expect(other_user_badge.reload.is_favorite).to eq(true)
+
+      user_badge3 =
+        UserBadge.create(
+          badge: badge,
+          user: user,
+          granted_by: Discourse.system_user,
+          granted_at: Time.now,
+          seq: 2,
+        )
+
+      put "/user_badges/#{user_badge3.id}/toggle_favorite.json"
+      expect(response.status).to eq(204)
+      expect(user_badge.reload.is_favorite).to eq(false)
+      expect(user_badge2.reload.is_favorite).to eq(false)
+      expect(user_badge3.reload.is_favorite).to eq(false)
     end
   end
 end

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -321,6 +321,22 @@ RSpec.describe BadgeGranter do
       expect(UserBadge.where(user_id: user.id).count).to eq(2)
     end
 
+    it "updates is_favorite when granting multiple badges" do
+      badge = Fabricate(:badge, multiple_grant: true)
+      user_badge =
+        UserBadge.create(
+          badge: badge,
+          user: user,
+          granted_by: Discourse.system_user,
+          granted_at: Time.now,
+          is_favorite: true,
+        )
+      user_badge2 = BadgeGranter.grant(badge, user)
+
+      expect(user_badge2).to be_present
+      expect(user_badge2.reload.is_favorite).to eq(true)
+    end
+
     it "sets granted_at" do
       day_ago = freeze_time 1.day.ago
       user_badge = BadgeGranter.grant(badge, user)


### PR DESCRIPTION
This PR addresses the issue discussed in https://meta.discourse.org/t/failed-error-when-trying-to-un-star-the-bug-reporter-badge/330523

1. Fixed an issue in `user_badges_controller.rb` where the `toggle_favorite` method could incorrectly treat badges already marked as favorite as not being favorite.  
2. Automatically synchronize the `is_favorite` status for new badges when a user is granted a multiple-grant badge.