### PR TITLE
UX: Modal to inherit border radius

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -19,6 +19,7 @@
     flex-direction: column;
     pointer-events: auto;
     box-sizing: border-box;
+    border-radius: var(--d-border-radius);
     margin: 0 auto;
     background-color: var(--secondary);
     box-shadow: var(--shadow-modal);


### PR DESCRIPTION
This PR causes modals to inherit the border radius set by `--d-border-radius`.

![CleanShot 2025-05-13 at 14 35 05@2x](https://github.com/user-attachments/assets/8742290f-f241-4f98-a74c-c87cbfe1b457)
