### PR TITLE
FIX: redirect to new themes page after deletion

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -420,7 +420,7 @@ export default class AdminCustomizeThemesShowController extends Controller {
         model.setProperties({ recentlyInstalled: false });
         model.destroyRecord().then(() => {
           this.allThemes.removeObject(model);
-          this.router.transitionTo("adminCustomizeThemes");
+          this.router.transitionTo("adminConfig.customize.themes");
         });
       },
     });

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -7,6 +7,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
   let(:config_area) { PageObjects::Pages::AdminCustomizeThemesConfigArea.new }
   let(:install_modal) { PageObjects::Modals::InstallTheme.new }
+  let(:admin_customize_themes_page) { PageObjects::Pages::AdminCustomizeThemes.new }
 
   before { sign_in(admin) }
 
@@ -40,9 +41,13 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     expect(config_area).to have_no_badge(theme, "--selectable")
   end
 
-  it "allows to edit theme" do
+  it "allows to edit and delete theme" do
     config_area.visit
     config_area.click_edit(theme)
     expect(page).to have_current_path("/admin/customize/themes/#{theme.id}")
+
+    admin_customize_themes_page.click_delete
+    admin_customize_themes_page.confirm_delete
+    expect(page).to have_current_path("/admin/config/customize/themes")
   end
 end

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -109,6 +109,14 @@ module PageObjects
         has_no_css?(".themes-list-search__input")
       end
 
+      def click_delete
+        find(".theme-controls .btn-danger").click
+      end
+
+      def confirm_delete
+        find(".dialog-footer .btn-primary").click
+      end
+
       private
 
       def setting_selector(setting_name, overridden: false)


### PR DESCRIPTION
When a theme is deleted, we should redirect to new themes page.