### PR TITLE
UX: add fallback width for modal

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -329,8 +329,7 @@
       &__container {
         width: 100%;
         margin-top: 0;
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
+        border-radius: 0;
       }
     }
   }


### PR DESCRIPTION
Potentially due specificity changes in #32733  , the `max-modal-width` is undefined when rendering mobile, resulting in:

![image](https://github.com/user-attachments/assets/8bd8551b-a52e-46a1-92cc-7a3e79db042d)

Despite my expecting the MQ to take preference, it doesn't:
![CleanShot 2025-05-27 at 12 16 08@2x](https://github.com/user-attachments/assets/a897564d-0173-4442-82df-8d5dbaa3411d)

This commit:
* Added a fallback 
* Increased specificity for good measure
* Fixed border-radius (should be zero, aligned with top and full-width)

![CleanShot 2025-05-27 at 12 23 56@2x](https://github.com/user-attachments/assets/9d43ce30-424a-4855-ad43-1b915d251f0d)

