### PR TITLE
DEV: Migrate add-groups-to-about component settings to site settings

### DIFF
--- a/db/post_migrate/20250526063633_copy_add_groups_to_about_component_settings.rb
+++ b/db/post_migrate/20250526063633_copy_add_groups_to_about_component_settings.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class CopyAddGroupsToAboutComponentSettings < ActiveRecord::Migration[7.2]
+  MAPPING = {
+    "about_groups" => "about_page_extra_groups",
+    "order_additional_groups" => "about_page_extra_groups_order",
+    "show_group_description" => "about_page_extra_groups_show_description",
+    "show_initial_members" => "about_page_extra_groups_initial_members",
+  }
+
+  def up
+    theme_settings = execute(<<~SQL).to_a
+      SELECT name, value
+      FROM theme_settings
+      WHERE theme_id = (
+        SELECT id
+        FROM themes
+        WHERE name = 'Add Groups to About'
+        AND enabled = true
+      )
+    SQL
+
+    return if theme_settings.blank?
+
+    theme_settings.each do |theme_setting|
+      site_setting = MAPPING[theme_setting["name"]]
+
+      next if !site_setting
+
+      SiteSetting.set(MAPPING[theme_setting["name"]], theme_setting["value"])
+    end
+
+    SiteSetting.set("show_additional_about_groups", true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
### What is this change?

We're moving the [add-groups-to-about](https://github.com/discourse/discourse-add-groups-to-about-component) theme component into core. We have already added the logic and switchover in #32659.

This PR adds a data migration that maps the theme settings to the relevant site settings, then enables the core implementation.

### Testing

**Using the theme component:**

<img width="368" alt="Screenshot 2025-05-26 at 3 21 16 PM" src="https://github.com/user-attachments/assets/3baa345e-ceab-4256-ab88-ece88b2ef019" />

**After running the migration:**

<img width="368" alt="Screenshot 2025-05-26 at 3 22 02 PM" src="https://github.com/user-attachments/assets/cff1db3b-7ed6-43de-bf7c-09e5f2c45efb" />

**After deleting the theme component:**

<img width="368" alt="Screenshot 2025-05-26 at 3 22 02 PM" src="https://github.com/user-attachments/assets/cff1db3b-7ed6-43de-bf7c-09e5f2c45efb" />
