### PR TITLE
FIX: Wait for data before showing admin search results

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-search.gjs
@@ -23,11 +23,13 @@ export default class AdminSearch extends Component {
   @tracked searchResults = [];
   @tracked showFilters = true;
   @tracked loading = false;
+  @tracked dataReady = false;
 
   constructor() {
     super(...arguments);
 
     this.adminSearchDataSource.buildMap().then(() => {
+      this.dataReady = true;
       if (this.filter !== "") {
         this.loading = true;
         this.runSearch();
@@ -119,6 +121,10 @@ export default class AdminSearch extends Component {
     this.loading = false;
   }
 
+  get showLoadingSpinner() {
+    return this.filter !== "" && (this.loading || !this.dataReady);
+  }
+
   <template>
     <div
       class="admin-search__input-container
@@ -148,12 +154,22 @@ export default class AdminSearch extends Component {
         }}
       {{/if}}
       {{#if
-        (and this.filter (not this.searchResults.length) (not this.loading))
+        (and
+          this.filter
+          (not this.searchResults.length)
+          (not this.showLoadingSpinner)
+        )
       }}
         {{this.noResultsDescription}}
       {{/if}}
     </div>
-    {{#if (and this.filter (not this.searchResults.length) (not this.loading))}}
+    {{#if
+      (and
+        this.filter
+        (not this.searchResults.length)
+        (not this.showLoadingSpinner)
+      )
+    }}
       <p class="admin-search__no-results" aria-live="polite" role="status">
         {{this.noResultsDescription}}
       </p>
@@ -161,7 +177,7 @@ export default class AdminSearch extends Component {
     <div
       class="admin-search__results {{if this.searchResults '--has-results'}}"
     >
-      <ConditionalLoadingSpinner @condition={{this.loading}}>
+      <ConditionalLoadingSpinner @condition={{this.showLoadingSpinner}}>
         {{#each this.searchResults as |result|}}
           <div class="admin-search__result" data-result-type={{result.type}}>
             <a


### PR DESCRIPTION
### What is the problem?

When we construct the admin search component, we fire off a call to get data from the back-end. When this is done, there's an async callback that re-does the search. This can result in confusing flickering of the results.

This was compounded by a separate issue that caused the data endpoint to be extremely slow if we had two specific plugins installed at the same time. That issue has already been resolved.

### How does this fix it?

The first time we construct the component (and fetch the data) we initialize it with a flag to indicate that data is still loading. Until the data is loaded, we will show the regular loading spinner if the admin starts typing.

On Meta the endpoint takes ~600ms. That countdown starts when you click or use the shortcut, then you need to start typing as well, so this delay shouldn't be a big issue.