### PR TITLE
FIX: autocomplete being cut on rich editor

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -7,7 +7,6 @@
   overflow-x: hidden;
   display: flex;
   height: 100%;
-  position: relative;
 }
 
 .ProseMirror {


### PR DESCRIPTION
The `.ProseMirror-container` is scrollable, and it being `position: relative` cuts mentions/hashtags/etc autocompletes. Removing it _should_ be safe and `.d-editor-textarea-wrapper` (a name we should change eventually btw...) becomes the new anchor for absolute positioning.

Before
![image](https://github.com/user-attachments/assets/21463af7-14e2-489d-bec2-f0763f2f4fab)

After
![image](https://github.com/user-attachments/assets/c86a394a-4dc0-4131-be29-2987f417cef6)
