### PR TITLE
FIX: Background body regressed in #32517

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -102,7 +102,6 @@ html {
 }
 
 body {
-  background-color: var(--secondary);
   background-attachment: fixed;
   background-size: cover;
   min-height: 100%;


### PR DESCRIPTION
Previously only mobile had body background, so that change made it cover the html backround (as seen on meta)