### PR TITLE
DEV: replace select-kit utils mixin methods with input-utils lib

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/input-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/input-utils-test.js
@@ -1,0 +1,204 @@
+import { module, test } from "qunit";
+import { isNumeric, isValidInput, normalize } from "select-kit/lib/input-utils";
+
+module("Unit | Lib | input-utils", function () {
+  module("isValidInput", function () {
+    test("returns false for non-input keys", function (assert) {
+      const nonInputKeys = [
+        "F1",
+        "F12",
+        "ArrowUp",
+        "ArrowDown",
+        "ArrowLeft",
+        "ArrowRight",
+        "Meta",
+        "Alt",
+        "Control",
+        "Shift",
+        "Delete",
+        "Enter",
+        "Escape",
+        "Tab",
+        "Space",
+        "Insert",
+        "Backspace",
+      ];
+
+      nonInputKeys.forEach((key) => {
+        assert.false(
+          isValidInput(key),
+          `${key} should not be a valid input key`
+        );
+      });
+    });
+
+    test("returns true for input keys", function (assert) {
+      const inputKeys = [
+        "a",
+        "z",
+        "A",
+        "Z",
+        "0",
+        "9",
+        "!",
+        "@",
+        "#",
+        "$",
+        "%",
+        "^",
+        "&",
+        "*",
+        "(",
+        ")",
+        "-",
+        "_",
+        "+",
+        "=",
+        "[",
+        "]",
+        "{",
+        "}",
+        "|",
+        "\\",
+        ";",
+        ":",
+        "'",
+        '"',
+        ",",
+        ".",
+        "/",
+        "?",
+        "é",
+        "ü",
+        "ñ", // Testing non-ASCII characters
+      ];
+
+      inputKeys.forEach((key) => {
+        assert.true(isValidInput(key), `${key} should be a valid input key`);
+      });
+    });
+
+    test("handles null/undefined", function (assert) {
+      assert.true(
+        isValidInput(null),
+        "null should be considered a valid input"
+      );
+      assert.true(
+        isValidInput(undefined),
+        "undefined should be considered a valid input"
+      );
+    });
+  });
+
+  module("isNumeric", function () {
+    test("returns true for numeric values", function (assert) {
+      const numericValues = [
+        0,
+        1,
+        -1,
+        1.5,
+        -1.5,
+        "0",
+        "1",
+        "-1",
+        "1.5",
+        "-1.5",
+        "1e5",
+        "-1e5",
+      ];
+
+      numericValues.forEach((value) => {
+        assert.true(isNumeric(value), `${value} should be considered numeric`);
+      });
+    });
+
+    test("returns false for non-numeric values", function (assert) {
+      const nonNumericValues = [
+        "",
+        " ",
+        "a",
+        "1a",
+        "a1",
+        "1,000",
+        NaN,
+        Infinity,
+        -Infinity,
+        null,
+        undefined,
+        {},
+        [],
+        true,
+        false,
+      ];
+
+      nonNumericValues.forEach((value) => {
+        assert.false(
+          isNumeric(value),
+          `${value} (${typeof value}) should not be considered numeric`
+        );
+      });
+    });
+  });
+
+  module("normalize", function () {
+    test("converts to lowercase", function (assert) {
+      assert.strictEqual(
+        normalize("AbC"),
+        "abc",
+        "should convert to lowercase"
+      );
+      assert.strictEqual(
+        normalize("ABC123"),
+        "abc123",
+        "should convert letters to lowercase and keep numbers"
+      );
+    });
+
+    test("removes diacritics", function (assert) {
+      assert.strictEqual(
+        normalize("café"),
+        "cafe",
+        "should remove acute accent"
+      );
+      assert.strictEqual(
+        normalize("naïve"),
+        "naive",
+        "should remove diaeresis"
+      );
+      assert.strictEqual(
+        normalize("résumé"),
+        "resume",
+        "should remove all diacritics"
+      );
+      assert.strictEqual(normalize("piñata"), "pinata", "should remove tilde");
+      assert.strictEqual(
+        normalize("Crème Brûlée"),
+        "creme brulee",
+        "should lowercase and remove all diacritics"
+      );
+    });
+
+    test("passes through nullish values", function (assert) {
+      assert.strictEqual(normalize(""), "", "should handle empty string");
+      assert.strictEqual(normalize(null), null, "should handle null");
+      assert.strictEqual(
+        normalize(undefined),
+        undefined,
+        "should handle undefined"
+      );
+    });
+
+    test("preserves symbols and numbers", function (assert) {
+      assert.strictEqual(
+        normalize("Hello! 123"),
+        "hello! 123",
+        "should preserve symbols and numbers"
+      );
+      assert.strictEqual(
+        normalize("@#$%^&*()"),
+        "@#$%^&*()",
+        "should preserve symbols"
+      );
+    });
+  });
+});

--- a/app/assets/javascripts/select-kit/addon/components/multi-select.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.gjs
@@ -13,6 +13,7 @@ import SelectKitComponent, {
   selectKitOptions,
 } from "select-kit/components/select-kit";
 import SelectKitBody from "select-kit/components/select-kit/select-kit-body";
