### PR TITLE
FIX: Lock Bullet gem to a compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ end
 
 group :development do
   gem "ruby-prof", require: false, platform: :mri
-  gem "bullet", require: !!ENV["BULLET"]
+  gem "bullet", "<= 8.0.3", require: !!ENV["BULLET"]
   gem "better_errors", platform: :mri, require: !!ENV["BETTER_ERRORS"]
   gem "binding_of_caller"
   gem "yaml-lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
-    bullet (8.0.6)
+    bullet (8.0.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
@@ -664,7 +664,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bullet
+  bullet (<= 8.0.3)
   byebug
   capybara
   capybara-playwright-driver
@@ -821,7 +821,7 @@ CHECKSUMS
   binding_of_caller (1.0.1) sha256=2b2902abff4246ddcfbc4da9b69bc4a019e22aeb300c2ff6289a173d4b90b29a
   bootsnap (1.18.4) sha256=ac4c42af397f7ee15521820198daeff545e4c360d2772c601fbdc2c07d92af55
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bullet (8.0.6) sha256=30cc4801df41bb4b80e866dd60dbcee37a6bc74d6912e43a520168c8d2ea060a
+  bullet (8.0.3) sha256=60e41446500a7e59272b3c2398cded214deec3662e883009de5bf30028a0642c
   byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.6) sha256=ef461ab97f9fca7df4ecdd10bb1b076d9246f804e89fc3ae127cf1677d855e26


### PR DESCRIPTION
### What is this change?

Because we use a custom `ContentSecurityPolicy` middleware, the latest versions (> 8.0.3) of Bullet error out on load:

<details><summary>Stacktrace</summary>

```
/Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/actionpack-7.2.2.1/lib/action_dispatch/middleware/stack.rb:180:in `assert_index': No such middleware to insert before: ActionDispatch::ContentSecurityPolicy::Middleware (RuntimeError)
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/actionpack-7.2.2.1/lib/action_dispatch/middleware/stack.rb:107:in `insert'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/configuration.rb:53:in `block in insert_before'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/configuration.rb:90:in `block in merge_into'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/configuration.rb:89:in `each'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/configuration.rb:89:in `merge_into'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/engine.rb:520:in `block in app'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/engine.rb:517:in `synchronize'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/engine.rb:517:in `app'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/application/finisher.rb:58:in `block in <module:Finisher>'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/initializable.rb:32:in `instance_exec'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/initializable.rb:32:in `run'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:350:in `each'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:350:in `call'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/initializable.rb:60:in `run_initializers'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/railties-7.2.2.1/lib/rails/application.rb:435:in `initialize!'
	from /Users/drenmi/Workspace/Discourse/discourse/config/environment.rb:7:in `<top (required)>'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from config.ru:7:in `block in <main>'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/rack-2.2.13/lib/rack/builder.rb:125:in `instance_eval'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/rack-2.2.13/lib/rack/builder.rb:125:in `initialize'
	from config.ru:1:in `new'
	from config.ru:1:in `<main>'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/unicorn-6.1.0/lib/unicorn.rb:54:in `eval'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/unicorn-6.1.0/lib/unicorn.rb:54:in `block in builder'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:821:in `build_app!'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:140:in `start'
	from /Users/drenmi/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/unicorn-6.1.0/bin/unicorn:128:in `<top (required)>'
	from /Users/drenmi/Workspace/Discourse/discourse/bin/unicorn:96:in `load'
	from /Users/drenmi/Workspace/Discourse/discourse/bin/unicorn:96:in `block in <main>'
	from /Users/drenmi/Workspace/Discourse/discourse/bin/unicorn:95:in `fork'
	from /Users/drenmi/Workspace/Discourse/discourse/bin/unicorn:95:in `<main>'
```

</details> 

This PR locks the gem to the latest compatible version.

Upstream: https://github.com/flyerhzm/bullet/issues/747