### PR TITLE
DEV: bring back admin search page priority test

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -146,6 +146,34 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
     let results = this.subject.search("about your title");
     assert.deepEqual(results[0].label, "About your site > Title");
   });
+
+  test("search - prioritize pages", async function (assert) {
+    this.subject.componentDataSourceItems = [];
+    this.subject.reportDataSourceItems = [];
+    this.subject.themeDataSourceItems = [];
+    this.subject.pageDataSourceItems = [
+      {
+        description: "first page",
+        icon: "house",
+        keywords: "exact setting",
+        label: "Page about exact setting",
+        type: "page",
+        url: "/admin",
+      },
+    ];
+    this.subject.settingDataSourceItems = [
+      {
+        description: "first setting",
+        icon: "house",
+        keywords: "exact setting",
+        label: "exact setting",
+        type: "setting",
+        url: "/admin",
+      },
+    ];
+    let results = this.subject.search("exact setting");
+    assert.deepEqual(results[0].label, "Page about exact setting");
+  });
 });
 
 module(


### PR DESCRIPTION
In this PR, test was removed

https://github.com/discourse/discourse/pull/32639

To be sure result are consistent, we need to define a data set which will confirm that the page is getting bonus points.