### PR TITLE
UX: fix topic statuses on category list

### DIFF
--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -129,6 +129,10 @@
       border: none;
       padding: 0;
     }
+
+    .topic-statuses {
+      display: flex;
+    }
   }
 
   tbody {


### PR DESCRIPTION
Multiple statuses are wrapping incorrectly, this fixes it 


Before:
![image](https://github.com/user-attachments/assets/f52f7fa0-f18e-416d-8235-f133146ba057)


After: 
![image](https://github.com/user-attachments/assets/724b12b1-b7f9-487e-a369-0026e67867b3)
