### PR TITLE
UX: composer starts with allowPreview default false

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -106,7 +106,7 @@ export default class ComposerService extends Service {
     ? false
     : (this.keyValueStore.get("composer.showPreview") || "true") === "true";
 
-  @tracked allowPreview = true;
+  @tracked allowPreview = false;
   checkedMessages = false;
   messageCount = null;
   showEditReason = false;


### PR DESCRIPTION
The rich editor is loaded asynchronously, so when `allowPreview` starts as `true`, if we're opening the composer for the 1st time, ProseMirror dependencies will be loaded async and while the rich editor is fully loaded, the composer animates from having a preview to not having one, shrinking in width.

This changes the `allowPreview` to be default `false`, so the animation never happens – when the default composer editor is set to the Markdown editor, it'll instantly and synchronously set the tracked property, before any animation kicks in.