### PR TITLE
FIX: Staff action log logs in default locale when a user deletes themselves

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -97,7 +97,11 @@ class UserDestroyer
         unless opts[:quiet]
           if @actor == user
             deleted_by = Discourse.system_user
-            opts[:context] = I18n.t("staff_action_logs.user_delete_self", url: opts[:context])
+            message =
+              I18n.with_locale(SiteSetting.default_locale) do
+                I18n.t("staff_action_logs.user_delete_self", url: opts[:context])
+              end
+            opts[:context] = message
           else
             deleted_by = @actor
           end

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -81,10 +81,15 @@ RSpec.describe UserDestroyer do
 
       include_examples "successfully destroy a user"
 
-      it "should log proper context" do
+      it "logs context in default locale" do
+        I18n.locale = :ja
+        SiteSetting.default_locale = :de
+
         destroy
         expect(UserHistory.where(action: UserHistory.actions[:delete_user]).last.context).to eq(
-          I18n.t("staff_action_logs.user_delete_self", url: "/u/username/preferences/account"),
+          I18n.with_locale(:de) do
+            I18n.t("staff_action_logs.user_delete_self", url: "/u/username/preferences/account")
+          end,
         )
       end
     end


### PR DESCRIPTION
There is a bug now where the staff action log that shows up in the user's locale when a user deletes themselves.

<img width="962" alt="Screenshot 2025-04-29 at 12 08 49 PM" src="https://github.com/user-attachments/assets/c367831d-25e6-453a-bce8-312ef7451a5c" />

This PR fixes that issue by scoping it to the site's default locale.