### PR TITLE
DEV: Remove post length check to allow loading to end

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-list/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/index.gjs
@@ -52,20 +52,17 @@ export default class PostList extends Component {
     }
     this.loading = true;
 
-    const posts = this.args.posts;
-    if (posts && posts.length) {
-      try {
-        const newPosts = await this.args.fetchMorePosts();
-        this.args.posts.addObjects(newPosts);
+    try {
+      const newPosts = await this.args.fetchMorePosts();
+      this.args.posts?.addObjects(newPosts);
 
-        if (newPosts.length === 0) {
-          this.canLoadMore = false;
-        }
-      } catch (error) {
-        popupAjaxError(error);
-      } finally {
-        this.loading = false;
+      if (newPosts.length === 0) {
+        this.canLoadMore = false;
       }
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.loading = false;
     }
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/group-activity-posts.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-activity-posts.js
@@ -9,7 +9,8 @@ export default class GroupActivityPostsController extends Controller {
   @action
   async fetchMorePosts() {
     const posts = this.model;
-    const before = posts[posts.length - 1].created_at;
+    const before =
+      posts.length > 0 ? posts[posts.length - 1]?.created_at : undefined;
     const group = this.group.model;
     const categoryId = this.groupActivity.category_id;
     const opts = { before, type: this.type, categoryId };


### PR DESCRIPTION
As reported: https://meta.discourse.org/t/endless-spinning-on-user-activity-of-user-without-activity/365313

If a user has no posts, their post list will show a loading spinner indefinitely 

![image](https://github.com/user-attachments/assets/23af7c84-444e-4f6b-bfbb-dcc84162b1f6)

This is because if there are no posts we never set `canLoadMore` or `loading` to `false`

If we always check for new posts we avoid the issue. 

![image](https://github.com/user-attachments/assets/8bfb0267-7b3c-44cc-8f77-8d442598c50d)
