### PR TITLE
FIX: attempts to fix flaky accelerator spec

### DIFF
--- a/spec/lib/freedom_patches/translate_accelerator_spec.rb
+++ b/spec/lib/freedom_patches/translate_accelerator_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "translate accelerator" do
   end
 
   describe "plugins" do
-    before do
+    it "loads plural rules from plugins" do
       DiscoursePluginRegistry.register_locale(
         "foo",
         name: "Foo",
@@ -107,20 +107,15 @@ RSpec.describe "translate accelerator" do
 
       LocaleSiteSetting.reset!
       I18n.reload!
-    end
-
-    after do
-      DiscoursePluginRegistry.unregister_locale("foo")
-      LocaleSiteSetting.reset!
-    end
-
-    it "loads plural rules from plugins" do
       I18n.locale = :foo
 
       expect(I18n.t("i18n.plural.keys")).to eq(%i[one few other])
       expect(I18n.t("items", count: 1)).to eq("one item")
       expect(I18n.t("items", count: 3)).to eq("some items")
       expect(I18n.t("items", count: 20)).to eq("20 items")
+    ensure
+      DiscoursePluginRegistry.unregister_locale("foo")
+      LocaleSiteSetting.reset!
     end
   end
 


### PR DESCRIPTION
I suspect something is coming to reset the DiscoursePluginRegistry between `before` and `it`, putting everything inside the `it` block might prevent this.

This is the error we got:

```
Failure/Error: self.locale_no_cache = value

I18n::InvalidLocale:
  :foo is not a valid locale

/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.7/lib/i18n.rb:382:in `enforce_available_locales!'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.7/lib/i18n/config.rb:15:in `locale='
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.7/lib/i18n.rb:75:in `locale='
./lib/freedom_patches/translate_accelerator.rb:254:in `locale='
```