### PR TITLE
UX: Establish a larger default border radius

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -5,11 +5,11 @@
   --topic-body-width: #{$topic-body-width};
   --topic-body-width-padding: #{$topic-body-width-padding};
   --topic-avatar-width: #{$topic-avatar-width};
-  --d-border-radius: 2px;
-  --d-border-radius-large: 2px;
+  --d-border-radius: 4px;
+  --d-border-radius-large: calc(var(--d-border-radius) * 2);
   --d-nav-pill-border-radius: var(--d-border-radius);
-  --d-button-border-radius: 2px;
-  --d-input-border-radius: 2px;
+  --d-button-border-radius: var(--d-border-radius);
+  --d-input-border-radius: var(--d-border-radius);
   --d-content-background: initial;
   --d-button-transition: none;
 }


### PR DESCRIPTION
This PR adjusts the default border radius from `2px` to `4px`. It also increase `--d-border-radius-large` by setting it to be `2x` the default. 