### PR TITLE
DEV: Introduce `with_security_key` system test helper

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -221,4 +221,52 @@ module SystemHelpers
   def is_mobile?
     !!RSpec.current_example.metadata[:mobile]
   end
+
+  # This method can be used to run a system test with a user that has a physical security key by adding a virtual
+  # authenticator to the browser. It will automatically remove the virtual authenticator after the block is executed.
+  #
+  # Example:
+  #  with_security_key(user) do
+  #    <your system test code here>
+  #  end
+  #
+  def with_security_key(user)
+    # The public and private keys are complicated to generate programmatically, so we generate it by running the
+    # `spec/user_preferences/security_keys_spec.rb` test and uncommenting the lines that print the keys.
+    public_key_base64 =
+      "pQECAyYgASFYIJhY+jDNJM8g0lyKP3ivDxs+mrKXqfKUY3f7Uo4pWTPDIlggj03xktSm0JTSqbDefhu5WAKH7VRQmWXotjtI/8ka/P0="
+    private_key_base64 =
+      "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2AWg10o6aoM0s55halZvcQLnpM2tVO2D8Ugw7wFCjzyhRANCAASYWPowzSTPINJcij94rw8bPpqyl6nylGN3-1KOKVkzw49N8ZLUptCU0qmw3n4buVgCh-1UUJll6LY7SP_JGvz9"
+    credential_id_base64 = Base64.strict_encode64(SecureRandom.random_bytes(32))
+    credential_id_bytes = Selenium::WebDriver::Credential.decode(credential_id_base64)
+    private_key_bytes = Selenium::WebDriver::Credential.decode(private_key_base64)
+
+    credential =
+      Selenium::WebDriver::Credential.new(
+        id: credential_id_bytes,
+        resident_credential: false,
+        rp_id: DiscourseWebauthn.rp_id,
+        private_key: private_key_bytes,
+        sign_count: 1,
+      )
+
+    authenticator =
+      page.driver.browser.add_virtual_authenticator(
+        Selenium::WebDriver::VirtualAuthenticatorOptions.new,
+      )
+
+    authenticator.add_credential(credential)
+
+    Fabricate(
+      :user_security_key,
+      user:,
+      public_key: public_key_base64,
+      credential_id: credential_id_base64,
+      name: "First Key",
+    )
+
+    yield
+  ensure
+    authenticator.remove! if authenticator
+  end
 end

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -20,26 +20,6 @@ shared_examples "forgot password scenarios" do
     visit("/u/password-reset/#{password_reset_token}")
   end
 
-  def create_user_security_key(user)
-    # testing the 2FA flow requires a user that was created > 5 minutes ago
-    user.update!(created_at: 6.minutes.ago)
-
-    sign_in(user)
-
-    user_preferences_security_page.visit(user)
-    user_preferences_security_page.visit_second_factor(user, "supersecurepassword")
-
-    find(".security-key .new-security-key").click
-    expect(user_preferences_security_page).to have_css("input#security-key-name")
-
-    find(".d-modal__body input#security-key-name").fill_in(with: "First Key")
-    find(".add-security-key").click
-
-    expect(user_preferences_security_page).to have_css(".security-key .second-factor-item")
-
-    user_menu.sign_out
-  end
-
   context "when user does not have any multi-factor authentication configured" do
     it "should allow a user to reset their password" do
       visit_reset_password_link
@@ -71,24 +51,17 @@ shared_examples "forgot password scenarios" do
 
     context "when user only has security key configured" do
       it "should allow a user to reset password with a security key" do
-        authenticator =
-          page.driver.browser.add_virtual_authenticator(
-            Selenium::WebDriver::VirtualAuthenticatorOptions.new,
-          )
+        with_security_key(user) do
+          visit_reset_password_link
 
-        create_user_security_key(user)
+          expect(user_reset_password_page).to have_no_toggle_button_to_second_factor_form
 
-        visit_reset_password_link
+          user_reset_password_page.submit_security_key
 
-        expect(user_reset_password_page).to have_no_toggle_button_to_second_factor_form
+          user_reset_password_page.fill_in_new_password("newsuperpassword").submit_new_password
 
-        user_reset_password_page.submit_security_key
-
-        user_reset_password_page.fill_in_new_password("newsuperpassword").submit_new_password
-
-        expect(user_reset_password_page).to have_logged_in_user
-      ensure
-        authenticator.remove!
+          expect(user_reset_password_page).to have_logged_in_user
+        end
       end
     end
 
@@ -114,28 +87,21 @@ shared_examples "forgot password scenarios" do
       fab!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user:) }
 
       it "should allow a user to reset password with backup code instead of security key" do
