### PR TITLE
FIX: Ensure site banner hides when user clicks on close button

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -209,6 +209,7 @@ export default class User extends RestModel.extend(Evented) {
 
   @tracked do_not_disturb_until;
   @tracked status;
+  @tracked dismissed_banner_key;
 
   @userOption("mailing_list_mode") mailing_list_mode;
   @userOption("external_links_in_new_tab") external_links_in_new_tab;

--- a/app/assets/javascripts/discourse/tests/acceptance/banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/banner-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
@@ -20,6 +20,29 @@ acceptance("Site Banner", function () {
     assert.dom("#banner #banner-content").hasText("hello world");
 
     await publishToMessageBus("/site/banner", null);
+
+    assert.dom("#banner").doesNotExist();
+  });
+});
+
+acceptance("Site Banner - Logged-in user", function (needs) {
+  needs.user();
+
+  test("hides correctly upon clicking close button", async function (assert) {
+    await visit("/");
+
+    assert.dom("#banner").doesNotExist();
+
+    await publishToMessageBus("/site/banner", {
+      html: "hello world",
+      key: 12,
+      url: "/t/12",
+    });
+
+    assert.dom("#banner #banner-content").hasText("hello world");
+    assert.dom("#banner .close").exists();
+
+    await click("#banner .close");
 
     assert.dom("#banner").doesNotExist();
   });


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/clicking-x-to-close-welcome-banner-does-not-work-until-page-refresh/363222

The site banner is not hidden when a logged-in user clicks on the close button.

This PR adds `@tracked` to the User model  `dismissed_banner_key` property so it is autotracked correctly by `DiscourseBanner` [`visible` getter](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/discourse-banner.gjs#L34-L49).