### PR TITLE
DEV: correctly returns contract error

### DIFF
--- a/plugins/chat/lib/chat_sdk/thread.rb
+++ b/plugins/chat/lib/chat_sdk/thread.rb
@@ -83,6 +83,7 @@ module ChatSDK
         },
       ) do
         on_success { |messages:| messages }
+        on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
         on_failed_policy(:can_view_thread) { raise "Guardian can't view thread" }
         on_failed_policy(:target_message_exists) { raise "Target message doesn't exist" }
         on_failure { raise "Unexpected error" }

--- a/plugins/chat/spec/lib/chat_sdk/thread_spec.rb
+++ b/plugins/chat/spec/lib/chat_sdk/thread_spec.rb
@@ -126,6 +126,14 @@ describe ChatSDK::Thread do
       end
     end
 
+    context "when page_size is too large" do
+      it "fails" do
+        expect { described_class.messages(**params, page_size: 9999) }.to raise_error(
+          "Page size must be less than or equal to 50",
+        )
+      end
+    end
+
     context "when target_message doesn’t exist" do
       it "fails" do
         expect { described_class.messages(**params, target_message_id: -999) }.to raise_error(


### PR DESCRIPTION
If a user was using invalid values for the contract we would return "Unexpected error", which is incorrect given we know the exact error. The user will now get the following exception: "Page size must be less than or equal to 50"