### PR TITLE
FIX: correct reload edit theme page

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
@@ -28,10 +28,12 @@ export default class AdminCustomizeThemesShowRoute extends Route {
 
     const parentController = this.controllerFor("adminCustomizeThemes");
 
-    const fromNewConfigPage = [
-      "adminConfig.customize.themes",
-      "adminConfig.customize.components",
-    ].includes(transition?.from?.name);
+    const fromNewConfigPage =
+      !transition.from ||
+      [
+        "adminConfig.customize.themes",
+        "adminConfig.customize.components",
+      ].includes(transition.from.name);
 
     parentController.setProperties({
       editingTheme: false,

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -50,4 +50,12 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     admin_customize_themes_page.confirm_delete
     expect(page).to have_current_path("/admin/config/customize/themes")
   end
+
+  it "has new look when edit theme is visited directly and can go back to themes" do
+    visit("/admin/customize/themes/#{theme.id}")
+    expect(page).to have_css(".back-to-themes-and-components")
+    expect(admin_customize_themes_page).to have_back_button_to_themes_page
+    admin_customize_themes_page.click_back_to_themes
+    expect(page).to have_current_path("/admin/config/customize/themes")
+  end
 end

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -38,6 +38,10 @@ module PageObjects
         )
       end
 
+      def click_back_to_themes
+        find(".back-to-themes-and-components a").click
+      end
+
       def has_back_button_to_components_page?
         has_css?(
           '.back-to-themes-and-components a[href="/admin/config/customize/components"]',


### PR DESCRIPTION
When edit theme page is reloaded or visited directly, we should display new layout.