### PR TITLE
DEV: update composer similar topics limit

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -706,6 +706,8 @@ class Topic < ActiveRecord::Base
   end
 
   MAX_SIMILAR_BODY_LENGTH = 200
+  SIMILAR_TOPIC_SEARCH_LIMIT = 10
+  SIMILAR_TOPIC_LIMIT = 3
 
   def self.similar_to(title, raw, user = nil)
     return [] if title.blank?
@@ -758,7 +760,7 @@ class Topic < ActiveRecord::Base
         .where("c.topic_id IS NULL")
         .where("topics.category_id NOT IN (#{excluded_category_ids_sql})")
         .order("ts_rank(search_data, #{tsquery}) DESC")
-        .limit(10)
+        .limit(SIMILAR_TOPIC_SEARCH_LIMIT)
 
     candidate_ids = candidates.pluck(:id)
 
@@ -769,7 +771,7 @@ class Topic < ActiveRecord::Base
         .joins("JOIN posts AS p ON p.topic_id = topics.id AND p.post_number = 1")
         .where("topics.id IN (?)", candidate_ids)
         .order("similarity DESC")
-        .limit(3)
+        .limit(SIMILAR_TOPIC_LIMIT)
 
     if raw.present?
       similars.select(

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -708,7 +708,6 @@ class Topic < ActiveRecord::Base
   MAX_SIMILAR_BODY_LENGTH = 200
 
   def self.similar_to(title, raw, user = nil)
-    return [] if SiteSetting.max_similar_results == 0
     return [] if title.blank?
 
     raw = raw.presence || ""
@@ -759,7 +758,7 @@ class Topic < ActiveRecord::Base
         .where("c.topic_id IS NULL")
         .where("topics.category_id NOT IN (#{excluded_category_ids_sql})")
         .order("ts_rank(search_data, #{tsquery}) DESC")
-        .limit(SiteSetting.max_similar_results * 3)
+        .limit(10)
 
     candidate_ids = candidates.pluck(:id)
 
@@ -770,7 +769,7 @@ class Topic < ActiveRecord::Base
         .joins("JOIN posts AS p ON p.topic_id = topics.id AND p.post_number = 1")
         .where("topics.id IN (?)", candidate_ids)
         .order("similarity DESC")
-        .limit(SiteSetting.max_similar_results)
+        .limit(3)
 
     if raw.present?
       similars.select(

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2267,7 +2267,6 @@ en:
     authorized_extensions: "A list of file extensions allowed for upload"
     authorized_extensions_for_staff: "A list of file extensions allowed for upload for staff users in addition to the list defined in the `authorized_extensions` site setting."
     theme_authorized_extensions: "A list of file extensions allowed for theme uploads"
-    max_similar_results: "How many similar topics to show above the editor when composing a new topic. Comparison is based on title and body."
 
     max_image_megapixels: "Maximum number of megapixels allowed for an image. Images with a higher number of megapixels will be rejected."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3180,9 +3180,6 @@ uncategorized:
     validator: "RegexpListValidator"
     area: "permalinks"
 
-  max_similar_results:
-    default: 5
-    area: "posts_and_topics"
   minimum_topics_similar:
     default: 50
     area: "posts_and_topics"


### PR DESCRIPTION
Updates the composer similar topics tips to return a maximum of 3 topic results. We are phasing out the site setting in an effort to improve the UX in the composer.

We will handle the migration to remove the site setting value from the database in a follow up PR.

/t/150274