### PR TITLE
DEV: Ensure that Serializers forward their scopes, now and forever

### DIFF
--- a/app/controllers/admin/email_logs_controller.rb
+++ b/app/controllers/admin/email_logs_controller.rb
@@ -61,7 +61,7 @@ class Admin::EmailLogsController < Admin::AdminController
   def incoming
     params.require(:id)
     incoming_email = IncomingEmail.find(params[:id].to_i)
-    serializer = IncomingEmailDetailsSerializer.new(incoming_email, root: false)
+    serializer = IncomingEmailDetailsSerializer.new(incoming_email, scope: PlaceholderGuardian.new, root: false)
     render_json_dump(serializer)
   end
 
@@ -93,7 +93,7 @@ class Admin::EmailLogsController < Admin::AdminController
 
       raise Discourse::NotFound if incoming_email.nil?
 
-      serializer = IncomingEmailDetailsSerializer.new(incoming_email, root: false)
+      serializer = IncomingEmailDetailsSerializer.new(incoming_email, scope: PlaceholderGuardian.new, root: false)
       render_json_dump(serializer)
     rescue => e
       render json: { errors: [e.message] }, status: 404

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -213,7 +213,7 @@ class Admin::ThemesController < Admin::AdminController
     @theme = Theme.include_relations.find_by(id: params[:id])
     raise Discourse::InvalidParameters.new(:id) unless @theme
 
-    original_json = ThemeSerializer.new(@theme, root: false).to_json
+    original_json = ThemeSerializer.new(@theme, scope: PlaceholderGuardian.new, root: false).to_json
     disables_component = [false, "false"].include?(theme_params[:enabled])
     enables_component = [true, "true"].include?(theme_params[:enabled])
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -129,7 +129,7 @@ class Admin::UsersController < Admin::StaffController
             full_suspend_reason: full_reason,
             suspended_till: user.suspended_till,
             suspended_at: user.suspended_at,
-            suspended_by: BasicUserSerializer.new(current_user, root: false).as_json,
+            suspended_by: BasicUserSerializer.new(current_user, scope: PlaceholderGuardian.new, root: false).as_json,
           },
         )
       end
@@ -327,6 +327,7 @@ class Admin::UsersController < Admin::StaffController
             silenced_by:
               BasicUserSerializer.new(
                 current_user,
+                scope: PlaceholderGuardian.new,
                 root: false,
                 include_silence_reason: true,
               ).as_json,
@@ -390,7 +391,7 @@ class Admin::UsersController < Admin::StaffController
         else
           render json: {
                    deleted: false,
-                   user: AdminDetailedUserSerializer.new(user, root: false).as_json,
+                   user: AdminDetailedUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false).as_json,
                  }
         end
       rescue UserDestroyer::PostsExistError
@@ -510,7 +511,7 @@ class Admin::UsersController < Admin::StaffController
       render json: success_json.merge(username: user.username)
     else
       render json:
-               failed_json.merge(user: AdminDetailedUserSerializer.new(user, root: false).as_json)
+               failed_json.merge(user: AdminDetailedUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false).as_json)
     end
   end
 

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -120,7 +120,7 @@ class DraftsController < ApplicationController
           end
 
           if conflict
-            conflict_user = BasicUserSerializer.new(post.last_editor, root: false)
+            conflict_user = BasicUserSerializer.new(post.last_editor, scope: PlaceholderGuardian.new, root: false)
             json.merge!(conflict_user:)
           end
         end

--- a/app/controllers/post_localizations_controller.rb
+++ b/app/controllers/post_localizations_controller.rb
@@ -14,6 +14,7 @@ class PostLocalizationsController < ApplicationController
                ActiveModel::ArraySerializer.new(
                  localizations,
                  each_serializer: PostLocalizationSerializer,
+                 scope: PlaceholderGuardian.new,
                  root: false,
                ).as_json,
              status: :ok

--- a/app/controllers/presence_controller.rb
+++ b/app/controllers/presence_controller.rb
@@ -30,7 +30,7 @@ class PresenceController < ApplicationController
     names.each do |name|
       channel = PresenceChannel.new(name)
       if channel.can_view?(user_id: current_user&.id, group_ids: user_group_ids)
-        result[name] = PresenceChannelStateSerializer.new(channel.state, root: nil)
+        result[name] = PresenceChannelStateSerializer.new(channel.state, scope: PlaceholderGuardian.new, root: nil)
       else
         result[name] = nil
       end

--- a/app/controllers/reviewable_claimed_topics_controller.rb
+++ b/app/controllers/reviewable_claimed_topics_controller.rb
@@ -45,7 +45,7 @@ class ReviewableClaimedTopicsController < ApplicationController
     if claimed_by.present?
       data = {
         topic_id: topic.id,
-        user: BasicUserSerializer.new(claimed_by, root: false).as_json,
+        user: BasicUserSerializer.new(claimed_by, scope: PlaceholderGuardian.new, root: false).as_json,
         automatic:,
       }
     else

--- a/app/controllers/tag_groups_controller.rb
+++ b/app/controllers/tag_groups_controller.rb
@@ -13,6 +13,7 @@ class TagGroupsController < ApplicationController
       ActiveModel::ArraySerializer.new(
         tag_groups,
         each_serializer: TagGroupSerializer,
+        scope: PlaceholderGuardian.new,
         root: "tag_groups",
       )
     respond_to do |format|
@@ -25,7 +26,7 @@ class TagGroupsController < ApplicationController
   end
 
   def show
-    serializer = TagGroupSerializer.new(@tag_group)
+    serializer = TagGroupSerializer.new(@tag_group, scope: PlaceholderGuardian.new)
     respond_to do |format|
       format.html do
         store_preloaded "tagGroup", MultiJson.dump(serializer)
@@ -41,6 +42,7 @@ class TagGroupsController < ApplicationController
       ActiveModel::ArraySerializer.new(
         tag_groups,
         each_serializer: TagGroupSerializer,
+        scope: PlaceholderGuardian.new,
         root: "tag_groups",
       )
     store_preloaded "tagGroup", MultiJson.dump(serializer)
@@ -53,7 +55,7 @@ class TagGroupsController < ApplicationController
     if @tag_group.save
       StaffActionLogger.new(current_user).log_tag_group_create(
         @tag_group.name,
-        TagGroupSerializer.new(@tag_group).to_json(root: false),
+        TagGroupSerializer.new(@tag_group, scope: PlaceholderGuardian.new).to_json(root: false),
       )
       render_serialized(@tag_group, TagGroupSerializer)
     else
@@ -63,10 +65,10 @@ class TagGroupsController < ApplicationController
 
   def update
     guardian.ensure_can_admin_tag_groups!
-    old_data = TagGroupSerializer.new(@tag_group).to_json(root: false)
+    old_data = TagGroupSerializer.new(@tag_group, scope: PlaceholderGuardian.new).to_json(root: false)
     json_result(@tag_group, serializer: TagGroupSerializer) do |tag_group|
       @tag_group.update(tag_groups_params)
-      new_data = TagGroupSerializer.new(@tag_group).to_json(root: false)
+      new_data = TagGroupSerializer.new(@tag_group, scope: PlaceholderGuardian.new).to_json(root: false)
       StaffActionLogger.new(current_user).log_tag_group_change(@tag_group.name, old_data, new_data)
     end
   end
@@ -75,7 +77,7 @@ class TagGroupsController < ApplicationController
     guardian.ensure_can_admin_tag_groups!
     StaffActionLogger.new(current_user).log_tag_group_destroy(
       @tag_group.name,
-      TagGroupSerializer.new(@tag_group).to_json(root: false),
+      TagGroupSerializer.new(@tag_group, scope: PlaceholderGuardian.new).to_json(root: false),
     )
     @tag_group.destroy
     render json: success_json

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -144,7 +144,7 @@ class TopicsController < ApplicationController
                   custom_message_params: {
                     group: group.name,
                   },
-                  group: serialize_data(group, BasicGroupSerializer, root: false),
+                  group: serialize_data(group, BasicGroupSerializer, scope: PlaceholderGuardian.new, root: false),
                 )
         end
 
@@ -542,7 +542,7 @@ class TopicsController < ApplicationController
     render json:
              success_json.merge!(
                topic_status_update:
-                 TopicTimerSerializer.new(TopicTimer.find_by(topic: @topic), root: false),
+                 TopicTimerSerializer.new(TopicTimer.find_by(topic: @topic), scope: PlaceholderGuardian.new, root: false),
              )
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -268,7 +268,7 @@ class UploadsController < ApplicationController
   def self.serialize_upload(data)
     # as_json.as_json is not a typo... as_json in AM serializer returns keys as symbols, we need them
     # as strings here
-    serialized = UploadSerializer.new(data, root: nil).as_json.as_json if Upload === data
+    serialized = UploadSerializer.new(data, scope: PlaceholderGuardian.new, root: nil).as_json.as_json if Upload === data
     serialized ||= (data || {}).as_json
   end
 

