### PR TITLE
FIX: add category title badges to boxed layout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
+import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { classNameBindings, tagName } from "@ember-decorators/component";
 import CategoriesBoxesTopic from "discourse/components/categories-boxes-topic";
@@ -7,7 +8,7 @@ import CategoryLogo from "discourse/components/category-logo";
 import CategoryTitleBefore from "discourse/components/category-title-before";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import categoryColorVariable from "discourse/helpers/category-color-variable";
-import icon from "discourse/helpers/d-icon";
+import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import discourseComputed from "discourse/lib/decorators";
 
 @tagName("section")
@@ -16,13 +17,20 @@ import discourseComputed from "discourse/lib/decorators";
   "anyLogos:with-logos:no-logos"
 )
 export default class CategoriesBoxesWithTopics extends Component {
-  lockIcon = "lock";
-
   @discourseComputed("categories.[].uploaded_logo.url")
   anyLogos() {
     return this.categories.any((c) => {
       return !isEmpty(c.get("uploaded_logo.url"));
     });
+  }
+
+  categoryName(category) {
+    return htmlSafe(
+      categoryBadgeHTML(category, {
+        allowUncategorized: true,
+        link: false,
+      })
+    );
   }
 
   <template>
@@ -44,10 +52,7 @@ export default class CategoriesBoxesWithTopics extends Component {
 
               <h3>
                 <CategoryTitleBefore @category={{c}} />
-                {{#if c.read_restricted}}
-                  {{icon this.lockIcon}}
-                {{/if}}
-                {{c.displayName}}
+                {{this.categoryName c}}
               </h3>
             </a>
           </div>

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -9,8 +9,9 @@ import CategoryTitleLink from "discourse/components/category-title-link";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import borderColor from "discourse/helpers/border-color";
 import categoryColorVariable from "discourse/helpers/category-color-variable";
-import categoryLink from "discourse/helpers/category-link";
-import icon from "discourse/helpers/d-icon";
+import categoryLink, {
+  categoryBadgeHTML,
+} from "discourse/helpers/category-link";
 import discourseComputed from "discourse/lib/decorators";
 
 @tagName("section")
@@ -20,8 +21,6 @@ import discourseComputed from "discourse/lib/decorators";
   "hasSubcategories:with-subcategories"
 )
 export default class CategoriesBoxes extends Component {
-  lockIcon = "lock";
-
   @discourseComputed("categories.[].uploaded_logo.url")
   anyLogos() {
     return this.categories.any((c) => !isEmpty(c.get("uploaded_logo.url")));
@@ -30,6 +29,15 @@ export default class CategoriesBoxes extends Component {
   @discourseComputed("categories.[].subcategories")
   hasSubcategories() {
     return this.categories.any((c) => !isEmpty(c.get("subcategories")));
+  }
+
+  categoryName(category) {
+    return htmlSafe(
+      categoryBadgeHTML(category, {
+        allowUncategorized: true,
+        link: false,
+      })
+    );
   }
 
   <template>
@@ -65,10 +73,7 @@ export default class CategoriesBoxes extends Component {
                 <a class="parent-box-link" href={{c.url}}>
                   <h3>
                     <CategoryTitleBefore @category={{c}} />
-                    {{#if c.read_restricted}}
-                      {{icon this.lockIcon}}
-                    {{/if}}
-                    {{c.displayName}}
+                    {{this.categoryName c}}
                   </h3>
                 </a>
               </div>


### PR DESCRIPTION
This was missed when adding category badges in #32109. Category title badges are now added when the site setting for `Desktop category page style` or `Mobile category page style` is set to either:

- Boxes with Subcategories
- Boxes with Featured Topics

### Before

<img width="1130" alt="Screenshot 2025-04-22 at 11 49 23 AM" src="https://github.com/user-attachments/assets/1b7bff60-a095-474f-a5b6-0fcedb1e9868" />

### After

<img width="1123" alt="Screenshot 2025-04-22 at 11 51 36 AM" src="https://github.com/user-attachments/assets/8685de02-bfbb-49aa-aeb1-698ce4594fca" />
