### PR TITLE
Revert "DEV: Update workflow concurrency controls to use `github.ref_name` (#32524)"

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: licenses-${{ format('{0}-{1}', github.ref_name, github.job) }}
+  group: licenses-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: linting-${{ format('{0}-{1}', github.ref_name, github.job) }}
+  group: linting-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -14,7 +14,7 @@ on:
       - "migrations/**"
 
 concurrency:
-  group: migration-tests-${{ format('{0}-{1}', github.ref_name, github.job) }}
+  group: migration-tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
       - "migrations/**"
 
 concurrency:
-  group: tests-${{ format('{0}-{1}', github.ref_name, github.job) }}
+  group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
This reverts commit 427d4d2b53fcddf771e450ebaa3dbf5140c9fb7a.

This prevents us from knowing which commit broke the build. Revert for
now while we figure out a better solution.
