### PR TITLE
DEV: add extra safety around original post only implementation

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -34,7 +34,7 @@ module DiscourseAutomation
 
           original_post_only = automation.trigger_field("original_post_only")
           if original_post_only["value"]
-            next if topic.posts_count > 1
+            next if post.post_number != 1
           end
 
           first_post_only = automation.trigger_field("first_post_only")


### PR DESCRIPTION
Instead of looking at post count that is cached, only ever look at the post_number
which is guaranteed to be correct

