### PR TITLE
Revert "DEV: Remove the word tags from adobe_analytics_tags_url"

### DIFF
--- a/app/helpers/common_helper.rb
+++ b/app/helpers/common_helper.rb
@@ -16,8 +16,8 @@ module CommonHelper
   end
 
   def render_adobe_analytics_tags_code
-    if SiteSetting.adobe_analytics_url.present?
-      content_tag(:script, "", src: SiteSetting.adobe_analytics_url, async: true)
+    if SiteSetting.adobe_analytics_tags_url.present?
+      content_tag(:script, "", src: SiteSetting.adobe_analytics_tags_url, async: true)
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2766,7 +2766,7 @@ en:
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     about_page_hidden_groups: "Do not show members of specific groups on the /about page."
-    adobe_analytics_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
+    adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
     experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
     rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer/352347' target='_blank'>see Meta for more details</a>."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -503,7 +503,7 @@ basic:
     default: ""
     type: group_list
     area: "group_permissions"
-  adobe_analytics_url:
+  adobe_analytics_tags_url:
     default: ""
     regex: "assets.adobedtm.com"
     area: "analytics"


### PR DESCRIPTION
Need the script to migrate existing settings to come together with this. 🙏 