### PR TITLE
FIX: Also show localized categories for users who are not logged in

### DIFF
--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -373,4 +373,60 @@ RSpec.describe Site do
       end
     end
   end
+
+  context "when there are anonymous users with different locales" do
+    let(:anon_guardian) { Guardian.new }
+    let!(:original_available_locales) { I18n.available_locales }
+    let(:original_locale) { I18n.locale }
+
+    before do
+      SiteSetting.login_required = false
+      Discourse.redis.flushdb
+      I18n.available_locales = %i[en ja]
+      I18n.locale = :en
+    end
+
+    after do
+      I18n.available_locales = original_available_locales
+      I18n.locale = original_locale
+    end
+
+    context "when experimental_content_localization is disabled" do
+      before { SiteSetting.experimental_content_localization = false }
+
+      it "caches anon site json with a global key (not locale scoped)" do
+        expect(Discourse.redis.get("site_json")).to be_nil
+
+        json = Site.json_for(anon_guardian)
+
+        expect(Discourse.redis.get("site_json")).to eq(json)
+
+        I18n.locale = :ja
+        json_ja = Site.json_for(anon_guardian)
+        expect(Discourse.redis.get("site_json")).to eq(json_ja)
+
+        # always overwritten, not per locale
+        I18n.locale = :en
+        expect(Discourse.redis.get("site_json")).to eq(json)
+      end
+    end
+
+    context "when experimental_content_localization is enabled" do
+      before { SiteSetting.experimental_content_localization = true }
+
+      it "caches anon site json separately for each locale" do
+        expect(Discourse.redis.get("site_json_en")).to be_nil
+        expect(Discourse.redis.get("site_json_ja")).to be_nil
+
+        json_en = Site.json_for(anon_guardian)
+        expect(Discourse.redis.get("site_json_en")).to eq(json_en)
+
+        I18n.locale = :ja
+        json_ja = Site.json_for(anon_guardian)
+        expect(Discourse.redis.get("site_json_ja")).to eq(json_ja)
+
+        expect(json_en).not_to eq(json_ja)
+      end
+    end
+  end
 end


### PR DESCRIPTION
A rework of https://github.com/discourse/discourse/pull/32460.

In the earlier PR that had to be reverted, we were directly deleting cache (redis) and it was causing our image build to fail (see dev chat).

In this PR, we will rely on the existing method of invalid the keys (which essentially will cause the next request to get the new site json since the seq is not the same).