### PR TITLE
DEV: allows chat thread sdk to query more messages

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class Chat::Api::ChannelThreadMessagesController < Chat::ApiController
+  MAX_PAGE_SIZE = 50
+
   def index
-    ::Chat::ListChannelThreadMessages.call(service_params) do |result|
+    ::Chat::ListChannelThreadMessages.call(
+      service_params.deep_merge(params: { page_size: MAX_PAGE_SIZE }),
+    ) do |result|
       on_success do
         render_serialized(
           result,

--- a/plugins/chat/app/queries/chat/messages_query.rb
+++ b/plugins/chat/app/queries/chat/messages_query.rb
@@ -21,7 +21,7 @@ module Chat
     PAST = "past"
     FUTURE = "future"
     VALID_DIRECTIONS = [PAST, FUTURE]
-    MAX_PAGE_SIZE = 50
+    MAX_PAGE_SIZE = 500
 
     # @param channel [Chat::Channel] The channel to query messages within.
     # @param guardian [Guardian] The guardian to use for permission checks.

--- a/plugins/chat/app/services/chat/list_channel_thread_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_thread_messages.rb
@@ -34,12 +34,7 @@ module Chat
                   in: Chat::MessagesQuery::VALID_DIRECTIONS,
                 },
                 allow_nil: true
-      validates :page_size,
-                numericality: {
-                  less_than_or_equal_to: Chat::MessagesQuery::MAX_PAGE_SIZE,
-                  only_integer: true,
-                },
-                allow_nil: true
+      validates :page_size, numericality: { only_integer: true }, allow_nil: true
     end
 
     model :thread
@@ -94,7 +89,7 @@ module Chat
           guardian: guardian,
           target_message_id: context.target_message_id,
           thread_id: thread.id,
-          page_size: params.page_size || Chat::MessagesQuery::MAX_PAGE_SIZE,
+          page_size: params.page_size,
           direction: params.direction,
           target_date: params.target_date,
           include_target_message_id:

--- a/plugins/chat/spec/queries/chat/messages_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/messages_query_spec.rb
@@ -106,6 +106,12 @@ RSpec.describe Chat::MessagesQuery do
       stub_const(described_class, "MAX_PAGE_SIZE", 1) { expect(query[:messages].length).to eq(1) }
     end
 
+    it "limits results to MAX_PAGE_SIZE" do
+      options[:page_size] = 2
+      options[:target_message_id] = nil
+      stub_const(described_class, "MAX_PAGE_SIZE", 1) { expect(query[:messages].length).to eq(1) }
+    end
+
     describe "when some messages are in threads" do
       fab!(:thread) { Fabricate(:chat_thread, channel: channel) }
 

--- a/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
@@ -60,9 +60,22 @@ RSpec.describe Chat::Api::ChannelThreadMessagesController do
       end
     end
 
+    context "when page_size is a above limit" do
+      fab!(:message_3) { Fabricate(:chat_message, thread: thread, chat_channel: thread.channel) }
+
+      it "clamps it to the max" do
+        stub_const(Chat::Api::ChannelThreadMessagesController, "MAX_PAGE_SIZE", 1) do
+          get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages?page_size=9999"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["messages"].length).to eq(1)
+        end
+      end
+    end
+
     context "when params are invalid" do
       it "returns a 400" do
-        get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages?page_size=9999"
+        get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages?direction=yolo"
 
         expect(response.status).to eq(400)
       end

--- a/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
+++ b/plugins/chat/spec/services/chat/list_channel_thread_messages_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Chat::ListChannelThreadMessages do
     it do
       is_expected.to allow_values(Chat::MessagesQuery::MAX_PAGE_SIZE, 1, "1", nil).for(:page_size)
     end
-    it { is_expected.not_to allow_values(Chat::MessagesQuery::MAX_PAGE_SIZE + 1).for(:page_size) }
   end
 
   describe ".call" do


### PR DESCRIPTION
The changes are:
- Chat Thread SDK can query up to 500 messages
- If you are above this number, we don't raise an error anymore but we clamp it to 500
- The controller using this service is forced into the old limit of 50 to avoid abuses