### PR TITLE
FIX: Topic timeline in mobile is not usable due to full height

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -90,7 +90,7 @@
       grid-row: 3;
       width: auto;
 
-      > * {
+      .btn-toggle-localized-content {
         height: 100%;
       }
     }


### PR DESCRIPTION
|   | before | after |
|---|---|---|
|   | <img width="335" alt="Screenshot 2025-05-29 at 10 18 32 AM" src="https://github.com/user-attachments/assets/c3cc74f6-b131-46c0-bf9c-f099b7f6654c" /> |  <img width="337" alt="Screenshot 2025-05-29 at 10 16 40 AM" src="https://github.com/user-attachments/assets/4c1ec71d-5f3e-4c7b-b3ac-125fffea7ee5" /> |
