### PR TITLE
DEV: Add `--exclude-pattern` to `bin/turbo_rspec`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -276,8 +276,7 @@ jobs:
         env:
           CHECKOUT_TIMEOUT: 10
         run: |
-          GLOBIGNORE="plugins/chat/*";
-          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
+          LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
         timeout-minutes: 30
 

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -16,6 +16,7 @@ profile_print_slowest_examples_count = 10
 use_runtime_info = nil
 enable_system_tests = nil
 retry_and_log_flaky_tests = ENV["DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS"].to_s == "1"
+exclude_pattern = nil
 
 OptionParser
   .new do |opts|
@@ -65,6 +66,11 @@ OptionParser
     opts.on("--enable-system-tests", "Run the system tests (defaults false)") do
       enable_system_tests = true
     end
+
+    opts.on(
+      "--exclude-pattern=pattern",
+      "Exclude files that matches against the pattern using unix-style pattern matching",
+    ) { |pattern| exclude_pattern = pattern }
   end
   .parse!(ARGV)
 
@@ -76,20 +82,26 @@ if ARGV.empty?
 
   run_system_tests = !!enable_system_tests
 
-  files =
-    if run_system_tests
-      ["#{Rails.root}/spec"]
-    else
-      TurboTests::Runner.default_spec_folders
-    end
+  files = Dir.glob("#{Rails.root}/spec/**/*_spec.rb")
+  files.reject! { |file| File.fnmatch("*spec/system*", file) } if !run_system_tests
 
   use_runtime_info = true if use_runtime_info.nil?
 else
   STDERR.puts "Ignoring system test options since files were specified" if enable_system_tests
 
-  files = ARGV
+  files =
+    ARGV.flat_map do |arg|
+      if File.directory?(arg)
+        Dir.glob("#{arg}/**/*_spec.rb")
+      else
+        arg
+      end
+    end
+
   use_runtime_info = false if use_runtime_info.nil?
 end
+
+files.reject! { |file| File.fnmatch(exclude_pattern, file) } if exclude_pattern
 
 requires.each { |f| require(f) }
 

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -42,14 +42,6 @@ module TurboTests
       ).run
     end
 
-    def self.default_spec_folders
-      # We do not want to include system specs by default, they are quite slow.
-      Dir
-        .entries("#{Rails.root}/spec")
-        .reject { |entry| !File.directory?("spec/#{entry}") || %w[.. . system].include?(entry) }
-        .map { |entry| "spec/#{entry}" }
-    end
-
     def initialize(opts)
       @reporter = opts[:reporter]
       @files = opts[:files]


### PR DESCRIPTION
This commit adds a new `--exclude-pattern` CLI option which supports
excluding files using unix style pattern matching.

This is to simplify a couple of situations:

1. Running `bin/turbo_rspec plugin/spec` but we want to exclude all
   tests in the `plugin/spec/system` folder.

   Example: `bin/turbo_rspec --exclude-pattern="*spec/system*"
plugin/spec`

2. Running `bin/turbo_rspec plugin/*/spec/system` but we want to exclude
   tests for a particular plugin.

   Example: `bin/turbo_rspec --exclude-pattern="plugins/chat/*"
plugin/*/spec/system`
