### PR TITLE
DEV: html height 100% -> 100dvh

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -341,7 +341,7 @@ export default class SearchMenu extends Component {
             this.search.noResults = results.resultTypes.length === 0;
             this.search.results = results;
             // focus out on topic search only
-            if (this.typeFilter === null) {
+            if (this.site.mobileView && this.typeFilter === null) {
               document.getElementById(this.searchInputId)?.blur();
             }
           }

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -340,6 +340,10 @@ export default class SearchMenu extends Component {
 
             this.search.noResults = results.resultTypes.length === 0;
             this.search.results = results;
+            // focus out on topic search only
+            if (this.typeFilter === null) {
+              document.getElementById(this.searchInputId)?.blur();
+            }
           }
         })
         .catch(popupAjaxError)

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -131,7 +131,7 @@ export default class AssistantItem extends Component {
     // Do not focus input on all topics search. In mobile, this prevents virtual
     // keyboard from hide-show-hide toggling (input is blurred in search-menu.gjs>pefrorm():345),
     // since the main goal is to use maximum viewport height for showing search results
-    if (!this.args.searchAllTopics) {
+    if (this.site.mobileView && !this.args.searchAllTopics) {
       this.search.focusSearchInput();
     }
   }

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -128,7 +128,12 @@ export default class AssistantItem extends Component {
       ...(inTopicContext &&
         !this.args.searchAllTopics && { setTopicContext: true }),
     });
-    this.search.focusSearchInput();
+    // Do not focus input on all topics search. In mobile, this prevents virtual
+    // keyboard from hide-show-hide toggling (input is blurred in search-menu.gjs>pefrorm():345),
+    // since the main goal is to use maximum viewport height for showing search results
+    if (!this.args.searchAllTopics) {
+      this.search.focusSearchInput();
+    }
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
@@ -104,6 +104,13 @@ export default class SearchTerm extends Component {
     e.preventDefault();
   }
 
+  @action
+  onFocusOut(e) {
+    // prevents focusout bubbling and closing the menu panel:
+    // `focusOutHandler` in `app/components/header.gjs`
+    e.stopPropagation();
+  }
+
   parseAndUpdateSearchTerm(originalVal, newVal) {
     // remove zero-width chars
     const parsedVal = newVal.replace(/[\u200B-\u200D\uFEFF]/, "");
@@ -127,6 +134,7 @@ export default class SearchTerm extends Component {
       {{on "keydown" this.onKeydown}}
       {{on "input" this.updateSearchTerm}}
       {{on "focus" @openSearchMenu}}
+      {{on "focusout" this.onFocusOut}}
       {{didInsert this.focus}}
     />
   </template>

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -98,7 +98,7 @@
 
 // Base Elements
 html {
-  height: 100%;
+  height: 100dvh;
 }
 
 body {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -258,6 +258,8 @@
 
       &.is-destroying {
         animation: search-slide-out 0.2s ease-in forwards;
+        height: 4rem;
+        transition: none;
       }
 
       @keyframes search-slide-in {


### PR DESCRIPTION
This PR includes three changes for the search panel in mobile view:

1. `<html>` height is set to dynamic `dvh` unit - this should fix the bottom page content overlay by the virtual keyboard. After this change, the user should be able to scroll to the very bottom of the page with the virtual keyboard shown.
2. The search input is blurred on the search results returned - this causes the virtual keyboard to hide, and provides more real estate for viewing search results.
3. The animation of closing the search panel is improved to give it a smoother look.