--- a/app/controllers/user_status_controller.rb
+++ b/app/controllers/user_status_controller.rb
@@ -6,7 +6,7 @@ class UserStatusController < ApplicationController
   def get
     ensure_feature_enabled
     respond_to do |format|
-      format.json { render json: UserStatusSerializer.new(current_user.user_status, root: false) }
+      format.json { render json: UserStatusSerializer.new(current_user.user_status, scope: PlaceholderGuardian.new, root: false) }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2280,6 +2280,7 @@ class UsersController < ApplicationController
       ActiveModel::ArraySerializer.new(
         users,
         each_serializer: FoundUserSerializer,
+        scope: PlaceholderGuardian.new,
         include_status: true,
       )
     { users: serializer.as_json }

--- a/app/jobs/regular/backup_chunks_merger.rb
+++ b/app/jobs/regular/backup_chunks_merger.rb
@@ -32,7 +32,7 @@ module Jobs
       # push an updated list to the clients
       store = BackupRestore::BackupStore.create
       data =
-        ActiveModel::ArraySerializer.new(store.files, each_serializer: BackupFileSerializer).as_json
+        ActiveModel::ArraySerializer.new(store.files, each_serializer: BackupFileSerializer, scope: PlaceholderGuardian.new).as_json
       MessageBus.publish("/admin/backups", data, group_ids: [Group::AUTO_GROUPS[:staff]])
     end
   end

--- a/app/jobs/scheduled/redeliver_web_hook_events.rb
+++ b/app/jobs/scheduled/redeliver_web_hook_events.rb
@@ -56,7 +56,7 @@ module Jobs
         "/web_hook_events/#{web_hook.id}",
         {
           type: type,
-          web_hook_event: AdminWebHookEventSerializer.new(web_hook_event, root: false).as_json,
+          web_hook_event: AdminWebHookEventSerializer.new(web_hook_event, scope: PlaceholderGuardian.new, root: false).as_json,
         },
       )
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -710,14 +710,14 @@ class Category < ActiveRecord::Base
       if group_ids.present?
         MessageBus.publish(
           "/categories",
-          { categories: ActiveModel::ArraySerializer.new([self]).as_json },
+          { categories: ActiveModel::ArraySerializer.new([self], scope: PlaceholderGuardian.new).as_json },
           group_ids: group_ids,
         )
       end
     else
       MessageBus.publish(
         "/categories",
-        { categories: ActiveModel::ArraySerializer.new([self]).as_json },
+        { categories: ActiveModel::ArraySerializer.new([self], scope: PlaceholderGuardian.new).as_json },
       )
     end
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -830,7 +830,7 @@ class Group < ActiveRecord::Base
     if self.categories.count < PUBLISH_CATEGORIES_LIMIT
       MessageBus.publish(
         "/categories",
-        { categories: ActiveModel::ArraySerializer.new(self.categories).as_json },
+        { categories: ActiveModel::ArraySerializer.new(self.categories, scope: PlaceholderGuardian.new).as_json },
         user_ids: [user.id],
       )
     else

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -112,6 +112,7 @@ class Site
         ActiveModel::ArraySerializer.new(
           categories,
           each_serializer: SiteCategorySerializer,
+          scope: PlaceholderGuardian.new,
         ).as_json
       end
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2099,7 +2099,7 @@ class Topic < ActiveRecord::Base
       stats = {
         posts_count: topic.posts_count,
         last_posted_at: topic.last_posted_at.as_json,
-        last_poster: BasicUserSerializer.new(topic.last_poster, root: false).as_json,
+        last_poster: BasicUserSerializer.new(topic.last_poster, scope: PlaceholderGuardian.new, root: false).as_json,
       }
     else
       stats = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -854,7 +854,7 @@ class User < ActiveRecord::Base
 
     # publish last notification json with the message so we can apply an update
     notification = notifications.visible.order("notifications.created_at desc").first
