### PR TITLE
DEV: allows to pass `@currentWhen` to `NavItem`

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-badges.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges.gjs
@@ -27,14 +27,6 @@ export default class AdminBadges extends Component {
     });
   }
 
-  @action
-  activeBadges(currentRoute) {
-    return (
-      currentRoute.name === "adminBadges.index" ||
-      currentRoute.name === "adminBadges.show"
-    );
-  }
-
   <template>
     <div class="badges">
       <DPageHeader
@@ -83,7 +75,7 @@ export default class AdminBadges extends Component {
           <NavItem
             @route="adminBadges.index"
             @label="admin.config.badges.title"
-            @currentWhen={{this.activeBadges}}
+            @currentWhen="adminBadges.show adminBadges.index"
             class="admin-badges-tabs__index"
           />
         </:tabs>

--- a/app/assets/javascripts/admin/addon/components/admin-badges.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges.gjs
@@ -27,6 +27,14 @@ export default class AdminBadges extends Component {
     });
   }
 
+  @action
+  activeBadges(currentRoute) {
+    return (
+      currentRoute.name === "adminBadges.index" ||
+      currentRoute.name === "adminBadges.show"
+    );
+  }
+
   <template>
     <div class="badges">
       <DPageHeader
@@ -75,6 +83,7 @@ export default class AdminBadges extends Component {
           <NavItem
             @route="adminBadges.index"
             @label="admin.config.badges.title"
+            @currentWhen={{this.activeBadges}}
             class="admin-badges-tabs__index"
           />
         </:tabs>

--- a/app/assets/javascripts/discourse/app/components/nav-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/nav-item.gjs
@@ -24,6 +24,10 @@ export default class NavItem extends Component {
       return;
     }
 
+    if (this.args.currentWhen) {
+      return this.args.currentWhen(this.router.currentRoute);
+    }
+
     if (this.args.routeParam) {
       // This is needed because the setting route is underneath /admin/plugins/:plugin_id,
       // but is not a child route of the plugin routes themselves. E.g. discourse-ai
@@ -58,9 +62,15 @@ export default class NavItem extends Component {
           @current-when={{this.active}}
         >{{this.contents}}</LinkTo>
       {{else if @route}}
-        <LinkTo @route={{@route}}>{{this.contents}}</LinkTo>
+        <LinkTo
+          @route={{@route}}
+          @current-when={{this.active}}
+        >{{this.contents}}</LinkTo>
       {{else}}
-        <a href={{getURL @path}} data-auto-route="true">{{this.contents}}</a>
+        <a
+          href={{getURL @path}}
+          data-auto-route="admin.badges"
+        >{{this.contents}}</a>
       {{/if}}
     </li>
   </template>

--- a/app/assets/javascripts/discourse/app/components/nav-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/nav-item.gjs
@@ -32,8 +32,8 @@ export default class NavItem extends Component {
         return input;
       }
 
-      const routes = input.split(" ").filter(Boolean);
-      if (routes.length) {
+      const routes = input?.split?.(" ")?.filter(Boolean);
+      if (routes?.length) {
         return routes.some((str) => str === this.router.currentRoute.name);
       }
 

--- a/app/assets/javascripts/discourse/app/components/nav-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/nav-item.gjs
@@ -67,10 +67,7 @@ export default class NavItem extends Component {
           @current-when={{this.active}}
         >{{this.contents}}</LinkTo>
       {{else}}
-        <a
-          href={{getURL @path}}
-          data-auto-route="admin.badges"
-        >{{this.contents}}</a>
+        <a href={{getURL @path}} data-auto-route="true">{{this.contents}}</a>
       {{/if}}
     </li>
   </template>

--- a/app/assets/javascripts/discourse/app/components/nav-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/nav-item.gjs
@@ -3,6 +3,7 @@ import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { isPresent } from "@ember/utils";
 import concatClass from "discourse/helpers/concat-class";
 import getURL from "discourse/lib/get-url";
 import { iconHTML } from "discourse/lib/icon-library";
@@ -24,8 +25,19 @@ export default class NavItem extends Component {
       return;
     }
 
-    if (this.args.currentWhen) {
-      return this.args.currentWhen(this.router.currentRoute);
+    if (isPresent(this.args.currentWhen)) {
+      const input = this.args.currentWhen;
+
+      if (typeof input === "boolean") {
+        return input;
+      }
+
+      const routes = input.split(" ").filter(Boolean);
+      if (routes.length) {
+        return routes.some((str) => str === this.router.currentRoute.name);
+      }
+
+      return false;
     }
 
     if (this.args.routeParam) {

--- a/app/assets/javascripts/discourse/app/components/nav-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/nav-item.gjs
@@ -26,18 +26,16 @@ export default class NavItem extends Component {
     }
 
     if (isPresent(this.args.currentWhen)) {
-      const input = this.args.currentWhen;
-
-      if (typeof input === "boolean") {
-        return input;
+      const currentWhen = this.args.currentWhen;
+      if (typeof currentWhen === "boolean") {
+        return currentWhen;
+      } else if (typeof currentWhen === "string") {
+        return currentWhen
+          .split(" ")
+          .some((route) => route === this.router.currentRoute.name);
+      } else {
+        return false;
       }
-
-      const routes = input?.split?.(" ")?.filter(Boolean);
-      if (routes?.length) {
-        return routes.some((str) => str === this.router.currentRoute.name);
-      }
-
-      return false;
     }
 
     if (this.args.routeParam) {


### PR DESCRIPTION
Some cases are more complex than the default behavior of `this.router.isActive(this.args.route)`, in this case you can give use `@currentWhen` on your `NavItem` component.

Example:

```gjs
get isItCurrent() {
  return true;
}

<template>
  <NavItem @i18nLabel="test" @currentWhen={{this.isItCurrent}} />
</template>

<template>
  <NavItem @i18nLabel="test" @currentWhen="foo" />
</template>

<template>
  <NavItem @i18nLabel="test" @currentWhen="foo.show foo.index" />
</template>
```

No test as I can't write a component test for this as it relies on the router.