### PR TITLE
DEV: use DButton for user header avatar menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
@@ -41,10 +41,8 @@ export default class UserDropdown extends Component {
         class="icon btn-flat"
         aria-haspopup="true"
         aria-expanded={{@active}}
-        aria-label={{i18n
-          "user.account_possessive"
-          name=(or this.currentUser.name this.currentUser.username)
-        }}
+        aria-label={{i18n "user.avatar.header_title"}}
+        title={{i18n "user.avatar.header_title"}}
         {{on "click" this.click}}
       >
         <Notifications @active={{@active}} />

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
+import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
@@ -35,7 +36,7 @@ export default class UserDropdown extends Component {
       }}
     >
       <PluginOutlet @name="user-dropdown-button__before" />
-      <button
+      <DButton
         id="toggle-current-user"
         class="icon btn-flat"
         aria-haspopup="true"
@@ -47,7 +48,7 @@ export default class UserDropdown extends Component {
         {{on "click" this.click}}
       >
         <Notifications @active={{@active}} />
-      </button>
+      </DButton>
       <PluginOutlet @name="user-dropdown-button__after" />
     </li>
   </template>

--- a/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/user-dropdown/notifications.gjs
@@ -24,7 +24,7 @@ export default class Notifications extends Component {
     return htmlSafe(
       renderAvatar(this.currentUser, {
         imageSize: this.avatarSize,
-        title: i18n("user.avatar.header_title"),
+        hideTitle: true,
         template: this.currentUser.avatar_template,
         username: this.currentUser.username,
         name: this.siteSettings.enable_names && this.currentUser.name,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1260,7 +1260,6 @@ en:
       said: "%{username}:"
       profile: "Profile"
       profile_possessive: "%{username}'s profile"
-      account_possessive: "%{name}'s account"
       mute: "Mute"
       edit: "Edit Preferences"
       download_archive:
@@ -2158,6 +2157,7 @@ en:
         title: "Registration IP Address"
       avatar:
         title: "Profile Picture"
+        header_title: "Notifications and account"
         name_and_description: "%{name} - %{description}"
         edit: "Edit Profile Picture"
       title:
@@ -3144,7 +3144,7 @@ en:
         additional_options:
           label: "Filter by post count and topic views"
 
-    hamburger_menu: "menu"
+    hamburger_menu: "Navigation menu"
     new_item: "new"
     go_back: "go back"
     not_logged_in_user: "user page with summary of current activity and preferences"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2158,7 +2158,6 @@ en:
         title: "Registration IP Address"
       avatar:
         title: "Profile Picture"
-        header_title: "profile, messages, bookmarks and preferences"
         name_and_description: "%{name} - %{description}"
         edit: "Edit Profile Picture"
       title:


### PR DESCRIPTION
We were using a vanilla `button` tag here, but can use `DButton` now, this helps us be more consistent with classes... we had a minor issue where class differences changed the active state between buttons here...


Before (hamburger and avatar forced active):
![image](https://github.com/user-attachments/assets/64511b29-40c0-4bdb-8564-410fb7b0f961)


After (hamburger and avatar forced active): 
![image](https://github.com/user-attachments/assets/d2412583-7f2e-4e1e-ae36-4369d6bf9e6b)


I also noticed we have a useless title attribute on the image here, the title should be on the button and the image doesn't need one. 

I've also cleaned up the titles:

* hamburger menu was previously just `menu` but we refer to this as `Navigation menu` generally, and that provides a lot more context 

* the notification menu was "Username's account" but more accurately it's "Notifications and account" (and I don't think we need the username present) 