### PR TITLE
DEV: More helper methods for topic localization

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2124,6 +2124,18 @@ class Topic < ActiveRecord::Base
     fields
   end
 
+  def has_localization?(locale = I18n.locale)
+    topic_localizations.exists?(locale: locale.to_s.sub("-", "_"))
+  end
+
+  def in_user_locale?
+    locale == I18n.locale.to_s
+  end
+
+  def get_localization(locale = I18n.locale)
+    topic_localizations.find_by(locale: locale.to_s.sub("-", "_"))
+  end
+
   private
 
   def invite_to_private_message(invited_by, target_user, guardian)

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -14,7 +14,16 @@ class ContentLocalization
   # @param post [Post] The post object
   # @return [Boolean]
   def self.show_translated_post?(post, scope)
-    SiteSetting.experimental_content_localization && post.locale.present? &&
+    SiteSetting.experimental_content_localization && post.raw.present? && post.locale.present? &&
       !post.in_user_locale? && !show_original?(scope)
+  end
+
+  # This method returns true when we should try to show the translated topic.
+  # @param scope [Object] The serializer scope from which the method is called
+  # @param topic [Topic] The topic record
+  # @return [Boolean]
+  def self.show_translated_topic?(topic, scope)
+    SiteSetting.experimental_content_localization && topic.locale.present? &&
+      !topic.in_user_locale? && !show_original?(scope)
   end
 end

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -46,6 +46,13 @@ describe ContentLocalization do
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
       end
 
+      it "returns false when post raw is nil" do
+        post.update_columns(raw: "")
+        scope = create_scope
+
+        expect(ContentLocalization.show_translated_post?(post, scope)).to be false
+      end
+
       it "returns false when post locale is nil" do
         post.update!(locale: nil)
         scope = create_scope
@@ -64,6 +71,54 @@ describe ContentLocalization do
         scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
 
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
+      end
+    end
+  end
+
+  describe ".show_translated_topic?" do
+    fab!(:topic)
+
+    it "returns true when criteria met" do
+      SiteSetting.experimental_content_localization = true
+      topic.update!(locale: "ja")
+      I18n.locale = "de"
+      scope = create_scope
+
+      expect(ContentLocalization.show_translated_topic?(topic, scope)).to be true
+    end
+
+    context "when criteria not met" do
+      before do
+        SiteSetting.experimental_content_localization = true
+        topic.update!(locale: "ja")
+        I18n.locale = "de"
+      end
+
+      it "returns false when experimental_content_localization is false" do
+        SiteSetting.experimental_content_localization = false
+        scope = create_scope
+
+        expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
+      end
+
+      it "returns false when topic locale is nil" do
+        topic.update!(locale: nil)
+        scope = create_scope
+
+        expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
+      end
+
+      it "returns false when topic is in user locale" do
+        topic.update!(locale: I18n.locale)
+        scope = create_scope
+
+        expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
+      end
+
+      it "returns false when show_original? is true" do
+        scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
+
+        expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
       end
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3589,4 +3589,43 @@ RSpec.describe Topic do
       end
     end
   end
+
+  describe "#has_localization?" do
+    it "returns true if the topic has localization" do
+      topic = Fabricate(:topic)
+      Fabricate(:topic_localization, topic: topic, locale: "zh_CN")
+
+      expect(topic.has_localization?(:zh_CN)).to eq(true)
+      expect(topic.has_localization?(:"zh_CN")).to eq(true)
+      expect(topic.has_localization?("zh-CN")).to eq(true)
+
+      expect(topic.has_localization?("z")).to eq(false)
+    end
+  end
+
+  describe "#get_localization" do
+    it "returns the localization with the specified locale" do
+      I18n.locale = "ja"
+      topic = Fabricate(:topic)
+      zh_localization = Fabricate(:topic_localization, topic: topic, locale: "zh_CN")
+      ja_localization = Fabricate(:topic_localization, topic: topic, locale: "ja")
+
+      expect(topic.get_localization(:zh_CN)).to eq(zh_localization)
+      expect(topic.get_localization("zh-CN")).to eq(zh_localization)
+      expect(topic.get_localization("xx")).to eq(nil)
+      expect(topic.get_localization).to eq(ja_localization)
+    end
+  end
+
+  describe "#in_user_locale?" do
+    it "returns true if the topic has localization in the user's locale" do
+      I18n.locale = "ja"
+      topic = Fabricate(:topic, locale: "ja")
+
+      expect(topic.in_user_locale?).to eq(true)
+
+      topic.update!(locale: "es")
+      expect(topic.in_user_locale?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This adds more methods on `Topic` so it can be used in a later PR that will localize topics.