### PR TITLE
DEV: Add locale column to categories

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1388,6 +1388,7 @@ end
 #  style_type                                :integer          default("square"), not null
 #  emoji                                     :string
 #  icon                                      :string
+#  locale                                    :string(20)
 #
 # Indexes
 #

--- a/db/migrate/20250528030212_add_locale_to_categories.rb
+++ b/db/migrate/20250528030212_add_locale_to_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocaleToCategories < ActiveRecord::Migration[7.2]
+  def change
+    add_column :categories, :locale, :string, limit: 20
+  end
+end


### PR DESCRIPTION
Previously we had omitted determining the locale of categories, as unlike posts, categories are usually single words and are usually only translated once.

Since there is no locale, a category called "Staff" would also have an English translation. With LLMs that perform poorly, we see that translating "Staff" to English may result in something entirely different (like "Personnelle" or "Personal").

Thus adding locale support to categories can mitigate this issue due to the uncertainty.