### PR TITLE
DEV: remove theme_download_screenshots site setting

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -269,19 +269,15 @@ class RemoteTheme < ActiveRecord::Base
       end
     end
 
-    # TODO (martin): Until we are ready to roll this out more
-    # widely, let's avoid doing this work for most sites.
-    if SiteSetting.theme_download_screenshots
-      begin
-        updated_fields.concat(
-          ThemeScreenshotsHandler.new(theme).parse_screenshots_as_theme_fields!(
-            theme_info["screenshots"],
-            importer,
-          ),
-        )
-      rescue ThemeScreenshotsHandler::ThemeScreenshotError => err
-        raise ImportError, err.message
-      end
+    begin
+      updated_fields.concat(
+        ThemeScreenshotsHandler.new(theme).parse_screenshots_as_theme_fields!(
+          theme_info["screenshots"],
+          importer,
+        ),
+      )
+    rescue ThemeScreenshotsHandler::ThemeScreenshotError => err
+      raise ImportError, err.message
     end
 
     # Update all theme attributes if this is just a placeholder

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1920,9 +1920,6 @@ files:
     default: "wasm|jpg|jpeg|png|woff|woff2|svg|eot|ttf|otf|gif|webp|avif|js"
     type: list
     list_type: file_types
-  theme_download_screenshots:
-    default: false
-    hidden: true
   authorized_extensions:
     client: true
     default: "jpg|jpeg|png|gif|heic|heif|webp|avif"

--- a/db/migrate/20250507013646_remove_theme_download_screenshots_site_settings.rb
+++ b/db/migrate/20250507013646_remove_theme_download_screenshots_site_settings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveThemeDownloadScreenshotsSiteSettings < ActiveRecord::Migration[7.2]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'theme_download_screenshots'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Enable theme screenshots to everyone

![Screenshot 2025-05-07 at 10 21 48 am](https://github.com/user-attachments/assets/263cc256-c6c6-49ed-bb9b-0ddff9bb1ecb)
