### PR TITLE
DEV: maps IST rails timezone to kolkata

### DIFF
--- a/config/initializers/100-custom-timezones.rb
+++ b/config/initializers/100-custom-timezones.rb
@@ -1,0 +1,1 @@
+ActiveSupport::TimeZone::MAPPING["IST"] = "Asia/Kolkata"

--- a/spec/initializers/custom_timezones_spec.rb
+++ b/spec/initializers/custom_timezones_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe "Custom timezones initializer" do
+  it "maps IST to Asia/Kolkata" do
+    expect(ActiveSupport::TimeZone["IST"].tzinfo).to eq(
+      ActiveSupport::TimeZone["Asia/Kolkata"].tzinfo,
+    )
+  end
+end


### PR DESCRIPTION
This commit ensures rails will recognise `IST` as a timezone. It will be mapped to the standard timezone `Asia/Kolkata`.

Its technically not a standard, but it's used by many people so we are adding it as a timezone in core.