### PR TITLE
DEV: flaky spec

### DIFF
--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -31,7 +31,7 @@ describe "Composer using review_media", type: :system do
       composer.click_toolbar_button("upload")
     end
 
-    within(".d-editor-preview") { expect(page).to have_css("img") }
+    expect(page).to have_css(".d-editor-preview img")
 
     topic_page.send_reply
 


### PR DESCRIPTION
Attempts to look from the page instead of the d-editor-preview which might be recreated when updating the image.

This spec is often flaky atm with this error:

```
Failure/Error: super

Playwright::Error:
  TypeError: Cannot read properties of null (reading 'namespaceURI')
      at eval (eval at evaluate (:313:29), <anonymous>:17:12)
      at UtilityScript.evaluate (<anonymous>:320:18)
      at UtilityScript.<anonymous> (<anonymous>:1:44)
  Call log:
```