### PR TITLE
UX: display search input and open modal on click

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -1,10 +1,10 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
-import { LinkTo } from "@ember/routing";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";

--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -1,4 +1,6 @@
 import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
@@ -194,6 +196,15 @@ export default class AdminSearch extends Component {
       </div>
       <DButton class="btn-flat" @icon="filter" @action={{this.toggleFilters}} />
     </div>
+    {{#if @fullPageLink}}
+      <LinkTo
+        @route="adminSearch"
+        @query={{hash filter=this.filter}}
+        class="admin-search__full-page-link"
+      >
+        {{i18n "admin.search.full_page_link"}}
+      </LinkTo>
+    {{/if}}
 
     {{#if this.showFilters}}
       <AdminSearchFilters

--- a/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
@@ -14,7 +14,7 @@ export default class AdminSearchModal extends Component {
       @inline={{@inline}}
       @hideHeader={{true}}
     >
-      <AdminSearch />
+      <AdminSearch @fullPageLink={{true}} />
     </DModal>
   </template>
 }

--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
@@ -1,6 +1,7 @@
 import Service, { service } from "@ember/service";
 import KeyValueStore from "discourse/lib/key-value-store";
 import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
+import AdminSearchModal from "admin/components/modal/admin-search";
 
 export default class AdminSidebarStateManager extends Service {
   @service sidebarState;
@@ -55,6 +56,10 @@ export default class AdminSidebarStateManager extends Service {
   stopForcingAdminSidebar() {
     this.sidebarState.setPanel(MAIN_PANEL);
     this.sidebarState.isForcingSidebar = false;
+  }
+
+  get modals() {
+    return { adminSearch: AdminSearchModal };
   }
 
   #forceAdminSidebar() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import BackToForum from "./back-to-forum";
+import Search from "./search";
 import ToggleAllSections from "./toggle-all-sections";
 
 export default class PanelHeader extends Component {
@@ -16,6 +17,9 @@ export default class PanelHeader extends Component {
         <div class="sidebar-panel-header__row">
           <BackToForum />
           <ToggleAllSections @sections={{@sections}} />
+        </div>
+        <div class="sidebar-panel-header__row">
+          <Search />
         </div>
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
-import BackToForum from "discourse/components/back-to-forum";
-import Search from "discourse/components/search";
+import BackToForum from "discourse/components/sidebar/back-to-forum";
+import Search from "discourse/components/sidebar/search";
 import ToggleAllSections from "./toggle-all-sections";
 
 export default class PanelHeader extends Component {

--- a/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/panel-header.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
-import BackToForum from "./back-to-forum";
-import Search from "./search";
+import BackToForum from "discourse/components/back-to-forum";
+import Search from "discourse/components/search";
 import ToggleAllSections from "./toggle-all-sections";
 
 export default class PanelHeader extends Component {

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -1,0 +1,45 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import { i18n } from "discourse-i18n";
+
+export default class Search extends Component {
+  @service sidebarState;
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+  }
+
+  get shouldDisplay() {
+    return this.sidebarState.currentPanel.searchable;
+  }
+
+  @action
+  onClick(event) {
+    event?.preventDefault();
+    return this.sidebarState.currentPanel.onSearchClick;
+  }
+
+  <template>
+    {{#if this.shouldDisplay}}
+      <div class="sidebar-search">
+        <div class="sidebar-search__input-container">
+          <DButton
+            @action={{this.onClick}}
+            @icon="magnifying-glass"
+            class="btn-transparent sidebar-search__icon"
+          />
+          <input
+            {{on "mouseup" this.onClick}}
+            placeholder={{i18n "sidebar.search"}}
+            type="text"
+            enterkeyhint="done"
+            class="sidebar-search__input"
+          />
+        </div>
+      </div>
+    {{/if}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -32,6 +32,7 @@ export default class Search extends Component {
             class="btn-transparent sidebar-search__icon"
           />
           <input
+            {{on "mousedown" this.onClick}}
             {{on "mouseup" this.onClick}}
             placeholder={{i18n "sidebar.search"}}
             type="text"

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -3,8 +3,8 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
-import { i18n } from "discourse-i18n";
 import { translateModKey } from "discourse/lib/utilities";
+import { i18n } from "discourse-i18n";
 
 export default class Search extends Component {
   @service sidebarState;

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -31,9 +31,9 @@ export default class Search extends Component {
             @icon="magnifying-glass"
             class="btn-transparent sidebar-search__icon"
           />
+          {{! template-lint-disable no-pointer-down-event-binding }}
           <input
             {{on "mousedown" this.onClick}}
-            {{on "mouseup" this.onClick}}
             placeholder={{i18n "sidebar.search"}}
             type="text"
             enterkeyhint="done"

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -9,10 +9,6 @@ import { translateModKey } from "discourse/lib/utilities";
 export default class Search extends Component {
   @service sidebarState;
 
-  willDestroy() {
-    super.willDestroy(...arguments);
-  }
-
   get shouldDisplay() {
     return this.sidebarState.currentPanel.searchable;
   }

--- a/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/search.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import { i18n } from "discourse-i18n";
+import { translateModKey } from "discourse/lib/utilities";
 
 export default class Search extends Component {
   @service sidebarState;
@@ -14,6 +15,10 @@ export default class Search extends Component {
 
   get shouldDisplay() {
     return this.sidebarState.currentPanel.searchable;
+  }
+
+  get sidebarShortcutCombo() {
+    return `${translateModKey("Meta")}+/`;
   }
 
   @action
@@ -39,6 +44,9 @@ export default class Search extends Component {
             enterkeyhint="done"
             class="sidebar-search__input"
           />
+          <span
+            class="sidebar-search__shortcut-hint"
+          >{{this.sidebarShortcutCombo}}</span>
         </div>
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -13,14 +13,6 @@ export const ADMIN_NAV_MAP = [
         moderator: true,
       },
       {
-        name: "admin_search",
-        route: "adminSearch",
-        label: "admin.config.search_everything.title",
-        description: "admin.config.search_everything.header_description",
-        icon: "magnifying-glass",
-        moderator: true,
-      },
-      {
         name: "admin_users",
         route: "adminUsers",
         label: "admin.config.users.title",

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -11,6 +11,7 @@ import BaseCustomSidebarSection from "discourse/lib/sidebar/base-custom-sidebar-
 import BaseCustomSidebarSectionLink from "discourse/lib/sidebar/base-custom-sidebar-section-link";
 import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
 import I18n, { i18n } from "discourse-i18n";
+import AdminSearchModal from "admin/components/modal/admin-search";
 
 let additionalAdminSidebarSectionLinks = {};
 
@@ -406,5 +407,13 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         currentUser
       );
     });
+  }
+
+  get searchable() {
+    return true;
+  }
+
+  get onSearchClick() {
+    getOwnerWithFallback(this).lookup("service:modal").show(AdminSearchModal);
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -11,7 +11,6 @@ import BaseCustomSidebarSection from "discourse/lib/sidebar/base-custom-sidebar-
 import BaseCustomSidebarSectionLink from "discourse/lib/sidebar/base-custom-sidebar-section-link";
 import { ADMIN_PANEL } from "discourse/lib/sidebar/panels";
 import I18n, { i18n } from "discourse-i18n";
-import AdminSearchModal from "admin/components/modal/admin-search";
 
 let additionalAdminSidebarSectionLinks = {};
 
@@ -414,6 +413,8 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
   }
 
   get onSearchClick() {
-    getOwnerWithFallback(this).lookup("service:modal").show(AdminSearchModal);
+    getOwnerWithFallback(this)
+      .lookup("service:modal")
+      .show(this.adminSidebarStateManager.modals.adminSearch);
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-panel.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-panel.js
@@ -54,6 +54,20 @@ export default class BaseCustomSidebarPanel {
     return false;
   }
 
+  /**
+   * @returns {boolean} Controls whether the search is shown
+   */
+  get searchable() {
+    return false;
+  }
+
+  /**
+   * @returns {Function} Action when search input is clicked.
+   */
+  onSearchClick() {
+    return null;
+  }
+
   get scrollActiveLinkIntoView() {
     return false;
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -114,7 +114,7 @@ acceptance("Admin - Site Settings", function (needs) {
 
     // navigate back to the "Settings" page, the title filter
     // has been removed from navigation
-    await click(".sidebar-section-link-wrapper:nth-child(5) a");
+    await click(".sidebar-section-link-wrapper:nth-child(4) a");
     assert.dom(".row.setting").exists({ count: 4 });
   });
 

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -150,4 +150,5 @@
 
 .admin-search-modal {
   --modal-max-width: 700px;
+  --modal-min-height: 200px;
 }

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -42,6 +42,11 @@
     background: none !important;
     width: 100% !important;
   }
+
+  &__full-page-link {
+    align-self: self-end;
+    padding-right: 2.3em;
+  }
 }
 
 // Fitler

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -229,6 +229,10 @@
   .badge-notification {
     vertical-align: text-bottom;
   }
+
+  .sidebar-search {
+    width: 100%;
+  }
 }
 
 .search-menu .menu-panel {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -351,6 +351,43 @@
   }
 }
 
+.sidebar-search {
+  width: 100%;
+
+  &__input-container {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--primary-400);
+    background: var(--d-input-bg-color);
+    box-sizing: border-box;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+  }
+
+  &__icon.btn.btn-transparent {
+    border: 0;
+    background: var(--d-input-bg-color);
+    padding-left: var(--d-sidebar-row-horizontal-padding);
+    padding-right: var(--d-sidebar-row-horizontal-padding);
+
+    &:hover {
+      background: var(--d-input-bg-color) !important;
+    }
+
+    .d-icon:hover {
+      color: var(--primary-high);
+    }
+  }
+
+  &__input[type="text"] {
+    margin-bottom: 0;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    height: var(--d-sidebar-row-height);
+  }
+}
+
 .sidebar-panel-header__row {
   display: flex;
   justify-content: space-between;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -385,6 +385,10 @@
     padding: 0;
     width: 100%;
     height: var(--d-sidebar-row-height);
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -385,10 +385,19 @@
     padding: 0;
     width: 100%;
     height: var(--d-sidebar-row-height);
+    cursor: pointer;
 
     &:focus {
       outline: none;
     }
+  }
+
+  &__shortcut-hint {
+    background-color: rgba(var(--tertiary-rgb), 0.1);
+    padding: 0.25em 0.5em;
+    margin-right: 0.5em;
+    font-size: var(--font-down-3);
+    color: var(--primary-medium);
   }
 }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5600,6 +5600,7 @@ en:
         modal_title: "Search anything in admin"
         title: "Search"
         instructions: "Type to search for pages, settings, reports, themes, components, and more..."
+        full_page_link: "Switch to full page search"
         no_results: "We couldn’t find anything matching ‘%{filter}’."
         result_types:
           page:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5081,6 +5081,7 @@ en:
       back_to_forum: "Back to Forum"
       collapse_all_sections: "Collapse all sections"
       expand_all_sections: "Expand all sections"
+      search: "Search everything"
       footer:
         interface_color_selector:
           light: "Light"

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -3,6 +3,7 @@
 describe "Admin Search", type: :system do
   fab!(:current_user) { Fabricate(:admin) }
   let(:search_modal) { PageObjects::Modals::AdminSearch.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
   before { sign_in(current_user) }
 
@@ -74,5 +75,13 @@ describe "Admin Search", type: :system do
     expect(search_modal).to have_content(
       "We couldn’t find anything matching ‘very long search phrase’.",
     )
+  end
+
+  it "opens search modal when search input is clicked" do
+    visit "/admin"
+    sidebar.click_search_input
+
+    search_modal.search("min_topic_title")
+    expect(search_modal.find_result("setting", 0)).to have_content("Min topic title length")
   end
 end

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -7,11 +7,6 @@ describe "Admin Search", type: :system do
 
   before { sign_in(current_user) }
 
-  def open_search_modal
-    send_keys([SystemHelpers::PLATFORM_KEY_MODIFIER, "/"])
-    expect(search_modal).to be_open
-  end
-
   it "can search for settings, pages, themes, components, and reports" do
     theme = Fabricate(:theme, name: "Discourse Invincible Theme")
     component = Fabricate(:theme, name: "Discourse Redacted", component: true)
@@ -21,7 +16,7 @@ describe "Admin Search", type: :system do
       .returns([stub(key: "theme_metadata.description", value: "Some description")])
 
     visit "/admin"
-    open_search_modal
+    sidebar.click_search_input
 
     search_modal.search("min_topic_title")
     expect(search_modal.find_result("setting", 0)).to have_content("Min topic title length")
@@ -56,7 +51,7 @@ describe "Admin Search", type: :system do
 
   it "can search full page" do
     visit "/admin"
-    open_search_modal
+    sidebar.click_search_input
     search_modal.search("min_topic_title")
     search_modal.input_enter
     expect(page).to have_current_path("/admin/search?filter=min_topic_title")
@@ -68,7 +63,7 @@ describe "Admin Search", type: :system do
 
   it "informs user about no results" do
     visit "/admin"
-    open_search_modal
+    sidebar.click_search_input
 
     search_modal.search("very long search phrase")
 
@@ -77,11 +72,10 @@ describe "Admin Search", type: :system do
     )
   end
 
-  it "opens search modal when search input is clicked" do
+  it "opens search modal with keyboard shortcut" do
     visit "/admin"
-    sidebar.click_search_input
 
-    search_modal.search("min_topic_title")
-    expect(search_modal.find_result("setting", 0)).to have_content("Min topic title length")
+    send_keys([SystemHelpers::PLATFORM_KEY_MODIFIER, "/"])
+    expect(search_modal).to be_open
   end
 end

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -61,6 +61,19 @@ describe "Admin Search", type: :system do
     )
   end
 
+  it "can go to full page search with link" do
+    visit "/admin"
+    sidebar.click_search_input
+    search_modal.search("min_topic_title")
+    search_modal.click_switch_to_full_page
+
+    expect(page).to have_current_path("/admin/search?filter=min_topic_title")
+    expect(search_modal.find_result("setting", 0)).to have_content("Min topic title length")
+    expect(search_modal.find_result("setting", 0)).to have_content(
+      I18n.t("site_settings.min_topic_title_length"),
+    )
+  end
+
   it "informs user about no results" do
     visit "/admin"
     sidebar.click_search_input

--- a/spec/system/admin_sidebar_navigation_spec.rb
+++ b/spec/system/admin_sidebar_navigation_spec.rb
@@ -60,7 +60,6 @@ describe "Admin | Sidebar Navigation", type: :system do
     expect(links.map(&:text)).to eq(
       [
         I18n.t("admin_js.admin.dashboard.title"),
-        I18n.t("admin_js.admin.config.search_everything.title"),
         I18n.t("admin_js.admin.config.users.title"),
         I18n.t("admin_js.admin.config.groups.title"),
         I18n.t("admin_js.admin.config.site_settings.title"),
@@ -98,11 +97,10 @@ describe "Admin | Sidebar Navigation", type: :system do
     )
 
     sidebar.toggle_all_sections
-    expect(page).to have_selector(".sidebar-section-link-content-text", count: 6)
+    expect(page).to have_selector(".sidebar-section-link-content-text", count: 5)
     expect(all(".sidebar-section-link-content-text").map(&:text)).to eq(
       [
         I18n.t("admin_js.admin.dashboard.title"),
-        I18n.t("admin_js.admin.config.search_everything.title"),
         I18n.t("admin_js.admin.config.users.title"),
         I18n.t("admin_js.admin.config.groups.title"),
         I18n.t("admin_js.admin.config.site_settings.title"),
@@ -152,7 +150,6 @@ describe "Admin | Sidebar Navigation", type: :system do
     expect(links.map(&:text)).to eq(
       [
         I18n.t("admin_js.admin.dashboard.title"),
-        I18n.t("admin_js.admin.config.search_everything.title"),
         I18n.t("admin_js.admin.config.users.title"),
         I18n.t("admin_js.admin.config.groups.title"),
         I18n.t("admin_js.admin.config.whats_new.title"),

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -69,6 +69,10 @@ module PageObjects
           page.find(".sidebar-sections__back-to-forum").click
           self
         end
+
+        def click_search_input
+          page.find(".sidebar-search__input").click
+        end
       end
     end
   end

--- a/spec/system/page_objects/modals/admin_search.rb
+++ b/spec/system/page_objects/modals/admin_search.rb
@@ -16,6 +16,10 @@ module PageObjects
       def input_enter
         find(".admin-search__input-field").send_keys(:enter)
       end
+
+      def click_switch_to_full_page
+        find(".admin-search__full-page-link").click
+      end
     end
   end
 end


### PR DESCRIPTION
In this PR we hide search input.

https://github.com/discourse/discourse/pull/32485

However, search input is much more intuitive. Therefore, input was brought back and opens modal on click. In addition, search link was removed.

Demo:
https://github.com/user-attachments/assets/5b193fab-918e-4a4d-9fdd-97c92c534850

Mobile:
![Screenshot 2025-04-30 at 3 00 47 pm](https://github.com/user-attachments/assets/50081258-be57-422a-9a06-d6e2122082c2)