### PR TITLE
DEV: Silence scss mixed-decls for themes/plugins

### DIFF
--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -62,7 +62,7 @@ module Stylesheet
           source_map_file: source_map_file,
           source_map_contents: true,
           load_paths: load_paths,
-          silence_deprecations: %w[color-functions import global-builtin],
+          silence_deprecations: %w[color-functions import global-builtin mixed-decls],
           fatal_deprecations: options[:strict_deprecations] ? %w[mixed-decls] : [],
           quiet: ENV["QUIET_SASS_DEPRECATIONS"] == "1",
         )


### PR DESCRIPTION
Fixing this everywhere will be a very large undertaking, so we're deferring it until there is a concrete timeline for it becoming an error in sass.

In the meantime, we'll be adding a stylelint rule to enforce ordering of declarations/nested-blocks/mixins, so that will go some way towards avoiding this deprecation.