### PR TITLE
A11Y: site-text-logo should not be an H1

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/home-logo-contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo-contents.gjs
@@ -28,9 +28,9 @@ const HomeLogoContents = <template>
       @darkUrl={{@logoUrlDark}}
     />
   {{else}}
-    <h1 id="site-text-logo" class="text-logo">
+    <div id="site-text-logo" class="text-logo">
       {{@title}}
-    </h1>
+    </div>
   {{/if}}
 </template>;
 

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -51,7 +51,7 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.title = title;
 
     await render(<template><HomeLogo @minimized={{false}} /></template>);
-    assert.dom("h1#site-text-logo.text-logo").exists({ count: 1 });
+    assert.dom("div#site-text-logo.text-logo").exists({ count: 1 });
     assert.dom("#site-text-logo").hasText(title, "has title as text logo");
   });
 

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -97,6 +97,7 @@
   #site-text-logo {
     margin: 0;
     font-size: var(--font-up-1);
+    font-weight: bold;
 
     @include ellipsis;
 


### PR DESCRIPTION
Without a site logo we render a the site name in the header as text, this is a nice fallback!

![image](https://github.com/user-attachments/assets/007b9ad3-cbd7-4bcf-b5a3-6e4c813609b2)

...but it's marked up as an H1, and having the same H1 on every page means it's not a meaningful page heading and can make headings fairly annoying to navigate using screenreaders and other assistive technologies 

This converts it to a div and ensures that it retains the bold styling previously applied by the heading tag. Font size is already handled by the ID, so there are no visual changes as a result. 