-    json = NotificationSerializer.new(notification).as_json if notification
+    json = NotificationSerializer.new(notification, scope: PlaceholderGuardian.new).as_json if notification
 
     sql = (<<~SQL)
        SELECT * FROM (

--- a/app/serializers/admin_user_action_serializer.rb
+++ b/app/serializers/admin_user_action_serializer.rb
@@ -69,7 +69,7 @@ class AdminUserActionSerializer < ApplicationSerializer
   end
 
   def deleted_by
-    BasicUserSerializer.new(object.deleted_by, root: false).as_json
+    BasicUserSerializer.new(object.deleted_by, scope: scope, root: false).as_json
   end
 
   def include_deleted_by?

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -5,6 +5,100 @@ require "distributed_cache"
 class ApplicationSerializer < ActiveModel::Serializer
   embed :ids, include: true
 
+  # NB: Set environment variable STRICT_SERIALIZER_SCOPE to either
+  #     "nil_or_guardian" or "only_guardian" to enforce stricter checking
+  #     of scope parameters.
+  #
+  #     See notes in initialize(), below, and in PlaceholderGuardian.new
+  #
+  @@require_strict_scope = ENV["STRICT_SERIALIZER_SCOPE"]&.intern
+
+  def self.require_strict_scope
+    @@require_strict_scope
+  end
+
+  def initialize(*args)
+    # Ensure that a scope: argument was provided to this Serializer.
+    #
+    # In a test environment, we treat this as an assertion and fail hard if no
+    # "scope:" has been provided.  Outside of testing, we merely log an error,
+    # since there are codepaths (that have no test coverage, apparently) that
+    # manage to function without a scope, and we do not want to break them in
+    # production.
+    #
+    # If you are reading this because you have encountered this warning/error,
+    # then you should add an appropriate "scope:" argument to the call-site
+    # which triggered it.
+    #
+    #  * If one serializer is constructing another one, simply forwarding the
+    #    scope of the parent serializer is almost always the right thing to do,
+    #    e.g., add "scope: scope".
+    #
+    #  * The scope should be a Guardian instance.  If there is already a
+    #    Guardian instance available (e.g., within the context of a Controller),
+    #    then simply using it is almost always the right thing to do,
+    #    e.g., add "scope: guardian".
+    #
+    #  * The guiding principle is that the Guardian should reflect what the
+    #    potential receiver of the serialized object is allowed to receive.
+    #    E.g., if the serialized object is going to be sent to user_x, then
+    #    a Guardian reflecting user_x ("Guardian.new(user_x)") is usually
+    #    (but not always) correct.
+    #
+    #  * If it is not clear whose Guardian to use and you need to kick-the-can
+    #    down-the-road a bit longer, use "scope: PlaceholderGuardian.new".  This
+    #    will make it easy to track this technical debt and find it later on.
+    #
+    unless args[-1].has_key?(:scope)
+      Rails.logger.error("Serializer initialized without scope:")
+      raise "Serializer initialized without scope:" if ENV["RAILS_ENV"] == "test"
+    end
+
+    super
+
+    # TODO (a) Impose the more stringent condition that every scope is either
+    #          nil or an instance of Guardian.
+    #          (I.e., set default @@require_strict_scope to :nil_or_guardian)
+    #
+    # TODO (b) Impose the even more stringent condition that every scope is
+    #          only an instance of Guardian.
+    #          (I.e., set default @@require_strict_scope to :only_guardian)
+    #
+    # Note, however:
+    #
+    #  1) There are bits of legacy code that provide non-Guardian scopes to
+    #     certain serializers, so both (a) and (b) must wait until those bits
+    #     are fixed (or, until someone is trying to find/fix those bits).
+    #
+    #  2) If there are still instances of "PlaceholderGuardian.new" in the
+    #     code, then PlaceholderGuardian#new will need to be tweaked to
+    #     generate "exploding placeholders" instead of nil, before (b) can
+    #     be put into effect.  (See the explanation in PlaceholderGuardian.)
+    #
+    #  3) There are bits of legacy code that check for and paper-over nil
+    #     scopes (e.g. "scope && scope.can_xxx?"), and these bits will explode
+    #     if they encounter an "exploding placeholder".  So, these checks need
+    #     to be removed before (2) can be done.
+    #
+    if @@require_strict_scope === :nil_or_guardian
+      # Ensure that the scope is nil or an instance of Guardian.
+      unless (nil === scope) || (Guardian === scope)
+        Rails.logger.error("Serializer initialized with a non-nil-or-Guardian scope")
+        if ENV["RAILS_ENV"] == "test"
+          raise "Serializer initialized with a non-nil-or-Guardian scope"
+        end
+      end
+    elsif @@require_strict_scope === :only_guardian
+      # Ensure that the scope is precisely an instance of Guardian.
+      unless Guardian === scope
+        Rails.logger.error("Serializer initialized with a non-Guardian scope")
+        if ENV["RAILS_ENV"] == "test"
+          raise "Serializer initialized with a non-Guardian scope"
+        end
+      end
+    end
+  end
+
   class CachedFragment
     def initialize(json)
       @json = json

--- a/app/serializers/concerns/user_status_mixin.rb
+++ b/app/serializers/concerns/user_status_mixin.rb
@@ -11,6 +11,6 @@ module UserStatusMixin
   end
 
   def status
-    UserStatusSerializer.new(object.user_status, root: false).as_json
+    UserStatusSerializer.new(object.user_status, scope: scope, root: false).as_json
   end
 end

--- a/app/serializers/grouped_search_result_serializer.rb
+++ b/app/serializers/grouped_search_result_serializer.rb
@@ -39,6 +39,7 @@ class GroupedSearchResultSerializer < ApplicationSerializer
       extra[:categories] = ActiveModel::ArraySerializer.new(
         object.extra_categories,
         each_serializer: BasicCategorySerializer,
+        scope: scope,
       )
     end
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -311,7 +311,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def deleted_by
-    BasicUserSerializer.new(object.deleted_by, root: false).as_json
+    BasicUserSerializer.new(object.deleted_by, scope: scope, root: false).as_json
   end
 
   def include_deleted_by?
@@ -536,7 +536,7 @@ class PostSerializer < BasicPostSerializer
     return if notice["created_by_user_id"].blank?
     found_user = notice_created_by_users&.find { |user| user.id == notice["created_by_user_id"] }
     return if !found_user
-    BasicUserSerializer.new(found_user, root: false).as_json
+    BasicUserSerializer.new(found_user, scope: scope, root: false).as_json
   end
 
   def notice
@@ -634,7 +634,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def user_status
-    UserStatusSerializer.new(object.user&.user_status, root: false)
+    UserStatusSerializer.new(object.user&.user_status, scope: scope, root: false)
   end
 
   def mentioned_users
@@ -647,7 +647,7 @@ class PostSerializer < BasicPostSerializer
         query = query.where(username_lower: object.mentions)
       end
 
-    users.map { |user| BasicUserSerializer.new(user, root: false, include_status: true).as_json }
+    users.map { |user| BasicUserSerializer.new(user, scope: scope, root: false, include_status: true).as_json }
   end
 
   def include_mentioned_users?

--- a/app/serializers/post_stream_serializer_mixin.rb
+++ b/app/serializers/post_stream_serializer_mixin.rb
@@ -40,7 +40,7 @@ module PostStreamSerializerMixin
     end
 
     if include_gaps? && object.gaps.present?
-      result[:gaps] = GapSerializer.new(object.gaps, root: false)
+      result[:gaps] = GapSerializer.new(object.gaps, scope: scope, root: false)
     end
 
     result

--- a/app/serializers/sidebar_section_serializer.rb
+++ b/app/serializers/sidebar_section_serializer.rb
@@ -4,7 +4,7 @@ class SidebarSectionSerializer < ApplicationSerializer
   attributes :id, :title, :links, :slug, :public, :section_type
 
   def links
-    object.sidebar_urls.map { |sidebar_url| SidebarUrlSerializer.new(sidebar_url, root: false) }
+    object.sidebar_urls.map { |sidebar_url| SidebarUrlSerializer.new(sidebar_url, scope: scope, root: false) }
   end
 
   def slug

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -81,6 +81,7 @@ class SiteSerializer < ApplicationSerializer
       ActiveModel::ArraySerializer.new(
         schemes,
         each_serializer: ColorSchemeSelectableSerializer,
+        scope: scope,
       ).as_json
     end
   end
@@ -88,6 +89,7 @@ class SiteSerializer < ApplicationSerializer
   def default_dark_color_scheme
     ColorSchemeSerializer.new(
       ColorScheme.find_by_id(SiteSetting.default_dark_mode_color_scheme_id),
+      scope: scope,
       root: false,
     ).as_json
   end
@@ -126,11 +128,12 @@ class SiteSerializer < ApplicationSerializer
       .fetch("post_action_types_#{I18n.locale}") do
         if PostActionType.overridden_by_plugin_or_skipped_db?
           types = ordered_flags(PostActionType.types.values)
-          ActiveModel::ArraySerializer.new(types).as_json
+          ActiveModel::ArraySerializer.new(types, scope: scope).as_json
         else
           ActiveModel::ArraySerializer.new(
             Flag.unscoped.order(:position).where(score_type: false).all,
             each_serializer: FlagSerializer,
+            scope: scope,
             target: :post_action,
             used_flag_ids: Flag.used_flag_ids,
           ).as_json
@@ -144,7 +147,7 @@ class SiteSerializer < ApplicationSerializer
       .fetch("post_action_flag_types_#{I18n.locale}") do
         if PostActionType.overridden_by_plugin_or_skipped_db?
           types = ordered_flags(PostActionType.topic_flag_types.values)
-          ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer).as_json
+          ActiveModel::ArraySerializer.new(types, each_serializer: TopicFlagTypeSerializer, scope: scope).as_json
         else
           ActiveModel::ArraySerializer.new(
             Flag
@@ -154,6 +157,7 @@ class SiteSerializer < ApplicationSerializer
               .order(:position)
               .all,
             each_serializer: FlagSerializer,
+            scope: scope,
             target: :topic_flag,
             used_flag_ids: Flag.used_flag_ids,
           ).as_json

--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -36,6 +36,7 @@ class ThemeSerializer < BasicThemeSerializer
     ActiveModel::ArraySerializer.new(
       object.theme_fields,
       each_serializer: ThemeFieldSerializer,
+      scope: scope,
       include_value: include_theme_field_values?,
     ).as_json
   end

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -133,7 +133,7 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def deleted_by
-    BasicUserSerializer.new(object.topic.deleted_by, root: false).as_json
+    BasicUserSerializer.new(object.topic.deleted_by, scope: scope, root: false).as_json
   end
 
   # Topic user stuff
@@ -210,7 +210,7 @@ class TopicViewSerializer < ApplicationSerializer
       return nil if !scope.can_see_category?(Category.find_by(id: topic_timer.category_id))
     end
 
-    TopicTimerSerializer.new(object.topic.public_topic_timer, root: false)
+    TopicTimerSerializer.new(object.topic.public_topic_timer, scope: scope, root: false)
   end
 
   def include_featured_link?

--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -12,7 +12,7 @@ class WatchedWordListSerializer < ApplicationSerializer
   end
 
   def words
-    object.map { |word| WatchedWordSerializer.new(word, root: false) }
+    object.map { |word| WatchedWordSerializer.new(word, scope: scope, root: false) }
   end
 
   def compiled_regular_expressions

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -259,7 +259,7 @@ class StaffActionLogger
   end
 
   def theme_json(theme)
-    ThemeSerializer.new(theme, root: false, include_theme_field_values: true).to_json
+    ThemeSerializer.new(theme, scope: PlaceholderGuardian.new, root: false, include_theme_field_values: true).to_json
   end
 
   def strip_duplicates(old, cur)

--- a/lib/application_layout_preloader.rb
+++ b/lib/application_layout_preloader.rb
@@ -141,7 +141,7 @@ class ApplicationLayoutPreloader
   end
 
   def custom_emoji
-    serializer = ActiveModel::ArraySerializer.new(Emoji.custom, each_serializer: EmojiSerializer)
+    serializer = ActiveModel::ArraySerializer.new(Emoji.custom, each_serializer: EmojiSerializer, scope: PlaceholderGuardian.new)
     MultiJson.dump(serializer)
   end
 end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -432,7 +432,7 @@ module Oneboxer
             date: user.created_at.strftime(I18n.t("datetime_formats.formats.date_only")),
           ),
         website: user.user_profile.website,
-        website_name: UserSerializer.new(user).website_name,
+        website_name: UserSerializer.new(user, scope: PlaceholderGuardian.new).website_name,
         original_url: url,
       }
 

--- a/lib/placeholder_guardian.rb
+++ b/lib/placeholder_guardian.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Class that provides a "placeholder Guardian" until real Guardian is available
+#
+# As part of the transition to ensuring that every Serializer has an appropriate
+# Guardian available as its scope, ApplicationSerializer#initialize checks that
+# it has been called with a scope: argument.  However, it may not be immediately
+# clear what the correct value for that scope: argument should be.
+#
+# In such cases, a developer can use the syntax "scope: PlaceholderGuardian.new"
+# to both:
+#  * satisfy the requirement that "scope:" is specified; and,
+#  * indicate that a correct value still needs to be figured out.
+#
+# By default, "PlaceholderGuardian.new" evaluates to nil.  This is because the
+# legacy code in many Serializers was perfectly happy to have no "scope:" argument
+# at all, because no code happened to use the scope.
+#
+# When a developer adds new code that does try to use a serializer's scope value
+# (i.e., calls a method on the scope), and that code fails because the scope is nil,
+# they will want to know where that nil value came from.  Setting the "@@exploding"
+# variable to true will cause any attempt to call a method on a PlaceholderGuardian
+# object to reveal where that object was instantiated.  Then, the developer can pin
+# down which PlaceholderGuardian needs to (finally) be replaced with a real Guardian.
+#
+class PlaceholderGuardian < Guardian
+
+  # When true, PlaceholderGuardian.new produces an "exploding placeholder" that
+  # reveals its point-of-construction when something tries to access it.
+  @@exploding = (ApplicationSerializer.require_strict_scope === :only_guardian)
+
+  class << self
+    def new(...)
+      if @@exploding
+        super
+      else
+        nil
+      end
+    end
+  end
+
+  # Undefine all the methods that were defined by Guardian.
+  instance_methods.difference(Object.instance_methods).each { |name| undef_method(name) }
+
+  def initialize(...)
+    # Record the site where initialize() was called.
+    @origin_caller = caller(2, 3)
+  end
+
+  def method_missing(*args)
+    # If anything tries to call one of the original Guardian methods, explode
+    # with a message that reveals where this instance was constructed.
+    raise(
+      "Something tried to actually use a PlaceholderGuardian that was constructed here: \n#{@origin_caller.join("\n")}",
+    )
+  end
+end

