### PR TITLE
DEV: add new application route behavior transformers

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,7 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-export const PLUGIN_API_VERSION = "2.1.1";
+export const PLUGIN_API_VERSION = "2.1.2";
 
 import Component from "@glimmer/component";
 import $ from "jquery";

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -1,5 +1,7 @@
 export const BEHAVIOR_TRANSFORMERS = Object.freeze([
   // use only lowercase names
+  "application-route-loading",
+  "application-route-will-transition",
   "composer-position:correct-scroll-position",
   "composer-position:editor-touch-move",
   "discovery-topic-list-load-more",
@@ -19,8 +21,8 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "composer-save-button-label",
   "composer-service-cannot-submit-post",
   "create-topic-label",
-  "flag-description",
   "flag-custom-placeholder",
+  "flag-description",
   "flag-formatted-name",
   "hamburger-dropdown-click-outside-exceptions",
   "header-notifications-avatar-size",


### PR DESCRIPTION
This adds two new BehaviorTransformers

- application-route-loading
- application-route-will-transition

that might be useful for plugins interested in allow or deny listing some routes.

Both are needed because of how Ember routing works differently when the application is first loaded vs when it's already loaded and you're navigating between routes.

Also minor-bumped the plugin api version and alphabetically sorted the list of value transformers.

Internal ref - t/141359