### PR TITLE
FIX: restore category text color field

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -133,13 +133,15 @@ export default class EditCategoryGeneral extends Component {
     field.set(bgColor);
 
     if (field.name === "color") {
-      const currentTextColor = this.args.transientData.text_color;
-      const colorDifference = this.colorDifference(bgColor, currentTextColor);
+      const whiteColorDiff = this.colorDifference(bgColor, this.textColors[0]);
+      const blackColorDiff = this.colorDifference(bgColor, this.textColors[1]);
+      const colorIndex = whiteColorDiff > blackColorDiff ? 0 : 1;
 
-      if (colorDifference < 400) {
-        const index = this.textColors.indexOf(currentTextColor) === 0 ? 1 : 0;
-        document.querySelectorAll(".edit-text-color button")[index]?.click();
+      if (this.args.transientData.text_color === this.textColors[colorIndex]) {
+        return;
       }
+
+      document.querySelectorAll(".edit-text-color button")[colorIndex]?.click();
     }
   }
 

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -124,24 +124,19 @@ export default class EditCategoryGeneral extends Component {
 
   @action
   updateColor(field, newColor) {
-    const bgColor = newColor.replace("#", "");
-
-    if (field.value === bgColor) {
-      return;
-    }
-
-    field.set(bgColor);
+    const color = newColor.replace("#", "");
 
     if (field.name === "color") {
-      const whiteColorDiff = this.colorDifference(bgColor, this.textColors[0]);
-      const blackColorDiff = this.colorDifference(bgColor, this.textColors[1]);
+      const whiteColorDiff = this.colorDifference(color, this.textColors[0]);
+      const blackColorDiff = this.colorDifference(color, this.textColors[1]);
       const colorIndex = whiteColorDiff > blackColorDiff ? 0 : 1;
 
-      if (this.args.transientData.text_color === this.textColors[colorIndex]) {
-        return;
-      }
-
-      document.querySelectorAll(".edit-text-color button")[colorIndex]?.click();
+      this.args.form.setProperties({
+        color,
+        text_color: this.textColors[colorIndex],
+      });
+    } else {
+      field.set(color);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -81,10 +81,10 @@ export default class EditCategoryGeneral extends Component {
     const category = this.args.category;
 
     const previewCategory = Category.create({
+      id: category.id,
       name: transientData.name || i18n("category.untitled"),
       color: transientData.color,
-      id: category.id,
-      text_color: category.text_color,
+      text_color: transientData.text_color,
       parent_category_id: parseInt(category.get("parent_category_id"), 10),
       read_restricted: category.get("read_restricted"),
     });

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -22,6 +22,7 @@ export default class EditCategoryGeneral extends Component {
   @service site;
   @service siteSettings;
 
+  textColors = ["FFFFFF", "000000"];
   uncategorizedSiteSettingLink = getURL(
     "/admin/site_settings/category/all_results?filter=allow_uncategorized_topics"
   );
@@ -123,7 +124,40 @@ export default class EditCategoryGeneral extends Component {
 
   @action
   updateColor(field, newColor) {
-    field.set(newColor.replace("#", ""));
+    const bgColor = newColor.replace("#", "");
+
+    if (field.value === bgColor) {
+      return;
+    }
+
+    field.set(bgColor);
+
+    if (field.name === "color") {
+      const currentTextColor = this.args.transientData.text_color;
+      const colorDifference = this.colorDifference(bgColor, currentTextColor);
+
+      if (colorDifference < 400) {
+        const index = this.textColors.indexOf(currentTextColor) === 0 ? 1 : 0;
+        document.querySelectorAll(".edit-text-color button")[index]?.click();
+      }
+    }
+  }
+
+  @action
+  colorDifference(color1, color2) {
+    const r1 = parseInt(color1.substr(0, 2), 16);
+    const g1 = parseInt(color1.substr(2, 2), 16);
+    const b1 = parseInt(color1.substr(4, 2), 16);
+
+    const r2 = parseInt(color2.substr(0, 2), 16);
+    const g2 = parseInt(color2.substr(2, 2), 16);
+    const b2 = parseInt(color2.substr(4, 2), 16);
+
+    const rDiff = Math.max(r1, r2) - Math.min(r1, r2);
+    const gDiff = Math.max(g1, g2) - Math.min(g1, g2);
+    const bDiff = Math.max(b1, b2) - Math.min(b1, b2);
+
+    return rDiff + gDiff + bDiff;
   }
 
   get categoryDescription() {
@@ -296,6 +330,31 @@ export default class EditCategoryGeneral extends Component {
                 <ColorPicker
                   @colors={{this.backgroundColors}}
                   @usedColors={{this.usedBackgroundColors}}
+                  @value={{readonly field.value}}
+                  @ariaLabel={{i18n "category.predefined_colors"}}
+                  @onSelectColor={{fn this.updateColor field}}
+                />
+              </div>
+            </div>
+          </field.Custom>
+        </@form.Field>
+
+        <@form.Field
+          @name="text_color"
+          @title={{i18n "category.foreground_color"}}
+          @format="full"
+          as |field|
+        >
+          <field.Custom>
+            <div class="category-color-editor">
+              <div class="colorpicker-wrapper edit-text-color">
+                <ColorInput
+                  @hexValue={{readonly field.value}}
+                  @ariaLabelledby="foreground-color-label"
+                  @onChangeColor={{fn this.updateColor field}}
+                />
+                <ColorPicker
+                  @colors={{this.textColors}}
                   @value={{readonly field.value}}
                   @ariaLabel={{i18n "category.predefined_colors"}}
                   @onSelectColor={{fn this.updateColor field}}

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -9,7 +9,10 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import categoryBadge from "discourse/helpers/category-badge";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import lazyHash from "discourse/helpers/lazy-hash";
-import { CATEGORY_STYLE_TYPES } from "discourse/lib/constants";
+import {
+  CATEGORY_STYLE_TYPES,
+  CATEGORY_TEXT_COLORS,
+} from "discourse/lib/constants";
 import getURL from "discourse/lib/get-url";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
@@ -22,7 +25,6 @@ export default class EditCategoryGeneral extends Component {
   @service site;
   @service siteSettings;
 
-  textColors = ["FFFFFF", "000000"];
   uncategorizedSiteSettingLink = getURL(
     "/admin/site_settings/category/all_results?filter=allow_uncategorized_topics"
   );
@@ -127,13 +129,13 @@ export default class EditCategoryGeneral extends Component {
     const color = newColor.replace("#", "");
 
     if (field.name === "color") {
-      const whiteColorDiff = this.colorDifference(color, this.textColors[0]);
-      const blackColorDiff = this.colorDifference(color, this.textColors[1]);
-      const colorIndex = whiteColorDiff > blackColorDiff ? 0 : 1;
+      const whiteDiff = this.colorDifference(color, CATEGORY_TEXT_COLORS[0]);
+      const blackDiff = this.colorDifference(color, CATEGORY_TEXT_COLORS[1]);
+      const colorIndex = whiteDiff > blackDiff ? 0 : 1;
 
       this.args.form.setProperties({
         color,
-        text_color: this.textColors[colorIndex],
+        text_color: CATEGORY_TEXT_COLORS[colorIndex],
       });
     } else {
       field.set(color);
@@ -351,7 +353,7 @@ export default class EditCategoryGeneral extends Component {
                   @onChangeColor={{fn this.updateColor field}}
                 />
                 <ColorPicker
-                  @colors={{this.textColors}}
+                  @colors={{CATEGORY_TEXT_COLORS}}
                   @value={{readonly field.value}}
                   @ariaLabel={{i18n "category.predefined_colors"}}
                   @onSelectColor={{fn this.updateColor field}}

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -122,7 +122,6 @@ export default class EditCategoryTabsController extends Controller {
     }
 
     this.model.setProperties(transientData);
-    this.setTextColor(this.model.color);
 
     this.set("saving", true);
 
@@ -187,16 +186,5 @@ export default class EditCategoryTabsController extends Controller {
   @action
   goBack() {
     DiscourseURL.routeTo(this.model.url);
-  }
-
-  @action
-  setTextColor(backgroundColor) {
-    const r = parseInt(backgroundColor.substr(0, 2), 16);
-    const g = parseInt(backgroundColor.substr(2, 2), 16);
-    const b = parseInt(backgroundColor.substr(4, 2), 16);
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-    const color = brightness >= 128 ? this.textColors[0] : this.textColors[1];
-
-    this.model.set("text_color", color);
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/constants.js
+++ b/app/assets/javascripts/discourse/app/lib/constants.js
@@ -24,6 +24,8 @@ export const SIDEBAR_SECTION = {
 
 export const CATEGORY_STYLE_TYPES = { square: 0, icon: 1, emoji: 2 };
 
+export const CATEGORY_TEXT_COLORS = ["FFFFFF", "000000"];
+
 export const AUTO_GROUPS = {
   everyone: {
     id: 0,

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -1,6 +1,7 @@
 import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import sinon from "sinon";
+import { CATEGORY_TEXT_COLORS } from "discourse/lib/constants";
 import { cloneJSON } from "discourse/lib/object";
 import DiscourseURL from "discourse/lib/url";
 import { fixturesByUrl } from "discourse/tests/helpers/create-pretender";
@@ -141,7 +142,7 @@ acceptance("Category text color", function (needs) {
 
     assert.strictEqual(
       previewTextColor,
-      "FFFFFF",
+      CATEGORY_TEXT_COLORS[0],
       "has the default text color"
     );
 
@@ -154,7 +155,7 @@ acceptance("Category text color", function (needs) {
 
     assert.strictEqual(
       previewTextColor,
-      "000000",
+      CATEGORY_TEXT_COLORS[1],
       "sets the contrast text color"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -135,35 +135,26 @@ acceptance("Category text color", function (needs) {
   test("Category text color is set based on contrast", async function (assert) {
     await visit("/new-category");
 
-    let previewTextColor = document
-      .querySelector(".category-style .badge-category__wrapper")
-      .style.getPropertyValue("--category-badge-text-color")
-      .trim();
+    let previewTextColor = document.querySelectorAll(
+      ".edit-text-color .hex-input"
+    )[0].value;
 
     assert.strictEqual(
       previewTextColor,
-      "#FFFFFF",
+      "FFFFFF",
       "has the default text color"
     );
 
     await fillIn("input.category-name", "testing");
     await fillIn(".category-color-editor .hex-input", "EEEEEE");
-    await click("#save-category");
 
-    assert.strictEqual(
-      currentURL(),
-      "/c/testing/edit/general",
-      "it transitions to the category edit route"
-    );
-
-    previewTextColor = document
-      .querySelector(".category-style .badge-category__wrapper")
-      .style.getPropertyValue("--category-badge-text-color")
-      .trim();
+    previewTextColor = document.querySelectorAll(
+      ".edit-text-color .hex-input"
+    )[0].value;
 
     assert.strictEqual(
       previewTextColor,
-      "#000000",
+      "000000",
       "sets the contrast text color"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -136,28 +136,16 @@ acceptance("Category text color", function (needs) {
   test("Category text color is set based on contrast", async function (assert) {
     await visit("/new-category");
 
-    let previewTextColor = document.querySelectorAll(
-      ".edit-text-color .hex-input"
-    )[0].value;
-
-    assert.strictEqual(
-      previewTextColor,
-      CATEGORY_TEXT_COLORS[0],
-      "has the default text color"
-    );
+    assert
+      .dom(".edit-text-color .hex-input")
+      .hasValue(CATEGORY_TEXT_COLORS[0], "has the default text color");
 
     await fillIn("input.category-name", "testing");
     await fillIn(".category-color-editor .hex-input", "EEEEEE");
 
-    previewTextColor = document.querySelectorAll(
-      ".edit-text-color .hex-input"
-    )[0].value;
-
-    assert.strictEqual(
-      previewTextColor,
-      CATEGORY_TEXT_COLORS[1],
-      "sets the contrast text color"
-    );
+    assert
+      .dom(".edit-text-color .hex-input")
+      .hasValue(CATEGORY_TEXT_COLORS[1], "sets the contrast text color");
   });
 });
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,6 +18,7 @@ class Category < ActiveRecord::Base
   include HasDestroyedWebHook
 
   SLUG_REF_SEPARATOR = ":"
+  DEFAULT_TEXT_COLORS = %w[FFFFFF 000000]
 
   belongs_to :topic
   belongs_to :topic_only_relative_url,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4181,6 +4181,7 @@ en:
       background_image_dark: "Dark Category Background Image"
       style: "Styles"
       background_color: "Color"
+      foreground_color: "Foreground color"
       styles:
         type: "Style"
         icon: "Icon"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4181,7 +4181,7 @@ en:
       background_image_dark: "Dark Category Background Image"
       style: "Styles"
       background_color: "Color"
-      foreground_color: "Foreground color"
+      foreground_color: "Text color"
       styles:
         type: "Style"
         icon: "Icon"

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -168,6 +168,8 @@ task "javascript:update_constants" => :environment do
 
     export const CATEGORY_STYLE_TYPES = #{Category.style_types.to_json};
 
+    export const CATEGORY_TEXT_COLORS = #{Category::DEFAULT_TEXT_COLORS};
+
     export const AUTO_GROUPS = #{auto_groups.to_json};
 
     export const GROUP_SMTP_SSL_MODES = #{Group.smtp_ssl_modes.to_json};


### PR DESCRIPTION
Restores the category text/foreground color field that was removed in #32015.

We are also retaining the auto text color selection that was introduced and applying on background color change rather than when the form is saved. The text color algorithm has been changed from color brightness to use color difference instead, which appears to be more reliable.

Algorithm for color difference: https://www.w3.org/TR/AERT/#color-contrast

https://github.com/user-attachments/assets/4d668ea1-b7b9-48d5-8131-d596fc0382ee



Internal ref: /t/154650 