### PR TITLE
DEV: Resolve flaky ThemeField spec

### DIFF
--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -168,7 +168,7 @@ HTML
       }
     SCSS
     theme.save!
-    expect(field.reload.error).to include("CssSyntaxError: Missed semicolon")
+    expect(field.reload.error).to include("Missed semicolon")
 
     theme.set_field(target: :common, name: :scss, value: "@import 'missingfile';")
     theme.save!


### PR DESCRIPTION
This error sometimes includes a filepath in the middle, which has a random tmp/ prefix. To workaround this, we can just assert for the "Missed semicolon" part