### PR TITLE
DEV: Improve site setting search ranking

### DIFF
--- a/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
@@ -104,10 +104,6 @@ export default class SiteSettingFilter {
         }
       );
 
-      if (fuzzyMatches.length > 0) {
-        siteSettings.pushObjects(fuzzyMatches);
-      }
-
       if (siteSettings.length > 0) {
         matches.pushObjects(siteSettings);
         matchesGroupedByCategory.pushObject({
@@ -136,7 +132,7 @@ export default class SiteSettingFilter {
   @bind
   sortSettings(settings) {
     // Sort the site settings so that fuzzy results are at the bottom
-    // and ordered by their gap count asc.
+    // and ordered by their match strength.
     return settings.sort((a, b) => {
       return (b.weight || 0) - (a.weight || 0);
     });

--- a/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
@@ -82,7 +82,7 @@ export default class SiteSettingFilter {
             setting.includes(filter) ||
             setting.replace(/_/g, " ").includes(filter)
           ) {
-            item.weight = -10;
+            item.weight = 10;
             return true;
           }
 
@@ -95,7 +95,7 @@ export default class SiteSettingFilter {
                 .includes(filter.replace(/_/g, " "))
             )
           ) {
-            item.weight = -5;
+            item.weight = 5;
             return true;
           }
 
@@ -104,7 +104,7 @@ export default class SiteSettingFilter {
             return true;
           }
 
-          // Site setitng value match.
+          // Site setting value match.
           if (
             (item.get("value") || "").toString().toLowerCase().includes(filter)
           ) {
@@ -122,7 +122,7 @@ export default class SiteSettingFilter {
             ) {
               const gapResult = strippedSetting.match(fuzzyRegexGaps);
               if (gapResult) {
-                item.weight = gapResult.filter((gap) => gap !== "").length;
+                item.weight -= gapResult.filter((gap) => gap !== "").length;
               }
               fuzzyMatches.push(item);
             }
@@ -170,7 +170,7 @@ export default class SiteSettingFilter {
     // Sort the site settings so that fuzzy results are at the bottom
     // and ordered by their gap count asc.
     return settings.sort((a, b) => {
-      return (a.weight || 0) - (b.weight || 0);
+      return (b.weight || 0) - (a.weight || 0);
     });
   }
 }

--- a/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
@@ -65,76 +65,83 @@ export default class SiteSettingFilter {
     this.siteSettings.forEach((settingsCategory) => {
       let fuzzyMatches = [];
 
-      const siteSettings = settingsCategory.siteSettings.filter((item) => {
-        item.weight = 0;
+      const siteSettings = settingsCategory.siteSettings.filter(
+        (siteSetting) => {
+          siteSetting.weight = 0;
 
-        if (opts.onlyOverridden && !item.get("overridden")) {
-          return false;
-        }
-        if (pluginFilter && item.plugin !== pluginFilter) {
-          return false;
-        }
-        if (filter) {
-          const setting = item.get("setting").toLowerCase();
-
-          // Site setting name match.
-          if (
-            setting.includes(filter) ||
-            setting.replace(/_/g, " ").includes(filter)
-          ) {
-            item.weight = 10;
-            return true;
+          if (opts.onlyOverridden && !siteSetting.get("overridden")) {
+            return false;
           }
-
-          // Site setting keyword match.
-          if (
-            (item.get("keywords") || []).any((keyword) =>
-              keyword
-                .replace(/_/g, " ")
-                .toLowerCase()
-                .includes(filter.replace(/_/g, " "))
-            )
-          ) {
-            item.weight = 5;
-            return true;
+          if (pluginFilter && siteSetting.plugin !== pluginFilter) {
+            return false;
           }
+          if (filter) {
+            const setting = siteSetting.get("setting").toLowerCase();
 
-          // Site setting description match.
-          if (item.get("description").toLowerCase().includes(filter)) {
-            return true;
-          }
-
-          // Site setting value match.
-          if (
-            (item.get("value") || "").toString().toLowerCase().includes(filter)
-          ) {
-            return true;
-          }
-
-          // Fuzzy site setting name match.
-          if (fuzzyRegex && fuzzyRegex.test(setting)) {
-            // Tightens up fuzzy search results a bit.
-            const fuzzySearchLimiter = 25;
-            const strippedSetting = setting.replace(/[^a-z0-9]/gi, "");
+            // Site setting name match.
             if (
-              strippedSetting.length <=
-              strippedQuery.length + fuzzySearchLimiter
+              setting.includes(filter) ||
+              setting.replace(/_/g, " ").includes(filter)
             ) {
-              const gapResult = strippedSetting.match(fuzzyRegexGaps);
-              if (gapResult) {
-                item.weight -= gapResult.filter((gap) => gap !== "").length;
-              }
-              fuzzyMatches.push(item);
+              siteSetting.weight = 10;
+              return true;
             }
 
+            // Site setting keyword match.
+            if (
+              (siteSetting.get("keywords") || []).any((keyword) =>
+                keyword
+                  .replace(/_/g, " ")
+                  .toLowerCase()
+                  .includes(filter.replace(/_/g, " "))
+              )
+            ) {
+              siteSetting.weight = 5;
+              return true;
+            }
+
+            // Site setting description match.
+            if (siteSetting.get("description").toLowerCase().includes(filter)) {
+              return true;
+            }
+
+            // Site setting value match.
+            if (
+              (siteSetting.get("value") || "")
+                .toString()
+                .toLowerCase()
+                .includes(filter)
+            ) {
+              return true;
+            }
+
+            // Fuzzy site setting name match.
+            if (fuzzyRegex && fuzzyRegex.test(setting)) {
+              // Tightens up fuzzy search results a bit.
+              const fuzzySearchLimiter = 25;
+              const strippedSetting = setting.replace(/[^a-z0-9]/gi, "");
+              if (
+                strippedSetting.length <=
+                strippedQuery.length + fuzzySearchLimiter
+              ) {
+                const gapResult = strippedSetting.match(fuzzyRegexGaps);
+                if (gapResult) {
+                  siteSetting.weight -= gapResult.filter(
+                    (gap) => gap !== ""
+                  ).length;
+                }
+                fuzzyMatches.push(siteSetting);
+              }
+
+              return true;
+            }
+
+            return false;
+          } else {
             return true;
           }
-
-          return false;
-        } else {
-          return true;
         }
-      });
+      );
 
       if (fuzzyMatches.length > 0) {
         siteSettings.pushObjects(fuzzyMatches);

--- a/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-filter.js
@@ -64,41 +64,43 @@ export default class SiteSettingFilter {
           if (opts.onlyOverridden && !siteSetting.get("overridden")) {
             return false;
           }
+
           if (pluginFilter && siteSetting.plugin !== pluginFilter) {
             return false;
           }
-          if (filter) {
-            const matcher = new SiteSettingMatcher(filter, siteSetting);
 
-            if (matcher.isNameMatch) {
-              siteSetting.weight = 10;
-              return true;
-            }
-
-            if (matcher.isKeywordMatch) {
-              siteSetting.weight = 5;
-              return true;
-            }
-
-            if (matcher.isDescriptionMatch) {
-              return true;
-            }
-
-            if (matcher.isValueMatch) {
-              return true;
-            }
-
-            if (matcher.isFuzzyNameMatch) {
-              siteSetting.weight += matcher.matchStrength;
-              fuzzyMatches.push(siteSetting);
-
-              return true;
-            }
-
-            return false;
-          } else {
+          if (!filter) {
             return true;
           }
+
+          const matcher = new SiteSettingMatcher(filter, siteSetting);
+
+          if (matcher.isNameMatch) {
+            siteSetting.weight = 10;
+            return true;
+          }
+
+          if (matcher.isKeywordMatch) {
+            siteSetting.weight = 5;
+            return true;
+          }
+
+          if (matcher.isDescriptionMatch) {
+            return true;
+          }
+
+          if (matcher.isValueMatch) {
+            return true;
+          }
+
+          if (matcher.isFuzzyNameMatch) {
+            siteSetting.weight += matcher.matchStrength;
+            fuzzyMatches.push(siteSetting);
+
+            return true;
+          }
+
+          return false;
         }
       );
 

--- a/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
@@ -58,16 +58,18 @@ export default class SiteSettingMatcher {
     const strippedSetting = name.replace(/[^a-z0-9]/gi, "");
 
     if (
-      strippedSetting.length <=
+      strippedSetting.length >
       this.strippedQuery.length + fuzzySearchLimiter
     ) {
-      const gapResult = strippedSetting.match(this.fuzzyRegexGaps);
-      if (gapResult) {
-        this.matchStrength -= gapResult.filter((gap) => gap !== "").length;
-      }
-      return true;
+      return false;
     }
 
-    return false;
+    const gapResult = strippedSetting.match(this.fuzzyRegexGaps);
+
+    if (gapResult) {
+      this.matchStrength -= gapResult.filter((gap) => gap !== "").length;
+    }
+
+    return true;
   }
 }

--- a/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
@@ -5,14 +5,14 @@ export default class SiteSettingMatcher {
     this.strippedQuery = filter.replace(/[^a-z0-9]/gi, "");
     this.fuzzyRegex = new RegExp(this.strippedQuery.split("").join(".*"), "i");
     this.fuzzyRegexGaps = new RegExp(
-      this.strippedQuery.split("").join("(.*)"),
+      ".*" + this.strippedQuery.split("").join("(.*)"),
       "i"
     );
     this.matchStrength = 0;
   }
 
   get isNameMatch() {
-    const name = this.siteSetting.get("setting").toLowerCase();
+    const name = this.siteSetting.setting.toLowerCase();
 
     return (
       name.includes(this.filter) ||
@@ -21,7 +21,7 @@ export default class SiteSettingMatcher {
   }
 
   get isKeywordMatch() {
-    (this.siteSetting.get("keywords") || []).any((keyword) =>
+    return (this.siteSetting.keywords || []).any((keyword) =>
       keyword
         .replace(/_/g, " ")
         .toLowerCase()
@@ -30,21 +30,18 @@ export default class SiteSettingMatcher {
   }
 
   get isDescriptionMatch() {
-    return this.siteSetting
-      .get("description")
-      .toLowerCase()
-      .includes(this.filter);
+    return this.siteSetting.description.toLowerCase().includes(this.filter);
   }
 
   get isValueMatch() {
-    (this.siteSetting.get("value") || "")
+    return (this.siteSetting.value || "")
       .toString()
       .toLowerCase()
       .includes(this.filter);
   }
 
   get isFuzzyNameMatch() {
-    const name = this.siteSetting.get("setting").toLowerCase();
+    const name = this.siteSetting.setting.toLowerCase();
 
     if (this.strippedQuery.length < 3) {
       return false;
@@ -67,7 +64,10 @@ export default class SiteSettingMatcher {
     const gapResult = strippedSetting.match(this.fuzzyRegexGaps);
 
     if (gapResult) {
-      this.matchStrength -= gapResult.filter((gap) => gap !== "").length;
+      // Discard empty gaps and disregard the full string match.
+      const numberOfGaps = gapResult.filter((gap) => gap !== "").length - 1;
+
+      this.matchStrength -= numberOfGaps;
     }
 
     return true;

--- a/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
+++ b/app/assets/javascripts/admin/addon/lib/site-setting-matcher.js
@@ -1,0 +1,73 @@
+export default class SiteSettingMatcher {
+  constructor(filter, siteSetting) {
+    this.filter = filter;
+    this.siteSetting = siteSetting;
+    this.strippedQuery = filter.replace(/[^a-z0-9]/gi, "");
+    this.fuzzyRegex = new RegExp(this.strippedQuery.split("").join(".*"), "i");
+    this.fuzzyRegexGaps = new RegExp(
+      this.strippedQuery.split("").join("(.*)"),
+      "i"
+    );
+    this.matchStrength = 0;
+  }
+
+  get isNameMatch() {
+    const name = this.siteSetting.get("setting").toLowerCase();
+
+    return (
+      name.includes(this.filter) ||
+      name.replace(/_/g, " ").includes(this.filter)
+    );
+  }
+
+  get isKeywordMatch() {
+    (this.siteSetting.get("keywords") || []).any((keyword) =>
+      keyword
+        .replace(/_/g, " ")
+        .toLowerCase()
+        .includes(this.filter.replace(/_/g, " "))
+    );
+  }
+
+  get isDescriptionMatch() {
+    return this.siteSetting
+      .get("description")
+      .toLowerCase()
+      .includes(this.filter);
+  }
+
+  get isValueMatch() {
+    (this.siteSetting.get("value") || "")
+      .toString()
+      .toLowerCase()
+      .includes(this.filter);
+  }
+
+  get isFuzzyNameMatch() {
+    const name = this.siteSetting.get("setting").toLowerCase();
+
+    if (this.strippedQuery.length < 3) {
+      return false;
+    }
+
+    if (!this.fuzzyRegex.test(name)) {
+      return false;
+    }
+
+    const fuzzySearchLimiter = 25;
+    const strippedSetting = name.replace(/[^a-z0-9]/gi, "");
+
+    if (
+      strippedSetting.length <=
+      this.strippedQuery.length + fuzzySearchLimiter
+    ) {
+      const gapResult = strippedSetting.match(this.fuzzyRegexGaps);
+      if (gapResult) {
+        this.matchStrength -= gapResult.filter((gap) => gap !== "").length;
+      }
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
### What is this change?

This change does a couple of things.

**Change in behaviour:**

- Matches on the site setting name and keywords now get a higher ranking in search results.
- When counting gaps for ranking fuzzy matches, we no consider the smallest number of gaps.
  **Example:**
  Filter: `abc`
  Setting: `axabxc`
  Previously this would have been counted as two gaps (`a__b_c`). It is now counted as one gap (`ab_c`).

**Code organization:**

- Extract a separate `SiteSettingMatcher` object for the matching logic.
- Flatten some conditionals to make control flow clearer.
- Higher weight now means higher in search results.