### PR TITLE
DEV: removes unnecessary lines

### DIFF
--- a/plugins/automation/admin/assets/javascripts/discourse/templates/admin-plugins/show/automation/edit.gjs
+++ b/plugins/automation/admin/assets/javascripts/discourse/templates/admin-plugins/show/automation/edit.gjs
@@ -195,13 +195,6 @@ export default RouteTemplate(
                   <Input
                     @type="checkbox"
                     @checked={{@controller.automationForm.enabled}}
-                    {{on
-                      "click"
-                      (withEventValue
-                        (fn (mut @controller.automationForm.enabled))
-                        "target.checked"
-                      )
-                    }}
                   />
                 </div>
               {{/if}}

--- a/plugins/automation/admin/assets/javascripts/discourse/templates/admin-plugins/show/automation/edit.gjs
+++ b/plugins/automation/admin/assets/javascripts/discourse/templates/admin-plugins/show/automation/edit.gjs
@@ -1,6 +1,5 @@
 import { Input } from "@ember/component";
 import { fn, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
 import { and } from "truth-helpers";
 import BackButton from "discourse/components/back-button";


### PR DESCRIPTION
Technically we want to follow DDAU but most of our usage in the code base are just mutating `@checked`. This will eventually get converted to form-kit but in the meantime we can just remove this bit of code as it's doing two times the same thing and you could even end up in the situation where they both fight for what is the correct value.