### PR TITLE
DEV: Remove accidental whitespace from PluginOutlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.gjs
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.gjs
@@ -160,16 +160,16 @@ export default class PluginOutletComponent extends Component {
 
       {{~#each (this.getConnectors hasBlock=(has-block)) as |c|~}}
         {{~#if c.componentClass~}}
-          {{#let
+          {{~#let
             (this.safeCurryComponent
               c.componentClass this.outletArgsWithDeprecations
             )
             as |CurriedComponent|
-          }}
+          ~}}
             <CurriedComponent
               @outletArgs={{this.outletArgsWithDeprecations}}
             >{{yield}}</CurriedComponent>
-          {{/let}}
+          {{~/let~}}
         {{~else if @defaultGlimmer~}}
           <c.templateOnly
             @outletArgs={{this.outletArgsWithDeprecations}}


### PR DESCRIPTION
A followup to 707a91243c35ea1693b80249e1c00fb5320f47cb