--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -340,6 +340,7 @@ class PresenceChannel
         message["entering_users"] = ActiveModel::ArraySerializer.new(
           users,
           each_serializer: BasicUserSerializer,
+          scope: PlaceholderGuardian.new,
         )
       end
     end

--- a/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
+++ b/plugins/automation/app/controllers/discourse_automation/admin_automations_controller.rb
@@ -111,7 +111,7 @@ module DiscourseAutomation
 
     def render_serialized_automation(automation)
       serializer =
-        DiscourseAutomation::AutomationSerializer.new(automation, root: "automation").as_json
+        DiscourseAutomation::AutomationSerializer.new(automation, scope: PlaceholderGuardian.new, root: "automation").as_json
       render_json_dump(serializer)
     end
   end

--- a/plugins/automation/app/serializers/discourse_automation/automation_serializer.rb
+++ b/plugins/automation/app/serializers/discourse_automation/automation_serializer.rb
@@ -14,7 +14,7 @@ module DiscourseAutomation
     attribute :stats
 
     def last_updated_by
-      BasicUserSerializer.new(object.last_updated_by || Discourse.system_user, root: false).as_json
+      BasicUserSerializer.new(object.last_updated_by || Discourse.system_user, scope: scope, root: false).as_json
     end
 
     def include_next_pending_automation_at?
@@ -135,6 +135,7 @@ module DiscourseAutomation
       ActiveModel::ArraySerializer.new(
         fields || [],
         each_serializer: DiscourseAutomation::FieldSerializer,
+        scope: scope,
       ).as_json || []
     end
 

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -105,6 +105,7 @@ after_initialize do
     ActiveModel::ArraySerializer.new(
       notices,
       each_serializer: DiscourseAutomation::UserGlobalNoticeSerializer,
+      scope: PlaceholderGuardian.new,
     ).as_json
   end
 

--- a/plugins/automation/spec/triggers/stalled_wiki_spec.rb
+++ b/plugins/automation/spec/triggers/stalled_wiki_spec.rb
@@ -39,7 +39,7 @@ describe "StalledWiki" do
     end
 
     it "supports manual triggering" do
-      DiscourseAutomation::AutomationSerializer.new(automation, root: "automation").as_json
+      DiscourseAutomation::AutomationSerializer.new(automation, scope: PlaceholderGuardian.new, root: "automation").as_json
     end
 
     context "when the post has been revised recently" do

--- a/plugins/chat/app/serializers/chat/block_serializer.rb
+++ b/plugins/chat/app/serializers/chat/block_serializer.rb
@@ -11,7 +11,7 @@ module Chat
     def elements
       object["elements"].map do |element|
         serializer = self.class.element_serializer_for(element["type"])
-        serializer.new(element, root: false).as_json
+        serializer.new(element, scope: scope, root: false).as_json
       end
     end
 

--- a/plugins/chat/app/serializers/chat/blocks/elements/button_serializer.rb
+++ b/plugins/chat/app/serializers/chat/blocks/elements/button_serializer.rb
@@ -19,7 +19,7 @@ module Chat
         end
 
         def text
-          Chat::Blocks::Elements::TextSerializer.new(object["text"], root: false).as_json
+          Chat::Blocks::Elements::TextSerializer.new(object["text"], scope: scope, root: false).as_json
         end
       end
     end

--- a/plugins/chat/app/serializers/chat/channel_index_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_index_serializer.rb
@@ -5,7 +5,7 @@ module Chat
     attributes :global_presence_channel_state
 
     def global_presence_channel_state
-      PresenceChannelStateSerializer.new(PresenceChannel.new("/chat/online").state, root: nil)
+      PresenceChannelStateSerializer.new(PresenceChannel.new("/chat/online").state, scope: scope, root: nil)
     end
   end
 end

--- a/plugins/chat/app/serializers/chat/channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_serializer.rb
@@ -61,7 +61,7 @@ module Chat
     def chatable
       case object.chatable_type
       when "Category"
-        BasicCategorySerializer.new(object.chatable, root: false).as_json
+        BasicCategorySerializer.new(object.chatable, scope: scope, root: false).as_json
       when "DirectMessage"
         Chat::DirectMessageSerializer.new(object.chatable, scope: scope, root: false).as_json
       when "Site"

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -44,7 +44,7 @@ module Chat
         .map(&:user)
         .compact
         .sort_by(&:id)
-        .map { |user| BasicUserSerializer.new(user, root: false, include_status: true) }
+        .map { |user| BasicUserSerializer.new(user, scope: scope, root: false, include_status: true) }
         .as_json
     end
 
@@ -54,7 +54,7 @@ module Chat
 
     def user
       user = object.user || Chat::NullUser.new
-      MessageUserSerializer.new(user, root: false, include_status: true).as_json
+      MessageUserSerializer.new(user, scope: scope, root: false, include_status: true).as_json
     end
 
     def excerpt
@@ -75,7 +75,7 @@ module Chat
             emoji: emoji,
             count: reactions.count,
             users:
-              ActiveModel::ArraySerializer.new(users, each_serializer: BasicUserSerializer).as_json,
+              ActiveModel::ArraySerializer.new(users, each_serializer: BasicUserSerializer, scope: scope).as_json,
             reacted: users_reactions.include?(emoji),
           }
         end

--- a/plugins/chat/app/serializers/chat/thread_original_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_original_message_serializer.rb
@@ -24,12 +24,12 @@ module Chat
         .map(&:user)
         .compact
         .sort_by(&:id)
-        .map { |user| BasicUserSerializer.new(user, root: false, include_status: true) }
+        .map { |user| BasicUserSerializer.new(user, scope: scope, root: false, include_status: true) }
         .as_json
     end
 
     def user
-      BasicUserSerializer.new(object.user, root: false, include_status: true).as_json
+      BasicUserSerializer.new(object.user, scope: scope, root: false, include_status: true).as_json
     end
   end
 end

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -84,6 +84,7 @@ module Chat
       preview =
         ::Chat::ThreadPreviewSerializer.new(
           thread,
+          scope: PlaceholderGuardian.new,
           participants: ::Chat::ThreadParticipantQuery.call(thread_ids: [thread.id])[thread.id],
           root: false,
         ).as_json
@@ -141,7 +142,7 @@ module Chat
         chat_channel,
         {
           action: action,
-          user: BasicUserSerializer.new(user, root: false).as_json,
+          user: BasicUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false).as_json,
           emoji: emoji,
           type: :reaction,
           chat_message_id: chat_message.id,

--- a/plugins/chat/spec/plugin_helper.rb
+++ b/plugins/chat/spec/plugin_helper.rb
@@ -131,7 +131,7 @@ module ChatSpecHelpers
   def create_draft(channel, thread: nil, user: Discourse.system_user, data: { message: "draft" })
     if data[:uploads]
       data[:uploads] = data[:uploads].map do |upload|
-        UploadSerializer.new(upload, root: false).as_json
+        UploadSerializer.new(upload, scope: PlaceholderGuardian.new, root: false).as_json
       end
     end
 

--- a/plugins/chat/spec/serializer/chat/thread_original_message_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/thread_original_message_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Chat::ThreadOriginalMessageSerializer do
     fab!(:user) { Fabricate(:user, user_status: user_status) }
     fab!(:message) { Fabricate(:chat_message, user: user) }
 
-    subject(:serializer) { described_class.new(message, root: nil) }
+    subject(:serializer) { described_class.new(message, scope: PlaceholderGuardian.new, root: nil) }
 
     it "adds status to user if status is enabled" do
       SiteSetting.enable_user_status = true
@@ -39,7 +39,7 @@ RSpec.describe Chat::ThreadOriginalMessageSerializer do
       Fabricate(:user_chat_mention, chat_message: message, user: mentioned_user)
     end
 
