### PR TITLE
FIX: improvements for admin search

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -62,10 +62,6 @@ export default class AdminSearch extends Component {
     );
   }
 
-  get showLoadingSpinner() {
-    return !this.adminSearchDataSource.isLoaded || this.loading;
-  }
-
   get noResultsDescription() {
     return i18n("admin.search.no_results", {
       filter: escapeExpression(this.filter),
@@ -215,7 +211,7 @@ export default class AdminSearch extends Component {
     {{/if}}
 
     <div class="admin-search__results">
-      <ConditionalLoadingSpinner @condition={{this.showLoadingSpinner}}>
+      <ConditionalLoadingSpinner @condition={{this.loading}}>
         {{#each this.searchResults as |result|}}
           <div class="admin-search__result" data-result-type={{result.type}}>
             <a

--- a/app/assets/javascripts/discourse/tests/fixtures/admin-search-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/admin-search-fixtures.js
@@ -47,7 +47,7 @@ export default {
         type: "page_view_anon_browser_reqs",
         title: "Anonymous Browser Pageviews",
         description:
-          "Number of pageviews by anonymous visitors using real browsers.",
+          "Number of pageviews by anonymous visitors using real browsers. Anonym to test word matching.",
         description_link: null,
       },
       {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
@@ -54,7 +54,7 @@ module("Integration | Component | AdminSearch", function (hooks) {
     await click(filterButtonCss("setting"));
     assert.dom(".admin-search__result").doesNotExist();
 
-    await fillIn(".admin-search__input-field", "admin login");
+    await fillIn(".admin-search__input-field", "admin logins");
     assert.dom(".admin-search__result").exists({ count: 1 });
 
     await click(filterButtonCss("report"));

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -134,6 +134,20 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
       "/admin/reports/page_view_anon_browser_reqs"
     );
   });
+
+  test("search - prioritize whole word matches", async function (assert) {
+    await this.subject.buildMap();
+    let results = this.subject.search("anonym");
+    assert.deepEqual(results.length, 1);
+    assert.deepEqual(results[0].label, "Anonymous Browser Pageviews");
+  });
+
+  test("search - prioritize beginning of label", async function (assert) {
+    await this.subject.buildMap();
+    let results = this.subject.search("about");
+    assert.deepEqual(results.length, 4);
+    assert.deepEqual(results[0].label, "About your site > Title");
+  });
 });
 
 module(

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -155,5 +155,4 @@
 
 .admin-search-modal {
   --modal-max-width: 700px;
-  --modal-min-height: 200px;
 }


### PR DESCRIPTION
Instead of simple match keywords, search login was a bit enhanced. Now results are searched in 4 loops:
1. Check if item label starts with searched phrase. This is to prioritize `automation` when `auto` is typed (but not `mail` when `ai` is typed);
2. Check if every whole word matches keywords. This is to prioritize `discourse-ai` when `ai` is typed;
3. Fallback to original phrase match.

In addition, stop showing loading sign when modal is opened.

⚠️ please do not merge, I would like to test another idea on Monday ⚠️ 

<img width="780" alt="Screenshot 2025-05-02 at 1 31 39 pm" src="https://github.com/user-attachments/assets/72f2aa02-f84f-47f4-90dc-fb4f9c956ade" />
