### PR TITLE
DEV: Revert unintended changes to GroupsController #add_members and its corresponding route

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -370,7 +370,7 @@ class GroupsController < ApplicationController
   end
 
   def add_members
-    group = Group.find(params[:name])
+    group = Group.find(params[:id])
     guardian.ensure_can_edit!(group)
 
     users = users_from_params.to_a

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -713,14 +713,14 @@ class GroupsController < ApplicationController
   end
 
   def test_email_settings
-    params.require(:name)
+    params.require(:group_id)
     params.require(:protocol)
     params.require(:port)
     params.require(:host)
     params.require(:username)
     params.require(:password)
 
-    group = Group.find(params[:name])
+    group = Group.find(params[:group_id])
     guardian.ensure_can_edit!(group)
 
     RateLimiter.new(current_user, "group_test_email_settings", 5, 1.minute).performed!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1163,6 +1163,7 @@ Discourse::Application.routes.draw do
           delete "members" => "groups#remove_member"
           delete "leave" => "groups#leave"
           put "handle_membership_request" => "groups#handle_membership_request"
+          put "members" => "groups#add_members"
         end
       end
 
@@ -1186,7 +1187,6 @@ Discourse::Application.routes.draw do
         get "manage/tags" => "groups#show"
         get "manage/logs" => "groups#show"
         get "permissions" => "groups#permissions"
-        put "members" => "groups#add_members"
 
         post "request_membership" => "groups#request_membership"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1151,6 +1151,8 @@ Discourse::Application.routes.draw do
                 only: %i[index new edit update],
                 id: RouteFormat.username,
                 path: root_path do
+        post "test_email_settings"
+
         collection do
           get "check-name" => "groups#check_name"
           get "custom/new" => "groups#new", :constraints => StaffConstraint.new
@@ -1202,7 +1204,6 @@ Discourse::Application.routes.draw do
         get "mentionable" => "groups#mentionable"
         get "messageable" => "groups#messageable"
         get "logs" => "groups#histories"
-        post "test_email_settings" => "groups#test_email_settings"
       end
     end
 


### PR DESCRIPTION
Reverted unintended changes to group routes made [here](https://github.com/discourse/discourse/pull/32442/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5)