### PR TITLE
DEV: Add `--rspec-cli-opts` CLI opt to `bin/turbo_rspec`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -276,8 +276,7 @@ jobs:
         env:
           CHECKOUT_TIMEOUT: 10
         run: |
-          GLOBIGNORE="plugins/chat/*";
-          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
+          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --rspec-cli-opts="--exclude-pattern 'plugins/chat/spec/**/*_spec.rb'" --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
         timeout-minutes: 30
 

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -16,6 +16,7 @@ profile_print_slowest_examples_count = 10
 use_runtime_info = nil
 enable_system_tests = nil
 retry_and_log_flaky_tests = ENV["DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS"].to_s == "1"
+rspec_cli_opts = nil
 
 OptionParser
   .new do |opts|
@@ -65,6 +66,8 @@ OptionParser
     opts.on("--enable-system-tests", "Run the system tests (defaults false)") do
       enable_system_tests = true
     end
+
+    opts.on("--rspec-cli-opts=options", "Extra RSpec CLI options") { |opts| rspec_cli_opts = opts }
   end
   .parse!(ARGV)
 
@@ -112,6 +115,7 @@ success =
     profile:,
     profile_print_slowest_examples_count:,
     retry_and_log_flaky_tests:,
+    rspec_cli_opts:,
   )
 
 if success


### PR DESCRIPTION
Example: `bin/turbo_rspec --rspec-cli-opts="--exclude-pattern
'plugins/chat/spec/**/*_spec.rb'" plugins/*/spec`
