### PR TITLE
DEV: Move the catch-all route to the bottom

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1765,8 +1765,6 @@ Discourse::Application.routes.draw do
 
     post "/pageview" => "pageview#index"
 
-    get "*url", to: "permalinks#show", constraints: PermalinkConstraint.new
-
     get "/form-templates/:id" => "form_templates#show"
     get "/form-templates" => "form_templates#index"
 
@@ -1778,5 +1776,8 @@ Discourse::Application.routes.draw do
       get "/test_net_http_timeouts" => "test_requests#test_net_http_timeouts"
       get "/test_net_http_headers" => "test_requests#test_net_http_headers"
     end
+
+    # This catch-all route should always be last
+    get "*url", to: "permalinks#show", constraints: PermalinkConstraint.new
   end
 end


### PR DESCRIPTION
This avoids making unnecessary database queries when routing to paths that were positioned below this entry, e.g.

```
curl http://localhost:3000/form-templates

# SELECT 1 AS one FROM "permalinks" WHERE "permalinks"."url" = 'form-templates' LIMIT 1
# …
```