### PR TITLE
UX: Focus on sign up form in social auth flow

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -383,6 +383,11 @@ export default class SignupPageController extends Controller {
     return hasAtLeastOneLoginButton && !authOptions;
   }
 
+  @discourseComputed("authOptions")
+  progressBarStep(authOptions) {
+    return authOptions ? "activate" : "signup";
+  }
+
   fetchConfirmationValue() {
     if (this._challengeDate === undefined && this._hpPromise) {
       // Request already in progress

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -380,7 +380,7 @@ export default class SignupPageController extends Controller {
 
   @discourseComputed("authOptions", "hasAtLeastOneLoginButton")
   showRightSide(authOptions, hasAtLeastOneLoginButton) {
-    return hasAtLeastOneLoginButton && !authOptions;
+    return !authOptions && hasAtLeastOneLoginButton;
   }
 
   @discourseComputed("authOptions")

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -378,6 +378,11 @@ export default class SignupPageController extends Controller {
     return findAll().length > 0;
   }
 
+  @discourseComputed("authOptions", "hasAtLeastOneLoginButton")
+  showRightSide(authOptions, hasAtLeastOneLoginButton) {
+    return hasAtLeastOneLoginButton && !authOptions;
+  }
+
   fetchConfirmationValue() {
     if (this._challengeDate === undefined && this._hpPromise) {
       // Request already in progress

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -316,11 +316,14 @@ export default RouteTemplate(
             {{/if}}
           </div>
 
-          {{#if @controller.hasAtLeastOneLoginButton}}
+          {{#if @controller.showRightSide}}
             {{#if @controller.site.mobileView}}
-              <div class="login-or-separator"><span>
-                  {{i18n "login.or"}}</span></div>{{/if}}
+              <div class="login-or-separator">
+                <span>{{i18n "login.or"}}</span>
+              </div>
+            {{/if}}
             <div class="login-right-side">
+              SIGNUP LOGIN RIGHT SIDE
               <LoginButtons
                 @externalLogin={{@controller.externalLogin}}
                 @context="create-account"

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -56,7 +56,7 @@ export default RouteTemplate(
               @controller.authOptions.auth_provider
             }}
           >
-            <SignupProgressBar @step="signup" />
+            <SignupProgressBar @step={{@controller.progressBarStep}} />
             <WelcomeHeader
               id="create-account-title"
               @header={{i18n "create_account.header_title"}}

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -323,7 +323,6 @@ export default RouteTemplate(
               </div>
             {{/if}}
             <div class="login-right-side">
-              SIGNUP LOGIN RIGHT SIDE
               <LoginButtons
                 @externalLogin={{@controller.externalLogin}}
                 @context="create-account"

--- a/spec/system/page_objects/pages/signup.rb
+++ b/spec/system/page_objects/pages/signup.rb
@@ -51,6 +51,10 @@ module PageObjects
         has_no_css?("#new-account-name")
       end
 
+      def has_no_right_side_column?
+        has_no_css?(".login-right-side")
+      end
+
       def fill_input(selector, text)
         if page.has_css?("html.mobile-view", wait: 0)
           expect(page).to have_no_css(".d-modal.is-animating")

--- a/spec/system/social_authentication_spec.rb
+++ b/spec/system/social_authentication_spec.rb
@@ -26,6 +26,8 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
+
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
@@ -44,6 +46,8 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
+
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
@@ -58,6 +62,8 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
           expect(signup_form).to have_no_password_input
           expect(signup_form).to have_valid_username
           expect(signup_form).to have_valid_email
+          expect(signup_form).to have_no_right_side_column
+
           signup_form.click_create_account
           expect(page).to have_css(".account-created")
         end
@@ -77,6 +83,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
@@ -91,6 +98,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
           expect(signup_form).to have_no_password_input
           expect(signup_form).to have_valid_username
           expect(signup_form).to have_valid_email
+          expect(signup_form).to have_no_right_side_column
           signup_form.click_create_account
           expect(page).to have_css(".account-created")
         end
@@ -111,6 +119,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         signup_form.fill_email(OmniauthHelpers::EMAIL)
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
         signup_form.click_create_account
         expect(page).to have_css(".account-created")
       end
@@ -145,6 +154,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
@@ -167,6 +177,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
@@ -186,6 +197,7 @@ shared_examples "social authentication scenarios" do |signup_page_object, login_
         expect(signup_form).to have_no_password_input
         expect(signup_form).to have_valid_username
         expect(signup_form).to have_valid_email
+        expect(signup_form).to have_no_right_side_column
         signup_form.click_create_account
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end


### PR DESCRIPTION
If user returns to the signup form with data from their social login, then we shouldn't show the right side column, because it is confusing to have buttons there that restart the social login flow. This PR makes it so we only show the signup form.

Internal ticket: /t/154184