### PR TITLE
FIX: Unblock social signup when name is required  and `auth overrides…

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -165,9 +165,13 @@ export default class SignupPageController extends Controller {
     return authOptions && !canEditUsername;
   }
 
-  @discourseComputed("authOptions", "authOptions.can_edit_name")
-  nameDisabled(authOptions, canEditName) {
-    return authOptions && !canEditName;
+  @discourseComputed(
+    "authOptions",
+    "authOptions.can_edit_name",
+    "authOptions.name"
+  )
+  nameDisabled(authOptions, canEditName, name) {
+    return authOptions && !canEditName && name && name.length > 0;
   }
 
   @discourseComputed

--- a/spec/system/page_objects/pages/signup.rb
+++ b/spec/system/page_objects/pages/signup.rb
@@ -51,6 +51,14 @@ module PageObjects
         has_no_css?("#new-account-name")
       end
 
+      def has_editable_name_input?
+        has_css?("#new-account-name:not([disabled])")
+      end
+
+      def has_disabled_name_input?
+        has_css?("#new-account-name[disabled]")
+      end
+
       def has_no_right_side_column?
         has_no_css?(".login-right-side")
       end

--- a/spec/system/social_authentication_spec.rb
+++ b/spec/system/social_authentication_spec.rb
@@ -128,7 +128,7 @@ shared_examples "social authentication scenarios" do
           expect(page).to have_css(".header-dropdown-toggle.current-user")
         end
 
-        it "lets user input Name when no name is provided" do
+        it "works with a provided name" do
           mock_github_auth(name: "Some Name")
           visit("/")
 

--- a/spec/system/social_authentication_spec.rb
+++ b/spec/system/social_authentication_spec.rb
@@ -103,6 +103,46 @@ shared_examples "social authentication scenarios" do
           expect(page).to have_css(".account-created")
         end
       end
+
+      context "when Full Name is set to Required and auth overrides name" do
+        before do
+          SiteSetting.full_name_requirement = "required_at_signup"
+          SiteSetting.auth_overrides_name = true
+        end
+
+        it "lets user input Name when no name is provided" do
+          mock_github_auth(name: "")
+          visit("/")
+
+          signup_form.open.click_social_button("github")
+          expect(signup_form).to be_open
+          expect(signup_form).to have_no_password_input
+          expect(signup_form).to have_valid_username
+          expect(signup_form).to have_valid_email
+          expect(signup_form).to have_editable_name_input
+
+          signup_form.fill_input("#new-account-name", "Test User")
+
+          expect(signup_form).to have_no_right_side_column
+          signup_form.click_create_account
+          expect(page).to have_css(".header-dropdown-toggle.current-user")
+        end
+
+        it "lets user input Name when no name is provided" do
+          mock_github_auth(name: "Some Name")
+          visit("/")
+
+          signup_form.open.click_social_button("github")
+          expect(signup_form).to be_open
+          expect(signup_form).to have_no_password_input
+          expect(signup_form).to have_valid_username
+          expect(signup_form).to have_valid_email
+          expect(signup_form).to have_disabled_name_input
+
+          signup_form.click_create_account
+          expect(page).to have_css(".header-dropdown-toggle.current-user")
+        end
+      end
     end
 
     context "with Twitter" do


### PR DESCRIPTION
… name` is enabled

In the edge case when:
- Full Name is set to Required
- `auth overrides name` is enabled

we were previously showing the name input as disabled, which blocked the signup process.