### PR TITLE
FIX: Ensure `hashtag_lookup` falls back to system user if post user is deleted

### DIFF
--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -111,11 +111,7 @@ module PrettyText
       # categories, however if the suppress_secured_categories_from_admin
       # site setting is activated then this user will not be able to access
       # secure categories, so hashtags that are secure will not render.
-      if cooking_user_id.blank?
-        cooking_user = Discourse.system_user
-      else
-        cooking_user = User.find(cooking_user_id)
-      end
+      cooking_user = User.find_by(id: cooking_user_id) || Discourse.system_user
 
       types_in_priority_order =
         types_in_priority_order.select do |type|

--- a/spec/lib/pretty_text/helpers_spec.rb
+++ b/spec/lib/pretty_text/helpers_spec.rb
@@ -162,5 +162,25 @@ RSpec.describe PrettyText::Helpers do
       Guardian.expects(:new).with(Discourse.system_user).returns(guardian_system)
       PrettyText::Helpers.hashtag_lookup("somecooltag", nil, %w[category tag])
     end
+
+    it "falls back to system user when cooking_user is deleted" do
+      user.destroy
+
+      expect(
+        PrettyText::Helpers.hashtag_lookup("somecooltag::tag", user.id, %w[category tag]),
+      ).to eq(
+        {
+          relative_url: tag.url,
+          text: "somecooltag",
+          description: "Coolest things ever",
+          colors: nil,
+          icon: "tag",
+          id: tag.id,
+          slug: "somecooltag",
+          ref: "somecooltag::tag",
+          type: "tag",
+        },
+      )
+    end
   end
 end


### PR DESCRIPTION
`hashtag_lookup` fails if called with a deleted user's ID. This change defaults to system user if the user does not exist.