-    subject(:serializer) { described_class.new(message, root: nil) }
+    subject(:serializer) { described_class.new(message, scope: PlaceholderGuardian.new, root: nil) }
 
     it "adds status to mentioned users if status is enabled" do
       SiteSetting.enable_user_status = true

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -266,7 +266,7 @@ class DiscoursePoll::Poll
     users =
       User
         .where(id: votes.map(&:user_id).uniq)
-        .map { |u| [u.id, UserNameSerializer.new(u).serializable_hash] }
+        .map { |u| [u.id, UserNameSerializer.new(u, scope: PlaceholderGuardian.new).serializable_hash] }
         .to_h
 
     polls_by_id = polls.index_by(&:id)

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -196,10 +196,10 @@ TEXT
         @plugin = TroutPlugin.new
         @trout = Trout.new
 
-        poison = TroutSerializer.new(@trout)
+        poison = TroutSerializer.new(@trout, scope: PlaceholderGuardian.new)
         poison.attributes
 
-        poison = TroutJuniorSerializer.new(@trout)
+        poison = TroutJuniorSerializer.new(@trout, scope: PlaceholderGuardian.new)
         poison.attributes
 
         # New method
@@ -221,8 +221,8 @@ TEXT
           include_condition: -> { !!object.data&.[](:has_scales) },
         ) { 4096 }
 
-        @serializer = TroutSerializer.new(@trout)
-        @child_serializer = TroutJuniorSerializer.new(@trout)
+        @serializer = TroutSerializer.new(@trout, scope: PlaceholderGuardian.new)
+        @child_serializer = TroutJuniorSerializer.new(@trout, scope: PlaceholderGuardian.new)
       end
 
       after { DiscourseEvent.off(:hello, &@set.first) }

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -984,7 +984,7 @@ RSpec.describe PostCreator do
         expect(stats_message.data[:posts_count]).to eq(2)
         expect(stats_message.data[:last_posted_at]).to eq(reply_timestamp.as_json)
         expect(stats_message.data[:last_poster]).to eq(
-          BasicUserSerializer.new(evil_trout, root: false).as_json,
+          BasicUserSerializer.new(evil_trout, scope: PlaceholderGuardian.new, root: false).as_json,
         )
       end
 

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1209,7 +1209,7 @@ RSpec.describe PostDestroyer do
       expect(stats_message.data[:posts_count]).to eq(2)
       expect(stats_message.data[:last_posted_at]).to eq(reply.created_at.as_json)
       expect(stats_message.data[:last_poster]).to eq(
-        BasicUserSerializer.new(reply.user, root: false).as_json,
+        BasicUserSerializer.new(reply.user, scope: PlaceholderGuardian.new, root: false).as_json,
       )
     end
 
@@ -1228,7 +1228,7 @@ RSpec.describe PostDestroyer do
       expect(stats_message.data[:posts_count]).to eq(2)
       expect(stats_message.data[:last_posted_at]).to eq(reply.created_at.as_json)
       expect(stats_message.data[:last_poster]).to eq(
-        BasicUserSerializer.new(reply.user, root: false).as_json,
+        BasicUserSerializer.new(reply.user, scope: PlaceholderGuardian.new, root: false).as_json,
       )
     end
 
@@ -1252,7 +1252,7 @@ RSpec.describe PostDestroyer do
       expect(stats_message.data[:posts_count]).to eq(3)
       expect(stats_message.data[:last_posted_at]).to eq(expendable_reply.created_at.as_json)
       expect(stats_message.data[:last_poster]).to eq(
-        BasicUserSerializer.new(expendable_reply.user, root: false).as_json,
+        BasicUserSerializer.new(expendable_reply.user, scope: PlaceholderGuardian.new, root: false).as_json,
       )
     end
   end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1683,7 +1683,7 @@ HTML
       queries_for_one =
         track_sql_queries do
           components.each do |component|
-            ComponentIndexSerializer.new(component, root: false).as_json
+            ComponentIndexSerializer.new(component, scope: PlaceholderGuardian.new, root: false).as_json
           end
         end
 
@@ -1693,7 +1693,7 @@ HTML
       queries_for_two =
         track_sql_queries do
           components.each do |component|
-            ComponentIndexSerializer.new(component, root: false).as_json
+            ComponentIndexSerializer.new(component, scope: PlaceholderGuardian.new, root: false).as_json
           end
         end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3562,7 +3562,7 @@ describe Topic do
         expect(stats_message.data[:posts_count]).to eq(topic.posts_count)
         expect(stats_message.data[:last_posted_at]).to eq(topic.last_posted_at.as_json)
         expect(stats_message.data[:last_poster]).to eq(
-          BasicUserSerializer.new(topic.last_poster, root: false).as_json,
+          BasicUserSerializer.new(topic.last_poster, scope: PlaceholderGuardian.new, root: false).as_json,
         )
       end
     end

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Admin::StaffActionLogsController do
         theme.set_field(target: :common, name: :scss, value: "omit-dupe")
 
         original_json =
-          ThemeSerializer.new(theme, root: false, include_theme_field_values: true).to_json
+          ThemeSerializer.new(theme, scope: PlaceholderGuardian.new, root: false, include_theme_field_values: true).to_json
 
         theme.set_field(target: :mobile, name: :scss, value: "body {.down}")
 
@@ -136,11 +136,11 @@ RSpec.describe Admin::StaffActionLogsController do
         tag3 = Fabricate(:tag)
         tag_group1 = Fabricate(:tag_group, tags: [tag1, tag2])
 
-        old_json = TagGroupSerializer.new(tag_group1, root: false).to_json
+        old_json = TagGroupSerializer.new(tag_group1, scope: PlaceholderGuardian.new, root: false).to_json
 
         tag_group2 = Fabricate(:tag_group, tags: [tag2, tag3])
 
-        new_json = TagGroupSerializer.new(tag_group2, root: false).to_json
+        new_json = TagGroupSerializer.new(tag_group2, scope: PlaceholderGuardian.new, root: false).to_json
 
         record =
           StaffActionLogger.new(Discourse.system_user).log_tag_group_change(

--- a/spec/requests/api/notifications_spec.rb
+++ b/spec/requests/api/notifications_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "notifications" do
 
         let(:notification) do
           notification = Fabricate(:notification)
-          NotificationSerializer.new(notification).as_json
+          NotificationSerializer.new(notification, scope: PlaceholderGuardian.new).as_json
         end
 
         run_test!

--- a/spec/requests/tag_groups_controller_spec.rb
+++ b/spec/requests/tag_groups_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe TagGroupsController do
     before { sign_in(admin) }
 
     it "should delete the tag group and log the deletion" do
-      previous_value = TagGroupSerializer.new(tag_group).to_json(root: false)
+      previous_value = TagGroupSerializer.new(tag_group, scope: PlaceholderGuardian.new).to_json(root: false)
 
       delete "/tag_groups/#{tag_group.id}.json"
 
@@ -216,7 +216,7 @@ RSpec.describe TagGroupsController do
     before { sign_in(admin) }
 
     it "should update the tag group and log the modification" do
-      previous_value = TagGroupSerializer.new(tag_group).to_json(root: false)
+      previous_value = TagGroupSerializer.new(tag_group, scope: PlaceholderGuardian.new).to_json(root: false)
 
       put "/tag_groups/#{tag_group.id}.json",
           params: {

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -1547,7 +1547,7 @@ RSpec.describe UploadsController do
 
         expect(response.status).to eq(200)
         result = response.parsed_body
-        expect(result[:upload]).to eq(JSON.parse(UploadSerializer.new(upload).to_json)[:upload])
+        expect(result[:upload]).to eq(JSON.parse(UploadSerializer.new(upload, scope: PlaceholderGuardian.new).to_json)[:upload])
       end
 
       describe "rate limiting" do

--- a/spec/serializers/admin_plugin_serializer_spec.rb
+++ b/spec/serializers/admin_plugin_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe AdminPluginSerializer do
-  subject(:serializer) { described_class.new(instance) }
+  subject(:serializer) { described_class.new(instance, scope: PlaceholderGuardian.new) }
 
   let(:all_test_plugins) { Plugin::Instance.find_all("#{Rails.root}/spec/fixtures/plugins") }
   let(:instance) { all_test_plugins.find { |plugin| plugin.name == "color_definition" } }
@@ -38,7 +38,7 @@ RSpec.describe AdminPluginSerializer do
 
   describe "has_settings" do
     it "is false for plugins with no settings" do
-      expect(described_class.new(instance).has_settings).to eq(false)
+      expect(described_class.new(instance, scope: PlaceholderGuardian.new).has_settings).to eq(false)
     end
 
     it "is true for plugins with settings" do
@@ -48,18 +48,18 @@ RSpec.describe AdminPluginSerializer do
           "color_definition_api_key" => "color_definition",
         },
       )
