### PR TITLE
UX: rich editor checklist undoable input rule

### DIFF
--- a/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/checklist/assets/javascripts/lib/rich-editor-extension.js
@@ -40,7 +40,6 @@ const extension = {
           end,
           state.schema.nodes.check.create({ checked: match[2] === "x" })
         ),
-      options: { undoable: false },
     },
   ],
 


### PR DESCRIPTION
Removes the rich editor checklist input rule `undoable: false`, which is not needed.

Making it undoable allows a backspace to undo the input rule conversion, so we can go from a check to a `[]` again