### PR TITLE
FIX: Themes and components page title

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-config-customize.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-customize.js
@@ -6,6 +6,6 @@ export default class AdminConfigThemesAndComponentsRoute extends DiscourseRoute 
   @service router;
 
   titleToken() {
-    return i18n("admin.config_areas.themes_and_components.title");
+    return i18n("admin.config.themes_and_components.title");
   }
 }


### PR DESCRIPTION
### What is this change?

We removed a duplicate translation key, but it was being used here. Update the title token to use the canonical one.