### PR TITLE
FIX: shorten search everything to search

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5081,7 +5081,7 @@ en:
       back_to_forum: "Back to Forum"
       collapse_all_sections: "Collapse all sections"
       expand_all_sections: "Expand all sections"
-      search: "Search everything"
+      search: "Search"
       footer:
         interface_color_selector:
           light: "Light"


### PR DESCRIPTION
`Search everything` was a bit too big.

Before:
![Screenshot 2025-05-01 at 3 41 56 pm](https://github.com/user-attachments/assets/d71ef702-2bcd-47fc-bf98-da26f0e2ea19)

After:
![Screenshot 2025-05-01 at 3 42 11 pm](https://github.com/user-attachments/assets/8fa850b4-e218-4d60-971c-56d958dd81f6)
