### PR TITLE
UX: Unhide the rich_editor site setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2769,6 +2769,7 @@ en:
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
     experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
+    rich_editor: "Enable the rich editor for all users, allowing each user to toggle between the markdown editor and rich editor. The rich editor is designed to provide a more intuitive and user-friendly interface for composing and editing content. See <a href='https://meta.discourse.org/t/test-our-new-composer-on-meta/352347'>Meta topic</a> for more details."
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2769,7 +2769,7 @@ en:
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
     experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
-    rich_editor: "Enable the rich editor for all users, allowing each user to toggle between the markdown editor and rich editor. The rich editor is designed to provide a more intuitive and user-friendly interface for composing and editing content. See <a href='https://meta.discourse.org/t/test-our-new-composer-on-meta/352347'>Meta topic</a> for more details."
+    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer-on-meta/352347' target='_blank'>see Meta for more details</a>."
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2769,7 +2769,7 @@ en:
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
     experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
-    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer-on-meta/352347' target='_blank'>see Meta for more details</a>."
+    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer/352347' target='_blank'>see Meta for more details</a>."
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3972,7 +3972,6 @@ experimental:
   rich_editor:
     client: true
     default: false
-    hidden: true
   experimental_content_localization:
     client: true
     default: false


### PR DESCRIPTION
This will show the experimental rich_editor setting and admins
can turn it on for their site. It is still marked experimental
because there are some features missing, but it works well for
95% of cases.

![image](https://github.com/user-attachments/assets/def77b6d-02c6-4ed2-84bb-002659452a93)

