### PR TITLE
FIX: Make post created/edited automation trigger regexes more specific

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -102,11 +102,14 @@ module DiscourseAutomation
             cooked = post.cooked
             # note the only 100% correct way is to lean on an actual HTML parser
             # however triggers may pop up during the post creation process, we can not afford a full parse
-            next if post_features.include?("with_images") && !cooked.match?(/<img[^>]+>/i)
-            next if post_features.include?("with_links") && !cooked.match?(/<a[^>]+>/i)
-            next if post_features.include?("with_code") && !cooked.match?(/<pre[^>]+>/i)
+            if post_features.include?("with_images") &&
+                 !cooked.match?(/<img(?![^>]*class=["'](emoji|avatar))[^>]*>/i)
+              next
+            end
+            next if post_features.include?("with_links") && !cooked.match?(/<a\s+[^>]*>/i)
+            next if post_features.include?("with_code") && !cooked.match?(/<pre[^>]*>/i)
             if post_features.include?("with_uploads") &&
-                 !cooked.match?(/<a[^>]+class=["']attachment[^>]+>/i)
+                 !cooked.match?(/<a\s+[^>]*class=["']attachment[^>]*>/i)
               next
             end
           end

--- a/plugins/automation/spec/triggers/post_created_edited_spec.rb
+++ b/plugins/automation/spec/triggers/post_created_edited_spec.rb
@@ -669,6 +669,35 @@ describe "PostCreatedEdited" do
 
         expect(list.length).to eq(0)
       end
+
+      it "doesn't fire the trigger when post has emojis but no regular images" do
+        list =
+          capture_contexts do
+            PostCreator.create(
+              user,
+              raw:
+                "This is regular text with an emoji but no non-emoji images :face_savoring_food:",
+              topic_id: topic.id,
+            )
+          end
+
+        expect(list.length).to eq(0)
+      end
+
+      it "doesn't fire the trigger when post has an avatar in a quote but no regular images" do
+        original_post =
+          PostCreator.create(user, raw: "This is regular text with no images", topic_id: topic.id)
+        quote_post_text = <<~QUOTE_POST
+            [quote=\"#{user.username}}, post:#{original_post.post_number}, topic:#{original_post.topic_id}\"]
+              regular text
+            [/quote]
+            This is a regular text post with a regular text quote, no image (but an avatar image in the quote)
+          QUOTE_POST
+        list =
+          capture_contexts { PostCreator.create(user, raw: quote_post_text, topic_id: topic.id) }
+
+        expect(list.length).to eq(0)
+      end
     end
 
     context "with links filter" do


### PR DESCRIPTION
- For `with_images`, ignore `<img>` tags representing emoji or a quote avatar
- For `with_links` and `with_uploads`, exclude tags starting with the letter "a" other than `<a>` (like `<aside>`)
- For `with_code`, the `<pre>` tag wasn't being detected because it was expecting an extra char before the ">" 