### PR TITLE
FIX: allows zooming of images in chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/lightbox.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/lightbox.js
@@ -21,6 +21,13 @@ export default function lightbox(images) {
         elementParse: (item) => {
           item.src = item.el[0].dataset.largeSrc || item.el[0].src;
         },
+        open: function () {
+          this.touchActionValue = document.body.style.touchAction;
+          document.body.style.touchAction = "";
+        },
+        close: function () {
+          document.body.style.touchAction = this.touchActionValue;
+        },
       },
     });
   });


### PR DESCRIPTION
Due to one of the side effects of `app/assets/javascripts/discourse/app/lib/body-scroll-lock.js` we are disabling touch actions on body which was impacting zooming of images in chat.

Im not sure we should keep this touch-action hack  in `app/assets/javascripts/discourse/app/lib/body-scroll-lock.js` but for now the simplest change is to just disable it when a chat image is lightboxed.