### PR TITLE
DEV: new topic map outlet and header participant flexibility

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/topic/participant.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/topic/participant.gjs
@@ -3,7 +3,7 @@ import { concat, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { eq } from "truth-helpers";
+import { eq, or } from "truth-helpers";
 import avatar from "discourse/helpers/bound-avatar-template";
 import icon from "discourse/helpers/d-icon";
 import getURL from "discourse/lib/get-url";
@@ -38,7 +38,11 @@ export default class Participant extends Component {
         title={{@username}}
       >
         {{#if (eq @type "user")}}
-          {{avatar @user.avatar_template "tiny" (hash title=@username)}}
+          {{avatar
+            @user.avatar_template
+            (or @avatarSize "tiny")
+            (hash title=@username)
+          }}
         {{else}}
           <span>
             {{icon "users"}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -408,6 +408,10 @@ export default class TopicMapSummary extends Component {
           @userFilters={{@postStream.userFilters}}
         />
       {{/if}}
+      <PluginOutlet
+        @name="topic-map-participants-after"
+        @outletArgs={{hash topic=@topic}}
+      />
       <div class="topic-map__buttons">
         {{#if this.readTimeMinutes}}
           <div class="estimated-read-time">

--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -102,13 +102,13 @@ body:not(.archetype-private_message) {
       gap: 0.75em;
 
       &.--single-stat {
-        button {
+        .fk-d-menu__trigger {
           flex-direction: row;
           gap: 0.25em;
 
           span {
             font-size: var(--font-0);
-            color: var(--primary-700) !important;
+            color: var(--primary-700);
             min-width: unset;
             overflow: visible;
           }


### PR DESCRIPTION
Header: 
* Allows optional avatar size for header participant component (for reuse elsewhere) 

Topic map:
* Adds a new `topic-map-participants-after` outlet
* Removes an `!important` 