### PR TITLE
A11Y: Update accessible headings for more flexible translations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
@@ -93,7 +93,7 @@ export default class AccessibleDiscoveryHeading extends Component {
 
   <template>
     {{#if @filter}}
-      <h1 id="topic-list-heading">{{this.label}}</h1>
+      <h1 id="topic-list-heading" class="sr-only">{{this.label}}</h1>
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/accessible-discovery-heading.gjs
@@ -16,19 +16,6 @@ export default class AccessibleDiscoveryHeading extends Component {
     return filter;
   }
 
-  get filterLabel() {
-    const key = this.filterKey;
-
-    // fallback to nothing, e.g, "topics in uncategorized"
-    // rather than "[en.discovery.headings.filter_labels.foo] topics in uncategorized"
-    const fallback = "";
-    const label = i18n(`discovery.headings.filter_labels.${key}`);
-
-    return label.includes("discovery.headings.filter_labels.")
-      ? fallback
-      : label;
-  }
-
   get type() {
     const { category, tag, additionalTags } = this.args;
 
@@ -53,44 +40,60 @@ export default class AccessibleDiscoveryHeading extends Component {
 
   get label() {
     const { category, tag, additionalTags, filter } = this.args;
+    const key = this.filterKey;
     const type = this.type;
 
     if (filter === "categories") {
       return i18n("discovery.headings.categories");
     }
 
-    const key = this.filterKey;
-    const isSpecial = ["posted", "bookmarks"].includes(key);
-    const scope = `discovery.headings`;
-
-    if (tag?.id === "none" && !additionalTags?.length) {
-      const noTagsType = category ? "category" : "all";
-
-      const noTagsKey = isSpecial
-        ? `${scope}.no_tags.${noTagsType}.${key}`
-        : `${scope}.no_tags.${noTagsType}_default`;
-
-      return i18n(noTagsKey, {
-        filter: this.filterLabel,
-        category: category?.name,
+    // tag intersections don't have additional filters
+    if (type === "multi_tag") {
+      return i18n("discovery.headings.multi_tag.default", {
+        tags: [tag?.id, ...(additionalTags || [])].filter(Boolean).join(" + "),
       });
     }
 
-    const translationKey = isSpecial
-      ? `${scope}.${type}.${key}`
-      : `${scope}.${type}.default`;
+    if (tag?.id === "none" && !additionalTags?.length) {
+      const noTagsType = category ? "category" : "all";
+      const prefix = `discovery.headings.no_tags.${noTagsType}`;
+      const specificKey = key ? `${prefix}.${key}` : null;
+      const fallbackKey = `${prefix}.default`;
 
-    return i18n(translationKey, {
-      filter: this.filterLabel,
+      const params = {
+        category: category?.name,
+        filter: key,
+      };
+
+      let label = specificKey ? i18n(specificKey, params) : "";
+      if (label === specificKey || label.includes("discovery.headings")) {
+        label = i18n(fallbackKey, params);
+      }
+
+      return label;
+    }
+
+    const base = `discovery.headings.${type}`;
+    const specificKey = key ? `${base}.${key}` : null;
+    const fallbackKey = `${base}.default`;
+
+    const params = {
       category: category?.name,
       tag: tag?.id,
-      tags: [tag?.id, ...(additionalTags || [])].join(" + "),
-    });
+      filter: key,
+    };
+
+    let label = specificKey ? i18n(specificKey, params) : "";
+    if (label === specificKey || label.includes("discovery.headings")) {
+      label = i18n(fallbackKey, params);
+    }
+
+    return label;
   }
 
   <template>
     {{#if @filter}}
-      <h1 id="topic-list-heading" class="sr-only">{{this.label}}</h1>
+      <h1 id="topic-list-heading">{{this.label}}</h1>
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
@@ -50,7 +50,7 @@ module("Component | discovery/accessible-discovery-heading", function (hooks) {
     assert
       .dom("#topic-list-heading")
       .hasText(
-        "topics in Development tagged with javascript",
+        "topics in Development tagged javascript",
         "The label is correct for a category and tag"
       );
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
@@ -20,7 +20,7 @@ module("Component | discovery/accessible-discovery-heading", function (hooks) {
 
   test("it renders the correct label for a single tag", async function (assert) {
     this.setProperties({
-      filter: "tag",
+      filter: "top",
       tag: { id: "javascript" },
     });
 
@@ -31,14 +31,14 @@ module("Component | discovery/accessible-discovery-heading", function (hooks) {
     assert
       .dom("#topic-list-heading")
       .hasText(
-        "topics tagged with javascript",
+        "Top topics tagged javascript",
         "The label is correct for a single tag"
       );
   });
 
   test("it renders the correct label for a category and tag", async function (assert) {
     this.setProperties({
-      filter: "tag",
+      filter: "latest",
       category: { name: "Development" },
       tag: { id: "javascript" },
     });
@@ -50,7 +50,7 @@ module("Component | discovery/accessible-discovery-heading", function (hooks) {
     assert
       .dom("#topic-list-heading")
       .hasText(
-        "topics in Development tagged javascript",
+        "Latest topics in Development tagged javascript",
         "The label is correct for a category and tag"
       );
   });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5215,49 +5215,76 @@ en:
     discovery:
       headings:
         all:
-          default: "All %{filter} topics"
+          latest: "All latest topics"
+          top: "All top topics"
+          new: "All new topics"
+          unread: "All unread topics"
+          unseen: "All unseen topics"
+          hot: "All hot topics"
           posted: "All topics you’ve posted in"
           bookmarks: "All topics you’ve bookmarked"
+          default: "All %{filter} topics"
 
         category:
-          default: "%{filter} topics in %{category}"
+          latest: "Latest topics in %{category}"
+          top: "Top topics in %{category}"
+          new: "New topics in %{category}"
+          unread: "Unread topics in %{category}"
+          unseen: "Unseen topics in %{category}"
+          hot: "Hot topics in %{category}"
           posted: "Topics in %{category} you’ve posted in"
           bookmarks: "Topics in %{category} you’ve bookmarked"
-
-        no_tags:
-          all_default: "All topics without tags"
-          category_default: "%{filter} topics in %{category} without tags"
-          all:
-            posted: "All topics without tags you've posted in"
-            bookmarks: "All topics without tags you've bookmarked"
-          category:
-            posted: "Topics in %{category} without tags you've posted in"
-            bookmarks: "Topics in %{category} without tags you've bookmarked"
+          default: "%{filter} topics in %{category}"
 
         single_tag:
-          default: "%{filter} topics tagged with %{tag}"
-          posted: "Topics tagged %{tag} you've posted in"
+          latest: "Latest topics tagged %{tag}"
+          top: "Top topics tagged %{tag}"
+          new: "New topics tagged %{tag}"
+          unread: "Unread topics tagged %{tag}"
+          unseen: "Unseen topics tagged %{tag}"
+          hot: "Hot topics tagged %{tag}"
+          posted: "Topics tagged %{tag} you’ve posted in"
           bookmarks: "Topics tagged %{tag} you’ve bookmarked"
+          default: "%{filter} topics tagged %{tag}"
 
         multi_tag:
-          default: "%{filter} topics tagged %{tags}"
-          posted: "Topics tagged %{tags} you've posted in"
-          bookmarks: "Topics tagged %{tags} you’ve bookmarked"
+          default: "Topics tagged %{tags}"
 
         category_tag:
-          default: "%{filter} topics in %{category} tagged with %{tag}"
+          latest: "Latest topics in %{category} tagged %{tag}"
+          top: "Top topics in %{category} tagged %{tag}"
+          new: "New topics in %{category} tagged %{tag}"
+          unread: "Unread topics in %{category} tagged %{tag}"
+          unseen: "Unseen topics in %{category} tagged %{tag}"
+          hot: "Hot topics in %{category} tagged %{tag}"
           posted: "Topics in %{category} tagged %{tag} you’ve posted in"
           bookmarks: "Topics in %{category} tagged %{tag} you’ve bookmarked"
+          default: "%{filter} topics in %{category} tagged %{tag}"
+
+        no_tags:
+          all:
+            latest: "Latest topics without tags"
+            top: "Top topics without tags"
+            new: "New topics without tags"
+            unread: "Unread topics without tags"
+            unseen: "Unseen topics without tags"
+            hot: "Hot topics without tags"
+            posted: "Topics without tags you’ve posted in"
+            bookmarks: "Topics without tags you’ve bookmarked"
+            default: "Topics without tags"
+
+          category:
+            latest: "Latest topics in %{category} without tags"
+            top: "Top topics in %{category} without tags"
+            new: "New topics in %{category} without tags"
+            unread: "Unread topics in %{category} without tags"
+            unseen: "Unseen topics in %{category} without tags"
+            hot: "Hot topics in %{category} without tags"
+            posted: "Topics in %{category} without tags you’ve posted in"
+            bookmarks: "Topics in %{category} without tags you’ve bookmarked"
+            default: "%{filter} topics in %{category} without tags"
 
         categories: "All categories"
-
-        filter_labels:
-          latest: "Latest"
-          top: "Top"
-          new: "New"
-          unread: "Unread"
-          hot: "Hot"
-          unseen: "Unseen"
 
   # This section is exported to the javascript for i18n in the admin section
   admin_js:

--- a/spec/system/discovery_h1_accessibility_spec.rb
+++ b/spec/system/discovery_h1_accessibility_spec.rb
@@ -32,7 +32,7 @@ describe "Discovery heading accessibility", type: :system do
 
   it "shows default heading for latest topics" do
     visit "/latest"
-    expect(page).to have_selector("h1", text: "All Latest topics")
+    expect(page).to have_selector("h1", text: "All latest topics")
   end
 
   it "shows heading for all categories view" do

--- a/spec/system/discovery_h1_accessibility_spec.rb
+++ b/spec/system/discovery_h1_accessibility_spec.rb
@@ -17,17 +17,17 @@ describe "Discovery heading accessibility", type: :system do
 
   it "shows correct heading for tagged view" do
     visit "/tags/#{tag.name}"
-    expect(page).to have_selector("h1", text: "Latest topics tagged with help")
+    expect(page).to have_selector("h1", text: "Latest topics tagged help")
   end
 
   it "shows correct heading for category + tag view" do
     visit "/tags/c/#{category.slug}/#{category.id}/#{tag.name}"
-    expect(page).to have_selector("h1", text: "Latest topics in General tagged with help")
+    expect(page).to have_selector("h1", text: "Latest topics in General tagged help")
   end
 
   it "shows correct heading for no tags view" do
-    visit "/tags/none"
-    expect(page).to have_selector("h1", text: "All topics without tags")
+    visit "/tag/none"
+    expect(page).to have_selector("h1", text: "Latest topics without tags")
   end
 
   it "shows default heading for latest topics" do


### PR DESCRIPTION
Follow-up to ca658a8bb093c82410927d1fa29e5ef1940260b7

The original attempt at this wasn't flexible enough for some languages where adjectives may depend on context, so this requires more translation but allows for full context in each string

Discussed here: https://meta.discourse.org/t/translating-filter-in-headings-for-discovery-routes/363520