### PR TITLE
UX: Include custom text field description in signup form

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-fields/text.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/text.gjs
@@ -21,13 +21,14 @@ export default class UserFieldText extends UserFieldBase {
         {{~#unless this.field.required}}
           {{i18n "user_fields.optional"}}{{/unless~}}
       </label>
-      <InputTip
-        @validation={{this.validation}}
-        class={{unless this.validation "hidden"}}
-      />
-      {{#unless this.validation}}
+      {{#if this.validation.failed}}
+        <InputTip
+          @validation={{this.validation}}
+          class={{unless this.validation "hidden"}}
+        />
+      {{else}}
         <div class="instructions">{{htmlSafe this.field.description}}</div>
-      {{/unless}}
+      {{/if}}
     </div>
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/user-fields/text.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/text.gjs
@@ -22,10 +22,7 @@ export default class UserFieldText extends UserFieldBase {
           {{i18n "user_fields.optional"}}{{/unless~}}
       </label>
       {{#if this.validation.failed}}
-        <InputTip
-          @validation={{this.validation}}
-          class={{unless this.validation "hidden"}}
-        />
+        <InputTip @validation={{this.validation}} />
       {{else}}
         <div class="instructions">{{htmlSafe this.field.description}}</div>
       {{/if}}

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -142,9 +142,13 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
           .fill_email(invite.email)
           .fill_username("john")
           .fill_password("supersecurepassword")
-          .click_create_account
+
+        expect(signup_form).to have_content("What you do for work")
+
+        signup_form.click_create_account
         expect(signup_form).to have_content(I18n.t("js.user_fields.required", name: "Occupation"))
         expect(signup_form).to have_no_css(".account-created")
+        expect(signup_form).to have_css(".tip.bad", text: "Please enter a value for \"Occupation\"")
       end
     end
 
@@ -345,13 +349,13 @@ shared_examples "signup scenarios" do |signup_page_object, login_page_object|
 end
 
 describe "Signup", type: :system do
-  context "when fullpage desktop" do
+  context "when desktop" do
     include_examples "signup scenarios",
                      PageObjects::Pages::Signup.new,
                      PageObjects::Pages::Login.new
   end
 
-  context "when fullpage mobile", mobile: true do
+  context "when mobile", mobile: true do
     include_examples "signup scenarios",
                      PageObjects::Pages::Signup.new,
                      PageObjects::Pages::Login.new


### PR DESCRIPTION
Reported in https://meta.discourse.org/t/signup-instructions-arent-showing-for-text-custom-user-fields/359935?u=rishabh