+import { isNumeric } from "select-kit/lib/input-utils";
 
 @classNames("multi-select")
 @selectKitOptions({
@@ -137,7 +138,7 @@ export default class MultiSelect extends SelectKitComponent {
   @computed("value.[]", "content.[]", "selectKit.noneItem")
   get selectedContent() {
     const value = makeArray(this.value).map((v) =>
-      this.selectKit.options.castInteger && this._isNumeric(v) ? Number(v) : v
+      this.selectKit.options.castInteger && isNumeric(v) ? Number(v) : v
     );
 
     if (value.length) {

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -18,6 +18,7 @@ import deprecated from "discourse/lib/deprecated";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import { makeArray } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
+import { normalize } from "select-kit/lib/input-utils";
 import {
   applyContentPluginApiCallbacks,
   applyOnChangePluginApiCallbacks,
@@ -1280,6 +1281,10 @@ export default class SelectKit extends Component.extend(UtilsMixin) {
         this.set(to, this.get(from));
       }
     });
+  }
+
+  _normalize(input) {
+    return normalize(input);
   }
 }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -6,6 +6,7 @@ import {
   classNames,
 } from "@ember-decorators/component";
 import { makeArray } from "discourse/lib/helpers";
+import { isValidInput } from "select-kit/lib/input-utils";
 import UtilsMixin from "select-kit/mixins/utils";
 
 @classNames("select-kit-header")
@@ -163,7 +164,7 @@ export default class SelectKitHeader extends Component.extend(UtilsMixin) {
       if (this.selectKit.isExpanded) {
         this._focusFilterInput();
       } else {
-        if (this.isValidInput(event.key)) {
+        if (isValidInput(event.key)) {
           this.selectKit.set("filter", event.key);
           this.selectKit.open(event);
           event.preventDefault();

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.gjs
@@ -12,6 +12,7 @@ import {
 import icon from "discourse/helpers/d-icon";
 import { makeArray } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
+import { isValidInput } from "select-kit/lib/input-utils";
 import UtilsMixin from "select-kit/mixins/utils";
 
 @classNames("select-kit-row")
@@ -194,7 +195,7 @@ export default class SelectKitRow extends Component.extend(UtilsMixin) {
         event.preventDefault();
         event.stopPropagation();
       } else {
-        if (this.isValidInput(event.key)) {
+        if (isValidInput(event.key)) {
           this.selectKit.set("filter", event.key);
           this.selectKit.triggerSearch();
           this.selectKit.focusFilter();

--- a/app/assets/javascripts/select-kit/addon/components/single-select.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/single-select.gjs
@@ -11,6 +11,7 @@ import SelectKitComponent, {
   selectKitOptions,
 } from "select-kit/components/select-kit";
 import SelectKitBody from "select-kit/components/select-kit/select-kit-body";
+import { isNumeric } from "select-kit/lib/input-utils";
 
 @classNames("single-select")
 @selectKitOptions({
@@ -26,7 +27,7 @@ export default class SingleSelect extends SelectKitComponent {
       let content;
 
       const value =
-        this.selectKit.options.castInteger && this._isNumeric(this.value)
+        this.selectKit.options.castInteger && isNumeric(this.value)
           ? Number(this.value)
           : this.value;
 

--- a/app/assets/javascripts/select-kit/addon/lib/input-utils.js
+++ b/app/assets/javascripts/select-kit/addon/lib/input-utils.js
@@ -1,0 +1,24 @@
+export function isValidInput(eventKey) {
+  // relying on passing the event to the input is risky as it could not work
+  // dispatching the event won't work as the event won't be trusted
+  // safest solution is to filter event and prefill filter with it
+  const nonInputKeysRegex =
+    /F\d+|Arrow.+|Meta|Alt|Control|Shift|Delete|Enter|Escape|Tab|Space|Insert|Backspace/;
+  return !nonInputKeysRegex.test(eventKey);
+}
+
+export function isNumeric(input) {
+  return !isNaN(parseFloat(input)) && isFinite(input);
+}
+
+export function normalize(input) {
+  if (input) {
+    input = input.toLowerCase();
+
+    if (typeof input.normalize === "function") {
+      input = input.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+    }
+  }
+
+  return input;
+}

--- a/app/assets/javascripts/select-kit/addon/mixins/utils.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/utils.js
@@ -2,15 +2,6 @@ import { get } from "@ember/object";
 import Mixin from "@ember/object/mixin";
 
 export default Mixin.create({
-  isValidInput(eventKey) {
-    // relying on passing the event to the input is risky as it could not work
-    // dispatching the event won't work as the event won't be trusted
-    // safest solution is to filter event and prefill filter with it
-    const nonInputKeysRegex =
-      /F\d+|Arrow.+|Meta|Alt|Control|Shift|Delete|Enter|Escape|Tab|Space|Insert|Backspace/;
-    return !nonInputKeysRegex.test(eventKey);
-  },
-
   defaultItem(value, name) {
     if (this.selectKit.valueProperty) {
       const item = {};
@@ -88,21 +79,5 @@ export default Mixin.create({
         return this[getter](contentItem) === name;
       });
     }
-  },
-
-  _isNumeric(input) {
-    return !isNaN(parseFloat(input)) && isFinite(input);
-  },
-
-  _normalize(input) {
-    if (input) {
-      input = input.toLowerCase();
-
-      if (typeof input.normalize === "function") {
-        input = input.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-      }
-    }
-
-    return input;
   },
 });


### PR DESCRIPTION
This PR replaces the set of methods related to validation and normalization of input values in the select-kit utils mixin with simple exported functions from a input-utils lib file. 

We maintain the `_normalize` method on the select-kit component because there are external repos dependent on that part of the interface.

We'll replace the remainder of the mixin with another utils lib file in a separate PR.