-      expect(described_class.new(instance).has_settings).to eq(true)
+      expect(described_class.new(instance, scope: PlaceholderGuardian.new).has_settings).to eq(true)
     end
   end
 
   describe "has_only_enabled_settings" do
     it "is false for plugins with no settings" do
-      expect(described_class.new(instance).has_settings).to eq(false)
+      expect(described_class.new(instance, scope: PlaceholderGuardian.new).has_settings).to eq(false)
     end
 
     it "is true if only enabled_site_setting is present for the plugin" do
       SiteSetting.expects(:plugins).returns({ "color_definition_enabled" => "color_definition" })
-      expect(described_class.new(instance).has_settings).to eq(true)
+      expect(described_class.new(instance, scope: PlaceholderGuardian.new).has_settings).to eq(true)
     end
 
     it "is false if there are other settings for the plugin" do
@@ -69,7 +69,7 @@ RSpec.describe AdminPluginSerializer do
           "color_definition_api_key" => "color_definition",
         },
       )
-      expect(described_class.new(instance).has_only_enabled_setting).to eq(false)
+      expect(described_class.new(instance, scope: PlaceholderGuardian.new).has_only_enabled_setting).to eq(false)
     end
   end
 

--- a/spec/serializers/basic_reviewable_flagged_post_serializer_spec.rb
+++ b/spec/serializers/basic_reviewable_flagged_post_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe BasicReviewableFlaggedPostSerializer do
-  subject(:serializer) { described_class.new(reviewable, root: false).as_json }
+  subject(:serializer) { described_class.new(reviewable, scope: PlaceholderGuardian.new, root: false).as_json }
 
   fab!(:topic) { Fabricate(:topic, title: "safe title <a> hello world") }
   fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/serializers/basic_reviewable_queued_post_serializer_spec.rb
+++ b/spec/serializers/basic_reviewable_queued_post_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe BasicReviewableQueuedPostSerializer do
-  subject(:serializer) { described_class.new(reviewable, root: false).as_json }
+  subject(:serializer) { described_class.new(reviewable, scope: PlaceholderGuardian.new, root: false).as_json }
 
   fab!(:topic) { Fabricate(:topic, title: "safe title <a> existing topic") }
   fab!(:reviewable) do

--- a/spec/serializers/basic_reviewable_serializer_spec.rb
+++ b/spec/serializers/basic_reviewable_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 describe BasicReviewableSerializer do
   fab!(:reviewable)
-  subject { described_class.new(reviewable, root: false).as_json }
+  subject { described_class.new(reviewable, scope: PlaceholderGuardian.new, root: false).as_json }
 
   include_examples "basic reviewable attributes"
 end

--- a/spec/serializers/basic_reviewable_user_serializer_spec.rb
+++ b/spec/serializers/basic_reviewable_user_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe BasicReviewableUserSerializer do
-  subject(:serializer) { described_class.new(reviewable, root: false).as_json }
+  subject(:serializer) { described_class.new(reviewable, scope: PlaceholderGuardian.new, root: false).as_json }
 
   fab!(:user)
   fab!(:reviewable) do

--- a/spec/serializers/basic_topic_serializer_spec.rb
+++ b/spec/serializers/basic_topic_serializer_spec.rb
@@ -5,7 +5,7 @@ describe BasicTopicSerializer do
 
   describe "#fancy_title" do
     it "returns the fancy title" do
-      json = BasicTopicSerializer.new(topic).as_json
+      json = BasicTopicSerializer.new(topic, scope: PlaceholderGuardian.new).as_json
 
       expect(json[:basic_topic][:fancy_title]).to eq(topic.title)
     end
@@ -16,7 +16,7 @@ describe BasicTopicSerializer do
       I18n.locale = "ja"
       topic.update!(locale: "en")
 
-      json = BasicTopicSerializer.new(topic).as_json
+      json = BasicTopicSerializer.new(topic, scope: PlaceholderGuardian.new).as_json
 
       expect(json[:basic_topic][:fancy_title]).to eq("X")
     end

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe BasicUserSerializer do
       before { SiteSetting.enable_user_status = true }
 
       it "doesn't add status by default" do
-        serializer = BasicUserSerializer.new(user, root: false)
+        serializer = BasicUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false)
         json = serializer.as_json
 
         expect(json.keys).not_to include :status
       end
 
       context "when including user status" do
-        let(:serializer) { BasicUserSerializer.new(user, root: false, include_status: true) }
+        let(:serializer) { BasicUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true) }
 
         it "adds status if `include_status: true` has been passed" do
           json = serializer.as_json
@@ -76,7 +76,7 @@ RSpec.describe BasicUserSerializer do
       before { SiteSetting.enable_user_status = false }
 
       it "doesn't add user status" do
-        serializer = BasicUserSerializer.new(user, root: false, include_status: true)
+        serializer = BasicUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true)
         json = serializer.as_json
 
         expect(json.keys).not_to include :status

--- a/spec/serializers/category_upload_serializer_spec.rb
+++ b/spec/serializers/category_upload_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe CategoryUploadSerializer do
-  subject(:serializer) { described_class.new(upload, root: false) }
+  subject(:serializer) { described_class.new(upload, scope: PlaceholderGuardian.new, root: false) }
 
   fab!(:upload)
 

--- a/spec/serializers/component_index_serializer_spec.rb
+++ b/spec/serializers/component_index_serializer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ComponentIndexSerializer do
     )
   end
 
-  let(:json) { described_class.new(component, root: false).as_json }
+  let(:json) { described_class.new(component, scope: PlaceholderGuardian.new, root: false).as_json }
 
   it "includes remote_theme object" do
     expect(json[:remote_theme][:id]).to eq(component.remote_theme.id)

--- a/spec/serializers/concerns/user_status_mixin_spec.rb
+++ b/spec/serializers/concerns/user_status_mixin_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UserStatusMixin do
     before { SiteSetting.enable_user_status = false }
 
     it "doesn't include status" do
-      serializer = DummySerializer.new(user, root: false, include_status: true)
+      serializer = DummySerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true)
       json = serializer.as_json
       expect(json[:status]).to be_nil
     end
@@ -22,20 +22,20 @@ RSpec.describe UserStatusMixin do
     before { SiteSetting.enable_user_status = true }
 
     it "doesn't include status by default" do
-      serializer = DummySerializer.new(user, root: false)
+      serializer = DummySerializer.new(user, scope: PlaceholderGuardian.new, root: false)
       json = serializer.as_json
       expect(json[:status]).to be_nil
     end
 
     it "includes status when include_status option is passed" do
-      serializer = DummySerializer.new(user, root: false, include_status: true)
+      serializer = DummySerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true)
       json = serializer.as_json
       expect(json[:status]).to be_present
     end
 
     it "doesn't include status if user hid profile and presence" do
       user.user_option.hide_profile = true
-      serializer = DummySerializer.new(user, root: false, include_status: true)
+      serializer = DummySerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true)
       json = serializer.as_json
       expect(json[:status]).to be_nil
     end

--- a/spec/serializers/directory_item_serializer_spec.rb
+++ b/spec/serializers/directory_item_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DirectoryItemSerializer do
             "user_field_2" => user_field_2.id,
           },
           searchable_fields: [user_field_1],
+          scope: PlaceholderGuardian.new,
         )
 
       expect(user_fields).to eq(
@@ -48,6 +49,7 @@ RSpec.describe DirectoryItemSerializer do
             "user_field_1" => user_field_1.id,
           },
           searchable_fields: [],
