### PR TITLE
UX: improve mobile date picker slightly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/date-input.gjs
+++ b/app/assets/javascripts/discourse/app/components/date-input.gjs
@@ -166,8 +166,22 @@ export default class DateInput extends Component {
     return null;
   }
 
+  _toggleHasValueClass(value) {
+    const input = this.element.querySelector(".date-picker");
+    if (!input) {
+      return;
+    }
+
+    if (value) {
+      input.classList.add("--has-value");
+    } else {
+      input.classList.remove("--has-value");
+    }
+  }
+
   @action
   onChangeDate(event) {
+    this._toggleHasValueClass(event.target.value);
     this._handleSelection(event.target.value);
   }
 

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
@@ -947,7 +947,7 @@ export default class SearchAdvancedOptions extends Component {
           <label class="control-label">{{i18n
               "search.advanced.post.time.label"
             }}</label>
-          <div class="controls inline-form full-width">
+          <div class="controls inline-form">
             <ComboBox
               @id="postTime"
               @valueProperty="value"

--- a/app/assets/stylesheets/common/components/date-input.scss
+++ b/app/assets/stylesheets/common/components/date-input.scss
@@ -25,7 +25,7 @@ $calendar-icon: '<svg xmlns="http://www.w3.org/2000/svg" width="14px" height="16
     }
 
     // iOS doesn't display the placeholder attribute for date inputs
-    html.ios-device &::after {
+    html.ios-device &:not(.--has-value)::after {
       font-size: var(--font-0);
       color: var(--primary-medium);
       content: attr(placeholder);


### PR DESCRIPTION
As seen in the advanced search filters... iOS doesn't show placeholders for the date input, so we have a CSS adjustment for this, but it doesn't clear when a value is present. 

This update adds a class when a value is present so the placeholder can be cleared. 

Before:
![image](https://github.com/user-attachments/assets/37edad10-886b-41d7-b412-b303be351603)


After:
![image](https://github.com/user-attachments/assets/fee713ab-09f9-49fb-9fda-96bd72a260e1)


Also fixed extra left margin by removing a class. 