### PR TITLE
A11Y: use singular tag in accessible category_tag string

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5233,9 +5233,9 @@ en:
           bookmarks: "Topics tagged %{tags} you’ve bookmarked"
 
         category_tag:
-          default: "%{filter} topics in %{category} tagged %{tags}"
-          posted: "Topics in %{category} tagged %{tags} you’ve posted in"
-          bookmarks: "Topics in %{category} tagged %{tags} you’ve bookmarked"
+          default: "%{filter} topics in %{category} tagged %{tag}"
+          posted: "Topics in %{category} tagged %{tag} you’ve posted in"
+          bookmarks: "Topics in %{category} tagged %{tag} you’ve bookmarked"
 
         categories: "All categories"
 


### PR DESCRIPTION
We don't do tag intersections when filtered to a category, so these can always be singular 

follow-up to https://github.com/discourse/discourse/commit/ca658a8bb093c82410927d1fa29e5ef1940260b7