### PR TITLE
DEV: Deprecate boundDate and formatAge helpers

### DIFF
--- a/app/assets/javascripts/admin/addon/components/flag-user.gjs
+++ b/app/assets/javascripts/admin/addon/components/flag-user.gjs
@@ -1,9 +1,8 @@
 import Component from "@ember/component";
 import { array } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import avatar from "discourse/helpers/avatar";
-import formatAge from "discourse/helpers/format-age";
-import rawDate from "discourse/helpers/raw-date";
 
 export default class FlagUser extends Component {
   <template>
@@ -24,8 +23,8 @@ export default class FlagUser extends Component {
           >
             {{this.user.username}}
           </LinkTo>
-          <div title={{rawDate this.date}} class="flag-user-date">
-            {{formatAge this.date}}
+          <div class="flag-user-date">
+            {{ageWithTooltip this.date}}
           </div>
         </div>
         <div class="flag-user-extra">

--- a/app/assets/javascripts/admin/addon/templates/search-logs-term.gjs
+++ b/app/assets/javascripts/admin/addon/templates/search-logs-term.gjs
@@ -4,10 +4,10 @@ import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import HighlightSearch from "discourse/components/highlight-search";
 import TopicStatus from "discourse/components/topic-status";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import avatar from "discourse/helpers/avatar";
 import categoryLink from "discourse/helpers/category-link";
 import discourseTag from "discourse/helpers/discourse-tag";
-import formatAge from "discourse/helpers/format-age";
 import htmlSafe from "discourse/helpers/html-safe";
 import { i18n } from "discourse-i18n";
 import Chart from "admin/components/chart";
@@ -83,7 +83,7 @@ export default RouteTemplate(
 
               <div class="blurb container">
                 <span class="date">
-                  {{formatAge result.created_at}}
+                  {{ageWithTooltip result.created_at}}
                   {{#if result.blurb}}
                     -
                   {{/if}}

--- a/app/assets/javascripts/discourse/app/components/featured-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/featured-topic.gjs
@@ -6,7 +6,7 @@ import {
 } from "@ember-decorators/component";
 import $ from "jquery";
 import TopicPostBadges from "discourse/components/topic-post-badges";
-import formatAge from "discourse/helpers/format-age";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import TopicStatus from "./topic-status";
 
 @classNameBindings(":featured-topic")
@@ -33,7 +33,7 @@ export default class FeaturedTopic extends Component {
       @url={{this.topic.lastUnreadUrl}}
     />
 
-    <a href={{this.topic.lastPostUrl}} class="last-posted-at">{{formatAge
+    <a href={{this.topic.lastPostUrl}} class="last-posted-at">{{ageWithTooltip
         this.topic.last_posted_at
       }}</a>
   </template>

--- a/app/assets/javascripts/discourse/app/components/group-manage-logs-row.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-manage-logs-row.gjs
@@ -3,8 +3,8 @@ import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import avatar from "discourse/helpers/avatar";
-import boundDate from "discourse/helpers/bound-date";
 import { i18n } from "discourse-i18n";
 
 @tagName("")
@@ -70,7 +70,7 @@ export default class GroupManageLogsRow extends Component {
         {{/if}}
       </td>
 
-      <td>{{boundDate this.log.created_at}}</td>
+      <td>{{ageWithTooltip this.log.created_at defaultFormat="medium"}}</td>
 
       <td class="group-manage-logs-expand-details">
         {{#if this.log.prev_value}}

--- a/app/assets/javascripts/discourse/app/components/group-manage-logs-row.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-manage-logs-row.gjs
@@ -70,7 +70,7 @@ export default class GroupManageLogsRow extends Component {
         {{/if}}
       </td>
 
-      <td>{{ageWithTooltip this.log.created_at defaultFormat="medium"}}</td>
+      <td>{{ageWithTooltip this.log.created_at format="medium"}}</td>
 
       <td class="group-manage-logs-expand-details">
         {{#if this.log.prev_value}}

--- a/app/assets/javascripts/discourse/app/components/mobile-category-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/mobile-category-topic.gjs
@@ -3,9 +3,8 @@ import { classNameBindings, tagName } from "@ember-decorators/component";
 import $ from "jquery";
 import PostCountOrBadges from "discourse/components/topic-list/post-count-or-badges";
 import TopicStatus from "discourse/components/topic-status";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import coldAgeClass from "discourse/helpers/cold-age-class";
-import formatAge from "discourse/helpers/format-age";
-import rawDate from "discourse/helpers/raw-date";
 import topicLink from "discourse/helpers/topic-link";
 
 export function showEntrance(e) {
@@ -40,10 +39,9 @@ export default class MobileCategoryTopic extends Component {
         {{#if this.topic.unseen}}
           <span class="badge-notification new-topic"></span>
         {{/if}}
-        <span
-          class={{coldAgeClass this.topic.last_posted_at}}
-          title={{rawDate this.topic.last_posted_at}}
-        >{{formatAge this.topic.last_posted_at}}</span>
+        <span class={{coldAgeClass this.topic.last_posted_at}}>{{ageWithTooltip
+            this.topic.last_posted_at
+          }}</span>
       </div>
     </td>
     <td class="num posts">

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
@@ -38,7 +38,7 @@ export default class Revision extends Component {
         />
 
         <span class="date">
-          {{ageWithTooltip @model.created_at defaultFormat="medium"}}
+          {{ageWithTooltip @model.created_at format="medium"}}
         </span>
 
         {{#if @model.edit_reason}}

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
@@ -6,8 +6,8 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { and, eq, not } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import boundAvatarTemplate from "discourse/helpers/bound-avatar-template";
-import boundDate from "discourse/helpers/bound-date";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -36,7 +36,11 @@ export default class Revision extends Component {
           @name="revision-user-details-after"
           @outletArgs={{hash model=@model}}
         />
-        <span class="date">{{boundDate @model.created_at}}</span>
+
+        <span class="date">
+          {{ageWithTooltip @model.created_at defaultFormat="medium"}}
+        </span>
+
         {{#if @model.edit_reason}}
           <span class="edit-reason">{{@model.edit_reason}}</span>
         {{/if}}

--- a/app/assets/javascripts/discourse/app/components/relative-date.gjs
+++ b/app/assets/javascripts/discourse/app/components/relative-date.gjs
@@ -1,27 +1,5 @@
-import Component from "@glimmer/component";
-import { longDate, relativeAge } from "discourse/lib/formatter";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 
-export default class RelativeDate extends Component {
-  get datetime() {
-    return new Date(this.args.date);
-  }
+const RelativeDate = <template>{{ageWithTooltip @date}}</template>;
 
-  get title() {
-    return longDate(this.datetime);
-  }
-
-  get time() {
-    return this.datetime.getTime();
-  }
-
-  <template>
-    <span
-      class="relative-date"
-      title={{this.title}}
-      data-time={{this.time}}
-      data-format="tiny"
-    >
-      {{relativeAge this.datetime}}
-    </span>
-  </template>
-}
+export default RelativeDate;

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/blurb.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/blurb.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import HighlightedSearch from "discourse/components/search-menu/highlighted-search";
-import formatAge from "discourse/helpers/format-age";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 
 export default class Blurb extends Component {
   @service siteSettings;
@@ -10,7 +10,7 @@ export default class Blurb extends Component {
 
   <template>
     <span class="blurb">
-      {{formatAge @result.created_at}}
+      {{ageWithTooltip @result.created_at}}
       <span class="blurb__separator"> - </span>
       {{#if this.siteSettings.use_pg_headlines_for_excerpt}}
         <span>{{htmlSafe @result.blurb}}</span>

--- a/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/featured-topic.gjs
@@ -2,7 +2,7 @@ import { on } from "@ember/modifier";
 import { htmlSafe } from "@ember/template";
 import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
-import formatAge from "discourse/helpers/format-age";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 
 const onTimestampClick = function (event) {
@@ -33,7 +33,7 @@ const FeaturedTopic = <template>
       {{on "click" onTimestampClick}}
       href={{@topic.lastPostUrl}}
       class="last-posted-at"
-    >{{formatAge @topic.last_posted_at}}</a>
+    >{{ageWithTooltip @topic.last_posted_at}}</a>
   </div>
 </template>;
 

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.gjs
@@ -5,10 +5,10 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DoNotDisturbModal from "discourse/components/modal/do-not-disturb";
 import UserStatusModal from "discourse/components/modal/user-status";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import emoji from "discourse/helpers/emoji";
-import formatAge from "discourse/helpers/format-age";
 import routeAction from "discourse/helpers/route-action";
 import { ajax } from "discourse/lib/ajax";
 import DoNotDisturb from "discourse/lib/do-not-disturb";
@@ -129,7 +129,7 @@ export default class UserMenuProfileTabContent extends Component {
               <span class="item-label">
                 {{this.currentUser.status.description}}
                 {{#if this.currentUser.status.ends_at}}
-                  {{formatAge this.currentUser.status.ends_at}}
+                  {{ageWithTooltip this.currentUser.status.ends_at}}
                 {{/if}}
               </span>
             {{else}}
@@ -179,7 +179,7 @@ export default class UserMenuProfileTabContent extends Component {
             {{#if this.isInDoNotDisturb}}
               <span>{{i18n "pause_notifications.label"}}</span>
               {{#if this.showDoNotDisturbEndDate}}
-                {{formatAge this.doNotDisturbDateTime}}
+                {{ageWithTooltip this.doNotDisturbDateTime}}
               {{/if}}
             {{else}}
               {{i18n "pause_notifications.label"}}

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-api-keys.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-api-keys.gjs
@@ -42,12 +42,12 @@ const UserApiKeys = <template>
 
             <p class="pref-user-api-keys__created-at">
               <span>{{i18n "user.api_approved"}}</span>
-              {{ageWithTooltip key.created_at defaultFormat="medium"}}
+              {{ageWithTooltip key.created_at format="medium"}}
             </p>
 
             <p class="pref-user-api-keys__last-used-at">
               <span>{{i18n "user.api_last_used_at"}}</span>
-              {{ageWithTooltip key.last_used_at defaultFormat="medium"}}
+              {{ageWithTooltip key.last_used_at format="medium"}}
             </p>
           </div>
         {{/each}}

--- a/app/assets/javascripts/discourse/app/components/user-preferences/user-api-keys.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/user-api-keys.gjs
@@ -1,6 +1,6 @@
 import { fn } from "@ember/helper";
 import DButton from "discourse/components/d-button";
-import boundDate from "discourse/helpers/bound-date";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
@@ -42,12 +42,12 @@ const UserApiKeys = <template>
 
             <p class="pref-user-api-keys__created-at">
               <span>{{i18n "user.api_approved"}}</span>
-              {{boundDate key.created_at}}
+              {{ageWithTooltip key.created_at defaultFormat="medium"}}
             </p>
 
             <p class="pref-user-api-keys__last-used-at">
               <span>{{i18n "user.api_last_used_at"}}</span>
-              {{boundDate key.last_used_at}}
+              {{ageWithTooltip key.last_used_at defaultFormat="medium"}}
             </p>
           </div>
         {{/each}}

--- a/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
+++ b/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
@@ -4,9 +4,9 @@ import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 export default function ageWithTooltip(dt, params = {}) {
   return htmlSafe(
     autoUpdatingRelativeAge(new Date(dt), {
-      customTitle: params.customTitle,
       title: true,
-      addAgo: params.addAgo || false,
+      customTitle: params.customTitle,
+      addAgo: params.addAgo,
       ...(params.defaultFormat && { defaultFormat: params.defaultFormat }),
     })
   );

--- a/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
+++ b/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
@@ -2,12 +2,6 @@ import { htmlSafe } from "@ember/template";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 
 export default function ageWithTooltip(dt, params = {}) {
-  return htmlSafe(
-    autoUpdatingRelativeAge(new Date(dt), {
-      title: true,
-      customTitle: params.customTitle,
-      addAgo: params.addAgo,
-      ...(params.defaultFormat && { defaultFormat: params.defaultFormat }),
-    })
-  );
+  params.title ??= true;
+  return htmlSafe(autoUpdatingRelativeAge(new Date(dt), params));
 }

--- a/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
+++ b/app/assets/javascripts/discourse/app/helpers/age-with-tooltip.js
@@ -2,6 +2,10 @@ import { htmlSafe } from "@ember/template";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 
 export default function ageWithTooltip(dt, params = {}) {
-  params.title ??= true;
-  return htmlSafe(autoUpdatingRelativeAge(new Date(dt), params));
+  return htmlSafe(
+    autoUpdatingRelativeAge(new Date(dt), {
+      ...params,
+      title: params.title ?? true,
+    })
+  );
 }

--- a/app/assets/javascripts/discourse/app/helpers/bound-date.js
+++ b/app/assets/javascripts/discourse/app/helpers/bound-date.js
@@ -1,7 +1,13 @@
 import { htmlSafe } from "@ember/template";
+import deprecated from "discourse/lib/deprecated";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 
 export default function boundDate(dt) {
+  deprecated(`boundDate helper is deprecated. Use ageWithTooltip instead.`, {
+    since: "3.5.0.beta5-dev",
+    id: "discourse.bound-date",
+  });
+
   return htmlSafe(
     autoUpdatingRelativeAge(new Date(dt), {
       format: "medium",

--- a/app/assets/javascripts/discourse/app/helpers/format-age.js
+++ b/app/assets/javascripts/discourse/app/helpers/format-age.js
@@ -1,7 +1,12 @@
 import { htmlSafe } from "@ember/template";
+import deprecated from "discourse/lib/deprecated";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 
 export default function formatAge(dt) {
-  dt = new Date(dt);
-  return htmlSafe(autoUpdatingRelativeAge(dt));
+  deprecated(`formatAge helper is deprecated. Use ageWithTooltip instead.`, {
+    since: "3.5.0.beta5-dev",
+    id: "discourse.format-age",
+  });
+
+  return htmlSafe(autoUpdatingRelativeAge(new Date(dt)));
 }

--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -155,9 +155,9 @@ export function duration(distance, ageOpts) {
   const distanceInMinutes = dividedDistance < 1 ? 1 : dividedDistance;
 
   const t = function (key, opts) {
-    const format = (ageOpts && ageOpts.format) || "tiny";
+    const format = ageOpts?.format || "tiny";
     const result = i18n("dates." + format + "." + key, opts);
-    return ageOpts && ageOpts.addAgo ? wrapAgo(result) : result;
+    return ageOpts?.addAgo ? wrapAgo(result) : result;
   };
 
   let formatted;
@@ -223,7 +223,7 @@ function relativeAgeTiny(date, ageOpts) {
   let formatted;
   const t = function (key, opts) {
     const result = i18n("dates." + format + "." + key, opts);
-    return ageOpts && ageOpts.addAgo ? wrapAgo(result) : result;
+    return ageOpts?.addAgo ? wrapAgo(result) : result;
   };
 
   // This file is in lib but it's used as a helper

--- a/app/assets/javascripts/discourse/app/templates/group-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.gjs
@@ -13,7 +13,7 @@ import ResponsiveTable from "discourse/components/responsive-table";
 import TableHeaderToggle from "discourse/components/table-header-toggle";
 import TextField from "discourse/components/text-field";
 import UserInfo from "discourse/components/user-info";
-import boundDate from "discourse/helpers/bound-date";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import routeAction from "discourse/helpers/route-action";
@@ -223,7 +223,7 @@ export default RouteTemplate(
                       <span>{{i18n "groups.member_added"}}</span>
                     </span>
                     <span class="directory-table__value">
-                      {{boundDate m.added_at}}
+                      {{ageWithTooltip m.added_at defaultFormat="medium"}}
                     </span>
                   </div>
                   <div
@@ -239,7 +239,7 @@ export default RouteTemplate(
                       </span>
                     {{/if}}
                     <span class="directory-table__value">
-                      {{boundDate m.last_posted_at}}
+                      {{ageWithTooltip m.last_posted_at defaultFormat="medium"}}
                     </span>
                   </div>
                   <div
@@ -255,7 +255,7 @@ export default RouteTemplate(
                       </span>
                     {{/if}}
                     <span class="directory-table__value">
-                      {{boundDate m.last_seen_at}}
+                      {{ageWithTooltip m.last_seen_at defaultFormat="medium"}}
                     </span>
                   </div>
                   {{#if @controller.canManageGroup}}

--- a/app/assets/javascripts/discourse/app/templates/group-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.gjs
@@ -223,7 +223,7 @@ export default RouteTemplate(
                       <span>{{i18n "groups.member_added"}}</span>
                     </span>
                     <span class="directory-table__value">
-                      {{ageWithTooltip m.added_at defaultFormat="medium"}}
+                      {{ageWithTooltip m.added_at format="medium"}}
                     </span>
                   </div>
                   <div
@@ -239,7 +239,7 @@ export default RouteTemplate(
                       </span>
                     {{/if}}
                     <span class="directory-table__value">
-                      {{ageWithTooltip m.last_posted_at defaultFormat="medium"}}
+                      {{ageWithTooltip m.last_posted_at format="medium"}}
                     </span>
                   </div>
                   <div
@@ -255,7 +255,7 @@ export default RouteTemplate(
                       </span>
                     {{/if}}
                     <span class="directory-table__value">
-                      {{ageWithTooltip m.last_seen_at defaultFormat="medium"}}
+                      {{ageWithTooltip m.last_seen_at format="medium"}}
                     </span>
                   </div>
                   {{#if @controller.canManageGroup}}

--- a/app/assets/javascripts/discourse/app/templates/group-requests.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.gjs
@@ -8,7 +8,7 @@ import ResponsiveTable from "discourse/components/responsive-table";
 import TableHeaderToggle from "discourse/components/table-header-toggle";
 import TextField from "discourse/components/text-field";
 import UserInfo from "discourse/components/user-info";
-import boundDate from "discourse/helpers/bound-date";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import { i18n } from "discourse-i18n";
 
@@ -64,7 +64,7 @@ export default RouteTemplate(
                       <span>{{i18n "groups.member_requested"}}</span>
                     </span>
                     <span class="directory-table__value">
-                      <span>{{boundDate m.requested_at}}</span>
+                      {{ageWithTooltip m.requested_at defaultFormat="medium"}}
                     </span>
                   </div>
                   <div

--- a/app/assets/javascripts/discourse/app/templates/group-requests.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.gjs
@@ -64,7 +64,7 @@ export default RouteTemplate(
                       <span>{{i18n "groups.member_requested"}}</span>
                     </span>
                     <span class="directory-table__value">
-                      {{ageWithTooltip m.requested_at defaultFormat="medium"}}
+                      {{ageWithTooltip m.requested_at format="medium"}}
                     </span>
                   </div>
                   <div

--- a/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
@@ -18,7 +18,7 @@ const CollapsedInfo = <template>
           <div>
             <dt class="created-at">{{i18n "user.created"}}</dt>
             <dd class="created-at">
-              {{ageWithTooltip @model.created_at defaultFormat="medium"}}
+              {{ageWithTooltip @model.created_at format="medium"}}
             </dd>
           </div>
         {{/if}}
@@ -26,7 +26,7 @@ const CollapsedInfo = <template>
           <div>
             <dt class="last-posted-at">{{i18n "user.last_posted"}}</dt>
             <dd class="last-posted-at">
-              {{ageWithTooltip @model.last_posted_at defaultFormat="medium"}}
+              {{ageWithTooltip @model.last_posted_at format="medium"}}
             </dd>
           </div>
         {{/if}}
@@ -34,7 +34,7 @@ const CollapsedInfo = <template>
           <div>
             <dt class="last-seen-at">{{i18n "user.last_seen"}}</dt>
             <dd class="last-seen-at">
-              {{ageWithTooltip @model.last_seen_at defaultFormat="medium"}}
+              {{ageWithTooltip @model.last_seen_at format="medium"}}
             </dd>
           </div>
         {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
@@ -2,7 +2,7 @@ import { fn, hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import boundDate from "discourse/helpers/bound-date";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
@@ -15,19 +15,28 @@ const CollapsedInfo = <template>
     <div class="secondary" id="collapsed-info-panel">
       <dl>
         {{#if @model.created_at}}
-          <div><dt class="created-at">{{i18n "user.created"}}</dt><dd
-              class="created-at"
-            >{{boundDate @model.created_at}}</dd></div>
+          <div>
+            <dt class="created-at">{{i18n "user.created"}}</dt>
+            <dd class="created-at">
+              {{ageWithTooltip @model.created_at defaultFormat="medium"}}
+            </dd>
+          </div>
         {{/if}}
         {{#if @model.last_posted_at}}
-          <div><dt class="last-posted-at">{{i18n "user.last_posted"}}</dt><dd
-              class="last-posted-at"
-            >{{boundDate @model.last_posted_at}}</dd></div>
+          <div>
+            <dt class="last-posted-at">{{i18n "user.last_posted"}}</dt>
+            <dd class="last-posted-at">
+              {{ageWithTooltip @model.last_posted_at defaultFormat="medium"}}
+            </dd>
+          </div>
         {{/if}}
         {{#if @model.last_seen_at}}
-          <div><dt class="last-seen-at">{{i18n "user.last_seen"}}</dt><dd
-              class="last-seen-at"
-            >{{boundDate @model.last_seen_at}}</dd></div>
+          <div>
+            <dt class="last-seen-at">{{i18n "user.last_seen"}}</dt>
+            <dd class="last-seen-at">
+              {{ageWithTooltip @model.last_seen_at defaultFormat="medium"}}
+            </dd>
+          </div>
         {{/if}}
         {{#if @model.profile_view_count}}
           <div><dt class="profile-view-count">{{i18n "views"}}</dt><dd

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
@@ -1,6 +1,6 @@
 import DButton from "discourse/components/d-button";
+import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import boundAvatar from "discourse/helpers/bound-avatar";
-import boundDate from "discourse/helpers/bound-date";
 import icon from "discourse/helpers/d-icon";
 import htmlSafe from "discourse/helpers/html-safe";
 import { i18n } from "discourse-i18n";
@@ -214,11 +214,20 @@ const UserAbout = <template>
         <div class="secondary">
           <dl>
             <dt>{{i18n "user.created"}}</dt>
-            <dd>{{boundDate @dummy.user.created_at}}</dd>
+            <dd>
+              {{ageWithTooltip @dummy.user.created_at defaultFormat="medium"}}
+            </dd>
             <dt>{{i18n "user.last_posted"}}</dt>
-            <dd>{{boundDate @dummy.user.last_posted_at}}</dd>
+            <dd>
+              {{ageWithTooltip
+                @dummy.user.last_posted_at
+                defaultFormat="medium"
+              }}
+            </dd>
             <dt>{{i18n "user.last_seen"}}</dt>
-            <dd>{{boundDate @dummy.user.last_seen_at}}</dd>
+            <dd>
+              {{ageWithTooltip @dummy.user.last_seen_at defaultFormat="medium"}}
+            </dd>
             <dt>{{i18n "views"}}</dt>
             <dd>{{@dummy.user.profile_view_count}}</dd>
             <dt class="invited-by">{{i18n "user.invited_by"}}</dt>
@@ -369,11 +378,20 @@ const UserAbout = <template>
         <div class="secondary">
           <dl>
             <dt>{{i18n "user.created"}}</dt>
-            <dd>{{boundDate @dummy.user.created_at}}</dd>
+            <dd>
+              {{ageWithTooltip @dummy.user.created_at defaultFormat="medium"}}
+            </dd>
             <dt>{{i18n "user.last_posted"}}</dt>
-            <dd>{{boundDate @dummy.user.last_posted_at}}</dd>
+            <dd>
+              {{ageWithTooltip
+                @dummy.user.last_posted_at
+                defaultFormat="medium"
+              }}
+            </dd>
             <dt>{{i18n "user.last_seen"}}</dt>
-            <dd>{{boundDate @dummy.user.last_seen_at}}</dd>
+            <dd>
+              {{ageWithTooltip @dummy.user.last_seen_at defaultFormat="medium"}}
+            </dd>
             <dt>{{i18n "views"}}</dt>
             <dd>{{@dummy.user.profile_view_count}}</dd>
             <dt class="invited-by">{{i18n "user.invited_by"}}</dt>

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
@@ -215,18 +215,15 @@ const UserAbout = <template>
           <dl>
             <dt>{{i18n "user.created"}}</dt>
             <dd>
-              {{ageWithTooltip @dummy.user.created_at defaultFormat="medium"}}
+              {{ageWithTooltip @dummy.user.created_at format="medium"}}
             </dd>
             <dt>{{i18n "user.last_posted"}}</dt>
             <dd>
-              {{ageWithTooltip
-                @dummy.user.last_posted_at
-                defaultFormat="medium"
-              }}
+              {{ageWithTooltip @dummy.user.last_posted_at format="medium"}}
             </dd>
             <dt>{{i18n "user.last_seen"}}</dt>
             <dd>
-              {{ageWithTooltip @dummy.user.last_seen_at defaultFormat="medium"}}
+              {{ageWithTooltip @dummy.user.last_seen_at format="medium"}}
             </dd>
             <dt>{{i18n "views"}}</dt>
             <dd>{{@dummy.user.profile_view_count}}</dd>
@@ -379,18 +376,15 @@ const UserAbout = <template>
           <dl>
             <dt>{{i18n "user.created"}}</dt>
             <dd>
-              {{ageWithTooltip @dummy.user.created_at defaultFormat="medium"}}
+              {{ageWithTooltip @dummy.user.created_at format="medium"}}
             </dd>
             <dt>{{i18n "user.last_posted"}}</dt>
             <dd>
-              {{ageWithTooltip
-                @dummy.user.last_posted_at
-                defaultFormat="medium"
-              }}
+              {{ageWithTooltip @dummy.user.last_posted_at format="medium"}}
             </dd>
             <dt>{{i18n "user.last_seen"}}</dt>
             <dd>
-              {{ageWithTooltip @dummy.user.last_seen_at defaultFormat="medium"}}
+              {{ageWithTooltip @dummy.user.last_seen_at format="medium"}}
             </dd>
             <dt>{{i18n "views"}}</dt>
             <dd>{{@dummy.user.profile_view_count}}</dd>


### PR DESCRIPTION
…and just leave `ageWithTooltip` helper (and `RelativeDate` component, replacing its implementation with that helper)

1. we don't need three helpers for the same thing
2. replacing the component impl might fix a bug with post timestamps in the glimmer post implementation 🤞