### PR TITLE
DEV: make category title badges optional

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-title-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-link.gjs
@@ -8,6 +8,10 @@ import dirSpan from "discourse/helpers/dir-span";
 @tagName("h3")
 export default class CategoryTitleLink extends Component {
   get displayName() {
+    if (this.unstyled === true) {
+      return dirSpan(this.category.displayName);
+    }
+
     const categoryBadge = categoryBadgeHTML(this.category, {
       allowUncategorized: true,
       link: false,


### PR DESCRIPTION
Allows themes and components to opt out of category title badge styling when using the `CategoryTitleLink`.

Using `@unstyled` allows the previous text only category name that we had prior to #32109:

```
<CategoryTitleLink @category={{c}} @unstyled={{true}} />
```

_Note: we don't appear to have a test for this specific component and this change just allows us to use it in the same way it was previously (before adding badges). Maybe later we can go back and add additional tests._