### PR TITLE
FIX: allow to email backup even if backups disabled

### DIFF
--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -8,7 +8,7 @@ class Admin::BackupsController < Admin::AdminController
 
   before_action :ensure_backups_enabled
   skip_before_action :check_xhr, only: %i[index show logs check_backup_chunk upload_backup_chunk]
-  skip_before_action :ensure_backups_enabled, only: %w[show status index]
+  skip_before_action :ensure_backups_enabled, only: %w[show status index email]
 
   def index
     respond_to do |format|

--- a/spec/requests/admin/backups_controller_spec.rb
+++ b/spec/requests/admin/backups_controller_spec.rb
@@ -835,6 +835,16 @@ RSpec.describe Admin::BackupsController do
         expect(response.status).to eq(200)
       end
 
+      it "works even when backups are disabled" do
+        SiteSetting.enable_backups = false
+        create_backup_files(backup_filename)
+
+        expect { put "/admin/backups/#{backup_filename}.json" }.to change {
+          Jobs::DownloadBackupEmail.jobs.size
+        }.by(1)
+        expect(response.status).to eq(200)
+      end
+
       it "returns 404 when the backup does not exist" do
         put "/admin/backups/#{backup_filename}.json"
 


### PR DESCRIPTION
In this PR, we allowed to download backups even if backups are disabled:

https://github.com/discourse/discourse/pull/32396

This PR is fixing bug and allowing email action.