### PR TITLE
DEV: Remove redundant step from tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,10 +274,6 @@ jobs:
         if: matrix.build_type == 'system'
         run: script/assemble_ember_build.rb
 
-      - name: Install playwright
-        if: matrix.build_type == 'system'
-        run: pnpm playwright install --with-deps --no-shell chromium
-
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
         env:


### PR DESCRIPTION
playwright and its dependencies are already being installed when we
build the `discourse/discourse_test:release` image used by the `tests`
workflow.
