### PR TITLE
FIX: back to forum button only from admin

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/back-to-forum.gjs
@@ -11,7 +11,10 @@ export default class BackToForum extends Component {
     const lastNonAdminUrl = this.routeHistory.history.find(
       (url) => !url.startsWith("/admin")
     );
-    if (lastNonAdminUrl) {
+    if (
+      lastNonAdminUrl &&
+      this.routeHistory.router.currentURL.startsWith("/admin")
+    ) {
       return getURL(lastNonAdminUrl);
     }
     return getURL("/");


### PR DESCRIPTION
Search for last not admin URL only when user is in admin panel. When back to forum link is clicked from documentation plugin link should lead to homepage.

Meta: https://meta.discourse.org/t/doc-sub-category-back-to-forum-loop/367513/10
Specs: https://github.com/discourse/discourse-doc-categories/pull/40