### PR TITLE
UX: fix long category name overflow in category boxes

### DIFF
--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -132,6 +132,10 @@
       display: none;
     }
   }
+
+  .badge-category__wrapper {
+    max-width: 100%;
+  }
 }
 
 .category-boxes {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/cc2906e1-5b37-4a11-8a9e-2bb26f420507)


After: 

![image](https://github.com/user-attachments/assets/75823f3f-9f29-4a78-9324-6572502d6f09)
