### PR TITLE
UX: improve spacing of text in topic list items

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -293,6 +293,7 @@
     align-items: center;
     margin-top: 0.3125em;
     gap: 0 0.5em;
+    line-height: var(--line-height-large);
 
     a.discourse-tag.box {
       padding-top: 0;

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -242,7 +242,7 @@
   }
 
   .topic-list-data {
-    line-height: var(--line-height-large);
+    line-height: var(--line-height-medium);
     text-align: left;
     vertical-align: middle;
   }
@@ -291,7 +291,8 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5em;
+    margin-top: 0.3125em;
+    gap: 0 0.5em;
 
     a.discourse-tag.box {
       padding-top: 0;

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -32,7 +32,7 @@
     padding: 0.8em 0.33em;
 
     &:first-of-type {
-      padding-left: 0.67em;
+      padding-inline: 0.67em;
     }
 
     &:last-of-type {


### PR DESCRIPTION
This tightens up some topic list spacing — our line height for titles has been kind of on the large size, we've got too much space between wrapping metadata, and sometimes not enough space between the right of titles and avatars.
 
Generally headline line-height is recommended to be within 1.1 - 1.3, and we were at 1.4, this puts it at 1.2
 
Before:
![image](https://github.com/user-attachments/assets/cc71ef47-5492-4aea-9caf-3b768e326b67)


After: 
![image](https://github.com/user-attachments/assets/f274a0bc-0077-41bf-abda-ddde71d805b6)
 

