### PR TITLE
UX: simplify admin search, make more accessible

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -15,8 +15,6 @@ import { escapeExpression } from "discourse/lib/utilities";
 import autoFocus from "discourse/modifiers/auto-focus";
 import { i18n } from "discourse-i18n";
 
-const ADMIN_SEARCH_FILTERS = "admin_search_filters";
-
 export default class AdminSearch extends Component {
   @service adminSearchDataSource;
   @service keyValueStore;
@@ -26,22 +24,9 @@ export default class AdminSearch extends Component {
   @tracked searchResults = [];
   @tracked showFilters = true;
   @tracked loading = false;
-  typeFilters = new TrackedObject({
-    page: true,
-    setting: true,
-    theme: true,
-    component: true,
-    report: true,
-  });
 
   constructor() {
     super(...arguments);
-
-    if (this.keyValueStore.getItem(ADMIN_SEARCH_FILTERS)) {
-      this.typeFilters = new TrackedObject(
-        JSON.parse(this.keyValueStore.getItem(ADMIN_SEARCH_FILTERS))
-      );
-    }
 
     this.adminSearchDataSource.buildMap().then(() => {
       if (this.filter !== "") {
@@ -49,12 +34,6 @@ export default class AdminSearch extends Component {
         this.runSearch();
       }
     });
-  }
-
-  get visibleTypes() {
-    return Object.keys(this.typeFilters).filter(
-      (type) => this.typeFilters[type]
-    );
   }
 
   get noResultsDescription() {
@@ -137,9 +116,7 @@ export default class AdminSearch extends Component {
   }
 
   #search() {
-    this.searchResults = this.adminSearchDataSource.search(this.filter, {
-      types: this.visibleTypes,
-    });
+    this.searchResults = this.adminSearchDataSource.search(this.filter);
     this.loading = false;
   }
 

--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -5,7 +5,6 @@ import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
-import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import { and, not } from "truth-helpers";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import icon from "discourse/helpers/d-icon";

--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -163,12 +163,7 @@ export default class AdminSearch extends Component {
         />
       </div>
     </div>
-    <div
-      id="admin-search-announcement"
-      class="sr-only"
-      aria-live="polite"
-      role="status"
-    >
+    <div class="sr-only" aria-live="polite" role="status">
       {{#if this.searchResults}}
         {{i18n
           "admin.search.result_count"
@@ -182,6 +177,11 @@ export default class AdminSearch extends Component {
         {{this.noResultsDescription}}
       {{/if}}
     </div>
+    {{#if (and this.filter (not this.searchResults.length) (not this.loading))}}
+      <p class="admin-search__no-results" aria-live="polite" role="status">
+        {{this.noResultsDescription}}
+      </p>
+    {{/if}}
     <div
       class="admin-search__results {{if this.searchResults '--has-results'}}"
     >
@@ -210,11 +210,6 @@ export default class AdminSearch extends Component {
             </a>
           </div>
         {{/each}}
-        {{#if (and (not this.searchResults) this.filter)}}
-          <p class="admin-search__no-results">
-            {{this.noResultsDescription}}
-          </p>
-        {{/if}}
       </ConditionalLoadingSpinner>
     </div>
   </template>

--- a/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
@@ -9,12 +9,12 @@ export default class AdminSearchModal extends Component {
   <template>
     <DModal
       @closeModal={{@closeModal}}
-      class="admin-search-modal"
+      class="admin-search-modal --quick-palette"
       @title="admin.search.modal_title"
       @inline={{@inline}}
       @hideHeader={{true}}
     >
-      <AdminSearch @fullPageLink={{true}} />
+      <AdminSearch />
     </DModal>
   </template>
 }

--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -262,12 +262,10 @@ export default class AdminSearchDataSource extends Service {
     this._mapCached = true;
   }
 
-  search(filter, opts = {}) {
+  search(filter) {
     if (filter.length < MIN_FILTER_LENGTH) {
       return [];
     }
-
-    opts.types = opts.types || ADMIN_SEARCH_RESULT_TYPES;
 
     let filteredResults = [];
     const escapedFilterRegExp = escapeRegExp(filter.toLowerCase());
@@ -284,7 +282,7 @@ export default class AdminSearchDataSource extends Service {
       .map((keyword) => new RegExp(`(${keyword})\\b`, "i"));
     const fallbackRegex = new RegExp(`${escapedFilterRegExp}`, "i");
 
-    opts.types.forEach((type) => {
+    ADMIN_SEARCH_RESULT_TYPES.forEach((type) => {
       const typeResults = [];
       this[`${type}DataSourceItems`].forEach((dataSourceItem) => {
         dataSourceItem.score = 0;

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-search-test.gjs
@@ -1,64 +1,17 @@
-import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
+import { fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { module, skip, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AdminSearch from "admin/components/admin-search";
 
-function filterButtonCss(filterType) {
-  return `.admin-search__filter.--${filterType} button`;
-}
-
-function assertFilterActive(assert, filterType, isActive = true) {
-  if (isActive) {
-    assert
-      .dom(`${filterButtonCss(filterType)}.admin-search__filter-item.is-active`)
-      .exists();
-  } else {
-    assert
-      .dom(`${filterButtonCss(filterType)}.admin-search__filter-item.is-active`)
-      .doesNotExist();
-  }
-}
-
 module("Integration | Component | AdminSearch", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("remembers last toggled filters, and opens filter controls by default", async function (assert) {
-    await render(<template><AdminSearch /></template>);
-
-    assert.dom(".admin-search__filters").exists();
-    assertFilterActive(assert, "page");
-    assertFilterActive(assert, "setting");
-    assertFilterActive(assert, "theme");
-    assertFilterActive(assert, "component");
-    assertFilterActive(assert, "report");
-
-    await click(filterButtonCss("page"));
-    await click(filterButtonCss("setting"));
-
-    assertFilterActive(assert, "page", false);
-    assertFilterActive(assert, "setting", false);
-
-    await render(<template><AdminSearch /></template>);
-
-    assertFilterActive(assert, "page", false);
-    assertFilterActive(assert, "setting", false);
-  });
-
-  test("filters different types of search results", async function (assert) {
+  test("shows search results", async function (assert) {
     await render(<template><AdminSearch /></template>);
     await fillIn(".admin-search__input-field", "title");
 
     assert.dom(".admin-search__results").exists();
     assert.dom(".admin-search__result").exists({ count: 1 });
-
-    await click(filterButtonCss("setting"));
-    assert.dom(".admin-search__result").doesNotExist();
-
-    await fillIn(".admin-search__input-field", "admin logins");
-    assert.dom(".admin-search__result").exists({ count: 1 });
-
-    await click(filterButtonCss("report"));
-    assert.dom(".admin-search__result").doesNotExist();
   });
 
   skip("navigates search results with keyboard, getting back to the input when reaching the end of results", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -122,19 +122,6 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
     assert.deepEqual(this.subject.search("a"), []);
   });
 
-  test("search - limits the returned types", async function (assert) {
-    await this.subject.buildMap();
-    let results = this.subject.search("anonymous");
-    assert.deepEqual(results.length, 3);
-
-    results = this.subject.search("anonymous", { types: ["report"] });
-    assert.deepEqual(results.length, 1);
-    assert.deepEqual(
-      results[0].url,
-      "/admin/reports/page_view_anon_browser_reqs"
-    );
-  });
-
   test("search - prioritize whole word matches", async function (assert) {
     await this.subject.buildMap();
     let results = this.subject.search("anonym");

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -9,7 +9,6 @@
 .admin-search {
   &__input-container {
     display: flex;
-    margin-bottom: var(--space-1);
   }
 
   &__input-group {
@@ -42,68 +41,12 @@
     background: none !important;
     width: 100% !important;
   }
-
-  &__full-page-link {
-    align-self: self-end;
-    padding-right: 2.3em;
-  }
-}
-
-// Fitler
-.admin-search__filters {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  flex-wrap: wrap;
-}
-
-.admin-search__filter {
-  &-item {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    padding: var(--space-1) var(--space-2);
-    background-color: var(--primary-low);
-    color: var(--primary-medium);
-    border-radius: var(--d-border-radius);
-    border: none;
-    cursor: pointer;
-    transition: background-color 0.2s;
-
-    &:hover,
-    &:focus {
-      color: var(--primary-low-mid);
-    }
-
-    &:focus {
-      outline: auto;
-    }
-
-    &.is-active {
-      background-color: var(--tertiary);
-      color: var(--secondary);
-
-      .d-icon {
-        color: var(--tertiary-low);
-      }
-
-      &:focus {
-        outline: auto;
-      }
-    }
-
-    &:not(.is-active) {
-      .d-icon {
-        color: var(--primary-low-mid);
-      }
-    }
-  }
 }
 
 // Results
 .admin-search__result {
   border-top: 1px solid var(--primary-low);
-  padding: var(--space-3) var(--space-2);
+  padding: var(--space-3) var(--space-4);
   display: block;
 
   &:first-child {
@@ -142,7 +85,7 @@
     margin-top: var(--space-1);
   }
 
-  a {
+  &__result-link {
     display: inline-block;
     width: 100%;
     pointer-events: auto;
@@ -155,4 +98,24 @@
 
 .admin-search-modal {
   --modal-max-width: 700px;
+
+  .admin-search__no-results,
+  .admin-search__input-container {
+    padding-inline: var(--space-4);
+  }
+
+  .admin-search__no-results {
+    margin-bottom: 0;
+  }
+
+  .admin-search__input-container {
+    position: sticky;
+    top: 0;
+    background: var(--secondary);
+    z-index: z("modal", "content"); // above title icons
+
+    &.--has-results {
+      padding-bottom: var(--space-4);
+    }
+  }
 }

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -304,23 +304,6 @@
 }
 
 .d-modal.chat-modal-new-message {
-  align-items: flex-start;
-
-  .d-modal {
-    &__container {
-      width: var(--modal-max-width);
-      margin-top: 1rem;
-    }
-
-    &__body {
-      padding: 0;
-
-      input {
-        width: auto;
-      }
-    }
-  }
-
   .chat-message-creator {
     &__add-members-header-container {
       padding-inline: 1rem 0.5rem;
@@ -559,6 +542,27 @@
       @include viewport.until(sm) {
         overflow: auto;
         flex-grow: 1;
+      }
+    }
+  }
+}
+
+.d-modal.--quick-palette {
+  align-items: flex-start;
+
+  .d-modal {
+    &__container {
+      width: var(--modal-max-width);
+      margin-top: 1rem;
+      padding-block: 1rem;
+    }
+
+    &__body {
+      padding: 0;
+      gap: 0;
+
+      input {
+        width: auto;
       }
     }
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5610,11 +5610,14 @@ en:
           header_description: "Discourse has the ability to embed the comments from a topic in a remote site using a Javascript API that creates an IFRAME"
 
       search:
-        modal_title: "Search anything in admin"
+        modal_title: "Search everything in admin"
         title: "Search"
-        instructions: "Type to search for pages, settings, reports, themes, components, and more..."
+        instructions: "Search everything in admin..."
         full_page_link: "Switch to full page search"
-        no_results: "We couldn’t find anything matching ‘%{filter}’."
+        no_results: 'We couldn’t find anything matching "%{filter}".'
+        result_count:
+          one: '%{count} result for "%{filter}"'
+          other: '%{count} results for "%{filter}"'
         result_types:
           page:
             one: "Page"
@@ -6707,7 +6710,7 @@ en:
           active_filter: "Active"
           inactive_filter: "Inactive"
           updates_available_filter: "Updates Available"
-          
+
         schema:
           title: "Edit %{name} setting"
           back_button: "Back to %{name}"

--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/new-message.gjs
@@ -17,7 +17,7 @@ export default class ChatModalNewMessage extends Component {
     {{#if this.shouldRender}}
       <DModal
         @closeModal={{@closeModal}}
-        class="chat-modal-new-message"
+        class="chat-modal-new-message --quick-palette"
         @title="chat.new_message_modal.title"
         @inline={{@inline}}
         @hideHeader={{true}}

--- a/plugins/chat/assets/stylesheets/common/chat-modal-new-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-modal-new-message.scss
@@ -9,7 +9,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding-block: 1rem;
   }
 
   .chat-message-creator__add-members-header-container {

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -68,7 +68,7 @@ describe "Admin Search", type: :system do
     search_modal.search("very long search phrase")
 
     expect(search_modal).to have_content(
-      "We couldn’t find anything matching ‘very long search phrase’.",
+      'We couldn’t find anything matching "very long search phrase".',
     )
   end
 

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -61,19 +61,6 @@ describe "Admin Search", type: :system do
     )
   end
 
-  it "can go to full page search with link" do
-    visit "/admin"
-    sidebar.click_search_input
-    search_modal.search("min_topic_title")
-    search_modal.click_switch_to_full_page
-
-    expect(page).to have_current_path("/admin/search?filter=min_topic_title")
-    expect(search_modal.find_result("setting", 0)).to have_content("Min topic title length")
-    expect(search_modal.find_result("setting", 0)).to have_content(
-      I18n.t("site_settings.min_topic_title_length"),
-    )
-  end
-
   it "informs user about no results" do
     visit "/admin"
     sidebar.click_search_input

--- a/spec/system/page_objects/modals/admin_search.rb
+++ b/spec/system/page_objects/modals/admin_search.rb
@@ -16,10 +16,6 @@ module PageObjects
       def input_enter
         find(".admin-search__input-field").send_keys(:enter)
       end
-
-      def click_switch_to_full_page
-        find(".admin-search__full-page-link").click
-      end
     end
   end
 end


### PR DESCRIPTION
This simplifies the admin search and adds some basic accessibility

Simplification: 
* Removes the filters for now, both in the modal and full-screen 
* Removes the link to full-screen from the modal
* Simpler input placeholder text
* Positioned to sit higher on the page, similar to a command palette 

Accessibility: 
* Results (or lack of) announced for screenreaders after query 

Bonus: 
* Makes the modal input sticky on scroll 
* Combined some styles shared between this and the chat menu (modifier + k) under a `--quick-palette` class 



Before:
![image](https://github.com/user-attachments/assets/0af2d741-e870-4ad2-b305-57dc4afc3946)


After:

![image](https://github.com/user-attachments/assets/a8492aed-03c7-4d73-a3d3-ae89834b82bc)
