### PR TITLE
FIX: correctly guard for missing close method

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
@@ -128,7 +128,9 @@ export default class UppyUpload {
       `upload-mixin:${this.config.id}:cancel-upload`,
       this.cancelSingleUpload
     );
-    this.uppyWrapper.uppyInstance?.close();
+    if (this.uppyWrapper.uppyInstance?.close) {
+      this.uppyWrapper.uppyInstance.close();
+    }
   }
 
   @bind


### PR DESCRIPTION
`?.close()` is an unsafe pattern

```
test = {}
test?.close()
￼VM363:1 Uncaught TypeError: test?.close is not a function
    at <anonymous>:1:7
```