### PR TITLE
Allow passing a redirect path to a param on the /login route

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -56,7 +56,7 @@ class StaticController < ApplicationController
     if params[:id] == "login"
       destination = validate_redirect_param
 
-      if (current_user)
+      if current_user
         return redirect_to(path(destination), allow_other_host: false)
       elsif destination != "/"
         cookies[:destination_url] = path(destination)

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -359,10 +359,7 @@ RSpec.describe StaticController do
     context "with an array" do
       it "redirects to the root" do
         post "/login.json", params: { redirect: ["/foo"] }
-        expect(response.status).to eq(400)
-        json = response.parsed_body
-        expect(json["errors"]).to be_present
-        expect(json["errors"]).to include(I18n.t("invalid_params", message: "redirect"))
+        expect(response).to redirect_to("/")
       end
     end
 

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe StaticController do
       end
     end
 
-    it "should redirect to / when logged in and path is /login" do
+    it "should redirect to / when logged in and path is /login without redirect" do
       sign_in(Fabricate(:user))
       get "/login"
       expect(response).to redirect_to("/")
@@ -251,6 +251,58 @@ RSpec.describe StaticController do
         get "/login"
         get "/login"
       end.to_not change { SiteSetting.title }
+    end
+
+    context "without a subfolder" do
+      it "redirects as requested when logged in and path is /login with valid redirect param" do
+        sign_in(Fabricate(:user))
+        get "/login", params: { redirect: "/foo" }
+        expect(response).to redirect_to("/foo")
+      end
+
+      it "redirects to / when logged in and path is /login with invalid redirect param" do
+        sign_in(Fabricate(:user))
+        get "/login", params: { redirect: "//foo" }
+        expect(response).to redirect_to("/")
+        get "/login", params: { redirect: "foo" }
+        expect(response).to redirect_to("/")
+        get "/login", params: { redirect: "http://foo" }
+        expect(response).to redirect_to("/")
+        get "/login", params: { redirect: "www.foo.bar" }
+        expect(response).to redirect_to("/")
+      end
+
+      it "sets the destination_url cookie when not logged in and path is /login with valid redirect param" do
+        get "/login", params: { redirect: "/foo" }
+        expect(response.cookies["destination_url"]).to eq("/foo")
+      end
+    end
+
+    context "with a subfolder" do
+      before { set_subfolder "/sub_test" }
+
+      it "redirects as requested when logged in and path is /login with valid redirect param" do
+        sign_in(Fabricate(:user))
+        get "/login", params: { redirect: "/foo" }
+        expect(response).to redirect_to("/sub_test/foo")
+      end
+
+      it "redirects to / when logged in and path is /login with invalid redirect param" do
+        sign_in(Fabricate(:user))
+        get "/login", params: { redirect: "//foo" }
+        expect(response).to redirect_to("/sub_test/")
+        get "/login", params: { redirect: "foo" }
+        expect(response).to redirect_to("/sub_test/")
+        get "/login", params: { redirect: "http://foo" }
+        expect(response).to redirect_to("/sub_test/")
+        get "/login", params: { redirect: "www.foo.bar" }
+        expect(response).to redirect_to("/sub_test/")
+      end
+
+      it "sets the destination_url cookie when not logged in and path is /login with valid redirect param" do
+        get "/login", params: { redirect: "/foo" }
+        expect(response.cookies["destination_url"]).to eq("/sub_test/foo")
+      end
     end
   end
 

--- a/spec/system/page_objects/pages/login.rb
+++ b/spec/system/page_objects/pages/login.rb
@@ -16,6 +16,11 @@ module PageObjects
         self
       end
 
+      def open_with_redirect(redirect_path)
+        visit("/login?redirect=#{redirect_path}")
+        self
+      end
+
       def open_from_header
         find(".login-button").click
       end


### PR DESCRIPTION
Detects the `redirect` queryParam on the /login route. If the user is already logged in, navigates to that page. Otherwise, sets the "destination_url" cookie so that the user will be redirected after logging in. 

If the param doesn't start with a  single slash, ignore it and follow previous behavior (navigate to "/" or log in then navigate there. 

Respects subfolder configs.