### PR TITLE
FIX: recalculate respects default invitee trust level

### DIFF
--- a/lib/trust_level.rb
+++ b/lib/trust_level.rb
@@ -37,8 +37,15 @@ class TrustLevel
     # Then consider the group locked level (or the previous trust level)
     granted_trust_level = user.group_granted_trust_level || 0
     previous_trust_level = use_previous_trust_level ? find_previous_trust_level(user) : 0
+    invitee_trust_level =
+      user.invited_user&.redeemed_at ? SiteSetting.default_invitee_trust_level : 0
 
-    [granted_trust_level, previous_trust_level, SiteSetting.default_trust_level].max
+    [
+      granted_trust_level,
+      previous_trust_level,
+      invitee_trust_level,
+      SiteSetting.default_trust_level,
+    ].max
   end
 
   private

--- a/spec/lib/promotion_spec.rb
+++ b/spec/lib/promotion_spec.rb
@@ -96,6 +96,23 @@ RSpec.describe Promotion do
       end
     end
 
+    context "when user was invited" do
+      it "respects default invitee trust level" do
+        SiteSetting.default_trust_level = 0
+        SiteSetting.default_invitee_trust_level = 1
+        Promotion.recalculate(user)
+        expect(user.trust_level).to eq(0)
+
+        invited_user = Fabricate(:invited_user, user: user)
+        Promotion.recalculate(user)
+        expect(user.trust_level).to eq(0)
+
+        invited_user.update!(redeemed_at: Time.now)
+        Promotion.recalculate(user)
+        expect(user.trust_level).to eq(1)
+      end
+    end
+
     context "when may send tl1 promotion messages" do
       before do
         stat = user.user_stat


### PR DESCRIPTION
Currently, trust level is calculated with this formula: `[granted_trust_level, previous_trust_level,  SiteSetting.default_trust_level].max`

When a user is invited, SiteSetting.default_invitee_trust_level should be respected in that calculation.