### PR TITLE
 FIX: key optimized images on format

### DIFF
--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -382,7 +382,7 @@ end
 #
 # Indexes
 #
-#  index_optimized_images_on_etag                            (etag)
-#  index_optimized_images_on_upload_id                       (upload_id)
-#  index_optimized_images_on_upload_id_and_width_and_height  (upload_id,width,height) UNIQUE
+#  index_optimized_images_on_etag       (etag)
+#  index_optimized_images_on_upload_id  (upload_id)
+#  index_optimized_images_unique        (upload_id,width,height,extension) UNIQUE
 #

--- a/db/migrate/20250505050610_optimized_image_format_index.rb
+++ b/db/migrate/20250505050610_optimized_image_format_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class OptimizedImageFormatIndex < ActiveRecord::Migration[7.2]
+  def up
+    remove_index :optimized_images, name: "index_optimized_images_on_upload_id_and_width_and_height"
+    add_index :optimized_images,
+              %i[upload_id width height extension],
+              name: "index_optimized_images_unique",
+              unique: true
+  end
+
+  def down
+    remove_index :optimized_images, name: "index_optimized_images_unique"
+    add_index :optimized_images,
+              %i[upload_id width height],
+              name: "index_optimized_images_on_upload_id_and_width_and_height"
+  end
+end


### PR DESCRIPTION
Previous to this change when we used to specify format it could get an image
in the incorrect format.

Also... allows image magick to decode svg

---

There remains a bug where the crop / resize information is not stored in optimized images
this means that sometimes when asking for a cropped image you may get a resized one.