### PR TITLE
UX: Handle long URLs in theme grid with overflow-wrap

### DIFF
--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -133,6 +133,7 @@
     display: flex;
     gap: 0.5rem;
     align-items: center;
+    overflow-wrap: anywhere;
   }
 
   &__description {


### PR DESCRIPTION
Added `overflow-wrap: anywhere` to prevent long URLs from breaking the layout

### Before
<img width="268" alt="image" src="https://github.com/user-attachments/assets/2512b44e-7af3-42cb-b1c6-d7fcb7dd0535" />


### After
<img width="260" alt="image" src="https://github.com/user-attachments/assets/9c5abf05-8f79-4434-bdb7-fc2b5fd2bd2e" />
