### PR TITLE
FIX: headerSearch not always appearing when welcomeBanner is removed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -27,7 +27,10 @@ export default class WelcomeBanner extends Component {
 
     observer.observe(element);
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      this.search.welcomeBannerSearchInViewport = false;
+    };
   });
 
   handleKeyboardShortcut = modifier(() => {


### PR DESCRIPTION
To reproduce...

Site settings must be enabled:  
`Enable welcome banner`
`Search experience` = `Search field in site header` 

1. Visit /categories, refresh, do not scroll
2. Click a category 
3. Observe no search banner or header search

![image](https://github.com/user-attachments/assets/3e9da6cd-aa8b-4141-8e98-5419e54ef685)

The fix resets `welcomeBannerSearchInViewport` when the search banner component is destroyed. 

![image](https://github.com/user-attachments/assets/63d799e7-4b1b-4e55-bb1b-cc2555a12a50)


