### PR TITLE
DEV: Fix broken `request/qunit_controller_spec.rb`

### DIFF
--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe QunitController do
     Rails.env.stubs(:production?).returns(true)
   end
 
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) { DiscourseJsProcessor::Transpiler.build_production_theme_transpiler }
+
+  after(:all) { File.delete(DiscourseJsProcessor::Transpiler::TRANSPILER_PATH) }
+
   it "hides page for regular users in production" do
     production_sign_in(Fabricate(:user))
     get "/theme-qunit"


### PR DESCRIPTION
This test file fails locally if `tmp/theme-transpiler.js` does not exists.
Since the test file stubs the production env, we have to ensure that
`DiscourseJsProcessor::Transpiler.build_production_theme_transpiler` is
run first to mirror the production environment where the theme
transpiler file is built as part of assets precompilation.

### Review notes:

Example failure: https://github.com/discourse/discourse/actions/runs/14529161497/job/40766003075

To repro locally, run the following steps: 

1. In your Discourse directory, run `rm -rf tmp`
2. `rspec spec/requests/qunit_controller_spec.rb`