### PR TITLE
FIX: Loading indicator should not show when no posts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-list/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/index.gjs
@@ -50,10 +50,11 @@ export default class PostList extends Component {
     ) {
       return;
     }
-    this.loading = true;
 
     const posts = this.args.posts;
+
     if (posts && posts.length) {
+      this.loading = true;
       try {
         const newPosts = await this.args.fetchMorePosts();
         this.args.posts.addObjects(newPosts);


### PR DESCRIPTION
## :mag: Overview
This update fixes an issue where the loading indicator was being shown despite a user not having any posts

## 📸 Screenshots