### PR TITLE
UX: avoid nested paragraph tags causing extra large category descriptions

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -89,11 +89,11 @@
 
 .category-heading {
   max-width: 100%;
+  font-size: var(--font-up-3);
 
   p {
     margin-top: 0;
     line-height: var(--line-height-large);
-    font-size: var(--font-up-3);
   }
 }
 


### PR DESCRIPTION
It seems there are some situations where we can get nested paragraph tags in category headings, and in these cases we end up with twice-as-large descriptions. Moving the font-size rule to the parent avoids this.


Before:
![image](https://github.com/user-attachments/assets/c4ff27e3-a16f-463a-a330-04d44e178f7e)


After:
![image](https://github.com/user-attachments/assets/b33e9a8e-6b48-48b8-b13f-76736aac1ac3)
