### PR TITLE
DEV: Add a flag to facilitate merging about groups into core

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -997,6 +997,9 @@ groups:
   max_automatic_membership_email_domains:
     default: 50
     hidden: true
+  show_additional_about_groups:
+    default: false
+    hidden: true
 
 posting:
   min_post_length:


### PR DESCRIPTION
### What is this change?

We are merging the [add-groups-to-about](https://github.com/discourse/discourse-add-groups-to-about-component/) theme component into core. As per protocol, we'll use a hidden site setting to facilitate the switchover.