### PR TITLE
DEV: revert admin users list change

### DIFF
--- a/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
+++ b/app/assets/javascripts/admin/addon/components/bulk-user-delete-confirmation.gjs
@@ -26,11 +26,7 @@ export default class BulkUserDeleteConfirmation extends Component {
   blockIpAndEmail = false;
 
   logsListener = modifierFn(() => {
-    this.messageBus.subscribe(
-      BULK_DELETE_CHANNEL,
-      this.onDeleteProgress,
-      this.args.model.lastBulkDeleteMessageBusId
-    );
+    this.messageBus.subscribe(BULK_DELETE_CHANNEL, this.onDeleteProgress);
 
     return () => {
       this.messageBus.unsubscribe(BULK_DELETE_CHANNEL, this.onDeleteProgress);

--- a/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
@@ -71,9 +71,8 @@ export default class IpLookup extends Component {
           data,
         });
         this.totalOthersWithSameIP = result.total;
-        let request = await AdminUser.findAll("active", data);
 
-        this.otherAccounts = request.users;
+        this.otherAccounts = await AdminUser.findAll("active", data);
         this.otherAccountsLoading = false;
       }
     } catch (error) {

--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -32,7 +32,6 @@ export default class AdminUsersListShowController extends Controller {
   refreshing = false;
   listFilter = null;
   lastSelected = null;
-  lastBulkDeleteMessageBusId = null;
 
   @computedI18n("search_hint") searchHint;
 
@@ -115,12 +114,8 @@ export default class AdminUsersListShowController extends Controller {
       page,
     })
       .then((result) => {
-        this.lastBulkDeleteMessageBusId =
-          result.meta?.message_bus_last_ids?.bulk_delete;
-
-        this._results[page] = result.users;
-
-        if (result.users.length === 0) {
+        this._results[page] = result;
+        if (result.length === 0) {
           this._canLoadMore = false;
         }
       })
@@ -219,7 +214,6 @@ export default class AdminUsersListShowController extends Controller {
   openBulkDeleteConfirmation() {
     this.modal.show(BulkUserDeleteConfirmation, {
       model: {
-        lastBulkDeleteMessageBusId: this.lastBulkDeleteMessageBusId,
         userIds: Array.from(this.bulkSelectedUserIdsSet),
         afterBulkDelete: this.afterBulkDelete,
       },

--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -21,12 +21,7 @@ export default class AdminUser extends User {
   static findAll(query, userFilter) {
     return ajax(`/admin/users/list/${query}.json`, {
       data: userFilter,
-    }).then((result) => {
-      return {
-        users: result.users.map((u) => AdminUser.create(u)),
-        meta: result.meta,
-      };
-    });
+    }).then((users) => users.map((u) => AdminUser.create(u)));
   }
 
   adminUserView = true;

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -8,17 +8,15 @@ acceptance("Admin - Users List", function (needs) {
 
   needs.pretender((server, helper) => {
     server.get("/admin/users/list/silenced.json", () =>
-      helper.response({
-        users: [
-          {
-            id: 2,
-            username: "kris",
-            email: "<small>kris@example.com</small>",
-            silenced_at: "2020-01-01T00:00:00.000Z",
-            silence_reason: "<strong>spam</strong>",
-          },
-        ],
-      })
+      helper.response([
+        {
+          id: 2,
+          username: "kris",
+          email: "<small>kris@example.com</small>",
+          silenced_at: "2020-01-01T00:00:00.000Z",
+          silence_reason: "<strong>spam</strong>",
+        },
+      ])
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -907,21 +907,17 @@ export function applyDefaultHandlers(pretender) {
       store = store.reverse();
     }
 
-    return response(200, {
-      users: store,
-    });
+    return response(200, store);
   });
 
   pretender.get("/admin/users/list/new.json", () => {
-    return response(200, {
-      users: [
-        {
-          id: 2,
-          username: "sam",
-          email: "<small>sam@example.com</small>",
-        },
-      ],
-    });
+    return response(200, [
+      {
+        id: 2,
+        username: "sam",
+        email: "<small>sam@example.com</small>",
+      },
+    ]);
   });
 
   pretender.get("/admin/customize/site_texts", (request) => {

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,16 +32,7 @@ class Admin::UsersController < Admin::StaffController
   def index
     users = ::AdminUserIndexQuery.new(params).find_users
 
-    opts = {
-      include_can_be_deleted: true,
-      include_silence_reason: true,
-      root: :users,
-      meta: {
-        message_bus_last_ids: {
-          bulk_delete: MessageBus.last_id("/bulk-user-delete"),
-        },
-      },
-    }
+    opts = { include_can_be_deleted: true, include_silence_reason: true }
     if params[:show_emails] == "true"
       StaffActionLogger.new(current_user).log_show_emails(users, context: request.path)
       opts[:emails_desired] = true

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::UsersController do
         get "/admin/users/list.json"
         expect(response.status).to eq(200)
 
-        silenced_user = response.parsed_body["users"].find { |u| u["id"] == user.id }
+        silenced_user = response.parsed_body.find { |u| u["id"] == user.id }
         expect(silenced_user["silence_reason"]).to eq("because I said so")
       end
 
@@ -42,7 +42,7 @@ RSpec.describe Admin::UsersController do
         it "returns email for all the users" do
           get "/admin/users/list.json", params: { show_emails: "true" }
           expect(response.status).to eq(200)
-          data = response.parsed_body["users"]
+          data = response.parsed_body
           data.each { |user| expect(user["email"]).to be_present }
         end
 

--- a/spec/requests/api/schemas/json/admin_user_list_response.json
+++ b/spec/requests/api/schemas/json/admin_user_list_response.json
@@ -1,130 +1,118 @@
 {
-  "type": "object",
-  "properties": {
-    "users": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "username": {
-            "type": "string"
-          },
-          "name": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "avatar_template": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "secondary_emails": {
-            "type": "array",
-            "items": {
-
-            }
-          },
-          "active": {
-            "type": "boolean"
-          },
-          "admin": {
-            "type": "boolean"
-          },
-          "moderator": {
-            "type": "boolean"
-          },
-          "last_seen_at": {
-            "type": ["string", "null"]
-          },
-          "last_emailed_at": {
-            "type": ["string", "null"]
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "last_seen_age": {
-            "type": ["number", "null"]
-          },
-          "last_emailed_age": {
-            "type": ["number", "null"]
-          },
-          "created_at_age": {
-            "type": ["number", "null"]
-          },
-          "trust_level": {
-            "type": "integer"
-          },
-          "manual_locked_trust_level": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "title": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "time_read": {
-            "type": "integer"
-          },
-          "staged": {
-            "type": "boolean"
-          },
-          "days_visited": {
-            "type": "integer"
-          },
-          "posts_read_count": {
-            "type": "integer"
-          },
-          "topics_entered": {
-            "type": "integer"
-          },
-          "post_count": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "id",
-          "username",
-          "name",
-          "avatar_template",
-          "active",
-          "admin",
-          "moderator",
-          "last_seen_at",
-          "last_emailed_at",
-          "created_at",
-          "last_seen_age",
-          "last_emailed_age",
-          "created_at_age",
-          "trust_level",
-          "manual_locked_trust_level",
-          "title",
-          "time_read",
-          "staged",
-          "days_visited",
-          "posts_read_count",
-          "topics_entered",
-          "post_count"
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "integer"
+      },
+      "username": {
+        "type": "string"
+      },
+      "name": {
+        "type": [
+          "string",
+          "null"
         ]
+      },
+      "avatar_template": {
+        "type": "string"
+      },
+      "email": {
+        "type": "string"
+      },
+      "secondary_emails": {
+        "type": "array",
+        "items": {
+
+        }
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "admin": {
+        "type": "boolean"
+      },
+      "moderator": {
+        "type": "boolean"
+      },
+      "last_seen_at": {
+        "type": ["string", "null"]
+      },
+      "last_emailed_at": {
+        "type": ["string", "null"]
+      },
+      "created_at": {
+        "type": "string"
+      },
+      "last_seen_age": {
+        "type": ["number", "null"]
+      },
+      "last_emailed_age": {
+        "type": ["number", "null"]
+      },
+      "created_at_age": {
+        "type": ["number", "null"]
+      },
+      "trust_level": {
+        "type": "integer"
+      },
+      "manual_locked_trust_level": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "title": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "time_read": {
+        "type": "integer"
+      },
+      "staged": {
+        "type": "boolean"
+      },
+      "days_visited": {
+        "type": "integer"
+      },
+      "posts_read_count": {
+        "type": "integer"
+      },
+      "topics_entered": {
+        "type": "integer"
+      },
+      "post_count": {
+        "type": "integer"
       }
     },
-    "meta": {
-      "type": "object"
-    }
-  },
-  "required": [
-    "users",
-    "meta"
-  ]
+    "required": [
+      "id",
+      "username",
+      "name",
+      "avatar_template",
+      "active",
+      "admin",
+      "moderator",
+      "last_seen_at",
+      "last_emailed_at",
+      "created_at",
+      "last_seen_age",
+      "last_emailed_age",
+      "created_at_age",
+      "trust_level",
+      "manual_locked_trust_level",
+      "title",
+      "time_read",
+      "staged",
+      "days_visited",
+      "posts_read_count",
+      "topics_entered",
+      "post_count"
+    ]
+  }
 }


### PR DESCRIPTION
This change was unfortunately introduced in https://github.com/discourse/discourse/commit/b6aad28ccffc276153fe847621d282549c4aac78#diff-5c7ecbec34de2166b60c5381df93a4e8438a2dbb6dcb8af0203cff4462fbc64b to prevent a failing spec due to the lack of last message bus id.

This commit reverts the change associated to it which was causing the JSON response to be an object instead of an array.