### PR TITLE
PERF: Improve performance of the new themes listing page

### DIFF
--- a/app/assets/javascripts/admin/addon/adapters/theme.js
+++ b/app/assets/javascripts/admin/addon/adapters/theme.js
@@ -7,6 +7,13 @@ export default class Theme extends RestAdapter {
     return "/admin/";
   }
 
+  pathFor(store, type, findArgs) {
+    if (findArgs?.useConfigAreaEndpoint) {
+      return "/admin/config/customize/themes";
+    }
+    return super.pathFor(...arguments);
+  }
+
   afterFindAll(results) {
     let map = {};
 

--- a/app/assets/javascripts/admin/addon/routes/admin-config-customize-themes.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-customize-themes.js
@@ -3,8 +3,11 @@ import { i18n } from "discourse-i18n";
 
 export default class AdminConfigThemesAndComponentsThemesRoute extends DiscourseRoute {
   async model() {
-    const themes = await this.store.findAll("theme");
-    return themes.reject((t) => t.component);
+    return (
+      await this.store.findAll("theme", {
+        useConfigAreaEndpoint: true,
+      })
+    ).content;
   }
 
   titleToken() {

--- a/app/controllers/admin/config/customize_controller.rb
+++ b/app/controllers/admin/config/customize_controller.rb
@@ -4,6 +4,14 @@ class Admin::Config::CustomizeController < Admin::AdminController
   PAGE_SIZE = 20
 
   def themes
+    themes =
+      Theme
+        .include_basic_relations
+        .includes(:theme_fields, color_scheme: [:color_scheme_colors])
+        .where(component: false)
+        .order(:name)
+
+    render json: { themes: serialize_data(themes, ThemeIndexSerializer) }
   end
 
   def components

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -358,6 +358,12 @@ class Theme < ActiveRecord::Base
     end
   end
 
+  def screenshot_url
+    theme_fields
+      .find { |field| field.type_id == ThemeField.types[:theme_screenshot_upload_var] }
+      &.upload_url
+  end
+
   def switch_to_component!
     return if component
 

--- a/app/serializers/theme_index_serializer.rb
+++ b/app/serializers/theme_index_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ThemeIndexSerializer < BasicThemeSerializer
+  attributes :user_selectable, :screenshot_url, :remote_theme_id, :enabled
+
+  has_one :color_scheme, serializer: ColorSchemeSerializer, embed: :object
+  has_one :remote_theme, serializer: RemoteThemeSerializer, embed: :objects
+end

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -47,13 +47,6 @@ class ThemeSerializer < BasicThemeSerializer
     @include_theme_field_values || object.remote_theme_id.nil?
   end
 
-  def screenshot_url
-    object
-      .theme_fields
-      .find { |field| field.type_id == ThemeField.types[:theme_screenshot_upload_var] }
-      &.upload_url
-  end
-
   def child_themes
     object.child_themes
   end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1700,4 +1700,22 @@ HTML
       expect(queries_for_two.size).to eq(queries_for_one.size)
     end
   end
+
+  describe "#screenshot_url" do
+    it "returns nil when no screenshot is set" do
+      expect(theme.screenshot_url).to be_nil
+    end
+
+    it "returns the upload URL when screenshot is set" do
+      upload = UploadCreator.new(file_from_fixtures("logo.png"), "logo.png").create_for(-1)
+      theme.set_field(
+        target: :common,
+        name: "screenshot",
+        upload_id: upload.id,
+        type: :theme_screenshot_upload_var,
+      )
+      theme.save!
+      expect(theme.screenshot_url).to eq(upload.url)
+    end
+  end
 end

--- a/spec/serializers/theme_index_serializer_spec.rb
+++ b/spec/serializers/theme_index_serializer_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe ThemeIndexSerializer do
+  fab!(:theme) { Fabricate(:theme, user_selectable: true) }
+  fab!(:screenshot_upload) do
+    UploadCreator.new(file_from_fixtures("logo.png"), "logo.png").create_for(-1)
+  end
+  fab!(:screenshot_field) do
+    Fabricate(
+      :theme_field,
+      theme:,
+      target_id: Theme.targets[:common],
+      name: "screenshot",
+      upload_id: screenshot_upload.id,
+      type_id: ThemeField.types[:theme_screenshot_upload_var],
+    )
+  end
+
+  let(:serializer) { ThemeIndexSerializer.new(theme, root: false) }
+  let(:json) { serializer.as_json }
+
+  it "includes basic theme attributes" do
+    expect(json[:id]).to eq(theme.id)
+    expect(json[:name]).to eq(theme.name)
+    expect(json[:enabled]).to eq(theme.enabled)
+    expect(json[:user_selectable]).to eq(true)
+  end
+
+  it "includes screenshot_url attribute" do
+    expect(json[:screenshot_url]).to eq(screenshot_upload.url)
+  end
+
+  it "includes color_scheme relationship when present" do
+    expect(json[:color_scheme]).to eq(nil)
+
+    theme.color_scheme = Fabricate(:color_scheme)
+    theme.save!
+
+    new_json = ThemeIndexSerializer.new(theme, root: false).as_json
+    expect(new_json[:color_scheme][:id]).to eq(theme.color_scheme.id)
+  end
+
+  it "includes remote_theme relationship when present" do
+    expect(json[:remote_theme]).to eq(nil)
+
+    remote_theme = RemoteTheme.create!(remote_url: "https://github.com/discourse/sample-theme")
+    theme.update!(remote_theme_id: remote_theme.id)
+
+    new_json = ThemeIndexSerializer.new(theme, root: false).as_json
+    expect(new_json[:remote_theme][:id]).to eq(remote_theme.id)
+  end
+end


### PR DESCRIPTION
The new themes listing page at `/admin/config/customize/themes` currently has poor performance compared to the components page (`/admin/config/customize/components`) due to various N+1 issues, loading all themes and components from the server when only themes are needed, and serializing data/attributes that aren't needed for rendering the themes grid.

This PR improves the performance by eliminating all N+1 that are currently present, excluding components from the page payload, and reducing the amount of data transmitted for each theme when loading the page.