### PR TITLE
DEV: do not convert (tm) and (TM) to emoji

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -275,7 +275,7 @@ class Emoji
           # special cased as we prefer to keep these as symbols
           next if name == "registered"
           next if name == "copyright"
-          next if name == "tm"
+          next if name == "trade_mark"
           next if name == "left_right_arrow"
 
           code = replacement_code(e["code"])

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Emoji do
       Emoji.clear_cache
     end
 
+    it "doesnt convert (TM) and (tm) do an emoji" do
+      expect(Emoji.lookup_unicode("trade_mark")).to eq("™")
+    end
+
     it "should return the emoji" do
       expect(Emoji.lookup_unicode("blonde_man")).to eq("👱‍♂️")
     end


### PR DESCRIPTION
This regressed because with recent emojis changes, the base name is now `trade_mark` and not `tm`. `tm` is just an alias emoji.