### PR TITLE
DEV: Reduce runtime of `spec/system/(login|signup)_spec.rb`

### DIFF
--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -359,16 +359,6 @@ shared_examples "login scenarios" do |login_page_object|
 end
 
 describe "Login", type: :system do
-  context "when desktop" do
-    before { SiteSetting.full_page_login = false }
-    include_examples "login scenarios", PageObjects::Modals::Login.new
-  end
-
-  context "when mobile", mobile: true do
-    before { SiteSetting.full_page_login = false }
-    include_examples "login scenarios", PageObjects::Modals::Login.new
-  end
-
   context "when fullpage desktop" do
     before { SiteSetting.full_page_login = true }
     include_examples "login scenarios", PageObjects::Pages::Login.new

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -349,20 +349,6 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
 end
 
 describe "Signup", type: :system do
-  context "when desktop" do
-    before { SiteSetting.full_page_login = false }
-    include_examples "signup scenarios",
-                     PageObjects::Modals::Signup.new,
-                     PageObjects::Modals::Login.new
-  end
-
-  context "when mobile", mobile: true do
-    before { SiteSetting.full_page_login = false }
-    include_examples "signup scenarios",
-                     PageObjects::Modals::Signup.new,
-                     PageObjects::Modals::Login.new
-  end
-
   context "when fullpage desktop" do
     before { SiteSetting.full_page_login = true }
     include_examples "signup scenarios",


### PR DESCRIPTION
This commit applies a similar optimisation as
d0d755ad8c478db45e3298df9de1cdabe59d9592.

Basically, the `full_page_login` site setting is going to be dropped
this week and these extra system tests we are running due to this site
setting is accounting for a significant percentage of the overall
runtime for core system tests.

### Reviewer notes

The PR to remove the `full_page_login` site setting is at https://github.com/discourse/discourse/pull/32189 and scheduled to be merged by us on 29th April.