### PR TITLE
FIX: attempts to fix flaky in review media

### DIFF
--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -17,7 +17,8 @@ describe "Composer using review_media", type: :system do
     topic_page.visit_topic_and_open_composer(topic)
     topic_page.fill_in_composer(" this one has an emoji: :mask: ")
 
-    within(".d-editor-preview") { expect(page).to have_css(".emoji") }
+    expect(page).to have_css(".d-editor-preview .emoji")
+
     topic_page.send_reply
 
     expect(topic_page).to have_post_number(2)


### PR DESCRIPTION
I suspect the within is doing a memoization of the preview at a moment where the emoji has not been rendered yet, when we render the emoji we might have a different instance of the preview in the within which doesn't have the emoji.

Im not super confident about this theory, but the within is useless here so it seems like a good thing to try first.

The error we have is:

```
Failure/Error: super

Playwright::Error:
  TypeError: Cannot read properties of null (reading 'namespaceURI')
      at eval (eval at evaluate (:313:29), <anonymous>:17:12)
      at UtilityScript.evaluate (<anonymous>:320:18)
      at UtilityScript.<anonymous> (<anonymous>:1:44)
  Call log:

[Screenshot Image]: /__w/discourse/discourse/tmp/capybara/failures_r_spec_example_groups_composer_using_review_media_does_not_flag_a_post_with_an_emoji_250.png

~~~~~~~ JS LOGS ~~~~~~~
ℹ️ Discourse v3.5.0.beta5-dev — https://github.com/discourse/discourse/commits/94932de163 — Ember v5.12.0
DEBUG: For more advanced debugging, install the Ember Inspector from https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi
Failed to load resource: net::ERR_CONNECTION_REFUSED
~~~~~ END JS LOGS ~~~~~

/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/promises.rb:1268:in `raise'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/promises.rb:1268:in `wait_until_resolved!'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/promises.rb:1482:in `value!'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/connection.rb:121:in `send_message_to_server'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/channel.rb:35:in `block in send_message_to_server_result'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/channel.rb:67:in `with_logging'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/channel.rb:34:in `send_message_to_server_result'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/channel.rb:20:in `send_message_to_server'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/javascript/expression.rb:10:in `evaluate'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright/channel_owners/js_handle.rb:19:in `evaluate'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/playwright-ruby-client-1.52.0/lib/playwright_api/js_handle.rb:46:in `evaluate'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:885:in `block in path'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:87:in `assert_element_not_stale'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-playwright-driver-0.5.6/lib/capybara/playwright/node.rb:884:in `path'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:578:in `inspect'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/queries/selector_query.rb:106:in `description'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/queries/selector_query.rb:115:in `applied_description'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/queries/selector_query.rb:180:in `failure_message'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/result.rb:114:in `failure_message'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/matchers.rb:112:in `block in assert_selector'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/matchers.rb:869:in `block in _verify_selector_result'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
./spec/rails_helper.rb:421:in `synchronize'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/matchers.rb:868:in `_verify_selector_result'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/matchers.rb:110:in `assert_selector'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:774:in `assert_selector'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/rspec/matchers/have_selector.rb:18:in `element_matches?'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/rspec/matchers/base.rb:52:in `matches?'
./spec/system/composer/review_media_unless_trust_level_spec.rb:20:in `block (3 levels) in <main>'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:366:in `within'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `call'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `within_element'
/var/www/discourse/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
./spec/system/composer/review_media_unless_trust_level_spec.rb:20:in `block (2 levels) in <main>'
```