### PR TITLE
DEV: Remove unused localisation strings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4044,52 +4044,6 @@ en:
     more_pm_participants:
       one: "%{participants} and %{count} other"
       other: "%{participants} and %{count} others"
-
-    invited_group_to_private_message_body: |
-      %{username} invited @%{group_name} to a message
-
-      > **[%{topic_title}](%{topic_url})**
-      >
-      > %{topic_excerpt}
-
-      at
-
-      > %{site_title} -- %{site_description}
-
-      To join the message, click the link below:
-
-      %{topic_url}
-
-    invited_to_private_message_body: |
-      %{username} invited you to a message
-
-      > **[%{topic_title}](%{topic_url})**
-      >
-      > %{topic_excerpt}
-
-      at
-
-      > %{site_title} -- %{site_description}
-
-      To join the message, click the link below:
-
-      %{topic_url}
-
-    invited_to_topic_body: |
-      %{username} invited you to a discussion
-
-      > **[%{topic_title}](%{topic_url})**
-      >
-      > %{topic_excerpt}
-
-      at
-
-      > %{site_title} -- %{site_description}
-
-      To join the discussion, click the link below:
-
-      %{topic_url}
-
     user_invited_to_private_message_pm_group:
       title: "User Invited Group to PM"
       subject_template: "[%{email_prefix}] %{username} invited @%{group_name} to a message '%{topic_title}'"


### PR DESCRIPTION
Tracing through some old work, I found that these strings are not used any more.

(Related: https://github.com/discourse/discourse/commit/b59dfb86f482d5a506018b020585161d0593c8ef)