### PR TITLE
UX: Do not reserve space for the tip message on the signup page

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -250,7 +250,6 @@ body.signup-page {
 
   .tip {
     font-size: var(--font-down-1);
-    min-height: 1.4em;
     display: block;
 
     &.bad {


### PR DESCRIPTION
Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/df30cae9-6734-4427-be7b-72fa24eb7d80" />

After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7ca5e8dc-15d6-42a5-9caf-f50ae10cbc1a" />
