### PR TITLE
FIX: Composite primary key output

### DIFF
--- a/migrations/lib/database/schema/table_writer.rb
+++ b/migrations/lib/database/schema/table_writer.rb
@@ -28,6 +28,7 @@ module Migrations::Database::Schema
 
     def output_columns(table)
       column_definitions = create_column_definitions(table)
+      column_definitions << "" if table.primary_key_column_names.size > 1
       @output.puts column_definitions.join(",\n")
     end
 


### PR DESCRIPTION
Ensure last column definition before a composite primary key definition has a comma.