### PR TITLE
DEV: Cache categories by locale

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -54,7 +54,7 @@ class Site
   end
 
   def self.categories_cache_key
-    "site_categories_#{Discourse.git_version}"
+    "site_categories_#{I18n.locale}_#{Discourse.git_version}"
   end
 
   def self.clear_cache

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -282,4 +282,67 @@ RSpec.describe Site do
     data = JSON.parse(Site.json_for(Guardian.new))
     expect(data["auth_providers"].map { |a| a["name"] }).to contain_exactly("facebook", "twitter")
   end
+
+  describe ".all_categories_cache" do
+    fab!(:category)
+    fab!(:category2) { Fabricate(:category) }
+
+    it "returns cached categories" do
+      categories_data = Site.all_categories_cache
+      expect(categories_data.map { |c| c[:id] }).to contain_exactly(
+        SiteSetting.uncategorized_category_id,
+        category.id,
+        category2.id,
+      )
+    end
+
+    it "caches the result" do
+      Site.all_categories_cache
+
+      category2.update_columns(name: "derp")
+
+      # The cached result should not contain
+      # the updated name that skipped validations
+      cached_names = Site.all_categories_cache.map { |c| c[:name] }
+      expect(cached_names).not_to include("derp")
+
+      Site.clear_cache
+      refreshed_names = Site.all_categories_cache.map { |c| c[:name] }
+      expect(refreshed_names).to include("derp")
+    end
+
+    it "includes preloaded custom fields" do
+      Site.reset_preloaded_category_custom_fields
+      Site.preloaded_category_custom_fields << "test_field"
+
+      category.custom_fields["test_field"] = "test_value"
+      category.save_custom_fields
+
+      categories_data = Site.all_categories_cache
+      category_data = categories_data.find { |c| c[:id] == category.id }
+
+      expect(category_data[:custom_fields]["test_field"]).to eq("test_value")
+    ensure
+      Site.reset_preloaded_category_custom_fields
+    end
+
+    it "applies plugin modifiers to the query" do
+      plugin_instance = Plugin::Instance.new
+      modifier_block =
+        Proc.new { |query| query.where("categories.name LIKE ?", "#{category.name}%") }
+
+      plugin_instance.register_modifier(:site_all_categories_cache_query, &modifier_block)
+
+      Site.clear_cache
+      categories_data = Site.all_categories_cache
+
+      expect(categories_data.map { |c| c[:id] }).to contain_exactly(category.id)
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(
+        plugin_instance,
+        :site_all_categories_cache_query,
+        &modifier_block
+      )
+    end
+  end
 end


### PR DESCRIPTION
Our category cache is currently specific to the site locale.

Expanding the key to take in `I18n.locale` as well to accommodate for category translations in core.