### PR TITLE
DEV: Add dedicated admin groups page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-groups-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-groups-index.js
@@ -1,0 +1,27 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import discourseDebounce from "discourse/lib/debounce";
+import { INPUT_DELAY } from "discourse/lib/environment";
+
+export default class AdminGroupsIndexController extends Controller {
+  queryParams = ["order", "asc", "filter", "type"];
+  order = null;
+  asc = null;
+  filter = "";
+  type = null;
+  groups = null;
+
+  @action
+  onTypeChanged(type) {
+    this.set("type", type);
+  }
+
+  @action
+  onFilterChanged(filter) {
+    discourseDebounce(this, this._debouncedFilter, filter, INPUT_DELAY);
+  }
+
+  _debouncedFilter(filter) {
+    this.set("filter", filter);
+  }
+}

--- a/app/assets/javascripts/admin/addon/controllers/admin-groups-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-groups-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminGroupsSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/controllers/admin-groups.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-groups.js
@@ -1,0 +1,3 @@
+import Controller from "@ember/controller";
+
+export default class AdminGroupsController extends Controller {}

--- a/app/assets/javascripts/admin/addon/routes/admin-groups-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-groups-index.js
@@ -1,0 +1,26 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminGroupsRoute extends DiscourseRoute {
+  queryParams = {
+    order: { refreshModel: true, replace: true },
+    asc: { refreshModel: true, replace: true },
+    filter: { refreshModel: true },
+    type: { refreshModel: true, replace: true },
+    username: { refreshModel: true },
+  };
+
+  titleToken() {
+    return i18n("admin.config.groups.title");
+  }
+
+  async model(params) {
+    const groups = await this.store.findAll("group", params);
+    return { groups };
+  }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.set("groups", model.groups);
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-groups-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-groups-settings.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class AdminGroupsSettingsRoute extends DiscourseRoute {
+  titleToken() {
+    return i18n("settings");
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-groups.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-groups.js
@@ -1,0 +1,3 @@
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default class AdminGroupsRoute extends DiscourseRoute {}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -220,6 +220,14 @@ export default function () {
     );
 
     this.route(
+      "adminGroups",
+      { path: "/groups", resetNamespace: true },
+      function () {
+        this.route("settings");
+      }
+    );
+
+    this.route(
       "adminConfig",
       { path: "/config", resetNamespace: true },
       function () {

--- a/app/assets/javascripts/admin/addon/templates/admin-groups-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/admin-groups-index.gjs
@@ -1,0 +1,14 @@
+import RouteTemplate from "ember-route-template";
+import GroupList from "discourse/components/group-list";
+
+export default RouteTemplate(
+  <template>
+    <GroupList
+      @groups={{@model.groups}}
+      @type={{@controller.type}}
+      @filter={{@controller.filter}}
+      @onTypeChanged={{@controller.onTypeChanged}}
+      @onFilterChanged={{@controller.onFilterChanged}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/admin-groups-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/admin-groups-settings.gjs
@@ -1,0 +1,13 @@
+import RouteTemplate from "ember-route-template";
+import AdminAreaSettings from "admin/components/admin-area-settings";
+
+export default RouteTemplate(
+  <template>
+    <AdminAreaSettings
+      @categories="groups"
+      @path="/admin/groups/settings"
+      @filter={{@controller.filter}}
+      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+    />
+  </template>
+);

--- a/app/assets/javascripts/admin/addon/templates/admin-groups.gjs
+++ b/app/assets/javascripts/admin/addon/templates/admin-groups.gjs
@@ -1,0 +1,39 @@
+import RouteTemplate from "ember-route-template";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DPageHeader from "discourse/components/d-page-header";
+import NavItem from "discourse/components/nav-item";
+import { i18n } from "discourse-i18n";
+
+export default RouteTemplate(
+  <template>
+    <DPageHeader
+      @titleLabel={{i18n "admin.config.groups.title"}}
+      @descriptionLabel={{i18n "admin.config.groups.header_description"}}
+      @hideTabs={{@controller.hideTabs}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/groups"
+          @label={{i18n "admin.config.groups.title"}}
+        />
+      </:breadcrumbs>
+      <:tabs>
+        <NavItem
+          @route="adminGroups.settings"
+          @label="settings"
+          class="admin-groups-tabs__settings"
+        />
+        <NavItem
+          @route="adminGroups.index"
+          @label="admin.config.groups.title"
+          class="admin-groups-tabs__index"
+        />
+      </:tabs>
+    </DPageHeader>
+
+    <div class="admin-container admin-config-page__main-area">
+      {{outlet}}
+    </div>
+  </template>
+);

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -30,7 +30,7 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_groups",
-        route: "groups",
+        route: "adminGroups",
         label: "admin.config.groups.title",
         description: "admin.config.groups.header_description",
         icon: "user-group",

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -3,6 +3,9 @@
 class Admin::GroupsController < Admin::StaffController
   MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP = 10
 
+  def index
+  end
+
   def create
     guardian.ensure_can_create_group!
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -396,6 +396,10 @@ Discourse::Application.routes.draw do
         end
       end
 
+      resources :groups, only: %i[index], constants: AdminConstraint.new do
+        collection { get "settings" => "site_settings#index" }
+      end
+
       get "search/all" => "search#index"
 
       namespace :config, constraints: StaffConstraint.new do


### PR DESCRIPTION
### What is this change?

Previously, clicking "Groups" on the admin dashboard would bring you to the public groups page. Historically, the public and admin actions have been mixed together on that page.

This is a bit of a frustrating experience when working on the admin dashboard, and also prevented us from adding a "Settings" tab for group-related site settings.

This PR adds an "admin groups" page, which is just an exact copy of the public groups index for now. This allows us to add the "Settings" tab, and lets us gradually work un disentangling the public- and admin parts of groups.

### Limitations

When you click a group, or click the button to create a new group, you are still brought to the public page of that group. We will work to disentangle these gradually.

### Screenshots

<img width="699" alt="Screenshot 2025-04-21 at 2 42 42 PM" src="https://github.com/user-attachments/assets/74762e13-3c0b-452a-b0df-819333b87c7e" />
<img width="449" alt="Screenshot 2025-04-21 at 2 42 32 PM" src="https://github.com/user-attachments/assets/c3777958-1306-40a8-bb76-9e8c2998954d" />
