### PR TITLE
FIX: simplify test to remove flaky part

### DIFF
--- a/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
+++ b/plugins/chat/spec/system/thread_tracking/full_page_spec.rb
@@ -99,10 +99,6 @@ describe "Thread tracking state | full page", type: :system do
       thread_page.notification_level = :tracking
 
       expect(thread_page).to have_notification_level("tracking")
-
-      chat_page.visit_channel(channel)
-
-      expect(thread_list_page).to have_thread(new_thread)
     end
 
     describe "sidebar unread indicators" do


### PR DESCRIPTION
This test is about testing that we can set notification_level, which it does correctly. The rest of the spec was testing some undefined behavior which is flaky.