### PR TITLE
UX: rich editor footnotes position

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -7,6 +7,7 @@
   overflow-x: hidden;
   display: flex;
   height: 100%;
+  position: relative;
 }
 
 .ProseMirror {
@@ -197,7 +198,6 @@
 
 // stylelint-disable-next-line no-duplicate-selectors
 .ProseMirror {
-  position: relative;
   word-wrap: break-word;
   white-space: break-spaces;
 }
@@ -259,7 +259,7 @@ li.ProseMirror-selectednode::after {
 .ProseMirror-gapcursor {
   display: none;
   pointer-events: none;
-  position: absolute;
+  position: sticky;
 }
 
 .ProseMirror-gapcursor::after {

--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -141,6 +141,7 @@
     padding-top: 0.5rem;
     background-color: var(--primary-50);
     border-radius: var(--d-border-radius);
+    z-index: z("modal", "tooltip");
 
     &:focus-within {
       outline: 1px solid var(--primary-low);


### PR DESCRIPTION
Moves `position: relative` from the editor itself to the scrollable container, to avoid the footnote sub-editor scrolling with the content. This also affects the gap cursor, which should scroll with the content, so it is now changed to `position: sticky`.

Fixes the z-index for the footnote sub-editor - it was being rendered behind code blocks.