### PR TITLE
FIX: Force Codepen embeds requests to always use the old UA.

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -644,6 +644,11 @@ module Oneboxer
 
     uri = URI(url)
 
+    # Codepen looks for the old Discourse user agent
+    if uri.hostname == "codepen.io"
+      fd_options[:headers]["User-Agent"] = "Discourse Forum Onebox v#{Discourse::VERSION::STRING}"
+    end
+
     # For private GitHub repos, we get a 404 when trying to use
     # FinalDestination to request the final URL because no auth headers
     # are sent. In this case we can ignore redirects and go straight to


### PR DESCRIPTION
## ✨ What's This?

After #31555, all Onebox embeds started sending a new User Agent header. Evidently, Codepen has some embed rate limiting that we've run into in the past, and the change in UA caused the rate limiting to kick in again.

This change switches Codepen embeds back to using the old UA, which appears to allow our embed requests to go through again.