### PR TITLE
DEV: add value transformer for hamburger click outside exceptions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
@@ -7,6 +7,7 @@ import { waitForPromise } from "@ember/test-waiters";
 import { isTesting } from "discourse/lib/environment";
 import discourseLater from "discourse/lib/later";
 import { isDocumentRTL } from "discourse/lib/text-direction";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { prefersReducedMotion } from "discourse/lib/utilities";
 import closeOnClickOutside from "../../modifiers/close-on-click-outside";
 import SidebarHamburgerDropdown from "../sidebar/hamburger-dropdown";
@@ -35,7 +36,15 @@ export default class HamburgerDropdownWrapper extends Component {
 
   @action
   clickOutside(e) {
-    if (e.target.closest(".sidebar-more-section-content")) {
+    let exceptionSelectors = [".sidebar-more-section-content"];
+
+    exceptionSelectors = applyValueTransformer(
+      "hamburger-dropdown-click-outside-exceptions",
+      exceptionSelectors,
+      { event: e }
+    );
+
+    if (exceptionSelectors.some((selector) => e.target.closest(selector))) {
       return;
     }
 

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -22,6 +22,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "flag-description",
   "flag-custom-placeholder",
   "flag-formatted-name",
+  "hamburger-dropdown-click-outside-exceptions",
   "header-notifications-avatar-size",
   "home-logo-href",
   "home-logo-image-url",


### PR DESCRIPTION
This allows themes to add exceptions for menus that may be triggered from the hamburger menu... like this 

```js
api.registerValueTransformer(
  "hamburger-dropdown-click-outside-exceptions",
  ({ value }) => {
    return [...value, ".topic-drafts-menu-content"];
  }
);
```