### PR TITLE
DEV: Fix flaky User#silenced_till test

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2487,7 +2487,7 @@ RSpec.describe User do
       end
 
       it "delegates the value from the main user record" do
-        expect(anon.silenced_till).to eq(main.silenced_till)
+        expect(anon.silenced_till).to be_within(1.second).of(main.silenced_till)
       end
     end
   end


### PR DESCRIPTION
### What is happening?

For some reason, not on local, and not on PRs, but in the build pipeline, the precision of the timestamp changes during a database roundtrip, causing the build to fail.

This fixes the build.