### PR TITLE
UX: fix search results unreachable bottom results and more button

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -48,6 +48,7 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  max-height: 100vh;
 
   // remove once glimmer search menu in place
   .widget-link,
@@ -189,10 +190,11 @@
     touch-action: pan-y pinch-zoom;
     overflow: hidden;
     height: 100%;
+    max-height: inherit;
   }
 
   .panel-body-contents {
-    max-height: 100%;
+    max-height: inherit;
     width: 100%;
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -190,11 +190,10 @@
     touch-action: pan-y pinch-zoom;
     overflow: hidden;
     height: 100%;
-    max-height: inherit;
   }
 
   .panel-body-contents {
-    max-height: inherit;
+    max-height: 100%;
     width: 100%;
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -157,6 +157,11 @@
       color: var(--primary);
     }
   }
+
+  .search-menu-panel {
+    // hacky but best guestimate we can do: full height of the viewport minus the header, minus the welcome banner spacing,  minus font-size:6 title
+    max-height: calc(100vh - var(--header-offset) - -3em - 4em);
+  }
 }
 
 // hide search icon from default search menu

--- a/app/assets/stylesheets/desktop/components/header-search.scss
+++ b/app/assets/stylesheets/desktop/components/header-search.scss
@@ -100,6 +100,7 @@
             padding: 0;
             border: 1px solid var(--primary-low);
             border-radius: var(--d-border-radius);
+            max-height: calc(100vh - var(--header-offset));
           }
 
           .search-input {


### PR DESCRIPTION
Meta report: https://meta.discourse.org/t/search-in-header-gives-too-deep-results/362973

The general problem of our `menu-panel` is that it had no proper max-height set, which mean you have to scroll the page instead of the panel to see bottom results. In the new header-search setup however, scrolling the page makes the panel disappear, effectively locking you out.

This commit adds a best-estimate max-height on the parent level `menu-panel`, dependent on where the search is triggered from (header VS welcome banner)

| Old | New |
|--------|--------|
| ![CleanShot 2025-05-23 at 14 58 07@2x](https://github.com/user-attachments/assets/4a96d518-13d0-4f97-b472-5d1f56bbaa1a) | ![CleanShot 2025-05-23 at 14 59 30@2x](https://github.com/user-attachments/assets/9c8546d2-a780-49b3-80d0-95eab81eff94) | 