+          scope: PlaceholderGuardian.new,
         )
 
       expect(user_fields[user_field_1.id]).to eq(
@@ -63,7 +65,8 @@ RSpec.describe DirectoryItemSerializer do
         DirectoryItem.find_by(user: user, period_type: DirectoryItem.period_types[:all])
       DirectoryItemSerializer.new(
         directory_item,
-        { attributes: DirectoryColumn.active_column_names },
+        { attributes: DirectoryColumn.active_column_names,
+          scope: PlaceholderGuardian.new },
       )
     end
 

--- a/spec/serializers/emoji_serializer_spec.rb
+++ b/spec/serializers/emoji_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EmojiSerializer do
   fab!(:custom_emoji) { CustomEmoji.create!(name: "trout", upload: Fabricate(:upload)) }
 
   describe "#url" do
-    subject(:serializer) { described_class.new(emoji, root: false) }
+    subject(:serializer) { described_class.new(emoji, scope: PlaceholderGuardian.new, root: false) }
 
     fab!(:emoji) { Emoji.load_custom.first }
 
@@ -28,7 +28,7 @@ RSpec.describe EmojiSerializer do
     it "doesn't raise an error with a missing upload and a CDN" do
       emoji = Emoji.load_custom.first
       set_cdn_url("https://cdn.com")
-      result = described_class.new(Emoji.load_custom.first, root: false).as_json
+      result = described_class.new(Emoji.load_custom.first, scope: PlaceholderGuardian.new, root: false).as_json
       expect(result[:url]).to be_blank
     end
 
@@ -40,7 +40,7 @@ RSpec.describe EmojiSerializer do
       SiteSetting.s3_access_key_id = "s3_access_key_id"
       SiteSetting.s3_secret_access_key = "s3_secret_access_key"
       SiteSetting.s3_cdn_url = "https://example.com"
-      result = described_class.new(Emoji.load_custom.first, root: false).as_json
+      result = described_class.new(Emoji.load_custom.first, scope: PlaceholderGuardian.new, root: false).as_json
 
       expect(result[:url]).to be_blank
     end

--- a/spec/serializers/flag_serializer_spec.rb
+++ b/spec/serializers/flag_serializer_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe FlagSerializer do
 
   context "when system flag" do
     it "returns translated name" do
-      serialized = described_class.new(flag, used_flag_ids: []).as_json
+      serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
       expect(serialized[:flag][:name]).to eq(I18n.t("post_action_types.illegal.title"))
     end
 
     it "returns translated description" do
-      serialized = described_class.new(flag, used_flag_ids: []).as_json
+      serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
       expect(serialized[:flag][:description]).to eq(I18n.t("post_action_types.illegal.description"))
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe FlagSerializer do
   context "when custom flag" do
     it "returns translated name and description" do
       flag = Fabricate(:flag, name: "custom title", description: "custom description")
-      serialized = described_class.new(flag, used_flag_ids: []).as_json
+      serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
       expect(serialized[:flag][:name]).to eq("custom title")
       expect(serialized[:flag][:description]).to eq("custom description")
       flag.destroy!
@@ -26,28 +26,28 @@ RSpec.describe FlagSerializer do
   end
 
   it "returns is_flag true for flags" do
-    serialized = described_class.new(flag, used_flag_ids: []).as_json
+    serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
     expect(serialized[:flag][:is_flag]).to be true
   end
 
   it "returns is_flag false for like" do
     flag = Flag.unscoped.find_by(name: "like")
-    serialized = described_class.new(flag, used_flag_ids: []).as_json
+    serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
     expect(serialized[:flag][:is_flag]).to be false
   end
 
   it "returns is_used false when not used" do
-    serialized = described_class.new(flag, used_flag_ids: []).as_json
+    serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
     expect(serialized[:flag][:is_used]).to be false
   end
 
   it "returns is_used true when used" do
-    serialized = described_class.new(flag, used_flag_ids: [flag.id]).as_json
+    serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: [flag.id]).as_json
     expect(serialized[:flag][:is_used]).to be true
   end
 
   it "returns applies_to" do
-    serialized = described_class.new(flag, used_flag_ids: []).as_json
+    serialized = described_class.new(flag, scope: PlaceholderGuardian.new, used_flag_ids: []).as_json
     expect(serialized[:flag][:applies_to]).to eq(%w[Post Topic Chat::Message])
   end
 

--- a/spec/serializers/found_user_serializer_spec.rb
+++ b/spec/serializers/found_user_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe FoundUserSerializer do
   fab!(:user)
-  let(:serializer) { described_class.new(user, root: false) }
+  let(:serializer) { described_class.new(user, scope: PlaceholderGuardian.new, root: false) }
 
   describe "#id" do
     it "returns user id" do
@@ -36,13 +36,13 @@ RSpec.describe FoundUserSerializer do
       before { SiteSetting.enable_user_status = true }
 
       it "doesn't add user status by default" do
-        serializer = FoundUserSerializer.new(user, root: false)
+        serializer = FoundUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false)
         json = serializer.as_json
         expect(json.keys).not_to include :status
       end
 
       context "when including user status" do
-        let(:serializer) { FoundUserSerializer.new(user, root: false, include_status: true) }
+        let(:serializer) { FoundUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true) }
 
         it "adds user status when enabled" do
           json = serializer.as_json
@@ -73,7 +73,7 @@ RSpec.describe FoundUserSerializer do
 
     context "when status is disabled in site settings" do
       before { SiteSetting.enable_user_status = false }
-      let(:serializer) { FoundUserSerializer.new(user, root: false, include_status: true) }
+      let(:serializer) { FoundUserSerializer.new(user, scope: PlaceholderGuardian.new, root: false, include_status: true) }
 
       it "doesn't add user status" do
         json = serializer.as_json

--- a/spec/serializers/new_post_result_serializer_spec.rb
+++ b/spec/serializers/new_post_result_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NewPostResultSerializer do
     result.message = "hello :)"
     result.route_to = "/cool-route"
 
-    serializer = described_class.new(result)
+    serializer = described_class.new(result, scope: PlaceholderGuardian.new)
     expect(serializer.success).to eq(true)
     expect(serializer.message).to eq("hello :)")
     expect(serializer.route_to).to eq("/cool-route")

--- a/spec/serializers/notification_serializer_spec.rb
+++ b/spec/serializers/notification_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NotificationSerializer do
   describe "#as_json" do
     fab!(:user)
     let(:notification) { Fabricate(:notification, user: user) }
-    let(:serializer) { NotificationSerializer.new(notification) }
+    let(:serializer) { NotificationSerializer.new(notification, scope: PlaceholderGuardian.new) }
     let(:json) { serializer.as_json }
 
     it "returns the user_id" do
@@ -23,7 +23,7 @@ RSpec.describe NotificationSerializer do
       user
     end
     let(:notification) { Fabricate(:notification, user: user) }
-    let(:serializer) { NotificationSerializer.new(notification) }
+    let(:serializer) { NotificationSerializer.new(notification, scope: PlaceholderGuardian.new) }
     let(:json) { serializer.as_json }
 
     it "should include the external_id" do

--- a/spec/serializers/poster_serializer_spec.rb
+++ b/spec/serializers/poster_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PosterSerializer do
   let(:poster) { Fabricate(:user, admin: false, moderator: false) }
 
   it "serializes the correct attributes" do
