### PR TITLE
DEV: Remove `discourse-logster-rate-limit-checker` from official plugins

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -42,7 +42,6 @@ class Plugin::Metadata
         discourse-lazy-videos
         discourse-local-dates
         discourse-login-with-amazon
-        discourse-logster-rate-limit-checker
         discourse-logster-transporter
         discourse-lti
         discourse-math


### PR DESCRIPTION
This is a plugin that is no longer maintained.
