### PR TITLE
DEV: Resolve mixed-decls misconfiguration

### DIFF
--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -54,6 +54,15 @@ module Stylesheet
       load_paths = [ASSET_ROOT]
       load_paths += options[:load_paths] if options[:load_paths]
 
+      silence_deprecations = %w[color-functions import global-builtin]
+      fatal_deprecations = []
+
+      if options[:strict_deprecations]
+        fatal_deprecations << "mixed-decls"
+      else
+        silence_deprecations << "mixed-decls"
+      end
+
       engine =
         SassC::Engine.new(
           stylesheet,
@@ -62,8 +71,8 @@ module Stylesheet
           source_map_file: source_map_file,
           source_map_contents: true,
           load_paths: load_paths,
-          silence_deprecations: %w[color-functions import global-builtin mixed-decls],
-          fatal_deprecations: options[:strict_deprecations] ? %w[mixed-decls] : [],
+          silence_deprecations:,
+          fatal_deprecations:,
           quiet: ENV["QUIET_SASS_DEPRECATIONS"] == "1",
         )
 


### PR DESCRIPTION
Marking mixed-decls as silenced & fatal simultaneously is causing a warning "Ignoring setting to silence mixed-decls deprecation, since it has also been made fatal"

The intention is for it to be silenced for themes/plugins, but fatal for core.