### PR TITLE
DEV: Apply transformer for composer editor reply placeholder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -131,10 +131,9 @@ export default class ComposerEditor extends Component {
 
   @discourseComputed("composer.model.requiredCategoryMissing")
   replyPlaceholder(requiredCategoryMissing) {
-    let placeholder;
-    if (requiredCategoryMissing) {
-      placeholder = "composer.reply_placeholder_choose_category";
-    } else {
+    let placeholder = "composer.reply_placeholder_choose_category";
+
+    if (!requiredCategoryMissing) {
       const key = authorizesOneOrMoreImageExtensions(
         this.currentUser.staff,
         this.siteSettings

--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -34,6 +34,7 @@ import {
 } from "discourse/lib/link-mentions";
 import { loadOneboxes } from "discourse/lib/load-oneboxes";
 import { generateCookFunction } from "discourse/lib/text";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import {
   authorizesOneOrMoreImageExtensions,
   IMAGE_MARKDOWN_REGEX,
@@ -130,8 +131,9 @@ export default class ComposerEditor extends Component {
 
   @discourseComputed("composer.model.requiredCategoryMissing")
   replyPlaceholder(requiredCategoryMissing) {
+    let placeholder;
     if (requiredCategoryMissing) {
-      return "composer.reply_placeholder_choose_category";
+      placeholder = "composer.reply_placeholder_choose_category";
     } else {
       const key = authorizesOneOrMoreImageExtensions(
         this.currentUser.staff,
@@ -139,8 +141,14 @@ export default class ComposerEditor extends Component {
       )
         ? "reply_placeholder"
         : "reply_placeholder_no_images";
-      return `composer.${key}`;
+      placeholder = `composer.${key}`;
     }
+
+    return applyValueTransformer(
+      "composer-editor-reply-placeholder",
+      placeholder,
+      { model: this.composer }
+    );
   }
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -16,6 +16,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "category-description-text",
   "category-display-name",
   "category-text-color",
+  "composer-editor-reply-placeholder",
   "composer-save-button-label",
   "composer-service-cannot-submit-post",
   "create-topic-label",

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -999,6 +999,24 @@ import { i18n } from "discourse-i18n";
           );
       });
 
+      test("modified placeholder with composer-editor-reply-placeholder is rendered", async function (assert) {
+        withPluginApi("0.8.14", (api) => {
+          api.registerValueTransformer(
+            "composer-editor-reply-placeholder",
+            () => {
+              return "modified_value";
+            }
+          );
+        });
+
+        await visit("/t/34");
+        await click("article#post_3 button.reply");
+
+        assert
+          .dom(".d-editor-container textarea")
+          .hasAttribute("placeholder", i18n("modified_value"));
+      });
+
       test("reply button has envelope icon when replying to private message", async function (assert) {
         await visit("/t/34");
         await click("article#post_3 button.reply");


### PR DESCRIPTION
This adds an `applyValueTransformer` for the Composer textarea's placeholder text. Shocked there isn't one already!