### PR TITLE
DEV: Move admin backups page to Advanced section

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -47,30 +47,6 @@ export const ADMIN_NAV_MAP = [
     ],
   },
   {
-    name: "account",
-    label: "admin.config_sections.account.title",
-    links: [
-      {
-        name: "admin_backups",
-        route: "admin.backups",
-        label: "admin.config.backups.title",
-        description: "admin.config.backups.header_description",
-        icon: "box-archive",
-        settings_category: "backups",
-        multi_tabbed: true,
-        links: [
-          {
-            name: "admin_backups_logs",
-            route: "admin.backups.logs",
-            label: "admin.config.backups.sub_pages.logs.title",
-            description:
-              "admin.config.backups.sub_pages.logs.header_description",
-          },
-        ],
-      },
-    ],
-  },
-  {
     name: "reports",
     label: "admin.config_sections.reports.title",
     links: [
@@ -469,6 +445,24 @@ export const ADMIN_NAV_MAP = [
     name: "advanced",
     label: "admin.config_sections.advanced.title",
     links: [
+      {
+        name: "admin_backups",
+        route: "admin.backups",
+        label: "admin.config.backups.title",
+        description: "admin.config.backups.header_description",
+        icon: "box-archive",
+        settings_category: "backups",
+        multi_tabbed: true,
+        links: [
+          {
+            name: "admin_backups_logs",
+            route: "admin.backups.logs",
+            label: "admin.config.backups.sub_pages.logs.title",
+            description:
+              "admin.config.backups.sub_pages.logs.header_description",
+          },
+        ],
+      },
       {
         name: "admin_api_keys",
         route: "adminApiKeys",

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -39,9 +39,6 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       .dom(".sidebar-section[data-section-name='admin-root']")
       .exists("root section is displayed");
     assert
-      .dom(".sidebar-section[data-section-name='admin-account']")
-      .exists("account section is displayed");
-    assert
       .dom(".sidebar-section[data-section-name='admin-reports']")
       .exists("reports section is displayed");
     assert


### PR DESCRIPTION
### What is this change?

We have gradually moved the pages out of the `Account` section in the admin sidebar. This moves the last one, `Backups`, to the `Advanced` section, and entirely removes `Account`.

<img width="255" alt="Screenshot 2025-05-06 at 3 00 36 PM" src="https://github.com/user-attachments/assets/d381bdba-30f9-405b-a1f5-0a735d77bf12" />
