### PR TITLE
FIX: Don't enforce strict loading on anon user main record

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,10 @@ class User < ActiveRecord::Base
   has_one :user_stat, dependent: :destroy
   has_one :user_profile, dependent: :destroy, inverse_of: :user
   has_one :single_sign_on_record, dependent: :destroy
-  has_one :anonymous_user_master, class_name: "AnonymousUser", dependent: :destroy
+  has_one :anonymous_user_master,
+          class_name: "AnonymousUser",
+          dependent: :destroy,
+          strict_loading: false
   has_one :anonymous_user_shadow,
           ->(record) { where(active: true) },
           foreign_key: :master_user_id,


### PR DESCRIPTION
### What is the problem?

Chat is currently broken in local development if anonymous mode is enabled in site settings. This is happening after #32416. One of the `strict_loading` directives in `ChannelFetcher` is trickling down to an anonymous user check.

### How does this fix it?

We don't need to enforce `strict_loading` on this 1-to-1 association that's only used in a few code paths, so mark it as `strict_loading: false` on the `User` model.

**Before:**

<img width="450" alt="Screenshot 2025-05-06 at 10 30 52 AM" src="https://github.com/user-attachments/assets/67cf3dd2-7ae4-4ac4-84c0-f7476889b5d8" />

**After:**

<img width="450" alt="Screenshot 2025-05-06 at 10 30 32 AM" src="https://github.com/user-attachments/assets/2d2c4ec3-a178-41f7-bc3b-531e0b75b782" />
