### PR TITLE
DEV: Bump tests workflow build job timeout for plugin system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     name: ${{ matrix.target }} ${{ matrix.build_type }}${{ (matrix.target == 'core' && matrix.build_type == 'frontend' && format(' ({0})', matrix.browser)) || '' }} # Update fetch-job-id step if changing this
     runs-on: ${{ (github.repository_owner == 'discourse' && 'debian-12') || 'ubuntu-latest' }}
     container: discourse/discourse_test:release
-    timeout-minutes: 20
+    timeout-minutes: ${{ (matrix.build_type == 'system' && matrix.target == 'plugin') && 30 || 20 }}
 
     env:
       RAILS_ENV: test
@@ -243,17 +243,14 @@ jobs:
       - name: Core QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'core'
         run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake qunit:test
-        timeout-minutes: 30
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
         run: QUNIT_WRITE_EXECUTION_FILE=1 bin/rake plugin:qunit['*']
-        timeout-minutes: 30
 
       - name: Theme QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'themes'
         run: DISCOURSE_DEV_DB=discourse_test bin/rake themes:qunit_all_official
-        timeout-minutes: 10
 
       - uses: actions/upload-artifact@v4
         if: always() && matrix.build_type == 'frontend'
@@ -278,14 +275,12 @@ jobs:
         run: |
           LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --exclude-pattern="plugins/chat/*" --use-runtime-info --profile=50 --verbose --format documentation plugins/*/spec/system
         shell: bash
-        timeout-minutes: 30
 
       - name: Chat System Tests
         if: matrix.build_type == 'system' && matrix.target == 'chat'
         env:
           CHECKOUT_TIMEOUT: 10
         run: LOAD_PLUGINS=1 RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --use-runtime-info --profile=50 --verbose --format documentation plugins/chat/spec/system
-        timeout-minutes: 30
 
       - name: Theme System Tests
         if: matrix.build_type == 'system' && matrix.target == 'themes'
@@ -294,7 +289,6 @@ jobs:
         run: |
           RAILS_ENABLE_TEST_LOG=1 RAILS_TEST_LOG_LEVEL=error bin/turbo_rspec --profile=50 --verbose --format documentation tmp/themes/*/spec/system
         shell: bash
-        timeout-minutes: 30
 
       - name: Check for failed system test screenshots
         id: check-failed-system-test-screenshots
@@ -358,7 +352,6 @@ jobs:
             git -c color.ui=always diff app/models/
             exit 1
           fi
-        timeout-minutes: 30
 
   merge:
     if: github.repository == 'discourse/discourse' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
While the step to run plugin system tests has been set with a timeout of
30 minutes, the overall job timeout was only set to 20 minutes. As a
result, we are starting to see the plugin system tests job fail due to
the job exceeding the 20 minutes timeout.

### Reviewer notes 

Example of plugin system tests exceeding 20 minutes timeout: https://github.com/discourse/discourse/actions/runs/14665943355/job/41160611627
