### PR TITLE
UX: apply signup page styles to invite page

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -332,7 +332,8 @@ body.signup-page {
   }
 }
 
-// Signup page
+// Signup and invite page
+.invite-page,
 .signup-fullpage {
   .password-confirmation {
     display: none;


### PR DESCRIPTION
These styles should generally apply to the invite page as well — fixes some inconsistencies, including this issue reported here: https://meta.discourse.org/t/user-fields-at-signup-visual-bug-when-invited-vs-regular-signup/364488

Before: 

![image](https://github.com/user-attachments/assets/78824fc0-ffe9-4135-8cb3-81e17c9a566f)


After:

![image](https://github.com/user-attachments/assets/fe9b09a9-765c-4cc4-af5c-c5a76dddb53c)