### PR TITLE
DEV: Avoid unnecessary redirect in system tests when visiting a topic

### DIFF
--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -11,9 +11,7 @@ module PageObjects
       end
 
       def visit_topic(topic, post_number: nil)
-        url = "/t/#{topic.id}"
-        url += "/#{post_number}" if post_number
-        page.visit(url)
+        page.visit(topic.url(post_number))
         self
       end
 


### PR DESCRIPTION
Visiting `/t/-/<topic_id>` results in an extra redirect request.
