### PR TITLE
UX: more consistent admin search hover/focus color

### DIFF
--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -57,7 +57,7 @@
   }
 
   &:hover {
-    background-color: var(--tertiary-very-low);
+    background-color: var(--d-hover);
   }
 
   &-name {
@@ -96,7 +96,7 @@
   }
 
   &:focus-within {
-    background: var(--d-selected);
+    background: var(--d-hover);
   }
 }
 


### PR DESCRIPTION
little follow-up to 264b9db18896d4125fa9a75898867bd127d80316 to make admin search match topic search hover/focus styles 


Before:
![image](https://github.com/user-attachments/assets/070643f6-eee4-4671-a891-c0e4d5695c03)


After: 
![image](https://github.com/user-attachments/assets/8637ee7b-9d62-44a7-ab08-a062dd63f4f1)
