### PR TITLE
DEV: Whitelist `symbol` SVG element

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -24,6 +24,7 @@ class UploadCreator
     stop
     style
     svg
+    symbol
     text
     textPath
     tref


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/svg-animates-arent-rendered-properly/366679/3

This PR whitelists the [`symbol`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/symbol) SVG element, allowing uploaded images that use those elements to be animated properly.
