### PR TITLE
DEV: remove deps

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -60,7 +60,7 @@ if !system "pnpm", "--dir=#{RAILS_ROOT}", "install"
   exit 1
 end
 
-system "pnpm", "playwright", "install", "--with-deps", "--no-shell", "chromium", exception: true
+system "pnpm", "playwright", "install", "--no-shell", "chromium", exception: true
 
 pnpm_env = {
   "TERM" => "dumb", # simple output from ember-cli, so we can parse/forward it more easily


### PR DESCRIPTION
Users won't be able to use video locally but we think it's not necessary for now. This could also cause permissions errors on CI as deps require sudo to be installed.