### PR TITLE
FIX: Purge ExtraLocalesController cache correctly for multisite

### DIFF
--- a/config/initializers/100-i18n.rb
+++ b/config/initializers/100-i18n.rb
@@ -16,7 +16,7 @@ Rails.application.reloader.to_prepare do
   unless Rails.env.test?
     MessageBus.subscribe("/i18n-flush") do
       I18n.reload!
-      ExtraLocalesController.clear_cache!
+      ExtraLocalesController.clear_cache!(all_sites: true)
     end
   end
 end


### PR DESCRIPTION
When Translation Overrides are changed, a message is sent on the `/i18n-flush` channel to ensure all running unicorns flush their caches. This message is not received in a database-specific context, so running `ExtraLocalesController.clear_cache!` was only affecting the default site in a multisite cluster. This commit updates it to flush caches for all sites.