### PR TITLE
UX: link to `/new-invite` in quick start guide

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -12,7 +12,7 @@ Email is required for new account signups and notifications.
 
 Collaborating with others?
 
-→ **[<kbd>Send invites</kbd>](%{base_url}/my/invited)** to your team members.
+→ **[<kbd>Send invites</kbd>](/new-invite)** to your team members.
 
 ## :speech_balloon: Start some conversations
 
@@ -36,7 +36,7 @@ Help your new members feel right at home when they first arrive.
 
 Welcome a few people in - the more, the merrier!
 
-→ Send out **[<kbd>invites</kbd>](%{base_url}/my/invited)** or send people the link to your community.
+→ Send out **[<kbd>invites</kbd>](/new-invite)** or send people the link to your community.
 
 ## :books: Learn more about Discourse
 

--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -12,7 +12,7 @@ Email is required for new account signups and notifications.
 
 Collaborating with others?
 
-→ **[<kbd>Send invites</kbd>](/new-invite)** to your team members.
+→ **[<kbd>Send invites</kbd>](%{base_url}/new-invite)** to your team members.
 
 ## :speech_balloon: Start some conversations
 
@@ -36,7 +36,7 @@ Help your new members feel right at home when they first arrive.
 
 Welcome a few people in - the more, the merrier!
 
-→ Send out **[<kbd>invites</kbd>](/new-invite)** or send people the link to your community.
+→ Send out **[<kbd>invites</kbd>](%{base_url}/new-invite)** or send people the link to your community.
 
 ## :books: Learn more about Discourse
 


### PR DESCRIPTION
The `/my/invited` page is kind of jarring to send a new admin to? 

Before, directs to `/my/invited`


![image](https://github.com/user-attachments/assets/11b75c5c-d613-4861-bb94-13d1a5fe892c)


After, `/new-invite` (opens the modal on the homepage) 

![image](https://github.com/user-attachments/assets/5534fa5c-6819-44af-8c4c-525bfba54e89)



