### PR TITLE
DEV: Remove precompile for locale js

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1446,7 +1446,6 @@ class Plugin::Instance
 
       if valid_locale?(opts)
         DiscoursePluginRegistry.register_locale(locale, opts)
-        Rails.configuration.assets.precompile << "locales/#{locale}.js"
       else
         msg = "Invalid locale! #{opts.inspect}"
         # The logger isn't always present during boot / parsing locales from plugins


### PR DESCRIPTION
The Rails asset pipeline isn't used for locale bundles any more. Plus, `assets.precompile` isn't used for anything since we switched to propshaft.