### PR TITLE
DEV: Group patch and minor bundler dev dependencies bump for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,11 @@ updates:
           - "> 1.2.0"
           - "< 2"
     groups:
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
       rails:
         patterns:
           - "actionmailer"


### PR DESCRIPTION
#### Reviewer notes

Useful reference to read: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--