### PR TITLE
DEV: Remove Top route title for crawlers

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -340,10 +340,6 @@ class ListController < ApplicationController
       @params = { period: period }
       @rss_description = "top_#{period}"
 
-      if use_crawler_layout?
-        @title = I18n.t("js.filters.top.#{period}.title") + " - #{SiteSetting.title}"
-      end
-
       respond_with_list(list)
     end
 


### PR DESCRIPTION
These lines of code would output "Period - Site name" as the page title for the crawlier view only for Top routes. This is too specific and unnecessary, since the top route isn't highly prioritized for crawlers. Without this, the page title defaults to "Site name" for these routes. 

One major advantage of this change is that when the homepage is set to the Top route, the page title for crawlers on the homepage is now "Site name", which is a lot better. 