### PR TITLE
FIX: don't error when no filter is set in discovery heading

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
@@ -5,7 +5,7 @@ export default class AccessibleDiscoveryHeading extends Component {
   get filterKey() {
     const filter = this.args.filter;
 
-    if (filter === "categories") {
+    if (!filter || filter === "categories") {
       return null;
     }
 


### PR DESCRIPTION
In some rare cases, plugins can add nav items without a filter. For example, the ActivityPub plugin does this. The recent change in https://github.com/discourse/discourse/pull/32422 results in a JS error on those pages, see report in https://meta.discourse.org/t/list-of-activitypub-followers-of-a-tag-actor-not-shown-on-discourse-meta/363971 

This fixes the issue. 