### PR TITLE
UX: Match theme install icon with component icon

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -223,7 +223,7 @@ export default class ThemeCard extends Component {
                       <dropdown.item>
                         <DButton
                           @action={{this.updateTheme}}
-                          @icon="download"
+                          @icon="cloud-arrow-down"
                           class="theme-card__button update"
                           @preventFocus={{true}}
                           @translatedLabel={{i18n


### PR DESCRIPTION
Just a small update to make the theme install icon match the one we use for components. 