### PR TITLE
DEV: Use ampersand for themes and components admin section

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5529,7 +5529,7 @@ en:
           header_description: "Components are smaller customizations that can be added to themes in order to change specific elements of the style of your forum design"
           keywords: "theme|component|extension"
         themes_and_components:
-          title: "Themes and components"
+          title: "Themes & components"
           header_description: "Personalize your Discourse site with themes and components to match your needs"
           keywords: "theme|component|extension|customize"
         site_admin:
@@ -6292,8 +6292,6 @@ en:
           more_options:
             title: "More options"
         themes_and_components:
-          title: "Themes and components"
-          description: "Personalize your Discourse site with themes and components to match your needs."
           breadcrumb_title: "Customize"
           install: "Install"
           themes:


### PR DESCRIPTION
### What is this change?

We use ampersand to concatenate sidebar sections, e.g. <kbd>Login & authentication</kbd>, <kbd>Logs & screening</kbd>, etc.

This updates <kbd>Themes & components</kbd> to have the same.

**Before:**

<img width="331" alt="Screenshot 2025-05-22 at 10 55 15 AM" src="https://github.com/user-attachments/assets/a203899a-dc66-4cc5-aab3-264e7a22822c" />

**After:**

<img width="331" alt="Screenshot 2025-05-22 at 10 54 55 AM" src="https://github.com/user-attachments/assets/b86d1d8d-b2e8-4f23-88c9-9b821968026d" />
