### PR TITLE
FIX: Badge not showing as disabled when it is

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges/show.js
@@ -18,6 +18,7 @@ export default class AdminBadgesShowRoute extends Route {
     if (params.badge_id === "new") {
       return Badge.create({
         name: i18n("admin.badges.new_badge"),
+        enabled: true,
         badge_type_id: this.adminBadges.badgeTypes[0].id,
         badge_grouping_id: this.adminBadges.badgeGroupings[0].id,
         trigger: this.adminBadges.badgeTriggers[0].id,

--- a/app/assets/javascripts/discourse/app/models/badge.js
+++ b/app/assets/javascripts/discourse/app/models/badge.js
@@ -7,15 +7,7 @@ import getURL from "discourse/lib/get-url";
 import BadgeGrouping from "discourse/models/badge-grouping";
 import RestModel from "discourse/models/rest";
 
-const DEFAULTS = {
-  enabled: true,
-};
-
 export default class Badge extends RestModel {
-  static create(args) {
-    return super.create({ ...args, ...DEFAULTS });
-  }
-
   static createFromJson(json) {
     // Create BadgeType objects.
     const badgeTypes = {};


### PR DESCRIPTION
### What is the problem?

In the `/admin/badges` view, badges are showing as enabled even when they are verifiably disabled in the database.

This is happening because the defaults (needed to render the "new badge" form) are overwriting the actual value.

### How does this fix it?

Since the `enabled` default is only used for "new badge" form, move it to the route where the other "new badge" defaults are being set.