### PR TITLE
DEV: Refactor lazy-video initialization for Glimmer compatibility

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -145,6 +145,7 @@ import {
 } from "discourse/widgets/post-small-action";
 import {
   addPostTransformCallback,
+  POST_STREAM_DEPRECATION_OPTIONS,
   preventCloak,
 } from "discourse/widgets/post-stream";
 import { disableNameSuppression } from "discourse/widgets/poster-name";
@@ -192,12 +193,6 @@ const DEPRECATED_POST_STREAM_WIDGETS = [
   "select-post",
   "topic-post-visited-line",
 ];
-
-export const POST_STREAM_DEPRECATION_OPTIONS = {
-  since: "v3.5.0.beta1-dev",
-  id: "discourse.post-stream-widget-overrides",
-  // url: "", // TODO (glimmer-post-stream) uncomment when the topic is created on meta
-};
 
 const blockedModifications = ["component:topic-list"];
 

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -16,6 +16,12 @@ import RenderGlimmer from "discourse/widgets/render-glimmer";
 import { createWidget } from "discourse/widgets/widget";
 import { i18n } from "discourse-i18n";
 
+export const POST_STREAM_DEPRECATION_OPTIONS = {
+  since: "v3.5.0.beta1-dev",
+  id: "discourse.post-stream-widget-overrides",
+  // url: "", // TODO (glimmer-post-stream) uncomment when the topic is created on meta
+};
+
 export let havePostStreamWidgetExtensions = null;
 
 registerDeprecationHandler((_, opts) => {

--- a/app/assets/javascripts/discourse/tests/integration/components/decorated-html-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/decorated-html-test.gjs
@@ -102,7 +102,7 @@ module("Integration | Component | <DecoratedHtml />", function (hooks) {
       withSilencedDeprecations("discourse.post-stream-widget-overrides", () => {
         helper.renderGlimmer(
           element,
-          hbs`<div id="render-glimmer">Hello from Glimmer Component</div>`
+          hbs("<div id='render-glimmer'>Hello from Glimmer Component</div>")
         );
       });
     };

--- a/plugins/discourse-lazy-videos/assets/javascripts/initializers/lazy-videos.gjs
+++ b/plugins/discourse-lazy-videos/assets/javascripts/initializers/lazy-videos.gjs
@@ -1,5 +1,5 @@
-import { hbs } from "ember-cli-htmlbars";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import LazyVideo from "../discourse/components/lazy-video";
 import getVideoAttributes from "../lib/lazy-video-attributes";
 
 function initLazyEmbed(api) {
@@ -23,9 +23,17 @@ function initLazyEmbed(api) {
             }
           };
 
-          const lazyVideo = helper.renderGlimmer(
-            "p.lazy-video-wrapper",
-            hbs`<LazyVideo @videoAttributes={{@data.param}} @onLoadedVideo={{@data.onLoadedVideo}}/>`,
+          const lazyVideo = document.createElement("p");
+          lazyVideo.classList.add("lazy-video-wrapper");
+
+          helper.renderGlimmer(
+            lazyVideo,
+            <template>
+              <LazyVideo
+                @videoAttributes={{@data.param}}
+                @onLoadedVideo={{@data.onLoadedVideo}}
+              />
+            </template>,
             { param: videoAttributes, onLoadedVideo }
           );
 
@@ -41,6 +49,6 @@ export default {
   name: "discourse-lazy-videos",
 
   initialize() {
-    withPluginApi("1.6.0", initLazyEmbed);
+    withPluginApi(initLazyEmbed);
   },
 };


### PR DESCRIPTION
Modernizes the renderGlimmer API to use Glimmer components, replacing deprecated ember-cli-htmlbars templates. Adds deprecation warnings for invalid parameters and improves compatibility with the new Glimmer Post Stream API.