### PR TITLE
UX: fast topic edit

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -364,6 +364,10 @@ export default class TopicController extends Controller {
     event?.preventDefault();
     if (this.get("model.details.can_edit")) {
       this.set("editingTopic", true);
+
+      schedule("afterRender", () => {
+        document.querySelector("#edit-title")?.focus();
+      });
     }
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -364,10 +364,6 @@ export default class TopicController extends Controller {
     event?.preventDefault();
     if (this.get("model.details.can_edit")) {
       this.set("editingTopic", true);
-
-      schedule("afterRender", () => {
-        document.querySelector("#edit-title")?.focus();
-      });
     }
   }
 

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -37,7 +37,6 @@ import TopicTimerInfo from "discourse/components/topic-timer-info";
 import TopicTitle from "discourse/components/topic-title";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import bodyClass from "discourse/helpers/body-class";
-import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
@@ -233,7 +232,9 @@ export default RouteTemplate(
                     }}
                     class="fancy-title"
                   >
-                    {{htmlSafe @controller.model.fancyTitle}}
+                    <span class="topic-title">{{htmlSafe
+                        @controller.model.fancyTitle
+                      }}</span>
 
                     {{#if @controller.model.details.can_edit}}
                       {{icon "pencil" class="edit-topic"}}

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -232,9 +232,7 @@ export default RouteTemplate(
                     }}
                     class="fancy-title"
                   >
-                    <span class="topic-title">{{htmlSafe
-                        @controller.model.fancyTitle
-                      }}</span>
+                    {{htmlSafe @controller.model.fancyTitle}}
 
                     {{#if @controller.model.details.can_edit}}
                       {{icon "pencil" class="edit-topic"}}

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -117,7 +117,7 @@ export default RouteTemplate(
                       @id="edit-title"
                       @value={{@controller.buffered.title}}
                       @maxlength={{@controller.siteSettings.max_topic_title_length}}
-                      @autofocus="true"
+                      @autofocus={{true}}
                     />
                   </PluginOutlet>
                 </div>

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -37,6 +37,7 @@ import TopicTimerInfo from "discourse/components/topic-timer-info";
 import TopicTitle from "discourse/components/topic-title";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import bodyClass from "discourse/helpers/body-class";
+import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
@@ -222,20 +223,22 @@ export default RouteTemplate(
                   <TopicStatus @topic={{@controller.model}} />
                   <a
                     href={{@controller.model.url}}
-                    {{on "click" @controller.jumpTop}}
+                    {{on
+                      "click"
+                      (if
+                        @controller.model.details.can_edit
+                        @controller.editTopic
+                        @controller.jumpTop
+                      )
+                    }}
                     class="fancy-title"
                   >
                     {{htmlSafe @controller.model.fancyTitle}}
-                  </a>
-                {{/if}}
 
-                {{#if @controller.model.details.can_edit}}
-                  <a
-                    href
-                    {{on "click" @controller.editTopic}}
-                    class="edit-topic"
-                    title={{i18n "edit_topic"}}
-                  >{{icon "pencil"}}</a>
+                    {{#if @controller.model.details.can_edit}}
+                      {{icon "pencil" class="edit-topic"}}
+                    {{/if}}
+                  </a>
                 {{/if}}
 
                 <PluginOutlet

--- a/app/assets/javascripts/discourse/app/templates/topic.gjs
+++ b/app/assets/javascripts/discourse/app/templates/topic.gjs
@@ -42,6 +42,7 @@ import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import htmlSafe from "discourse/helpers/html-safe";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
+import autoFocus from "discourse/modifiers/auto-focus";
 import stickyAvatars from "discourse/modifiers/sticky-avatars";
 import { i18n } from "discourse-i18n";
 import CategoryChooser from "select-kit/components/category-chooser";
@@ -118,6 +119,7 @@ export default RouteTemplate(
                       @value={{@controller.buffered.title}}
                       @maxlength={{@controller.siteSettings.max_topic_title_length}}
                       @autofocus={{true}}
+                      {{autoFocus}}
                     />
                   </PluginOutlet>
                 </div>

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -191,6 +191,29 @@
       width: 100%;
     }
 
+    .fancy-title {
+      .d-icon-pencil {
+        font-size: var(--font-down-3);
+      }
+    }
+
+    html.discourse-no-touch & {
+      .fancy-title {
+        .edit-topic {
+          opacity: 0;
+          transition: opacity 0.15s linear;
+          background: none;
+        }
+
+        &:hover,
+        &:focus {
+          .edit-topic {
+            opacity: 1;
+          }
+        }
+      }
+    }
+
     @include viewport.until(sm) {
       .topic-category {
         margin-top: 0.25em;


### PR DESCRIPTION
Changes of this commit:
- edit pencil will only show on hover on desktop
- clicking the topic title will display the topic edit UI

https://github.com/user-attachments/assets/58c55351-96ed-4f2d-8bd6-569310901cf0

/t/-/154792