### PR TITLE
FIX: N+1 in admin themes page

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -169,8 +169,10 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def index
-    @themes = Theme.include_relations.order(:name)
-    @color_schemes = ColorScheme.all.includes(:theme, color_scheme_colors: :color_scheme).to_a
+    @themes = Theme.strict_loading.include_relations.order(:name)
+
+    @color_schemes =
+      ColorScheme.strict_loading.all.includes(:theme, color_scheme_colors: :color_scheme).to_a
 
     payload = {
       themes: serialize_data(@themes, ThemeSerializer),

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -96,10 +96,10 @@ class Theme < ActiveRecord::Base
         -> do
           includes(
             :remote_theme,
-            :color_scheme,
             :user,
             :locale_fields,
             :theme_translation_overrides,
+            color_scheme: %i[theme],
             parent_themes: %i[color_scheme locale_fields theme_translation_overrides],
           )
         end

--- a/app/serializers/basic_theme_serializer.rb
+++ b/app/serializers/basic_theme_serializer.rb
@@ -12,6 +12,9 @@ class BasicThemeSerializer < ApplicationSerializer
   end
 
   def description
-    object.internal_translations.find { |t| t.key == "theme_metadata.description" }&.value
+    object
+      .internal_translations(preloaded_locale_fields: object.locale_fields)
+      .find { |t| t.key == "theme_metadata.description" }
+      &.value
   end
 end

--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -5,11 +5,7 @@ class ColorSchemeSerializer < ApplicationSerializer
   has_many :colors, serializer: ColorSchemeColorSerializer, embed: :objects
 
   def theme_name
-    object.theme&.name
-  end
-
-  def theme_id
-    object.theme&.id
+    (options[:theme] || object.theme)&.name
   end
 
   def colors

--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -5,7 +5,7 @@ class ColorSchemeSerializer < ApplicationSerializer
   has_many :colors, serializer: ColorSchemeColorSerializer, embed: :objects
 
   def theme_name
-    (options[:theme] || object.theme)&.name
+    object.theme&.name
   end
 
   def colors

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -3,7 +3,8 @@
 require "base64"
 
 class ThemeSerializer < BasicThemeSerializer
-  attributes :color_scheme_id,
+  attributes :color_scheme,
+             :color_scheme_id,
              :user_selectable,
              :auto_update,
              :remote_theme_id,
@@ -15,7 +16,6 @@ class ThemeSerializer < BasicThemeSerializer
              :theme_fields,
              :screenshot_url
 
-  has_one :color_scheme, serializer: ColorSchemeSerializer, embed: :object
   has_one :user, serializer: UserNameSerializer, embed: :object
   has_one :disabled_by, serializer: UserNameSerializer, embed: :object
 
@@ -30,6 +30,14 @@ class ThemeSerializer < BasicThemeSerializer
     @errors = []
 
     object.theme_fields.each { |o| @errors << o.error if o.error }
+  end
+
+  def color_scheme
+    ColorSchemeSerializer.new(object.color_scheme, root: false, theme: object)
+  end
+
+  def include_color_scheme?
+    object.color_scheme_id
   end
 
   def theme_fields

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -3,8 +3,7 @@
 require "base64"
 
 class ThemeSerializer < BasicThemeSerializer
-  attributes :color_scheme,
-             :color_scheme_id,
+  attributes :color_scheme_id,
              :user_selectable,
              :auto_update,
              :remote_theme_id,
@@ -16,6 +15,7 @@ class ThemeSerializer < BasicThemeSerializer
              :theme_fields,
              :screenshot_url
 
+  has_one :color_scheme, serializer: ColorSchemeSerializer, embed: :object
   has_one :user, serializer: UserNameSerializer, embed: :object
   has_one :disabled_by, serializer: UserNameSerializer, embed: :object
 
@@ -30,14 +30,6 @@ class ThemeSerializer < BasicThemeSerializer
     @errors = []
 
     object.theme_fields.each { |o| @errors << o.error if o.error }
-  end
-
-  def color_scheme
-    ColorSchemeSerializer.new(object.color_scheme, root: false, theme: object)
-  end
-
-  def include_color_scheme?
-    object.color_scheme_id
   end
 
   def theme_fields


### PR DESCRIPTION
`strict_loading` was added to prevent it happening in the future. Few adjustments had to be made:
- include color_scheme and color_scheme_colors, also for parent and child themes;
- internal translations were using preload_fields, but it was too deep to correctly use preloaded tables. I had to pass `preloaded_locale_fields` manually;
- include theme in color_scheme.

Before:
<img width="663" alt="Screenshot 2025-05-15 at 3 43 47 pm" src="https://github.com/user-attachments/assets/b55ce11e-80cb-43eb-8e31-940b0e9859f3" />

After:
<img width="665" alt="Screenshot 2025-05-16 at 11 29 00 am" src="https://github.com/user-attachments/assets/f00bac19-f64b-4048-b220-4d0a9d90a929" />
