### PR TITLE
DEV: Update Bullet to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ end
 
 group :development do
   gem "ruby-prof", require: false, platform: :mri
-  gem "bullet", "<= 8.0.3", require: !!ENV["BULLET"]
+  gem "bullet", require: !!ENV["BULLET"]
   gem "better_errors", platform: :mri, require: !!ENV["BETTER_ERRORS"]
   gem "binding_of_caller"
   gem "yaml-lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     builder (3.3.0)
-    bullet (8.0.3)
+    bullet (8.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (12.0.0)
@@ -673,7 +673,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bullet (<= 8.0.3)
+  bullet
   byebug
   capybara
   capybara-playwright-driver
@@ -830,7 +830,7 @@ CHECKSUMS
   binding_of_caller (1.0.1) sha256=2b2902abff4246ddcfbc4da9b69bc4a019e22aeb300c2ff6289a173d4b90b29a
   bootsnap (1.18.6) sha256=0ae2393c1e911e38be0f24e9173e7be570c3650128251bf06240046f84a07d00
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bullet (8.0.3) sha256=60e41446500a7e59272b3c2398cded214deec3662e883009de5bf30028a0642c
+  bullet (8.0.7) sha256=7d20550e81b38940e82c6166f483ab330df3cd5ef4eafc9e787934805ee379f1
   byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.6) sha256=ef461ab97f9fca7df4ecdd10bb1b076d9246f804e89fc3ae127cf1677d855e26


### PR DESCRIPTION
### What is this change?

A few minor versions of Bullet were incompatible with Discourse because we use our own content security policy middleware.

This has now been fixed upstream and released in 8.0.7: https://github.com/flyerhzm/bullet/issues/747#issuecomment-2882882825