### PR TITLE
DEV: backport login redirect param to stable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/login.js
+++ b/app/assets/javascripts/discourse/app/components/modal/login.js
@@ -137,6 +137,8 @@ export default class Login extends Component {
           } else if (destinationUrl) {
             removeCookie("destination_url");
             window.location.assign(destinationUrl);
+          } else if (this.args.model.referrerUrl) {
+            window.location.assign(this.args.model.referrerUrl);
           } else {
             window.location.reload();
           }
@@ -288,6 +290,8 @@ export default class Login extends Component {
           removeCookie("destination_url");
 
           applyHiddenFormInputValue(destinationUrl, "redirect");
+        } else if (this.args.model.referrerUrl) {
+          applyHiddenFormInputValue(this.args.model.referrerUrl, "redirect");
         } else {
           applyHiddenFormInputValue(window.location.href, "redirect");
         }

--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -160,6 +160,8 @@ export default class LoginPageController extends Controller {
           } else if (destinationUrl) {
             removeCookie("destination_url");
             window.location.assign(destinationUrl);
+          } else if (this.referrerUrl) {
+            window.location.assign(this.referrerUrl);
           } else {
             window.location.reload();
           }
@@ -337,6 +339,8 @@ export default class LoginPageController extends Controller {
           removeCookie("destination_url");
 
           applyHiddenFormInputValue(destinationUrl, "redirect");
+        } else if (this.referrerUrl) {
+          applyHiddenFormInputValue(this.referrerUrl, "redirect");
         } else {
           applyHiddenFormInputValue(window.location.href, "redirect");
         }

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -298,6 +298,9 @@ export default class ApplicationRoute extends DiscourseRoute {
             showNotActivated: (props) => this.send("showNotActivated", props),
             showCreateAccount: (props) => this.send("showCreateAccount", props),
             canSignUp: this.controller.canSignUp,
+            referrerUrl: DiscourseURL.isInternal(document.referrer)
+              ? document.referrer
+              : null,
           },
         });
       }

--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -1,5 +1,6 @@
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
+import DiscourseURL from "discourse/lib/url";
 import { defaultHomepage } from "discourse/lib/utilities";
 import StaticPage from "discourse/models/static-page";
 import DiscourseRoute from "discourse/routes/discourse";
@@ -9,7 +10,11 @@ export default class LoginRoute extends DiscourseRoute {
   @service router;
   @service login;
 
-  beforeModel() {
+  beforeModel(transition) {
+    if (transition.from) {
+      this.internalReferrer = this.router.urlFor(transition.from.name);
+    }
+
     if (this.siteSettings.login_required) {
       if (
         this.login.isOnlyOneExternalLoginMethod &&
@@ -48,6 +53,10 @@ export default class LoginRoute extends DiscourseRoute {
     controller.set("canSignUp", canSignUp);
     controller.set("flashType", "");
     controller.set("flash", "");
+
+    if (this.internalReferrer || DiscourseURL.isInternal(document.referrer)) {
+      controller.set("referrerUrl", this.internalReferrer || document.referrer);
+    }
 
     if (this.siteSettings.login_required) {
       controller.set("showLogin", false);

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -27,9 +27,36 @@ class StaticController < ApplicationController
   }
   CUSTOM_PAGES = {} # Add via `#add_topic_static_page` in plugin API
 
+  def extract_redirect_param
+    redirect_path = params[:redirect]
+    if redirect_path.present?
+      begin
+        forum_host = URI(Discourse.base_url).host
+        uri = URI(redirect_path)
+
+        if uri.path.present? && !uri.path.starts_with?(login_path) &&
+             (uri.host.blank? || uri.host == forum_host) && uri.path =~ %r{\A\/{1}[^\.\s]*\z}
+          return "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
+        end
+      rescue URI::Error, ArgumentError
+        # If the URI is invalid, return "/" below
+      end
+    end
+
+    "/"
+  end
+
   def show
-    if current_user && (params[:id] == "login" || params[:id] == "signup")
-      return redirect_to(path "/")
+    if params[:id] == "login"
+      destination = extract_redirect_param
+
+      if current_user
+        return redirect_to(path(destination), allow_other_host: false)
+      elsif destination != "/"
+        cookies[:destination_url] = path(destination)
+      end
+    elsif params[:id] == "signup" && current_user
+      return redirect_to path("/")
     end
 
     if SiteSetting.login_required? && current_user.nil? && %w[faq guidelines].include?(params[:id])
@@ -123,26 +150,7 @@ class StaticController < ApplicationController
     params.delete(:username)
     params.delete(:password)
 
-    destination = path("/")
-
-    redirect_location = params[:redirect]
-    if redirect_location.present? && !redirect_location.is_a?(String)
-      raise Discourse::InvalidParameters.new(:redirect)
-    elsif redirect_location.present? &&
-          begin
-            forum_uri = URI(Discourse.base_url)
-            uri = URI(redirect_location)
-
-            if uri.path.present? && !uri.path.starts_with?(login_path) &&
-                 (uri.host.blank? || uri.host == forum_uri.host) &&
-                 uri.path =~ %r{\A\/{1}[^\.\s]*\z}
-              destination = "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
-            end
-          rescue URI::Error
-            # Do nothing if the URI is invalid
-          end
-    end
-
+    destination = extract_redirect_param
     redirect_to(destination, allow_other_host: false)
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -86,7 +86,12 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     cookies["_bypass_cache"] = true
     cookies[:authentication_data] = { value: client_hash.to_json, path: Discourse.base_path("/") }
-    redirect_to @origin
+
+    if !current_user && @origin.start_with?("/user-api-key/new")
+      redirect_to path("/")
+    else
+      redirect_to @origin
+    end
   end
 
   def valid_origin?(uri)

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -123,6 +123,8 @@ class Auth::Result
       user.update(associated_group_ids: associated_group_ids)
       AssociatedGroup.where(id: associated_group_ids).update_all("last_used = CURRENT_TIMESTAMP")
     end
+
+    Group.user_trust_level_change!(user.id, user.trust_level) if user && !user.staged
   end
 
   def can_edit_name

--- a/spec/system/page_objects/modals/login.rb
+++ b/spec/system/page_objects/modals/login.rb
@@ -16,6 +16,11 @@ module PageObjects
         self
       end
 
+      def open_with_redirect(redirect_path)
+        visit("/login?redirect=#{redirect_path}")
+        self
+      end
+
       def open_from_header
         find(".login-button").click
       end

--- a/spec/system/page_objects/pages/login.rb
+++ b/spec/system/page_objects/pages/login.rb
@@ -16,6 +16,11 @@ module PageObjects
         self
       end
 
+      def open_with_redirect(redirect_path)
+        visit("/login?redirect=#{redirect_path}")
+        self
+      end
+
       def open_from_header
         find(".login-button").click
       end


### PR DESCRIPTION
This backports to stable my changes to add a redirect queryParam to the /login route.

Pulled in a couple other commits that affect the login process and the same spec that I modified.

Had to add a commit cleaning up the modal login helper for login_spec.rb to pass here since the modal login was already removed in main.