### PR TITLE
FIX: improvements for admin search

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -62,10 +62,6 @@ export default class AdminSearch extends Component {
     );
   }
 
-  get showLoadingSpinner() {
-    return !this.adminSearchDataSource.isLoaded || this.loading;
-  }
-
   get noResultsDescription() {
     return i18n("admin.search.no_results", {
       filter: escapeExpression(this.filter),
@@ -215,7 +211,7 @@ export default class AdminSearch extends Component {
     {{/if}}
 
     <div class="admin-search__results">
-      <ConditionalLoadingSpinner @condition={{this.showLoadingSpinner}}>
+      <ConditionalLoadingSpinner @condition={{this.loading}}>
         {{#each this.searchResults as |result|}}
           <div class="admin-search__result" data-result-type={{result.type}}>
             <a

--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -300,7 +300,7 @@ export default class AdminSearchDataSource extends Service {
           dataSourceItem.score += SEARCH_SCORES.exactKeyword;
         }
         if (dataSourceItem.keywords.match(fallbackRegex)) {
-          dataSourceItem.score = dataSourceItem.score + SEARCH_SCORES.fallback;
+          dataSourceItem.score += SEARCH_SCORES.fallback;
         }
 
         if (dataSourceItem.score > 0) {

--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -296,8 +296,8 @@ export default class AdminSearchDataSource extends Service {
             return dataSourceItem.label.match(regex);
           })
         ) {
-          dataSourceItem.score =
-          dataSourceItem.score += SEARCH_SCORES.exactKeyword;
+          dataSourceItem.score = dataSourceItem.score +=
+            SEARCH_SCORES.exactKeyword;
         }
         if (dataSourceItem.keywords.match(fallbackRegex)) {
           dataSourceItem.score += SEARCH_SCORES.fallback;

--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -289,8 +289,7 @@ export default class AdminSearchDataSource extends Service {
         dataSourceItem.score = 0;
 
         if (dataSourceItem.label.match(labelStartRegex)) {
-          dataSourceItem.score =
-            dataSourceItem.score + SEARCH_SCORES.labelStart;
+          dataSourceItem.score += SEARCH_SCORES.labelStart;
         }
         if (
           exactKeywordRegexes.every((regex) => {

--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -297,7 +297,7 @@ export default class AdminSearchDataSource extends Service {
           })
         ) {
           dataSourceItem.score =
-            dataSourceItem.score + SEARCH_SCORES.exactKeyword;
+          dataSourceItem.score += SEARCH_SCORES.exactKeyword;
         }
         if (dataSourceItem.keywords.match(fallbackRegex)) {
           dataSourceItem.score = dataSourceItem.score + SEARCH_SCORES.fallback;

--- a/app/assets/javascripts/discourse/tests/fixtures/admin-search-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/admin-search-fixtures.js
@@ -47,7 +47,7 @@ export default {
         type: "page_view_anon_browser_reqs",
         title: "Anonymous Browser Pageviews",
         description:
-          "Number of pageviews by anonymous visitors using real browsers.",
+          "Number of pageviews by anonymous visitors using real browsers. Anonym to test word matching.",
         description_link: null,
       },
       {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
@@ -54,7 +54,7 @@ module("Integration | Component | AdminSearch", function (hooks) {
     await click(filterButtonCss("setting"));
     assert.dom(".admin-search__result").doesNotExist();
 
-    await fillIn(".admin-search__input-field", "admin login");
+    await fillIn(".admin-search__input-field", "admin logins");
     assert.dom(".admin-search__result").exists({ count: 1 });
 
     await click(filterButtonCss("report"));

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -138,14 +138,12 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
   test("search - prioritize whole word matches", async function (assert) {
     await this.subject.buildMap();
     let results = this.subject.search("anonym");
-    assert.deepEqual(results.length, 1);
     assert.deepEqual(results[0].label, "Anonymous Browser Pageviews");
   });
 
   test("search - prioritize beginning of label", async function (assert) {
     await this.subject.buildMap();
     let results = this.subject.search("about");
-    assert.deepEqual(results.length, 4);
     assert.deepEqual(results[0].label, "About your site > Title");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -134,6 +134,20 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
       "/admin/reports/page_view_anon_browser_reqs"
     );
   });
+
+  test("search - prioritize whole word matches", async function (assert) {
+    await this.subject.buildMap();
+    let results = this.subject.search("anonym");
+    assert.deepEqual(results.length, 1);
+    assert.deepEqual(results[0].label, "Anonymous Browser Pageviews");
+  });
+
+  test("search - prioritize beginning of label", async function (assert) {
+    await this.subject.buildMap();
+    let results = this.subject.search("about");
+    assert.deepEqual(results.length, 4);
+    assert.deepEqual(results[0].label, "About your site > Title");
+  });
 });
 
 module(

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -155,5 +155,4 @@
 
 .admin-search-modal {
   --modal-max-width: 700px;
-  --modal-min-height: 200px;
 }


### PR DESCRIPTION
Instead of simple match keywords, search login was a bit enhanced by calculating score.

1. 20 points if item label starts with searched phrase. This is to prioritize `automation` when `auto` is typed;
2. 10 points for each exact word matches keywords. This is to prioritize `discourse-ai` when `ai` is typed;
3. 5 points if matches fallback to original phrase match.

In addition, stop showing loading sign when modal is opened.

![Screenshot 2025-05-05 at 11 35 54 am](https://github.com/user-attachments/assets/d4291fcb-e3c2-4db6-8353-d74a3acca985)
![Screenshot 2025-05-05 at 11 36 01 am](https://github.com/user-attachments/assets/5ce04c22-1471-4524-a432-31cfbbcd7f20)
![Screenshot 2025-05-05 at 11 36 09 am](https://github.com/user-attachments/assets/d0f8791d-f5b7-4455-9f6e-8e775c69fbd0)
![Screenshot 2025-05-05 at 11 36 20 am](https://github.com/user-attachments/assets/e89e6035-4f22-461d-b0a8-897decbb4ee0)

