### PR TITLE
UX: Close admin search modal immediately when result is selected

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/admin-search.gjs
@@ -5,6 +5,17 @@ import AdminSearch from "admin/components/admin-search";
 
 export default class AdminSearchModal extends Component {
   @service currentUser;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    this.router.on("routeWillChange", this.args.closeModal);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.router.off("routeWillChange", this.args.closeModal);
+  }
 
   <template>
     <DModal


### PR DESCRIPTION
Previously it was relying on the default Modal behavior, which is to close **after** the next route transition.