### PR TITLE
DEV: adds unregister_locale

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -169,6 +169,8 @@ class DiscoursePluginRegistry
   end
 
   def self.unregister_locale(locale)
+    raise "unregister_locale can only be used in tests" if !Rails.env.test?
+
     self.locales.delete(locale)
   end
 

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -168,6 +168,10 @@ class DiscoursePluginRegistry
     self.locales[locale] = options
   end
 
+  def self.unregister_locale(locale)
+    self.locales.delete(locale)
+  end
+
   def register_archetype(name, options = {})
     Archetype.register(name, options)
   end

--- a/spec/lib/freedom_patches/translate_accelerator_spec.rb
+++ b/spec/lib/freedom_patches/translate_accelerator_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "translate accelerator" do
     end
 
     after do
-      DiscoursePluginRegistry.reset!
+      DiscoursePluginRegistry.unregister_locale("foo")
       LocaleSiteSetting.reset!
     end
 


### PR DESCRIPTION
Running this spec locally I was getting an error:

```
  1) translate accelerator plugins loads plural rules from plugins
     Failure/Error: raise "Clearing modifiers during a plugin spec run will affect all future specs. Use unregister_modifier instead."

     RuntimeError:
       Clearing modifiers during a plugin spec run will affect all future specs. Use unregister_modifier instead.
     # ./lib/discourse_plugin_registry.rb:257:in `clear_modifiers!'
     # ./lib/discourse_plugin_registry.rb:302:in `reset!'
     # ./spec/lib/freedom_patches/translate_accelerator_spec.rb:113:in `block (3 levels) in <main>'
```

On top of this, this spec was flakey, Im not sure this is going to fix flakyness, but this seems like a good first step.