### PR TITLE
FIX: Also show localized categories for users who are not logged in

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -275,7 +275,9 @@ class Site
     # invalidate both the legacy and localized caches if necessary
     MessageBus.publish(SITE_JSON_CHANNEL, "")
 
-    # also handle localized cache if enabled
+    # always clear legacy cache keys
+    Discourse.redis.del("site_json", "site_json_seq", "site_json_version")
+
     if SiteSetting.experimental_content_localization
       locales =
         begin
@@ -289,8 +291,6 @@ class Site
       locales.each do |loc|
         Discourse.redis.del("site_json_#{loc}", "site_json_seq_#{loc}", "site_json_version_#{loc}")
       end
-    else
-      Discourse.redis.del("site_json", "site_json_seq", "site_json_version")
     end
   end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -376,12 +376,19 @@ RSpec.describe Site do
 
   context "when there are anonymous users with different locales" do
     let(:anon_guardian) { Guardian.new }
+    let!(:original_available_locales) { I18n.available_locales }
+    let(:original_locale) { I18n.locale }
 
     before do
       SiteSetting.login_required = false
       Discourse.redis.flushdb
       I18n.available_locales = %i[en ja]
       I18n.locale = :en
+    end
+
+    after do
+      I18n.available_locales = original_available_locales
+      I18n.locale = original_locale
     end
 
     context "when experimental_content_localization is disabled" do


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/32380, we started showing localized categories. However we missed out anon users.

This PR ensures the site cache is also localized.