### PR TITLE
UX: Do not let composer affect chat window height

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -133,7 +133,9 @@ export default class ComposerBody extends Component {
     this.lastMousePos = mouseYPos(event);
 
     DRAG_EVENTS.forEach((dragEvent) => {
-      document.addEventListener(dragEvent, this.throttledPerformDrag);
+      document.addEventListener(dragEvent, this.throttledPerformDrag, {
+        capture: true,
+      });
     });
 
     END_DRAG_EVENTS.forEach((endDragEvent) => {
@@ -148,7 +150,9 @@ export default class ComposerBody extends Component {
     this.appEvents.trigger("composer:resize-ended");
 
     DRAG_EVENTS.forEach((dragEvent) => {
-      document.removeEventListener(dragEvent, this.throttledPerformDrag);
+      document.removeEventListener(dragEvent, this.throttledPerformDrag, {
+        capture: true,
+      });
     });
 
     END_DRAG_EVENTS.forEach((endDragEvent) => {

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1,6 +1,5 @@
 html.composer-open {
   #main-outlet {
-    padding-bottom: var(--composer-height);
     transition: padding-bottom 250ms ease;
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-height-mixin.scss
@@ -5,7 +5,7 @@
     var(--composer-vh, 1vh) * 100 - var(--main-outlet-offset, 0px) - 1px -
       $inset
   );
-  height: calc($base-height - var(--composer-height, 0px));
+  height: calc($base-height);
 
   // mobile with keyboard opened
   html.keyboard-visible & {
@@ -14,13 +14,11 @@
 
   // ipad
   html.footer-nav-ipad & {
-    height: calc($base-height - var(--composer-height, 0px));
+    height: calc($base-height);
   }
 
   // PWA/HUB without keyboard
   html.footer-nav-visible:not(.keyboard-visible) & {
-    height: calc(
-      $base-height - var(--composer-height, 0px) - var(--footer-nav-height, 0px)
-    );
+    height: calc($base-height - var(--footer-nav-height, 0px));
   }
 }


### PR DESCRIPTION
This PR will allow composer to hover over chat, as it does in the rest of the app.

FYI: on dragging there is sometimes a jitter hover effect of chat action messages, but this is an edge case and would be encountered very rarely

**After**
![CleanShot 2025-04-23 at 15 07 47@2x](https://github.com/user-attachments/assets/8671ed9d-84f6-4553-8e93-023d0881c162)

**Before**
![CleanShot 2025-04-23 at 15 08 29@2x](https://github.com/user-attachments/assets/4f7ebbd4-82c8-4942-8d1a-10136c08444b)
