### PR TITLE
DEV: Add className to flag name in flagging modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-action-type.gjs
+++ b/app/assets/javascripts/discourse/app/components/flag-action-type.gjs
@@ -135,7 +135,7 @@ export default class FlagActionType extends Component {
               name="post_action_type_index"
             />
             <div class="flag-action-type-details">
-              <strong>{{this.formattedName}}</strong>
+              <strong class="flag-name">{{this.formattedName}}</strong>
               <div class="description">{{htmlSafe this.flagDescription}}</div>
               {{#if this.showMessageInput}}
                 <Textarea


### PR DESCRIPTION
There is currently no selector on this `div` and I need a better selector than `strong` for a CSS customization in a private theme.