### PR TITLE
FIX: prioritize pages over other categories in admin search

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -19,6 +19,7 @@ const SEARCH_SCORES = {
   labelStart: 20,
   exactKeyword: 10,
   fallback: 5,
+  pageBonusScore: 20,
 };
 
 function labelOrText(obj, fallback = "") {
@@ -304,6 +305,10 @@ export default class AdminSearchDataSource extends Service {
         }
 
         if (dataSourceItem.score > 0) {
+          if (type === "page") {
+            dataSourceItem.score += SEARCH_SCORES.pageBonusScore;
+          }
+
           typeResults.push(dataSourceItem);
         }
       });

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -143,8 +143,14 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
 
   test("search - prioritize beginning of label", async function (assert) {
     await this.subject.buildMap();
-    let results = this.subject.search("about");
+    let results = this.subject.search("about your title");
     assert.deepEqual(results[0].label, "About your site > Title");
+  });
+
+  test("search - prioritize pages", async function (assert) {
+    await this.subject.buildMap();
+    let results = this.subject.search("theme");
+    assert.deepEqual(results[0].label, "Appearance > Color palettes");
   });
 });
 


### PR DESCRIPTION
Add 20 points for matched pages to move them higher.

Before:
![Screenshot 2025-05-07 at 3 53 41 pm](https://github.com/user-attachments/assets/cb54516a-d81b-45f0-ada3-7b33e43352a9)

After:
![Screenshot 2025-05-07 at 3 53 53 pm](https://github.com/user-attachments/assets/93a9a83b-761f-490c-853e-926762940353)
