### PR TITLE
DEV: Refactor Chat::LookupChannelThreads to follow best practices

### DIFF
--- a/plugins/chat/app/services/chat/action/fetch_threads.rb
+++ b/plugins/chat/app/services/chat/action/fetch_threads.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Chat
+  module Action
+    class FetchThreads < Service::ActionBase
+      option :user_id
+      option :channel_id
+      option :limit
+      option :offset
+
+      def call
+        ::Chat::Thread
+          .includes(
+            :channel,
+            :user_chat_thread_memberships,
+            original_message_user: :user_status,
+            last_message: [
+              :uploads,
+              :chat_webhook_event,
+              :chat_channel,
+              user_mentions: {
+                user: :user_status,
+              },
+              user: :user_status,
+            ],
+            original_message: [
+              :uploads,
+              :chat_webhook_event,
+              :chat_channel,
+              user_mentions: {
+                user: :user_status,
+              },
+              user: :user_status,
+            ],
+          )
+          .joins(
+            "LEFT JOIN user_chat_thread_memberships ON chat_threads.id = user_chat_thread_memberships.thread_id AND user_chat_thread_memberships.user_id = #{user_id} AND user_chat_thread_memberships.notification_level NOT IN (#{::Chat::UserChatThreadMembership.notification_levels[:muted]})",
+          )
+          .joins(
+            "LEFT JOIN chat_messages AS last_message ON chat_threads.last_message_id = last_message.id",
+          )
+          .joins(
+            "INNER JOIN chat_messages AS original_message ON chat_threads.original_message_id = original_message.id",
+          )
+          .where(channel_id:)
+          .where("original_message.chat_channel_id = chat_threads.channel_id")
+          .where("original_message.deleted_at IS NULL")
+          .where("last_message.chat_channel_id = chat_threads.channel_id")
+          .where("last_message.deleted_at IS NULL")
+          .where("chat_threads.replies_count > 0")
+          .order(
+            "CASE WHEN user_chat_thread_memberships.last_read_message_id IS NULL OR user_chat_thread_memberships.last_read_message_id < chat_threads.last_message_id THEN true ELSE false END DESC, last_message.created_at DESC",
+          )
+          .limit(limit)
+          .offset(offset)
+      end
+    end
+  end
+end

--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -42,16 +42,20 @@ module Chat
         self.limit = (limit || THREADS_LIMIT).to_i.clamp(1, THREADS_LIMIT)
         self.offset = [offset || 0, 0].max
       end
+
+      def offset_query
+        { offset: offset + limit }.to_query
+      end
     end
 
     model :channel
     policy :threading_enabled_for_channel
     policy :can_view_channel
     model :threads
-    step :fetch_tracking
-    step :fetch_memberships
-    step :fetch_participants
-    step :build_load_more_url
+    model :tracking, optional: true
+    model :memberships, optional: true
+    model :participants, optional: true
+    model :load_more_url, optional: true
 
     private
 
@@ -60,7 +64,7 @@ module Chat
     end
 
     def threading_enabled_for_channel(channel:)
-      channel.threading_enabled
+      channel.threading_enabled?
     end
 
     def can_view_channel(guardian:, channel:)
@@ -68,76 +72,37 @@ module Chat
     end
 
     def fetch_threads(guardian:, channel:, params:)
-      ::Chat::Thread
-        .includes(
-          :channel,
-          :user_chat_thread_memberships,
-          original_message_user: :user_status,
-          last_message: [
-            :uploads,
-            :chat_webhook_event,
-            :chat_channel,
-            user_mentions: {
-              user: :user_status,
-            },
-            user: :user_status,
-          ],
-          original_message: [
-            :uploads,
-            :chat_webhook_event,
-            :chat_channel,
-            user_mentions: {
-              user: :user_status,
-            },
-            user: :user_status,
-          ],
-        )
-        .joins(
-          "LEFT JOIN user_chat_thread_memberships ON chat_threads.id = user_chat_thread_memberships.thread_id AND user_chat_thread_memberships.user_id = #{guardian.user.id} AND user_chat_thread_memberships.notification_level NOT IN (#{::Chat::UserChatThreadMembership.notification_levels[:muted]})",
-        )
-        .joins(
-          "LEFT JOIN chat_messages AS last_message ON chat_threads.last_message_id = last_message.id",
-        )
-        .joins(
-          "INNER JOIN chat_messages AS original_message ON chat_threads.original_message_id = original_message.id",
-        )
-        .where(channel_id: channel.id)
-        .where("original_message.chat_channel_id = chat_threads.channel_id")
-        .where("original_message.deleted_at IS NULL")
-        .where("last_message.chat_channel_id = chat_threads.channel_id")
-        .where("last_message.deleted_at IS NULL")
-        .where("chat_threads.replies_count > 0")
-        .order(
-          "CASE WHEN user_chat_thread_memberships.last_read_message_id IS NULL OR user_chat_thread_memberships.last_read_message_id < chat_threads.last_message_id THEN true ELSE false END DESC, last_message.created_at DESC",
-        )
-        .limit(params.limit)
-        .offset(params.offset)
+      Chat::Action::FetchThreads.call(
+        user_id: guardian.user.id,
+        channel_id: channel.id,
+        limit: params.limit,
+        offset: params.offset,
+      )
     end
 
     def fetch_tracking(guardian:, threads:)
