### PR TITLE
DEV: Add ability to hide shortcut in title

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
@@ -148,6 +148,7 @@ export default class Toolbar {
       preventFocus: buttonAttrs.preventFocus || false,
       condition: buttonAttrs.condition || (() => true),
       shortcutAction: buttonAttrs.shortcutAction, // (optional) custom shortcut action
+      hideShortcutInTitle: buttonAttrs.hideShortcutInTitle || false, // (optional) hide shortcut in title
     };
 
     if (buttonAttrs.sendAction) {
@@ -160,7 +161,12 @@ export default class Toolbar {
         PLATFORM_KEY_MODIFIER + "+"
       )}${translateModKey(buttonAttrs.shortcut)}`;
 
-      createdButton.title = `${title} (${shortcutTitle})`;
+      if (buttonAttrs.hideShortcutInTitle) {
+        createdButton.title = title;
+      } else {
+        createdButton.title = `${title} (${shortcutTitle})`;
+      }
+
       this.shortcuts[
         `${PLATFORM_KEY_MODIFIER}+${buttonAttrs.shortcut}`.toLowerCase()
       ] = createdButton;

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1443,6 +1443,34 @@ import { i18n } from "discourse-i18n";
           );
       });
 
+      test("buttons with shortcuts can have their shortcut in title conditionally hidden", async function (assert) {
+        withPluginApi((api) => {
+          api.onToolbarCreate((toolbar) => {
+            toolbar.addButton({
+              id: "smile",
+              group: "extras",
+              name: "smile",
+              icon: "far-face-smile",
+              title: "cheese",
+              shortcut: "ALT+S",
+              hideShortcutInTitle: true,
+            });
+          });
+        });
+
+        await visit("/t/internationalization-localization/280");
+        await click(".post-controls button.reply");
+        await fillIn(".d-editor-input", "hello the world");
+
+        assert
+          .dom(".d-editor-button-bar .smile")
+          .hasAttribute(
+            "title",
+            i18n("cheese"),
+            "shows the title without the shortcut"
+          );
+      });
+
       test("buttons can support a shortcut that triggers a custom action", async function (assert) {
         withPluginApi("1.37.1", (api) => {
           api.onToolbarCreate((toolbar) => {


### PR DESCRIPTION
## :mag: Overview
This update add an _optional_ attribute to the `toolbar.addButton()` API so that we can conditionally hide the shortcut showing up in the title.

Although for most cases, showing the shortcut in the title is fine. For complex uses of `toolbar.addButton` where it triggers a menu, it isn't ideal. For example, in Discourse AI, the toolbar API is used to show a menu for the AI composer helper. The shortcut in the API is used to trigger the proofreading item, but not necessarily for all other items. As such, we want the shortcut hidden in the title.

## 🛠️ Usage

```diff
        withPluginApi((api) => {
          api.onToolbarCreate((toolbar) => {
            toolbar.addButton({
              id: "smile",
              group: "extras",
              name: "smile",
              icon: "far-face-smile",
              title: "cheese",
              shortcut: "ALT+S",
+              hideShortcutInTitle: true,
            });
          });
        });
``` 

### ← Before

Title shows:

> Cheese (Ctrl + Alt + S)

### → After

Title shows:

> Cheese