### PR TITLE
UX: switch sidebar focus to focus-visible

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -23,7 +23,7 @@
     color: var(--d-sidebar-link-color);
     transition: background-color 0.25s;
 
-    &:focus,
+    &:focus-visible,
     &:hover {
       background: var(--d-sidebar-highlight-background);
       color: var(--d-sidebar-highlight-color);


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/dmenu-for-more-in-sidebar-selects-first-item-even-if-it-is-not-the-current-page/367344

focus-visible will make the focus state only appear when needed (like when navigating with your keyboard), rather than appearing on menu open 

![image](https://github.com/user-attachments/assets/9a6288a6-f67b-4493-a63c-aaaeb4214652)
