### PR TITLE
FIX: check if sidebar hidden and remove scrollLock when hiding hamburger menu

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
+++ b/app/assets/javascripts/admin/addon/services/admin-sidebar-state-manager.js
@@ -1,5 +1,6 @@
 import Service, { service } from "@ember/service";
 import KeyValueStore from "discourse/lib/key-value-store";
+import scrollLock from "discourse/lib/scroll-lock";
 import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
 import AdminSearchModal from "admin/components/modal/admin-search";
 
@@ -71,7 +72,10 @@ export default class AdminSidebarStateManager extends Service {
 
     // we may navigate to admin from the header dropdown
     // and when we do, we have to close it
-    this.header.hamburgerVisible = false;
+    if (this.sidebarState.sidebarHidden) {
+      this.header.hamburgerVisible = false;
+      scrollLock(false);
+    }
 
     return true;
   }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/dashboard-freezes-until-sidebar-is-opened/366402

This is a follow-up to https://github.com/discourse/discourse/pull/32651, when navigating from the homepage to admin the hamburger gets force-hidden because we switch from the dropdown to the sidebar nav but the scrollLock was unintentionally left behind. 

This makes sure we're only messing with hamburger state when the sidebar is hidden (with ` {{hideApplicationSidebar}}`) and also removes the scroll lock when the hamburger is force-hidden. 