-      context[:tracking] = ::Chat::TrackingStateReportQuery.call(
-        guardian: guardian,
+      ::Chat::TrackingStateReportQuery.call(
+        guardian:,
         thread_ids: threads.map(&:id),
         include_threads: true,
       ).thread_tracking
     end
 
     def fetch_memberships(guardian:, threads:)
-      context[:memberships] = ::Chat::UserChatThreadMembership.where(
+      ::Chat::UserChatThreadMembership.where(
         thread_id: threads.map(&:id),
         user_id: guardian.user.id,
       )
     end
 
     def fetch_participants(threads:)
-      context[:participants] = ::Chat::ThreadParticipantQuery.call(thread_ids: threads.map(&:id))
+      ::Chat::ThreadParticipantQuery.call(thread_ids: threads.map(&:id))
     end
 
-    def build_load_more_url(channel:, params:)
-      load_more_params = { offset: params.offset + params.limit }.to_query
-      context[:load_more_url] = ::URI::HTTP.build(
+    def fetch_load_more_url(channel:, params:)
+      ::URI::HTTP.build(
         path: "/chat/api/channels/#{channel.id}/threads",
-        query: load_more_params,
+        query: params.offset_query,
       ).request_uri
     end
   end

--- a/plugins/chat/spec/services/actions/fetch_threads_spec.rb
+++ b/plugins/chat/spec/services/actions/fetch_threads_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::Action::FetchThreads do
+  subject(:threads) do
+    described_class.call(user_id: current_user.id, channel_id: channel.id, limit:, offset:)
+  end
+
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
+  fab!(:thread_1) { Fabricate(:chat_thread, channel:) }
+  fab!(:thread_2) { Fabricate(:chat_thread, channel:) }
+  fab!(:thread_3) { Fabricate(:chat_thread, channel:) }
+
+  let(:limit) { 10 }
+  let(:offset) { 0 }
+
+  before do
+    channel.add(current_user)
+    [thread_1, thread_2, thread_3].each.with_index do |t, index|
+      t.original_message.update!(created_at: (index + 1).weeks.ago)
+      t.update!(replies_count: 2)
+      t.add(current_user)
+    end
+  end
+
+  context "when there are new messages" do
+    before do
+      [
+        [thread_1, 10.minutes.ago],
+        [thread_2, 1.day.ago],
+        [thread_3, 2.seconds.ago],
+      ].each do |thread, created_at|
+        message =
+          Fabricate(:chat_message, user: current_user, chat_channel: channel, thread:, created_at:)
+        thread.update!(last_message: message)
+      end
+    end
+
+    it "orders threads by the last reply created_at timestamp" do
+      expect(threads.map(&:id)).to eq([thread_3.id, thread_1.id, thread_2.id])
+    end
+  end
+
+  context "when there are unread messages" do
+    let(:unread_message) { Fabricate(:chat_message, chat_channel: channel, thread: thread_2) }
+
+    before do
+      unread_message.update!(created_at: 2.days.ago)
+      thread_2.update!(last_message: unread_message)
+    end
+
+    it "sorts by unread over recency" do
+      expect(threads.map(&:id)).to eq([thread_2.id, thread_1.id, thread_3.id])
+    end
+  end
+
+  context "when there are more threads than the limit" do
+    let(:limit) { 5 }
+    let(:thread_4) { Fabricate(:chat_thread, channel:) }
+    let(:thread_5) { Fabricate(:chat_thread, channel:) }
+    let(:thread_6) { Fabricate(:chat_thread, channel:) }
+    let(:thread_7) { Fabricate(:chat_thread, channel:) }
+
+    before do
+      [thread_4, thread_5, thread_6, thread_7].each do |t|
+        t.update!(replies_count: 2)
+        t.add(current_user)
+        t.membership_for(current_user).mark_read!
+      end
+      [thread_1, thread_2, thread_3].each { |t| t.membership_for(current_user).mark_read! }
+      # The old unread messages.
+      Fabricate(:chat_message, chat_channel: channel, thread: thread_7).update!(
+        created_at: 2.months.ago,
+      )
+      Fabricate(:chat_message, chat_channel: channel, thread: thread_6).update!(
+        created_at: 3.months.ago,
+      )
+    end
+
+    it "sorts very old unreads to top over recency, and sorts both unreads and other threads by recency" do
+      expect(threads.map(&:id)).to eq(
+        [thread_7.id, thread_6.id, thread_5.id, thread_4.id, thread_1.id],
+      )
+    end
+  end
+
+  context "when the original message is trashed" do
+    before { thread_1.original_message.trash! }
+
+    it "does not return its associated thread" do
+      expect(threads.map(&:id)).to eq([thread_2.id, thread_3.id])
+    end
+  end
+
+  context "when the original message is deleted" do
+    before { thread_1.original_message.destroy }
+
+    it "does not return the associated thread" do
+      expect(threads.map(&:id)).to eq([thread_2.id, thread_3.id])
+    end
+  end
+
+  context "when there are threads in other channels" do
+    let(:thread_4) { Fabricate(:chat_thread) }
+    let!(:message) do
+      Fabricate(
+        :chat_message,
+        user: current_user,
+        thread: thread_4,
+        chat_channel: thread_4.channel,
+        created_at: 2.seconds.ago,
+      )
+    end
+
+    it "does not return those threads" do
+      expect(threads.map(&:id)).to eq([thread_1.id, thread_2.id, thread_3.id])
+    end
+  end
+
+  context "when there is a thread with no membership" do
+    let(:thread_4) { Fabricate(:chat_thread, channel:) }
+
+    before { thread_4.update!(replies_count: 2) }
+
+    it "returns every threads of the channel, no matter the tracking notification level or membership" do
+      expect(threads.map(&:id)).to match_array([thread_1.id, thread_2.id, thread_3.id, thread_4.id])
+    end
+  end
+
+  context "when there are muted threads" do
+    let(:thread) { Fabricate(:chat_thread, channel:) }
+
+    before do
+      thread.add(current_user)
+      thread.membership_for(current_user).update!(
+        notification_level: ::Chat::UserChatThreadMembership.notification_levels[:muted],
+      )
+    end
+
+    it "does not return them" do
+      expect(threads.map(&:id)).not_to include(thread.id)
+    end
+  end
+
+  context "when there are deleted messages" do
+    let!(:original_last_message_id) { thread_3.reload.last_message_id }
+    let(:unread_message) { Fabricate(:chat_message, chat_channel: channel, thread: thread_3) }
+
+    before do
+      unread_message.update!(created_at: 2.days.ago)
+      unread_message.trash!
+      thread_3.reload.update!(last_message_id: original_last_message_id)
+    end
+
+    it "does not count deleted messages for sort order" do
+      expect(threads.map(&:id)).to eq([thread_1.id, thread_2.id, thread_3.id])
+    end
+  end
+
+  context "when offset param is set" do
+    let(:offset) { 1 }
+
+    it "returns results from the offset the number of threads returned" do
+      expect(threads).to eq([thread_2, thread_3])
+    end
+  end
+end

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -1,12 +1,81 @@
 # frozen_string_literal: true
 
 RSpec.describe ::Chat::LookupChannelThreads::Contract, type: :model do
-  subject(:contract) { described_class.new(channel_id: 1) }
-
   it { is_expected.to validate_presence_of(:channel_id) }
   it { is_expected.to allow_values(1, 0, nil, "a").for(:limit) }
   it do
     is_expected.not_to allow_values(::Chat::LookupChannelThreads::THREADS_LIMIT + 1).for(:limit)
+  end
+
+  describe "Limits" do
+    subject(:contract) { described_class.new }
+
+    context "when limit is not set" do
+      it "defaults to a max value" do
+        contract.validate
+        expect(contract.limit).to eq(::Chat::LookupChannelThreads::THREADS_LIMIT)
+      end
+    end
+
+    context "when limit is over max" do
+      before { contract.limit = ::Chat::LookupChannelThreads::THREADS_LIMIT + 1 }
+
+      it "sets limit to max" do
+        contract.validate
+        expect(contract.limit).to eq(::Chat::LookupChannelThreads::THREADS_LIMIT)
+      end
+    end
+
+    context "when limit is allowed" do
+      before { contract.limit = 5 }
+
+      it "sets limit to the value" do
+        contract.validate
+        expect(contract.limit).to eq(5)
+      end
+    end
+  end
+
+  describe "Offsets" do
+    subject(:contract) { described_class.new }
+
+    context "when offset is not set" do
+      it "defaults to zero" do
+        contract.validate
+        expect(contract.offset).to be_zero
+      end
+    end
+
+    context "when offset is under 0" do
+      before { contract.offset = -1 }
+
+      it "sets offset to zero" do
+        contract.validate
+        expect(contract.offset).to be_zero
+      end
+    end
+
+    context "when offset is allowed" do
+      before { contract.offset = 5 }
+
+      it "sets offset to the value" do
+        contract.validate
+        expect(contract.offset).to eq(5)
+      end
+    end
+  end
+
+  describe "#offset_query" do
+    subject(:contract) { described_class.new }
+
+    before do
+      contract.limit = 10
+      contract.offset = 5
+    end
+
+    it "returns the offset query string" do
+      expect(contract.offset_query).to eq("offset=15")
+    end
   end
 end
 
@@ -14,287 +83,94 @@ RSpec.describe ::Chat::LookupChannelThreads do
   subject(:result) { described_class.call(params:, **dependencies) }
 
   fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
 
   let(:guardian) { Guardian.new(current_user) }
-  let(:channel_id) { nil }
+  let(:channel_id) { channel.id }
   let(:limit) { 10 }
   let(:offset) { 0 }
   let(:params) { { channel_id:, limit:, offset: } }
   let(:dependencies) { { guardian: } }
 
-  describe "step - set_limit" do
-    fab!(:channel_1) { Fabricate(:chat_channel) }
-    let(:channel_id) { channel_1.id }
+  context "when data is invalid" do
+    let(:channel_id) { nil }
 
-    context "when limit is not set" do
-      let(:limit) { nil }
-
-      it "defaults to a max value" do
-        expect(result.params.limit).to eq(described_class::THREADS_LIMIT)
-      end
-    end
-
-    context "when limit is over max" do
-      let(:limit) { described_class::THREADS_LIMIT + 1 }
-
-      it { is_expected.to fail_a_contract }
-    end
-
-    context "when limit is under min" do
-      let(:limit) { 0 }
-
-      it "defaults to a max value" do
-        expect(result.params.limit).to eq(1)
-      end
-    end
+    it { is_expected.to fail_a_contract }
   end
 
-  describe "step - set_offset" do
-    fab!(:channel_1) { Fabricate(:chat_channel) }
-    let(:channel_id) { channel_1.id }
+  context "when channel doesn’t exist" do
+    let(:channel_id) { -999 }
 
-    context "when offset is not set" do
-      let(:offset) { nil }
-
-      it "defaults to zero" do
-        expect(result.params.offset).to eq(0)
-      end
-    end
-
-    context "when offset is under min" do
-      let(:offset) { -99 }
-
-      it "defaults to a min value" do
-        expect(result.params.offset).to eq(0)
-      end
-    end
+    it { is_expected.to fail_to_find_a_model(:channel) }
   end
 
-  describe "model - channel" do
-    context "when channel doesn’t exist" do
-      let(:channel_id) { -999 }
+  context "when channel threading is disabled" do
+    before { channel.update!(threading_enabled: false) }
 
-      it { is_expected.to fail_to_find_a_model(:channel) }
-    end
+    it { is_expected.to fail_a_policy(:threading_enabled_for_channel) }
   end
 
-  describe "policy - threading_enabled_for_channel" do
-    context "when channel threading is disabled" do
-      fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: false) }
-      let(:channel_id) { channel_1.id }
+  context "when channel cannot be previewed" do
+    fab!(:channel) { Fabricate(:private_category_channel, threading_enabled: true) }
 
-      it { is_expected.to fail_a_policy(:threading_enabled_for_channel) }
-    end
-  end
-
-  describe "policy - can_view_channel" do
-    context "when channel threading is disabled" do
-      fab!(:channel_1) { Fabricate(:private_category_channel, threading_enabled: true) }
-      let(:channel_id) { channel_1.id }
-
-      it { is_expected.to fail_a_policy(:can_view_channel) }
-    end
+    it { is_expected.to fail_a_policy(:can_view_channel) }
   end
 
   context "when channel has no threads" do
-    fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
-    let(:channel_id) { channel_1.id }
-
-    describe "model - threads" do
-      it "returns an empty list of threads" do
-        expect(result.threads).to eq([])
-      end
-    end
+    it { is_expected.to fail_to_find_a_model(:threads) }
   end
 
-  context "when channel has threads" do
-    fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
-    fab!(:thread_1) { Fabricate(:chat_thread, channel: channel_1) }
-    fab!(:thread_2) { Fabricate(:chat_thread, channel: channel_1) }
-    fab!(:thread_3) { Fabricate(:chat_thread, channel: channel_1) }
-
-    let(:channel_id) { channel_1.id }
+  context "when everything is ok" do
+    fab!(:threads) { Fabricate.times(3, :chat_thread, channel:) }
 
     before do
-      [thread_1, thread_2, thread_3].each.with_index do |t, index|
+      channel.add(current_user)
+      threads.each.with_index do |t, index|
         t.original_message.update!(created_at: (index + 1).weeks.ago)
         t.update!(replies_count: 2)
         t.add(current_user)
       end
+      allow(Chat::Action::FetchThreads).to receive(:call).with(
+        user_id: current_user.id,
+        channel_id: channel.id,
+        limit:,
+        offset:,
+      ).and_return(threads)
     end
 
-    describe "model - threads" do
-      before { channel_1.add(current_user) }
+    it { is_expected.to run_successfully }
 
-      it { is_expected.to run_successfully }
-
-      it "orders threads by the last reply created_at timestamp" do
-        [
-          [thread_1, 10.minutes.ago],
-          [thread_2, 1.day.ago],
-          [thread_3, 2.seconds.ago],
-        ].each do |thread, created_at|
-          message =
-            Fabricate(
-              :chat_message,
-              user: current_user,
-              chat_channel: channel_1,
-              thread: thread,
-              created_at: created_at,
-            )
-          thread.update!(last_message: message)
-        end
-
-        expect(result.threads.map(&:id)).to eq([thread_3.id, thread_1.id, thread_2.id])
-      end
-
-      it "sorts by unread over recency" do
-        unread_message = Fabricate(:chat_message, chat_channel: channel_1, thread: thread_2)
-        unread_message.update!(created_at: 2.days.ago)
-        thread_2.update!(last_message: unread_message)
-
-        expect(result.threads.map(&:id)).to eq([thread_2.id, thread_1.id, thread_3.id])
-      end
-
-      describe "when there are more threads than the limit" do
-        let(:limit) { 5 }
-
-        it "sorts very old unreads to top over recency, and sorts both unreads and other threads by recency" do
-          thread_4 = Fabricate(:chat_thread, channel: channel_1)
-          thread_4.update!(replies_count: 2)
-          thread_5 = Fabricate(:chat_thread, channel: channel_1)
-          thread_5.update!(replies_count: 2)
-          thread_6 = Fabricate(:chat_thread, channel: channel_1)
-          thread_6.update!(replies_count: 2)
-          thread_7 = Fabricate(:chat_thread, channel: channel_1)
-          thread_7.update!(replies_count: 2)
-
-          [thread_4, thread_5, thread_6, thread_7].each do |t|
-            t.add(current_user)
-            t.membership_for(current_user).mark_read!
-          end
-          [thread_1, thread_2, thread_3].each { |t| t.membership_for(current_user).mark_read! }
-
-          # The old unread messages.
-          Fabricate(:chat_message, chat_channel: channel_1, thread: thread_7).update!(
-            created_at: 2.months.ago,
-          )
-          Fabricate(:chat_message, chat_channel: channel_1, thread: thread_6).update!(
-            created_at: 3.months.ago,
-          )
-
-          expect(result.threads.map(&:id)).to eq(
-            [thread_7.id, thread_6.id, thread_5.id, thread_4.id, thread_1.id],
-          )
-        end
-      end
-
-      it "does not return threads where the original message is trashed" do
-        thread_1.original_message.trash!
-
-        expect(result.threads.map(&:id)).to eq([thread_2.id, thread_3.id])
-      end
-
-      it "does not return threads where the original message is deleted" do
-        thread_1.original_message.destroy
-
-        expect(result.threads.map(&:id)).to eq([thread_2.id, thread_3.id])
-      end
-
-      it "does not return threads from another channel" do
-        thread_4 = Fabricate(:chat_thread)
-        Fabricate(
-          :chat_message,
-          user: current_user,
-          thread: thread_4,
-          chat_channel: thread_4.channel,
-          created_at: 2.seconds.ago,
-        )
-
-        expect(result.threads.map(&:id)).to eq([thread_1.id, thread_2.id, thread_3.id])
-      end
-
-      it "returns every threads of the channel, no matter the tracking notification level or membership" do
-        thread_4 = Fabricate(:chat_thread, channel: channel_1)
-        thread_4.update!(replies_count: 2)
-
-        expect(result.threads.map(&:id)).to match_array(
-          [thread_1.id, thread_2.id, thread_3.id, thread_4.id],
-        )
-      end
-
-      it "doesnt return muted threads" do
-        thread = Fabricate(:chat_thread, channel: channel_1)
-        thread.add(current_user)
-        thread.membership_for(current_user).update!(
-          notification_level: ::Chat::UserChatThreadMembership.notification_levels[:muted],
-        )
-
-        expect(result.threads.map(&:id)).to_not include(thread.id)
-      end
-
-      it "does not count deleted messages for sort order" do
-        original_last_message_id = thread_3.reload.last_message_id
-        unread_message = Fabricate(:chat_message, chat_channel: channel_1, thread: thread_3)
-        unread_message.update!(created_at: 2.days.ago)
-        unread_message.trash!
-        thread_3.reload.update!(last_message_id: original_last_message_id)
-
-        expect(result.threads.map(&:id)).to eq([thread_1.id, thread_2.id, thread_3.id])
-      end
-
-      context "when limit param is set" do
-        let(:limit) { 1 }
-
-        it "limits the number of threads returned" do
-          expect(result.threads).to contain_exactly(thread_1)
-        end
-      end
-
-      context "when offset param is set" do
-        let(:offset) { 1 }
-
-        it "returns results from the offset the number of threads returned" do
-          expect(result.threads).to eq([thread_2, thread_3])
-        end
-      end
+    it "returns the threads" do
+      expect(result.threads).to eq(threads)
     end
 
-    describe "step - fetch_tracking" do
-      it "returns correct threads tracking" do
-        expect(result.tracking).to eq(
-          ::Chat::TrackingStateReportQuery.call(
-            guardian: guardian,
-            thread_ids: [thread_1, thread_2, thread_3].map(&:id),
-            include_threads: true,
-          ).thread_tracking,
-        )
-      end
+    it "returns threads tracking" do
+      expect(result.tracking).to eq(
+        ::Chat::TrackingStateReportQuery.call(
+          guardian: guardian,
+          thread_ids: threads.map(&:id),
+          include_threads: true,
+        ).thread_tracking,
+      )
     end
 
-    describe "step - fetch_memberships" do
-      it "returns correct memberships" do
-        expect(result.memberships).to eq(
-          ::Chat::UserChatThreadMembership.where(
-            thread_id: [thread_1, thread_2, thread_3].map(&:id),
-            user_id: current_user.id,
-          ),
-        )
-      end
+    it "returns memberships" do
+      expect(result.memberships).to eq(
+        ::Chat::UserChatThreadMembership.where(
+          thread_id: threads.map(&:id),
+          user_id: current_user.id,
+        ),
+      )
     end
 
-    describe "step - fetch_participants" do
-      it "returns correct participants" do
-        expect(result.participants).to eq(
-          ::Chat::ThreadParticipantQuery.call(thread_ids: [thread_1, thread_2, thread_3].map(&:id)),
-        )
-      end
+    it "returns participants" do
+      expect(result.participants).to eq(
+        ::Chat::ThreadParticipantQuery.call(thread_ids: threads.map(&:id)),
+      )
     end
 
-    describe "step - build_load_more_url" do
-      it "returns a url with the correct params" do
-        expect(result.load_more_url).to eq("/chat/api/channels/#{channel_1.id}/threads?offset=10")
-      end
+    it "returns a url with the correct params" do
+      expect(result.load_more_url).to eq("/chat/api/channels/#{channel.id}/threads?offset=10")
     end
   end
 end


### PR DESCRIPTION
- use `model` where possible
- extract threads fetching logic to its own action
- refactor specs to follow current guidelines/best practices