### PR TITLE
UX: Locale and name shouldn't be "optional"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
@@ -37,6 +37,7 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
             @name="locale"
             @title={{i18n "category.localization.locale"}}
             @format="full"
+            @validation="required"
             as |field|
           >
             <field.Select as |select|>
@@ -53,7 +54,7 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
           <collection.Field
             @name="name"
             @title={{i18n "category.localization.name"}}
-            @validation="length:1,50"
+            @validation="required|length:1,50"
             as |field|
           >
             <field.Input


### PR DESCRIPTION
## :mag: Overview
The validation was already working and you can't submit localizations without name and locale, but we want to add the client-side validation and ensure the "optional" label is removed from the form.

## :camera_flash: Screenshots

### ←Before
![Screenshot 2025-04-24 at 10 08 54](https://github.com/user-attachments/assets/088e7281-b03c-4c7f-8454-451c0cb53348)

### → After
![Screenshot 2025-04-24 at 10 07 35](https://github.com/user-attachments/assets/3a6e4b1f-714c-44c8-acae-bb96f63bf9f6)
