### PR TITLE
DEV: Add site description to crawler homepage view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,6 +80,7 @@ class ApplicationController < ActionController::Base
             CrawlerDetection.crawler?(request.user_agent, request.headers["HTTP_VIA"])
         )
   end
+  helper_method :use_crawler_layout?
 
   def perform_refresh_session
     refresh_session(current_user) unless @readonly_mode

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -288,6 +288,9 @@ module ApplicationHelper
     )
   end
 
+  def is_crawler_homepage?
+    request.path == "/" && use_crawler_layout?
+  end
   # Creates open graph and twitter card meta data
   def crawlable_meta_data(opts = nil)
     opts ||= {}

--- a/app/views/layouts/_noscript_header.html.erb
+++ b/app/views/layouts/_noscript_header.html.erb
@@ -1,5 +1,6 @@
 <header>
-  <a href="<%= path "/" %>">
-    <%=SiteSetting.title%>
-  </a>
+  <a href="<%= path "/" %>"><%=SiteSetting.title%></a>
+  <% if is_crawler_homepage? %>
+    <p><%= SiteSetting.site_description %></p>
+  <% end %>
 </header>

--- a/spec/requests/home_page_controller_spec.rb
+++ b/spec/requests/home_page_controller_spec.rb
@@ -53,14 +53,21 @@ RSpec.describe HomePageController do
         get "/", headers: { "HTTP_USER_AGENT" => "Googlebot" }
 
         expect(response.status).to eq(200)
-        expect(response.body).to include("This is a test description")
+        expect(response.body).to include("<p>This is a test description</p>")
+        expect(response.body).to include(
+          "<meta name=\"description\" content=\"This is a test description\">",
+        )
       end
 
       it "should not display the site description on another route" do
         get "/top", headers: { "HTTP_USER_AGENT" => "Googlebot" }
 
         expect(response.status).to eq(200)
-        expect(response.body).to include("This is a test description")
+        expect(response.body).not_to include("<p>This is a test description</p>")
+        # but still includes the meta tag
+        expect(response.body).to include(
+          "<meta name=\"description\" content=\"This is a test description\">",
+        )
       end
     end
   end

--- a/spec/requests/home_page_controller_spec.rb
+++ b/spec/requests/home_page_controller_spec.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe HomePageController do
-  describe "#custom" do
+  describe "homepage" do
     context "with crawler view" do
+      before do
+        SiteSetting.site_description = "This is a test description"
+        SiteSetting.has_login_hint = false
+      end
+
       it "should display the menu by default" do
         get "/custom", headers: { "HTTP_USER_AGENT" => "Googlebot" }
 
@@ -42,6 +47,20 @@ RSpec.describe HomePageController do
           Discourse.plugins.delete plugin
           DiscoursePluginRegistry.reset!
         end
+      end
+
+      it "should display the site description on the homepage" do
+        get "/", headers: { "HTTP_USER_AGENT" => "Googlebot" }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("This is a test description")
+      end
+
+      it "should not display the site description on another route" do
+        get "/top", headers: { "HTTP_USER_AGENT" => "Googlebot" }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("This is a test description")
       end
     end
   end


### PR DESCRIPTION
In some cases, Google crawlers don't output the meta description but rather they output the first bit of text in the UI. Sometimes that is a mix of table headings, topic titles and excerpts, which don't reflect the site's mission. Adding the description to the homepage header might help.

Internal ticket t/154372