### PR TITLE
UX: Decrease spacing between content sections in theme-card UI

### DIFF
--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -121,7 +121,8 @@
   }
 
   &__content {
-    padding: 1rem;
+    padding-inline: 1rem;
+    padding-top: 1rem;
     display: flex;
     flex-direction: column;
     flex-grow: 1;
@@ -160,10 +161,9 @@
   }
 
   &__footer {
-    margin-top: auto;
     flex-direction: column;
-    padding: 1rem;
-    gap: 0.75rem;
+    padding-inline: 1rem;
+    padding-bottom: 1rem;
   }
 
   &__controls {
@@ -182,7 +182,7 @@
     flex-wrap: wrap;
     gap: 0.5rem;
     align-items: flex-start;
-    min-height: 3rem;
+    min-height: 2rem;
   }
 
   &__badge {


### PR DESCRIPTION
This PR aims to decrease spacing between content sections in theme-card UI

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/49e35808-a463-4723-97f2-61200977e965)|![image](https://github.com/user-attachments/assets/f5f36d96-96f2-4bf4-a756-f58b16dd53f7)|