### PR TITLE
Revert "FIX: Stop non-rgb header background colors crashing Discourse…

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -435,17 +435,9 @@ export function prefersReducedMotion() {
 }
 
 export function postRNWebviewMessage(prop, value) {
-  if (window.ReactNativeWebView === undefined) {
-    return;
+  if (window.ReactNativeWebView !== undefined) {
+    window.ReactNativeWebView.postMessage(JSON.stringify({ [prop]: value }));
   }
-
-  if (prop === "headerBg" && !value.startsWith("rgb(")) {
-    // eslint-disable-next-line no-console
-    console.warn("Skipping unsupported headerBg value:", value);
-    return;
-  }
-
-  window.ReactNativeWebView.postMessage(JSON.stringify({ [prop]: value }));
 }
 
 function pickMarker(text) {


### PR DESCRIPTION
…Hub (#31929)"

This reverts commit 5f8a183abf24d0f54f7334d19152a09e9ae241c6. The issue has been resolved in the latest version of the DiscourseHub app. (Will merge this once that version goes through Apple review.) 