### PR TITLE
DEV: Added the ability to use users' names in group mention notifications and mentions shown in emails

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -6,13 +6,9 @@ export default class extends NotificationTypeBase {
 
   get label() {
     let name;
-    
-    console.error(this.siteSettings.prioritize_username_in_ux, "prioritize_username_in_ux");
-console.error(JSON.stringify(this.notification, null, 2), "notification");
-    console.error(this.notification.data, "notification")
-    console.error(this.notification.acting_user_name, "user name")
+
     if (!this.siteSettings.prioritize_username_in_ux) {
-      name = this.notification.acting_user_name || this.username;
+      name = this.notification.data.original_name || this.username;
     } else {
       name = this.username;
     }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -1,8 +1,18 @@
+import { service } from "@ember/service";
 import NotificationTypeBase from "discourse/lib/notification-types/base";
 
 export default class extends NotificationTypeBase {
+  @service siteSettings;
+
   get label() {
-    return `${this.username} @${this.notification.data.group_name}`;
+    let name;
+    if (this.siteSettings.prioritize_username_in_ux) {
+      name = this.notification.acting_user_name;
+    } else {
+      name = this.username;
+    }
+
+    return `${name} @${this.notification.data.group_name}`;
   }
 
   get labelClasses() {

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -6,6 +6,8 @@ export default class extends NotificationTypeBase {
 
   get label() {
     let name;
+    console.log(this.siteSettings.prioritize_username_in_ux);
+    console.log(this.notification)
     if (!this.siteSettings.prioritize_username_in_ux) {
       name = this.notification.acting_user_name || this.username;
     } else {

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -7,7 +7,7 @@ export default class extends NotificationTypeBase {
   get label() {
     let name;
 
-    if (!this.siteSettings.prioritize_username_in_ux) {
+    if (this.siteSettings.prioritize_full_name_in_ux) {
       name = this.notification.acting_user_name || this.username;
     } else {
       name = this.username;

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -6,8 +6,8 @@ export default class extends NotificationTypeBase {
 
   get label() {
     let name;
-    if (this.siteSettings.prioritize_username_in_ux) {
-      name = this.notification.acting_user_name;
+    if (!this.siteSettings.prioritize_username_in_ux) {
+      name = this.notification.acting_user_name || this.username;
     } else {
       name = this.username;
     }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -9,7 +9,8 @@ export default class extends NotificationTypeBase {
     
     console.error(this.siteSettings.prioritize_username_in_ux, "prioritize_username_in_ux");
     console.error(this.notification, "notification")
-    console.error(this.notificationacting_user_name, "user name")
+    console.error(this.notification.data, "notification")
+    console.error(this.notification.acting_user_name, "user name")
     if (!this.siteSettings.prioritize_username_in_ux) {
       name = this.notification.acting_user_name || this.username;
     } else {

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -8,7 +8,7 @@ export default class extends NotificationTypeBase {
     let name;
 
     if (!this.siteSettings.prioritize_username_in_ux) {
-      name = this.notification.data.original_name || this.username;
+      name = this.notification.data.display_name || this.username;
     } else {
       name = this.username;
     }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -6,8 +6,10 @@ export default class extends NotificationTypeBase {
 
   get label() {
     let name;
-    console.log(this.siteSettings.prioritize_username_in_ux);
-    console.log(this.notification)
+    
+    console.error(this.siteSettings.prioritize_username_in_ux, "prioritize_username_in_ux");
+    console.error(this.notification, "notification")
+    console.error(this.notificationacting_user_name, "user name")
     if (!this.siteSettings.prioritize_username_in_ux) {
       name = this.notification.acting_user_name || this.username;
     } else {

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -8,7 +8,7 @@ export default class extends NotificationTypeBase {
     let name;
 
     if (!this.siteSettings.prioritize_username_in_ux) {
-      name = this.notification.data.display_name || this.username;
+      name = this.notification.acting_user_name || this.username;
     } else {
       name = this.username;
     }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -8,7 +8,7 @@ export default class extends NotificationTypeBase {
     let name;
     
     console.error(this.siteSettings.prioritize_username_in_ux, "prioritize_username_in_ux");
-    console.error(this.notification, "notification")
+console.error(JSON.stringify(this.notification, null, 2), "notification");
     console.error(this.notification.data, "notification")
     console.error(this.notification.acting_user_name, "user name")
     if (!this.siteSettings.prioritize_username_in_ux) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
@@ -28,6 +28,7 @@ function getNotification(overrides = {}) {
           original_username: "kolary",
           original_name: "Osama Obama",
           display_username: "osama",
+          display_name: "Osama Obama",
           group_id: 333,
           group_name: "hikers",
         },
@@ -44,7 +45,7 @@ module("Unit | Notification Types | group-mentioned", function (hooks) {
     this.owner.register(
       "service:site-settings",
       class extends Service {
-        prioritize_username_in_ux = true;
+        prioritize_full_name_in_ux = false;
       }
     );
 
@@ -68,7 +69,7 @@ module("Unit | Notification Types | group-mentioned", function (hooks) {
   });
 
   test("label uses the user's name when prioritize_username_in_ux is false", function (assert) {
-    this.siteSettings.prioritize_username_in_ux = false;
+    this.siteSettings.prioritize_full_name_in_ux = true;
 
     const notification = getNotification();
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
@@ -26,6 +26,7 @@ function getNotification(overrides = {}) {
           original_post_id: 112,
           original_post_type: 1,
           original_username: "kolary",
+          original_name: "Osama Obama",
           display_username: "osama",
           group_id: 333,
           group_name: "hikers",

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -394,7 +394,7 @@ class UserNotifications < ActionMailer::Base
     opts[:show_category_in_subject] = true
     opts[:show_tags_in_subject] = true
 
-    if SiteSetting.prioritize_username_in_ux
+    if !SiteSetting.prioritize_username_in_ux
       opts[:post].cooked = replace_username_with_name_from_post(opts[:post], user)
     end
 

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -393,6 +393,11 @@ class UserNotifications < ActionMailer::Base
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
     opts[:show_tags_in_subject] = true
+
+    if SiteSetting.prioritize_username_in_ux
+      opts[:post].cooked = replace_username_with_name_from_post(opts[:post], user)
+    end
+
     notification_email(user, opts)
   end
 
@@ -706,6 +711,7 @@ class UserNotifications < ActionMailer::Base
           (SiteSetting.max_emails_per_day_per_user - 1)
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
+
       if SiteSetting.private_email?
         message = I18n.t("system_messages.contents_hidden")
       else
@@ -871,5 +877,20 @@ class UserNotifications < ActionMailer::Base
         .where("created_at > ?", date)
         .count
         .tap { Discourse.redis.setex(key, 1.day, _1) }
+  end
+
+  def replace_username_with_name_from_post(post, user)
+    alnum = '\p{Alphabetic}\p{Mark}\p{Decimal_Number}'
+    mention_regex =
+      /
+      @(
+        [#{alnum}_]                    
+        [#{alnum}._-]{0,58}            
+        [#{alnum}]                     
+      ) |
+      @([#{alnum}_])                   
+    /ux
+
+    post.cooked.gsub!(mention_regex) { |match| user.name ? "@#{user.name}" : match }
   end
 end

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -92,6 +92,24 @@ Fabricator(:mentioned_notification, from: :notification) do
   end
 end
 
+Fabricator(:group_mentioned_notification, from: :notification) do
+  transient :group
+  notification_type Notification.types[:group_mentioned]
+  data do |attrs|
+    {
+      topic_title: attrs[:topic].title,
+      original_post_id: attrs[:post].id,
+      original_post_type: attrs[:post].post_type,
+      original_username: attrs[:post].user.username,
+      revision_number: nil,
+      display_username: attrs[:post].user.username,
+      display_name: attrs[:user].name,
+      group_id: attrs[:group].id,
+      group_name: attrs[:group].name,
+    }.to_json
+  end
+end
+
 Fabricator(:watching_first_post_notification, from: :notification) do
   notification_type Notification.types[:watching_first_post]
   data do |attrs|

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -700,72 +700,75 @@ RSpec.describe UserNotifications do
     end
     let(:notification) { Fabricate(:mentioned_notification, user: user, post: response) }
 
-    context "when user has name" do
-      it "generates a correct email" do
-        mail =
-          UserNotifications.user_mentioned(
-            user,
-            post: response,
-            notification_type: notification.notification_type,
-            notification_data_hash: notification.data_hash,
-          )
+    context "when prioritize_username_in_ux is false" do
+      before { SiteSetting.prioritize_username_in_ux = false }
+      context "when user has name" do
+        it "generates a correct email" do
+          mail =
+            UserNotifications.user_mentioned(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
 
-        # from should include full user name
-        expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
+          # from should include full user name
+          expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
 
-        # subject should include category name
-        expect(mail.subject).to match(/India/)
+          # subject should include category name
+          expect(mail.subject).to match(/India/)
 
-        mail_html = mail.html_part.body.to_s
+          mail_html = mail.html_part.body.to_s
 
-        expect(mail_html.scan(%r{@#{user.name}</a> response to post}).count).to eq(1)
+          expect(mail_html.scan(%r{@#{user.name}</a> response to post}).count).to eq(1)
 
-        expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+          expect(mail_html.scan(/Visit Topic/).count).to eq(1)
 
-        expect(mail_html.scan(/to respond/).count).to eq(1)
+          expect(mail_html.scan(/to respond/).count).to eq(1)
 
-        # 1 unsubscribe
-        expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+          # 1 unsubscribe
+          expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
 
-        # side effect, topic user is updated with post number
-        tu = TopicUser.get(post.topic_id, user)
-        expect(tu.last_emailed_post_number).to eq(response.post_number)
+          # side effect, topic user is updated with post number
+          tu = TopicUser.get(post.topic_id, user)
+          expect(tu.last_emailed_post_number).to eq(response.post_number)
+        end
       end
-    end
 
-    context "when user doesn't have a name" do
-      it "generates a correct email" do
-        user.name = nil
-        user.save
+      context "when user doesn't have a name" do
+        it "generates a correct email" do
+          user.name = nil
+          user.save
 
-        mail =
-          UserNotifications.user_mentioned(
-            user,
-            post: response,
-            notification_type: notification.notification_type,
-            notification_data_hash: notification.data_hash,
-          )
+          mail =
+            UserNotifications.user_mentioned(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
 
-        # from should include full user name
-        expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
+          # from should include full user name
+          expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
 
-        # subject should include category name
-        expect(mail.subject).to match(/India/)
+          # subject should include category name
+          expect(mail.subject).to match(/India/)
 
-        mail_html = mail.html_part.body.to_s
+          mail_html = mail.html_part.body.to_s
 
-        expect(mail_html.scan(%r{@#{user.username}</a> response to post}).count).to eq(1)
+          expect(mail_html.scan(%r{@#{user.username}</a> response to post}).count).to eq(1)
 
-        expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+          expect(mail_html.scan(/Visit Topic/).count).to eq(1)
 
-        expect(mail_html.scan(/to respond/).count).to eq(1)
+          expect(mail_html.scan(/to respond/).count).to eq(1)
 
-        # 1 unsubscribe
-        expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+          # 1 unsubscribe
+          expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
 
-        # side effect, topic user is updated with post number
-        tu = TopicUser.get(post.topic_id, user)
-        expect(tu.last_emailed_post_number).to eq(response.post_number)
+          # side effect, topic user is updated with post number
+          tu = TopicUser.get(post.topic_id, user)
+          expect(tu.last_emailed_post_number).to eq(response.post_number)
+        end
       end
     end
   end

--- a/spec/system/page_objects/pages/user_notifications.rb
+++ b/spec/system/page_objects/pages/user_notifications.rb
@@ -12,7 +12,7 @@ module PageObjects
         PageObjects::Components::SelectKit.new(".notifications-filter")
       end
 
-      def notification(notification)
+      def find_notification(notification)
         find(".notification a[href='#{notification.url}']")
       end
 

--- a/spec/system/page_objects/pages/user_notifications.rb
+++ b/spec/system/page_objects/pages/user_notifications.rb
@@ -12,6 +12,10 @@ module PageObjects
         PageObjects::Components::SelectKit.new(".notifications-filter")
       end
 
+      def notification(notification)
+        find(".notification a[href='#{notification.url}']")
+      end
+
       def set_filter_value(value)
         filter_dropdown.select_row_by_value(value)
       end

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -83,11 +83,6 @@ describe "User notifications", type: :system do
 
         notification = user_notifications_page.notification(group_mention_notification)
 
-        puts "prioritize_username_in_ux: #{SiteSetting.prioritize_username_in_ux}"
-        puts "User name: #{user.name}, username: #{user.username}"
-        puts group_mention_notification.inspect
-        puts group_mention_notification.data
-
         expect(notification).to have_content(group.name)
         expect(notification).to have_content(user.name)
       end

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -81,7 +81,7 @@ describe "User notifications", type: :system do
 
         expect(user_notifications_page).to have_notification(group_mention_notification)
 
-        notification = user_notifications_page.notification(group_mention_notification)
+        notification = user_notifications_page.find_notification(group_mention_notification)
 
         expect(notification).to have_content(group.name)
         expect(notification).to have_content(user.name)

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "User notifications", type: :system do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, name: "Awesome Name") }
   let(:user_notifications_page) { PageObjects::Pages::UserNotifications.new }
   let(:user_page) { PageObjects::Pages::User.new }
 
@@ -49,6 +49,60 @@ describe "User notifications", type: :system do
       # It is 1 here because we blocked infinite scrolling. Even though the limit is 1,
       # without the callback, we would have 2 items here as it immediately fires another request.
       expect(user_notifications_page).to have_notification_count_of(1)
+    end
+  end
+
+  describe "user group notifications" do
+    fab!(:group) { Fabricate(:group, name: "Awesome_Group") }
+    fab!(:topic) { Fabricate(:topic, title: "Group Mention Notification test") }
+    fab!(:post) do
+      Fabricate(
+        :post,
+        raw: "@#{group.name} this is a post to create a group mention notification",
+        user: user,
+        topic: topic,
+      )
+    end
+    fab!(:user2) { Fabricate(:user) }
+    fab!(:group_mention_notification) do
+      Fabricate(:group_mentioned_notification, post: post, user: user2, group: group)
+    end
+
+    before { group.add(user2) }
+
+    context "when prioritize_username_in_ux is true" do
+      before do
+        SiteSetting.prioritize_username_in_ux = true
+        sign_in(user2)
+      end
+      it "shows the user name in the notification" do
+        user_notifications_page.visit(user2)
+
+        expect(user_notifications_page).to have_notification(group_mention_notification)
+
+        notification = user_notifications_page.notification(group_mention_notification)
+
+        expect(notification).to have_content(group.name)
+        expect(notification).to have_content(user.name)
+      end
+
+      context "when user doesn't have a name" do
+        before do
+          user.name = nil
+          user.save
+        end
+
+        it "shows the username in the notification instead" do
+          user_notifications_page.visit(user2)
+
+          expect(user_notifications_page).to have_notification(group_mention_notification)
+
+          notification = user_notifications_page.notification(group_mention_notification)
+
+          expect(notification).to have_content(group.name)
+          expect(notification).to have_content(user.username)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -86,6 +86,7 @@ describe "User notifications", type: :system do
         puts "prioritize_username_in_ux: #{SiteSetting.prioritize_username_in_ux}"
         puts "User name: #{user.name}, username: #{user.username}"
         puts group_mention_notification.inspect
+        puts group_mention_notification.data
 
         expect(notification).to have_content(group.name)
         expect(notification).to have_content(user.name)

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -73,6 +73,7 @@ describe "User notifications", type: :system do
     context "when prioritize_username_in_ux is false" do
       before do
         SiteSetting.prioritize_username_in_ux = false
+        SiteSetting.enable_names = true
         sign_in(user2)
       end
 

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -72,8 +72,7 @@ describe "User notifications", type: :system do
 
     context "when prioritize_username_in_ux is false" do
       before do
-        SiteSetting.prioritize_username_in_ux = false
-        SiteSetting.enable_names = true
+        SiteSetting.prioritize_full_name_in_ux = true
         sign_in(user2)
       end
 

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -70,9 +70,9 @@ describe "User notifications", type: :system do
 
     before { group.add(user2) }
 
-    context "when prioritize_username_in_ux is true" do
+    context "when prioritize_username_in_ux is false" do
       before do
-        SiteSetting.prioritize_username_in_ux = true
+        SiteSetting.prioritize_username_in_ux = false
         sign_in(user2)
       end
       it "shows the user name in the notification" do

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -98,7 +98,7 @@ describe "User notifications", type: :system do
 
           expect(user_notifications_page).to have_notification(group_mention_notification)
 
-          notification = user_notifications_page.notification(group_mention_notification)
+          notification = user_notifications_page.find_notification(group_mention_notification)
 
           expect(notification).to have_content(group.name)
           expect(notification).to have_content(user.username)

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -82,6 +82,9 @@ describe "User notifications", type: :system do
 
         notification = user_notifications_page.notification(group_mention_notification)
 
+        puts "prioritize_username_in_ux: #{SiteSetting.prioritize_username_in_ux}"
+        puts "User name: #{user.name}, username: #{user.username}"
+
         expect(notification).to have_content(group.name)
         expect(notification).to have_content(user.name)
       end

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -75,6 +75,7 @@ describe "User notifications", type: :system do
         SiteSetting.prioritize_username_in_ux = false
         sign_in(user2)
       end
+
       it "shows the user name in the notification" do
         user_notifications_page.visit(user2)
 
@@ -84,6 +85,7 @@ describe "User notifications", type: :system do
 
         puts "prioritize_username_in_ux: #{SiteSetting.prioritize_username_in_ux}"
         puts "User name: #{user.name}, username: #{user.username}"
+        puts group_mention_notification.inspect
 
         expect(notification).to have_content(group.name)
         expect(notification).to have_content(user.name)


### PR DESCRIPTION
**Description**
This is part of a series of changes to allow customers to dsiplay users' names instead of the users' username. 

When a user belongs to a group that has been mentioned by another user. It shows the name of the user that mentioned the group.

**Before**
![imagen](https://github.com/user-attachments/assets/b62224fb-9b69-4603-be00-e7aa61d9b33c)

**After**
![imagen](https://github.com/user-attachments/assets/8495cb63-6530-4d86-a51c-f0510d48f6c7)

When a email is sent to the user when mentioned in a post 

**Before**

![imagen](https://github.com/user-attachments/assets/94e674da-085a-41cb-8145-ba6fbe3636ce)

**After**
![imagen](https://github.com/user-attachments/assets/490cb365-bf85-4745-93b9-e47048b2f02e)

