### PR TITLE
DEV: Fix small issues in the Glimmer Post Stream

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/date.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/date.gjs
@@ -12,8 +12,8 @@ export default class PostMetaDataDate extends Component {
   @service modal;
 
   get date() {
-    if (this.args.post.wiki && this.args.post.lastWikiEdit) {
-      return this.args.post.lastWikiEdit;
+    if (this.args.post.wiki && this.args.post.last_wiki_edit) {
+      return this.args.post.last_wiki_edit;
     } else {
       return this.args.post.created_at;
     }

--- a/app/assets/javascripts/discourse/app/components/post/small-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/small-action.gjs
@@ -117,10 +117,6 @@ export default class PostSmallAction extends Component {
   }
 
   get path() {
-    if (!this.args.post.action_code_path || this.args.post.topic?.id) {
-      return;
-    }
-
     return getURL(
       this.args.post.action_code_path || `/t/${this.args.post.topic.id}`
     );

--- a/app/assets/javascripts/discourse/app/lib/post-cooked-html-decorators/mentions.gjs
+++ b/app/assets/javascripts/discourse/app/lib/post-cooked-html-decorators/mentions.gjs
@@ -61,16 +61,21 @@ export default function (element, context) {
 function _renderUserStatusOnMentions(mentions, user, helper) {
   mentions.forEach((mention) => {
     let wrapper = mention.querySelector(".user-status-message-wrapper");
-    if (!wrapper) {
-      wrapper = document.createElement("span");
-      wrapper.classList.add("user-status-message-wrapper");
-      mention.appendChild(wrapper);
-    }
 
-    helper.renderGlimmer(mention, CookedUserStatusMessage, {
-      wrapper,
-      status: user.status,
-    });
+    if (user.status) {
+      if (!wrapper) {
+        wrapper = document.createElement("span");
+        wrapper.classList.add("user-status-message-wrapper");
+        mention.appendChild(wrapper);
+      }
+
+      helper.renderGlimmer(mention, CookedUserStatusMessage, {
+        wrapper,
+        status: user.status,
+      });
+    } else {
+      wrapper?.remove?.();
+    }
   });
 }
 

--- a/app/assets/javascripts/discourse/app/lib/user-status-message.js
+++ b/app/assets/javascripts/discourse/app/lib/user-status-message.js
@@ -56,7 +56,7 @@ export class UserStatusMessage {
 
   #tooltipHtml(status) {
     const html = document.createElement("div");
-    html.classList.add("user-status-message-tooltip");
+    html.classList.add("user-status-message-tooltip-content");
     html.innerHTML = this.#emojiHtml(status.emoji);
 
     const description = document.createElement("span");

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -1264,6 +1264,7 @@ export default class PostStream extends RestModel {
     post.user = this.store.createRecord("user", {
       id: post.user_id,
       username: post.username,
+      avatar_template: post.avatar_template,
     });
 
     if (post.user_status) {

--- a/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-inline-mentions-test.js
@@ -30,189 +30,245 @@ function topicWithUserStatus(topicId, mentionedUserId, status) {
   return topic;
 }
 
-acceptance("Post inline mentions", function (needs) {
-  needs.user();
-  needs.settings({ enable_user_status: true });
-
-  const topicId = 130;
-  const mentionedUserId = 1;
-  const status = {
-    description: "Surfing",
-    emoji: "surfing_man",
-    ends_at: null,
-  };
-
-  test("shows user status on inline mentions", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      return response(topicWithUserStatus(topicId, mentionedUserId, status));
-    });
-
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("user status is shown");
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message img")
-      .hasAttribute("src", /surfing_man/, "status emoji is correct");
-  });
-
-  test("inserts user status on message bus message", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      return response(topicWithoutUserStatus(topicId, mentionedUserId));
-    });
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .doesNotExist("user status isn't shown");
-
-    await publishToMessageBus("/user-status", {
-      [mentionedUserId]: {
-        description: status.description,
-        emoji: status.emoji,
-      },
-    });
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("user status is shown");
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message img")
-      .hasAttribute("src", /surfing_man/, "status emoji is correct");
-  });
-
-  test("updates user status on message bus message", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      return response(topicWithUserStatus(topicId, mentionedUserId, status));
-    });
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("initial user status is shown");
-
-    const newStatus = {
-      description: "off to dentist",
-      emoji: "tooth",
-    };
-    await publishToMessageBus("/user-status", {
-      [mentionedUserId]: {
-        description: newStatus.description,
-        emoji: newStatus.emoji,
-      },
-    });
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("updated user status is shown");
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message img")
-      .hasAttribute("src", /tooth/, "updated status emoji is correct");
-  });
-
-  test("removes user status on message bus message", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      return response(topicWithUserStatus(topicId, mentionedUserId, status));
-    });
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("initial user status is shown");
-
-    await publishToMessageBus("/user-status", {
-      [mentionedUserId]: null,
-    });
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .doesNotExist("updated user has disappeared");
-  });
-});
-
-acceptance("Post inline mentions – user status tooltip", function (needs) {
-  needs.user();
-  needs.settings({ enable_user_status: true });
-
-  const topicId = 130;
-  const mentionedUserId = 1;
-  const status = {
-    description: "Surfing",
-    emoji: "surfing_man",
-    ends_at: null,
-  };
-
-  async function mouseMove(selector) {
-    await triggerEvent(selector, "pointermove");
-  }
-
-  test("shows user status tooltip", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      return response(topicWithUserStatus(topicId, mentionedUserId, status));
-    });
-
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("user status is shown");
-
-    await mouseMove(".topic-post .cooked .mention .user-status-message");
-
-    assert
-      .dom(".user-status-message-tooltip")
-      .exists("status tooltip is shown");
-    assert.true(
-      document
-        .querySelector(".user-status-message-tooltip img")
-        .src.includes(status.emoji),
-      "emoji is correct"
-    );
-    assert
-      .dom(".user-status-tooltip-description")
-      .hasText(status.description, "status description is correct");
-  });
-});
-
-acceptance("Post inline mentions as an anonymous user", function (needs) {
-  needs.settings({ enable_user_status: true });
-
-  const topicId = 130;
-  const mentionedUserId = 1;
-  const status = {
-    description: "Surfing",
-    emoji: "surfing_man",
-    ends_at: null,
-  };
-
-  test("an anonymous user can see user status on mentions", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      const topic = topicWithUserStatus(topicId, mentionedUserId, status);
-      return response(topic);
-    });
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
-
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("user status is shown");
-  });
-
-  test("an anonymous user can see user status with an end date on mentions", async function (assert) {
-    pretender.get(`/t/${topicId}.json`, () => {
-      const statusWithEndDate = Object.assign(status, {
-        ends_at: "2100-02-01T09:00:00.000Z",
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `Post inline mentions (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        glimmer_post_stream_mode: postStreamMode,
+        enable_user_status: true,
       });
-      const topic = topicWithUserStatus(
-        topicId,
-        mentionedUserId,
-        statusWithEndDate
-      );
-      return response(topic);
-    });
-    await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
 
-    assert
-      .dom(".topic-post .cooked .mention .user-status-message")
-      .exists("user status is shown");
-  });
+      const topicId = 130;
+      const mentionedUserId = 1;
+      const status = {
+        description: "Surfing",
+        emoji: "surfing_man",
+        ends_at: null,
+      };
+
+      test("shows user status on inline mentions", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(
+            topicWithUserStatus(topicId, mentionedUserId, status)
+          );
+        });
+
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("user status is shown");
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message img")
+          .hasAttribute("src", /surfing_man/, "status emoji is correct");
+      });
+
+      test("do not show status in inline mentions if the user status is empty ", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(topicWithUserStatus(topicId, mentionedUserId));
+        });
+
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message-wrapper")
+          .doesNotExist("the wrapper is not present in the DOM");
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .doesNotExist("the user status is not shown");
+      });
+
+      test("inserts user status on message bus message", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(topicWithoutUserStatus(topicId, mentionedUserId));
+        });
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .doesNotExist("user status isn't shown");
+
+        await publishToMessageBus("/user-status", {
+          [mentionedUserId]: {
+            description: status.description,
+            emoji: status.emoji,
+          },
+        });
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("user status is shown");
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message img")
+          .hasAttribute("src", /surfing_man/, "status emoji is correct");
+      });
+
+      test("updates user status on message bus message", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(
+            topicWithUserStatus(topicId, mentionedUserId, status)
+          );
+        });
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("initial user status is shown");
+
+        const newStatus = {
+          description: "off to dentist",
+          emoji: "tooth",
+        };
+        await publishToMessageBus("/user-status", {
+          [mentionedUserId]: {
+            description: newStatus.description,
+            emoji: newStatus.emoji,
+          },
+        });
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("updated user status is shown");
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message img")
+          .hasAttribute("src", /tooth/, "updated status emoji is correct");
+      });
+
+      test("removes user status on message bus message", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(
+            topicWithUserStatus(topicId, mentionedUserId, status)
+          );
+        });
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        // TODO (glimmer-post-stream-mode) remove the `if` surrounding the assertion when removing the legacy code
+        if (this.siteSettings.glimmer_post_stream_mode === "enabled") {
+          assert
+            .dom(".topic-post .cooked .mention .user-status-message-wrapper")
+            .exists("the wrapper is present in the DOM");
+        }
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("initial user status is shown");
+
+        await publishToMessageBus("/user-status", {
+          [mentionedUserId]: null,
+        });
+
+        // TODO (glimmer-post-stream-mode) remove the `if` surrounding the assertion when removing the legacy code
+        if (this.siteSettings.glimmer_post_stream_mode === "enabled") {
+          assert
+            .dom(".topic-post .cooked .mention .user-status-message-wrapper")
+            .doesNotExist("the wrapper was removed from the DOM");
+        }
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .doesNotExist("updated user has disappeared");
+      });
+    }
+  );
+
+  acceptance(
+    `Post inline mentions – user status tooltip (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        glimmer_post_stream_mode: postStreamMode,
+        enable_user_status: true,
+      });
+
+      const topicId = 130;
+      const mentionedUserId = 1;
+      const status = {
+        description: "Surfing",
+        emoji: "surfing_man",
+        ends_at: null,
+      };
+
+      async function mouseMove(selector) {
+        await triggerEvent(selector, "pointermove");
+      }
+
+      test("shows user status tooltip", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          return response(
+            topicWithUserStatus(topicId, mentionedUserId, status)
+          );
+        });
+
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("user status is shown");
+
+        await mouseMove(".topic-post .cooked .mention .user-status-message");
+
+        assert
+          .dom(".user-status-message-tooltip-content")
+          .exists("status tooltip is shown");
+        assert.true(
+          document
+            .querySelector(".user-status-message-tooltip-content img")
+            .src.includes(status.emoji),
+          "emoji is correct"
+        );
+        assert
+          .dom(".user-status-tooltip-description")
+          .hasText(status.description, "status description is correct");
+      });
+    }
+  );
+
+  acceptance(
+    `Post inline mentions as an anonymous user (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.settings({
+        glimmer_post_stream_mode: postStreamMode,
+        enable_user_status: true,
+      });
+
+      const topicId = 130;
+      const mentionedUserId = 1;
+      const status = {
+        description: "Surfing",
+        emoji: "surfing_man",
+        ends_at: null,
+      };
+
+      test("an anonymous user can see user status on mentions", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          const topic = topicWithUserStatus(topicId, mentionedUserId, status);
+          return response(topic);
+        });
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("user status is shown");
+      });
+
+      test("an anonymous user can see user status with an end date on mentions", async function (assert) {
+        pretender.get(`/t/${topicId}.json`, () => {
+          const statusWithEndDate = Object.assign(status, {
+            ends_at: "2100-02-01T09:00:00.000Z",
+          });
+          const topic = topicWithUserStatus(
+            topicId,
+            mentionedUserId,
+            statusWithEndDate
+          );
+          return response(topic);
+        });
+        await visit(`/t/lorem-ipsum-dolor-sit-amet/${topicId}`);
+
+        assert
+          .dom(".topic-post .cooked .mention .user-status-message")
+          .exists("user status is shown");
+      });
+    }
+  );
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
@@ -61,6 +61,7 @@ module("Integration | Component | Post", function (hooks) {
       topic,
       like_count: 3,
       actions_summary: [{ id: 2, count: 1, hidden: false, can_act: true }],
+      created_at: new Date(new Date().getTime() - 30 * 60 * 1000),
     });
 
     this.post = post;
@@ -71,6 +72,14 @@ module("Integration | Component | Post", function (hooks) {
 
     assert.dom(".names").exists("includes poster name");
     assert.dom("a.post-date").exists("includes post date");
+
+    assert
+      .dom("a.post-date .relative-date")
+      .hasAttribute(
+        "data-time",
+        this.post.created_at.getTime().toString(10),
+        "the relative date has the correct time"
+      );
   });
 
   test("can add classes to the component", async function (assert) {
@@ -166,10 +175,19 @@ module("Integration | Component | Post", function (hooks) {
     this.post.wiki = true;
     this.post.version = 2;
     this.post.can_view_edit_history = true;
+    this.post.last_wiki_edit = new Date();
 
     await renderComponent(this.post, {
       showHistory: () => assert.step("show history called"),
     });
+
+    assert
+      .dom("a.post-date .relative-date")
+      .hasAttribute(
+        "data-time",
+        this.post.last_wiki_edit.getTime().toString(10),
+        "the relative date is based in the last time the wiki was edited"
+      );
 
     await click(".post-info .wiki");
     assert.verifySteps(

--- a/plugins/chat/test/javascripts/components/chat-channel-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.gjs
@@ -201,7 +201,7 @@ module(
 
       assert
         .dom(
-          `.user-status-message-tooltip img[alt='${mentionedUser.status.emoji}']`
+          `.user-status-message-tooltip-content img[alt='${mentionedUser.status.emoji}']`
         )
         .exists("status emoji is correct");
     });


### PR DESCRIPTION
- When using the Glimmer Post Stream, ensure the status wrapper is only rendered for mentions of users with a status set.
  This prevents an empty wrapper from adding a small blank space at the end of the mention.

- Ensures the post's user field in initialized with the `avatar_template` in the PostStream to prevent missing avatar on small actions

- Fix an issue where the path would be incorrectly linked on small actions 

- Fix an issue where the relative timestamp would be incorrectly displayed in wiki posts