### PR TITLE
FIX: Serve RTL CSS for themes and components

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -304,7 +304,7 @@ class Stylesheet::Manager
         stylesheets = []
 
         if is_theme_target
-          scss_checker = ScssChecker.new(target, @theme_ids)
+          scss_checker = ScssChecker.new(target.to_s.delete_suffix("_rtl"), @theme_ids)
           themes = load_themes(@theme_ids)
           themes.each do |theme|
             theme_id = theme&.id

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe Stylesheet::Manager do
       end
     end
 
+    it "generates RTL stylesheets for themes with components" do
+      manager = manager(theme.id)
+
+      hrefs = manager.stylesheet_details(:common_theme_rtl, "all")
+      expect(hrefs.size).to eq(2)
+      expect(hrefs.map { |href| href[:theme_id] }).to contain_exactly(theme.id, child_theme.id)
+      expect(hrefs[0][:new_href]).to start_with("/stylesheets/common_theme_rtl_")
+      expect(hrefs[1][:new_href]).to start_with("/stylesheets/common_theme_rtl_")
+    end
+
     it "generates the right links for non-theme targets" do
       manager = manager(nil)
 


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/32881

Stylesheet `<link>` tags for themes/components are aren't getting included/rendered in the HTML document due to a missing check in stylesheet manager. See https://meta.discourse.org/t/ui-layout-broken-for-rtl-language-after-latest-update/367434?u=osama. 