### PR TITLE
DEV: Introduce experimental viewport-based mobile mode

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-styles.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-styles.gjs
@@ -1,11 +1,13 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import htmlClass from "discourse/helpers/html-class";
 import { getURLWithCDN } from "discourse/lib/get-url";
 
 export default class DStyles extends Component {
   @service session;
   @service site;
   @service interfaceColor;
+  @service siteSettings;
 
   get categoryColors() {
     return [
@@ -80,6 +82,12 @@ export default class DStyles extends Component {
   }
 
   <template>
+    {{#if this.siteSettings.viewport_based_mobile_mode}}
+      {{htmlClass (if this.site.mobileView "mobile-view" "desktop-view")}}
+      {{htmlClass
+        (if this.site.mobileView "mobile-device" "not-mobile-device")
+      }}
+    {{/if}}
     {{! template-lint-disable no-forbidden-elements }}
     <style id="d-styles">
       {{#if this.site.categories}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.gjs
@@ -23,6 +23,9 @@ export default class SidebarFooter extends Component {
   }
 
   get showToggleMobileButton() {
+    if (this.siteSettings.viewport_based_mobile_mode) {
+      return false;
+    }
     return (
       this.site.mobileView ||
       (this.siteSettings.enable_mobile_theme && this.capabilities.touch)

--- a/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
@@ -6,13 +6,11 @@ export default {
   after: "inject-objects",
 
   initialize(owner) {
+    if (owner.lookup("service:site-settings").viewport_based_mobile_mode) {
+      return;
+    }
+
     Mobile.init();
-    const site = owner.lookup("service:site");
-
-    site.set("mobileView", Mobile.mobileView);
-    site.set("desktopView", !Mobile.mobileView);
-    site.set("isMobileDevice", Mobile.isMobileDevice);
-
     setResolverOption("mobileView", Mobile.mobileView);
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/mobile.js
+++ b/app/assets/javascripts/discourse/app/lib/mobile.js
@@ -59,10 +59,12 @@ const Mobile = {
 
 export function forceMobile() {
   mobileForced = true;
+  Mobile.init();
 }
 
 export function resetMobile() {
   mobileForced = false;
+  Mobile.init();
 }
 
 export default Mobile;

--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import EmberObject, { computed, get } from "@ember/object";
+import { dependentKeyCompat } from "@ember/object/compat";
 import { alias, sort } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
@@ -8,6 +9,7 @@ import discourseComputed from "discourse/lib/decorators";
 import deprecated from "discourse/lib/deprecated";
 import { isRailsTesting, isTesting } from "discourse/lib/environment";
 import { getOwnerWithFallback } from "discourse/lib/get-owner";
+import Mobile from "discourse/lib/mobile";
 import PreloadStore from "discourse/lib/preload-store";
 import singleton from "discourse/lib/singleton";
 import Archetype from "discourse/models/archetype";
@@ -81,6 +83,7 @@ export default class Site extends RestModel {
 
   @service siteSettings;
   @service currentUser;
+  @service capabilities;
 
   @tracked categories;
 
@@ -95,6 +98,25 @@ export default class Site extends RestModel {
 
     this.topicCountDesc = ["topic_count:desc"];
     this.categories = this.categories || [];
+  }
+
+  @dependentKeyCompat
+  get desktopView() {
+    return !this.mobileView;
+  }
+
+  @dependentKeyCompat
+  get mobileView() {
+    if (this.siteSettings.viewport_based_mobile_mode) {
+      return !this.capabilities.viewport.sm;
+    } else {
+      return Mobile.mobileView;
+    }
+  }
+
+  @dependentKeyCompat
+  get isMobileDevice() {
+    return this.mobileView;
   }
 
   get useGlimmerPostStream() {

--- a/app/assets/javascripts/discourse/app/static/dev-tools/toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/static/dev-tools/toolbar.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import icon from "discourse/helpers/d-icon";
 import draggable from "discourse/modifiers/draggable";
@@ -13,6 +14,8 @@ import SafeModeButton from "./safe-mode/button";
 import VerboseLocalizationButton from "./verbose-localization/button";
 
 export default class Toolbar extends Component {
+  @service siteSettings;
+
   @tracked top = 250;
   @tracked ownSize = 0;
 
@@ -63,7 +66,9 @@ export default class Toolbar extends Component {
       <PluginOutletDebugButton />
       <SafeModeButton />
       <VerboseLocalizationButton />
-      <MobileViewButton />
+      {{#unless this.siteSettings.viewport_based_mobile_mode}}
+        <MobileViewButton />
+      {{/unless}}
       <button
         title="Disable dev tools"
         class="disable-dev-tools"

--- a/app/assets/javascripts/discourse/tests/integration/components/d-modal-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-modal-test.gjs
@@ -6,6 +6,7 @@ import { module, test } from "qunit";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import noop from "discourse/helpers/noop";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module("Integration | Component | d-modal", function (hooks) {
@@ -72,7 +73,7 @@ module("Integration | Component | d-modal", function (hooks) {
 
     assert.dom(".d-modal").doesNotIncludeText("headerPrimaryActionContent");
 
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(
       <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -11,6 +11,7 @@ import {
 import { module, test } from "qunit";
 import DButton from "discourse/components/d-button";
 import element_ from "discourse/helpers/element";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DDefaultToast from "float-kit/components/d-default-toast";
 import DMenu from "float-kit/components/d-menu";
@@ -53,7 +54,7 @@ module("Integration | Component | FloatKit | d-menu", function (hooks) {
   });
 
   test("@modalForMobile", async function (assert) {
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(
       <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-toast-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-toast-test.gjs
@@ -2,6 +2,7 @@ import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import {
   disableRaiseOnDeprecation,
@@ -38,7 +39,7 @@ module("Integration | Component | FloatKit | d-toast", function (hooks) {
 
   test("swipe up to close", async function (assert) {
     let closing = false;
-    this.site.mobileView = true;
+    forceMobile();
     const toast = createCustomToastInstance(getOwner(this), {}, () => {
       closing = true;
     });

--- a/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
@@ -7,6 +7,7 @@ import {
   triggerKeyEvent,
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DDefaultToast from "float-kit/components/d-default-toast";
 import DTooltip from "float-kit/components/d-tooltip";
@@ -320,7 +321,7 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
   });
 
   test("a tooltip is triggered/untriggered by click on mobile", async function (assert) {
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(
       <template><DTooltip @inline={{true}} @label="label" /></template>

--- a/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/home-logo-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import HomeLogo from "discourse/components/header/home-logo";
+import { forceMobile } from "discourse/lib/mobile";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
@@ -67,7 +68,7 @@ module("Integration | Component | home-logo", function (hooks) {
   test("mobile logo", async function (assert) {
     this.siteSettings.site_mobile_logo_url = mobileLogo;
     this.siteSettings.site_logo_small_url = smallLogo;
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(<template><HomeLogo /></template>);
     assert.dom("img#site-logo.logo-mobile").exists({ count: 1 });
@@ -76,7 +77,7 @@ module("Integration | Component | home-logo", function (hooks) {
 
   test("mobile without logo", async function (assert) {
     this.siteSettings.site_logo_url = bigLogo;
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(<template><HomeLogo /></template>);
     assert.dom("img#site-logo.logo-big").exists({ count: 1 });
@@ -109,7 +110,7 @@ module("Integration | Component | home-logo", function (hooks) {
     this.siteSettings.site_mobile_logo_dark_url = darkLogo;
     this.session.set("darkModeAvailable", true);
 
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(<template><HomeLogo /></template>);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/navigation-bar-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/navigation-bar-test.gjs
@@ -2,6 +2,7 @@ import EmberObject from "@ember/object";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import NavigationBar from "discourse/components/navigation-bar";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 const navItems = [
@@ -65,7 +66,7 @@ module("Integration | Component | navigation-bar", function (hooks) {
   });
 
   test("display navigation bar items behind a dropdown on mobile", async function (assert) {
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(<template><NavigationBar @navItems={{navItems}} /></template>);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/notifications-tracking-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/notifications-tracking-test.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import TopicNotificationsTracking from "discourse/components/topic-notifications-tracking";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
@@ -92,7 +93,7 @@ module("Integration | Component | TopicTracking - Mobile", function (hooks) {
   setupRenderingTest(hooks);
 
   test("no caret", async function (assert) {
-    this.site.desktopView = false;
+    forceMobile();
 
     await render(<template><TopicNotificationsTracking /></template>);
 

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
@@ -8,9 +8,6 @@ module("Unit | Controller | preferences/account", function (hooks) {
     const siteSettings = this.owner.lookup("service:site-settings");
     siteSettings.enable_google_oauth2_logins = true;
 
-    const site = this.owner.lookup("service:site");
-    site.set("isMobileDevice", false);
-
     const controller = this.owner.lookup("controller:preferences/account");
     controller.setProperties({
       model: {

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -4,6 +4,7 @@ import { settled } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import { forceMobile } from "discourse/lib/mobile";
 import { Placeholder } from "discourse/lib/posts-with-placeholders";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
@@ -242,8 +243,7 @@ module("Unit | Controller | topic", function (hooks) {
 
     assert.false(controller.showSelectedPostsAtBottom, "false on desktop");
 
-    const site = getOwner(this).lookup("service:site");
-    site.set("mobileView", true);
+    forceMobile();
 
     assert.false(
       controller.showSelectedPostsAtBottom,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -178,8 +178,10 @@ module ApplicationHelper
 
   def html_classes
     list = []
-    list << (mobile_view? ? "mobile-view" : "desktop-view")
-    list << (mobile_device? ? "mobile-device" : "not-mobile-device")
+    unless SiteSetting.viewport_based_mobile_mode
+      list << (mobile_view? ? "mobile-view" : "desktop-view")
+      list << (mobile_device? ? "mobile-device" : "not-mobile-device")
+    end
     list << "rtl" if rtl?
     list << text_size_class
     list << "anon" unless current_user
@@ -654,7 +656,13 @@ module ApplicationHelper
         stylesheet_manager
       end
 
-    manager.stylesheet_link_tag(name, "all", self.method(:add_resource_preload_list))
+    name = :"#{name}_rtl" if opts[:supports_rtl] && rtl?
+
+    manager.stylesheet_link_tag(
+      name,
+      opts[:media] || "all",
+      self.method(:add_resource_preload_list),
+    )
   end
 
   def discourse_preload_color_scheme_stylesheets

--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -1,34 +1,47 @@
 <%= discourse_color_scheme_stylesheets %>
 
-<%- if rtl? %>
-  <%= discourse_stylesheet_link_tag(:common_rtl) %>
-  <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_rtl : :desktop_rtl) %>
-<%- else %>
-  <%= discourse_stylesheet_link_tag(:common) %>
-  <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile : :desktop) %>
-<%- end %>
+<%= discourse_stylesheet_link_tag(:common, supports_rtl: true) %>
+
+<% if SiteSetting.viewport_based_mobile_mode %>
+  <%= discourse_stylesheet_link_tag(:mobile, supports_rtl: true, media: "(max-width: 39.99999rem)") %>
+  <%= discourse_stylesheet_link_tag(:desktop, supports_rtl: true, media: "(min-width: 40rem)") %>
+<% else %>
+  <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile : :desktop, supports_rtl: true) %>
+<% end %>
 
 <%- if staff? %>
-  <%- if rtl? %>
-    <%= discourse_stylesheet_link_tag(:admin_rtl) %>
-  <%- else %>
-    <%= discourse_stylesheet_link_tag(:admin) %>
-  <%- end %>
+  <%= discourse_stylesheet_link_tag(:admin, supports_rtl: true) %>
 <%- end %>
 
 <%- if admin? %>
-  <%- if rtl? %>
-    <%= discourse_stylesheet_link_tag(:wizard_rtl) %>
-  <%- else %>
-    <%= discourse_stylesheet_link_tag(:wizard) %>
-  <%- end %>
+  <%= discourse_stylesheet_link_tag(:wizard, supports_rtl: true) %>
 <%- end %>
 
-<%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: mobile_view?, desktop_view: !mobile_view?, request: request, rtl: rtl?).each do |file| %>
-  <%= discourse_stylesheet_link_tag(file) %>
-<%- end %>
+<% if SiteSetting.viewport_based_mobile_mode %>
+  <%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: true, desktop_view: true, request: request, rtl: false).each do |file| %>
+    <%= 
+      media = if file.end_with?("_mobile")
+        "(max-width: 39.99999rem)"
+      elsif file.end_with?("_desktop")
+        "(min-width: 40rem)"
+      else
+        nil
+      end
+      discourse_stylesheet_link_tag(file, media: media, supports_rtl: true) 
+    %>
+  <%- end %>
+<% else %>
+  <%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: mobile_view?, desktop_view: !mobile_view?, request: request, rtl: rtl?).each do |file| %>
+    <%= discourse_stylesheet_link_tag(file) %>
+  <%- end %>
+<% end %>
 
 <%- if theme_id.present? %>
   <%= discourse_stylesheet_link_tag(:common_theme) %>
-  <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
+  <% if SiteSetting.viewport_based_mobile_mode %>
+    <%= discourse_stylesheet_link_tag(:mobile_theme, media: "(max-width: 39.99999rem)") %>
+    <%= discourse_stylesheet_link_tag(:desktop_theme, media: "(min-width: 40rem)") %>
+  <% else %>
+    <%= discourse_stylesheet_link_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
+  <% end %>
 <%- end %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2774,6 +2774,7 @@ en:
     experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
     rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer/352347' target='_blank'>see Meta for more details</a>."
     experimental_content_localization_allowed_groups: 'Groups allowed to update localized content. Requires "experimental content localization" to be enabled.'
+    viewport_based_mobile_mode: "EXPERIMENTAL: Disable the user-agent-based mobile/desktop modes and use viewport width instead."
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2926,6 +2926,9 @@ developer:
     default: 50
     hidden: true
     client: true
+  viewport_based_mobile_mode:
+    default: false
+    client: true
 
 navigation:
   navigation_menu:

--- a/plugins/chat/test/javascripts/components/chat-channel-leave-btn-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-leave-btn-test.gjs
@@ -1,6 +1,7 @@
 import { getOwner } from "@ember/owner";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
@@ -66,7 +67,7 @@ module("Discourse Chat | Component | chat-channel-leave-btn", function (hooks) {
   test("is not visible on mobile", async function (assert) {
     const self = this;
 
-    this.site.desktopView = false;
+    forceMobile();
     this.channel = new ChatFabricators(getOwner(this)).channel();
 
     await render(

--- a/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
@@ -3,6 +3,7 @@ import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import CoreFabricators from "discourse/lib/fabricators";
+import { forceMobile, resetMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatChannelRow from "discourse/plugins/chat/discourse/components/chat-channel-row";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
@@ -101,7 +102,7 @@ module("Discourse Chat | Component | chat-channel-row", function (hooks) {
   test("renders membership toggling button when necessary", async function (assert) {
     const self = this;
 
-    this.site.desktopView = false;
+    forceMobile();
 
     await render(
       <template>
@@ -121,7 +122,7 @@ module("Discourse Chat | Component | chat-channel-row", function (hooks) {
 
     assert.dom(".toggle-channel-membership-button").doesNotExist();
 
-    this.site.desktopView = true;
+    resetMobile();
 
     await render(
       <template>

--- a/plugins/chat/test/javascripts/components/chat-header-icon-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-header-icon-test.gjs
@@ -1,6 +1,7 @@
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
+import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import Icon from "discourse/plugins/chat/discourse/components/chat/header/icon";
@@ -42,7 +43,7 @@ module("Discourse Chat | Component | chat-header-icon", function (hooks) {
   });
 
   test("mobile", async function (assert) {
-    this.site.mobileView = true;
+    forceMobile();
 
     await render(<template><Icon /></template>);
 

--- a/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
@@ -2,7 +2,7 @@ import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
-import Site from "discourse/models/site";
+import { forceMobile } from "discourse/lib/mobile";
 import {
   addChatDrawerStateCallback,
   resetChatDrawerStateCallbacks,
@@ -33,7 +33,7 @@ module(
       assert.false(this.subject.isFullPagePreferred);
 
       this.subject.prefersDrawer();
-      Site.currentProp("mobileView", true);
+      forceMobile();
 
       assert.true(this.subject.isFullPagePreferred);
     });

--- a/spec/system/mobile_mode_spec.rb
+++ b/spec/system/mobile_mode_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe "Viewport-based mobile mode", type: :system do
+  before { SiteSetting.viewport_based_mobile_mode = true }
+
+  it "has both stylesheets, and updates classes at runtime" do
+    visit "/"
+
+    mobile_stylesheet = find("link[rel=stylesheet][href*='stylesheets/mobile']", visible: false)
+    desktop_stylesheet = find("link[rel=stylesheet][href*='stylesheets/desktop']", visible: false)
+
+    expect(mobile_stylesheet["media"]).to include("max-width")
+    expect(desktop_stylesheet["media"]).to include("min-width")
+
+    expect(page).to have_css("html.desktop-view")
+    expect(page).not_to have_css("html.mobile-view")
+
+    resize_window(width: 400) do
+      expect(page).to have_css("html.mobile-view")
+      expect(page).not_to have_css("html.desktop-view")
+    end
+  end
+end


### PR DESCRIPTION
Introduces the viewport_based_mobile_mode experimental site setting. When enabled, user-agent-based mobile/desktop detection will be replaced with viewport-width logic. 'mobile mode' is enabled for any viewport less than our 'sm' breakpoint (40rem, or 640px at default font size).

When this mode is enabled, mobile/desktop toggle buttons are hidden, since they are non-functional.

Tests are also updated to use a consistent method for force-enabling the legacy mobile mode. All state is now stored in `lib/mobile`, and the `Site` model references that via a getter.