-        authenticator =
-          page.driver.browser.add_virtual_authenticator(
-            Selenium::WebDriver::VirtualAuthenticatorOptions.new,
-          )
+        with_security_key(user) do
+          visit_reset_password_link
 
-        create_user_security_key(user)
+          user_reset_password_page.try_another_way
 
-        visit_reset_password_link
+          expect(user_reset_password_page).to have_no_toggle_button_in_second_factor_form
 
-        user_reset_password_page.try_another_way
+          user_reset_password_page
+            .fill_in_backup_code("iAmValidBackupCode")
+            .submit_backup_code
+            .fill_in_new_password("newsuperpassword")
+            .submit_new_password
 
-        expect(user_reset_password_page).to have_no_toggle_button_in_second_factor_form
-
-        user_reset_password_page
-          .fill_in_backup_code("iAmValidBackupCode")
-          .submit_backup_code
-          .fill_in_new_password("newsuperpassword")
-          .submit_new_password
-
-        expect(user_reset_password_page).to have_logged_in_user
-      ensure
-        authenticator.remove!
+          expect(user_reset_password_page).to have_logged_in_user
+        end
       end
     end
 
@@ -144,28 +110,21 @@ shared_examples "forgot password scenarios" do
       fab!(:user_second_factor_backup) { Fabricate(:user_second_factor_backup, user:) }
 
       it "should allow a user to toggle from security key to TOTP and between TOTP and backup codes" do
-        authenticator =
-          page.driver.browser.add_virtual_authenticator(
-            Selenium::WebDriver::VirtualAuthenticatorOptions.new,
-          )
+        with_security_key(user) do
+          visit_reset_password_link
 
-        create_user_security_key(user)
+          user_reset_password_page.try_another_way
 
-        visit_reset_password_link
+          expect(user_reset_password_page).to have_totp_description
 
-        user_reset_password_page.try_another_way
+          user_reset_password_page.use_backup_codes
 
-        expect(user_reset_password_page).to have_totp_description
+          expect(user_reset_password_page).to have_backup_codes_description
 
-        user_reset_password_page.use_backup_codes
+          user_reset_password_page.use_totp
 
-        expect(user_reset_password_page).to have_backup_codes_description
-
-        user_reset_password_page.use_totp
-
-        expect(user_reset_password_page).to have_totp_description
-      ensure
-        authenticator.remove!
+          expect(user_reset_password_page).to have_totp_description
+        end
       end
     end
 
@@ -173,28 +132,21 @@ shared_examples "forgot password scenarios" do
       fab!(:user_second_factor_totp) { Fabricate(:user_second_factor_totp, user:) }
 
       it "should allow a user to reset password with TOTP instead of security key" do
-        authenticator =
-          page.driver.browser.add_virtual_authenticator(
-            Selenium::WebDriver::VirtualAuthenticatorOptions.new,
-          )
+        with_security_key(user) do
+          visit_reset_password_link
 
-        create_user_security_key(user)
+          user_reset_password_page.try_another_way
 
-        visit_reset_password_link
+          expect(user_reset_password_page).to have_no_toggle_button_in_second_factor_form
 
-        user_reset_password_page.try_another_way
+          user_reset_password_page
+            .fill_in_totp(ROTP::TOTP.new(user_second_factor_totp.data).now)
+            .submit_totp
+            .fill_in_new_password("newsuperpassword")
+            .submit_new_password
 
-        expect(user_reset_password_page).to have_no_toggle_button_in_second_factor_form
-
-        user_reset_password_page
-          .fill_in_totp(ROTP::TOTP.new(user_second_factor_totp.data).now)
-          .submit_totp
-          .fill_in_new_password("newsuperpassword")
-          .submit_new_password
-
-        expect(user_reset_password_page).to have_logged_in_user
-      ensure
-        authenticator.remove!
+          expect(user_reset_password_page).to have_logged_in_user
+        end
       end
     end
   end

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -36,6 +36,11 @@ describe "User preferences | Security", type: :system do
 
       user_menu.sign_out
 
+      # puts <<~STRING
+      # public_key_base64 = \"#{user.second_factor_security_keys.first.public_key}\"
+      # private_key_string = \"#{authenticator.credentials.first.private_key}\"
+      # STRING
+
       # login flow
       find(".d-header .login-button").click
       find("input#login-account-name").fill_in(with: user.username)


### PR DESCRIPTION
Instead of having each test go incur the overhead of having to go
through the actual user flow to register a security key, we can generate
the WebAuthn credentials on the server side and adds it to the virtual
authenticator.
