### PR TITLE
UX: Add missing `discourse-table` SVG icon

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -93,6 +93,7 @@ module SvgSprite
         discourse-other-tab
         discourse-sidebar
         discourse-sparkles
+        discourse-table
         discourse-threads
         download
         earth-americas

--- a/vendor/assets/svg-icons/discourse-additional.svg
+++ b/vendor/assets/svg-icons/discourse-additional.svg
@@ -53,6 +53,14 @@ Additional SVG icons
       </clipPath>
     </defs>
   </symbol>
+  <!-- "Discourse Table" is a Discourse derivative of https://fontawesome.com/v6/icons/table-list?f=classic&s=solid  -->
+  <symbol id="discourse-table" viewBox="0 0 512 512">
+    <g>
+      <g id="Layer_1">
+        <path d="M0,96C0,60.7,28.7,32,64,32h384c35.3,0,64,28.7,64,64v320c0,35.3-28.7,64-64,64H64c-35.3,0-64-28.7-64-64V96ZM448,96H64v64h384v-64ZM448,224H64v64h384v-64ZM448,352H64v64h384v-64Z"/>
+      </g>
+    </g>
+  </symbol>
   <symbol id="discourse-threads" viewBox="0 0 16 17" fill-rule="evenodd" clip-rule="evenodd">
     <path d="M5 0L4.57143 3H1V5H4.28571L3.71429 9H0V11H3.42857L3 14L4.9799 14.2828L5.44888 11H7V9H5.73459L6.30602 5H11.2857L11 7H13.0203L13.306 5H16V3H13.5917L13.9799 0.282843L12 0L11.5714 3H6.59173L6.9799 0.282843L5 0ZM8 13.5V9C8 8.44772 8.44771 8 9 8H15C15.5523 8 16 8.44771 16 9V13.5C16 14.0523 15.5523 14.5 15 14.5H12.1194C11.5042 15.2014 10.396 16.3544 10.0417 16C9.97944 15.9223 9.99982 15.0667 10.0206 14.5H9C8.44771 14.5 8 14.0523 8 13.5Z"/>
   </symbol>


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/icon-missing-in-admin-panel-after-updating-discourse-today/363295

The `discourse-table` icon usage was introduced in https://github.com/discourse/discourse/commit/464726d973a267802bbe9c06653f11cfd9d0d93a.
However, the SVG doesn't exist in core, but instead in the [AI plugin](https://github.com/discourse/discourse-ai/blob/main/svg-icons/icons-sprite.svg?short_path=9d0511c).

The PR adds this SVG icon to the core.