### PR TITLE
DEV: add fallback for calling `helper.widget` decorating cooked content when using the Glimmer Post Stream

### DIFF
--- a/app/assets/javascripts/discourse/app/components/decorated-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/decorated-html.gjs
@@ -3,6 +3,8 @@ import { untrack } from "@glimmer/validator";
 import { htmlSafe, isHTMLSafe } from "@ember/template";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import helperFn from "discourse/helpers/helper-fn";
+import deprecated from "discourse/lib/deprecated";
+import { POST_STREAM_DEPRECATION_OPTIONS } from "discourse/lib/plugin-api";
 
 const detachedDocument = document.implementation.createHTMLDocument("detached");
 
@@ -88,6 +90,26 @@ class DecorateHtmlHelper {
 
   getModel() {
     return this.model;
+  }
+
+  // TODO (glimmer-post-stream): remove this when we remove the legacy post stream code
+  get widget() {
+    deprecated(
+      "Accessing `helper.widget` is not supported when using `api.decorateCookedElement` with the Glimmer Post Stream and can yield unexpected results.",
+      POST_STREAM_DEPRECATION_OPTIONS
+    );
+
+    const attrs = this.model;
+
+    return {
+      get attrs() {
+        return attrs;
+      },
+      scheduleRerender() {
+        // This is a no-op when using the new glimmer components.
+        // the component will rerender automatically when the model changes.
+      },
+    };
   }
 
   teardown() {

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -193,7 +193,7 @@ const DEPRECATED_POST_STREAM_WIDGETS = [
   "topic-post-visited-line",
 ];
 
-const POST_STREAM_DEPRECATION_OPTIONS = {
+export const POST_STREAM_DEPRECATION_OPTIONS = {
   since: "v3.5.0.beta1-dev",
   id: "discourse.post-stream-widget-overrides",
   // url: "", // TODO (glimmer-post-stream) uncomment when the topic is created on meta

--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -1,6 +1,6 @@
-import { getOwner } from "@ember/owner";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { getOwnerWithFallback } from "discourse/lib/get-owner";
 import { iconHTML } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { i18n } from "discourse-i18n";
@@ -59,7 +59,8 @@ export function checklistSyntax(elem, postDecorator) {
   addUlClasses(boxes);
 
   // TODO (glimmer-post-stream): remove this when we remove the legacy post stream code
-  const postWidget = getOwner(this).lookup("service:site").useGlimmerPostStream
+  const postWidget = getOwnerWithFallback(this).lookup("service:site")
+    .useGlimmerPostStream
     ? null
     : postDecorator?.widget;
   const postModel = postDecorator?.getModel();

--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -1,3 +1,4 @@
+import { getOwner } from "@ember/owner";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { iconHTML } from "discourse/lib/icon-library";
@@ -57,7 +58,10 @@ export function checklistSyntax(elem, postDecorator) {
   const boxes = [...elem.getElementsByClassName("chcklst-box")];
   addUlClasses(boxes);
 
-  const postWidget = postDecorator?.widget;
+  // TODO (glimmer-post-stream): remove this when we remove the legacy post stream code
+  const postWidget = getOwner(this).lookup("service:site").useGlimmerPostStream
+    ? null
+    : postDecorator?.widget;
   const postModel = postDecorator?.getModel();
 
   if (!postModel?.can_edit) {
@@ -151,8 +155,11 @@ export function checklistSyntax(elem, postDecorator) {
           edit_reason: i18n("checklist.edit_reason"),
         });
 
-        postWidget.attrs.isSaving = false;
-        postWidget.scheduleRerender();
+        // TODO (glimmer-post-stream): remove the following code when removing the legacy post stream code
+        if (postWidget) {
+          postWidget.attrs.isSaving = false;
+          postWidget.scheduleRerender();
+        }
       } catch (e) {
         popupAjaxError(e);
       } finally {
@@ -168,6 +175,6 @@ export default {
   name: "checklist",
 
   initialize() {
-    withPluginApi("0.1", (api) => initializePlugin(api));
+    withPluginApi((api) => initializePlugin(api));
   },
 };


### PR DESCRIPTION
This PR adds a basic fallback to prevent errors for extensions accessing `helper.widget` when using `api.decorateCookedElement`.

The purpose of the fallback is provide access to `.widget.attrs`and `scheduleRerender()` which are common scenarios. 

Since the call to the callback happens only when rendering the auto mode of the Glimmer Post Stream can't detect the existence of these customizations. The PR also adds a deprecation notice in the console.

There are no additional tests because the existing ones should cover the existing functionality
 