### PR TITLE
DEV: Add test for plugin-outlet whitespace

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -1134,3 +1134,53 @@ module(
     });
   }
 );
+
+module(
+  "Integration | Component | plugin-outlet | whitespace",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("no whitespace for unused outlet", async function (assert) {
+      await render(
+        <template>
+          <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
+        </template>
+      );
+      assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
+    });
+
+    test("no whitespace for used outlet", async function (assert) {
+      extraConnectorComponent("test-name", <template></template>);
+
+      await render(
+        <template>
+          <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
+        </template>
+      );
+      assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
+    });
+
+    test("no whitespace for unused wrapper outlet", async function (assert) {
+      await render(
+        <template>
+          <div class="test-wrapper"><PluginOutlet
+              @name="test-name"
+            >foo</PluginOutlet></div>
+        </template>
+      );
+      assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
+    });
+
+    test("no whitespace for used wrapper outlet", async function (assert) {
+      extraConnectorComponent("test-name", <template>{{yield}}</template>);
+      await render(
+        <template>
+          <div class="test-wrapper"><PluginOutlet
+              @name="test-name"
+            >foo</PluginOutlet></div>
+        </template>
+      );
+      assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -1172,7 +1172,10 @@ module(
     });
 
     test("no whitespace for used wrapper outlet", async function (assert) {
-      extraConnectorComponent("test-name", <template>{{yield}}</template>);
+      extraConnectorComponent(
+        "test-name",
+        <template>{{! template-lint-disable no-yield-only }}{{yield}}</template>
+      );
       await render(
         <template>
           <div class="test-wrapper"><PluginOutlet


### PR DESCRIPTION
Fixes for recent regressions:
- da6b82f7767cbeb038dfbebda92a4474626ff1e8
- 2a18834db1cb6b9c8f071eeab8554257336b2802

These tests should stop it happening for a third time 😅 