### PR TITLE
DEV: Fix flaky system tests

### DIFF
--- a/spec/system/page_objects/modals/sidebar_edit_categories.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_categories.rb
@@ -34,15 +34,7 @@ module PageObjects
       end
 
       def has_categories?(categories)
-        category_names = categories.map(&:name)
-
-        categories =
-          all(
-            ".sidebar-categories-form .sidebar-categories-form__category-row",
-            count: category_names.length,
-          )
-
-        expect(categories.map(&:text)).to eq(category_names)
+        has_css?(".sidebar-categories-form", text: categories.map(&:name).join("\n"))
       end
 
       def toggle_category_checkbox(category)


### PR DESCRIPTION
We were not correctly relying on capybara matchers leading to test
flakiness

```
ailure/Error: super

Capybara::Playwright::Node::StaleReferenceError:
  Element is not attached to the DOM

/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:91:in `rescue in assert_element_not_stale'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:81:in `assert_element_not_stale'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:124:in `visible_text'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:60:in `block in text'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
./spec/rails_helper.rb:421:in `synchronize'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:60:in `text'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/result.rb:44:in `each'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/result.rb:44:in `each'
./spec/system/page_objects/modals/sidebar_edit_categories.rb:45:in `map'
./spec/system/page_objects/modals/sidebar_edit_categories.rb:45:in `has_categories?'
./spec/system/editing_sidebar_categories_navigation_spec.rb:161:in `block (2 levels) in <main>'
```
