### PR TITLE
FIX: Don't null out category attributes if no param keys

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -177,8 +177,8 @@ class CategoriesController < ApplicationController
       category_params.delete(:custom_fields)
 
       # properly null the value so the database constraint doesn't catch us
-      category_params[:email_in] = nil if category_params[:email_in].blank?
-      category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags].blank?
+      category_params[:email_in] = nil if category_params[:email_in]&.blank?
+      category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags]&.blank?
 
       old_permissions = cat.permissions_params
       old_permissions = { "everyone" => 1 } if old_permissions.empty?

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -933,6 +933,23 @@ RSpec.describe CategoriesController do
           expect(response.status).to eq(200)
           expect(category.reload.moderating_groups).to be_blank
         end
+
+        it "can correctly convert blank strings to appropriate null values" do
+          put "/categories/#{category.id}.json", params: { email_in: "", minimum_required_tags: "" }
+          expect(response.status).to eq(200)
+          expect(category.reload.email_in).to be_nil
+          expect(category.reload.minimum_required_tags).to eq(0)
+        end
+
+        it "does not convert params when their key isn't present" do
+          category.update!(email_in: "ted@discourse.org", minimum_required_tags: 5)
+
+          put "/categories/#{category.id}.json", params: {}
+
+          expect(response.status).to eq(200)
+          expect(category.reload.email_in).to eq("ted@discourse.org")
+          expect(category.reload.minimum_required_tags).to eq(5)
+        end
       end
     end
   end


### PR DESCRIPTION
### What is the problem?

This is a bug introduced by me by thinking the lonely operator is redundant here. It is not. Sometimes the param keys are not sent, and when they aren't we should preserve the existing attribute value, not null it out.

This PR fixes that and also adds a regression test explaining why it's needed.