### PR TITLE
DEV: add create-topic-label value transformer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -35,7 +35,13 @@ export default class DNavigation extends Component {
   @setting("fixed_category_positions") fixedCategoryPositions;
 
   get createTopicLabel() {
-    return this.site.desktopView ? "topic.create" : "";
+    const defaultKey = "topic.create";
+
+    return applyValueTransformer(
+      "create-topic-label",
+      this.site.desktopView ? defaultKey : "",
+      { site: this.site, defaultKey }
+    );
   }
 
   get showBulkSelectInNavControls() {

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -18,6 +18,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "category-text-color",
   "composer-save-button-label",
   "composer-service-cannot-submit-post",
+  "create-topic-label",
   "flag-description",
   "flag-custom-placeholder",
   "flag-formatted-name",


### PR DESCRIPTION
On mobile we remove the create topic button label:

![image](https://github.com/user-attachments/assets/18dfb2e1-c7fc-4253-b24e-ba95d8533855)

and we don't have a great way to add it back (https://meta.discourse.org/t/new-topic-button-hidden-text/364902) 

this will allow the translation to be set for both mobile and desktop like this: 

```js
import { apiInitializer } from "discourse/lib/api";

export default apiInitializer((api) => {
  api.registerValueTransformer("create-topic-label", ({ value, context }) => {
    return context.defaultKey;
  });
});
```

![image](https://github.com/user-attachments/assets/7e1200f0-e8fc-4966-9693-310b3fad3682)


and also grants the flexibility to have a custom labels for mobile and desktop 