### PR TITLE
FIX: Use binary mode when opening files for S3 upload to prevent corruption

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -38,7 +38,7 @@ def upload(path, remote_path, content_type, content_encoding = nil, logger:)
   else
     logger << "Uploading: #{remote_path}\n"
 
-    File.open(path) { |file| helper.upload(file, remote_path, options) }
+    File.open(path, "rb") { |file| helper.upload(file, remote_path, options) }
   end
 end
 


### PR DESCRIPTION
In [**lib/task/s3.rake**](https://github.com/discourse/discourse/blob/main/lib/tasks/s3.rake#L41) files are opened in text mode. This causes corruption with Brotli compressed files which are binary. After these files are opened in text mode, they are put into the AWS SDK upload in [**lib/s3_helper.rb**](https://github.com/discourse/discourse/blob/main/lib/s3_helper.rb#L81). The corruption was observed when uploading assets to Cloudflare R2 for CDN mode with `rake s3:upload_assets`. This can be fixed by opening the files with `File.open(path, "rb")` in the `s3.rake` task. Below is a hook that will apply this change to an existing installation and correct the issue.

I have been using Cloudflare R2 CDN for a while and only noticed this issue when doing a redeployment, not sure if it's a change somewhere else in the codebase or just a change in the Brotli data that happened to contain a byte sequence that triggered processing in text mode. But either way, Brotli compressed files should not be opened in text mode.

```
hooks:
  after_assets_precompile:
    - exec:
        cd: $home
        cmd:
          - sed -i 's/File\.open(path) { |file| helper\.upload(file, remote_path, options) }/File.open(path, "rb") { |file| helper.upload(file, remote_path, options) }/' /var/www/discourse/lib/tasks/s3.rake
          - sudo -E -u discourse bundle exec rake s3:upload_assets
```