### PR TITLE
UX: add gap to sidebar items

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -150,6 +150,9 @@
 
   .sidebar-section-content {
     margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--d-sidebar-vertical-gap);
   }
 }
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -3,6 +3,7 @@
 :root {
   --d-sidebar-width: #{$d-sidebar-width};
   --d-sidebar-row-horizontal-padding: 1rem;
+  --d-sidebar-vertical-gap: 0.125rem;
 
   // ems so height is variable along with font size
   --d-sidebar-row-height: 2.2em;


### PR DESCRIPTION
This PR adds a small gap between the sidebar items. Currently, when hovering over an item, and a previous element is active, there is no gap between the two.

**Issue**
![CleanShot 2025-05-28 at 14 11 13@2x](https://github.com/user-attachments/assets/bbac9053-bdfa-40f3-9c27-b9b5ecf33018)


**Fix**
![CleanShot 2025-05-28 at 14 10 54@2x](https://github.com/user-attachments/assets/262c4cc7-b723-420b-8c99-29fed54abd37)
