### PR TITLE
FIX: fix label and description not working in type objects for site settings

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-setting/editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-setting/editor.gjs
@@ -141,12 +141,12 @@ export default class SchemaSettingNewEditor extends Component {
     return descriptions[key];
   }
 
-  fieldLabel(fieldName) {
-    return this.descriptions(fieldName, "label") || fieldName;
+  fieldLabel(fieldName, spec) {
+    return this.descriptions(fieldName, "label") || spec?.label || fieldName;
   }
 
-  fieldDescription(fieldName) {
-    return this.descriptions(fieldName, "description");
+  fieldDescription(fieldName, spec) {
+    return this.descriptions(fieldName, "description") || spec?.description;
   }
 
   get fields() {
@@ -163,8 +163,8 @@ export default class SchemaSettingNewEditor extends Component {
           name,
           spec,
           value: activeObject[name],
-          description: this.fieldDescription(name),
-          label: this.fieldLabel(name),
+          description: this.fieldDescription(name, spec),
+          label: this.fieldLabel(name, spec),
         });
       }
     }

--- a/app/assets/javascripts/discourse/tests/fixtures/theme-setting-schema-data.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/theme-setting-schema-data.js
@@ -23,6 +23,8 @@ export default function schemaAndData(version = 1, mode = SCHEMA_MODES.THEME) {
             properties: {
               name: {
                 type: "string",
+                label: "Level 2 Label",
+                description: "Description for level 2",
               },
               grandchildren: {
                 type: "objects",

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
@@ -1553,7 +1553,7 @@ module(
 
       const inputFields = new InputFieldsFromDOM();
 
-      assert.dom(inputFields.fields.name.labelElement).hasText("name");
+      assert.dom(inputFields.fields.name.labelElement).hasText("Level 2 Label");
 
       await click(TOP_LEVEL_ADD_BTN);
       tree.refresh();

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
@@ -206,6 +206,12 @@ module(
       tree.refresh();
       assert.strictEqual(tree.nodes.length, 4);
 
+      const inputFields = new InputFieldsFromDOM();
+      assert.dom(inputFields.fields.name.labelElement).hasText("Level 2 Label");
+      assert
+        .dom(inputFields.fields.name.descriptionElement)
+        .hasText("Description for level 2");
+
       assert.dom(tree.nodes[0].textElement).hasText("child 2-1");
       assert.false(tree.nodes[0].active);
       assert.strictEqual(tree.nodes[0].children.length, 0);

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
@@ -72,6 +72,9 @@ class InputFieldsFromDOM {
         inputElement: field.querySelector(".schema-field__input").children[0],
         countElement: field.querySelector(".schema-field__input-count"),
         errorElement: field.querySelector(".schema-field__input-error"),
+        descriptionElement: field.querySelector(
+          ".schema-field__input-description"
+        ),
         selector: `.schema-field[data-name="${field.dataset.name}"]`,
       };
     });
@@ -2210,6 +2213,14 @@ module(
       assert.dom(inputFields.fields.name.inputElement).hasValue("item 1");
       assert.dom(inputFields.fields.name.labelElement).hasText("name");
       assert.dom(".--back-btn").doesNotExist();
+
+      await click(tree.nodes[0].children[0].element);
+      tree.refresh();
+      inputFields.refresh();
+      assert.dom(inputFields.fields.name.labelElement).hasText("Level 2 Label");
+      assert
+        .dom(inputFields.fields.name.descriptionElement)
+        .hasText("Description for level 2");
     });
   }
 );


### PR DESCRIPTION
`label` and `description` did not work in `type: objects` in site settings; this PR fixes that.

In theme settings, it is still working as expected(added tests for it ).