### PR TITLE
FIX: wizard logo preview

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/image.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/image.gjs
@@ -1,6 +1,5 @@
 import Component from "@ember/component";
 import { warn } from "@ember/debug";
-import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { classNames } from "@ember-decorators/component";
@@ -21,8 +20,7 @@ export default class Image extends Component {
 
   @discourseComputed("field.id")
   previewComponent(id) {
-    const name = imagePreviews[dasherize(id)] ?? imagePreviews.generic;
-    return getOwner(this).resolveRegistration(`component:${name}`);
+    return imagePreviews[dasherize(id)] ?? imagePreviews.generic;
   }
 
   didInsertElement() {

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -67,9 +67,9 @@ To get you started, think about what you want new members to **know about your c
 
 To customize the look and feel of your community beyond what you configured in the [setup wizard](%{base_url}/wizard), you can change the following settings in the [admin interface](%{base_url}/admin):
 
-- [Logo images](%{base_url}/admin/config/logo)
+- [Logo images](%{base_url}/admin/config/logo-and-fonts)
 - [Color palettes](%{base_url}/admin/customize/colors)
-- [Font styles](%{base_url}/admin/config/fonts)
+- [Font styles](%{base_url}/admin/config/logo-and-fonts)
 - [Site theme](%{base_url}/admin/customize/themes)
 - [Navigation menu](%{base_url}/admin/config/navigation)
 - [Custom user fields](%{base_url}/admin/config/user-fields)

--- a/spec/system/page_objects/pages/wizard.rb
+++ b/spec/system/page_objects/pages/wizard.rb
@@ -86,6 +86,10 @@ class PageObjects::Pages::Wizard::BrandingStep < PageObjects::Pages::Wizard::Ste
   def has_upload?(field_id)
     wizard.find_field("image", field_id).has_css?(".wizard-container__button-upload.has-upload")
   end
+
+  def has_preview?(field_id)
+    wizard.find_field("image", field_id).has_css?(".wizard-container__preview")
+  end
 end
 
 class PageObjects::Pages::Wizard::StylingStep < PageObjects::Pages::Wizard::StepBase

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -67,8 +67,10 @@ describe "Wizard", type: :system do
       expect(wizard_page).to be_on_step("branding")
       attach_file(file_path_1) { wizard_page.branding_step.click_upload_button("logo") }
       expect(wizard_page.branding_step).to have_upload("logo")
+      expect(wizard_page.branding_step).to have_preview("logo")
       attach_file(file_path_2) { wizard_page.branding_step.click_upload_button("logo-small") }
       expect(wizard_page.branding_step).to have_upload("logo-small")
+      expect(wizard_page.branding_step).to have_preview("logo-small")
       wizard_page.go_to_next_step
       expect(wizard_page).to be_on_step("ready")
 


### PR DESCRIPTION
Bug introduced in this commit - https://github.com/discourse/discourse/commit/e41897a3066

`imagePreviews` already returns component classes.

I tried:
`return getOwner(this).resolveRegistration("component:${id}");` but in wizard `getOwner(this)` throws error.

In addition, links to logo page in admin guide were fixed.

![Screenshot 2025-05-01 at 11 13 31 am](https://github.com/user-attachments/assets/19822a8c-415d-4341-a4c2-6a6b18f1929f)


