### PR TITLE
DEV: Remove social authentication system tests for non full page login

### DIFF
--- a/spec/system/social_authentication_spec.rb
+++ b/spec/system/social_authentication_spec.rb
@@ -173,7 +173,6 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
     end
 
     # These tests use Google, but they should be the same for all providers
-
     context "when opening the external auth from /login" do
       before { SiteSetting.enable_google_oauth2_logins = true }
       after { reset_omniauth_config(:google_oauth2) }
@@ -453,20 +452,6 @@ end
 
 describe "Social authentication", type: :system do
   before { SiteSetting.full_name_requirement = "optional_at_signup" }
-
-  context "when desktop" do
-    before { SiteSetting.full_page_login = false }
-    include_examples "social authentication scenarios",
-                     PageObjects::Modals::Signup.new,
-                     PageObjects::Modals::Login.new
-  end
-
-  context "when mobile", mobile: true do
-    before { SiteSetting.full_page_login = false }
-    include_examples "social authentication scenarios",
-                     PageObjects::Modals::Signup.new,
-                     PageObjects::Modals::Login.new
-  end
 
   context "when fullpage desktop" do
     before { SiteSetting.full_page_login = true }


### PR DESCRIPTION
The `full_page_login` site setting is going to be removed soon so I am
dropping the social authentication system tests for when `SiteSetting.full_page_login = false`.

This cuts the runtime for `spec/system/social_authentication_spec.rb` by
half from around 4 minutes to 2 minutes on my local machine.

### Reviewer notes

Runtime example on my local machine:

```
rspec spec/system/social_authentication_spec.rb --headful

Randomized with seed 39977
................................................................................................

Finished in 3 minutes 55.7 seconds (files took 2.16 seconds to load)
96 examples, 0 failures
```