### PR TITLE
FEATURE: sharing link to PWA renders url in title in new Topic to leverage core link expansion

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -59,8 +59,9 @@ class MetadataController < ApplicationController
         method: "GET",
         enctype: "application/x-www-form-urlencoded",
         params: {
-          title: "title",
           text: "body",
+          title: "title",
+          url: "title",
         },
       },
       shortcuts: [

--- a/spec/requests/metadata_controller_spec.rb
+++ b/spec/requests/metadata_controller_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe MetadataController do
       )
     end
 
+    it "includes share target configuration" do
+      get "/manifest.webmanifest"
+      expect(response.status).to eq(200)
+      manifest = JSON.parse(response.body)
+      expect(manifest["share_target"]).to be_present
+      expect(manifest["share_target"]["params"]["title"]).to eq("title")
+      expect(manifest["share_target"]["params"]["text"]).to eq("body")
+      expect(manifest["share_target"]["params"]["url"]).to eq("title")
+    end
+
     it "can guess mime types" do
       upload =
         UploadCreator.new(file_from_fixtures("logo.jpg"), "logo.jpg").create_for(


### PR DESCRIPTION
Discourse has a fantastic feature whereby when installed as PWA (on Android or Windows), you can share content to that Discourse from other apps and browsers.

Currently when sharing a link to a Discourse PWA, it pre-populates a draft Topic body with the link.

Whilst this is really nice already, we can improve this further.  Currently, sharing a link to the body misses out on the auto-magic core feature of pasting a link in the title which simultaneously hydrates a title from the og tag and creates a one-box in the body.

This PR remedies this whilst carefully maintaining the current behaviour for text shares.

Documentation for the standard is here:

https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Share_data_between_apps

Demo of this working change is implemented in this plugin:

https://github.com/merefield/discourse-share-to-link-oneboxer

I added a test to check presence of share target in manifest endpoint. 
