### PR TITLE
DEV: d-multi-select and chat-channel-multi-select

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-multi-select.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-multi-select.gjs
@@ -77,7 +77,7 @@ export default class DMultiSelect extends Component {
 
   @action
   focus(input) {
-    input.focus();
+    input.focus({ preventScroll: true });
   }
 
   @action

--- a/app/assets/stylesheets/common/components/d-multi-select.scss
+++ b/app/assets/stylesheets/common/components/d-multi-select.scss
@@ -7,7 +7,7 @@
   gap: 0.25em;
   line-height: normal;
   box-sizing: border-box;
-  width: 200px;
+  width: 300px;
   border: 1px solid var(--primary-medium);
   justify-content: space-between;
 

--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -5,9 +5,13 @@ class Chat::Api::ChannelsController < Chat::ApiController
   CATEGORY_CHANNEL_EDITABLE_PARAMS = %i[auto_join_users allow_channel_wide_mentions]
 
   def index
-    permitted = params.permit(:filter, :limit, :offset, :status)
+    permitted = params.permit(:filter, :limit, :offset, :status, ids: [])
 
-    options = { filter: permitted[:filter], limit: (permitted[:limit] || 25).to_i }
+    options = {
+      filter: permitted[:filter],
+      limit: (permitted[:limit] || 25).to_i,
+      ids: permitted[:ids],
+    }
     options[:offset] = permitted[:offset].to_i
     options[:status] = Chat::Channel.statuses[permitted[:status]] ? permitted[:status] : nil
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-multi-select.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-multi-select.gjs
@@ -1,0 +1,65 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import AsyncContent from "discourse/components/async-content";
+import DButton from "discourse/components/d-button";
+import DMultiSelect from "discourse/components/d-multi-select";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
+
+export default class ChatChannelMultiSelect extends Component {
+  initialIds = this.args.initialIds || [];
+
+  @action
+  async filterChannels(filter) {
+    return await this.loadChannels({ filter });
+  }
+
+  @action
+  async loadInitialSelection() {
+    if (!this.initialIds?.length) {
+      return [];
+    }
+
+    const channels = await this.loadChannels({ ids: this.initialIds });
+
+    this.args.onChange?.(channels);
+    return channels;
+  }
+
+  async loadChannels(data = { filter: null, ids: null }) {
+    try {
+      const response = await ajax("/chat/api/channels", {
+        type: "GET",
+        data,
+      });
+
+      return response.channels.map((channel) => ChatChannel.create(channel));
+    } catch (error) {
+      popupAjaxError(error);
+    }
+  }
+
+  <template>
+    <AsyncContent @asyncData={{this.loadInitialSelection}}>
+      <:content>
+        <DMultiSelect
+          @selection={{@selection}}
+          @loadFn={{this.filterChannels}}
+          @onChange={{@onChange}}
+        >
+          <:selection as |result|>{{result.title}}</:selection>
+          <:result as |result|>{{result.title}}</:result>
+        </DMultiSelect>
+      </:content>
+      <:loading>
+        <DButton
+          @label="loading"
+          @icon="spinner"
+          @disabled={{true}}
+          class="chat-channels-multi-select__loading"
+        />
+      </:loading>
+    </AsyncContent>
+  </template>
+}

--- a/plugins/chat/assets/stylesheets/common/chat-channels-multi-select.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channels-multi-select.scss
@@ -1,0 +1,9 @@
+.chat-channels-multi-select__loading {
+  justify-content: flex-start;
+  width: 300px;
+  border: 1px solid var(--primary-medium);
+
+  .d-icon {
+    animation: rotate-forever 1s infinite linear;
+  }
+}

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -69,3 +69,4 @@
 @import "chat-message-text";
 @import "chat-messages-scroller";
 @import "chat-footer";
+@import "chat-channels-multi-select";

--- a/plugins/chat/lib/chat/channel_fetcher.rb
+++ b/plugins/chat/lib/chat/channel_fetcher.rb
@@ -102,13 +102,12 @@ module Chat
           ],
         )
       channels = channels.includes(:chat_channel_archive) if options[:include_archives]
-
       channels =
         channels
           .with_categories
           .where(chatable_type: Chat::Channel.public_channel_chatable_types)
           .where("chat_channels.id IN (#{allowed_channel_ids})")
-
+      channels = channels.where("chat_channels.id IN (:ids)", ids: options[:ids]) if options[:ids]
       channels = channels.where(status: options[:status]) if options[:status].present?
 
       if options[:filter].present?

--- a/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_fetcher_spec.rb
@@ -22,6 +22,16 @@ describe Chat::ChannelFetcher do
 
   before { SiteSetting.chat_allowed_groups = chatters }
 
