### PR TITLE
DEV: trigger single event when multiple posts are destroyed at once

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -424,6 +424,7 @@ class PostsController < ApplicationController
         ).destroy
       end
     end
+    DiscourseEvent.trigger(:posts_destroyed, posts, current_user)
 
     render body: nil
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -406,6 +406,18 @@ RSpec.describe PostsController do
         expect(response.status).to eq(200)
       end
 
+      it "triggers DiscourseEvent with :posts_destroyed and correct params" do
+        sign_in(poster)
+        # Use spy to monitor DiscourseEvent.trigger
+        allow(DiscourseEvent).to receive(:trigger).and_call_original
+        delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
+        expect(DiscourseEvent).to have_received(:trigger).with(
+          :posts_destroyed,
+          kind_of(Array),
+          poster,
+        )
+      end
+
       it "updates the highest read data for the forum" do
         sign_in(poster)
         Topic.expects(:reset_highest).twice

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -405,17 +405,17 @@ RSpec.describe PostsController do
         delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
         expect(response.status).to eq(200)
       end
-
+      # bookmark
       it "triggers DiscourseEvent with :posts_destroyed and correct params" do
         sign_in(poster)
-        # Use spy to monitor DiscourseEvent.trigger
-        allow(DiscourseEvent).to receive(:trigger).and_call_original
-        delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
-        expect(DiscourseEvent).to have_received(:trigger).with(
-          :posts_destroyed,
-          kind_of(Array),
-          poster,
-        )
+        events =
+          DiscourseEvent.track_events do
+            delete "/posts/destroy_many.json", params: { post_ids: [post1.id, post2.id] }
+          end
+        event = events.find { |e| e[:event_name] == :posts_destroyed }
+        expect(event).to be_present
+        expect(event[:params][0].length).to eq(2)
+        expect(event[:params][1]).to eq(poster)
       end
 
       it "updates the highest read data for the forum" do


### PR DESCRIPTION
a complement to the :post_destroyed event - customer needed an action to happen just once when the wrench icon was used to delete one or more posts ...