### PR TITLE
DEV: fix flaky in admin site texts

### DIFF
--- a/spec/system/page_objects/pages/admin_site_texts.rb
+++ b/spec/system/page_objects/pages/admin_site_texts.rb
@@ -42,6 +42,10 @@ module PageObjects
 
       def edit_translation(key)
         find(".site-text[data-site-text-id='#{key}']").find(".site-text-edit").click
+        has_current_path?(
+          "/admin/customize/site_texts/#{key}?locale=#{I18n.locale}",
+          ignore_query: false,
+        )
       end
 
       def override_translation(value)


### PR DESCRIPTION
A spec could potentially go so fast that it would attempt to fill in the input before we have gone through the various redirects resulting in an error.

```
Failure/Error: super

Playwright::Error:
  TypeError: Cannot read properties of null (reading 'namespaceURI')
      at eval (eval at evaluate (:313:29), <anonymous>:17:12)
      at UtilityScript.evaluate (<anonymous>:320:18)
      at UtilityScript.<anonymous> (<anonymous>:1:44)
  Call log:
```

Now that we ensure that we have the current final state path we should avoid this error.