### PR TITLE
DEV: Update workflow concurrency controls to use `github.ref_name`

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: licenses-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: licenses-${{ format('{0}-{1}', github.ref_name, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: linting-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: linting-${{ format('{0}-{1}', github.ref_name, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -14,7 +14,7 @@ on:
       - "migrations/**"
 
 concurrency:
-  group: migration-tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: migration-tests-${{ format('{0}-{1}', github.ref_name, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
       - "migrations/**"
 
 concurrency:
-  group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: tests-${{ format('{0}-{1}', github.ref_name, github.job) }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
`github.ref_name` is

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.
> 
> For pull requests, the format is <pr_number>/merge.

Not sure why we use `github.run_number` when it is a unique number for
each run of a workflow. `github.head_ref` is only present on pull request events so it is blank when the workflow is ran on 
other branches.

By updating the key to `github.ref_name` + `github.job` we ensure that
only one workflow will be running for a given PR or branch.
