### PR TITLE
UX: add missing import to admin_base.scss

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1276,6 +1276,7 @@ a.inline-editable-field {
 @import "admin/admin_intro";
 @import "admin/mini_profiler";
 @import "admin/schema_setting_editor";
+@import "admin/customize_show_schema";
 @import "admin/admin_bulk_users_delete_modal";
 @import "admin/color-palette-editor";
 @import "admin/admin_config_color_palettes";


### PR DESCRIPTION
While re-reviewing what I did in https://github.com/discourse/discourse/pull/32706,  I noticed that the import for customize_show_schema in `admin_base.scss` file was missing. Probably removed by mistake in the rebase.