### PR TITLE
FIX: avoid infinite loop when synonym tag is self

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -146,7 +146,9 @@ class TagsController < ::ApplicationController
         Tag
           .where_name(params[:tag_id])
           .where.not(target_tag_id: nil)
-          .joins("JOIN tags parent_tags ON parent_tags.id = tags.target_tag_id")
+          .joins(
+            "JOIN tags parent_tags ON parent_tags.id = tags.target_tag_id AND tags.target_tag_id != tags.id",
+          )
           .pick("parent_tags.name")
 
       if parent_tag_name

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -432,6 +432,13 @@ RSpec.describe TagsController do
       expect(response.redirect_url).to match(%r{/tag/#{tag.name}/l/top.json\?period=daily})
     end
 
+    it "is not creating infinite redirect loop when tag is a synonym of itself" do
+      tag.update!(target_tag_id: tag.id)
+
+      get "/tag/#{tag.name}/l/top.json?period=daily"
+      expect(response.status).to eq(200)
+    end
+
     it "does not show staff-only tags" do
       _tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: ["test"])
 


### PR DESCRIPTION
When tag synonym is tag itself, it should not redirect to prevent infinite loop.