### PR TITLE
FIX: hide unnecessary tabs and buttons when backups disabled

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/backups-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/backups-index.gjs
@@ -16,17 +16,19 @@ export default RouteTemplate(
     <DPageSubheader @titleLabel={{i18n "admin.backups.files_title"}}>
       <:actions as |actions|>
         <actions.Wrapped as |wrapped|>
-          {{#if @controller.localBackupStorage}}
-            <UppyBackupUploader
-              class={{wrapped.buttonClass}}
-              @done={{routeAction "uploadSuccess"}}
-              @localBackupStorage={{@controller.localBackupStorage}}
-            />
-          {{else}}
-            <UppyBackupUploader
-              class={{wrapped.buttonClass}}
-              @done={{routeAction "remoteUploadSuccess"}}
-            />
+          {{#if @controller.siteSettings.enable_backups}}
+            {{#if @controller.localBackupStorage}}
+              <UppyBackupUploader
+                class={{wrapped.buttonClass}}
+                @done={{routeAction "uploadSuccess"}}
+                @localBackupStorage={{@controller.localBackupStorage}}
+              />
+            {{else}}
+              <UppyBackupUploader
+                class={{wrapped.buttonClass}}
+                @done={{routeAction "remoteUploadSuccess"}}
+              />
+            {{/if}}
           {{/if}}
         </actions.Wrapped>
       </:actions>
@@ -76,37 +78,39 @@ export default RouteTemplate(
                   class="btn-default btn-small backup-item-row__download"
                 />
 
-                <DMenu
-                  @identifier="backup-item-menu"
-                  @title={{i18n "more_options"}}
-                  @icon="ellipsis-vertical"
-                  class="btn-default btn-small"
-                >
-                  <:content>
-                    <DropdownMenu as |dropdown|>
-                      <dropdown.item>
-                        <DButton
-                          @icon="play"
-                          @action={{fn (routeAction "startRestore") backup}}
-                          @disabled={{@controller.status.restoreDisabled}}
-                          @title={{@controller.restoreTitle}}
-                          @label="admin.backups.operations.restore.label"
-                          class="btn-transparent backup-item-row__restore"
-                        />
-                      </dropdown.item>
-                      <dropdown.item>
-                        <DButton
-                          @icon="trash-can"
-                          @action={{fn (routeAction "destroyBackup") backup}}
-                          @disabled={{@controller.status.isOperationRunning}}
-                          @title={{@controller.deleteTitle}}
-                          @label="admin.backups.operations.destroy.title"
-                          class="btn-transparent btn-danger backup-item-row__delete"
-                        />
-                      </dropdown.item>
-                    </DropdownMenu>
-                  </:content>
-                </DMenu>
+                {{#if @controller.siteSettings.enable_backups}}
+                  <DMenu
+                    @identifier="backup-item-menu"
+                    @title={{i18n "more_options"}}
+                    @icon="ellipsis-vertical"
+                    class="btn-default btn-small"
+                  >
+                    <:content>
+                      <DropdownMenu as |dropdown|>
+                        <dropdown.item>
+                          <DButton
+                            @icon="play"
+                            @action={{fn (routeAction "startRestore") backup}}
+                            @disabled={{@controller.status.restoreDisabled}}
+                            @title={{@controller.restoreTitle}}
+                            @label="admin.backups.operations.restore.label"
+                            class="btn-transparent backup-item-row__restore"
+                          />
+                        </dropdown.item>
+                        <dropdown.item>
+                          <DButton
+                            @icon="trash-can"
+                            @action={{fn (routeAction "destroyBackup") backup}}
+                            @disabled={{@controller.status.isOperationRunning}}
+                            @title={{@controller.deleteTitle}}
+                            @label="admin.backups.operations.destroy.title"
+                            class="btn-transparent btn-danger backup-item-row__delete"
+                          />
+                        </dropdown.item>
+                      </DropdownMenu>
+                    </:content>
+                  </DMenu>
+                {{/if}}
               </div>
             </td>
           </tr>

--- a/app/assets/javascripts/admin/addon/templates/backups.gjs
+++ b/app/assets/javascripts/admin/addon/templates/backups.gjs
@@ -22,7 +22,9 @@ export default RouteTemplate(
           />
         </:breadcrumbs>
         <:actions as |actions|>
-          <AdminBackupsActions @actions={{actions}} @backups={{@model}} />
+          {{#if @controller.siteSettings.enable_backups}}
+            <AdminBackupsActions @actions={{actions}} @backups={{@model}} />
+          {{/if}}
         </:actions>
         <:tabs>
           <NavItem

--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -8,6 +8,7 @@ class Admin::BackupsController < Admin::AdminController
 
   before_action :ensure_backups_enabled
   skip_before_action :check_xhr, only: %i[index show logs check_backup_chunk upload_backup_chunk]
+  skip_before_action :ensure_backups_enabled, only: %w[show status index]
 
   def index
     respond_to do |format|

--- a/spec/requests/admin/backups_controller_spec.rb
+++ b/spec/requests/admin/backups_controller_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Admin::BackupsController do
     context "when logged in as an admin" do
       before { sign_in(admin) }
 
-      it "raises an error when backups are disabled" do
+      it "works even when backups are disabled" do
         SiteSetting.enable_backups = false
         get "/admin/backups.json"
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(200)
       end
 
       context "with html format" do

--- a/spec/system/admin_backups_spec.rb
+++ b/spec/system/admin_backups_spec.rb
@@ -80,4 +80,13 @@ describe "Admin Backups Page", type: :system do
     backups_page.click_tab("settings")
     expect(settings_page).to have_setting("enable_backups")
   end
+
+  it "shows only settings tab when backups are not enabled" do
+    SiteSetting.enable_backups = false
+    backups_page.visit_page
+
+    expect(backups_page).to have_no_read_only_button
+    expect(backups_page).to have_no_backup_button
+    expect(backups_page).to have_no_backup_item_more_menu
+  end
 end

--- a/spec/system/page_objects/pages/admin_backups.rb
+++ b/spec/system/page_objects/pages/admin_backups.rb
@@ -53,6 +53,18 @@ module PageObjects
       def toggle_read_only
         find(".admin-backups__toggle-read-only").click
       end
+
+      def has_no_read_only_button?
+        page.has_no_css?(".admin-backups__toggle-read-only")
+      end
+
+      def has_no_backup_button?
+        page.has_no_css?(".admin-backups__start")
+      end
+
+      def has_no_backup_item_more_menu?
+        page.has_no_css?(".backup-item-menu-trigger")
+      end
     end
   end
 end


### PR DESCRIPTION
When backups are disabled, backup files and logs tabs should be hidden. Same for backup and read only button.

Demo

https://github.com/user-attachments/assets/7ce373cc-4fab-4f0f-89ef-d9fc7b889255

https://meta.discourse.org/t/disabling-backups-does-not-remove-item-from-admin-sidebar/36209