### PR TITLE
FEATURE: trigger an event when chat channel is trashed

### DIFF
--- a/plugins/chat/app/services/chat/trash_channel.rb
+++ b/plugins/chat/app/services/chat/trash_channel.rb
@@ -57,6 +57,7 @@ module Chat
 
     def soft_delete_channel(guardian:, channel:)
       channel.trash!(guardian.user)
+      DiscourseEvent.trigger(:chat_channel_trashed, channel, guardian.user)
     end
 
     def log_channel_deletion(guardian:, channel:)

--- a/plugins/chat/spec/services/chat/trash_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/trash_channel_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Chat::TrashChannel do
         expect(result[:channel].slug).to include("deleted")
       end
 
+      it "triggers the chat_channel_trashed event" do
+        DiscourseEvent.expects(:trigger).with(
+          "chat_channel_trashed",
+          result[:channel],
+          current_user,
+        )
+        result
+      end
+
       it "queues a job to delete channel relations" do
         expect { result }.to change(Jobs::Chat::ChannelDelete.jobs, :size).by(1)
       end


### PR DESCRIPTION
Required for this PR: https://github.com/discourse/discourse-livestream/pull/55