### PR TITLE
UX: Add hover state to theme cards

### DIFF
--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -1,7 +1,7 @@
 .admin-config-area-card {
   padding: 20px 5px 20px 20px;
   border: 1px solid var(--primary-low);
-  border-radius: 2px;
+  border-radius: var(--d-border-radius);
   background-color: var(--secondary);
   margin-bottom: 1em;
 

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -95,6 +95,8 @@
     align-items: center;
     justify-content: center;
     border-bottom: 1px solid var(--primary-low);
+    border-top-left-radius: var(--d-border-radius);
+    border-top-right-radius: var(--d-border-radius);
 
     svg {
       width: 100%;
@@ -108,7 +110,6 @@
     height: 100%;
     object-fit: cover;
     object-position: top left;
-    border-radius: calc(var(--d-border-radius) + 1px);
   }
 
   .ember-checkbox {
@@ -243,6 +244,10 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  &:hover {
+    border-color: var(--tertiary-medium);
+  }
 
   .admin-config-area-card__content {
     margin: 0;


### PR DESCRIPTION
Added a subtle hover border to theme cards for better visual feedback. Cursor stays default since the card itself isn’t clickable.

### Before
Nada
<img width="591" alt="image" src="https://github.com/user-attachments/assets/d1df6b46-0557-4dfa-af68-166b2b721595" />


### After
Applies `--tertiary-medium` on hover
<img width="585" alt="image" src="https://github.com/user-attachments/assets/1e08f638-738f-40bc-948e-17912b634c0f" />

