### PR TITLE
UX: fix border-radius on image upload inputs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.gjs
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.gjs
@@ -187,7 +187,7 @@ export default class UppyImageUploader extends Component {
         {{else}}
           <div class="image-upload-controls">
             <label
-              class="btn btn-default btn-small btn-transparent
+              class="btn btn-transparent
                 {{if this.disabled 'disabled'}}
                 {{if this.uppyUpload.uploading 'hidden'}}"
               title={{this.disabledReason}}

--- a/app/assets/stylesheets/common/base/upload.scss
+++ b/app/assets/stylesheets/common/base/upload.scss
@@ -5,7 +5,7 @@
   height: 80px;
   margin-bottom: 0.5em;
   box-sizing: border-box;
-  border-radius: var(--d-border-radius);
+  border-radius: var(--d-input-border-radius);
   background-origin: content-box;
   background-clip: content-box;
 
@@ -71,6 +71,7 @@
     height: 100%;
     background-color: var(--primary-very-low);
     transition: background 0.25s;
+    border-radius: var(--d-input-border-radius);
 
     &:hover {
       background-color: var(--tertiary-very-low);
@@ -83,6 +84,7 @@
       width: 100%;
       height: 100%;
       box-sizing: border-box;
+      border-radius: var(--d-input-border-radius);
 
       svg {
         color: var(--primary-high);


### PR DESCRIPTION
Noticed problems on themes that use border-radius (like Horizon), where these get the button radius applied, which is too large since, despite **functioning** like a button, they are essentially inputs and lean more toward the input styling. Also removed `btn-default` as this element couldn't be further from a default button if it tried.

| Before | After |
|--------|--------|
| ![CleanShot 2025-05-27 at 11 43 42@2x](https://github.com/user-attachments/assets/fa0aa793-e812-40ed-b142-f47158e2d01b) | ![CleanShot 2025-05-27 at 11 42 01@2x](https://github.com/user-attachments/assets/bba289e7-3707-4725-925e-a993fec32da8) | 

