### PR TITLE
DEV: Avoid installing minio binaries in CI

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -198,6 +198,8 @@ module SystemHelpers
     SiteSetting.enable_direct_s3_uploads = enable_direct_s3_uploads
     SiteSetting.secure_uploads = enable_secure_uploads
 
+    # On CI, the minio binary is preinstalled in the docker image so there is no need for us to check for a new binary
+    MinioRunner.config.cache_time = 2.day.to_i if ENV["CI"]
     MinioRunner.start
   end
 


### PR DESCRIPTION
We are seeing test timeouts on CI due to attempts to download the minio
binaries while the tests are running. Example backtrace:

```
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:229:in `wait_readable'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:229:in `rbuf_fill'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:164:in `read'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:723:in `read'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:631:in `read_chunked'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:595:in `block in read_body_0'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:570:in `inflater'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:593:in `read_body_0'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:363:in `read_body'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:401:in `body'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http/response.rb:321:in `reading_body'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2430:in `transport_request'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:2384:in `request'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:108:in `block in request'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:113:in `request'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:1990:in `get'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/network.rb:36:in `block in get'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:130:in `start_without_connect'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/webmock-3.25.1/lib/webmock/http_lib_adapters/net_http.rb:157:in `start'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/net-http-0.6.0/lib/net/http.rb:1070:in `start'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/network.rb:31:in `get'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/network.rb:64:in `block in download'
  /usr/local/lib/ruby/3.3.0/tempfile.rb:371:in `open'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/network.rb:63:in `download'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/binary_manager.rb:48:in `download_binary'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/binary_manager.rb:23:in `install'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner/binary_manager.rb:9:in `install'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner.rb:69:in `install_binaries'
  /var/www/discourse/vendor/bundle/ruby/3.3.0/gems/minio_runner-0.1.2/lib/minio_runner.rb:52:in `start'
  /__w/discourse/discourse/spec/support/system_helpers.rb:201:in `setup_or_skip_s3_system_test'
  /__w/discourse/discourse/spec/system/s3_secure_uploads_spec.rb:26:in `block (3 levels) in <main>'
```
