### PR TITLE
FIX: enable drafts dropdown on private categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -43,7 +43,7 @@ export default class CreateTopicButton extends Component {
       </DButtonTooltip>
 
       {{#if @showDrafts}}
-        <TopicDraftsDropdown @disabled={{this.disabled}} />
+        <TopicDraftsDropdown @disabled={{false}} />
       {{/if}}
     {{/if}}
   </template>

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -114,7 +114,7 @@ describe "Drafts dropdown", type: :system do
       category_page.visit(category)
 
       expect(category_page).to have_button("New Topic", disabled: true)
-      expect(drafts_dropdown).to be_disabled
+      expect(drafts_dropdown).to be_enabled
     end
   end
 end

--- a/spec/system/page_objects/components/drafts_menu.rb
+++ b/spec/system/page_objects/components/drafts_menu.rb
@@ -13,8 +13,12 @@ module PageObjects
         has_no_css?(MENU_SELECTOR + "-trigger")
       end
 
+      def enabled?
+        has_no_css?(MENU_SELECTOR + "-trigger[disabled]")
+      end
+
       def disabled?
-        find(MENU_SELECTOR + "-trigger")["disabled"]
+        has_css?(MENU_SELECTOR + "-trigger[disabled]")
       end
 
       def open?


### PR DESCRIPTION
Reinstates the draft dropdown on private category pages.

### How it looks

Default theme:

<img width="268" alt="Screenshot 2025-04-18 at 4 49 00 PM" src="https://github.com/user-attachments/assets/0ac447ef-4ddb-44db-8522-efd20454aa1a" />

Internal ref: /t/151641