### PR TITLE
DEV: introduces PLAYWRIGHT_NO_VIEWPORT

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -475,7 +475,11 @@ RSpec.configure do |config|
     end
 
     Capybara.register_driver(:playwright_chrome) do |app|
-      Capybara::Playwright::Driver.new(app, **driver_options, screen: { width: 1400, height: 1400 })
+      Capybara::Playwright::Driver.new(
+        app,
+        **driver_options,
+        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 1400, height: 1400 },
+      )
     end
 
     Capybara.register_driver(:playwright_mobile_chrome) do |app|
@@ -488,14 +492,7 @@ RSpec.configure do |config|
         userAgent:
           "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1",
         defaultBrowserType: "webkit",
-        screen: {
-          width: 390,
-          height: 844,
-        },
-        viewport: {
-          width: 390,
-          height: 664,
-        },
+        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 390, height: 664 },
       )
     end
 


### PR DESCRIPTION
The way playwright renders headed browser is different than selenium, and depending on the size of your screen you could not be able to see part of the app. To avoid this issue you can now use `PLAYWRIGHT_NO_VIEWPORT=1` which will default to a smaller viewport.

Note that to ensure we don't fail randomly on CI, the viewport on CI will always be 1400x1400, so if you develop with `PLAYWRIGHT_NO_VIEWPORT=1` you might experience failures on CI.