### PR TITLE
DEV: Expose show_additional_about_groups to client

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -998,6 +998,7 @@ groups:
     default: 50
     hidden: true
   show_additional_about_groups:
+    client: true
     default: false
     hidden: true
 


### PR DESCRIPTION
### What is this change?

We just added this site setting to be used for switchover as we merge a theme component into core. However, as it wasn't marked `client: true`, the theme component cannot read it. 🤦 