### PR TITLE
DEV: remove max similar results site setting

### DIFF
--- a/db/migrate/20250527101351_remove_max_similar_results_site_setting.rb
+++ b/db/migrate/20250527101351_remove_max_similar_results_site_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveMaxSimilarResultsSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "DELETE FROM site_settings WHERE name='max_similar_results'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
We phased out the site setting for `max_similar_results` in #32934 - this change is a follow up migration to delete the site setting from the database.