### PR TITLE
DEV: clean up review queue button classes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-bundled-action.gjs
@@ -26,6 +26,20 @@ export default class ReviewableBundledAction extends Component {
     return `${vertical}-${horizontal}`;
   }
 
+  get buttonClass() {
+    const buttonIdentifier = dasherize(
+      this.first.button_class || this.first.id
+    );
+
+    if (buttonIdentifier === "reject-post") {
+      return "btn-danger";
+    } else if (buttonIdentifier === "approve-post") {
+      return "btn-success";
+    } else {
+      return "btn-default";
+    }
+  }
+
   @action
   perform(id) {
     if (id) {
@@ -47,6 +61,8 @@ export default class ReviewableBundledAction extends Component {
           disabled=@reviewableUpdating
           placement=this.placement
           translatedNone=@bundle.label
+          customStyle=true
+          btnCustomClasses=this.buttonClass
         }}
         class={{concatClass
           "reviewable-action-dropdown"
@@ -61,9 +77,10 @@ export default class ReviewableBundledAction extends Component {
         @translatedLabel={{this.first.label}}
         @disabled={{@reviewableUpdating}}
         class={{concatClass
-          "btn-default reviewable-action"
+          "reviewable-action"
           (dasherize this.first.id)
           this.first.button_class
+          this.buttonClass
         }}
       />
     {{/if}}

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -464,18 +464,6 @@
       white-space: nowrap;
     }
 
-    .approve-post,
-    .approve-post > summary {
-      background-color: var(--success);
-      color: var(--secondary);
-    }
-
-    .reject-post,
-    .reject-post > summary {
-      background-color: var(--danger);
-      color: var(--secondary);
-    }
-
     .reviewable-action,
     .reviewable-action-dropdown {
       margin-right: 0.5em;

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -185,6 +185,16 @@
   );
 }
 
+.btn-success {
+  @include btn(
+    $text-color: var(--secondary),
+    $bg-color: var(--success),
+    $icon-color: var(--success-low),
+    $hover-bg-color: var(--success-hover),
+    $hover-icon-color: var(--success-low)
+  );
+}
+
 // ✘ and ✔ buttons
 // --------------------------------------------------
 .btn.cancel {

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -96,10 +96,10 @@ describe "Reviewables", type: :system do
       visit("/review")
 
       expect(page).to have_css(".approve-post.btn-success")
-      expect(page).to have_css(".reject-post.btn-danger")
+      expect(page).to have_css(".reject-post. btn-danger")
 
       expect(page).to have_no_css(".approve-post.btn-default")
-      expect(page).to have_no_css(".reject-post.btn-default")
+      expect(page).to have_no_css(".reject-post. btn-default")
     end
   end
 

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -91,6 +91,16 @@ describe "Reviewables", type: :system do
       expect(review_page).to have_no_post_body_collapsed
       expect(review_page).to have_no_post_body_toggle
     end
+
+    it "should apply correct button classes to actions" do
+      visit("/review")
+
+      expect(page).to have_css(".approve-post.btn-success")
+      expect(page).to have_css(".reject-post.btn-danger")
+
+      expect(page).to have_no_css(".approve-post.btn-default")
+      expect(page).to have_no_css(".reject-post.btn-default")
+    end
   end
 
   describe "when there is a queued post reviewable with a long post" do

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -96,10 +96,10 @@ describe "Reviewables", type: :system do
       visit("/review")
 
       expect(page).to have_css(".approve-post.btn-success")
-      expect(page).to have_css(".reject-post. btn-danger")
+      expect(page).to have_css(".reject-post .btn-danger")
 
       expect(page).to have_no_css(".approve-post.btn-default")
-      expect(page).to have_no_css(".reject-post. btn-default")
+      expect(page).to have_no_css(".reject-post .btn-default")
     end
   end
 


### PR DESCRIPTION
These reject/approve buttons were getting `btn-default` classes rather than `btn-danger` or `btn-success`, which meant the styles for the colors had to be applied separately to `.approve-post` and `.reject-post`. This also meant the styles needed an additional override in themes. 

Moving to our common button classes helps centralize the styles and avoids a manual override being needed in themes. 

Button appearance is the same before/after 

![image](https://github.com/user-attachments/assets/941514f6-90c4-477c-b2e2-a02b2f296acc)
