### PR TITLE
DEV: bump max_image_size_kb to 10MB

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1900,7 +1900,7 @@ email:
 files:
   max_image_size_kb:
     client: true
-    default: 4096
+    default: 10240
     max: 102400
     type: file_size_restriction
   max_attachment_size_kb:


### PR DESCRIPTION
This allows, in particular, for larger animated image uploads. Due to optimizing (clientside and serverside), the actual size of the uploaded (non-animated) image often ends up being smaller than the o riginal size. I.e. it may already be optimized before hitting this limit.