### PR TITLE
FIX: wrong class in schema setting editor stylesheet file

### DIFF
--- a/app/assets/stylesheets/admin/schema_setting_editor.scss
+++ b/app/assets/stylesheets/admin/schema_setting_editor.scss
@@ -1,7 +1,7 @@
 @use "lib/viewport";
 
-.schema-theme-setting-editor {
-  .schema-theme-setting-editor__wrapper {
+.schema-setting-editor {
+  .schema-setting-editor__wrapper {
     --schema-space: 0.5em;
     display: grid;
     grid-template-columns: minmax(10em, 0.3fr) 1fr;


### PR DESCRIPTION
relates to https://github.com/discourse/discourse/pull/32707 and https://github.com/discourse/discourse/pull/32706

I've retested manually and all should be fine now.