### PR TITLE
DEV: update styling class reference to d-icon-magnifying-glass

### DIFF
--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -51,7 +51,7 @@
       }
     }
 
-    .d-icon-search {
+    .d-icon-magnifying-glass {
       margin: 0;
     }
 
@@ -149,7 +149,7 @@
         margin: 0;
       }
 
-      .d-icon-search {
+      .d-icon-magnifying-glass {
         display: none;
       }
     }


### PR DESCRIPTION
The css class selector `d-icon-search` refers to a deprecated icon name, this PR updates it to the correct name.  