### PR TITLE
DEV: extract composer toolbar class for future reuse

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -920,7 +920,10 @@ export default class ComposerEditor extends Component {
       icon: "gear",
       title: "composer.options",
       sendAction: this.onExpandPopupMenuOptions.bind(this),
-      popupMenu: true,
+      popupMenu: {
+        options: () => this.composer.popupMenuOptions,
+        action: this.composer.onPopupMenuAction,
+      },
     });
   }
 

--- a/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
@@ -1,0 +1,68 @@
+import Component from "@glimmer/component";
+import { fn, hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { eq } from "truth-helpers";
+import DButton from "discourse/components/d-button";
+import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
+import ToolbarPopupMenuOptions from "select-kit/components/toolbar-popup-menu-options";
+
+export default class ComposerToolbarButtons extends Component {
+  firstButton = this.args.data.groups.mapBy("buttons").flat().firstObject;
+
+  @action
+  applyCondition(button) {
+    return button.condition === undefined
+      ? true
+      : button.condition(this.args.data);
+  }
+
+  @action
+  tabIndex(button) {
+    return button === this.firstButton ? 0 : button.tabindex;
+  }
+
+  <template>
+    {{#each @data.groups as |group|}}
+      {{#each group.buttons as |button|}}
+        {{#if (this.applyCondition button)}}
+          {{#if button.href}}
+            <a
+              href={{button.href}}
+              target="_blank"
+              rel="noopener noreferrer"
+              class={{concatClass "btn no-text btn-icon" button.className}}
+              title={{button.title}}
+              tabindex={{this.tabIndex button}}
+            >
+              {{icon button.icon}}
+            </a>
+          {{else if button.popupMenu}}
+            <ToolbarPopupMenuOptions
+              @content={{(button.popupMenu.options)}}
+              @onChange={{button.popupMenu.action}}
+              @onOpen={{fn button.action button}}
+              @tabindex={{this.tabIndex button}}
+              @onKeydown={{@rovingButtonBar}}
+              @options={{hash icon=button.icon focusAfterOnChange=false}}
+              class={{button.className}}
+            />
+          {{else if (eq button.type "separator")}}
+            <div class="toolbar-separator"></div>
+          {{else}}
+            <DButton
+              @action={{fn button.action button}}
+              @translatedTitle={{button.title}}
+              @label={{button.label}}
+              @icon={{button.icon}}
+              @preventFocus={{button.preventFocus}}
+              @onKeyDown={{@rovingButtonBar}}
+              tabindex={{this.tabIndex button}}
+              class={{button.className}}
+            />
+          {{/if}}
+        {{/if}}
+      {{/each}}
+    {{/each}}
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
@@ -13,6 +13,7 @@ import { translations } from "pretty-text/emoji/data";
 import { Promise } from "rsvp";
 import TextareaEditor from "discourse/components/composer/textarea-editor";
 import ToggleSwitch from "discourse/components/composer/toggle-switch";
+import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import DEditorPreview from "discourse/components/d-editor-preview";
@@ -41,7 +42,6 @@ import {
   renderUserStatusHtml,
 } from "discourse/lib/user-status-on-autocomplete";
 import { i18n } from "discourse-i18n";
-import ToolbarPopupMenuOptions from "select-kit/components/toolbar-popup-menu-options";
 
 let _createCallbacks = [];
 
@@ -68,6 +68,7 @@ export default class DEditor extends Component {
   @tracked editorComponent;
   /** @type {TextManipulation} */
   @tracked textManipulation;
+  @tracked replacedToolbarInstance;
 
   @tracked preview;
 
@@ -171,7 +172,7 @@ export default class DEditor extends Component {
   @discourseComputed()
   toolbar() {
     const toolbar = new Toolbar(
-      this.getProperties("site", "siteSettings", "showLink", "capabilities")
+      this.getProperties("siteSettings", "showLink", "capabilities")
     );
     toolbar.context = this;
 
@@ -179,11 +180,6 @@ export default class DEditor extends Component {
 
     if (this.extraButtons) {
       this.extraButtons(toolbar);
-    }
-
-    const firstButton = toolbar.groups.mapBy("buttons").flat().firstObject;
-    if (firstButton) {
-      firstButton.tabindex = 0;
     }
 
     return toolbar;
@@ -617,6 +613,11 @@ export default class DEditor extends Component {
   }
 
   @action
+  replaceToolbar(toolbarInstance) {
+    this.replacedToolbarInstance = toolbarInstance;
+  }
+
+  @action
   onChange(event) {
     this.set("value", event?.target?.value);
     this.change?.(event);
@@ -715,45 +716,40 @@ export default class DEditor extends Component {
             {{if this.disabled 'disabled'}}
             {{if this.isEditorFocused 'in-focus'}}"
         >
-          <div class="d-editor-button-bar" role="toolbar">
-            {{#if this.siteSettings.rich_editor}}
-              <ToggleSwitch
-                @preventFocus={{true}}
-                @disabled={{@disableSubmit}}
-                @state={{this.isRichEditorEnabled}}
-                {{on "click" this.toggleRichEditor}}
-              />
-            {{/if}}
 
-            {{#each this.toolbar.groups as |group|}}
-              {{#each group.buttons as |b|}}
-                {{#if (b.condition this)}}
-                  {{#if b.popupMenu}}
-                    <ToolbarPopupMenuOptions
-                      @content={{this.popupMenuOptions}}
-                      @onChange={{this.onPopupMenuAction}}
-                      @onOpen={{fn b.action b}}
-                      @tabindex={{-1}}
-                      @onKeydown={{this.rovingButtonBar}}
-                      @options={{hash icon=b.icon focusAfterOnChange=false}}
-                      class={{b.className}}
-                    />
-                  {{else}}
-                    <DButton
-                      @action={{fn b.action b}}
-                      @translatedTitle={{b.title}}
-                      @label={{b.label}}
-                      @icon={{b.icon}}
-                      @preventFocus={{b.preventFocus}}
-                      @onKeyDown={{this.rovingButtonBar}}
-                      tabindex={{b.tabindex}}
-                      class={{b.className}}
-                    />
-                  {{/if}}
-                {{/if}}
-              {{/each}}
-            {{/each}}
-          </div>
+          {{#if this.replacedToolbarInstance}}
+            <div class="d-editor-button-bar --replaced-toolbar" role="toolbar">
+              <DButton
+                @action={{fn this.replaceToolbar null}}
+                @icon="angle-left"
+                @preventFocus={{true}}
+                @onKeyDown={{this.rovingButtonBar}}
+                @tabindex="-1"
+                class="btn-flat d-editor-button-bar__back"
+              />
+              <ToolbarButtons
+                @data={{this.replacedToolbarInstance}}
+                @rovingButtonBar={{this.rovingButtonBar}}
+              />
+            </div>
+          {{else}}
+            <div class="d-editor-button-bar" role="toolbar">
+              {{#if this.siteSettings.rich_editor}}
+                <ToggleSwitch
+                  @preventFocus={{true}}
+                  @disabled={{@disableSubmit}}
+                  @state={{this.isRichEditorEnabled}}
+                  {{on "click" this.toggleRichEditor}}
+                  {{on "keydown" this.rovingButtonBar}}
+                />
+              {{/if}}
+
+              <ToolbarButtons
+                @data={{this.toolbar}}
+                @rovingButtonBar={{this.rovingButtonBar}}
+              />
+            </div>
+          {{/if}}
 
           <ConditionalLoadingSpinner @condition={{this.loading}} />
           <this.editorComponent
@@ -770,6 +766,7 @@ export default class DEditor extends Component {
             @categoryId={{@categoryId}}
             @topicId={{@topicId}}
             @id={{this.textAreaId}}
+            @replaceToolbar={{this.replaceToolbar}}
           />
           <PopupInputTip @validation={{this.validation}} />
           <PluginOutlet

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.gjs
@@ -11,6 +11,7 @@ import {
 } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DEditor from "discourse/components/d-editor";
+import { ToolbarBase } from "discourse/lib/composer/toolbar";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setCaretPosition } from "discourse/lib/utilities";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -1313,6 +1314,56 @@ third line`
       });
     }
   })();
+
+  test("toolbar instance replacement", async function (assert) {
+    const self = this;
+
+    const customToolbar = new ToolbarBase({
+      siteSettings: this.siteSettings,
+      capabilities: this.capabilities,
+      showLink: true,
+    });
+    customToolbar.addButton({
+      id: "custom-toolbar-button",
+      icon: "plus",
+      title: "Custom Toolbar Button",
+    });
+
+    withPluginApi("0.1", (api) => {
+      api.onToolbarCreate((toolbar) => {
+        toolbar.addButton({
+          id: "replace-toolbar",
+          icon: "xmark",
+          group: "extras",
+          action: () => {
+            toolbar.context.replaceToolbar(customToolbar);
+          },
+          condition: () => true,
+        });
+      });
+    });
+
+    this.value = "hello";
+
+    await render(<template><DEditor @value={{self.value}} /></template>);
+
+    assert.dom(".d-editor-button-bar").exists();
+    assert.dom(".d-editor-button-bar.--replaced-toolbar").doesNotExist();
+
+    await click("button.replace-toolbar");
+
+    assert
+      .dom(
+        ".d-editor-button-bar.--replaced-toolbar button.custom-toolbar-button"
+      )
+      .exists("It should show the custom toolbar button");
+
+    // Back button
+    await click(".d-editor-button-bar__back");
+
+    assert.dom(".d-editor-button-bar").exists();
+    assert.dom(".d-editor-button-bar.--replaced-toolbar").doesNotExist();
+  });
 });
 
 module("Integration | Component | d-editor | rich editor", function (hooks) {


### PR DESCRIPTION
Starts defining a more generic API, so a different toolbar instance can be used as a replacement on the main toolbar as well as a foundation for rendering the same toolbar as a floating element.

