### PR TITLE
FEATURE: Add color palette list selection to new UI

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -167,116 +167,114 @@ export default class AdminConfigAreasColorPalette extends Component {
       data-palette-id={{@colorPalette.id}}
       as |form transientData|
     >
-      <div class="admin-config-area">
-        <div class="admin-config-area__primary-content">
-          <div class="admin-config-color-palettes__top-controls">
-            <form.Field
-              @name="name"
-              @showTitle={{false}}
-              @title={{i18n "admin.config_areas.color_palettes.palette_name"}}
-              @validation="required"
-              @format="full"
-              @onSet={{this.handleNameChange}}
-              as |field|
-            >
-              {{#if transientData.editingName}}
+      <div>
+        <div class="admin-config-color-palettes__top-controls">
+          <form.Field
+            @name="name"
+            @showTitle={{false}}
+            @title={{i18n "admin.config_areas.color_palettes.palette_name"}}
+            @validation="required"
+            @format="full"
+            @onSet={{this.handleNameChange}}
+            as |field|
+          >
+            {{#if transientData.editingName}}
+              <div class="admin-config-color-palettes__name-control">
+                <field.Input />
+                <DButton
+                  class="btn-flat"
+                  @icon="xmark"
+                  @action={{this.toggleEditingName}}
+                />
+              </div>
+            {{else}}
+              <field.Custom>
                 <div class="admin-config-color-palettes__name-control">
-                  <field.Input />
+                  <h2>{{@colorPalette.name}}</h2>
                   <DButton
                     class="btn-flat"
-                    @icon="xmark"
+                    @icon="pencil"
                     @action={{this.toggleEditingName}}
                   />
                 </div>
-              {{else}}
-                <field.Custom>
-                  <div class="admin-config-color-palettes__name-control">
-                    <h2>{{@colorPalette.name}}</h2>
-                    <DButton
-                      class="btn-flat"
-                      @icon="pencil"
-                      @action={{this.toggleEditingName}}
-                    />
-                  </div>
-                </field.Custom>
-              {{/if}}
-            </form.Field>
-            <DButton
-              class="duplicate-palette"
-              @label="admin.customize.copy"
-              @action={{this.duplicate}}
-            />
-          </div>
-          <form.Alert class="fonts-and-logos-hint">
-            <div class="admin-config-color-palettes__logo-and-fonts-hint">
-              <span>{{i18n
-                  "admin.config_areas.color_palettes.logo_and_fonts_hint"
-                }}</span>
-              <LinkTo @route="adminConfig.logo-and-fonts">{{i18n
-                  "admin.config_areas.color_palettes.go_to_logo_and_fonts"
-                }}</LinkTo>
-            </div>
-          </form.Alert>
-          <AdminConfigAreaCard
-            @heading="admin.config_areas.color_palettes.color_options.title"
-          >
-            <:content>
-              <form.Field
-                @name="user_selectable"
-                @title={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle"
-                }}
-                @showTitle={{false}}
-                @description={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle_description"
-                }}
-                @format="full"
-                @onSet={{this.handleUserSelectableChange}}
-                as |field|
-              >
-                <field.Toggle />
-              </form.Field>
-            </:content>
-          </AdminConfigAreaCard>
-          <AdminConfigAreaCard
-            @heading="admin.config_areas.color_palettes.colors.title"
-          >
-            <:content>
-              <form.Field
-                @name="colors"
-                @title={{i18n "admin.config_areas.color_palettes.colors.title"}}
-                @showTitle={{false}}
-                @format="full"
-                as |field|
-              >
-                <field.Custom>
-                  <ColorPaletteEditor
-                    @initialMode={{this.editorMode}}
-                    @colors={{transientData.colors}}
-                    @onLightColorChange={{this.onLightColorChange}}
-                    @onDarkColorChange={{this.onDarkColorChange}}
-                    @onTabSwitch={{this.onEditorTabSwitch}}
-                  />
-                </field.Custom>
-              </form.Field>
-            </:content>
-          </AdminConfigAreaCard>
-          <AdminConfigAreaCard>
-            <:content>
-              <div class="admin-config-color-palettes__save-card">
-                {{#if this.hasUnsavedChanges}}
-                  <span class="admin-config-color-palettes__unsaved-changes">
-                    {{i18n "admin.config_areas.color_palettes.unsaved_changes"}}
-                  </span>
-                {{/if}}
-                <form.Submit
-                  @isLoading={{this.saving}}
-                  @label="admin.config_areas.color_palettes.save_changes"
-                />
-              </div>
-            </:content>
-          </AdminConfigAreaCard>
+              </field.Custom>
+            {{/if}}
+          </form.Field>
+          <DButton
+            class="duplicate-palette"
+            @label="admin.customize.copy"
+            @action={{this.duplicate}}
+          />
         </div>
+        <form.Alert class="fonts-and-logos-hint">
+          <div class="admin-config-color-palettes__logo-and-fonts-hint">
+            <span>{{i18n
+                "admin.config_areas.color_palettes.logo_and_fonts_hint"
+              }}</span>
+            <LinkTo @route="adminConfig.logo-and-fonts">{{i18n
+                "admin.config_areas.color_palettes.go_to_logo_and_fonts"
+              }}</LinkTo>
+          </div>
+        </form.Alert>
+        <AdminConfigAreaCard
+          @heading="admin.config_areas.color_palettes.color_options.title"
+        >
+          <:content>
+            <form.Field
+              @name="user_selectable"
+              @title={{i18n
+                "admin.config_areas.color_palettes.color_options.toggle"
+              }}
+              @showTitle={{false}}
+              @description={{i18n
+                "admin.config_areas.color_palettes.color_options.toggle_description"
+              }}
+              @format="full"
+              @onSet={{this.handleUserSelectableChange}}
+              as |field|
+            >
+              <field.Toggle />
+            </form.Field>
+          </:content>
+        </AdminConfigAreaCard>
+        <AdminConfigAreaCard
+          @heading="admin.config_areas.color_palettes.colors.title"
+        >
+          <:content>
+            <form.Field
+              @name="colors"
+              @title={{i18n "admin.config_areas.color_palettes.colors.title"}}
+              @showTitle={{false}}
+              @format="full"
+              as |field|
+            >
+              <field.Custom>
+                <ColorPaletteEditor
+                  @initialMode={{this.editorMode}}
+                  @colors={{transientData.colors}}
+                  @onLightColorChange={{this.onLightColorChange}}
+                  @onDarkColorChange={{this.onDarkColorChange}}
+                  @onTabSwitch={{this.onEditorTabSwitch}}
+                />
+              </field.Custom>
+            </form.Field>
+          </:content>
+        </AdminConfigAreaCard>
+        <AdminConfigAreaCard>
+          <:content>
+            <div class="admin-config-color-palettes__save-card">
+              {{#if this.hasUnsavedChanges}}
+                <span class="admin-config-color-palettes__unsaved-changes">
+                  {{i18n "admin.config_areas.color_palettes.unsaved_changes"}}
+                </span>
+              {{/if}}
+              <form.Submit
+                @isLoading={{this.saving}}
+                @label="admin.config_areas.color_palettes.save_changes"
+              />
+            </div>
+          </:content>
+        </AdminConfigAreaCard>
       </div>
     </Form>
   </template>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -97,7 +97,7 @@ export default class AdminConfigAreasColorPalette extends Component {
       name: this.args.colorPalette.name,
     });
     await copy.save();
-    this.router.replaceWith("adminConfig.color-palettes-show", copy);
+    this.router.replaceWith("adminConfig.colorPalettes.show", copy);
     this.toasts.success({
       data: {
         message: i18n("admin.config_areas.color_palettes.copy_created", {
@@ -164,6 +164,7 @@ export default class AdminConfigAreasColorPalette extends Component {
     <Form
       @data={{this.data}}
       @onSubmit={{this.handleSubmit}}
+      data-palette-id={{@colorPalette.id}}
       as |form transientData|
     >
       <div class="admin-config-area">

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palettes.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palettes.gjs
@@ -1,0 +1,94 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
+import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
+import DButton from "discourse/components/d-button";
+import DPageHeader from "discourse/components/d-page-header";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+import ColorSchemeSelectBaseModal from "admin/components/modal/color-scheme-select-base";
+
+export default class AdminConfigAreasColorPalettes extends Component {
+  @service router;
+  @service modal;
+
+  get baseColorPalettes() {
+    return this.args.palettes.filter((palette) => palette.is_base);
+  }
+
+  @action
+  newColorPalette() {
+    this.modal.show(ColorSchemeSelectBaseModal, {
+      model: {
+        baseColorSchemes: this.baseColorPalettes,
+        newColorSchemeWithBase: this.newColorPaletteWithBase,
+      },
+    });
+  }
+
+  @action
+  async newColorPaletteWithBase(baseKey) {
+    const base = this.baseColorPalettes.find(
+      (palette) => palette.base_scheme_id === baseKey
+    );
+    const newPalette = base.copy();
+    newPalette.setProperties({
+      name: i18n("admin.customize.colors.new_name"),
+      base_scheme_id: base.get("base_scheme_id"),
+    });
+    await newPalette.save();
+    await this.router.refresh();
+    this.router.replaceWith("adminConfig.colorPalettes.show", newPalette);
+  }
+
+  <template>
+    <DPageHeader
+      @titleLabel={{i18n "admin.config.color_palettes.title"}}
+      @descriptionLabel={{i18n
+        "admin.config.color_palettes.header_description"
+      }}
+      @learnMoreUrl="https://meta.discourse.org/t/allow-users-to-select-new-color-palettes/60857"
+      @hideTabs={{true}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/config/colors"
+          @label={{i18n "admin.config.color_palettes.title"}}
+        />
+      </:breadcrumbs>
+    </DPageHeader>
+
+    <div class="content-list">
+      <ul>
+        {{#each @palettes as |palette|}}
+          {{#unless palette.is_base}}
+            <li data-palette-id={{palette.id}}>
+              <LinkTo
+                @route="adminConfig.colorPalettes.show"
+                @model={{palette}}
+                @replace={{true}}
+              >
+                {{icon "paintbrush"}}
+                {{palette.description}}
+              </LinkTo>
+            </li>
+          {{/unless}}
+        {{/each}}
+      </ul>
+
+      <PluginOutlet @name="admin-customize-colors-new-button">
+        <DButton
+          @action={{this.newColorPalette}}
+          @icon="plus"
+          @label="admin.customize.new"
+          class="btn-default create-new-palette"
+        />
+      </PluginOutlet>
+    </div>
+
+    {{outlet}}
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palettes.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palettes.gjs
@@ -61,34 +61,37 @@ export default class AdminConfigAreasColorPalettes extends Component {
       </:breadcrumbs>
     </DPageHeader>
 
-    <div class="content-list">
-      <ul>
-        {{#each @palettes as |palette|}}
-          {{#unless palette.is_base}}
-            <li data-palette-id={{palette.id}}>
-              <LinkTo
-                @route="adminConfig.colorPalettes.show"
-                @model={{palette}}
-                @replace={{true}}
-              >
-                {{icon "paintbrush"}}
-                {{palette.description}}
-              </LinkTo>
-            </li>
-          {{/unless}}
-        {{/each}}
-      </ul>
+    <div class="admin-config-area">
+      <div class="admin-config-area__aside color-palettes-list">
+        <ul>
+          {{#each @palettes as |palette|}}
+            {{#unless palette.is_base}}
+              <li data-palette-id={{palette.id}}>
+                <LinkTo
+                  @route="adminConfig.colorPalettes.show"
+                  @model={{palette}}
+                  @replace={{true}}
+                >
+                  {{icon "paintbrush"}}
+                  {{palette.description}}
+                </LinkTo>
+              </li>
+            {{/unless}}
+          {{/each}}
+        </ul>
+        <PluginOutlet @name="admin-customize-colors-new-button">
+          <DButton
+            @action={{this.newColorPalette}}
+            @icon="plus"
+            @label="admin.customize.new"
+            class="btn-default create-new-palette"
+          />
+        </PluginOutlet>
+      </div>
 
-      <PluginOutlet @name="admin-customize-colors-new-button">
-        <DButton
-          @action={{this.newColorPalette}}
-          @icon="plus"
-          @label="admin.customize.new"
-          class="btn-default create-new-palette"
-        />
-      </PluginOutlet>
+      <div class="admin-config-area__primary-content">
+        {{outlet}}
+      </div>
     </div>
-
-    {{outlet}}
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/modal/color-scheme-select-base.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/color-scheme-select-base.gjs
@@ -19,12 +19,14 @@ export default class ColorSchemeSelectBase extends Component {
 
   <template>
     <DModal
+      class="create-color-palette"
       @title={{i18n "admin.customize.colors.select_base.title"}}
       @closeModal={{@closeModal}}
     >
       <:body>
         {{i18n "admin.customize.colors.select_base.description"}}
         <ComboBox
+          class="select-base-palette"
           @content={{@model.baseColorSchemes}}
           @value={{this.selectedBaseThemeId}}
           @onChange={{fn (mut this.selectedBaseThemeId)}}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-color-palettes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-color-palettes-show.js
@@ -1,8 +1,11 @@
 import DiscourseRoute from "discourse/routes/discourse";
-import ColorScheme from "admin/models/color-scheme";
 
 export default class AdminConfigColorPalettesShowRoute extends DiscourseRoute {
   model(params) {
-    return ColorScheme.find(params.palette_id);
+    const id = parseInt(params.palette_id, 10);
+
+    return this.modelFor("adminConfig.colorPalettes").content.find(
+      (palette) => palette.id === id
+    );
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-config-color-palettes.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-color-palettes.js
@@ -1,0 +1,8 @@
+import DiscourseRoute from "discourse/routes/discourse";
+import ColorScheme from "admin/models/color-scheme";
+
+export default class AdminConfigColorPalettesShowRoute extends DiscourseRoute {
+  model() {
+    return ColorScheme.findAll();
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -379,9 +379,17 @@ export default function () {
           this.route("settings", { path: "/" });
         });
 
-        this.route("color-palettes-show", {
-          path: "/colors/:palette_id",
-        });
+        this.route(
+          "colorPalettes",
+          {
+            path: "/colors",
+          },
+          function () {
+            this.route("show", {
+              path: "/:palette_id",
+            });
+          }
+        );
       }
     );
 

--- a/app/assets/javascripts/admin/addon/templates/config-color-palettes-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-color-palettes-show.gjs
@@ -2,5 +2,5 @@ import RouteTemplate from "ember-route-template";
 import ColorPalette from "admin/components/admin-config-areas/color-palette";
 
 export default RouteTemplate(
-  <template><ColorPalette @colorPalette={{@controller.model}} /></template>
+  <template><ColorPalette @colorPalette={{@model}} /></template>
 );

--- a/app/assets/javascripts/admin/addon/templates/config-color-palettes.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-color-palettes.gjs
@@ -1,0 +1,6 @@
+import RouteTemplate from "ember-route-template";
+import ColorPalettes from "admin/components/admin-config-areas/color-palettes";
+
+export default RouteTemplate(
+  <template><ColorPalettes @palettes={{@model.content}} /></template>
+);

--- a/app/assets/stylesheets/admin/admin_config_color_palettes.scss
+++ b/app/assets/stylesheets/admin/admin_config_color_palettes.scss
@@ -1,4 +1,12 @@
-.admin-config.color-palettes-show {
+.admin-config.color-palettes {
+  .content-list {
+    margin-right: 1em;
+  }
+
+  .create-new-palette {
+    margin-top: 1em;
+  }
+
   .admin-config-color-palettes {
     &__name-control {
       display: flex;

--- a/app/assets/stylesheets/admin/admin_config_color_palettes.scss
+++ b/app/assets/stylesheets/admin/admin_config_color_palettes.scss
@@ -1,6 +1,34 @@
 .admin-config.color-palettes {
-  .content-list {
-    margin-right: 1em;
+  .color-palettes-list {
+    ul {
+      list-style: none;
+      margin: 0;
+    }
+
+    li {
+      border-bottom: 1px solid var(--primary-low);
+
+      &:first-of-type {
+        border-top: 1px solid var(--primary-low);
+      }
+
+      a {
+        display: block;
+        padding: 10px;
+        color: var(--primary);
+
+        &:hover {
+          background-color: var(--primary-low);
+          color: var(--primary);
+        }
+
+        &.active {
+          font-weight: bold;
+          color: var(--primary);
+          background: var(--d-selected);
+        }
+      }
+    }
   }
 
   .create-new-palette {

--- a/app/controllers/admin/config/color_palettes_controller.rb
+++ b/app/controllers/admin/config/color_palettes_controller.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 class Admin::Config::ColorPalettesController < Admin::AdminController
+  def index
+  end
+
   def show
     render_serialized(ColorScheme.find(params[:id]), ColorSchemeSerializer, root: false)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -432,6 +432,7 @@ Discourse::Application.routes.draw do
         put "/logo" => "logo#update"
         put "/fonts" => "fonts#update"
         get "colors/:id" => "color_palettes#show"
+        get "colors" => "color_palettes#index"
 
         resources :flags, only: %i[index new create update destroy] do
           put "toggle"

--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+describe "Admin Color Palette Config Area Page", type: :system do
+  fab!(:admin)
+  fab!(:color_scheme) { Fabricate(:color_scheme, user_selectable: false, name: "A Test Palette") }
+
+  let(:config_area) { PageObjects::Pages::AdminColorPaletteConfigArea.new }
+  let(:toasts) { PageObjects::Components::Toasts.new }
+
+  before { sign_in(admin) }
+
+  it "allows editing the palette name" do
+    config_area.visit(color_scheme.id)
+
+    config_area.edit_name_button.click
+    config_area.name_field.fill_in("Changed name 2.0")
+
+    expect(config_area).to have_unsaved_changes_indicator
+
+    config_area.form.submit
+
+    expect(toasts).to have_success(I18n.t("js.saved"))
+    expect(config_area).to have_no_unsaved_changes_indicator
+    expect(color_scheme.reload.name).to eq("Changed name 2.0")
+    expect(config_area.name_heading.text).to eq("Changed name 2.0")
+  end
+
+  it "allows changing the user selectable field" do
+    config_area.visit(color_scheme.id)
+
+    config_area.user_selectable_field.toggle
+
+    expect(config_area).to have_unsaved_changes_indicator
+
+    config_area.form.submit
+
+    expect(toasts).to have_success(I18n.t("js.saved"))
+    expect(config_area).to have_no_unsaved_changes_indicator
+    expect(config_area.user_selectable_field.value).to eq(true)
+    expect(color_scheme.reload.user_selectable).to eq(true)
+  end
+
+  it "allows changing colors" do
+    config_area.visit(color_scheme.id)
+
+    expect(config_area.color_palette_editor).to have_light_tab_active
+
+    config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#abcdef")
+
+    expect(config_area).to have_unsaved_changes_indicator
+
+    config_area.color_palette_editor.switch_to_dark_tab
+    expect(config_area.color_palette_editor).to have_dark_tab_active
+
+    config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#fedcba")
+    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#111222")
+
+    config_area.form.submit
+
+    expect(toasts).to have_success(I18n.t("js.saved"))
+    expect(config_area).to have_no_unsaved_changes_indicator
+    expect(config_area.color_palette_editor).to have_dark_tab_active
+    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#fedcba")
+    expect(config_area.color_palette_editor.input_for_color("secondary").value).to eq("#111222")
+
+    config_area.color_palette_editor.switch_to_light_tab
+    expect(config_area.color_palette_editor).to have_light_tab_active
+    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#abcdef")
+
+    expect(color_scheme.colors.find_by(name: "primary").hex).to eq("abcdef")
+    expect(color_scheme.colors.find_by(name: "primary").dark_hex).to eq("fedcba")
+    expect(color_scheme.colors.find_by(name: "secondary").dark_hex).to eq("111222")
+  end
+
+  it "allows duplicating the color palette" do
+    max_id = ColorScheme.maximum(:id)
+    color_scheme.update!(user_selectable: true)
+
+    config_area.visit(color_scheme.id)
+
+    expect(config_area.user_selectable_field.value).to eq(true)
+
+    config_area.duplicate_button.click
+
+    expect(page).to have_current_path("/admin/config/colors/#{max_id + 1}")
+    expect(config_area).to have_no_unsaved_changes_indicator
+    expect(config_area.name_heading.text).to eq(
+      I18n.t("admin_js.admin.config_areas.color_palettes.copy_of", name: color_scheme.name),
+    )
+    expect(toasts).to have_success(
+      I18n.t("admin_js.admin.config_areas.color_palettes.copy_created", name: color_scheme.name),
+    )
+    expect(config_area.user_selectable_field.value).to eq(false)
+  end
+
+  it "applies the changes live when editing the currently active palette" do
+    admin.user_option.update!(color_scheme_id: color_scheme.id)
+    config_area.visit(color_scheme.id)
+    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#aa339f")
+
+    expect(config_area).to have_unsaved_changes_indicator
+    config_area.form.submit
+    expect(toasts).to have_success(I18n.t("js.saved"))
+    expect(config_area).to have_no_unsaved_changes_indicator
+
+    href = Stylesheet::Manager.new.color_scheme_stylesheet_link_tag_href(color_scheme.id)
+
+    expect(page).to have_css(
+      "link[data-scheme-id=\"#{color_scheme.id}\"][href=\"#{href}\"]",
+      visible: false,
+    )
+    expect(find("html").native.css_value("background-color")).to eq(
+      "rgba(#{"aa".to_i(16)}, #{"33".to_i(16)}, #{"9f".to_i(16)}, 1)",
+    )
+  end
+
+  it "doesn't apply changes when editing a palette that's not currently active" do
+    config_area.visit(color_scheme.id)
+    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#aa339f")
+
+    expect(config_area).to have_unsaved_changes_indicator
+    config_area.form.submit
+    expect(toasts).to have_success(I18n.t("js.saved"))
+    expect(config_area).to have_no_unsaved_changes_indicator
+
+    href = Stylesheet::Manager.new.color_scheme_stylesheet_link_tag_href(color_scheme.id)
+
+    expect(page).to have_no_css("link[href=\"#{href}\"]", visible: false)
+  end
+end

--- a/spec/system/admin_color_palettes_config_area_spec.rb
+++ b/spec/system/admin_color_palettes_config_area_spec.rb
@@ -2,129 +2,36 @@
 
 describe "Admin Color Palettes Config Area Page", type: :system do
   fab!(:admin)
-  fab!(:color_scheme) { Fabricate(:color_scheme, user_selectable: false, name: "A Test Palette") }
+  fab!(:palette_1) { Fabricate(:color_scheme, user_selectable: false, name: "A Test Palette 1") }
+  fab!(:palette_2) { Fabricate(:color_scheme, user_selectable: false, name: "A Test Palette 2") }
 
   let(:config_area) { PageObjects::Pages::AdminColorPalettesConfigArea.new }
-  let(:toasts) { PageObjects::Components::Toasts.new }
+  let(:edit_config_area) { PageObjects::Pages::AdminColorPaletteConfigArea.new }
+  let(:create_color_palette_modal) { PageObjects::Modals::CreateColorPalette.new }
 
   before { sign_in(admin) }
 
-  it "allows editing the palette name" do
-    config_area.visit(color_scheme.id)
+  it "can navigate between different palettes" do
+    config_area.visit
 
-    config_area.edit_name_button.click
-    config_area.name_field.fill_in("Changed name 2.0")
+    config_area.palette(palette_1.id).click
+    expect(edit_config_area.palette_id).to eq(palette_1.id)
+    expect(page).to have_current_path("/admin/config/colors/#{palette_1.id}")
 
-    expect(config_area).to have_unsaved_changes_indicator
-
-    config_area.form.submit
-
-    expect(toasts).to have_success(I18n.t("js.saved"))
-    expect(config_area).to have_no_unsaved_changes_indicator
-    expect(color_scheme.reload.name).to eq("Changed name 2.0")
-    expect(config_area.name_heading.text).to eq("Changed name 2.0")
+    config_area.palette(palette_2.id).click
+    expect(edit_config_area.palette_id).to eq(palette_2.id)
+    expect(page).to have_current_path("/admin/config/colors/#{palette_2.id}")
   end
 
-  it "allows changing the user selectable field" do
-    config_area.visit(color_scheme.id)
+  it "can create new color palettes" do
+    config_area.visit
 
-    config_area.user_selectable_field.toggle
+    max_id = ColorScheme.maximum(:id) + 1
+    config_area.create_button.click
+    create_color_palette_modal.base_dropdown.select_row_by_name("Grey Amber")
+    create_color_palette_modal.create_button.click
 
-    expect(config_area).to have_unsaved_changes_indicator
-
-    config_area.form.submit
-
-    expect(toasts).to have_success(I18n.t("js.saved"))
-    expect(config_area).to have_no_unsaved_changes_indicator
-    expect(config_area.user_selectable_field.value).to eq(true)
-    expect(color_scheme.reload.user_selectable).to eq(true)
-  end
-
-  it "allows changing colors" do
-    config_area.visit(color_scheme.id)
-
-    expect(config_area.color_palette_editor).to have_light_tab_active
-
-    config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#abcdef")
-
-    expect(config_area).to have_unsaved_changes_indicator
-
-    config_area.color_palette_editor.switch_to_dark_tab
-    expect(config_area.color_palette_editor).to have_dark_tab_active
-
-    config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#fedcba")
-    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#111222")
-
-    config_area.form.submit
-
-    expect(toasts).to have_success(I18n.t("js.saved"))
-    expect(config_area).to have_no_unsaved_changes_indicator
-    expect(config_area.color_palette_editor).to have_dark_tab_active
-    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#fedcba")
-    expect(config_area.color_palette_editor.input_for_color("secondary").value).to eq("#111222")
-
-    config_area.color_palette_editor.switch_to_light_tab
-    expect(config_area.color_palette_editor).to have_light_tab_active
-    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#abcdef")
-
-    expect(color_scheme.colors.find_by(name: "primary").hex).to eq("abcdef")
-    expect(color_scheme.colors.find_by(name: "primary").dark_hex).to eq("fedcba")
-    expect(color_scheme.colors.find_by(name: "secondary").dark_hex).to eq("111222")
-  end
-
-  it "allows duplicating the color palette" do
-    max_id = ColorScheme.maximum(:id)
-    color_scheme.update!(user_selectable: true)
-
-    config_area.visit(color_scheme.id)
-
-    expect(config_area.user_selectable_field.value).to eq(true)
-
-    config_area.duplicate_button.click
-
-    expect(page).to have_current_path("/admin/config/colors/#{max_id + 1}")
-    expect(config_area).to have_no_unsaved_changes_indicator
-    expect(config_area.name_heading.text).to eq(
-      I18n.t("admin_js.admin.config_areas.color_palettes.copy_of", name: color_scheme.name),
-    )
-    expect(toasts).to have_success(
-      I18n.t("admin_js.admin.config_areas.color_palettes.copy_created", name: color_scheme.name),
-    )
-    expect(config_area.user_selectable_field.value).to eq(false)
-  end
-
-  it "applies the changes live when editing the currently active palette" do
-    admin.user_option.update!(color_scheme_id: color_scheme.id)
-    config_area.visit(color_scheme.id)
-    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#aa339f")
-
-    expect(config_area).to have_unsaved_changes_indicator
-    config_area.form.submit
-    expect(toasts).to have_success(I18n.t("js.saved"))
-    expect(config_area).to have_no_unsaved_changes_indicator
-
-    href = Stylesheet::Manager.new.color_scheme_stylesheet_link_tag_href(color_scheme.id)
-
-    expect(page).to have_css(
-      "link[data-scheme-id=\"#{color_scheme.id}\"][href=\"#{href}\"]",
-      visible: false,
-    )
-    expect(find("html").native.css_value("background-color")).to eq(
-      "rgba(#{"aa".to_i(16)}, #{"33".to_i(16)}, #{"9f".to_i(16)}, 1)",
-    )
-  end
-
-  it "doesn't apply changes when editing a palette that's not currently active" do
-    config_area.visit(color_scheme.id)
-    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#aa339f")
-
-    expect(config_area).to have_unsaved_changes_indicator
-    config_area.form.submit
-    expect(toasts).to have_success(I18n.t("js.saved"))
-    expect(config_area).to have_no_unsaved_changes_indicator
-
-    href = Stylesheet::Manager.new.color_scheme_stylesheet_link_tag_href(color_scheme.id)
-
-    expect(page).to have_no_css("link[href=\"#{href}\"]", visible: false)
+    expect(page).to have_current_path("/admin/config/colors/#{max_id}")
+    expect(edit_config_area.palette_id).to eq(max_id)
   end
 end

--- a/spec/system/page_objects/modals/create_color_palette.rb
+++ b/spec/system/page_objects/modals/create_color_palette.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class CreateColorPalette < PageObjects::Pages::Base
+      def modal
+        find(".create-color-palette")
+      end
+
+      def base_dropdown
+        PageObjects::Components::SelectKit.new(".select-base-palette")
+      end
+
+      def create_button
+        within(modal) { find(".btn-primary") }
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_color_palette_config_area.rb
+++ b/spec/system/page_objects/pages/admin_color_palette_config_area.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminColorPaletteConfigArea < PageObjects::Pages::Base
+      def visit(palette_id)
+        page.visit("/admin/config/colors/#{palette_id}")
+      end
+
+      def form
+        PageObjects::Components::FormKit.new(".admin-config.color-palettes .form-kit")
+      end
+
+      def palette_id
+        find(form.component)["data-palette-id"].to_i
+      end
+
+      def edit_name_button
+        name_field.component.find(".btn-flat")
+      end
+
+      def name_field
+        form.field("name")
+      end
+
+      def name_heading
+        name_field.find("h2")
+      end
+
+      def user_selectable_field
+        form.field("user_selectable")
+      end
+
+      def color_palette_editor
+        PageObjects::Components::ColorPaletteEditor.new(
+          form.field("colors").component.find(".color-palette-editor"),
+        )
+      end
+
+      def duplicate_button
+        page.find(".duplicate-palette")
+      end
+
+      def has_unsaved_changes_indicator?
+        page.has_text?(I18n.t("admin_js.admin.config_areas.color_palettes.unsaved_changes"))
+      end
+
+      def has_no_unsaved_changes_indicator?
+        page.has_no_text?(I18n.t("admin_js.admin.config_areas.color_palettes.unsaved_changes"))
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_color_palettes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_color_palettes_config_area.rb
@@ -3,46 +3,16 @@
 module PageObjects
   module Pages
     class AdminColorPalettesConfigArea < PageObjects::Pages::Base
-      def visit(palette_id)
-        page.visit("/admin/config/colors/#{palette_id}")
+      def visit
+        page.visit("/admin/config/colors")
       end
 
-      def form
-        PageObjects::Components::FormKit.new(".admin-config.color-palettes-show .form-kit")
+      def palette(id)
+        find(".content-list li[data-palette-id=\"#{id}\"]")
       end
 
-      def edit_name_button
-        name_field.component.find(".btn-flat")
-      end
-
-      def name_field
-        form.field("name")
-      end
-
-      def name_heading
-        name_field.find("h2")
-      end
-
-      def user_selectable_field
-        form.field("user_selectable")
-      end
-
-      def color_palette_editor
-        PageObjects::Components::ColorPaletteEditor.new(
-          form.field("colors").component.find(".color-palette-editor"),
-        )
-      end
-
-      def duplicate_button
-        page.find(".duplicate-palette")
-      end
-
-      def has_unsaved_changes_indicator?
-        page.has_text?(I18n.t("admin_js.admin.config_areas.color_palettes.unsaved_changes"))
-      end
-
-      def has_no_unsaved_changes_indicator?
-        page.has_no_text?(I18n.t("admin_js.admin.config_areas.color_palettes.unsaved_changes"))
+      def create_button
+        find(".create-new-palette")
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_color_palettes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_color_palettes_config_area.rb
@@ -8,7 +8,7 @@ module PageObjects
       end
 
       def palette(id)
-        find(".content-list li[data-palette-id=\"#{id}\"]")
+        find(".color-palettes-list li[data-palette-id=\"#{id}\"]")
       end
 
       def create_button


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/31742

This PR adds a color palettes list to the new color palette edit page that was introduced in the linked PR to allow navigating between color palettes. It reuses the same UI that we already have in the legacy color palette UI (`/admin/customize/colors`), but we may redesign the page in the future.

Screenshot:

<img src="https://github.com/user-attachments/assets/5a662ce1-623a-4b16-b07f-18c8a1767ab8" width=500>