### PR TITLE
FIX: remove z-index from user-status in header

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -452,7 +452,6 @@ textarea {
   position: absolute;
   right: -3px;
   bottom: -1px;
-  z-index: 1002;
 }
 
 .user-status-background {


### PR DESCRIPTION
After some new changes in the header, the user-status' z-index caused issues
![CleanShot 2025-04-21 at 13 41 39@2x](https://github.com/user-attachments/assets/a417dd20-842d-47d1-92cd-9b1ae37b1ab6)

AFAICT there is no need for that z-index to begin with.