### PR TITLE
UX: make the notification panel consistent with new search panel styles

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -126,9 +126,9 @@
   --bronze: #{$bronze};
   --shadow-modal: 0 8px 60px rgba(0, 0, 0, #{$shadow-opacity-modal});
   --shadow-composer: 0 -1px 40px rgba(0, 0, 0, #{$shadow-opacity-composer});
-  --shadow-menu-panel: 0 8px 12px rgba(0, 0, 0, #{$shadow-opacity-menu-panel});
   --shadow-card: 0 4px 14px rgba(0, 0, 0, #{$shadow-opacity-card});
   --shadow-dropdown: 0 2px 12px 0 rgba(0, 0, 0, #{$shadow-opacity-dropdown});
+  --shadow-menu-panel: var(--shadow-dropdown);
   --shadow-header: 0 0 0 1px var(--primary-low);
   --shadow-footer-nav: 0 0 2px 0 rgba(0, 0, 0, #{$shadow-opacity-footer-nav});
   --shadow-focus-danger: 0 0 6px 0 var(--danger);

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -674,12 +674,15 @@
       }
     }
 
-    &.unread .icon-avatar__icon-wrapper {
-      background: var(--tertiary);
-      font-size: var(--font-down-1);
+    &.unread,
+    &.pending {
+      .icon-avatar__icon-wrapper {
+        background: var(--tertiary);
+        font-size: var(--font-down-1);
 
-      .d-icon {
-        color: var(--secondary);
+        .d-icon {
+          color: var(--secondary);
+        }
       }
     }
   }

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -327,7 +327,6 @@
       flex-wrap: nowrap;
       height: 100%;
       align-items: center;
-      overflow-x: visible;
       overflow-y: auto; // really short viewports
     }
 
@@ -340,7 +339,7 @@
         // button, a, and everything else
         align-items: center;
         margin: 0;
-        padding: 0.35em 1rem;
+        padding: 0.5em 1rem;
         flex: 1 1 auto;
       }
 

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -38,6 +38,7 @@
 }
 
 .menu-panel {
+  --list-item-padding: 0.5em 1rem;
   box-shadow: var(--shadow-dropdown);
   background-color: var(--secondary);
   z-index: z("header");
@@ -346,7 +347,7 @@
         // button, a, and everything else
         align-items: center;
         margin: 0;
-        padding: 0.5em 1rem;
+        padding: var(--list-item-padding);
         flex: 1 1 auto;
       }
 
@@ -538,10 +539,7 @@
 
     a {
       display: flex;
-    }
-
-    button {
-      padding: 0.25em 0.5em;
+      padding: var(--list-item-padding);
     }
 
     a,
@@ -623,7 +621,6 @@
     a {
       color: var(--primary);
       align-items: center;
-      padding: 0.5em 1rem;
 
       .item-label {
         font-weight: bold;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -38,8 +38,7 @@
 }
 
 .menu-panel {
-  border: 1px solid var(--primary-low);
-  box-shadow: var(--shadow-menu-panel);
+  box-shadow: var(--shadow-dropdown);
   background-color: var(--secondary);
   z-index: z("header");
   padding: 0.5em;
@@ -169,7 +168,8 @@
   }
 
   hr {
-    margin: 3px 0;
+    margin: 0;
+    height: auto;
   }
 
   .panel-header {
@@ -199,9 +199,9 @@
 
   .panel-body-bottom {
     display: flex;
-    flex: 1 0 0%; // safari height fix
-    margin-top: 0.5em;
+    flex: 1 0 0;
     flex-wrap: wrap;
+    padding: 0.75em 0.75em max(env(safe-area-inset-bottom), 0.75em);
 
     .show-all {
       display: flex;
@@ -254,8 +254,7 @@
   .menu-tabs-container {
     display: flex;
     flex-direction: column;
-    border-left: 1px solid var(--primary-low);
-    padding: 0.75em 0 0;
+    padding: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
   }
@@ -268,7 +267,7 @@
       display: flex;
       position: relative;
       border-radius: 0;
-      padding: 0.857em;
+      padding: 0.875em;
 
       @media screen and (height <= 400px) {
         // helps with 400% zoom level
@@ -315,34 +314,34 @@
 
   .quick-access-panel {
     width: 320px;
-    padding: 0.75em;
-    padding-bottom: max(env(safe-area-inset-bottom), 0.75em);
     justify-content: space-between;
     box-sizing: border-box;
+    border-right: 1px solid var(--primary-low);
     min-width: 0; // makes sure menu tabs don't go off screen
   }
 
   #quick-access-profile {
     display: inline;
-    max-height: 99%; //  macOS Chrome sometimes adds an unneeded scrollbar at 100%
 
     ul {
       flex-wrap: nowrap;
       height: 100%;
       align-items: center;
+      overflow-x: visible;
       overflow-y: auto; // really short viewports
     }
 
     li {
       flex: 1 1 auto;
-      max-height: 3em; // prevent buttons from getting too tall
+      display: flex;
+      flex-direction: column;
 
       > * {
         // button, a, and everything else
-        height: 100%;
         align-items: center;
         margin: 0;
-        padding: 0 0.5em;
+        padding: 0.35em 1rem;
+        flex: 1 1 auto;
       }
 
       img.emoji {
@@ -416,9 +415,6 @@
   flex-direction: column;
   min-height: 0;
   max-height: 100%;
-  border-top: 1px solid var(--primary-low);
-  padding-top: 0.75em;
-  margin-top: -1px;
 
   /* as a big ol' click target, don't let text inside be selected */
   @include unselectable;
@@ -534,11 +530,8 @@
       }
     }
 
-    a,
-    .profile-tab-btn {
+    a {
       display: flex;
-      margin: 0.25em;
-      padding: 0 0.25em;
     }
 
     button {
@@ -624,7 +617,7 @@
     a {
       color: var(--primary);
       align-items: center;
-      padding: 0.15em 0;
+      padding: 0.5em 1rem;
 
       .item-label {
         font-weight: bold;
@@ -677,6 +670,7 @@
 
     &.unread .icon-avatar__icon-wrapper {
       background: var(--tertiary);
+      font-size: var(--font-down-1);
 
       .d-icon {
         color: var(--secondary);

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -340,6 +340,7 @@
       flex: 1 1 auto;
       display: flex;
       flex-direction: column;
+      max-height: 3.25em;
 
       > * {
         // button, a, and everything else

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -242,6 +242,7 @@
 }
 
 .user-menu.revamped {
+  --user-menu-border-width: 1px;
   right: 0;
   width: 320px;
   padding: 0;
@@ -257,6 +258,7 @@
     padding: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
+    margin-inline: calc(var(--user-menu-border-width) * -1);
   }
 
   .tabs-list {
@@ -267,7 +269,7 @@
       display: flex;
       position: relative;
       border-radius: 0;
-      padding: 0.875em;
+      padding: 0.875em 1em 0.875em 0.875em;
 
       @media screen and (height <= 400px) {
         // helps with 400% zoom level
@@ -297,14 +299,18 @@
         background-color: var(--d-selected);
       }
 
-      &:hover {
-        background-color: var(--d-hover);
+      .discourse-no-touch & {
+        &:hover {
+          background-color: var(--d-hover);
+          border-left: var(--user-menu-border-width) solid var(--primary-low);
+          padding-left: calc(0.875em - var(--user-menu-border-width));
+        }
       }
     }
   }
 
   .bottom-tabs {
-    border-top: 1px solid var(--primary-low);
+    border-top: var(--user-menu-border-width) solid var(--primary-low);
   }
 
   .panel-body-contents {
@@ -316,7 +322,7 @@
     width: 320px;
     justify-content: space-between;
     box-sizing: border-box;
-    border-right: 1px solid var(--primary-low);
+    border-right: var(--user-menu-border-width) solid var(--primary-low);
     min-width: 0; // makes sure menu tabs don't go off screen
   }
 
@@ -387,7 +393,7 @@
     }
 
     hr {
-      border-top: 1px solid var(--primary-low);
+      border-top: var(--user-menu-border-width) solid var(--primary-low);
       width: 100%;
     }
   }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -13,7 +13,7 @@
 
 $search-pad-vertical: 0.25em;
 $search-pad-horizontal: 0.5em;
-$search-result-element-padding: 0.5em 1rem; // hate myself but .25em is too tight and .5 too loose
+$search-result-element-padding: 0.5em 1rem;
 
 .search-menu.glimmer-search-menu {
   .search-input-wrapper {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -13,7 +13,7 @@
 
 $search-pad-vertical: 0.25em;
 $search-pad-horizontal: 0.5em;
-$search-result-element-padding: 0.35em 1rem; // hate myself but .25em is too tight and .5 too loose
+$search-result-element-padding: 0.5em 1rem; // hate myself but .25em is too tight and .5 too loose
 
 .search-menu.glimmer-search-menu {
   .search-input-wrapper {
@@ -86,8 +86,6 @@ $search-result-element-padding: 0.35em 1rem; // hate myself but .25em is too tig
   }
 
   .menu-panel {
-    border: 0;
-    box-shadow: var(--shadow-dropdown);
     padding: 0; // overrule generic menu panels to achieve full width hover effect
 
     @include viewport.from(sm) {
@@ -138,7 +136,6 @@ $search-result-element-padding: 0.35em 1rem; // hate myself but .25em is too tig
   .results {
     display: flex;
     flex-direction: column;
-    padding-top: $search-pad-vertical;
     border-radius: var(--d-border-radius);
 
     .heading {
@@ -420,7 +417,7 @@ $search-result-element-padding: 0.35em 1rem; // hate myself but .25em is too tig
 }
 
 .search-random-quick-tip {
-  padding: max(0.5rem, 0.5em) 1rem;
+  padding: 0 1rem max(0.5rem, 0.5em);
   font-size: var(--font-down-2);
   color: var(--primary-medium);
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -11,11 +11,9 @@
   border-top: 1px solid var(--primary-low);
 }
 
-$search-pad-vertical: 0.25em;
-$search-pad-horizontal: 0.5em;
-$search-result-element-padding: 0.5em 1rem;
-
 .search-menu.glimmer-search-menu {
+  --search-result-element-padding: 0.5em 1rem;
+
   .search-input-wrapper {
     @include viewport.until(sm) {
       position: fixed;
@@ -42,7 +40,7 @@ $search-result-element-padding: 0.5em 1rem;
 
     .search-menu-panel & {
       @include viewport.from(sm) {
-        padding: $search-result-element-padding;
+        padding: 0.75em 1rem 0.5em;
       }
     }
   }
@@ -166,7 +164,7 @@ $search-result-element-padding: 0.5em 1rem;
   }
 
   .search-link {
-    padding: $search-result-element-padding;
+    padding: var(--search-result-element-padding);
 
     &.category,
     &.user,
@@ -417,7 +415,7 @@ $search-result-element-padding: 0.5em 1rem;
 }
 
 .search-random-quick-tip {
-  padding: 0 1rem max(0.5rem, 0.5em);
+  padding: 0 1rem max(0.75rem, 0.75em);
   font-size: var(--font-down-2);
   color: var(--primary-medium);
 
@@ -461,5 +459,5 @@ $search-result-element-padding: 0.5em 1rem;
 }
 
 .no-results {
-  padding: $search-result-element-padding;
+  padding: var(--search-result-element-padding);
 }

--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -43,7 +43,7 @@
     border-radius: var(--d-border-radius);
     background-color: var(--secondary);
     border: 1px solid var(--primary-low);
-    box-shadow: var(--shadow-menu-panel);
+    box-shadow: var(--shadow-dropdown);
     overscroll-behavior: contain;
     overflow: auto;
   }

--- a/app/assets/stylesheets/common/float-kit/d-toasts.scss
+++ b/app/assets/stylesheets/common/float-kit/d-toasts.scss
@@ -27,7 +27,7 @@
     overflow: hidden;
     background-color: var(--secondary);
     border: 1px solid var(--primary-low);
-    box-shadow: var(--shadow-menu-panel);
+    box-shadow: var(--shadow-dropdown);
     overflow-wrap: break-word;
     display: flex;
     animation: d-toast-opening 0.3s ease-in-out;

--- a/app/assets/stylesheets/common/float-kit/d-tooltip.scss
+++ b/app/assets/stylesheets/common/float-kit/d-tooltip.scss
@@ -34,7 +34,7 @@
     background-color: var(--secondary);
     border-radius: var(--d-border-radius);
     border: 1px solid var(--primary-low);
-    box-shadow: var(--shadow-menu-panel);
+    box-shadow: var(--shadow-dropdown);
     z-index: z("max");
     width: max-content;
     position: absolute;

--- a/app/assets/stylesheets/mobile/post-action-feedback.scss
+++ b/app/assets/stylesheets/mobile/post-action-feedback.scss
@@ -22,7 +22,7 @@
   overflow: hidden;
   background-color: var(--tertiary-very-low);
   border: 1px solid var(--primary-low);
-  box-shadow: var(--shadow-menu-panel);
+  box-shadow: var(--shadow-dropdown);
   overflow-wrap: break-word;
   animation: d-toast-opening 0.3s ease-in-out;
   will-change: transform;

--- a/app/assets/stylesheets/qunit-custom.scss
+++ b/app/assets/stylesheets/qunit-custom.scss
@@ -272,9 +272,9 @@ body {
     --bronze: #cd7f32;
     --shadow-modal: 0 8px 60px rgba(0, 0, 0, 1);
     --shadow-composer: 0 -1px 40px rgba(0, 0, 0, 0.35);
-    --shadow-menu-panel: 0 8px 12px rgba(0, 0, 0, 0.35);
     --shadow-card: 0 4px 14px rgba(0, 0, 0, 0.5);
     --shadow-dropdown: 0 2px 12px 0 rgba(0, 0, 0, 0.25);
+    --shadow-menu-panel: var(--shadow-dropdown);
     --shadow-header: 0 2px 4px -1px rgba(0, 0, 0, 0.45);
     --shadow-footer-nav: 0 0 2px 0 rgba(0, 0, 0, 0.4);
     --shadow-focus-danger: 0 0 6px 0 var(--danger);


### PR DESCRIPTION
This eliminates menu panel container padding, which gets us a closer match to the recent search panel adjustments. I've also eliminated the menu-panel box-shadow variant — if we're not going to use it on the search panel we should consolidate and eliminate the variance.  




Before:
![image](https://github.com/user-attachments/assets/07122788-61a4-4767-a697-47cc3118d84e)


After:
![image](https://github.com/user-attachments/assets/a6f66c6f-37cd-4144-930d-d05546bba801)
