### PR TITLE
UX: don't always fill username for forgot password

### DIFF
--- a/app/assets/javascripts/discourse/app/components/local-login-form.gjs
+++ b/app/assets/javascripts/discourse/app/components/local-login-form.gjs
@@ -25,6 +25,7 @@ import { i18n } from "discourse-i18n";
 
 export default class LocalLoginForm extends Component {
   @service modal;
+  @service siteSettings;
 
   @tracked maskPassword = true;
   @tracked processingEmailLink = false;
@@ -129,9 +130,20 @@ export default class LocalLoginForm extends Component {
   handleForgotPassword(event) {
     event?.preventDefault();
 
+    let filledLoginName = this.args.loginName;
+
+    // no spaces, at least one dot, one @ with one or more characters before & after
+    const likelyEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+      filledLoginName?.trim()
+    );
+
+    if (this.siteSettings.hide_email_address_taken && !likelyEmail) {
+      filledLoginName = null;
+    }
+
     this.modal.show(ForgotPassword, {
       model: {
-        emailOrUsername: this.args.loginName,
+        emailOrUsername: filledLoginName,
       },
     });
   }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/autofill-with-username-in-forgot-password-modal/365310

When `hide_email_address_taken` is enabled, we don't want to populate the username in the forgot email input, because we require an email address. This will remove username content that doesn't look like an email when that site setting is enabled.

Before (username populated when email required): 
![image](https://github.com/user-attachments/assets/7a6eb638-9b5e-4767-b111-e32cec94d8a7)

After (username not populated, email is):
![image](https://github.com/user-attachments/assets/2d5eff84-92f8-4f76-bc98-b66bc6381fd3)

![image](https://github.com/user-attachments/assets/ecd071a0-804e-45ef-b0a2-ae331f87f029)

