### PR TITLE
FIX: Allow existing users to accept invites that add them to a group.

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -28,18 +28,21 @@ class InvitesController < ApplicationController
 
     invite = Invite.find_by(invite_key: params[:id])
 
-    # automatically redirect to the topic if the user is logged in and can see it
+    if !invite.present? || !invite.redeemable?
+      show_irredeemable_invite(invite)
+      return
+    end
+
+    # automatically redirect to the topic if the user is logged in and can see it,
+    # but only if the invite wouldn't also add the user to a group
     if current_user
-      if topic = invite.topics.first
+      new_group_ids = invite.groups.pluck(:id) - current_user.group_users.pluck(:group_id)
+      if new_group_ids.empty? && topic = invite.topics.first
         return redirect_to(topic.url) if current_user.guardian.can_see?(topic)
       end
     end
 
-    if invite.present? && invite.redeemable?
-      show_invite(invite)
-    else
-      show_irredeemable_invite(invite)
-    end
+    show_invite(invite) if invite.present?
   rescue RateLimiter::LimitExceeded => e
     flash.now[:error] = e.description
     render layout: "no_ember"

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe InvitesController do
       end
 
       it "doesn't automatically redirect to the topic if the invite has expired" do
+        invite.update!(topics: [Fabricate(:topic)])
         invite.update!(expires_at: 1.day.ago)
 
         get "/invites/#{invite.invite_key}"
@@ -131,6 +132,7 @@ RSpec.describe InvitesController do
       end
 
       it "shows the accept invite page when the user can access the topic, but the invite would also add them to a group" do
+        invite.update!(topics: [Fabricate(:topic)])
         InvitedGroup.create!(invite: invite, group: group)
 
         get "/invites/#{invite.invite_key}"
@@ -143,6 +145,17 @@ RSpec.describe InvitesController do
             base_url: Discourse.base_url,
           ),
         )
+      end
+
+      it "automatically redirects to the topic if the user can access it, and they're already a member of the invite group" do
+        invite.update!(topics: [Fabricate(:topic)])
+
+        group.add(user)
+        InvitedGroup.create!(invite: invite, group: group)
+
+        get "/invites/#{invite.invite_key}"
+        expect(response.status).to eq(302)
+        expect(response.location).to eq(invite.topics.first.url)
       end
 
       it "shows the accept invite page when user's email matches the invite email" do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -120,6 +120,31 @@ RSpec.describe InvitesController do
         expect(response.status).to eq(200)
       end
 
+      it "doesn't automatically redirect to the topic if the invite has expired" do
+        invite.update!(expires_at: 1.day.ago)
+
+        get "/invites/#{invite.invite_key}"
+        expect(response.status).to eq(200)
+
+        expect(response.body).to have_tag(:body, with: { class: "no-ember" })
+        expect(response.body).to include(I18n.t("invite.expired", base_url: Discourse.base_url))
+      end
+
+      it "shows the accept invite page when the user can access the topic, but the invite would also add them to a group" do
+        InvitedGroup.create!(invite: invite, group: group)
+
+        get "/invites/#{invite.invite_key}"
+        expect(response.status).to eq(200)
+        expect(response.body).to_not have_tag(:body, with: { class: "no-ember" })
+        expect(response.body).not_to include(
+          I18n.t(
+            "invite.not_found_template",
+            site_name: SiteSetting.title,
+            base_url: Discourse.base_url,
+          ),
+        )
+      end
+
       it "shows the accept invite page when user's email matches the invite email" do
         invite.update_columns(email: user.email)
 


### PR DESCRIPTION
## ✨ What's This?

This is a tweak to the change in #31301.

That change allowed existing users to be redirected to a topic that they already have access to by bypassing the invite acceptance step, and simply redirecting them there. Since some invites also add the invited user to one or more groups as well, this was causing the group adding step to be skipped in existing workflows.

This change addresses the issue by checking to see if the user would be added to any groups before redirecting. To avoid introducing a CSRF issue, it works by forcing the user through the normal invite acceptance flow, ensure there's user interaction before being added to any groups.

This change also tweaks the behaviour of #31301 to not follow redirects of expired invitations.

## 👑 Testing

### Basic functionality

1. Create a test user.
2. Create an invite that lands on a topic that the test user can access already.
3. Add a group to the invite (which the test user isn’t currently a member of).
4. Login as the test user.
5. Visit the invite link with that user.

### Variations

1. Add the test user to the group before they visit the link.
2. Add multiple groups to the invite, of which the test user is a member of some, or all.