### PR TITLE
FIX: ensure we can lookup identical ip addresses

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
@@ -71,10 +71,9 @@ export default class IpLookup extends Component {
           data,
         });
         this.totalOthersWithSameIP = result.total;
+        let request = await AdminUser.findAll("active", data);
 
-        const users = await AdminUser.findAll("active", data)?.users;
-
-        this.otherAccounts = users;
+        this.otherAccounts = request.users;
         this.otherAccountsLoading = false;
       }
     } catch (error) {

--- a/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
@@ -72,7 +72,8 @@ export default class IpLookup extends Component {
         });
         this.totalOthersWithSameIP = result.total;
 
-        const users = await AdminUser.findAll("active", data);
+        let users = await AdminUser.findAll("active", data)?.users;
+
         this.otherAccounts = users;
         this.otherAccountsLoading = false;
       }

--- a/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.gjs
@@ -72,7 +72,7 @@ export default class IpLookup extends Component {
         });
         this.totalOthersWithSameIP = result.total;
 
-        let users = await AdminUser.findAll("active", data)?.users;
+        const users = await AdminUser.findAll("active", data)?.users;
 
         this.otherAccounts = users;
         this.otherAccountsLoading = false;

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -39,6 +39,12 @@ describe "Admin User Page", type: :system do
 
     before { admin_user_page.visit(user) }
 
+    it "can list accounts with identic IPs" do
+      find(".ip-lookup-trigger").click
+
+      expect(page).to have_content("#{I18n.t("js.ip_lookup.other_accounts")}\n3")
+    end
+
     it "displays the suspend and silence buttons" do
       expect(admin_user_page).to have_suspend_button
       expect(admin_user_page).to have_silence_button

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -43,6 +43,11 @@ describe "Admin User Page", type: :system do
       find(".ip-lookup-trigger").click
 
       expect(page).to have_content("#{I18n.t("js.ip_lookup.other_accounts")}\n3")
+
+      table = page.find(".other-accounts table")
+      expect(table).to have_content(similar_user.username)
+      expect(table).to have_content(another_mod.username)
+      expect(table).to have_content(another_admin.username)
     end
 
     it "displays the suspend and silence buttons" do


### PR DESCRIPTION
This has been broken in https://github.com/discourse/discourse/commit/b6aad28ccffc276153fe847621d282549c4aac78

We correctly access the users object and added a test to prevent future regressions.