### PR TITLE
DEV: support un-hiding site settings programmatically

### DIFF
--- a/lib/site_settings/hidden_provider.rb
+++ b/lib/site_settings/hidden_provider.rb
@@ -13,6 +13,10 @@ class SiteSettings::HiddenProvider
     @hidden_settings << site_setting_name
   end
 
+  def remove_hidden(site_setting_name)
+    @hidden_settings.delete(site_setting_name)
+  end
+
   def all
     DiscoursePluginRegistry.apply_modifier(:hidden_site_settings, @hidden_settings)
   end

--- a/spec/lib/site_settings/hidden_provider_spec.rb
+++ b/spec/lib/site_settings/hidden_provider_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe SiteSettings::HiddenProvider do
       hidden_provider.add_hidden(:secret_setting)
       hidden_provider.add_hidden(:internal_thing)
       expect(hidden_provider.all).to contain_exactly(:secret_setting, :internal_thing)
+
+      hidden_provider.remove_hidden(:secret_setting)
+      expect(hidden_provider.all).to contain_exactly(:internal_thing)
     end
 
     it "can return results from modifiers" do


### PR DESCRIPTION
This might be useful to revert changes made by plugins when they're disabled for example.