### PR TITLE
PERF: Introduce lazyHash and update PluginOutlet calls to use it

### DIFF
--- a/.template-lintrc.cjs
+++ b/.template-lintrc.cjs
@@ -8,6 +8,5 @@ module.exports = {
     "require-button-type": false,
     "no-action": true,
     "require-strict-mode": true,
-    "discourse/plugin-outlet-lazy-hash": false,
   },
 };

--- a/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
@@ -8,6 +8,7 @@ import Form from "discourse/components/form";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import iconOrImage from "discourse/helpers/icon-or-image";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -555,7 +556,7 @@ export default class AdminBadgesShow extends Component {
 
         <PluginOutlet
           @name="admin-above-badge-buttons"
-          @outletArgs={{hash badge=this.buffered form=form}}
+          @outletArgs={{lazyHash badge=this.buffered form=form}}
         />
 
         <form.Actions>

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { eq } from "truth-helpers";

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
@@ -9,6 +9,7 @@ import ConditionalLoadingSection from "discourse/components/conditional-loading-
 import Form from "discourse/components/form";
 import GroupSelector from "discourse/components/group-selector";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import WebhookEventChooser from "admin/components/webhook-event-chooser";
@@ -260,7 +261,7 @@ export default class AdminConfigAreasWebhookForm extends Component {
                 <PluginOutlet
                   @name="web-hook-fields"
                   @connectorTagName="div"
-                  @outletArgs={{hash model=this.webhook}}
+                  @outletArgs={{lazyHash model=this.webhook}}
                 />
 
                 <form.Field

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
@@ -82,7 +83,7 @@ export default class AdminPluginsListItem extends Component {
           <PluginOutlet
             @name="admin-plugin-list-name-badge-after"
             @connectorTagName="span"
-            @outletArgs={{hash plugin=@plugin}}
+            @outletArgs={{lazyHash plugin=@plugin}}
           />
         </div>
         <div class="d-admin-row__overview-author admin-plugins-list__author">
@@ -109,7 +110,7 @@ export default class AdminPluginsListItem extends Component {
         <div class="plugin-version">
           <PluginOutlet
             @name="admin-plugin-list-item-version"
-            @outletArgs={{hash plugin=@plugin}}
+            @outletArgs={{lazyHash plugin=@plugin}}
           >
             {{@plugin.version}}<br />
             <PluginCommitHash @plugin={{@plugin}} />
@@ -122,7 +123,7 @@ export default class AdminPluginsListItem extends Component {
         </div>
         <PluginOutlet
           @name="admin-plugin-list-item-enabled"
-          @outletArgs={{hash plugin=@plugin}}
+          @outletArgs={{lazyHash plugin=@plugin}}
         >
           {{#if @plugin.enabledSetting}}
             <DToggleSwitch
@@ -137,7 +138,7 @@ export default class AdminPluginsListItem extends Component {
       <td class="d-admin-row__controls admin-plugins-list__settings">
         <PluginOutlet
           @name="admin-plugin-list-item-settings"
-          @outletArgs={{hash plugin=@plugin}}
+          @outletArgs={{lazyHash plugin=@plugin}}
         >
           {{#if this.showPluginSettingsButton}}
             {{#if @plugin.useNewShowRoute}}

--- a/app/assets/javascripts/admin/addon/components/admin-user-fields-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-fields-form.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { schedule } from "@ember/runloop";

--- a/app/assets/javascripts/admin/addon/components/admin-user-fields-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-fields-form.gjs
@@ -8,6 +8,7 @@ import { service } from "@ember/service";
 import { eq, or } from "truth-helpers";
 import Form from "discourse/components/form";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 import ValueList from "admin/components/value-list";
@@ -250,7 +251,7 @@ export default class AdminUserFieldsForm extends Component {
 
       <PluginOutlet
         @name="after-admin-user-fields"
-        @outletArgs={{hash userField=@userField form=form}}
+        @outletArgs={{lazyHash userField=@userField form=form}}
       />
 
       <form.Actions>

--- a/app/assets/javascripts/admin/addon/components/themes-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-list-item.gjs
@@ -8,6 +8,7 @@ import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import escape from "discourse/lib/escape";
 import { iconHTML } from "discourse/lib/icon-library";
 import { i18n } from "discourse-i18n";
@@ -88,7 +89,7 @@ export default class ThemesListItem extends Component {
           <PluginOutlet
             @name="admin-customize-themes-list-item"
             @connectorTagName="span"
-            @outletArgs={{hash theme=@theme}}
+            @outletArgs={{lazyHash theme=@theme}}
           />
         </span>
 

--- a/app/assets/javascripts/admin/addon/components/themes-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-list-item.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/admin/addon/components/version-checks.gjs
+++ b/app/assets/javascripts/admin/addon/components/version-checks.gjs
@@ -4,6 +4,7 @@ import CustomHtml from "discourse/components/custom-html";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import dashIfEmpty from "discourse/helpers/dash-if-empty";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class VersionChecks extends Component {
@@ -150,7 +151,7 @@ export default class VersionChecks extends Component {
 
       <PluginOutlet
         @name="admin-upgrade-header"
-        @outletArgs={{hash versionCheck=this.versionCheck}}
+        @outletArgs={{lazyHash versionCheck=this.versionCheck}}
       />
     </div>
   </template>

--- a/app/assets/javascripts/admin/addon/components/version-checks.gjs
+++ b/app/assets/javascripts/admin/addon/components/version-checks.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import CustomHtml from "discourse/components/custom-html";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
@@ -12,6 +12,7 @@ import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import formatUsername from "discourse/helpers/format-username";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import InlineEditCheckbox from "admin/components/inline-edit-checkbox";
 import ThemeSettingEditor from "admin/components/theme-setting-editor";
@@ -55,7 +56,7 @@ export default RouteTemplate(
           <PluginOutlet
             @name="admin-customize-themes-show-top"
             @connectorTagName="div"
-            @outletArgs={{hash theme=@controller.model}}
+            @outletArgs={{lazyHash theme=@controller.model}}
           />
         </span>
 
@@ -84,7 +85,7 @@ export default RouteTemplate(
 
         <PluginOutlet
           @name="admin-customize-theme-before-errors"
-          @outletArgs={{hash theme=@controller.model}}
+          @outletArgs={{lazyHash theme=@controller.model}}
         />
 
         {{#each @controller.model.errors as |error|}}
@@ -564,7 +565,7 @@ export default RouteTemplate(
 
           <PluginOutlet
             @name="admin-customize-theme-before-controls"
-            @outletArgs={{hash theme=@controller.model}}
+            @outletArgs={{lazyHash theme=@controller.model}}
           />
           <div class="theme-controls">
             <a

--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.gjs
@@ -8,6 +8,7 @@ import basePath from "discourse/helpers/base-path";
 import formatDate from "discourse/helpers/format-date";
 import getUrl from "discourse/helpers/get-url";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import AdminReport from "admin/components/admin-report";
 import DashboardPeriodSelector from "admin/components/dashboard-period-selector";
@@ -223,7 +224,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="admin-dashboard-general-bottom"
         @connectorTagName="div"
-        @outletArgs={{hash filters=@controller.filters}}
+        @outletArgs={{lazyHash filters=@controller.filters}}
       />
     </ConditionalLoadingSpinner>
   </template>

--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSection from "discourse/components/conditional-loading-section";

--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import getUrl from "discourse/helpers/get-url";

--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.gjs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import getUrl from "discourse/helpers/get-url";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import AdminReport from "admin/components/admin-report";
 import DashboardPeriodSelector from "admin/components/dashboard-period-selector";
@@ -63,7 +64,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="admin-dashboard-moderation-bottom"
           @connectorTagName="div"
-          @outletArgs={{hash filters=@controller.lastWeekFilters}}
+          @outletArgs={{lazyHash filters=@controller.lastWeekFilters}}
         />
       </div>
     </div>

--- a/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import htmlSafe from "discourse/helpers/html-safe";

--- a/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import AdminConfigAreaCard from "admin/components/admin-config-area-card";
 import AdminConfigAreaEmptyList from "admin/components/admin-config-area-empty-list";
@@ -60,7 +61,7 @@ export default RouteTemplate(
 
     <PluginOutlet
       @name="after-embeddable-hosts-table"
-      @outletArgs={{hash embedding=@controller.embedding}}
+      @outletArgs={{lazyHash embedding=@controller.embedding}}
     />
   </template>
 );

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -5,6 +5,7 @@ import DPageHeader from "discourse/components/d-page-header";
 import NavItem from "discourse/components/nav-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import AdminPluginsList from "admin/components/admin-plugins-list";
 
@@ -64,7 +65,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="admin-below-plugins-index"
           @connectorTagName="div"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
       </span>
     </div>

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DPageHeader from "discourse/components/d-page-header";

--- a/app/assets/javascripts/admin/addon/templates/user-badges.gjs
+++ b/app/assets/javascripts/admin/addon/templates/user-badges.gjs
@@ -9,6 +9,7 @@ import UserBadge from "discourse/components/user-badge";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import avatar from "discourse/helpers/avatar";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -34,7 +35,7 @@ export default RouteTemplate(
         {{else}}
           <PluginOutlet
             @name="badge-granter-form"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               availableBadges=@controller.availableBadges
               userBadges=@controller.userBadges
               user=@controller.user
@@ -67,7 +68,7 @@ export default RouteTemplate(
 
         <PluginOutlet
           @name="badge-granter-table"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             groupedBadges=@controller.groupedBadges
             revokeBadge=@controller.revokeBadge
             expandGroup=@controller.expandGroup

--- a/app/assets/javascripts/admin/addon/templates/user-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.gjs
@@ -11,6 +11,7 @@ import formatDate from "discourse/helpers/format-date";
 import formatDuration from "discourse/helpers/format-duration";
 import htmlSafe from "discourse/helpers/html-safe";
 import i18nYesNo from "discourse/helpers/i18n-yes-no";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 import AdminEditableField from "admin/components/admin-editable-field";
@@ -56,7 +57,7 @@ export default RouteTemplate(
         {{/if}}
         <PluginOutlet
           @name="admin-user-controls-after"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
       </div>
 
@@ -80,7 +81,7 @@ export default RouteTemplate(
 
       <PluginOutlet
         @name="admin-user-below-names"
-        @outletArgs={{hash user=@controller.model}}
+        @outletArgs={{lazyHash user=@controller.model}}
       />
 
       {{#if @controller.canCheckEmails}}
@@ -319,7 +320,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="admin-user-details"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 
@@ -940,7 +941,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="after-user-details"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.gjs
@@ -1,4 +1,4 @@
-import { concat, fn, get, hash } from "@ember/helper";
+import { concat, fn, get } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.gjs
@@ -17,6 +17,7 @@ import icon from "discourse/helpers/d-icon";
 import formatDuration from "discourse/helpers/format-duration";
 import htmlSafe from "discourse/helpers/html-safe";
 import i18nYesNo from "discourse/helpers/i18n-yes-no";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 import rawDate from "discourse/helpers/raw-date";
 import { i18n } from "discourse-i18n";
@@ -195,7 +196,10 @@ export default RouteTemplate(
             {{/if}}
             <PluginOutlet
               @name="admin-users-list-thead-after"
-              @outletArgs={{hash order=@controller.order asc=@controller.asc}}
+              @outletArgs={{lazyHash
+                order=@controller.order
+                asc=@controller.asc
+              }}
             />
 
             {{#if @controller.siteSettings.must_approve_users}}
@@ -370,7 +374,7 @@ export default RouteTemplate(
 
                 <PluginOutlet
                   @name="admin-users-list-td-after"
-                  @outletArgs={{hash user=user query=@controller.query}}
+                  @outletArgs={{lazyHash user=user query=@controller.query}}
                 />
 
                 {{#if @controller.siteSettings.must_approve_users}}
@@ -415,7 +419,7 @@ export default RouteTemplate(
                   <PluginOutlet
                     @name="admin-users-list-icon"
                     @connectorTagName="div"
-                    @outletArgs={{hash user=user query=@controller.query}}
+                    @outletArgs={{lazyHash user=user query=@controller.query}}
                   />
                 </div>
               </div>

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -8,6 +8,7 @@ import AboutPageExtraGroups from "discourse/components/about-page-extra-groups";
 import AboutPageUsers from "discourse/components/about-page-users";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import escape from "discourse/lib/escape";
 import { number } from "discourse/lib/formatter";
 import I18n, { i18n } from "discourse-i18n";
@@ -259,7 +260,7 @@ export default class AboutPage extends Component {
       <PluginOutlet
         @name="about-after-description"
         @connectorTagName="section"
-        @outletArgs={{hash model=@model}}
+        @outletArgs={{lazyHash model=@model}}
       />
     </section>
     <div class="about__main-content">
@@ -289,7 +290,7 @@ export default class AboutPage extends Component {
         <PluginOutlet
           @name="about-after-admins"
           @connectorTagName="section"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
 
         {{#if @model.moderators.length}}
@@ -301,7 +302,7 @@ export default class AboutPage extends Component {
         <PluginOutlet
           @name="about-after-moderators"
           @connectorTagName="section"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
         {{#if this.showExtraGroups}}
           <AboutPageExtraGroups />

--- a/app/assets/javascripts/discourse/app/components/badge-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.gjs
@@ -7,6 +7,7 @@ import { eq, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import iconOrImage from "discourse/helpers/icon-or-image";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 import { emojiUnescape, sanitize } from "discourse/lib/text";
 import { i18n } from "discourse-i18n";
@@ -52,7 +53,7 @@ export default class BadgeCard extends Component {
       <div class="badge-contents">
         <PluginOutlet
           @name="badge-contents-top"
-          @outletArgs={{hash badge=@badge url=this.url}}
+          @outletArgs={{lazyHash badge=@badge url=this.url}}
         />
         <span
           class="badge-icon {{@badge.badgeTypeClassName}}"

--- a/app/assets/javascripts/discourse/app/components/badge-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { eq, not } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
@@ -23,6 +23,7 @@ import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
 import formatDate from "discourse/helpers/format-date";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicLink from "discourse/helpers/topic-link";
 import { ajax } from "discourse/lib/ajax";
 import { BookmarkFormData } from "discourse/lib/bookmark-form-data";
@@ -294,7 +295,7 @@ export default class BookmarkList extends Component {
                 <td class="main-link topic-list-data">
                   <PluginOutlet
                     @name="bookmark-list-before-link"
-                    @outletArgs={{hash bookmark=bookmark}}
+                    @outletArgs={{lazyHash bookmark=bookmark}}
                   />
 
                   <span class="link-top-line">

--- a/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";

--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.gjs
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.gjs
@@ -5,6 +5,7 @@ import { classNameBindings, tagName } from "@ember-decorators/component";
 //  A breadcrumb including category drop downs
 import PluginOutlet from "discourse/components/plugin-outlet";
 import categoryVariables from "discourse/helpers/category-variables";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
 import CategoryDrop from "select-kit/components/category-drop";
@@ -134,7 +135,7 @@ export default class BreadCrumbs extends Component {
     <PluginOutlet
       @name="bread-crumbs-left"
       @connectorTagName="li"
-      @outletArgs={{hash
+      @outletArgs={{lazyHash
         tagId=this.tag.id
         additionalTags=this.additionalTags
         noSubcategories=this.noSubcategories
@@ -196,7 +197,7 @@ export default class BreadCrumbs extends Component {
     <PluginOutlet
       @name="bread-crumbs-right"
       @connectorTagName="li"
-      @outletArgs={{hash
+      @outletArgs={{lazyHash
         tagId=this.tag.id
         additionalTags=this.additionalTags
         noSubcategories=this.noSubcategories

--- a/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { classNameBindings, tagName } from "@ember-decorators/component";

--- a/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.gjs
@@ -9,6 +9,7 @@ import CategoryTitleBefore from "discourse/components/category-title-before";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import categoryColorVariable from "discourse/helpers/category-color-variable";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 
 @tagName("section")
@@ -71,7 +72,7 @@ export default class CategoriesBoxesWithTopics extends Component {
 
           <PluginOutlet
             @name="category-box-below-each-category"
-            @outletArgs={{hash category=c}}
+            @outletArgs={{lazyHash category=c}}
           />
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { classNameBindings, tagName } from "@ember-decorators/component";

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -12,6 +12,7 @@ import categoryColorVariable from "discourse/helpers/category-color-variable";
 import categoryLink, {
   categoryBadgeHTML,
 } from "discourse/helpers/category-link";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 
 @tagName("section")
@@ -43,12 +44,12 @@ export default class CategoriesBoxes extends Component {
   <template>
     <PluginOutlet
       @name="categories-boxes-wrapper"
-      @outletArgs={{hash categories=this.categories}}
+      @outletArgs={{lazyHash categories=this.categories}}
     >
       {{#each this.categories as |c|}}
         <PluginOutlet
           @name="category-box-before-each-box"
-          @outletArgs={{hash category=c}}
+          @outletArgs={{lazyHash category=c}}
         />
 
         <div
@@ -144,21 +145,21 @@ export default class CategoriesBoxes extends Component {
 
             <PluginOutlet
               @name="category-box-below-each-category"
-              @outletArgs={{hash category=c}}
+              @outletArgs={{lazyHash category=c}}
             />
           </div>
         </div>
 
         <PluginOutlet
           @name="category-box-after-each-box"
-          @outletArgs={{hash category=c}}
+          @outletArgs={{lazyHash category=c}}
         />
       {{/each}}
     </PluginOutlet>
 
     <PluginOutlet
       @name="category-boxes-after-boxes"
-      @outletArgs={{hash category=this.c}}
+      @outletArgs={{lazyHash category=this.c}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/categories-only.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-only.gjs
@@ -6,6 +6,7 @@ import { tagName } from "@ember-decorators/component";
 import ParentCategoryRow from "discourse/components/parent-category-row";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 
@@ -63,7 +64,7 @@ export default class CategoriesOnly extends Component {
   <template>
     <PluginOutlet
       @name="categories-only-wrapper"
-      @outletArgs={{hash categories=this.categories}}
+      @outletArgs={{lazyHash categories=this.categories}}
     >
       {{#if this.categories}}
         {{#if this.filteredCategories}}
@@ -71,7 +72,7 @@ export default class CategoriesOnly extends Component {
             <div class="category-list {{if this.showTopics 'with-topics'}}">
               <PluginOutlet
                 @name="mobile-categories"
-                @outletArgs={{hash categories=this.filteredCategories}}
+                @outletArgs={{lazyHash categories=this.filteredCategories}}
               >
                 {{#each this.filteredCategories as |c|}}
                   <ParentCategoryRow
@@ -174,7 +175,10 @@ export default class CategoriesOnly extends Component {
     <PluginOutlet
       @name="below-categories-only"
       @connectorTagName="div"
-      @outletArgs={{hash categories=this.categories showTopics=this.showTopics}}
+      @outletArgs={{lazyHash
+        categories=this.categories
+        showTopics=this.showTopics
+      }}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/categories-only.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-only.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/app/assets/javascripts/discourse/app/components/category-name-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-name-fields.gjs
@@ -2,13 +2,14 @@ import Component from "@ember/component";
 import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TextField from "discourse/components/text-field";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class CategoryNameFields extends Component {
   <template>
     <PluginOutlet
       @name="category-name-fields-details"
-      @outletArgs={{hash category=this.category}}
+      @outletArgs={{lazyHash category=this.category}}
     >
       <section class="field category-name-fields">
         {{#unless this.category.isUncategorizedCategory}}

--- a/app/assets/javascripts/discourse/app/components/category-name-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-name-fields.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TextField from "discourse/components/text-field";
 import lazyHash from "discourse/helpers/lazy-hash";

--- a/app/assets/javascripts/discourse/app/components/category-title-before.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-before.gjs
@@ -1,10 +1,11 @@
 import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 const CategoryTitleBefore = <template>
   <PluginOutlet
     @name="category-title-before"
-    @outletArgs={{hash category=@category}}
+    @outletArgs={{lazyHash category=@category}}
   />
 </template>;
 

--- a/app/assets/javascripts/discourse/app/components/category-title-before.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-before.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 

--- a/app/assets/javascripts/discourse/app/components/composer-container.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.gjs
@@ -23,6 +23,7 @@ import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import htmlClass from "discourse/helpers/html-class";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { i18n } from "discourse-i18n";
 import CategoryChooser from "select-kit/components/category-chooser";
@@ -80,7 +81,7 @@ export default class ComposerContainer extends Component {
               <PluginOutlet
                 @name="composer-open"
                 @connectorTagName="div"
-                @outletArgs={{hash model=this.composer.model}}
+                @outletArgs={{lazyHash model=this.composer.model}}
               />
             </span>
 
@@ -94,7 +95,7 @@ export default class ComposerContainer extends Component {
 
                   <PluginOutlet
                     @name="composer-action-after"
-                    @outletArgs={{hash model=this.composer.model}}
+                    @outletArgs={{lazyHash model=this.composer.model}}
                   />
 
                   {{#if this.site.desktopView}}
@@ -128,7 +129,7 @@ export default class ComposerContainer extends Component {
 
               <PluginOutlet
                 @name="before-composer-controls"
-                @outletArgs={{hash model=this.composer.model}}
+                @outletArgs={{lazyHash model=this.composer.model}}
               />
 
               <ComposerToggles
@@ -145,7 +146,7 @@ export default class ComposerContainer extends Component {
               <div class="composer-fields">
                 <PluginOutlet
                   @name="before-composer-fields"
-                  @outletArgs={{hash model=this.composer.model}}
+                  @outletArgs={{lazyHash model=this.composer.model}}
                 />
                 {{#unless this.composer.model.viewFullscreen}}
                   {{#if this.composer.model.canEditTitle}}
@@ -196,7 +197,9 @@ export default class ComposerContainer extends Component {
                           />
                           <PluginOutlet
                             @name="after-composer-category-input"
-                            @outletArgs={{hash composer=this.composer.model}}
+                            @outletArgs={{lazyHash
+                              composer=this.composer.model
+                            }}
                           />
                           <PopupInputTip
                             @validation={{this.composer.categoryValidation}}
@@ -217,7 +220,9 @@ export default class ComposerContainer extends Component {
                           />
                           <PluginOutlet
                             @name="after-composer-tag-input"
-                            @outletArgs={{hash composer=this.composer.model}}
+                            @outletArgs={{lazyHash
+                              composer=this.composer.model
+                            }}
                           />
                           <PopupInputTip
                             @validation={{this.composer.tagValidation}}
@@ -227,7 +232,7 @@ export default class ComposerContainer extends Component {
 
                       <PluginOutlet
                         @name="after-title-and-category"
-                        @outletArgs={{hash
+                        @outletArgs={{lazyHash
                           model=this.composer.model
                           tagValidation=this.composer.tagValidation
                           canEditTags=this.composer.canEditTags
@@ -241,7 +246,7 @@ export default class ComposerContainer extends Component {
                     <PluginOutlet
                       @name="composer-fields"
                       @connectorTagName="div"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         model=this.composer.model
                         showPreview=this.composer.isPreviewVisible
                       }}
@@ -254,7 +259,7 @@ export default class ComposerContainer extends Component {
             <span>
               <PluginOutlet
                 @name="composer-after-composer-editor"
-                @outletArgs={{hash model=this.composer.model}}
+                @outletArgs={{lazyHash model=this.composer.model}}
               />
             </span>
 
@@ -263,7 +268,7 @@ export default class ComposerContainer extends Component {
                 <PluginOutlet
                   @name="composer-fields-below"
                   @connectorTagName="div"
-                  @outletArgs={{hash model=this.composer.model}}
+                  @outletArgs={{lazyHash model=this.composer.model}}
                 />
               </span>
 
@@ -304,7 +309,7 @@ export default class ComposerContainer extends Component {
                 <span>
                   <PluginOutlet
                     @name="composer-after-save-or-cancel"
-                    @outletArgs={{hash model=this.composer.model}}
+                    @outletArgs={{lazyHash model=this.composer.model}}
                   />
                 </span>
               </div>
@@ -313,7 +318,7 @@ export default class ComposerContainer extends Component {
                 <span>
                   <PluginOutlet
                     @name="composer-mobile-buttons-bottom"
-                    @outletArgs={{hash model=this.composer.model}}
+                    @outletArgs={{lazyHash model=this.composer.model}}
                   />
                 </span>
 

--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -16,6 +16,7 @@ import DEditorPreview from "discourse/components/d-editor-preview";
 import Wrapper from "discourse/components/form-template-field/wrapper";
 import PickFilesButton from "discourse/components/pick-files-button";
 import PostTranslationEditor from "discourse/components/post-translation-editor";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { tinyAvatar } from "discourse/lib/avatar-utils";
 import { setupComposerPosition } from "discourse/lib/composer/composer-position";
@@ -1054,7 +1055,10 @@ export default class ComposerEditor extends Component {
         @onPopupMenuAction={{this.composer.onPopupMenuAction}}
         @popupMenuOptions={{this.composer.popupMenuOptions}}
         @disabled={{this.composer.disableTextarea}}
-        @outletArgs={{hash composer=this.composer.model editorType="composer"}}
+        @outletArgs={{lazyHash
+          composer=this.composer.model
+          editorType="composer"
+        }}
         @topicId={{this.composer.model.topic.id}}
         @categoryId={{this.composer.model.category.id}}
         @replyingToUserId={{this.composer.replyingToUserId}}

--- a/app/assets/javascripts/discourse/app/components/composer-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-title.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import EmberObject from "@ember/object";
 import { alias, or } from "@ember/object/computed";
 import { next, schedule } from "@ember/runloop";

--- a/app/assets/javascripts/discourse/app/components/composer-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-title.gjs
@@ -10,6 +10,7 @@ import { lookupCache } from "pretty-text/oneboxer-cache";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PopupInputTip from "discourse/components/popup-input-tip";
 import TextField from "discourse/components/text-field";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed from "discourse/lib/decorators";
@@ -253,7 +254,7 @@ export default class ComposerTitle extends Component {
     <PluginOutlet
       @name="after-composer-title-input"
       @connectorTagName="div"
-      @outletArgs={{hash composer=this.composer}}
+      @outletArgs={{lazyHash composer=this.composer}}
     />
 
     <PopupInputTip @validation={{this.validation}} />

--- a/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.gjs
+++ b/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { eq } from "truth-helpers";
 import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";

--- a/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.gjs
+++ b/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.gjs
@@ -1,13 +1,14 @@
 import { hash } from "@ember/helper";
 import { eq } from "truth-helpers";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import PluginOutlet from "./plugin-outlet";
 
 const ConditionalLoadingSpinner = <template>
   <PluginOutlet
     @name="conditional-loading-spinner"
     @defaultGlimmer={{true}}
-    @outletArgs={{hash condition=@condition size=@size}}
+    @outletArgs={{lazyHash condition=@condition size=@size}}
   >
     <div
       class={{concatClass

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -16,6 +16,7 @@ import NavigationBar from "discourse/components/navigation-bar";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TagNotificationsTracking from "discourse/components/tag-notifications-tracking";
 import TopicDismissButtons from "discourse/components/topic-dismiss-buttons";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { setting } from "discourse/lib/computed";
 import discourseComputed from "discourse/lib/decorators";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
@@ -242,7 +243,7 @@ export default class DNavigation extends Component {
 
     <PluginOutlet
       @name="after-breadcrumbs"
-      @outletArgs={{hash
+      @outletArgs={{lazyHash
         categories=this.categories
         category=this.category
         tag=this.tag
@@ -319,7 +320,7 @@ export default class DNavigation extends Component {
 
       <PluginOutlet
         @name="before-create-topic-button"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           canCreateTopic=this.canCreateTopic
           createTopicDisabled=this.createTopicDisabled
           createTopicLabel=this.createTopicLabel
@@ -341,7 +342,7 @@ export default class DNavigation extends Component {
 
       <PluginOutlet
         @name="after-create-topic-button"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           canCreateTopic=this.canCreateTopic
           createTopicDisabled=this.createTopicDisabled
           createTopicLabel=this.createTopicLabel

--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import CategoriesAndLatestTopics from "discourse/components/categories-and-latest-topics";
 import CategoriesAndTopTopics from "discourse/components/categories-and-top-topics";

--- a/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/categories-display.gjs
@@ -11,6 +11,7 @@ import ConditionalLoadingSpinner from "discourse/components/conditional-loading-
 import LoadMore from "discourse/components/load-more";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import SubcategoriesWithFeaturedTopics from "discourse/components/subcategories-with-featured-topics";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { MAX_UNOPTIMIZED_CATEGORIES } from "discourse/lib/constants";
 
 const subcategoryComponents = {
@@ -95,7 +96,7 @@ export default class CategoriesDisplay extends Component {
     <PluginOutlet
       @name="above-discovery-categories"
       @connectorTagName="div"
-      @outletArgs={{hash categories=@categories topics=@topics}}
+      @outletArgs={{lazyHash categories=@categories topics=@topics}}
     />
     {{#if this.canLoadMore}}
       <LoadMore @action={{@loadMore}}>

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { and } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
@@ -10,6 +10,7 @@ import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
 import { resettableTracked } from "discourse/lib/tracked-tools";
@@ -75,7 +76,7 @@ export default class DiscoveryFilterNavigation extends Component {
           {{! EXPERIMENTAL OUTLET - don't use because it will be removed soon  }}
           <PluginOutlet
             @name="below-filter-input"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               updateQueryString=this.updateQueryString
               newQueryString=this.newQueryString
             }}

--- a/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import CategoryReadOnlyBanner from "discourse/components/category-read-only-banner";
 import DiscourseBanner from "discourse/components/discourse-banner";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 const Layout = <template>
   <div class="container">
@@ -17,7 +18,7 @@ const Layout = <template>
   <PluginOutlet
     @name="discovery-list-controls-above"
     @connectorTagName="div"
-    @outletArgs={{hash
+    @outletArgs={{lazyHash
       category=@model.category
       tag=@model.tag
       toggleTagInfo=@toggleTagInfo
@@ -28,7 +29,7 @@ const Layout = <template>
     <PluginOutlet
       @name="discovery-navigation-bar-above"
       @connectorTagName="div"
-      @outletArgs={{hash category=@model.category tag=@model.tag}}
+      @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
     />
     <div class="container">
       {{yield to="navigation"}}
@@ -38,7 +39,7 @@ const Layout = <template>
   <PluginOutlet
     @name="discovery-above"
     @connectorTagName="div"
-    @outletArgs={{hash category=@model.category tag=@model.tag}}
+    @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
   />
 
   <div class="container list-container">
@@ -48,7 +49,7 @@ const Layout = <template>
           {{yield to="header"}}
           <PluginOutlet
             @name="header-list-container-bottom"
-            @outletArgs={{hash category=@model.category tag=@model.tag}}
+            @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
           />
         </div>
       </div>
@@ -57,12 +58,12 @@ const Layout = <template>
       <div class="full-width">
         <PluginOutlet
           @name="before-list-area"
-          @outletArgs={{hash category=@model.category tag=@model.tag}}
+          @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
         />
         <div id="list-area">
           <PluginOutlet
             @name="discovery-list-area"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               category=@model.category
               tag=@model.tag
               model=@model
@@ -72,7 +73,7 @@ const Layout = <template>
             <PluginOutlet
               @name="discovery-list-container-top"
               @connectorTagName="span"
-              @outletArgs={{hash category=@model.category tag=@model.tag}}
+              @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
             />
             {{yield to="list"}}
           </PluginOutlet>
@@ -84,7 +85,7 @@ const Layout = <template>
   <PluginOutlet
     @name="discovery-below"
     @connectorTagName="div"
-    @outletArgs={{hash category=@model.category tag=@model.tag}}
+    @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
   />
 </template>;
 

--- a/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import CategoryReadOnlyBanner from "discourse/components/category-read-only-banner";
 import DiscourseBanner from "discourse/components/discourse-banner";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { array, hash } from "@ember/helper";
+import { array } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import AddCategoryTagClasses from "discourse/components/add-category-tag-classes";

--- a/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
@@ -11,6 +11,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
 import dirSpan from "discourse/helpers/dir-span";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { calculateFilterMode } from "discourse/lib/filter-mode";
 import { TRACKED_QUERY_PARAM_VALUE } from "discourse/lib/topic-list-tracked-filter";
 import DiscourseURL from "discourse/lib/url";
@@ -85,7 +86,7 @@ export default class DiscoveryNavigation extends Component {
     {{#if @category}}
       <PluginOutlet
         @name="above-category-heading"
-        @outletArgs={{hash category=@category tag=@tag}}
+        @outletArgs={{lazyHash category=@category tag=@tag}}
       />
 
       <section class="category-heading">
@@ -100,7 +101,7 @@ export default class DiscoveryNavigation extends Component {
           <PluginOutlet
             @name="category-heading"
             @connectorTagName="div"
-            @outletArgs={{hash category=@category tag=@tag}}
+            @outletArgs={{lazyHash category=@category tag=@tag}}
           />
         </span>
       </section>
@@ -145,7 +146,7 @@ export default class DiscoveryNavigation extends Component {
         <PluginOutlet
           @name="category-navigation"
           @connectorTagName="div"
-          @outletArgs={{hash category=@category tag=@tag}}
+          @outletArgs={{lazyHash category=@category tag=@tag}}
         />
       {{/if}}
 
@@ -153,7 +154,7 @@ export default class DiscoveryNavigation extends Component {
         <PluginOutlet
           @name="tag-navigation"
           @connectorTagName="div"
-          @outletArgs={{hash category=@category tag=@tag}}
+          @outletArgs={{lazyHash category=@category tag=@tag}}
         />
       {{/if}}
     </section>

--- a/app/assets/javascripts/discourse/app/components/discovery/topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/topics.gjs
@@ -19,6 +19,7 @@ import List from "discourse/components/topic-list/list";
 import basePath from "discourse/helpers/base-path";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
@@ -306,7 +307,7 @@ export default class DiscoveryTopics extends Component {
         <PluginOutlet
           @name="before-topic-list"
           @connectorTagName="div"
-          @outletArgs={{hash category=@category tag=@tag}}
+          @outletArgs={{lazyHash category=@category tag=@tag}}
         />
       </span>
 
@@ -342,7 +343,7 @@ export default class DiscoveryTopics extends Component {
         <PluginOutlet
           @name="after-topic-list"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             category=@category
             tag=@tag
             loadingMore=@model.loadingMore
@@ -357,7 +358,7 @@ export default class DiscoveryTopics extends Component {
       {{#if this.allLoaded}}
         <PluginOutlet
           @name="topic-list-bottom"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             category=@category
             tag=@tag
             allLoaded=this.allLoaded

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -8,6 +8,7 @@ import { eq } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import categoryBadge from "discourse/helpers/category-badge";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { CATEGORY_STYLE_TYPES } from "discourse/lib/constants";
 import getURL from "discourse/lib/get-url";
 import Category from "discourse/models/category";
@@ -158,7 +159,7 @@ export default class EditCategoryGeneral extends Component {
 
       <PluginOutlet
         @name="category-name-fields-details"
-        @outletArgs={{hash form=@form category=@category}}
+        @outletArgs={{lazyHash form=@form category=@category}}
       >
         {{#unless @category.isUncategorizedCategory}}
           <@form.Field

--- a/app/assets/javascripts/discourse/app/components/edit-category-security.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-security.gjs
@@ -4,6 +4,7 @@ import { not } from "@ember/object/computed";
 import CategoryPermissionRow from "discourse/components/category-permission-row";
 import { buildCategoryPanel } from "discourse/components/edit-category-panel";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import PermissionType from "discourse/models/permission-type";
 import { i18n } from "discourse-i18n";
@@ -129,7 +130,7 @@ export default class EditCategorySecurity extends buildCategoryPanel(
     <section>
       <PluginOutlet
         @name="category-custom-security"
-        @outletArgs={{hash category=this.category}}
+        @outletArgs={{lazyHash category=this.category}}
       />
     </section>
   </template>

--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.gjs
@@ -10,6 +10,7 @@ import TextField from "discourse/components/text-field";
 import icon from "discourse/helpers/d-icon";
 import getUrl from "discourse/helpers/get-url";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import { setting } from "discourse/lib/computed";
 import { SEARCH_PRIORITIES } from "discourse/lib/constants";
@@ -556,7 +557,7 @@ export default class EditCategorySettings extends buildCategoryPanel(
           <PluginOutlet
             @name="category-email-in"
             @connectorTagName="div"
-            @outletArgs={{hash category=this.category}}
+            @outletArgs={{lazyHash category=this.category}}
           />
         </span>
       {{/if}}
@@ -578,7 +579,7 @@ export default class EditCategorySettings extends buildCategoryPanel(
     <section>
       <PluginOutlet
         @name="category-custom-settings"
-        @outletArgs={{hash category=this.category}}
+        @outletArgs={{lazyHash category=this.category}}
       />
     </section>
   </template>

--- a/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
@@ -13,6 +13,7 @@ import DButton from "discourse/components/d-button";
 import FilterInput from "discourse/components/filter-input";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import noop from "discourse/helpers/noop";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import withEventValue from "discourse/helpers/with-event-value";
@@ -450,7 +451,7 @@ export default class EmojiPicker extends Component {
       <div class="emoji-picker__filter-container">
         <PluginOutlet
           @name="emoji-picker-filter-container"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             term=this.term
             focusFilter=this.focusFilter
             registerFilterInput=this.registerFilterInput

--- a/app/assets/javascripts/discourse/app/components/fast-edit.gjs
+++ b/app/assets/javascripts/discourse/app/components/fast-edit.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/components/fast-edit.gjs
+++ b/app/assets/javascripts/discourse/app/components/fast-edit.gjs
@@ -5,6 +5,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { translateModKey } from "discourse/lib/utilities";
@@ -93,7 +94,7 @@ export default class FastEdit extends Component {
         <PluginOutlet
           @name="fast-edit-footer-after"
           @defaultGlimmer={{true}}
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             initialValue=@initialValue
             newValue=@newValue
             updateValue=this.updateValueProperty

--- a/app/assets/javascripts/discourse/app/components/google-search.gjs
+++ b/app/assets/javascripts/discourse/app/components/google-search.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { alias } from "@ember/object/computed";
 import { classNameBindings, classNames } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
 import { i18n } from "discourse-i18n";
@@ -20,7 +21,7 @@ export default class GoogleSearch extends Component {
   <template>
     <PluginOutlet
       @name="google-search"
-      @outletArgs={{hash searchTerm=this.searchTerm siteUrl=this.siteUrl}}
+      @outletArgs={{lazyHash searchTerm=this.searchTerm siteUrl=this.siteUrl}}
       @defaultGlimmer={{true}}
     >
       <form action="//google.com/search" id="google-search" class="inline-form">

--- a/app/assets/javascripts/discourse/app/components/google-search.gjs
+++ b/app/assets/javascripts/discourse/app/components/google-search.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { alias } from "@ember/object/computed";
 import { classNameBindings, classNames } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/group-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-card.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import AvatarFlair from "discourse/components/avatar-flair";
 import GroupInfo from "discourse/components/group-info";

--- a/app/assets/javascripts/discourse/app/components/group-card.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-card.gjs
@@ -6,6 +6,7 @@ import GroupMembershipButton from "discourse/components/group-membership-button"
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
@@ -74,7 +75,7 @@ const GroupCard = <template>
           <PluginOutlet
             @name="group-index-box-after"
             @connectorTagName="div"
-            @outletArgs={{hash model=@group}}
+            @outletArgs={{lazyHash model=@group}}
           />
         </span>
       </div>

--- a/app/assets/javascripts/discourse/app/components/group-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-info.gjs
@@ -1,12 +1,13 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default class GroupInfo extends Component {
   <template>
     <PluginOutlet
       @name="group-info-details"
-      @outletArgs={{hash group=@group}}
+      @outletArgs={{lazyHash group=@group}}
       @defaultGlimmer={{true}}
     >
       <span class="group-info-details">

--- a/app/assets/javascripts/discourse/app/components/group-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-info.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 

--- a/app/assets/javascripts/discourse/app/components/group-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-navigation.gjs
@@ -5,6 +5,7 @@ import { service } from "@ember/service";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import GroupDropdown from "select-kit/components/group-dropdown";
 
@@ -48,7 +49,7 @@ export default class GroupNavigation extends Component {
       {{/each}}
       <PluginOutlet
         @name="group-reports-nav-item"
-        @outletArgs={{hash group=@group}}
+        @outletArgs={{lazyHash group=@group}}
         @connectorTagName="li"
       />
     </HorizontalOverflowNav>

--- a/app/assets/javascripts/discourse/app/components/group-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/group-navigation.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";

--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.gjs
@@ -3,6 +3,7 @@ import { fn, hash } from "@ember/helper";
 import { or } from "@ember/object/computed";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TextField from "discourse/components/text-field";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import { i18n } from "discourse-i18n";
@@ -221,7 +222,7 @@ export default class GroupsFormInteractionFields extends Component {
           <PluginOutlet
             @name="group-email-in"
             @connectorTagName="div"
-            @outletArgs={{hash model=this.model}}
+            @outletArgs={{lazyHash model=this.model}}
           />
         </span>
       </div>
@@ -246,7 +247,7 @@ export default class GroupsFormInteractionFields extends Component {
       <PluginOutlet
         @name="groups-interaction-custom-options"
         @connectorTagName="div"
-        @outletArgs={{hash model=this.model}}
+        @outletArgs={{lazyHash model=this.model}}
       />
     </span>
   </template>

--- a/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.gjs
@@ -6,6 +6,7 @@ import { not, readOnly } from "@ember/object/computed";
 import ExpandingTextArea from "discourse/components/expanding-text-area";
 import GroupFlairInputs from "discourse/components/group-flair-inputs";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import discourseComputed from "discourse/lib/decorators";
 import AssociatedGroup from "discourse/models/associated-group";
@@ -183,7 +184,7 @@ export default class GroupsFormMembershipFields extends Component {
         <PluginOutlet
           @name="groups-form-membership-below-automatic"
           @connectorTagName="div"
-          @outletArgs={{hash model=this.model}}
+          @outletArgs={{lazyHash model=this.model}}
         />
       </span>
 

--- a/app/assets/javascripts/discourse/app/components/groups-form-profile-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-profile-fields.gjs
@@ -9,6 +9,7 @@ import GroupFlairInputs from "discourse/components/group-flair-inputs";
 import InputTip from "discourse/components/input-tip";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TextField from "discourse/components/text-field";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed from "discourse/lib/decorators";
@@ -169,7 +170,7 @@ export default class GroupsFormProfileFields extends Component {
         <PluginOutlet
           @name="group-edit"
           @connectorTagName="div"
-          @outletArgs={{hash group=this.model}}
+          @outletArgs={{lazyHash group=this.model}}
         />
       </span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/groups-form-profile-fields.gjs
+++ b/app/assets/javascripts/discourse/app/components/groups-form-profile-fields.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import EmberObject from "@ember/object";
 import { not } from "@ember/object/computed";
 import { isEmpty } from "@ember/utils";

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import { and, eq, not, or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import DAG from "discourse/lib/dag";
 import scrollLock from "discourse/lib/scroll-lock";
 import { scrollTop } from "discourse/lib/scroll-top";
@@ -324,7 +325,7 @@ export default class GlimmerHeader extends Component {
       </div>
       <PluginOutlet
         @name="after-header"
-        @outletArgs={{hash minimized=@topicInfoVisible}}
+        @outletArgs={{lazyHash minimized=@topicInfoVisible}}
       />
     </header>
   </template>

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { and } from "truth-helpers";
 import deprecatedOutletArgument from "discourse/helpers/deprecated-outlet-argument";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import BootstrapModeNotice from "../bootstrap-mode-notice";
 import PluginOutlet from "../plugin-outlet";
@@ -65,7 +66,7 @@ export default class Contents extends Component {
     <div class="contents">
       <PluginOutlet
         @name="header-contents__before"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           topicInfo=@topicInfo
           topicInfoVisible=@topicInfoVisible
         }}
@@ -117,7 +118,7 @@ export default class Contents extends Component {
       <div class="before-header-panel-outlet">
         <PluginOutlet
           @name="before-header-panel"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             topicInfo=@topicInfo
             topicInfoVisible=@topicInfoVisible
           }}
@@ -137,7 +138,7 @@ export default class Contents extends Component {
       <div class="after-header-panel-outlet">
         <PluginOutlet
           @name="after-header-panel"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             topicInfo=@topicInfo
             topicInfoVisible=@topicInfoVisible
           }}
@@ -155,7 +156,7 @@ export default class Contents extends Component {
       </div>
       <PluginOutlet
         @name="header-contents__after"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           topicInfo=@topicInfo
           topicInfoVisible=@topicInfoVisible
         }}

--- a/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/home-logo.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import getURL from "discourse/lib/get-url";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { applyValueTransformer } from "discourse/lib/transformer";
@@ -89,12 +90,15 @@ export default class HomeLogo extends Component {
   }
 
   <template>
-    <PluginOutlet @name="home-logo" @outletArgs={{hash minimized=@minimized}}>
+    <PluginOutlet
+      @name="home-logo"
+      @outletArgs={{lazyHash minimized=@minimized}}
+    >
       <div class={{concatClass (if @minimized "title--minimized") "title"}}>
         <a href={{this.href}} {{on "click" this.click}}>
           <PluginOutlet
             @name="home-logo-contents"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               logoSmallUrl=this.logoSmallUrl
               logoSmallUrlDark=this.logoSmallUrlDark
               logoUrl=this.logoUrl

--- a/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/info.gjs
@@ -9,6 +9,7 @@ import TopicStatus from "discourse/components/topic-status";
 import categoryLink from "discourse/helpers/category-link";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import renderTags from "discourse/lib/render-tags";
 import DiscourseURL from "discourse/lib/url";
@@ -89,7 +90,7 @@ export default class Info extends Component {
     >
       <PluginOutlet
         @name="header-topic-info__before"
-        @outletArgs={{hash topic=@topicInfo}}
+        @outletArgs={{lazyHash topic=@topicInfo}}
       />
       <div class={{concatClass (if this.twoRows "two-rows") "extra-info"}}>
         <div class="title-wrapper">
@@ -123,7 +124,7 @@ export default class Info extends Component {
               <span class="header-topic-title-suffix">
                 <PluginOutlet
                   @name="header-topic-title-suffix"
-                  @outletArgs={{hash topic=@topicInfo}}
+                  @outletArgs={{lazyHash topic=@topicInfo}}
                 />
               </span>
             {{/if}}
@@ -142,7 +143,7 @@ export default class Info extends Component {
               <div class="categories-wrapper">
                 <PluginOutlet
                   @name="header-categories-wrapper"
-                  @outletArgs={{hash category=@topicInfo.category}}
+                  @outletArgs={{lazyHash category=@topicInfo.category}}
                 >
                   {{#if @topicInfo.category.parentCategory}}
                     {{#if
@@ -201,7 +202,7 @@ export default class Info extends Component {
       </div>
       <PluginOutlet
         @name="header-topic-info__after"
-        @outletArgs={{hash topic=@topicInfo}}
+        @outletArgs={{lazyHash topic=@topicInfo}}
       />
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/components/modal/flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/modal/flag.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/flag.gjs
@@ -12,6 +12,7 @@ import FlagActionType from "discourse/components/flag-action-type";
 import FlagSelection from "discourse/components/flag-selection";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ReviewableBundledAction from "discourse/components/reviewable-bundled-action";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { reload } from "discourse/helpers/page-reloader";
 import { MAX_MESSAGE_LENGTH } from "discourse/models/post-action-type";
 import User from "discourse/models/user";
@@ -237,7 +238,7 @@ export default class Flag extends Component {
         <PluginOutlet
           @name="after-flag-modal-review-process-description"
           @connectorTagName="div"
-          @outletArgs={{hash post=@model.flagModel}}
+          @outletArgs={{lazyHash post=@model.flagModel}}
         />
         <form>
           <FlagSelection
@@ -260,7 +261,7 @@ export default class Flag extends Component {
         <PluginOutlet
           @name="flag-modal-bottom"
           @connectorTagName="div"
-          @outletArgs={{hash post=@model.flagModel}}
+          @outletArgs={{lazyHash post=@model.flagModel}}
         />
       </:body>
       <:footer>

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revision.gjs
@@ -10,6 +10,7 @@ import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import boundAvatarTemplate from "discourse/helpers/bound-avatar-template";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class Revision extends Component {
@@ -34,7 +35,7 @@ export default class Revision extends Component {
         </LinkTo>
         <PluginOutlet
           @name="revision-user-details-after"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
 
         <span class="date">

--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import EmberObject from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";

--- a/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/history/revisions.gjs
@@ -10,6 +10,7 @@ import Avatar from "discourse/helpers/bound-avatar-template";
 import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 function tagClasses(tagChanges, state, className) {
   return (tagChanges || []).reduce((classMap, tagChange) => {
@@ -131,7 +132,7 @@ export default class Revisions extends Component {
         <PluginOutlet
           @name="post-revisions"
           @connectorTagName="div"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
       </span>
 

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
@@ -13,6 +13,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import RadioButton from "discourse/components/radio-button";
 import TextField from "discourse/components/text-field";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import DiscourseURL from "discourse/lib/url";
 import { mergeTopic, movePosts } from "discourse/models/topic";
@@ -395,7 +396,7 @@ export default class MoveToTopic extends Component {
                   />
                   <PluginOutlet
                     @name="split-new-topic-title-after"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       selectedPosts=@model.selectedPosts
                       updateTopicName=this.updateTopicName
                     }}
@@ -411,7 +412,7 @@ export default class MoveToTopic extends Component {
                   />
                   <PluginOutlet
                     @name="split-new-topic-category-after"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       selectedPosts=@model.selectedPosts
                       updateCategoryId=this.updateCategoryId
                     }}
@@ -427,7 +428,7 @@ export default class MoveToTopic extends Component {
                     />
                     <PluginOutlet
                       @name="split-new-topic-tag-after"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         selectedPosts=@model.selectedPosts
                         updateTags=this.updateTags
                         tags=this.tags

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
@@ -1,5 +1,4 @@
 import Component, { Input } from "@ember/component";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { readOnly } from "@ember/object/computed";
 import { getOwner } from "@ember/owner";

--- a/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/share-topic.gjs
@@ -10,6 +10,7 @@ import DModal from "discourse/components/d-modal";
 import CreateInvite from "discourse/components/modal/create-invite";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ShareSource from "discourse/components/share-source";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed, { afterRender } from "discourse/lib/decorators";
 import { longDateNoYear } from "discourse/lib/formatter";
 import { getAbsoluteURL } from "discourse/lib/get-url";
@@ -191,7 +192,7 @@ export default class ShareTopicModal extends Component {
             {{/if}}
             <PluginOutlet
               @name="share-topic-sources"
-              @outletArgs={{hash topic=this.topic post=this.post}}
+              @outletArgs={{lazyHash topic=this.topic post=this.post}}
             />
           </div>
         </div>

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.gjs
@@ -7,6 +7,7 @@ import DropdownMenu from "discourse/components/dropdown-menu";
 import NavigationItem from "discourse/components/navigation-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import DMenu from "float-kit/components/d-menu";
@@ -78,7 +79,7 @@ export default class NavigationBarComponent extends Component {
                   <PluginOutlet
                     @name="extra-nav-item"
                     @connectorTagName="span"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       category=@category
                       tag=@tag
                       filterMode=@filterMode
@@ -93,7 +94,7 @@ export default class NavigationBarComponent extends Component {
           <PluginOutlet
             @name="inline-extra-nav-item"
             @connectorTagName="span"
-            @outletArgs={{hash category=@category filterMode=@filterMode}}
+            @outletArgs={{lazyHash category=@category filterMode=@filterMode}}
           />
         </li>
       {{else}}
@@ -108,7 +109,7 @@ export default class NavigationBarComponent extends Component {
         <PluginOutlet
           @name="extra-nav-item"
           @connectorTagName="li"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             category=@category
             tag=@tag
             filterMode=@filterMode

--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -7,6 +7,7 @@ import DropdownMenu from "discourse/components/dropdown-menu";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { allLevels, buttonDetails } from "discourse/lib/notification-levels";
 import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
@@ -145,7 +146,7 @@ export default class NotificationsTracking extends Component {
                 <div class="notifications-tracking-btn__icons">
                   <PluginOutlet
                     @name="notifications-tracking-icons"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       selectedLevelId=@levelId
                       level=level
                       topic=@topic

--- a/app/assets/javascripts/discourse/app/components/parent-category-row.gjs
+++ b/app/assets/javascripts/discourse/app/components/parent-category-row.gjs
@@ -13,6 +13,7 @@ import FeaturedTopic from "discourse/components/topic-list/featured-topic";
 import borderColor from "discourse/helpers/border-color";
 import categoryColorVariable from "discourse/helpers/category-color-variable";
 import dirSpan from "discourse/helpers/dir-span";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class ParentCategoryRow extends CategoryListItem {
@@ -20,13 +21,13 @@ export default class ParentCategoryRow extends CategoryListItem {
     {{#unless this.isHidden}}
       <PluginOutlet
         @name="category-list-above-each-category"
-        @outletArgs={{hash category=this.category}}
+        @outletArgs={{lazyHash category=this.category}}
       />
 
       {{#if this.site.mobileView}}
         <PluginOutlet
           @name="category-list-before-category-mobile"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             category=this.category
             listType=this.listType
             isMuted=this.isMuted
@@ -46,7 +47,7 @@ export default class ParentCategoryRow extends CategoryListItem {
                 </th>
                 <PluginOutlet
                   @name="category-list-after-title-mobile-section"
-                  @outletArgs={{hash category=this.category}}
+                  @outletArgs={{lazyHash category=this.category}}
                 />
               </tr>
               {{#if this.category.description_excerpt}}
@@ -121,7 +122,10 @@ export default class ParentCategoryRow extends CategoryListItem {
 
           <PluginOutlet
             @name="category-list-before-category-section"
-            @outletArgs={{hash category=this.category listType=this.listType}}
+            @outletArgs={{lazyHash
+              category=this.category
+              listType=this.listType
+            }}
           />
 
           <td
@@ -132,7 +136,7 @@ export default class ParentCategoryRow extends CategoryListItem {
             <PluginOutlet
               @name="below-category-title-link"
               @connectorTagName="div"
-              @outletArgs={{hash category=this.category}}
+              @outletArgs={{lazyHash category=this.category}}
             />
 
             {{#if this.category.description_excerpt}}
@@ -185,12 +189,12 @@ export default class ParentCategoryRow extends CategoryListItem {
 
           <PluginOutlet
             @name="category-list-before-topics-section"
-            @outletArgs={{hash category=this.category}}
+            @outletArgs={{lazyHash category=this.category}}
           />
 
           <PluginOutlet
             @name="category-list-topics-wrapper"
-            @outletArgs={{hash category=this.category}}
+            @outletArgs={{lazyHash category=this.category}}
           >
             <td class="topics">
               <div title={{this.category.statTitle}}>{{htmlSafe
@@ -208,12 +212,12 @@ export default class ParentCategoryRow extends CategoryListItem {
 
           <PluginOutlet
             @name="category-list-after-topics-section"
-            @outletArgs={{hash category=this.category}}
+            @outletArgs={{lazyHash category=this.category}}
           />
 
           <PluginOutlet
             @name="category-list-latest-wrapper"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               category=this.category
               showTopics=this.showTopics
             }}
@@ -227,7 +231,7 @@ export default class ParentCategoryRow extends CategoryListItem {
                 </td>
                 <PluginOutlet
                   @name="category-list-after-latest-section"
-                  @outletArgs={{hash category=this.category}}
+                  @outletArgs={{lazyHash category=this.category}}
                 />
               {{/if}}
             {{/unless}}

--- a/app/assets/javascripts/discourse/app/components/plugin-connector.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-connector.js
@@ -27,7 +27,7 @@ export default class PluginConnector extends Component {
         defineProperty(
           this,
           key,
-          computed("args", function () {
+          computed(`args.${key}`, function () {
             return this.args[key];
           })
         );

--- a/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-list/item/details.gjs
@@ -8,6 +8,7 @@ import avatar from "discourse/helpers/avatar";
 import categoryLink from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import getURL from "discourse/lib/get-url";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { i18n } from "discourse-i18n";
@@ -115,7 +116,7 @@ export default class PostListItemDetails extends Component {
 
           <PluginOutlet
             @name="post-list-additional-member-info"
-            @outletArgs={{hash user=@user post=@post}}
+            @outletArgs={{lazyHash user=@user post=@post}}
           />
 
           {{!
@@ -124,7 +125,7 @@ export default class PostListItemDetails extends Component {
           }}
           <PluginOutlet
             @name="group-post-additional-member-info"
-            @outletArgs={{hash user=@user}}
+            @outletArgs={{lazyHash user=@user}}
           />
         </div>
       {{/if}}

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -10,6 +10,7 @@ import FastEdit from "discourse/components/fast-edit";
 import FastEditModal from "discourse/components/modal/fast-edit";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { getAbsoluteURL } from "discourse/lib/get-url";
 import Sharing from "discourse/lib/sharing";
@@ -211,7 +212,7 @@ export default class PostTextSelectionToolbar extends Component {
         <PluginOutlet
           @name="post-text-buttons"
           @defaultGlimmer={{true}}
-          @outletArgs={{hash data=@data post=this.post}}
+          @outletArgs={{lazyHash data=@data post=this.post}}
         >
           {{#if this.embedQuoteButton}}
             <DButton
@@ -246,7 +247,7 @@ export default class PostTextSelectionToolbar extends Component {
           <PluginOutlet
             @name="quote-share-buttons-before"
             @connectorTagName="span"
-            @outletArgs={{hash data=@data}}
+            @outletArgs={{lazyHash data=@data}}
           />
 
           {{#if this.quoteSharingEnabled}}
@@ -272,7 +273,7 @@ export default class PostTextSelectionToolbar extends Component {
                 <PluginOutlet
                   @name="quote-share-buttons-after"
                   @connectorTagName="span"
-                  @outletArgs={{hash data=@data}}
+                  @outletArgs={{lazyHash data=@data}}
                 />
               </span>
             </span>

--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/post-translation-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-translation-editor.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DEditor from "discourse/components/d-editor";
 import TextField from "discourse/components/text-field";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import DropdownSelectBox from "select-kit/components/dropdown-select-box";
 
@@ -85,7 +86,10 @@ export default class PostTranslationEditor extends Component {
         @disableSubmit={{this.composer.disableSubmit}}
         @topicId={{this.composer.model.topic.id}}
         @categoryId={{this.composer.model.category.id}}
-        @outletArgs={{hash composer=this.composer.model editorType="composer"}}
+        @outletArgs={{lazyHash
+          composer=this.composer.model
+          editorType="composer"
+        }}
       />
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/components/post/avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/avatar.gjs
@@ -4,6 +4,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAvatar from "discourse/components/user-avatar";
 import UserAvatarFlair from "discourse/components/user-avatar-flair";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default class PostAvatar extends Component {
   get size() {
@@ -27,7 +28,7 @@ export default class PostAvatar extends Component {
     <div class="topic-avatar">
       <PluginOutlet
         @name="post-avatar"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           post=@post
           size=this.size
           user=this.user

--- a/app/assets/javascripts/discourse/app/components/post/avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/avatar.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAvatar from "discourse/components/user-avatar";
 import UserAvatarFlair from "discourse/components/user-avatar-flair";

--- a/app/assets/javascripts/discourse/app/components/post/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu.gjs
@@ -14,6 +14,7 @@ import SmallUserList, {
 } from "discourse/components/small-user-list";
 import UserTip from "discourse/components/user-tip";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import DAG from "discourse/lib/dag";
 import {
   applyBehaviorTransformer,
@@ -612,7 +613,7 @@ export default class PostMenu extends Component {
     {{! <section class="post-menu-area clearfix"> }}
     <PluginOutlet
       @name="post-menu"
-      @outletArgs={{hash post=@post state=this.state}}
+      @outletArgs={{lazyHash post=@post state=this.state}}
     >
       <nav
         {{! this.collapsed is included in the check below because "Show More" button can be overriden to be always visible }}

--- a/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
@@ -10,6 +10,7 @@ import UserLink from "discourse/components/user-link";
 import UserStatusMessage from "discourse/components/user-status-message";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import userPrioritizedName from "discourse/helpers/user-prioritized-name";
 import { bind } from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
@@ -123,7 +124,7 @@ export default class PostMetaDataPosterName extends Component {
     >
       <PluginOutlet
         @name="post-meta-data-poster-name"
-        @outletArgs={{hash post=@post}}
+        @outletArgs={{lazyHash post=@post}}
       >
         <span
           class={{concatClass
@@ -143,7 +144,7 @@ export default class PostMetaDataPosterName extends Component {
           {{! use the position argument to choose between the first and second name if needed}}
           <PluginOutlet
             @name="post-meta-data-poster-name-user-link"
-            @outletArgs={{hash position="first" name=this.name post=@post}}
+            @outletArgs={{lazyHash position="first" name=this.name post=@post}}
           >
             <UserLink @user={{@post}}>
               {{this.name}}
@@ -167,7 +168,11 @@ export default class PostMetaDataPosterName extends Component {
               {{! use the position argument to choose between the first and second name if needed}}
               <PluginOutlet
                 @name="post-meta-data-poster-name-user-link"
-                @outletArgs={{hash position="second" name=this.name post=@post}}
+                @outletArgs={{lazyHash
+                  position="second"
+                  name=this.name
+                  post=@post
+                }}
               >
                 <UserLink @user={{@post}}>
                   {{#if this.nameFirst}}

--- a/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { and, or } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserLink from "discourse/components/user-link";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 const ReviewableCreatedByName = <template>
@@ -19,7 +20,7 @@ const ReviewableCreatedByName = <template>
     <PluginOutlet
       @name="after-reviewable-post-user"
       @connectorTagName="div"
-      @outletArgs={{hash user=@user}}
+      @outletArgs={{lazyHash user=@user}}
     />
   </div>
 </template>;

--- a/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserLink from "discourse/components/user-link";
 import icon from "discourse/helpers/d-icon";

--- a/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.gjs
@@ -9,6 +9,7 @@ import ReviewableCreatedBy from "discourse/components/reviewable-created-by";
 import ReviewablePostEdits from "discourse/components/reviewable-post-edits";
 import ReviewablePostHeader from "discourse/components/reviewable-post-header";
 import ReviewableTopicLink from "discourse/components/reviewable-topic-link";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { bind } from "discourse/lib/decorators";
 import highlightWatchedWords from "discourse/lib/highlight-watched-words";
 import { i18n } from "discourse-i18n";
@@ -84,7 +85,7 @@ export default class ReviewableFlaggedPost extends Component {
           <PluginOutlet
             @name="after-reviewable-flagged-post-body"
             @connectorTagName="div"
-            @outletArgs={{hash model=@reviewable}}
+            @outletArgs={{lazyHash model=@reviewable}}
           />
         </span>
         {{yield}}

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
-import { concat, fn, hash } from "@ember/helper";
+import { concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action, set } from "@ember/object";
 import { alias } from "@ember/object/computed";

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
@@ -24,6 +24,7 @@ import icon from "discourse/helpers/d-icon";
 import dasherizeHelper from "discourse/helpers/dasherize";
 import editableValue from "discourse/helpers/editable-value";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import reviewableStatus from "discourse/helpers/reviewable-status";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -698,7 +699,7 @@ export default class ReviewableItem extends Component {
         <PluginOutlet
           @name="reviewable-item-actions"
           @connectorTagName="div"
-          @outletArgs={{hash reviewable=this.reviewable}}
+          @outletArgs={{lazyHash reviewable=this.reviewable}}
         />
       </div>
     </div>

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
@@ -11,6 +11,7 @@ import DButton from "discourse/components/d-button";
 import DateInput from "discourse/components/date-input";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
@@ -778,7 +779,7 @@ export default class SearchAdvancedOptions extends Component {
         <PluginOutlet
           @name="advanced-search-options-above"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             searchedTerms=this.searchedTerms
             onChangeSearchedTermField=this.onChangeSearchedTermField
           }}
@@ -969,7 +970,7 @@ export default class SearchAdvancedOptions extends Component {
         <PluginOutlet
           @name="advanced-search-options-below"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             searchedTerms=this.searchedTerms
             onChangeSearchedTermField=this.onChangeSearchedTermField
           }}

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -15,6 +15,7 @@ import ClearButton from "discourse/components/search-menu/clear-button";
 import Results from "discourse/components/search-menu/results";
 import SearchTerm from "discourse/components/search-menu/search-term";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
@@ -418,7 +419,7 @@ export default class SearchMenu extends Component {
 
           <PluginOutlet
             @name="search-menu-before-term-input"
-            @outletArgs={{hash openSearchMenu=this.open}}
+            @outletArgs={{lazyHash openSearchMenu=this.open}}
           />
 
           <SearchTerm

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
@@ -9,6 +9,7 @@ import Assistant from "discourse/components/search-menu/results/assistant";
 import InitialOptions from "discourse/components/search-menu/results/initial-options";
 import MoreLink from "discourse/components/search-menu/results/more-link";
 import Types from "discourse/components/search-menu/results/types";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import CategoryViewComponent from "./results/type/category";
 import GroupViewComponent from "./results/type/group";
@@ -68,7 +69,7 @@ export default class Results extends Component {
         <div class="results">
           <PluginOutlet
             @name="search-menu-results-top"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               closeSearchMenu=@closeSearchMenu
               searchTerm=this.search.activeGlobalSearchTerm
               inTopicContext=this.search.inTopicContext
@@ -134,12 +135,12 @@ export default class Results extends Component {
             {{/if}}
             <PluginOutlet
               @name="search-menu-with-results-bottom"
-              @outletArgs={{hash resultTypes=this.resultTypesWithComponent}}
+              @outletArgs={{lazyHash resultTypes=this.resultTypesWithComponent}}
             />
           {{/if}}
           <PluginOutlet
             @name="search-menu-results-bottom"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               inTopicContext=this.search.inTopicContext
               searchTermChanged=@searchTermChanged
               searchTopics=@searchTopics

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { and, not } from "truth-helpers";
 import ConditionalLoadingSection from "discourse/components/conditional-loading-section";

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, get, hash } from "@ember/helper";
+import { concat, get } from "@ember/helper";
 import { service } from "@ember/service";
 import { eq } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant.gjs
@@ -4,6 +4,7 @@ import { service } from "@ember/service";
 import { eq } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import AssistantItem from "discourse/components/search-menu/results/assistant-item";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 const suggestionShortcuts = [
@@ -212,7 +213,7 @@ export default class Assistant extends Component {
       {{else}}
         <PluginOutlet
           @name="search-menu-results-assistant-shortcut-top"
-          @outletArgs={{hash suggestionShortcuts=this.suggestionShortcuts}}
+          @outletArgs={{lazyHash suggestionShortcuts=this.suggestionShortcuts}}
         />
         {{#each this.suggestionShortcuts as |item|}}
           <AssistantItem

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
@@ -7,6 +7,7 @@ import { MODIFIER_REGEXP } from "discourse/components/search-menu";
 import AssistantItem from "discourse/components/search-menu/results/assistant-item";
 import RandomQuickTip from "discourse/components/search-menu/results/random-quick-tip";
 import RecentSearches from "discourse/components/search-menu/results/recent-searches";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import Assistant from "./assistant";
 
@@ -151,7 +152,7 @@ export default class InitialOptions extends Component {
     <ul class="search-menu-initial-options">
       <PluginOutlet
         @name="search-menu-initial-options"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           termMatchesContextTypeKeyword=this.termMatchesContextTypeKeyword
           contextTypeComponent=this.contextTypeComponent
           slug=this.slug

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/initial-options.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { and, or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import { and } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
@@ -9,6 +9,7 @@ import Blurb from "discourse/components/search-menu/results/blurb";
 import TopicStatus from "discourse/components/topic-status";
 import categoryLink from "discourse/helpers/category-link";
 import discourseTags from "discourse/helpers/discourse-tags";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 
 export default class Results extends Component {
@@ -39,7 +40,7 @@ export default class Results extends Component {
           {{/if}}
           <PluginOutlet
             @name="search-menu-results-topic-title-suffix"
-            @outletArgs={{hash topic=@result.topic}}
+            @outletArgs={{lazyHash topic=@result.topic}}
           />
         </span>
       </span>

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { logSearchLinkClick } from "discourse/lib/search";
 import DiscourseURL from "discourse/lib/url";
@@ -76,7 +77,7 @@ export default class Types extends Component {
       <div class={{resultType.componentName}}>
         <PluginOutlet
           @name="search-menu-results-type-top"
-          @outletArgs={{hash resultType=resultType}}
+          @outletArgs={{lazyHash resultType=resultType}}
         />
         <ul
           class="list"

--- a/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
@@ -18,6 +18,7 @@ import categoryLink from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { logSearchLinkClick } from "discourse/lib/search";
 
@@ -47,7 +48,7 @@ export default class SearchResultEntry extends Component {
   <template>
     <PluginOutlet
       @name="search-results-topic-avatar-wrapper"
-      @outletArgs={{hash post=this.post}}
+      @outletArgs={{lazyHash post=this.post}}
     >
       <div class="author">
         <a href={{this.post.userPath}} data-user-card={{this.post.username}}>
@@ -92,7 +93,7 @@ export default class SearchResultEntry extends Component {
           </span>
           <PluginOutlet
             @name="search-results-topic-title-suffix"
-            @outletArgs={{hash topic=this.post.topic}}
+            @outletArgs={{lazyHash topic=this.post.topic}}
           />
         </a>
 
@@ -108,7 +109,7 @@ export default class SearchResultEntry extends Component {
             <PluginOutlet
               @name="full-page-search-category"
               @connectorTagName="div"
-              @outletArgs={{hash post=this.post}}
+              @outletArgs={{lazyHash post=this.post}}
             />
           </span>
         </div>
@@ -116,7 +117,7 @@ export default class SearchResultEntry extends Component {
 
       <PluginOutlet
         @name="search-result-entry-blurb-wrapper"
-        @outletArgs={{hash post=this.post logClick=this.logClick}}
+        @outletArgs={{lazyHash post=this.post logClick=this.logClick}}
       >
         <div class="blurb container">
           <span class="date">
@@ -140,7 +141,7 @@ export default class SearchResultEntry extends Component {
 
       <PluginOutlet
         @name="search-result-entry-stats-wrapper"
-        @outletArgs={{hash post=this.post}}
+        @outletArgs={{lazyHash post=this.post}}
       >
         {{#if this.showLikeCount}}
           {{#if this.post.like_count}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import DeferredRender from "discourse/components/deferred-render";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import ApiPanels from "./api-panels";
 import Footer from "./footer";
 import Sections from "./sections";
@@ -57,7 +58,7 @@ export default class SidebarHamburgerDropdown extends Component {
               >
                 <PluginOutlet
                   @name="before-sidebar-sections"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     toggleNavigationMenu=@toggleNavigationMenu
                   }}
                 />

--- a/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { schedule } from "@ember/runloop";

--- a/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import CategoryTitleLink from "discourse/components/category-title-link";
 import ParentCategoryRow from "discourse/components/parent-category-row";

--- a/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.gjs
+++ b/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.gjs
@@ -4,6 +4,7 @@ import { htmlSafe } from "@ember/template";
 import CategoryTitleLink from "discourse/components/category-title-link";
 import ParentCategoryRow from "discourse/components/parent-category-row";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class SubcategoriesWithFeaturedTopics extends Component {
@@ -12,7 +13,7 @@ export default class SubcategoriesWithFeaturedTopics extends Component {
       {{#if this.site.mobileView}}
         <PluginOutlet
           @name="mobile-subcategories-with-featured-topics-list"
-          @outletArgs={{hash category=category}}
+          @outletArgs={{lazyHash category=category}}
         >
           <div class="category-list subcategory-list with-topics">
             <div class="parent-category">
@@ -40,7 +41,7 @@ export default class SubcategoriesWithFeaturedTopics extends Component {
       {{else}}
         <PluginOutlet
           @name="subcategories-with-featured-topics-list"
-          @outletArgs={{hash category=category}}
+          @outletArgs={{lazyHash category=category}}
         >
           <table class="category-list subcategory-list with-topics">
             <thead>

--- a/app/assets/javascripts/discourse/app/components/tag-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.gjs
@@ -1,5 +1,5 @@
 import Component, { Textarea } from "@ember/component";
-import { array, fn, hash } from "@ember/helper";
+import { array, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { and, reads } from "@ember/object/computed";

--- a/app/assets/javascripts/discourse/app/components/tag-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.gjs
@@ -14,6 +14,7 @@ import basePath from "discourse/helpers/base-path";
 import categoryLink from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import discourseTag from "discourse/helpers/discourse-tag";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -380,7 +381,7 @@ export default class TagInfo extends Component {
         {{#if this.canAdminTag}}
           <PluginOutlet
             @name="tag-custom-settings"
-            @outletArgs={{hash tag=this.tagInfo}}
+            @outletArgs={{lazyHash tag=this.tagInfo}}
             @connectorTagName="section"
           />
 

--- a/app/assets/javascripts/discourse/app/components/topic-category.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-category.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import boundCategoryLink from "discourse/helpers/bound-category-link";
 import discourseTags from "discourse/helpers/discourse-tags";

--- a/app/assets/javascripts/discourse/app/components/topic-category.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-category.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import boundCategoryLink from "discourse/helpers/bound-category-link";
 import discourseTags from "discourse/helpers/discourse-tags";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 
 // Injections don't occur without a class
@@ -30,7 +31,7 @@ export default class TopicCategory extends Component {
       <PluginOutlet
         @name="topic-category"
         @connectorTagName="div"
-        @outletArgs={{hash topic=this.topic category=this.topic.category}}
+        @outletArgs={{lazyHash topic=this.topic category=this.topic.category}}
       />
     </span>
   </template>

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
@@ -13,6 +13,7 @@ import TopicAdminMenu from "discourse/components/topic-admin-menu";
 import UserTip from "discourse/components/user-tip";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import { getTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
@@ -236,7 +237,7 @@ export default class TopicFooterButtons extends Component {
 
       <PluginOutlet
         @name="topic-footer-main-buttons-before-create"
-        @outletArgs={{hash topic=this.topic}}
+        @outletArgs={{lazyHash topic=this.topic}}
         @connectorTagName="span"
       />
 
@@ -252,7 +253,7 @@ export default class TopicFooterButtons extends Component {
 
       <PluginOutlet
         @name="after-topic-footer-main-buttons"
-        @outletArgs={{hash topic=this.topic}}
+        @outletArgs={{lazyHash topic=this.topic}}
         @connectorTagName="span"
       />
     </div>
@@ -285,7 +286,7 @@ export default class TopicFooterButtons extends Component {
 
     <PluginOutlet
       @name="after-topic-footer-buttons"
-      @outletArgs={{hash topic=this.topic}}
+      @outletArgs={{lazyHash topic=this.topic}}
       @connectorTagName="span"
     />
   </template>

--- a/app/assets/javascripts/discourse/app/components/topic-list/header/sortable-column.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/header/sortable-column.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/topic-list/header/sortable-column.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/header/sortable-column.gjs
@@ -8,6 +8,7 @@ import NewListHeaderControls from "discourse/components/topic-list/new-list-head
 import TopicBulkSelectDropdown from "discourse/components/topic-list/topic-bulk-select-dropdown";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class SortableColumn extends Component {
@@ -141,7 +142,7 @@ export default class SortableColumn extends Component {
 
       <PluginOutlet
         @name="topic-list-heading-bottom"
-        @outletArgs={{hash name=@name bulkSelectEnabled=@bulkSelectEnabled}}
+        @outletArgs={{lazyHash name=@name bulkSelectEnabled=@bulkSelectEnabled}}
       />
     </th>
   </template>

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -17,6 +17,7 @@ import categoryLink from "discourse/helpers/category-link";
 import concatClass from "discourse/helpers/concat-class";
 import discourseTags from "discourse/helpers/discourse-tags";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import {
@@ -260,13 +261,13 @@ export default class Item extends Component {
     >
       <PluginOutlet
         @name="above-topic-list-item"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       />
       {{! Do not include @columns as argument to the wrapper outlet below ~}}
       {{! We don't want it to be able to override core behavior just copy/pasting the code ~}}
       <PluginOutlet
         @name="topic-list-item"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           topic=@topic
           bulkSelectEnabled=@bulkSelectEnabled
           onBulkSelectToggle=this.onBulkSelectToggle
@@ -298,7 +299,7 @@ export default class Item extends Component {
               {{else}}
                 <PluginOutlet
                   @name="topic-list-item-mobile-avatar"
-                  @outletArgs={{hash topic=@topic}}
+                  @outletArgs={{lazyHash topic=@topic}}
                 >
                   <a
                     href={{@topic.lastPostUrl}}
@@ -316,14 +317,14 @@ export default class Item extends Component {
               {{~! no whitespace ~}}
               <PluginOutlet
                 @name="topic-list-before-link"
-                @outletArgs={{hash topic=@topic}}
+                @outletArgs={{lazyHash topic=@topic}}
               />
 
               <div class="main-link">
                 {{~! no whitespace ~}}
                 <PluginOutlet
                   @name="topic-list-before-status"
-                  @outletArgs={{hash topic=@topic}}
+                  @outletArgs={{lazyHash topic=@topic}}
                 />
                 {{~! no whitespace ~}}
                 <TopicStatus @topic={{@topic}} @context="topic-list" />
@@ -340,7 +341,7 @@ export default class Item extends Component {
                 {{~/if~}}
                 <PluginOutlet
                   @name="topic-list-after-title"
-                  @outletArgs={{hash topic=@topic}}
+                  @outletArgs={{lazyHash topic=@topic}}
                 />
                 {{~#if @topic.unseen~}}
                   <span class="topic-post-badges">&nbsp;<span
@@ -349,14 +350,14 @@ export default class Item extends Component {
                 {{~/if~}}
                 <PluginOutlet
                   @name="topic-list-after-badges"
-                  @outletArgs={{hash topic=@topic}}
+                  @outletArgs={{lazyHash topic=@topic}}
                 />
                 {{~#if this.expandPinned~}}
                   <TopicExcerpt @topic={{@topic}} />
                 {{~/if~}}
                 <PluginOutlet
                   @name="topic-list-main-link-bottom"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     topic=@topic
                     expandPinned=this.expandPinned
                   }}
@@ -365,7 +366,7 @@ export default class Item extends Component {
               {{~! no whitespace ~}}
               <PluginOutlet
                 @name="topic-list-after-main-link"
-                @outletArgs={{hash topic=@topic}}
+                @outletArgs={{lazyHash topic=@topic}}
               />
 
               <div class="pull-right">
@@ -380,13 +381,13 @@ export default class Item extends Component {
                   {{#unless @hideCategory}}
                     <PluginOutlet
                       @name="topic-list-before-category"
-                      @outletArgs={{hash topic=@topic}}
+                      @outletArgs={{lazyHash topic=@topic}}
                     />
                     {{categoryLink @topic.category}}
                     {{~! no whitespace ~}}
                     <PluginOutlet
                       @name="topic-list-after-category"
-                      @outletArgs={{hash topic=@topic}}
+                      @outletArgs={{lazyHash topic=@topic}}
                     />{{~! no whitespace ~}}
                   {{/unless}}
                   {{~! no whitespace ~}}
@@ -396,7 +397,7 @@ export default class Item extends Component {
                 <div class="num activity last">
                   <PluginOutlet
                     @name="topic-list-item-mobile-bumped-at"
-                    @outletArgs={{hash topic=@topic}}
+                    @outletArgs={{lazyHash topic=@topic}}
                   >
                     <span title={{@topic.bumpedAtTitle}} class="age activity">
                       <a href={{@topic.lastPostUrl}}>{{formatDate

--- a/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/activity-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/activity-cell.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import coldAgeClass from "discourse/helpers/cold-age-class";

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/activity-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/activity-cell.gjs
@@ -4,6 +4,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import coldAgeClass from "discourse/helpers/cold-age-class";
 import concatClass from "discourse/helpers/concat-class";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 const ActivityCell = <template>
   <td
@@ -18,7 +19,7 @@ const ActivityCell = <template>
       {{~! no whitespace ~}}
       <PluginOutlet
         @name="topic-list-before-relative-date"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       />
       {{~formatDate @topic.bumpedAt format="tiny" noTitle="true"~}}
     </a>

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/replies-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/replies-cell.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import element from "discourse/helpers/element";

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/replies-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/replies-cell.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import element from "discourse/helpers/element";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 import { i18n } from "discourse-i18n";
 
@@ -63,7 +64,7 @@ export default class RepliesCell extends Component {
       >
         <PluginOutlet
           @name="topic-list-before-reply-count"
-          @outletArgs={{hash topic=@topic}}
+          @outletArgs={{lazyHash topic=@topic}}
         />
         {{number @topic.replyCount noTitle="true"}}
       </a>

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/topic-cell.gjs
@@ -13,6 +13,7 @@ import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
 import categoryLink from "discourse/helpers/category-link";
 import discourseTags from "discourse/helpers/discourse-tags";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { groupPath } from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
@@ -52,19 +53,19 @@ export default class TopicCell extends Component {
     <td class="main-link topic-list-data" colspan="1">
       <PluginOutlet
         @name="topic-list-before-link"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       />
 
       <span class="link-top-line" role="heading" aria-level="2">
         {{~! no whitespace ~}}
         <PluginOutlet
           @name="topic-list-before-status"
-          @outletArgs={{hash topic=@topic}}
+          @outletArgs={{lazyHash topic=@topic}}
         />
         {{~! no whitespace ~}}
         <PluginOutlet
           @name="topic-list-topic-cell-link-top-line"
-          @outletArgs={{hash topic=@topic tagsForUser=@tagsForUser}}
+          @outletArgs={{lazyHash topic=@topic tagsForUser=@tagsForUser}}
         >
           {{~! no whitespace ~}}
           <TopicStatus @topic={{@topic}} @context="topic-list" />
@@ -81,7 +82,7 @@ export default class TopicCell extends Component {
           {{~/if~}}
           <PluginOutlet
             @name="topic-list-after-title"
-            @outletArgs={{hash topic=@topic}}
+            @outletArgs={{lazyHash topic=@topic}}
           />
           {{~! no whitespace ~}}
           <UnreadIndicator @topic={{@topic}} />
@@ -95,7 +96,7 @@ export default class TopicCell extends Component {
           {{~/if~}}
           <PluginOutlet
             @name="topic-list-after-badges"
-            @outletArgs={{hash topic=@topic}}
+            @outletArgs={{lazyHash topic=@topic}}
           />
         </PluginOutlet>
       </span>
@@ -103,18 +104,18 @@ export default class TopicCell extends Component {
       <div class="link-bottom-line">
         <PluginOutlet
           @name="topic-list-topic-cell-link-bottom-line"
-          @outletArgs={{hash topic=@topic tagsForUser=@tagsForUser}}
+          @outletArgs={{lazyHash topic=@topic tagsForUser=@tagsForUser}}
         >
           {{#unless @hideCategory}}
             {{#unless @topic.isPinnedUncategorized}}
               <PluginOutlet
                 @name="topic-list-before-category"
-                @outletArgs={{hash topic=@topic}}
+                @outletArgs={{lazyHash topic=@topic}}
               />
               {{categoryLink @topic.category}}
               <PluginOutlet
                 @name="topic-list-after-category"
-                @outletArgs={{hash topic=@topic}}
+                @outletArgs={{lazyHash topic=@topic}}
               />
             {{/unless}}
           {{/unless}}
@@ -140,7 +141,7 @@ export default class TopicCell extends Component {
 
       <PluginOutlet
         @name="topic-list-main-link-bottom"
-        @outletArgs={{hash topic=@topic expandPinned=@expandPinned}}
+        @outletArgs={{lazyHash topic=@topic expandPinned=@expandPinned}}
       />
     </td>
   </template>

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/views-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/views-cell.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";

--- a/app/assets/javascripts/discourse/app/components/topic-list/item/views-cell.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/item/views-cell.gjs
@@ -1,13 +1,14 @@
 import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 
 const ViewsCell = <template>
   <td class={{concatClass "num views topic-list-data" @topic.viewsHeat}}>
     <PluginOutlet
       @name="topic-list-before-view-count"
-      @outletArgs={{hash topic=@topic}}
+      @outletArgs={{lazyHash topic=@topic}}
     />
     {{number @topic.views numberKey="views_long"}}
   </td>

--- a/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
@@ -11,6 +11,7 @@ import categoryLink from "discourse/helpers/category-link";
 import concatClass from "discourse/helpers/concat-class";
 import discourseTags from "discourse/helpers/discourse-tags";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import topicLink from "discourse/helpers/topic-link";
 import { applyValueTransformer } from "discourse/lib/transformer";
@@ -45,12 +46,12 @@ export default class LatestTopicListItem extends Component {
       <PluginOutlet
         @name="above-latest-topic-list-item"
         @connectorTagName="div"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       />
 
       <PluginOutlet
         @name="latest-topic-list-item-topic-poster"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       >
         <div class="topic-poster">
           <UserLink @user={{@topic.lastPosterUser}}>
@@ -64,7 +65,7 @@ export default class LatestTopicListItem extends Component {
         <div class="top-row">
           <PluginOutlet
             @name="latest-topic-list-item-main-link-top-row"
-            @outletArgs={{hash topic=@topic}}
+            @outletArgs={{lazyHash topic=@topic}}
           >
             <TopicStatus @topic={{@topic}} @context="topic-list" />
 
@@ -83,7 +84,7 @@ export default class LatestTopicListItem extends Component {
         <div class="bottom-row">
           <PluginOutlet
             @name="latest-topic-list-item-main-link-bottom-row"
-            @outletArgs={{hash topic=@topic}}
+            @outletArgs={{lazyHash topic=@topic}}
           >
             {{categoryLink @topic.category~}}
             {{~discourseTags @topic mode="list"}}
@@ -91,7 +92,7 @@ export default class LatestTopicListItem extends Component {
           <PluginOutlet
             @name="below-latest-topic-list-item-bottom-row"
             @connectorTagName="span"
-            @outletArgs={{hash topic=@topic}}
+            @outletArgs={{lazyHash topic=@topic}}
           />
         </div>
       </div>
@@ -100,11 +101,11 @@ export default class LatestTopicListItem extends Component {
         <PluginOutlet
           @name="above-latest-topic-list-item-post-count"
           @connectorTagName="div"
-          @outletArgs={{hash topic=@topic}}
+          @outletArgs={{lazyHash topic=@topic}}
         />
         <PluginOutlet
           @name="latest-topic-list-item-topic-stats"
-          @outletArgs={{hash topic=@topic}}
+          @outletArgs={{lazyHash topic=@topic}}
         >
           <ItemRepliesCell @topic={{@topic}} @tagName="div" />
           <div class="topic-last-activity">

--- a/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/latest-topic-list-item.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ItemRepliesCell from "discourse/components/topic-list/item/replies-cell";
 import TopicPostBadges from "discourse/components/topic-post-badges";

--- a/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
@@ -7,6 +7,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import Header from "discourse/components/topic-list/header";
 import Item from "discourse/components/topic-list/item";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import DAG from "discourse/lib/dag";
 import {
   applyMutableValueTransformer,
@@ -217,7 +218,7 @@ export default class TopicList extends Component {
 
       <PluginOutlet
         @name="before-topic-list-body"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           topics=@topics
           selected=this.selected
           bulkSelectEnabled=this.bulkSelectEnabled
@@ -257,7 +258,7 @@ export default class TopicList extends Component {
 
           <PluginOutlet
             @name="after-topic-list-item"
-            @outletArgs={{hash topic=topic index=index}}
+            @outletArgs={{lazyHash topic=topic index=index}}
             @connectorTagName="tr"
           />
         {{/each}}
@@ -265,7 +266,7 @@ export default class TopicList extends Component {
 
       <PluginOutlet
         @name="after-topic-list-body"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           topics=@topics
           selected=this.selected
           bulkSelectEnabled=this.bulkSelectEnabled

--- a/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/list.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { eq, or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default class TopicLink extends Component {
   get url() {
@@ -12,7 +13,7 @@ export default class TopicLink extends Component {
 
   <template>
     {{~! no whitespace ~}}
-    <PluginOutlet @name="topic-link" @outletArgs={{hash topic=@topic}}>
+    <PluginOutlet @name="topic-link" @outletArgs={{lazyHash topic=@topic}}>
       {{~! no whitespace ~}}
       <a
         href={{this.url}}

--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";

--- a/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PrivateMessageMap from "discourse/components/topic-map/private-message-map";
 import TopicMapSummary from "discourse/components/topic-map/topic-map-summary";

--- a/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/index.gjs
@@ -2,12 +2,13 @@ import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PrivateMessageMap from "discourse/components/topic-map/private-message-map";
 import TopicMapSummary from "discourse/components/topic-map/topic-map-summary";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 const TopicMap = <template>
   {{#unless @model.postStream.loadingFilter}}
     <PluginOutlet
       @name="topic-map"
-      @outletArgs={{hash topic=@model postStream=@postStream}}
+      @outletArgs={{lazyHash topic=@model postStream=@postStream}}
     >
       <section class="topic-map__contents">
         <TopicMapSummary
@@ -20,7 +21,7 @@ const TopicMap = <template>
       <PluginOutlet
         @name="topic-map-expanded-after"
         @defaultGlimmer={{true}}
-        @outletArgs={{hash topic=@model postStream=@postStream}}
+        @outletArgs={{lazyHash topic=@model postStream=@postStream}}
       />
 
       {{#if @showPMMap}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -411,7 +411,7 @@ export default class TopicMapSummary extends Component {
       {{/if}}
       <PluginOutlet
         @name="topic-map-participants-after"
-        @outletArgs={{hash topic=@topic}}
+        @outletArgs={{lazyHash topic=@topic}}
       />
       <div class="topic-map__buttons">
         {{#if this.readTimeMinutes}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -15,6 +15,7 @@ import TopicViewsChart from "discourse/components/topic-map/topic-views-chart";
 import avatar from "discourse/helpers/bound-avatar-template";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 import { ajax } from "discourse/lib/ajax";
 import { emojiUnescape } from "discourse/lib/text";
@@ -298,7 +299,7 @@ export default class TopicMapSummary extends Component {
             <ConditionalLoadingSpinner @condition={{this.loading}}>
               <PluginOutlet
                 @name="most-liked-replies"
-                @outletArgs={{hash posts=this.top3LikedPosts}}
+                @outletArgs={{lazyHash posts=this.top3LikedPosts}}
               >
                 <ul>
                   {{#each this.top3LikedPosts as |post|}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
@@ -4,6 +4,7 @@ import { htmlSafe } from "@ember/template";
 import { gt } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAvatarFlair from "discourse/components/user-avatar-flair";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { avatarImg } from "discourse/lib/avatar-utils";
 import { userPath } from "discourse/lib/url";
 
@@ -56,7 +57,7 @@ export default class TopicParticipant extends Component {
   <template>
     <PluginOutlet
       @name="topic-participant"
-      @outletArgs={{hash participant=@participant}}
+      @outletArgs={{lazyHash participant=@participant}}
     >
       <div class={{this.participantClasses}}>
         <a

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-participant.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { gt } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/topic-status.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-status.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/app/assets/javascripts/discourse/app/components/topic-status.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-status.gjs
@@ -7,6 +7,7 @@ import { and } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import element from "discourse/helpers/element";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class TopicStatus extends Component {
@@ -109,7 +110,7 @@ export default class TopicStatus extends Component {
       {{~/if~}}
       <PluginOutlet
         @name="after-topic-status"
-        @outletArgs={{hash topic=@topic context=@context}}
+        @outletArgs={{lazyHash topic=@topic context=@context}}
       />
       {{~! no whitespace ~}}
     </this.wrapperElement>

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -16,6 +16,7 @@ import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import categoryLink from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { bind, debounce } from "discourse/lib/decorators";
 import domUtils from "discourse/lib/dom-utils";
@@ -547,7 +548,7 @@ export default class TopicTimelineScrollArea extends Component {
       <div class="timeline-controls">
         <PluginOutlet
           @name="timeline-controls-before"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
 
         {{#if this.displayLocalizationToggle}}
@@ -691,7 +692,7 @@ export default class TopicTimelineScrollArea extends Component {
 
         <PluginOutlet
           @name="timeline-footer-controls-after"
-          @outletArgs={{hash model=@model fullscreen=@fullscreen}}
+          @outletArgs={{lazyHash model=@model fullscreen=@fullscreen}}
         />
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/topic-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-title.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";

--- a/app/assets/javascripts/discourse/app/components/topic-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-title.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { isiPad } from "discourse/lib/utilities";
 import observeIntersection from "discourse/modifiers/observe-intersection";
 
@@ -57,7 +58,7 @@ export default class TopicTitle extends Component {
       <PluginOutlet
         @name="topic-title"
         @connectorTagName="div"
-        @outletArgs={{hash model=@model}}
+        @outletArgs={{lazyHash model=@model}}
       />
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
@@ -23,6 +23,7 @@ import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import formatDuration from "discourse/helpers/format-duration";
 import formatUsername from "discourse/helpers/format-username";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import userStatus from "discourse/helpers/user-status";
 import CanCheckEmailsHelper from "discourse/lib/can-check-emails-helper";
@@ -337,7 +338,7 @@ export default class UserCardContents extends CardContentsBase {
     {{#if this.visible}}
       <PluginOutlet
         @name="before-user-card-content"
-        @outletArgs={{hash user=this.user}}
+        @outletArgs={{lazyHash user=this.user}}
       />
       <div class="card-content">
         {{#if this.loading}}
@@ -365,7 +366,7 @@ export default class UserCardContents extends CardContentsBase {
           <div class="card-row first-row">
             <PluginOutlet
               @name="user-card-main-info"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 user=this.user
                 post=this.post
                 contentHidden=this.contentHidden
@@ -393,7 +394,7 @@ export default class UserCardContents extends CardContentsBase {
                   <PluginOutlet
                     @name="user-card-avatar-flair"
                     @connectorTagName="div"
-                    @outletArgs={{hash user=this.user}}
+                    @outletArgs={{lazyHash user=this.user}}
                   />
                 </div>
               </div>
@@ -436,7 +437,7 @@ export default class UserCardContents extends CardContentsBase {
                 <PluginOutlet
                   @name="user-card-after-username"
                   @connectorTagName="div"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     user=this.user
                     showUser=this.handleShowUser
                   }}
@@ -473,7 +474,7 @@ export default class UserCardContents extends CardContentsBase {
                   <PluginOutlet
                     @name="user-card-post-names"
                     @connectorTagName="div"
-                    @outletArgs={{hash user=this.user}}
+                    @outletArgs={{lazyHash user=this.user}}
                   />
                 </div>
               </div>
@@ -492,7 +493,7 @@ export default class UserCardContents extends CardContentsBase {
               <PluginOutlet
                 @name="user-card-below-message-button"
                 @connectorTagName="li"
-                @outletArgs={{hash user=this.user close=this.close}}
+                @outletArgs={{lazyHash user=this.user close=this.close}}
               />
               {{#if this.showFilter}}
                 <li>
@@ -526,13 +527,13 @@ export default class UserCardContents extends CardContentsBase {
               <PluginOutlet
                 @name="user-card-additional-buttons"
                 @connectorTagName="li"
-                @outletArgs={{hash user=this.user close=this.close}}
+                @outletArgs={{lazyHash user=this.user close=this.close}}
               />
             </ul>
             <PluginOutlet
               @name="user-card-additional-controls"
               @connectorTagName="div"
-              @outletArgs={{hash user=this.user close=this.close}}
+              @outletArgs={{lazyHash user=this.user close=this.close}}
             />
           </div>
 
@@ -643,7 +644,7 @@ export default class UserCardContents extends CardContentsBase {
                   <PluginOutlet
                     @name="user-card-location-and-website"
                     @connectorTagName="div"
-                    @outletArgs={{hash user=this.user}}
+                    @outletArgs={{lazyHash user=this.user}}
                   />
                 </span>
               </div>
@@ -699,14 +700,14 @@ export default class UserCardContents extends CardContentsBase {
                 <PluginOutlet
                   @name="user-card-metadata"
                   @connectorTagName="div"
-                  @outletArgs={{hash user=this.user}}
+                  @outletArgs={{lazyHash user=this.user}}
                 />
               </div>
             {{/unless}}
             <PluginOutlet
               @name="user-card-after-metadata"
               @connectorTagName="div"
-              @outletArgs={{hash user=this.user}}
+              @outletArgs={{lazyHash user=this.user}}
             />
           </div>
 
@@ -747,14 +748,14 @@ export default class UserCardContents extends CardContentsBase {
           <PluginOutlet
             @name="user-card-before-badges"
             @connectorTagName="div"
-            @outletArgs={{hash user=this.user}}
+            @outletArgs={{lazyHash user=this.user}}
           />
 
           {{#if this.showBadges}}
             <div class="card-row">
               <PluginOutlet
                 @name="user-card-badges"
-                @outletArgs={{hash user=this.user post=this.post}}
+                @outletArgs={{lazyHash user=this.user post=this.post}}
               >
                 {{#if this.user.featured_user_badges}}
                   <div class="badge-section">

--- a/app/assets/javascripts/discourse/app/components/user-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-info.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { alias } from "@ember/object/computed";
 import {
   attributeBindings,

--- a/app/assets/javascripts/discourse/app/components/user-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-info.gjs
@@ -11,6 +11,7 @@ import UserAvatarFlair from "discourse/components/user-avatar-flair";
 import UserStatusMessage from "discourse/components/user-status-message";
 import avatar from "discourse/helpers/avatar";
 import formatUsername from "discourse/helpers/format-username";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { userPath } from "discourse/lib/url";
@@ -89,7 +90,7 @@ export default class UserInfo extends Component {
         <PluginOutlet
           @name="after-user-name"
           @connectorTagName="span"
-          @outletArgs={{hash user=this.user}}
+          @outletArgs={{lazyHash user=this.user}}
         />
       </div>
       <div class="title">{{@user.title}}</div>
@@ -103,7 +104,7 @@ export default class UserInfo extends Component {
     <PluginOutlet
       @name="after-user-info"
       @connectorTagName="div"
-      @outletArgs={{hash user=this.user}}
+      @outletArgs={{lazyHash user=this.user}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.gjs
@@ -9,6 +9,7 @@ import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import MenuItem from "discourse/components/user-menu/menu-item";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default class UserMenuItemsList extends Component {
@@ -107,7 +108,7 @@ export default class UserMenuItemsList extends Component {
   <template>
     <PluginOutlet
       @name="before-panel-body"
-      @outletArgs={{hash closeUserMenu=@closeUserMenu}}
+      @outletArgs={{lazyHash closeUserMenu=@closeUserMenu}}
     />
     {{#if this.loading}}
       <div class="spinner-container">
@@ -143,7 +144,7 @@ export default class UserMenuItemsList extends Component {
         {{/if}}
         <PluginOutlet
           @name="panel-body-bottom"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             itemsCacheKey=this.itemsCacheKey
             closeUserMenu=@closeUserMenu
             showDismiss=this.showDismiss
@@ -154,14 +155,14 @@ export default class UserMenuItemsList extends Component {
     {{else}}
       <PluginOutlet
         @name="user-menu-items-list-empty-state"
-        @outletArgs={{hash model=this}}
+        @outletArgs={{lazyHash model=this}}
       >
         <this.resolvedEmptyStateComponent />
       </PluginOutlet>
     {{/if}}
     <PluginOutlet
       @name="after-panel-body"
-      @outletArgs={{hash closeUserMenu=@closeUserMenu}}
+      @outletArgs={{lazyHash closeUserMenu=@closeUserMenu}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import { concat, fn, hash } from "@ember/helper";
+import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.gjs
@@ -7,6 +7,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import MenuTab from "discourse/components/user-menu/menu-tab";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { bind } from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
 import getUrl from "discourse/lib/get-url";
@@ -365,7 +366,7 @@ export default class UserMenu extends Component {
 
             <PluginOutlet
               @name="user-menu-tabs-list__after"
-              @outletArgs={{hash user=this.currentUser}}
+              @outletArgs={{lazyHash user=this.currentUser}}
             />
           </div>
           <div

--- a/app/assets/javascripts/discourse/app/components/user-nav.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-nav.gjs
@@ -4,6 +4,7 @@ import DNavigationItem from "discourse/components/d-navigation-item";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 const UserNav = <template>
@@ -73,7 +74,7 @@ const UserNav = <template>
       <PluginOutlet
         @name="user-main-nav"
         @connectorTagName="li"
-        @outletArgs={{hash model=@user}}
+        @outletArgs={{lazyHash model=@user}}
       />
 
       {{#if @user.can_edit}}

--- a/app/assets/javascripts/discourse/app/components/user-nav.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-nav.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { and } from "truth-helpers";
 import DNavigationItem from "discourse/components/d-navigation-item";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";

--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.gjs
@@ -1,4 +1,4 @@
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";

--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.gjs
@@ -1,6 +1,7 @@
 import { fn, hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import CategorySelector from "select-kit/components/category-selector";
 
@@ -108,7 +109,7 @@ const Categories = <template>
     <PluginOutlet
       @name="user-preferences-categories"
       @connectorTagName="div"
-      @outletArgs={{hash model=@model save=@save}}
+      @outletArgs={{lazyHash model=@model save=@save}}
     />
   </span>
 
@@ -118,7 +119,7 @@ const Categories = <template>
     <PluginOutlet
       @name="user-custom-controls"
       @connectorTagName="div"
-      @outletArgs={{hash model=@model}}
+      @outletArgs={{lazyHash model=@model}}
     />
   </span>
 </template>;

--- a/app/assets/javascripts/discourse/app/components/user-preferences/tags.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/tags.gjs
@@ -1,6 +1,7 @@
 import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import TagChooser from "select-kit/components/tag-chooser";
 
@@ -72,12 +73,12 @@ const Tags = <template>
     <PluginOutlet
       @name="user-preferences-tags"
       @connectorTagName="div"
-      @outletArgs={{hash model=@model save=@save}}
+      @outletArgs={{lazyHash model=@model save=@save}}
     />
     <PluginOutlet
       @name="user-custom-controls"
       @connectorTagName="div"
-      @outletArgs={{hash model=@model}}
+      @outletArgs={{lazyHash model=@model}}
     />
   {{/if}}
 </template>;

--- a/app/assets/javascripts/discourse/app/components/user-profile-avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-profile-avatar.gjs
@@ -3,17 +3,18 @@ import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAvatarFlair from "discourse/components/user-avatar-flair";
 import boundAvatar from "discourse/helpers/bound-avatar";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default class UserProfileAvatar extends Component {
   <template>
     <PluginOutlet
       @name="user-profile-avatar-wrapper"
-      @outletArgs={{hash user=@user}}
+      @outletArgs={{lazyHash user=@user}}
     >
       <div class="user-profile-avatar">
         <PluginOutlet
           @name="user-profile-avatar-img-wrapper"
-          @outletArgs={{hash user=@user}}
+          @outletArgs={{lazyHash user=@user}}
         >
           {{boundAvatar @user "huge"}}
         </PluginOutlet>
@@ -22,7 +23,7 @@ export default class UserProfileAvatar extends Component {
         <div>
           <PluginOutlet
             @name="user-profile-avatar-flair"
-            @outletArgs={{hash model=@user}}
+            @outletArgs={{lazyHash model=@user}}
           />
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/components/user-profile-avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-profile-avatar.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAvatarFlair from "discourse/components/user-avatar-flair";
 import boundAvatar from "discourse/helpers/bound-avatar";

--- a/app/assets/javascripts/discourse/app/components/user-stream-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream-item.gjs
@@ -12,6 +12,7 @@ import avatar from "discourse/helpers/avatar";
 import categoryLink from "discourse/helpers/category-link";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { propertyEqual } from "discourse/lib/computed";
 import discourseComputed from "discourse/lib/decorators";
@@ -66,7 +67,7 @@ export default class UserStreamItem extends Component {
   <template>
     <PluginOutlet
       @name="user-stream-item-above"
-      @outletArgs={{hash item=@item}}
+      @outletArgs={{lazyHash item=@item}}
     />
 
     <div class="user-stream-item__header info">
@@ -126,7 +127,7 @@ export default class UserStreamItem extends Component {
         <PluginOutlet
           @name="user-stream-item-header"
           @connectorTagName="div"
-          @outletArgs={{hash item=@item}}
+          @outletArgs={{lazyHash item=@item}}
         />
       </span>
     </div>

--- a/app/assets/javascripts/discourse/app/components/user-stream-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream-item.gjs
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { computed } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import { classNameBindings, tagName } from "@ember-decorators/component";

--- a/app/assets/javascripts/discourse/app/components/user-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";

--- a/app/assets/javascripts/discourse/app/components/user-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream.gjs
@@ -10,6 +10,7 @@ import PostList from "discourse/components/post-list";
 import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import ClickTrack from "discourse/lib/click-track";
 import DiscourseURL from "discourse/lib/url";
@@ -134,7 +135,7 @@ export default class UserStreamComponent extends Component {
       <:abovePostItemHeader as |post|>
         <PluginOutlet
           @name="user-stream-item-above"
-          @outletArgs={{hash item=post}}
+          @outletArgs={{lazyHash item=post}}
         />
       </:abovePostItemHeader>
       <:belowPostItemMetaData as |post|>
@@ -142,7 +143,7 @@ export default class UserStreamComponent extends Component {
           <PluginOutlet
             @name="user-stream-item-header"
             @connectorTagName="div"
-            @outletArgs={{hash item=post}}
+            @outletArgs={{lazyHash item=post}}
           />
         </span>
       </:belowPostItemMetaData>

--- a/app/assets/javascripts/discourse/app/components/user-summary-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-summary-topic.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/components/user-summary-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-summary-topic.gjs
@@ -5,6 +5,7 @@ import { tagName } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import number from "discourse/helpers/number";
 
 @tagName("li")
@@ -12,7 +13,7 @@ export default class UserSummaryTopic extends Component {
   <template>
     <PluginOutlet
       @name="user-summary-topic-wrapper"
-      @outletArgs={{hash
+      @outletArgs={{lazyHash
         topic=@topic
         url=@url
         createdAt=@createdAt

--- a/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
+++ b/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
@@ -1,0 +1,14 @@
+import { setInternalHelperManager } from "@glimmer/manager";
+import { createConstRef } from "@glimmer/reference";
+
+// Like ember's builtin hash helper, but instead of returning a reified object
+// every time its referenced, it returns a static proxy object with auto-trackable keys.
+export default setInternalHelperManager(({ named }) => {
+  const proxy = new Proxy(named, {
+    get(target, prop) {
+      return target[prop]?.compute();
+    },
+  });
+
+  return createConstRef(proxy);
+}, {});

--- a/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
+++ b/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
@@ -1,35 +1,28 @@
 import { setInternalHelperManager } from "@glimmer/manager";
 import { createConstRef, valueForRef } from "@glimmer/reference";
+import { dependentKeyCompat } from "@ember/object/compat";
+
+class LazyHash {
+  constructor(namedRefs) {
+    for (const [key, value] of Object.entries(namedRefs)) {
+      Object.defineProperty(
+        this,
+        key,
+        dependentKeyCompat(this, key, {
+          get() {
+            return valueForRef(value);
+          },
+          enumerable: true,
+          configurable: false,
+        })
+      );
+    }
+    Object.preventExtensions(this);
+  }
+}
 
 // Like ember's builtin hash helper, but instead of returning a reified object
 // every time its referenced, it returns a static proxy object with auto-trackable keys.
-export default setInternalHelperManager(({ named }) => {
-  const proxy = new Proxy(named, {
-    get(target, prop) {
-      if (target[prop]) {
-        return valueForRef(target[prop]);
-      }
-    },
-    isExtensible() {
-      return false;
-    },
-    getOwnPropertyDescriptor(target, key) {
-      if (key in target) {
-        return {
-          enumerable: true,
-          configurable: true,
-          get() {
-            if (target[key]) {
-              return valueForRef(target[key]);
-            }
-          },
-        };
-      }
-    },
-    set() {
-      return false;
-    },
-  });
-
-  return createConstRef(proxy);
+export default setInternalHelperManager(({ named: namedRefs }) => {
+  return createConstRef(new LazyHash(namedRefs));
 }, {});

--- a/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
+++ b/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
@@ -1,5 +1,5 @@
 import { setInternalHelperManager } from "@glimmer/manager";
-import { createConstRef, valueForRef } from "@glimmer/reference";
+import { createComputeRef, valueForRef } from "@glimmer/reference";
 import { dependentKeyCompat } from "@ember/object/compat";
 
 class LazyHash {
@@ -24,5 +24,10 @@ class LazyHash {
 // Like ember's builtin hash helper, but instead of returning a reified object
 // every time its referenced, it returns a static proxy object with auto-trackable keys.
 export default setInternalHelperManager(({ named: namedRefs }) => {
-  return createConstRef(new LazyHash(namedRefs));
+  let instance;
+  return createComputeRef(
+    () => (instance ??= new LazyHash(namedRefs)),
+    null,
+    "lazy-hash"
+  );
 }, {});

--- a/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
+++ b/app/assets/javascripts/discourse/app/helpers/lazy-hash.js
@@ -1,12 +1,33 @@
 import { setInternalHelperManager } from "@glimmer/manager";
-import { createConstRef } from "@glimmer/reference";
+import { createConstRef, valueForRef } from "@glimmer/reference";
 
 // Like ember's builtin hash helper, but instead of returning a reified object
 // every time its referenced, it returns a static proxy object with auto-trackable keys.
 export default setInternalHelperManager(({ named }) => {
   const proxy = new Proxy(named, {
     get(target, prop) {
-      return target[prop]?.compute();
+      if (target[prop]) {
+        return valueForRef(target[prop]);
+      }
+    },
+    isExtensible() {
+      return false;
+    },
+    getOwnPropertyDescriptor(target, key) {
+      if (key in target) {
+        return {
+          enumerable: true,
+          configurable: true,
+          get() {
+            if (target[key]) {
+              return valueForRef(target[key]);
+            }
+          },
+        };
+      }
+    },
+    set() {
+      return false;
     },
   });
 

--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/checkbox.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/checkbox.gjs
@@ -1,5 +1,4 @@
 import Component, { Input } from "@ember/component";
-import { hash } from "@ember/helper";
 import { tagName } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";

--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/checkbox.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/checkbox.gjs
@@ -3,6 +3,7 @@ import { hash } from "@ember/helper";
 import { tagName } from "@ember-decorators/component";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 @tagName("")
 export default class Checkbox extends Component {
@@ -10,7 +11,7 @@ export default class Checkbox extends Component {
     <label class="wizard-container__label">
       <PluginOutlet
         @name="wizard-checkbox"
-        @outletArgs={{hash disabled=this.field.disabled}}
+        @outletArgs={{lazyHash disabled=this.field.disabled}}
       >
         <Input
           @type="checkbox"
@@ -29,7 +30,7 @@ export default class Checkbox extends Component {
 
       <PluginOutlet
         @name="below-wizard-checkbox"
-        @outletArgs={{hash disabled=this.field.disabled}}
+        @outletArgs={{lazyHash disabled=this.field.disabled}}
       />
     </label>
   </template>

--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action, set } from "@ember/object";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/radio.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action, set } from "@ember/object";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 
 export default class Radio extends Component {
@@ -42,7 +43,7 @@ export default class Radio extends Component {
           <label class="wizard-container__label">
             <PluginOutlet
               @name="wizard-radio"
-              @outletArgs={{hash disabled=choice.disabled}}
+              @outletArgs={{lazyHash disabled=choice.disabled}}
             >
               <input
                 type="radio"
@@ -59,7 +60,7 @@ export default class Radio extends Component {
 
             <PluginOutlet
               @name="below-wizard-radio"
-              @outletArgs={{hash disabled=choice.disabled}}
+              @outletArgs={{lazyHash disabled=choice.disabled}}
             />
           </label>
         </div>

--- a/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
@@ -5,6 +5,7 @@ import { dasherize } from "@ember/string";
 import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import fields from "./fields";
 
 export default class WizardFieldComponent extends Component {
@@ -83,7 +84,7 @@ export default class WizardFieldComponent extends Component {
 
         <PluginOutlet
           @name="below-wizard-extra-description"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             id=@field.id
             disabled=@field.disabled
             value=@field.value
@@ -93,7 +94,7 @@ export default class WizardFieldComponent extends Component {
 
       <PluginOutlet
         @name="below-wizard-field"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           id=@field.id
           disabled=@field.disabled
           value=@field.value

--- a/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/wizard-field.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { assert } from "@ember/debug";
-import { hash } from "@ember/helper";
 import { dasherize } from "@ember/string";
 import { htmlSafe } from "@ember/template";
 import { or } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/templates/about.gjs
+++ b/app/assets/javascripts/discourse/app/templates/about.gjs
@@ -4,13 +4,14 @@ import RouteTemplate from "ember-route-template";
 import AboutPage from "discourse/components/about-page";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
   <template>
     <PluginOutlet
       @name="about-wrapper"
-      @outletArgs={{hash
+      @outletArgs={{lazyHash
         model=@controller.model
         contactInfo=@controller.contactInfo
         faqOverridden=@controller.faqOverridden

--- a/app/assets/javascripts/discourse/app/templates/about.gjs
+++ b/app/assets/javascripts/discourse/app/templates/about.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import AboutPage from "discourse/components/about-page";

--- a/app/assets/javascripts/discourse/app/templates/application.gjs
+++ b/app/assets/javascripts/discourse/app/templates/application.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import DialogHolder from "dialog-holder/components/dialog-holder";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/discourse/app/templates/application.gjs
+++ b/app/assets/javascripts/discourse/app/templates/application.gjs
@@ -26,6 +26,7 @@ import Sidebar from "discourse/components/sidebar";
 import SoftwareUpdatePrompt from "discourse/components/software-update-prompt";
 import TopicEntrance from "discourse/components/topic-entrance";
 import WelcomeBanner from "discourse/components/welcome-banner";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 import DMenus from "float-kit/components/d-menus";
@@ -48,7 +49,9 @@ export default RouteTemplate(
       <PluginOutlet
         @name="above-site-header"
         @connectorTagName="div"
-        @outletArgs={{hash currentPath=@controller.router._router.currentPath}}
+        @outletArgs={{lazyHash
+          currentPath=@controller.router._router.currentPath
+        }}
       />
 
       {{#if @controller.showSiteHeader}}
@@ -74,7 +77,9 @@ export default RouteTemplate(
       <PluginOutlet
         @name="below-site-header"
         @connectorTagName="div"
-        @outletArgs={{hash currentPath=@controller.router._router.currentPath}}
+        @outletArgs={{lazyHash
+          currentPath=@controller.router._router.currentPath
+        }}
       />
 
       <div id="main-outlet-wrapper" class="wrap" role="main">
@@ -104,7 +109,7 @@ export default RouteTemplate(
             <PluginOutlet
               @name="top-notices"
               @connectorTagName="div"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 currentPath=@controller.router._router.currentPath
               }}
             />
@@ -115,7 +120,7 @@ export default RouteTemplate(
           <CardContainer />
           <PluginOutlet
             @name="main-outlet-bottom"
-            @outletArgs={{hash showFooter=@controller.showFooter}}
+            @outletArgs={{lazyHash showFooter=@controller.showFooter}}
           />
         </div>
 
@@ -129,7 +134,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="above-footer"
         @connectorTagName="div"
-        @outletArgs={{hash showFooter=@controller.showFooter}}
+        @outletArgs={{lazyHash showFooter=@controller.showFooter}}
       />
       {{#if @controller.showFooter}}
         <CustomHtml
@@ -141,7 +146,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="below-footer"
         @connectorTagName="div"
-        @outletArgs={{hash showFooter=@controller.showFooter}}
+        @outletArgs={{lazyHash showFooter=@controller.showFooter}}
       />
 
       <ModalContainer />

--- a/app/assets/javascripts/discourse/app/templates/badges/show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/discourse/app/templates/badges/show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.gjs
@@ -11,6 +11,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import UserInfo from "discourse/components/user-info";
 import formatDate from "discourse/helpers/format-date";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -61,7 +62,7 @@ export default RouteTemplate(
           >
             <PluginOutlet
               @name="selectable-user-badges"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 selectableUserBadges=@controller.selectableUserBadges
                 closeAction=@controller.toggleSetUserTitle
               }}

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.gjs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.gjs
@@ -9,6 +9,7 @@ import Navigation from "discourse/components/discovery/navigation";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default RouteTemplate(
   <template>
@@ -65,7 +66,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="below-discovery-categories"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             categories=@controller.model.categories
             topics=@controller.model.topics
           }}

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.gjs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
 import { and } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/templates/discovery/login-required.gjs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/login-required.gjs
@@ -6,6 +6,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import hideApplicationHeaderButtons from "discourse/helpers/hide-application-header-buttons";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 
 export default RouteTemplate(
@@ -20,7 +21,7 @@ export default RouteTemplate(
         <div class="login-welcome">
           <PluginOutlet
             @name="above-login"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
           <PluginOutlet @name="above-static" />
 
@@ -31,7 +32,7 @@ export default RouteTemplate(
           <PluginOutlet @name="below-static" />
           <PluginOutlet
             @name="below-login"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
 
           <div class="body-page-button-container">
@@ -53,7 +54,7 @@ export default RouteTemplate(
 
           <PluginOutlet
             @name="below-login-buttons"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/templates/discovery/login-required.gjs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/login-required.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
@@ -18,6 +18,7 @@ import bodyClass from "discourse/helpers/body-class";
 import categoryLink from "discourse/helpers/category-link";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -34,7 +35,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="full-page-search-above-search-header"
         @connectorTagName="div"
-        @outletArgs={{hash searchTerm=@controller.searchTerm}}
+        @outletArgs={{lazyHash searchTerm=@controller.searchTerm}}
       />
       <div class="search-header" role="search">
         <h1 class="search-page-heading">
@@ -96,7 +97,7 @@ export default RouteTemplate(
           <div class="search-filters">
             <PluginOutlet
               @name="full-page-search-filters"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 searchTerm=(readonly @controller.searchTerm)
                 onChangeSearchTerm=(fn (mut @controller.searchTerm))
                 search=(fn @controller.search (hash collapseFilters=true))
@@ -135,7 +136,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="full-page-search-below-search-header"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             search=@controller.searchTerm
             type=@controller.search_type
             model=@controller.model
@@ -205,7 +206,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="full-page-search-below-search-info"
           @connectorTagName="div"
-          @outletArgs={{hash search=@controller.searchTerm}}
+          @outletArgs={{lazyHash search=@controller.searchTerm}}
         />
 
         {{#if @controller.searching}}
@@ -348,7 +349,7 @@ export default RouteTemplate(
               {{/if}}
               <PluginOutlet
                 @name="full-page-search-below-results"
-                @outletArgs={{hash canLoadMore=@controller.canLoadMore}}
+                @outletArgs={{lazyHash canLoadMore=@controller.canLoadMore}}
               />
             </LoadMore>
           </div>

--- a/app/assets/javascripts/discourse/app/templates/group-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.gjs
@@ -1,5 +1,5 @@
 import { Input } from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
 import { or } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/templates/group-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.gjs
@@ -16,6 +16,7 @@ import UserInfo from "discourse/components/user-info";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
@@ -123,7 +124,7 @@ export default RouteTemplate(
 
               <PluginOutlet
                 @name="group-index-table-header-after-username"
-                @outletArgs={{hash
+                @outletArgs={{lazyHash
                   group=@controller.model
                   asc=@controller.asc
                   order=@controller.order
@@ -213,7 +214,7 @@ export default RouteTemplate(
 
                   <PluginOutlet
                     @name="group-index-table-row-after-username"
-                    @outletArgs={{hash member=m}}
+                    @outletArgs={{lazyHash member=m}}
                   />
 
                   <div

--- a/app/assets/javascripts/discourse/app/templates/group.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group.gjs
@@ -9,6 +9,7 @@ import GroupMembershipButton from "discourse/components/group-membership-button"
 import GroupNavigation from "discourse/components/group-navigation";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 import DTooltip from "float-kit/components/d-tooltip";
@@ -19,7 +20,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="before-group-container"
         @connectorTagName="div"
-        @outletArgs={{hash group=@controller.model}}
+        @outletArgs={{lazyHash group=@controller.model}}
       />
     </span>
 
@@ -108,7 +109,7 @@ export default RouteTemplate(
           <PluginOutlet
             @name="group-details-after"
             @connectorTagName="div"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
         </div>
 

--- a/app/assets/javascripts/discourse/app/templates/group.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";
 import { and, or } from "truth-helpers";

--- a/app/assets/javascripts/discourse/app/templates/group/manage/tags.gjs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/tags.gjs
@@ -3,6 +3,7 @@ import RouteTemplate from "ember-route-template";
 import GroupManageSaveButton from "discourse/components/group-manage-save-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import TagChooser from "select-kit/components/tag-chooser";
 
@@ -13,7 +14,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="before-manage-group-tags"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
 
       <div class="control-group">

--- a/app/assets/javascripts/discourse/app/templates/login.gjs
+++ b/app/assets/javascripts/discourse/app/templates/login.gjs
@@ -12,6 +12,7 @@ import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
 import hideApplicationHeaderButtons from "discourse/helpers/hide-application-header-buttons";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import { i18n } from "discourse-i18n";
 
@@ -36,7 +37,7 @@ export default RouteTemplate(
           <PluginOutlet
             @name="login-before-modal-body"
             @connectorTagName="div"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               flashChanged=this.flashChanged
               flashTypeChanged=this.flashTypeChanged
             }}
@@ -64,7 +65,9 @@ export default RouteTemplate(
               <WelcomeHeader @header={{i18n "login.header_title"}}>
                 <PluginOutlet
                   @name="login-header-bottom"
-                  @outletArgs={{hash createAccount=@controller.createAccount}}
+                  @outletArgs={{lazyHash
+                    createAccount=@controller.createAccount
+                  }}
                 />
               </WelcomeHeader>
               {{#if @controller.showLoginButtons}}
@@ -82,7 +85,7 @@ export default RouteTemplate(
                   <WelcomeHeader @header={{i18n "login.header_title"}}>
                     <PluginOutlet
                       @name="login-header-bottom"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         createAccount=@controller.createAccount
                       }}
                     />

--- a/app/assets/javascripts/discourse/app/templates/preferences.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import DNavigationItem from "discourse/components/d-navigation-item";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";

--- a/app/assets/javascripts/discourse/app/templates/preferences.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.gjs
@@ -5,6 +5,7 @@ import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav"
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -99,12 +100,12 @@ export default RouteTemplate(
         <PluginOutlet
           @name="user-preferences-nav-under-interface"
           @connectorTagName="div"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
         <PluginOutlet
           @name="user-preferences-nav"
           @connectorTagName="li"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
       </HorizontalOverflowNav>
     </div>
@@ -114,7 +115,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="above-user-preferences"
           @connectorTagName="div"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
       </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.gjs
@@ -14,6 +14,7 @@ import UsernamePreference from "discourse/components/username-preference";
 import boundAvatar from "discourse/helpers/bound-avatar";
 import icon from "discourse/helpers/d-icon";
 import dasherize from "discourse/helpers/dasherize";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -365,7 +366,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-account"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
     </span>
 
@@ -375,7 +376,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/apps.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/apps.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserApiKeys from "discourse/components/user-preferences/user-api-keys";
+import lazyHash from "discourse/helpers/lazy-hash";
 
 export default RouteTemplate(
   <template>
@@ -11,7 +12,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-apps"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
   </template>

--- a/app/assets/javascripts/discourse/app/templates/preferences/apps.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/apps.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserApiKeys from "discourse/components/user-preferences/user-api-keys";

--- a/app/assets/javascripts/discourse/app/templates/preferences/emails.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/emails.gjs
@@ -4,6 +4,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import SaveControls from "discourse/components/save-controls";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -85,7 +86,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="user-preferences-emails-pref-email-settings"
           @connectorTagName="div"
-          @outletArgs={{hash model=@controller.model save=@controller.save}}
+          @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
         />
       </span>
     </div>
@@ -161,7 +162,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-emails"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
     </span>
 
@@ -171,7 +172,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
@@ -4,6 +4,7 @@ import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import SaveControls from "discourse/components/save-controls";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -13,7 +14,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-interface-top"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
     </span>
 
@@ -272,7 +273,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-interface"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
     </span>
 
@@ -282,7 +283,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.gjs
@@ -1,4 +1,4 @@
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import DesktopNotificationConfig from "discourse/components/desktop-notification-config";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.gjs
@@ -4,6 +4,7 @@ import DesktopNotificationConfig from "discourse/components/desktop-notification
 import PluginOutlet from "discourse/components/plugin-outlet";
 import SaveControls from "discourse/components/save-controls";
 import UserNotificationSchedule from "discourse/components/user-notification-schedule";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -44,7 +45,10 @@ export default RouteTemplate(
           <PluginOutlet
             @name="user-preferences-desktop-notifications"
             @connectorTagName="div"
-            @outletArgs={{hash model=@controller.model save=@controller.save}}
+            @outletArgs={{lazyHash
+              model=@controller.model
+              save=@controller.save
+            }}
           />
         </span>
       </div>
@@ -56,7 +60,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-notifications"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
     </span>
 
@@ -66,7 +70,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.gjs
@@ -10,6 +10,7 @@ import SaveControls from "discourse/components/save-controls";
 import UppyImageUploader from "discourse/components/uppy-image-uploader";
 import UserField from "discourse/components/user-field";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -229,19 +230,19 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-profile"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=@controller.save}}
+        @outletArgs={{lazyHash model=@controller.model save=@controller.save}}
       />
 
       <PluginOutlet
         @name="user-custom-preferences"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
 
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     {{/unless}}
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.gjs
@@ -1,5 +1,5 @@
 import { Input } from "@ember/component";
-import { array, fn, hash } from "@ember/helper";
+import { array, fn } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -1,4 +1,4 @@
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -9,6 +9,7 @@ import UserApiKeys from "discourse/components/user-preferences/user-api-keys";
 import UserPasskeys from "discourse/components/user-preferences/user-passkeys";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
@@ -181,7 +182,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-preferences-security"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model save=this.save}}
+        @outletArgs={{lazyHash model=@controller.model save=this.save}}
       />
     </span>
 
@@ -191,7 +192,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
   </template>

--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.gjs
@@ -1,4 +1,4 @@
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";

--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.gjs
@@ -6,6 +6,7 @@ import SaveControls from "discourse/components/save-controls";
 import Categories from "discourse/components/user-preferences/categories";
 import Tags from "discourse/components/user-preferences/tags";
 import bodyClass from "discourse/helpers/body-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -67,7 +68,7 @@ export default RouteTemplate(
 
         <PluginOutlet
           @name="user-preferences-tracking-topics"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             model=@controller.model
             customAttrNames=@controller.customAttrNames
           }}

--- a/app/assets/javascripts/discourse/app/templates/preferences/users.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/users.gjs
@@ -5,6 +5,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import SaveControls from "discourse/components/save-controls";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import UserChooser from "select-kit/components/user-chooser";
 
@@ -91,7 +92,7 @@ export default RouteTemplate(
       <PluginOutlet
         @name="user-custom-controls"
         @connectorTagName="div"
-        @outletArgs={{hash model=@controller.model}}
+        @outletArgs={{lazyHash model=@controller.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/review-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.gjs
@@ -10,6 +10,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import ReviewableItem from "discourse/components/reviewable-item";
 import icon from "discourse/helpers/d-icon";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import CategoryChooser from "select-kit/components/category-chooser";
 import ComboBox from "select-kit/components/combo-box";
@@ -101,7 +102,7 @@ export default RouteTemplate(
             <PluginOutlet
               @name="above-review-filters"
               @connectorTagName="div"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 model=@controller.model
                 additionalFilters=@controller.additionalFilters
               }}

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -21,6 +21,7 @@ import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationHeaderButtons from "discourse/helpers/hide-application-header-buttons";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
+import lazyHash from "discourse/helpers/lazy-hash";
 import loadingSpinner from "discourse/helpers/loading-spinner";
 import routeAction from "discourse/helpers/route-action";
 import valueEntered from "discourse/helpers/value-entered";
@@ -63,7 +64,7 @@ export default RouteTemplate(
             >
               <PluginOutlet
                 @name="create-account-header-bottom"
-                @outletArgs={{hash showLogin=(routeAction "showLogin")}}
+                @outletArgs={{lazyHash showLogin=(routeAction "showLogin")}}
               />
             </WelcomeHeader>
             {{#if @controller.showCreateForm}}
@@ -156,7 +157,7 @@ export default RouteTemplate(
 
                 <PluginOutlet
                   @name="create-account-before-password"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     accountName=@controller.accountName
                     accountUsername=@controller.accountUsername
                     accountPassword=@controller.accountPassword
@@ -250,7 +251,7 @@ export default RouteTemplate(
 
                 <PluginOutlet
                   @name="create-account-after-password"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     accountName=@controller.accountName
                     accountUsername=@controller.accountUsername
                     accountPassword=@controller.accountPassword
@@ -291,7 +292,7 @@ export default RouteTemplate(
 
                 <PluginOutlet
                   @name="create-account-after-user-fields"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     accountName=@controller.accountName
                     accountUsername=@controller.accountUsername
                     accountPassword=@controller.accountPassword

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -1,5 +1,4 @@
 import { Input } from "@ember/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/discourse/app/templates/tags/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
 import DiscourseBanner from "discourse/components/discourse-banner";

--- a/app/assets/javascripts/discourse/app/templates/tags/index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.gjs
@@ -5,6 +5,7 @@ import DiscourseBanner from "discourse/components/discourse-banner";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TagList from "discourse/components/tag-list";
 import TagsAdminDropdown from "discourse/components/tags-admin-dropdown";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -26,7 +27,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="tags-below-title"
           @connectorTagName="div"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
       </div>
 

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -39,6 +39,7 @@ import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import stickyAvatars from "discourse/modifiers/sticky-avatars";
 import { i18n } from "discourse-i18n";
@@ -83,7 +84,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="topic-above-post-stream"
           @connectorTagName="div"
-          @outletArgs={{hash
+          @outletArgs={{lazyHash
             model=@controller.model
             editFirstPost=@controller.editFirstPost
           }}
@@ -106,7 +107,7 @@ export default RouteTemplate(
                 <div class="edit-title__wrapper">
                   <PluginOutlet
                     @name="edit-topic-title"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       model=@controller.model
                       buffered=@controller.buffered
                     }}
@@ -124,7 +125,7 @@ export default RouteTemplate(
                   <div class="edit-category__wrapper">
                     <PluginOutlet
                       @name="edit-topic-category"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         model=@controller.model
                         buffered=@controller.buffered
                       }}
@@ -142,7 +143,7 @@ export default RouteTemplate(
                   <div class="edit-tags__wrapper">
                     <PluginOutlet
                       @name="edit-topic-tags"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         model=@controller.model
                         buffered=@controller.buffered
                       }}
@@ -165,7 +166,7 @@ export default RouteTemplate(
                 <PluginOutlet
                   @name="edit-topic"
                   @connectorTagName="div"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     model=@controller.model
                     buffered=@controller.buffered
                   }}
@@ -235,13 +236,13 @@ export default RouteTemplate(
 
                 <PluginOutlet
                   @name="topic-title-suffix"
-                  @outletArgs={{hash model=@controller.model}}
+                  @outletArgs={{lazyHash model=@controller.model}}
                 />
               </h1>
 
               <PluginOutlet
                 @name="topic-category-wrapper"
-                @outletArgs={{hash topic=@controller.model}}
+                @outletArgs={{lazyHash topic=@controller.model}}
               >
                 <TopicCategory
                   @topic={{@controller.model}}
@@ -329,7 +330,7 @@ export default RouteTemplate(
             <PluginOutlet
               @name="topic-navigation"
               @connectorTagName="div"
-              @outletArgs={{hash
+              @outletArgs={{lazyHash
                 topic=@controller.model
                 renderTimeline=info.renderTimeline
                 topicProgressExpanded=info.topicProgressExpanded
@@ -376,7 +377,7 @@ export default RouteTemplate(
                   <PluginOutlet
                     @name="before-topic-progress"
                     @connectorTagName="div"
-                    @outletArgs={{hash
+                    @outletArgs={{lazyHash
                       model=@controller.model
                       jumpToPost=@controller.jumpToPost
                     }}
@@ -406,7 +407,7 @@ export default RouteTemplate(
             <PluginOutlet
               @name="topic-navigation-bottom"
               @connectorTagName="div"
-              @outletArgs={{hash model=@controller.model}}
+              @outletArgs={{lazyHash model=@controller.model}}
             />
           </TopicNavigation>
 
@@ -426,7 +427,7 @@ export default RouteTemplate(
                   <PluginOutlet
                     @name="topic-above-posts"
                     @connectorTagName="div"
-                    @outletArgs={{hash model=@controller.model}}
+                    @outletArgs={{lazyHash model=@controller.model}}
                   />
                 </span>
 
@@ -529,7 +530,7 @@ export default RouteTemplate(
                           <div class="reviewable-actions">
                             <PluginOutlet
                               @name="topic-additional-reviewable-actions"
-                              @outletArgs={{hash pending=pending}}
+                              @outletArgs={{lazyHash pending=pending}}
                             />
                             <DButton
                               @label="review.delete"
@@ -618,7 +619,7 @@ export default RouteTemplate(
               <PluginOutlet
                 @name="topic-area-bottom"
                 @connectorTagName="div"
-                @outletArgs={{hash model=@controller.model}}
+                @outletArgs={{lazyHash model=@controller.model}}
               />
             </section>
           </div>
@@ -634,7 +635,7 @@ export default RouteTemplate(
                 <PluginOutlet
                   @name="topic-above-footer-buttons"
                   @connectorTagName="div"
-                  @outletArgs={{hash model=@controller.model}}
+                  @outletArgs={{lazyHash model=@controller.model}}
                 />
               </span>
 
@@ -673,14 +674,14 @@ export default RouteTemplate(
             <PluginOutlet
               @name="topic-above-suggested"
               @connectorTagName="div"
-              @outletArgs={{hash model=@controller.model}}
+              @outletArgs={{lazyHash model=@controller.model}}
             />
           </span>
 
           <MoreTopics @topic={{@controller.model}} />
           <PluginOutlet
             @name="topic-below-suggested"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
         {{/if}}
       {{else}}

--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -11,6 +11,7 @@ import UserStatusMessage from "discourse/components/user-status-message";
 import icon from "discourse/helpers/d-icon";
 import formatUsername from "discourse/helpers/format-username";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import routeAction from "discourse/helpers/route-action";
 import userStatus from "discourse/helpers/user-status";
@@ -23,7 +24,7 @@ export default RouteTemplate(
     <PluginOutlet
       @name="above-user-profile"
       @connectorTagName="div"
-      @outletArgs={{hash model=@controller.model}}
+      @outletArgs={{lazyHash model=@controller.model}}
     />
     <div
       class="container
@@ -159,7 +160,7 @@ export default RouteTemplate(
             <div class="primary">
               <PluginOutlet
                 @name="before-user-profile-avatar"
-                @outletArgs={{hash model=@controller.model}}
+                @outletArgs={{lazyHash model=@controller.model}}
               />
               <UserProfileAvatar @user={{@controller.model}} @tagName="" />
               <div class="primary-textual">
@@ -202,7 +203,7 @@ export default RouteTemplate(
                     <PluginOutlet
                       @name="user-post-names"
                       @connectorTagName="div"
-                      @outletArgs={{hash model=@controller.model}}
+                      @outletArgs={{lazyHash model=@controller.model}}
                     />
                   </span>
                 </div>
@@ -255,7 +256,7 @@ export default RouteTemplate(
                     <PluginOutlet
                       @name="user-location-and-website"
                       @connectorTagName="div"
-                      @outletArgs={{hash model=@controller.model}}
+                      @outletArgs={{lazyHash model=@controller.model}}
                     />
                   </span>
                 </div>
@@ -263,7 +264,7 @@ export default RouteTemplate(
                 <PluginOutlet
                   @name="before-user-profile-bio"
                   @connectorTagName="div"
-                  @outletArgs={{hash
+                  @outletArgs={{lazyHash
                     model=@controller.model
                     publicUserFields=@controller.publicUserFields
                     collapsedInfo=@controller.collapsedInfo
@@ -338,7 +339,7 @@ export default RouteTemplate(
                       <PluginOutlet
                         @name="user-profile-public-fields"
                         @connectorTagName="div"
-                        @outletArgs={{hash
+                        @outletArgs={{lazyHash
                           publicUserFields=@controller.publicUserFields
                           model=@controller.model
                         }}
@@ -351,7 +352,7 @@ export default RouteTemplate(
                   <PluginOutlet
                     @name="user-profile-primary"
                     @connectorTagName="div"
-                    @outletArgs={{hash model=@controller.model}}
+                    @outletArgs={{lazyHash model=@controller.model}}
                   />
                 </span>
               </div>
@@ -394,7 +395,7 @@ export default RouteTemplate(
                   <PluginOutlet
                     @name="user-profile-controls"
                     @connectorTagName="li"
-                    @outletArgs={{hash model=@controller.model}}
+                    @outletArgs={{lazyHash model=@controller.model}}
                   />
 
                   {{#if @controller.canExpandProfile}}

--- a/app/assets/javascripts/discourse/app/templates/user/activity.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.gjs
@@ -6,6 +6,7 @@ import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav"
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -97,7 +98,7 @@ export default RouteTemplate(
           <PluginOutlet
             @name="user-activity-bottom"
             @connectorTagName="li"
-            @outletArgs={{hash model=@controller.model}}
+            @outletArgs={{lazyHash model=@controller.model}}
           />
         </HorizontalOverflowNav>
       </div>

--- a/app/assets/javascripts/discourse/app/templates/user/activity.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import { gt } from "truth-helpers";
 import DNavigationItem from "discourse/components/d-navigation-item";

--- a/app/assets/javascripts/discourse/app/templates/user/badges.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.gjs
@@ -1,4 +1,4 @@
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import BadgeCard from "discourse/components/badge-card";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/app/assets/javascripts/discourse/app/templates/user/badges.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.gjs
@@ -3,6 +3,7 @@ import RouteTemplate from "ember-route-template";
 import BadgeCard from "discourse/components/badge-card";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -12,7 +13,7 @@ export default RouteTemplate(
     <section class="user-content" id="user-content">
       <PluginOutlet
         @name="user-badges-content"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           sortedBadges=@controller.sortedBadges
           maxFavBadges=@controller.siteSettings.max_favorite_badges
           favoriteBadges=@controller.favoriteBadges
@@ -45,7 +46,7 @@ export default RouteTemplate(
           {{/each}}
           <PluginOutlet
             @name="after-user-profile-badges"
-            @outletArgs={{hash user=@controller.user.model}}
+            @outletArgs={{lazyHash user=@controller.user.model}}
           />
         </div>
       </PluginOutlet>

--- a/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/collapsed-info.gjs
@@ -3,13 +3,14 @@ import { LinkTo } from "@ember/routing";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
 const CollapsedInfo = <template>
   <PluginOutlet
     @name="user-profile-above-collapsed-info"
-    @outletArgs={{hash model=@model collapsedInfo=@collapsedInfo}}
+    @outletArgs={{lazyHash model=@model collapsedInfo=@collapsedInfo}}
   />
   {{#unless @collapsedInfo}}
     <div class="secondary" id="collapsed-info-panel">
@@ -104,7 +105,7 @@ const CollapsedInfo = <template>
 
         <PluginOutlet
           @name="user-profile-secondary"
-          @outletArgs={{hash model=@model}}
+          @outletArgs={{lazyHash model=@model}}
         />
       </dl>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/user/messages.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.gjs
@@ -6,6 +6,7 @@ import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav"
 import PluginOutlet from "discourse/components/plugin-outlet";
 import MessagesDropdown from "discourse/components/user-nav/messages-dropdown";
 import bodyClass from "discourse/helpers/body-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 
 export default RouteTemplate(
@@ -14,7 +15,7 @@ export default RouteTemplate(
 
     <PluginOutlet
       @name="user-messages-above-navigation"
-      @outletArgs={{hash model=@controller.model}}
+      @outletArgs={{lazyHash model=@controller.model}}
     />
 
     <div class="user-navigation user-navigation-secondary">
@@ -55,7 +56,7 @@ export default RouteTemplate(
         {{/if}}
         <PluginOutlet
           @name="user-messages-controls-bottom"
-          @outletArgs={{hash showNewPM=@controller.showNewPM}}
+          @outletArgs={{lazyHash showNewPM=@controller.showNewPM}}
         />
       </div>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/user/messages.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import BulkSelectToggle from "discourse/components/bulk-select-toggle";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/templates/user/notifications-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications-index.gjs
@@ -4,6 +4,7 @@ import ConditionalLoadingSpinner from "discourse/components/conditional-loading-
 import EmptyState from "discourse/components/empty-state";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import MenuItem from "discourse/components/user-menu/menu-item";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import NotificationsFilter from "select-kit/components/notifications-filter";
 
@@ -33,7 +34,7 @@ export default RouteTemplate(
         />
         <PluginOutlet
           @name="user-notifications-after-filter"
-          @outletArgs={{hash items=@controller.items}}
+          @outletArgs={{lazyHash items=@controller.items}}
         />
       </div>
 
@@ -47,7 +48,7 @@ export default RouteTemplate(
           <ConditionalLoadingSpinner @condition={{@controller.loading}} />
           <PluginOutlet
             @name="user-notifications-list-bottom"
-            @outletArgs={{hash controller=@controller}}
+            @outletArgs={{lazyHash controller=@controller}}
           />
         </div>
       {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user/notifications-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications-index.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import EmptyState from "discourse/components/empty-state";

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.gjs
@@ -9,6 +9,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -80,7 +81,7 @@ export default RouteTemplate(
         <PluginOutlet
           @name="user-notifications-bottom"
           @connectorTagName="li"
-          @outletArgs={{hash model=@controller.model}}
+          @outletArgs={{lazyHash model=@controller.model}}
         />
 
       </HorizontalOverflowNav>

--- a/app/assets/javascripts/discourse/app/templates/user/summary.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";

--- a/app/assets/javascripts/discourse/app/templates/user/summary.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.gjs
@@ -13,6 +13,7 @@ import UserSummaryUser from "discourse/components/user-summary-user";
 import UserSummaryUsersList from "discourse/components/user-summary-users-list";
 import bodyClass from "discourse/helpers/body-class";
 import categoryLink from "discourse/helpers/category-link";
+import lazyHash from "discourse/helpers/lazy-hash";
 import shortenUrl from "discourse/helpers/shorten-url";
 import { i18n } from "discourse-i18n";
 
@@ -23,7 +24,7 @@ export default RouteTemplate(
     <div class="user-content" id="user-content">
       <PluginOutlet
         @name="above-user-summary-stats"
-        @outletArgs={{hash model=@controller.model user=@controller.user}}
+        @outletArgs={{lazyHash model=@controller.model user=@controller.user}}
       />
       {{#if @controller.model.can_see_summary_stats}}
         <div class="top-section stats-section">
@@ -153,7 +154,10 @@ export default RouteTemplate(
             <PluginOutlet
               @name="user-summary-stat"
               @connectorTagName="li"
-              @outletArgs={{hash model=@controller.model user=@controller.user}}
+              @outletArgs={{lazyHash
+                model=@controller.model
+                user=@controller.user
+              }}
             />
           </ul>
         </div>
@@ -161,7 +165,7 @@ export default RouteTemplate(
 
       <PluginOutlet
         @name="below-user-summary-stats"
-        @outletArgs={{hash model=@controller.model user=@controller.user}}
+        @outletArgs={{lazyHash model=@controller.model user=@controller.user}}
       />
 
       <div class="top-section replies-and-topics-section">
@@ -302,7 +306,7 @@ export default RouteTemplate(
                   <tr>
                     <PluginOutlet
                       @name="user-summary-top-category-row"
-                      @outletArgs={{hash
+                      @outletArgs={{lazyHash
                         category=category
                         user=@controller.user
                       }}
@@ -354,7 +358,7 @@ export default RouteTemplate(
               {{/each}}
               <PluginOutlet
                 @name="after-user-summary-badges"
-                @outletArgs={{hash
+                @outletArgs={{lazyHash
                   model=@controller.model
                   user=@controller.user
                 }}

--- a/app/assets/javascripts/discourse/app/templates/users.gjs
+++ b/app/assets/javascripts/discourse/app/templates/users.gjs
@@ -11,6 +11,7 @@ import basePath from "discourse/helpers/base-path";
 import bodyClass from "discourse/helpers/body-class";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
+import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -31,7 +32,7 @@ export default RouteTemplate(
               <PluginOutlet
                 @name="users-top"
                 @connectorTagName="div"
-                @outletArgs={{hash model=@controller.model}}
+                @outletArgs={{lazyHash model=@controller.model}}
               />
             </span>
             <div class="directory-controls">
@@ -84,7 +85,7 @@ export default RouteTemplate(
                 {{/if}}
                 <PluginOutlet
                   @name="users-directory-controls"
-                  @outletArgs={{hash model=@controller.model}}
+                  @outletArgs={{lazyHash model=@controller.model}}
                 />
               </div>
             </div>

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-decorator-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-decorator-test.gjs
@@ -3,6 +3,7 @@ import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { withSilencedDeprecations } from "discourse/lib/deprecated";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -53,7 +54,7 @@ module("Plugin Outlet - Decorator", function (hooks) {
         <PluginOutlet
           @connectorTagName="div"
           @name="my-outlet-name"
-          @outletArgs={{hash value=true}}
+          @outletArgs={{lazyHash value=true}}
         />
       </template>
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-decorator-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-decorator-test.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -8,6 +8,7 @@ import { module, test } from "qunit";
 import sinon from "sinon";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import deprecatedOutletArgument from "discourse/helpers/deprecated-outlet-argument";
+import lazyHash from "discourse/helpers/lazy-hash";
 import deprecated, {
   withSilencedDeprecations,
   withSilencedDeprecationsAsync,
@@ -175,7 +176,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         this.template = hbs`
           <PluginOutlet
             @name="outlet-with-default"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               shouldDisplay=this.shouldDisplay
               yieldCore=this.yieldCore
               enableClashingConnector=this.enableClashingConnector
@@ -272,7 +273,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         await render(hbs`
           <PluginOutlet
             @name="outlet-with-default"
-            @outletArgs={{hash shouldDisplay=true}}
+            @outletArgs={{lazyHash shouldDisplay=true}}
           >
             <span class="result">Core implementation</span>
           </PluginOutlet>
@@ -301,7 +302,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         await render(hbs`
           <PluginOutlet
             @name="outlet-with-default"
-            @outletArgs={{hash shouldDisplay=true}}
+            @outletArgs={{lazyHash shouldDisplay=true}}
           >
             <span class="result">Core implementation</span>
           </PluginOutlet>
@@ -327,7 +328,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         await render(hbs`
           <PluginOutlet
             @name="outlet-with-default"
-            @outletArgs={{hash shouldDisplay=true}}
+            @outletArgs={{lazyHash shouldDisplay=true}}
           >
             <span class="result">Core implementation</span>
           </PluginOutlet>
@@ -355,7 +356,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         await render(hbs`
           <PluginOutlet
             @name="outlet-with-default"
-            @outletArgs={{hash shouldDisplay=true}}
+            @outletArgs={{lazyHash shouldDisplay=true}}
           >
             <span class="result">Core implementation</span>
           </PluginOutlet>
@@ -389,7 +390,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
     await render(hbs`
       <PluginOutlet
         @name="test-name"
-        @outletArgs={{hash shouldDisplay=this.shouldDisplay}}
+        @outletArgs={{lazyHash shouldDisplay=this.shouldDisplay}}
       />
     `);
     assert
@@ -428,7 +429,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
     await render(hbs`
       <PluginOutlet
         @name="test-name"
-        @outletArgs={{hash shouldDisplay=this.shouldDisplay}}
+        @outletArgs={{lazyHash shouldDisplay=this.shouldDisplay}}
       />
     `);
 
@@ -595,7 +596,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
         <template>
           <PluginOutlet
             @name="test-name"
-            @outletArgs={{hash shouldDisplay=true}}
+            @outletArgs={{lazyHash shouldDisplay=true}}
             @deprecatedArgs={{hash
               argNotUsed=(deprecatedOutletArgument value=true)
             }}
@@ -631,7 +632,7 @@ module(
 
     test("uses classic PluginConnector by default", async function (assert) {
       await render(hbs`
-        <PluginOutlet @name="test-name" @outletArgs={{hash hello="world"}} />
+        <PluginOutlet @name="test-name" @outletArgs={{lazyHash hello="world"}} />
       `);
 
       assert.dom(".outletArgHelloValue").hasText("world");
@@ -642,7 +643,7 @@ module(
       await render(hbs`
         <PluginOutlet
           @name="test-name"
-          @outletArgs={{hash hello="world"}}
+          @outletArgs={{lazyHash hello="world"}}
           @defaultGlimmer={{true}}
         />
       `);
@@ -671,7 +672,7 @@ module(
       await render(hbs`
         <PluginOutlet
           @name="test-name"
-          @outletArgs={{hash hello="world" someBoolean=this.someBoolean}}
+          @outletArgs={{lazyHash hello="world" someBoolean=this.someBoolean}}
         />
       `);
 
@@ -702,7 +703,7 @@ module(
             <template>
               <PluginOutlet
                 @name="test-name"
-                @outletArgs={{hash hello="world"}}
+                @outletArgs={{lazyHash hello="world"}}
                 @defaultGlimmer={{true}}
               />
             </template>
@@ -733,7 +734,7 @@ module(
       await render(hbs`
         <PluginOutlet
           @name="test-name"
-          @outletArgs={{hash hello="world" someBoolean=this.someBoolean}}
+          @outletArgs={{lazyHash hello="world" someBoolean=this.someBoolean}}
         />
       `);
 
@@ -761,7 +762,7 @@ module(
       await render(hbs`
         <PluginOutlet
           @name="test-name"
-          @outletArgs={{hash hello="world" someBoolean=this.someBoolean}}
+          @outletArgs={{lazyHash hello="world" someBoolean=this.someBoolean}}
         />
       `);
 
@@ -949,7 +950,7 @@ module(
 
       test("unused arguments", async function (assert) {
         await render(hbs`
-          <PluginOutlet @name="test-name" @outletArgs={{hash hello="world"}} @deprecatedArgs={{hash argNotUsed=(deprecated-outlet-argument value="not used")}} />
+          <PluginOutlet @name="test-name" @outletArgs={{lazyHash hello="world"}} @deprecatedArgs={{hash argNotUsed=(deprecated-outlet-argument value="not used")}} />
         `);
 
         // deprecated argument still works

--- a/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
@@ -4,6 +4,7 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserStatusMessage from "discourse/components/user-status-message";
+import lazyHash from "discourse/helpers/lazy-hash";
 import replaceEmoji from "discourse/helpers/replace-emoji";
 import ChatChannelUnreadIndicator from "../chat-channel-unread-indicator";
 
@@ -80,7 +81,7 @@ export default class ChatChannelName extends Component {
         {{#if this.showPluginOutlet}}
           <PluginOutlet
             @name="after-chat-channel-username"
-            @outletArgs={{hash user=@user}}
+            @outletArgs={{lazyHash user=@user}}
             @tagName=""
             @connectorTagName=""
           />

--- a/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channel-name/index.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { get, hash } from "@ember/helper";
+import { get } from "@ember/helper";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-direct.gjs
@@ -8,6 +8,7 @@ import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
 import EmptyChannelsList from "discourse/plugins/chat/discourse/components/empty-channels-list";
@@ -130,7 +131,7 @@ export default class ChannelsListDirect extends Component {
     <PluginOutlet
       @name="below-direct-chat-channels"
       @tagName=""
-      @outletArgs={{hash inSidebar=this.inSidebar}}
+      @outletArgs={{lazyHash inSidebar=this.inSidebar}}
     />
   </template>
 }

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list-public.gjs
@@ -8,6 +8,7 @@ import { and } from "truth-helpers";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import EmptyChannelsList from "discourse/plugins/chat/discourse/components/empty-channels-list";
 import ChatChannelRow from "./chat-channel-row";
@@ -119,7 +120,7 @@ export default class ChannelsListPublic extends Component {
     <PluginOutlet
       @name="below-public-chat-channels"
       @tagName=""
-      @outletArgs={{hash inSidebar=this.inSidebar}}
+      @outletArgs={{lazyHash inSidebar=this.inSidebar}}
     />
   </template>
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -24,6 +24,7 @@ import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
 import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { SKIP } from "discourse/lib/autocomplete";
 import renderEmojiAutocomplete from "discourse/lib/autocomplete/emoji";
 import userAutocomplete from "discourse/lib/autocomplete/user";
@@ -763,7 +764,7 @@ export default class ChatComposer extends Component {
 
             <PluginOutlet
               @name="chat-composer-inline-buttons"
-              @outletArgs={{hash composer=this channel=@channel}}
+              @outletArgs={{lazyHash composer=this channel=@channel}}
             />
 
             {{#if this.site.desktopView}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { cancel, next, throttle } from "@ember/runloop";
 import { service } from "@ember/service";

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
@@ -10,6 +10,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
 import htmlClass from "discourse/helpers/html-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { bind } from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
 import DiscourseURL from "discourse/lib/url";
@@ -258,7 +259,7 @@ export default class ChatDrawer extends Component {
 
           <PluginOutlet
             @name="chat-drawer-before-content"
-            @outletArgs={{hash
+            @outletArgs={{lazyHash
               currentRouteName=this.chatDrawerRouter.currentRouteName
             }}
           />

--- a/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";

--- a/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/toggle-channel-membership-button.gjs
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 
@@ -106,7 +107,7 @@ export default class ToggleChannelMembershipButton extends Component {
     {{else}}
       <PluginOutlet
         @name="chat-join-channel-button"
-        @outletArgs={{hash
+        @outletArgs={{lazyHash
           onJoinChannel=this.onJoinChannel
           channel=@channel
           icon=this.options.joinIcon


### PR DESCRIPTION
This is a more efficient version of `{{hash`, where the values are only evaluated when they're actually accessed

Also bumps `@discourse/lint-configs`, which now includes an ember-template-lint rule to ensure `{{hash}}` is not reintroduced