### PR TITLE
fix Right-To-Left rendering of ordered lists in posts

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -93,7 +93,7 @@ dd {
 .d-editor-preview {
   ul,
   ol {
-    padding-left: 1.25em;
+    padding-inline-start: 1.25em;
   }
 }
 


### PR DESCRIPTION
change "padding-left" to "padding-inline-start".

See:
https://meta.discourse.org/t/rtl-numbered-or-bullet-lists-are-broken/367516