### PR TITLE
DEV: remove wrapping span from full-page-search-below-search-info outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
@@ -202,13 +202,11 @@ export default RouteTemplate(
           {{/if}}
         {{/if}}
 
-        <span>
-          <PluginOutlet
-            @name="full-page-search-below-search-info"
-            @connectorTagName="div"
-            @outletArgs={{hash search=@controller.searchTerm}}
-          />
-        </span>
+        <PluginOutlet
+          @name="full-page-search-below-search-info"
+          @connectorTagName="div"
+          @outletArgs={{hash search=@controller.searchTerm}}
+        />
 
         {{#if @controller.searching}}
           {{loadingSpinner size="medium"}}


### PR DESCRIPTION
This span renders even when the plugin outlet isn't being used, so it can get in the way. I did a quick search and don't see it targeted anywhere obvious (it would be difficult to do without a unique class anyway)