### PR TITLE
DEV: prevent files being watched warning when using devenv

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -22,10 +22,11 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
     # Skip a bunch of unnecessary directories to reduce the cost
     # Ref https://github.com/guard/listen/issues/556
     require "rb-inotify"
+
     INotify::Notifier.prepend(
       Module.new do
         def watch(path, *flags, &callback)
-          return if path.end_with?("/node_modules", "/.git")
+          return if path.end_with?("/node_modules", "/.git", "/.devenv")
           super(path, *flags, &callback)
         end
       end,
@@ -37,7 +38,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
       *paths,
       # Aside from .rb files, this will also match site_settings.yml, as well as any plugin settings.yml files.
       only: /(\.rb|settings.yml)$/,
-      ignore: [/node_modules/],
+      ignore: [/node_modules/, /\.git/, /\.devenv/],
     ) do |modified, added, removed|
       supervisor_pid = UNICORN_DEV_SUPERVISOR_PID
       auto_restart = supervisor_pid && ENV["AUTO_RESTART"] != "0"


### PR DESCRIPTION
Ignore any files/directories in '.devenv' like we do for those in 'node_modules' to 1) speed-up watching files and 2) prevent files from being watched multiples times (due to symlinks).

No specs since this is only a warning that is being shown in development when using devenv.

---

Here's an example of the 100s of warning you get when using devenv

```plain
** ERROR: directory is already being watched! **

Directory: /Users/zogstrip/Poetry/discourse/plugins/discourse-login-client/.devenv/profile

is already being watched through: /nix/store/jp4qhxc2f98nyq90kia200mrygl2ndcy-devenv-profile

MORE INFO: https://github.com/guard/listen/blob/master/README.md        
```