### PR TITLE
FIX: Fix category title link to update when category changes, add tests

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-title-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-link.gjs
@@ -1,18 +1,19 @@
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { or } from "truth-helpers";
 import CategoryLogo from "discourse/components/category-logo";
 import CategoryTitleBefore from "discourse/components/category-title-before";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import dirSpan from "discourse/helpers/dir-span";
+import element from "discourse/helpers/element";
 
-@tagName("h3")
+//@tagName("h3")
 export default class CategoryTitleLink extends Component {
   get displayName() {
-    if (this.unstyled === true) {
-      return dirSpan(this.category.displayName);
+    if (this.args.unstyled === true) {
+      return dirSpan(this.args.category.displayName);
     }
 
-    const categoryBadge = categoryBadgeHTML(this.category, {
+    const categoryBadge = categoryBadgeHTML(this.args.category, {
       allowUncategorized: true,
       link: false,
     });
@@ -21,15 +22,19 @@ export default class CategoryTitleLink extends Component {
   }
 
   <template>
-    <a class="category-title-link" href={{this.category.url}}>
-      <div class="category-text-title">
-        <CategoryTitleBefore @category={{this.category}} />
-        <span class="category-name">{{this.displayName}}</span>
-      </div>
-      {{#if this.category.uploaded_logo.url}}
-        <CategoryLogo @category={{this.category}} />
-      {{/if}}
-    </a>
+    {{#let (element (or @tagName "h3")) as |TagName|}}
+      <TagName>
+        <a class="category-title-link" href={{@category.url}}>
+          <div class="category-text-title">
+            <CategoryTitleBefore @category={{@category}} />
+            <span class="category-name">{{this.displayName}}</span>
+          </div>
+          {{#if @category.uploaded_logo.url}}
+            <CategoryLogo @category={{@category}} />
+          {{/if}}
+        </a>
+      </TagName>
+    {{/let}}
   </template>
 }
 

--- a/app/assets/javascripts/discourse/app/components/category-title-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-title-link.gjs
@@ -6,7 +6,6 @@ import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import dirSpan from "discourse/helpers/dir-span";
 import element from "discourse/helpers/element";
 
-//@tagName("h3")
 export default class CategoryTitleLink extends Component {
   get displayName() {
     if (this.args.unstyled === true) {

--- a/app/assets/javascripts/discourse/tests/integration/components/category-title-link-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/category-title-link-test.gjs
@@ -1,0 +1,146 @@
+import { tracked } from "@glimmer/tracking";
+import EmberObject from "@ember/object";
+import { render, settled } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { module, test } from "qunit";
+import CategoryTitleLink from "discourse/components/category-title-link";
+import Category from "discourse/models/category";
+import RestModel from "discourse/models/rest";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Category Title Link", function (hooks) {
+  setupRenderingTest(hooks);
+
+  const testCategories = [
+    Category.create({
+      id: 0,
+      name: "category one",
+      description: "first test category",
+    }),
+    Category.create({
+      id: 1,
+      name: "category two",
+      description: "second test category with icon",
+      style_type: "icon",
+      icon: "heart",
+    }),
+    Category.create({
+      id: 2,
+      name: "category three",
+      description: "third test category with icon",
+      style_type: "emoji",
+      emoji: "face_savoring_food",
+      uploaded_logo: {
+        url: "/images/avatar.png",
+      },
+    }),
+  ];
+
+  test("Shows title, icon/emoji, and logo when switching categories in styled mode", async function (assert) {
+    const testState = new (class {
+      @tracked category = testCategories[0];
+    })();
+
+    await render(
+      <template>
+        <CategoryTitleLink
+          @category={{testState.category}}
+          @unstyled={{false}}
+        />
+      </template>
+    );
+
+    assert.dom(".category-title-link").hasText(testCategories[0].name);
+
+    testState.category = testCategories[1];
+    await settled();
+    assert
+      .dom(".category-title-link .badge-category svg")
+      .hasClass("d-icon-heart", "shows icon");
+    assert
+      .dom(".category-title-link")
+      .hasText(testCategories[1].name, "shows title");
+
+    testState.category = testCategories[2];
+    await settled();
+    assert
+      .dom(".category-title-link .category-logo img")
+      .hasAttribute("src", "/images/avatar.png", "shows logo");
+    assert
+      .dom(".category-title-link .badge-category img.emoji")
+      .hasAttribute(
+        "src",
+        new RegExp("^.*face_savoring_food.*$"),
+        "shows emoji"
+      );
+    assert
+      .dom(".category-title-link")
+      .hasText(testCategories[2].name, "shows title");
+  });
+
+  test("Shows title only when switching categories in unstyled mode", async function (assert) {
+    const testState = new (class {
+      @tracked category = testCategories[0];
+    })();
+
+    await render(
+      <template>
+        <CategoryTitleLink
+          @category={{testState.category}}
+          @unstyled={{true}}
+        />
+      </template>
+    );
+    assert
+      .dom(".category-title-link")
+      .hasText(testCategories[0].name, "shows title");
+
+    testState.category = testCategories[1];
+    await settled();
+    assert
+      .dom(".category-title-link .badge-category svg")
+      .doesNotExist("does not show icon");
+    assert
+      .dom(".category-title-link")
+      .hasText(testCategories[1].name, "shows title");
+
+    testState.category = testCategories[2];
+    await settled();
+    assert
+      .dom(".category-title-link .badge-category img.emoji")
+      .doesNotExist("does not show emoji");
+    assert
+      .dom(".category-title-link")
+      .hasText(testCategories[2].name, "shows title");
+  });
+
+  test("Respects the tagName attribute", async function (assert) {
+    const testState = new (class {
+      @tracked category = testCategories[0];
+    })();
+
+    await render(
+      <template>
+        <CategoryTitleLink @category={{testState.category}} />
+      </template>
+    );
+
+    assert.dom("h3:has(> .category-title-link)").exists(); // defaults to h3
+
+    await render(
+      <template>
+        <CategoryTitleLink @category={{testState.category}} @tagName="h1" />
+      </template>
+    );
+
+    assert.dom("h1:has(> .category-title-link)").exists();
+
+    await render(
+      <template>
+        <CategoryTitleLink @category={{testState.category}} @tagName="span" />
+      </template>
+    );
+
+    assert.dom("span:has(> .category-title-link)").exists();
+  });
+});

--- a/app/assets/javascripts/discourse/tests/integration/components/category-title-link-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/category-title-link-test.gjs
@@ -1,11 +1,8 @@
 import { tracked } from "@glimmer/tracking";
-import EmberObject from "@ember/object";
 import { render, settled } from "@ember/test-helpers";
-import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
 import CategoryTitleLink from "discourse/components/category-title-link";
 import Category from "discourse/models/category";
-import RestModel from "discourse/models/rest";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module("Integration | Component | Category Title Link", function (hooks) {


### PR DESCRIPTION
Related to [this issue on meta](https://meta.discourse.org/t/category-headers-missing-the-titles/361954).

Apparently a few customers with themes using the CategoryTitleLink component got hit with the category title not updating correctly when the category changed.

The component was importing `@ember/component` but not marking the category arg as tracked. Changed to `@glimmer/component` so the category arg is tracked, and cleaned up the rest of the component to match.