### PR TITLE
DEV: add user email to chat summary mailer

### DIFF
--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -17,6 +17,7 @@ module Chat
               :user_email,
               type: "chat_summary",
               user_id: user.id,
+              to_address: user.email,
               force_respect_seen_recently: true,
             )
           end


### PR DESCRIPTION
Pass user email rather than relying on enrichment when sending summary emails.