### PR TITLE
FEATURE: allow minimizing composer when no text

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -846,13 +846,7 @@ export default class ComposerService extends Service {
 
     const composer = this.model;
 
-    if (
-      isEmpty(composer?.reply) &&
-      isEmpty(composer?.title) &&
-      !this.hasFormTemplate
-    ) {
-      this.close();
-    } else if (composer?.viewOpenOrFullscreen) {
+    if (composer?.viewOpenOrFullscreen) {
       this.shrink();
     } else {
       await this.cancelComposer();
@@ -1671,15 +1665,7 @@ export default class ComposerService extends Service {
   }
 
   shrink() {
-    if (
-      this.get("model.replyDirty") ||
-      (this.get("model.canEditTitle") && this.get("model.titleDirty")) ||
-      this.hasFormTemplate
-    ) {
-      this.collapse();
-    } else {
-      this.close();
-    }
+    this.collapse();
   }
 
   _saveDraft() {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -99,6 +99,14 @@ import { i18n } from "discourse-i18n";
           "sets --composer-height to 400px when creating topic"
         );
 
+        await click(".toggle-minimize");
+        assert.strictEqual(
+          document.documentElement.style.getPropertyValue("--composer-height"),
+          "40px",
+          "sets --composer-height to 40px when composer is minimized without content"
+        );
+
+        await click(".toggle-fullscreen");
         await fillIn(
           ".d-editor-input",
           "this is the *content* of a new topic post"
@@ -118,7 +126,7 @@ import { i18n } from "discourse-i18n";
         );
 
         await fillIn(".d-editor-input", "");
-        await click(".toggle-minimize");
+        await click(".btn.cancel");
         assert.strictEqual(
           document.documentElement.style.getPropertyValue("--composer-height"),
           "",


### PR DESCRIPTION
This change updates the minimize button to always minimize the composer so we don’t inadvertently delete user input.

Internal ref: /t/129123