### PR TITLE
FIX: Delegate silenced_till from anonymous user to main user account

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1316,6 +1316,10 @@ class User < ActiveRecord::Base
     !!(suspended_till && suspended_till > Time.zone.now)
   end
 
+  def silenced_till
+    main_user_record[:silenced_till]
+  end
+
   def silenced?
     !!(silenced_till && silenced_till > Time.zone.now)
   end
@@ -2144,6 +2148,10 @@ class User < ActiveRecord::Base
   end
 
   private
+
+  def main_user_record
+    anonymous? ? master_user : self
+  end
 
   def set_default_sidebar_section_links(update: false)
     return if staged? || bot?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2476,6 +2476,22 @@ RSpec.describe User do
     end
   end
 
+  describe "#silenced_till" do
+    context "when the user is an anonymous shadow" do
+      let(:main) { Fabricate(:user, silenced_till: 1.day.from_now) }
+      let(:anon) { Fabricate(:anonymous) }
+
+      before do
+        SiteSetting.allow_anonymous_mode = true
+        anon.anonymous_user_master.update(master_user_id: main.id)
+      end
+
+      it "delegates the value from the main user record" do
+        expect(anon.silenced_till).to eq(main.silenced_till)
+      end
+    end
+  end
+
   describe "silenced?" do
     it "is not silenced by default" do
       expect(Fabricate(:user)).not_to be_silenced


### PR DESCRIPTION
### What is the problem?

When a user is silenced they can, given they have the permissions, enter anonymous mode and keep posting, essentially bypassing the silence that way.

### How does this fix it?

This change delegates the `silenced_till` attribute to the main user record if the user is anonymous.

### Trade-offs and alternative approaches

Given anonymous posting is enabled, as of this change, each call to `silenced_till` will produce a minimal query to `anonymous_users` to select one record based on pkey.

The alternative to this is to add logic to update the anonymous record's value when it is created and when a user is silenced or unsilenced.

Given this choice of a theoretical minimal performance impact on a lukewarm path and a significantly more involved implementation, I chose the former.