+  describe ".secured_public_channel_search" do
+    it "can filter by ids" do
+      filtered_channel = Fabricate(:category_channel, chatable: category)
+
+      channels = described_class.secured_public_channel_search(guardian, ids: [filtered_channel.id])
+
+      expect(channels).to contain_exactly(filtered_channel)
+    end
+  end
+
   describe ".structured" do
     it "returns open channel only" do
       category_channel.user_chat_channel_memberships.create!(user: user1, following: true)

--- a/plugins/chat/test/javascripts/components/chat-channel-multi-select-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-multi-select-test.gjs
@@ -1,0 +1,69 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { array, fn } from "@ember/helper";
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import ChatChannelMultiSelect from "discourse/plugins/chat/discourse/components/chat-channel-multi-select";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+class TestTemplate extends Component {
+  @tracked selection = this.args.selection || [];
+
+  <template>
+    <ChatChannelMultiSelect
+      @initialIds={{@initialIds}}
+      @selection={{this.selection}}
+      @onChange={{fn (mut this.selection)}}
+    />
+  </template>
+}
+
+module(
+  "Discourse Chat | Component | chat-channel-multi-select",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("@initialIds", async function (assert) {
+      const channel = new ChatFabricators(getOwner(this)).channel();
+
+      pretender.get("/chat/api/channels", () => {
+        return response({
+          channels: [
+            { id: channel.id, title: channel.title, slug: channel.slug },
+          ],
+        });
+      });
+
+      await render(
+        <template><TestTemplate @initialIds={{array channel.id}} /></template>
+      );
+
+      assert
+        .dom(".d-multi-select-trigger__selection-label:nth-of-type(1)")
+        .hasText(channel.title);
+    });
+
+    test("@selection", async function (assert) {
+      const channel = new ChatFabricators(getOwner(this)).channel();
+
+      pretender.get("/chat/api/channels", () => {
+        return response({
+          channels: [
+            { id: channel.id, title: channel.title, slug: channel.slug },
+          ],
+        });
+      });
+
+      await render(
+        <template><TestTemplate @selection={{array channel}} /></template>
+      );
+
+      assert
+        .dom(".d-multi-select-trigger__selection-label:nth-of-type(1)")
+        .hasText(channel.title);
+    });
+  }
+);

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/multi-select.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/multi-select.gjs
@@ -1,12 +1,16 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { array, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import DMultiSelect from "discourse/components/d-multi-select";
+import ChatChannelMultiSelect from "discourse/plugins/chat/discourse/components/chat-channel-multi-select";
 import StyleguideComponent from "../../styleguide/component";
 import StyleguideExample from "../../styleguide-example";
 
 export default class MultiSelect extends Component {
   @tracked selection = [{ id: 1, name: "foo" }];
+
+  @tracked selectedChannels = null;
 
   @action
   onChange(selection) {
@@ -38,6 +42,20 @@ export default class MultiSelect extends Component {
             <:result as |result|>{{result.name}}</:result>
             <:selection as |result|>{{result.name}}</:selection>
           </DMultiSelect>
+        </:sample>
+      </StyleguideComponent>
+    </StyleguideExample>
+    <StyleguideExample @title="<ChatChannelMultiSelect />">
+      <StyleguideComponent @tag="d-multi-select component">
+        <:sample>
+          <ChatChannelMultiSelect
+            @onChange={{fn (mut this.selectedChannels)}}
+            @initialIds={{array 2}}
+            @selection={{this.selectedChannels}}
+          >
+            <:result as |result|>{{result.name}}</:result>
+            <:selection as |result|>{{result.name}}</:selection>
+          </ChatChannelMultiSelect>
         </:sample>
       </StyleguideComponent>
     </StyleguideExample>


### PR DESCRIPTION
Implement a new component called `d-multi-select` which allows to select multiple items.

It has the following features:
- accepts a `loadFn` to load data
- yield result to customise results
- yield selection to customise selection

Usage:

```gjs
 <DMultiSelect
  @loadFn={{this.loadData}}
  @onChange={{this.onChange}}
  @selection={{this.selection}}
>
  <:selection as |item|>{{item.name}}</:selection>
  <:result as |result|>{{result.name}}</:result>
</DMultiSelect>
```

For chat channels, we added a dedicated component on top of `DMultiselect`, which allows you to pass a list of ids or a selection if you already have the channels objects:

```gjs
<ChatChannelMultiSelect
  @onChange={{fn (mut this.selectedChannels)}}
  @initialIds={{array 2}}
  @selection={{this.selectedChannels}}
>
  <:selection as |item|>{{item.name}}</:selection>
  <:result as |result|>{{result.name}}</:result>
</ChatChannelMultiSelect>