### PR TITLE
FIX: Add missing about group ordering option

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page-extra-groups.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page-extra-groups.gjs
@@ -40,6 +40,13 @@ export default class AboutPageExtraGroups extends Component {
         this.siteSettings.about_page_extra_groups_order === "order of creation"
       ) {
         groupsToFetch.sort((a, b) => a.id - b.id);
+      } else if (
+        this.siteSettings.about_page_extra_groups_order ===
+        "order of theme setting"
+      ) {
+        groupsToFetch.sort(
+          (a, b) => groupsSetting.indexOf(a.id) - groupsSetting.indexOf(b.id)
+        );
       }
 
       const groupPromises = groupsToFetch.map(async (group) => {

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -522,6 +522,7 @@ basic:
     choices:
       - "alphabetically"
       - "order of creation"
+      - "order of theme setting"
     area: "about"
   about_page_extra_groups_show_description:
     client: true


### PR DESCRIPTION
### What is the problem?

We are missing one of the options for ordering of extra groups on the about page. This setting uses the exact order the groups are selected in the settings.

### Fix

**Sorting by creation date:**

<img width="365" alt="Screenshot 2025-05-27 at 10 39 19 AM" src="https://github.com/user-attachments/assets/f9bcc7f1-4d88-4e3d-8d4b-ccfb1ed18a20" />

<img width="365" alt="Screenshot 2025-05-26 at 3 22 02 PM" src="https://github.com/user-attachments/assets/da5f5cd8-0dea-480b-a212-de51f3f05fb9" />

**Sorting by order of setting:**

<img width="365" alt="Screenshot 2025-05-27 at 10 34 49 AM" src="https://github.com/user-attachments/assets/1a599391-c4f6-45e3-aca4-dd13deab2036" />

<img width="365" alt="Screenshot 2025-05-27 at 10 40 02 AM" src="https://github.com/user-attachments/assets/ccc4a8f4-d2d0-4e3f-8cc3-643660c78b5b" />
