### PR TITLE
DEV: Add locale for topics

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2233,6 +2233,7 @@ end
 #  bannered_until            :datetime
 #  external_id               :string
 #  visibility_reason_id      :integer
+#  locale                    :string(20)
 #
 # Indexes
 #

--- a/db/migrate/20250507110205_add_locale_to_topic.rb
+++ b/db/migrate/20250507110205_add_locale_to_topic.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocaleToTopic < ActiveRecord::Migration[7.2]
+  def change
+    add_column :topics, :locale, :string, limit: 20
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/discourse/discourse/pull/32526.

Reviewer note: There had been some deliberation if we should just take the `topic.first_post.locale` instead of having a `topic.locale`. Ultimately, titles may be of a different language of the post itself, and secondarily in some cases it could be faster without having to load the first_post at all.