### PR TITLE
FIX: attempts to fix flaky in stat spec

### DIFF
--- a/plugins/automation/spec/models/stat_spec.rb
+++ b/plugins/automation/spec/models/stat_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe DiscourseAutomation::Stat do
     context "with block form" do
       it "measures the execution time and records it" do
         # Mock Process.clock_gettime to return controlled values
-        allow(Process).to receive(:clock_gettime).and_return(10, 10.75)
+        allow(Process).to receive(:clock_gettime).and_return(10.0, 10.75)
 
         result = DiscourseAutomation::Stat.log(automation_id) { "test result" }
 
@@ -162,7 +162,7 @@ RSpec.describe DiscourseAutomation::Stat do
 
       context "when an error occurs" do
         it "yields the correct error and records it" do
-          allow(Process).to receive(:clock_gettime).and_return(10, 10.75)
+          allow(Process).to receive(:clock_gettime).and_return(10.0, 10.75)
 
           expect { DiscourseAutomation::Stat.log(automation_id) { raise } }.to raise_error(
             RuntimeError,


### PR DESCRIPTION
I suspect that by having an integer and not a float sometimes the value we get is converted to 0.

This is the error we have atm:

```
Failure/Error: measurement = Benchmark.measure { example.run }

  expected: 0.75
       got: 0.0

  (compared using ==)
```

This might not fix it, but it feels right to make this change.