### PR TITLE
DEV: Fix state leak in test

### DIFF
--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -376,7 +376,6 @@ RSpec.describe Site do
 
   context "when there are anonymous users with different locales" do
     let(:anon_guardian) { Guardian.new }
-    let!(:original_available_locales) { I18n.available_locales }
     let(:original_locale) { I18n.locale }
 
     before do
@@ -387,7 +386,7 @@ RSpec.describe Site do
     end
 
     after do
-      I18n.available_locales = original_available_locales
+      I18n.available_locales = nil
       I18n.locale = original_locale
     end
 


### PR DESCRIPTION
```
rspec --seed 52075 spec/models/site_spec.rb spec/lib/freedom_patches/translate_accelerator_spec.rb

Randomized with seed 52075
....................................................F

Failures:

  1) translate accelerator plugins loads plural rules from plugins
     Failure/Error: self.locale_no_cache = value

     I18n::InvalidLocale:
       :foo is not a valid locale
     # ./lib/freedom_patches/translate_accelerator.rb:254:in 'I18n.locale='
     # ./spec/lib/freedom_patches/translate_accelerator_spec.rb:118:in 'block (3 levels) in <main>'
```

This is because setting `I18n.config.available_locales` is equivalent to hard coding the
locales for the entire process. It should not be set so that `I18n` will
fallback to `backend.locales`.
