### PR TITLE
FIX: rich editor link backspace edge case

### DIFF
--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -620,6 +620,18 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(composer).to have_value("![image|244x66](upload://4uyKKMzLG4oNnAYDWCgpRMjBr9X.png)")
     end
+
+    it "should correctly merge text with link marks created from parsing" do
+      cdp.allow_clipboard
+      open_composer_and_toggle_rich_editor
+
+      cdp.copy_paste("This is a [link](https://example.com)")
+      expect(rich).to have_css("a", text: "link")
+
+      composer.send_keys(%i[space left backspace])
+
+      expect(rich).to have_css("a", text: "lin")
+    end
   end
 
   describe "trailing paragraph" do


### PR DESCRIPTION
Fixes an edge case when backspacing at the end of a link mark, the entire link was getting lost – the test may help understanding.

The main fix is making sure the `markup` attr falls back to `null` if it comes as empty `""` string from the markdown-it tokens.

I didn't investigate too far as this solved it for us, but for some reason the link mark was getting lost when text node after the mark was being merged with the text node with the mark containing the "" markup.

The rest of the changes are `DEV`. `isPlainURL` is not necessary anymore as we're tracking the markup to determine if it should be serialized as an `<https://auto.link>`.