### PR TITLE
UX: fix rich editor placeholder being cut on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -108,7 +108,9 @@ export default class UppyComposerUpload {
       this.fileInputEventListener
     );
 
-    this.#editorEl?.removeEventListener("paste", this._pasteEventListener);
+    this.#editorEl?.removeEventListener("paste", this._pasteEventListener, {
+      capture: true,
+    });
 
     this.appEvents.off(`${this.composerEventPrefix}:add-files`, this._addFiles);
     this.appEvents.off(
@@ -147,7 +149,9 @@ export default class UppyComposerUpload {
       this.#fileInputEl,
       this._addFiles
     );
-    this.#editorEl.addEventListener("paste", this._pasteEventListener, true);
+    this.#editorEl.addEventListener("paste", this._pasteEventListener, {
+      capture: true,
+    });
 
     this.uppyWrapper.uppyInstance = new Uppy({
       id: this.uppyId,

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -93,7 +93,6 @@
 
   p[data-placeholder] {
     overflow: hidden;
-    position: relative;
 
     &::before {
       pointer-events: none;
@@ -198,6 +197,7 @@
 
 // stylelint-disable-next-line no-duplicate-selectors
 .ProseMirror {
+  position: relative;
   word-wrap: break-word;
   white-space: break-spaces;
 }


### PR DESCRIPTION
After adjusting an overflow on the rich editor placeholder, it started being cut on mobile, as the parent paragraph can be smaller than the area the placeholder takes.

This fixes it by returning the `position: relative` to the `.ProseMirror` editor, which also fixes some weird positioning errors for "fake" cursors (gap cursor, codemark cursor, drop cursor) and absolute-positioned elements that relied upon the editor being `position: relative`.

Before
![image](https://github.com/user-attachments/assets/e3eb7981-8229-4da1-b549-759b5a6c1c11)

After
![image](https://github.com/user-attachments/assets/def338b2-97ee-449f-ae7c-895be51dc16e)

