### PR TITLE
DEV: revert long press changes

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -74,38 +74,13 @@ module PageObjects
         message_by_id(message.id).find(".chat-message-expand").click
       end
 
+      def emoji(message, code)
+        messages.emoji(message, code)
+      end
+
       def expand_message_actions(message)
         hover_message(message)
         click_more_button
-      end
-
-      def expand_message_actions_mobile(message, delay: 2)
-        message = find("#{message_by_id_selector(message.id)} .chat-message-content")
-        page.execute_script(<<-JS, message, delay)
-          arguments[0].dispatchEvent(new TouchEvent("touchstart", {
-            cancelable: true,
-            bubbles: true,
-            touches: [
-              new Touch({ identifier: Date.now(), target: arguments[0] })
-            ],
-          }));
-
-
-          setTimeout(() => {
-            arguments[0].dispatchEvent(new TouchEvent("touchend", {
-              cancelable: true,
-              bubbles: true,
-              touches: [
-                new Touch({ identifier: Date.now(), target: arguments[0] })
-              ],
-            }));
-          }, arguments[1] * 1000);
-        JS
-      end
-
-      def click_message_action_mobile(message, message_action)
-        expand_message_actions_mobile(message, delay: 0.4)
-        find(".chat-message-actions [data-id=\"#{message_action}\"]").click
       end
 
       def hover_message(message)
@@ -127,15 +102,7 @@ module PageObjects
       end
 
       def bookmark_message(message)
-        messages.has_message?(id: message.id)
-
-        if page.has_css?("html.mobile-view", wait: 0)
-          click_message_action_mobile(message, "bookmark")
-          expect(page).to have_css(".d-modal:not(.is-animating)")
-        else
-          hover_message(message)
-          find(".bookmark-btn").click
-        end
+        messages.bookmark(message)
       end
 
       def click_more_button
@@ -160,7 +127,7 @@ module PageObjects
         messages.has_message?(id: message.id)
 
         if page.has_css?("html.mobile-view", wait: 0)
-          click_message_action_mobile(message, "reply")
+          messages.reply_to(message)
         else
           hover_message(message)
           find(".reply-btn").click

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -80,7 +80,27 @@ module PageObjects
       end
 
       def expand_message_actions_mobile(message, delay: 2)
-        find(message_by_id_selector(message.id)).find(".chat-message-content").click(delay: delay)
+        message = find("#{message_by_id_selector(message.id)} .chat-message-content")
+        page.execute_script(<<-JS, message, delay)
+          arguments[0].dispatchEvent(new TouchEvent("touchstart", {
+            cancelable: true,
+            bubbles: true,
+            touches: [
+              new Touch({ identifier: Date.now(), target: arguments[0] })
+            ],
+          }));
+
+
+          setTimeout(() => {
+            arguments[0].dispatchEvent(new TouchEvent("touchend", {
+              cancelable: true,
+              bubbles: true,
+              touches: [
+                new Touch({ identifier: Date.now(), target: arguments[0] })
+              ],
+            }));
+          }, arguments[1] * 1000);
+        JS
       end
 
       def click_message_action_mobile(message, message_action)

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -41,7 +41,7 @@ module PageObjects
         end
 
         def open_mobile_actions
-          page.execute_script(<<-JS, component, 0.6)
+          page.execute_script(<<-JS, component)
             arguments[0].dispatchEvent(new TouchEvent("touchstart", {
               cancelable: true,
               bubbles: true,
@@ -59,7 +59,7 @@ module PageObjects
                   new Touch({ identifier: Date.now(), target: arguments[0] })
                 ],
               }));
-            }, arguments[1] * 1000);
+            }, 600);
           JS
         end
 

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -63,6 +63,15 @@ module PageObjects
           JS
         end
 
+        def bookmark
+          if page.has_css?("html.mobile-view", wait: 0)
+            secondary_action("bookmark")
+          else
+            hover
+            page.find(".chat-message-actions .bookmark-btn").click
+          end
+        end
+
         def emoji(code)
           if page.has_css?("html.mobile-view", wait: 0)
             open_mobile_actions

--- a/plugins/chat/spec/system/page_objects/chat/components/message.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/message.rb
@@ -32,12 +32,45 @@ module PageObjects
 
         def secondary_action(action)
           if page.has_css?("html.mobile-view", wait: 0)
-            component.find(".chat-message-text").click(delay: 0.6)
+            open_mobile_actions
             page.find(".chat-message-actions [data-id=\"#{action}\"]").click
           else
             open_more_menu
             page.find("[data-value='#{action}']").click
           end
+        end
+
+        def open_mobile_actions
+          page.execute_script(<<-JS, component, 0.6)
+            arguments[0].dispatchEvent(new TouchEvent("touchstart", {
+              cancelable: true,
+              bubbles: true,
+              touches: [
+                new Touch({ identifier: Date.now(), target: arguments[0] })
+              ],
+            }));
+
+
+            setTimeout(() => {
+              arguments[0].dispatchEvent(new TouchEvent("touchend", {
+                cancelable: true,
+                bubbles: true,
+                touches: [
+                  new Touch({ identifier: Date.now(), target: arguments[0] })
+                ],
+              }));
+            }, arguments[1] * 1000);
+          JS
+        end
+
+        def emoji(code)
+          if page.has_css?("html.mobile-view", wait: 0)
+            open_mobile_actions
+          else
+            hover
+          end
+
+          page.find(".chat-message-actions [data-emoji-name='#{code}']").click
         end
 
         def select(shift: false)

--- a/plugins/chat/spec/system/page_objects/chat/components/messages.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/messages.rb
@@ -21,7 +21,7 @@ module PageObjects
         end
 
         def bookmark(message)
-          find(message).secondary_action("bookmark")
+          find(message).bookmark
         end
 
         def copy_text(message)

--- a/plugins/chat/spec/system/page_objects/chat/components/messages.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/messages.rb
@@ -20,12 +20,24 @@ module PageObjects
           find(message).secondary_action("copyLink")
         end
 
+        def bookmark(message)
+          find(message).secondary_action("bookmark")
+        end
+
         def copy_text(message)
           find(message).secondary_action("copyText")
         end
 
         def flag(message)
           find(message).secondary_action("flag")
+        end
+
+        def reply_to(message)
+          find(message).secondary_action("reply")
+        end
+
+        def emoji(message, code)
+          find(message).emoji(code)
         end
 
         def delete(message)

--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -138,8 +138,7 @@ RSpec.describe "React to message", type: :system do
         it "adds a reaction" do
           sign_in(current_user)
           chat.visit_channel(category_channel_1)
-          channel.expand_message_actions_mobile(message_1)
-          find(".main-actions [data-emoji-name=\"+1\"]").click
+          channel.emoji(message_1, "+1")
 
           expect(channel.message_reactions_list(message_1)).to have_css("[data-emoji-name=\"+1\"]")
         end


### PR DESCRIPTION
These changes have been made for playwright as it was hard to test a long press event on playwright given `click` won't trigger `touchstart` even with `isMobile:true` and `hasTouch:true`. You have to use `tap`, but you don't have the `delay` option on tap, so you can't make it a long tap.

Sadly this code is apparently not working correctly on Android 15. This commit will revert the modifier to what it was before and is relying on native JS to trigger the fake long press in specs, which seems to work nicely.

This commit also attempts to centralize the actions on messages in page objects to avoid code duplication.