### PR TITLE
DEV: Speed up system tests by allowing more maximum puma threads

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -370,6 +370,8 @@ RSpec.configure do |config|
         (ENV["CAPYBARA_SERVER_PORT"].presence || "31_337").to_i + ENV["TEST_ENV_NUMBER"].to_i
     end
 
+    Capybara.server = [:puma, { Threads: "0:10", Silent: true }]
+
     module IgnoreUnicornCapturedErrors
       def raise_server_error!
         super


### PR DESCRIPTION
With 0:4 Puma threads:

```
rspec spec/system/social_authentication_spec.rb

Randomized with seed 970
................................................

Finished in 1 minute 55.97 seconds (files took 2.18 seconds to load)
48 examples, 0 failures
```

With 0:20 Puma threads:

```
rspec spec/system/social_authentication_spec.rb

Randomized with seed 14523
................................................

Finished in 1 minute 26.34 seconds (files took 2 seconds to load)
48 examples, 0 failures
```