-    expect(PosterSerializer.new(poster).attributes.keys).to contain_exactly(
+    expect(PosterSerializer.new(poster, scope: PlaceholderGuardian.new).attributes.keys).to contain_exactly(
       :trust_level,
       :avatar_template,
       :id,
@@ -24,7 +24,7 @@ RSpec.describe PosterSerializer do
       )
     groupie = Fabricate(:user, flair_group: group)
 
-    expect(PosterSerializer.new(groupie).attributes.keys).to contain_exactly(
+    expect(PosterSerializer.new(groupie, scope: PlaceholderGuardian.new).attributes.keys).to contain_exactly(
       :trust_level,
       :avatar_template,
       :id,

--- a/spec/serializers/remote_theme_serializer_spec.rb
+++ b/spec/serializers/remote_theme_serializer_spec.rb
@@ -11,26 +11,26 @@ RSpec.describe RemoteThemeSerializer do
 
   describe "about_url" do
     it "returns the about_url" do
-      serialized = RemoteThemeSerializer.new(remote_theme).as_json[:remote_theme]
+      serialized = RemoteThemeSerializer.new(remote_theme, scope: PlaceholderGuardian.new).as_json[:remote_theme]
       expect(serialized[:about_url]).to eq("https://meta.discourse.org/t/some-theme/123")
     end
 
     it "returns nil if the URL is not a valid URL" do
       remote_theme.update!(about_url: "todo: Put your theme's public repo or Meta topic URL here")
-      serialized = RemoteThemeSerializer.new(remote_theme).as_json[:remote_theme]
+      serialized = RemoteThemeSerializer.new(remote_theme, scope: PlaceholderGuardian.new).as_json[:remote_theme]
       expect(serialized[:about_url]).to be_nil
     end
   end
 
   describe "license_url" do
     it "returns the license_url" do
-      serialized = RemoteThemeSerializer.new(remote_theme).as_json[:remote_theme]
+      serialized = RemoteThemeSerializer.new(remote_theme, scope: PlaceholderGuardian.new).as_json[:remote_theme]
       expect(serialized[:license_url]).to eq("https://github.com/repo/repo/LICENSE.md")
     end
 
     it "returns nil if the URL is not a valid URL" do
       remote_theme.update!(license_url: "todo: Put your theme's LICENSE URL here")
-      serialized = RemoteThemeSerializer.new(remote_theme).as_json[:remote_theme]
+      serialized = RemoteThemeSerializer.new(remote_theme, scope: PlaceholderGuardian.new).as_json[:remote_theme]
       expect(serialized[:license_url]).to be_nil
     end
   end

--- a/spec/serializers/tag_group_serializer_spec.rb
+++ b/spec/serializers/tag_group_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TagGroupSerializer do
     ]
     tag_group.save!
 
-    serialized = TagGroupSerializer.new(tag_group, root: false).as_json
+    serialized = TagGroupSerializer.new(tag_group, scope: PlaceholderGuardian.new, root: false).as_json
 
     expect(serialized[:permissions].keys).to contain_exactly(Group::AUTO_GROUPS[:staff])
   end
@@ -20,7 +20,7 @@ RSpec.describe TagGroupSerializer do
     tag = Fabricate(:tag)
     synonym = Fabricate(:tag, target_tag: tag)
     tag_group = Fabricate(:tag_group, tags: [tag, synonym])
-    serialized = TagGroupSerializer.new(tag_group, root: false).as_json
+    serialized = TagGroupSerializer.new(tag_group, scope: PlaceholderGuardian.new, root: false).as_json
     expect(serialized[:tag_names]).to contain_exactly(tag.name)
   end
 end

--- a/spec/serializers/theme_index_serializer_spec.rb
+++ b/spec/serializers/theme_index_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ThemeIndexSerializer do
     )
   end
 
-  let(:serializer) { ThemeIndexSerializer.new(theme, root: false) }
+  let(:serializer) { ThemeIndexSerializer.new(theme, scope: PlaceholderGuardian.new, root: false) }
   let(:json) { serializer.as_json }
 
   it "includes basic theme attributes" do
@@ -36,7 +36,7 @@ RSpec.describe ThemeIndexSerializer do
     theme.color_scheme = Fabricate(:color_scheme)
     theme.save!
 
-    new_json = ThemeIndexSerializer.new(theme, root: false).as_json
+    new_json = ThemeIndexSerializer.new(theme, scope: PlaceholderGuardian.new, root: false).as_json
     expect(new_json[:color_scheme][:id]).to eq(theme.color_scheme.id)
   end
 
@@ -46,7 +46,7 @@ RSpec.describe ThemeIndexSerializer do
     remote_theme = RemoteTheme.create!(remote_url: "https://github.com/discourse/sample-theme")
     theme.update!(remote_theme_id: remote_theme.id)
 
-    new_json = ThemeIndexSerializer.new(theme, root: false).as_json
+    new_json = ThemeIndexSerializer.new(theme, scope: PlaceholderGuardian.new, root: false).as_json
     expect(new_json[:remote_theme][:id]).to eq(remote_theme.id)
   end
 end

--- a/spec/serializers/theme_objects_setting_metadata_serializer_spec.rb
+++ b/spec/serializers/theme_objects_setting_metadata_serializer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ThemeObjectsSettingMetadataSerializer do
     it "should return a hash of the settings property descriptions" do
       objects_setting_locale
 
-      payload = described_class.new(theme_setting[:objects_setting], root: false).as_json
+      payload = described_class.new(theme_setting[:objects_setting], scope: PlaceholderGuardian.new, root: false).as_json
 
       expect(payload[:property_descriptions]).to eq(
         {

--- a/spec/serializers/theme_serializer_spec.rb
+++ b/spec/serializers/theme_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ThemeSerializer do
         .any_instance
         .stubs(:settings)
         .raises(ThemeSettingsParser::InvalidYaml, I18n.t("themes.settings_errors.invalid_yaml"))
-      serialized = ThemeSerializer.new(theme).as_json[:theme]
+      serialized = ThemeSerializer.new(theme, scope: PlaceholderGuardian.new).as_json[:theme]
       expect(serialized[:settings]).to be_nil
       expect(serialized[:errors].count).to eq(1)
       expect(serialized[:errors][0]).to eq(I18n.t("themes.settings_errors.invalid_yaml"))
@@ -18,7 +18,7 @@ RSpec.describe ThemeSerializer do
     it "should add errors messages from theme fields" do
       error = "error when compiling theme field"
       theme_field = Fabricate(:theme_field, error: error, theme: theme)
-      serialized = ThemeSerializer.new(theme.reload).as_json[:theme]
+      serialized = ThemeSerializer.new(theme.reload, scope: PlaceholderGuardian.new).as_json[:theme]
       expect(serialized[:errors].count).to eq(1)
       expect(serialized[:errors][0]).to eq(error)
     end
@@ -26,7 +26,7 @@ RSpec.describe ThemeSerializer do
 
   describe "screenshot_url" do
     fab!(:theme)
-    let(:serialized) { ThemeSerializer.new(theme.reload).as_json[:theme] }
+    let(:serialized) { ThemeSerializer.new(theme.reload, scope: PlaceholderGuardian.new).as_json[:theme] }
 
     it "should include screenshot_url when there is a theme field with screenshot upload type" do
       Fabricate(

--- a/spec/serializers/theme_settings_serializer_spec.rb
+++ b/spec/serializers/theme_settings_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ThemeSettingsSerializer do
 
   describe "#objects_schema" do
     it "should include the attribute when theme setting is typed objects" do
-      payload = ThemeSettingsSerializer.new(theme_setting[:objects_setting]).as_json
+      payload = ThemeSettingsSerializer.new(theme_setting[:objects_setting], scope: PlaceholderGuardian.new).as_json
 
       expect(payload[:theme_settings][:objects_schema][:name]).to eq("section")
     end

--- a/spec/serializers/topic_link_serializer_spec.rb
+++ b/spec/serializers/topic_link_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TopicLinkSerializer do
   it "correctly serializes the topic link" do
     post = Fabricate(:post, raw: "https://meta.discourse.org/")
     TopicLink.extract_from(post)
-    serialized = described_class.new(post.topic_links.first, root: false).as_json
+    serialized = described_class.new(post.topic_links.first, scope: PlaceholderGuardian.new, root: false).as_json
 
     expect(serialized[:domain]).to eq("meta.discourse.org")
     expect(serialized[:root_domain]).to eq("discourse.org")

--- a/spec/serializers/upload_serializer_spec.rb
+++ b/spec/serializers/upload_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UploadSerializer do
-  subject(:serializer) { UploadSerializer.new(upload, root: false) }
+  subject(:serializer) { UploadSerializer.new(upload, scope: PlaceholderGuardian.new, root: false) }
 
   fab!(:upload)
 

--- a/spec/serializers/user_bookmark_list_serializer_spec.rb
+++ b/spec/serializers/user_bookmark_list_serializer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UserBookmarkListSerializer do
     def run_serializer
       bookmark_list = UserBookmarkList.new(user: user, guardian: Guardian.new(user))
       bookmark_list.load
-      UserBookmarkListSerializer.new(bookmark_list)
+      UserBookmarkListSerializer.new(bookmark_list, scope: PlaceholderGuardian.new)
     end
 
     it "chooses the correct class of serializer for all the bookmarkable types" do

--- a/spec/serializers/user_export_serializer_spec.rb
+++ b/spec/serializers/user_export_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UserExportSerializer do
-  subject(:serializer) { UserExportSerializer.new(user_export, root: false) }
+  subject(:serializer) { UserExportSerializer.new(user_export, scope: PlaceholderGuardian.new, root: false) }
 
   fab!(:user_export) do
     user = Fabricate(:user)

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe StaffActionLogger do
     end
 
     it "logs updated site customizations" do
-      old_json = ThemeSerializer.new(theme, root: false).to_json
+      old_json = ThemeSerializer.new(theme, scope: PlaceholderGuardian.new, root: false).to_json
 
       theme.set_field(target: :common, name: :scss, value: "body{margin: 10px;}")
 
@@ -248,7 +248,7 @@ RSpec.describe StaffActionLogger do
     end
 
     it "doesn't log values when the json is too large" do
-      old_json = ThemeSerializer.new(theme, root: false).to_json
+      old_json = ThemeSerializer.new(theme, scope: PlaceholderGuardian.new, root: false).to_json
 
       theme.set_field(target: :common, name: :scss, value: long_string)
 


### PR DESCRIPTION
This commit is based on the premise that every serializer should have a `scope` parameter which is an instance of a `Guardian`.

In many places, serializers which construct other serializers neglect to forward their `scope` parameter to the sub-serializer.  When one of these sub-serializers is later modified to make use of its scope in a new way or under a new circumstance, the missing scope along certain code paths can cause failures which are hard to debug.  It is difficult to pin down where, within a chain of serializers, the scope has not been forwarded.

This commit fixes all the current call-sites (in code with test coverage), where a serializer has neglected to forward its scope.  It also introduces a mechanism to track where other classes fail to provide a scope when constructing a serializer.  This mechanism will cause the codebase to evolve to a state where all serializers are reliably and predictably provided with a `Guardian` as their scope.

Elements of this commit:

 1. Modify `ApplicationSerializer#new` to log/raise an error if a serializer is constructed without a `scope:` argument.  (Error is raised only in a test environment.)

 2. Add a `scope: scope` argument to every call-site where a serializer is constructed *by another serializer* (forwarding sites) and the `scope:` argument is missing.

 3. Define `PlaceholderGuardian`, to be used to provide a `scope:` argument wherever one was missing in a non-forwarding serializer construction.

 4. Add a new `scope: PlaceholderGuardian.new` argument to every remaining (non-forwarding) call-site where a serializer is constructed without a `scope:` argument.  (Call-sites which already have a `scope:` argument have been left untouched, even if it assigned the `scope` to `nil`.)