### PR TITLE
FIX: allow tags to be restricted to admin only

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -670,7 +670,7 @@ module DiscourseTagging
 
   # read-only tags for this user
   def self.readonly_tag_names(guardian = nil)
-    return [] if guardian&.is_staff?
+    return [] if guardian&.is_admin?
 
     query =
       Tag.joins(tag_groups: :tag_group_permissions).where(

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -96,6 +96,10 @@ module Helpers
     create_limited_tags("Staff Tags", Group::AUTO_GROUPS[:staff], tag_names)
   end
 
+  def create_admin_only_tags(tag_names)
+    create_limited_tags("Admin Tags", Group::AUTO_GROUPS[:admins], tag_names)
+  end
+
   def create_limited_tags(tag_group_name, group_id, tag_names)
     tag_group = Fabricate(:tag_group, name: tag_group_name)
     TagGroupPermission.where(


### PR DESCRIPTION
Allow creating a tag group with tags that are visible to everyone but can be used by admin only.