### PR TITLE
UX: Add subheader to admin themes page

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
@@ -172,7 +172,6 @@ export default class AdminConfigAreasComponents extends Component {
     >
       <:actions as |actions|>
         <actions.Primary
-          disabled={{this.loading}}
           @label="admin.config_areas.themes_and_components.components.install"
           @action={{this.installModal}}
         />

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/themes.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/themes.gjs
@@ -3,8 +3,8 @@ import { action } from "@ember/object";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
+import DPageSubheader from "discourse/components/d-page-subheader";
 import { i18n } from "discourse-i18n";
-import InstallThemeCard from "admin/components/admin-config-area-cards/install-theme-card";
 import InstallThemeModal from "admin/components/modal/install-theme";
 import ThemesGrid from "admin/components/themes-grid";
 import { THEMES } from "admin/models/theme";
@@ -82,12 +82,23 @@ export default class AdminConfigAreasThemes extends Component {
   }
 
   <template>
+    <DPageSubheader
+      @titleLabel={{i18n
+        "admin.config_areas.themes_and_components.themes.title"
+      }}
+      @descriptionLabel={{i18n
+        "admin.config_areas.themes_and_components.themes.description"
+      }}
+    >
+      <:actions as |actions|>
+        <actions.Primary
+          @label="admin.config_areas.themes_and_components.themes.install"
+          @action={{this.installModal}}
+        />
+      </:actions>
+    </DPageSubheader>
     <div class="admin-detail">
-      <ThemesGrid @themes={{@themes}}>
-        <:specialCard>
-          <InstallThemeCard @openModal={{this.installModal}} />
-        </:specialCard>
-      </ThemesGrid>
+      <ThemesGrid @themes={{@themes}} />
     </div>
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -86,7 +86,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
     const themeUrl = "git@github.com:discourse/discourse.git";
     await visit("/admin/config/customize/themes");
 
-    await click(".theme-install-card__install-button");
+    await click(".d-page-subheader__actions .btn-primary");
     await click("#remote");
     await fillIn(urlInput, themeUrl);
     await click(".install-theme-content .inputs .advanced-repo");
@@ -97,7 +97,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
 
     await click(".d-modal__footer .d-modal-cancel");
 
-    await click(".theme-install-card__install-button");
+    await click(".d-page-subheader__actions .btn-primary");
     await click("#remote");
     await click(".install-theme-content .inputs .advanced-repo");
     assert.dom(urlInput).hasValue("", "url input is reset");
@@ -114,7 +114,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
       "discourse@discourse.git.backlog.com:/TEST_THEME/test-theme.git";
     await visit("/admin/customize/themes");
 
-    await click(".theme-install-card__install-button");
+    await click(".d-page-subheader__actions .btn-primary");
     await click("#remote");
     await fillIn(urlInput, themeUrl);
     await click(".install-theme-content .inputs .advanced-repo");
@@ -162,7 +162,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
 
   test("installed themes are matched with the popular list by URL", async function (assert) {
     await visit("/admin/config/customize/themes");
-    await click(".theme-install-card__install-button");
+    await click(".d-page-subheader__actions .btn-primary");
 
     assert
       .dom(

--- a/app/assets/javascripts/discourse/tests/acceptance/themes-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/themes-test.js
@@ -166,7 +166,7 @@ acceptance("Theme", function (needs) {
   test("can force install themes", async function (assert) {
     await visit("/admin/config/customize/themes");
 
-    await click(".theme-install-card .btn-primary");
+    await click(".d-page-subheader__actions .btn-primary");
     await click(".install-theme-items #remote");
     await fillIn(
       ".install-theme-content .repo input",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6336,9 +6336,11 @@ en:
           install: "Install"
           themes:
             title: "Themes"
+            description: "Site-wide themes that change the overall look and feel of your site for all users."
             themes_intro: "Install a new theme to get started, or create your own from scratch using these resources."
             new_theme: "New theme"
             back: "Back to themes"
+            install: "Install"
           components:
             title: "Components"
             description: "Customizations that change surface elements of your forum design, or add extra front-end features"

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -11,14 +11,10 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
   before { sign_in(admin) }
 
-  it "has a special card for installing new themes" do
+  it "has an install button in the subheader" do
     config_area.visit
 
-    expect(config_area.install_card).to have_text(
-      I18n.t("admin_js.admin.config_areas.themes_and_components.themes.new_theme"),
-    )
-
-    config_area.install_card.find(".btn-primary").click
+    config_area.subheader.find(".btn-primary").click
     expect(install_modal).to be_open
     expect(install_modal.popular_options.first).to have_text("Air")
   end

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -11,8 +11,8 @@ module PageObjects
         find(".theme-card.#{theme.name.parameterize}")
       end
 
-      def install_card
-        find(".theme-install-card")
+      def subheader
+        find(".d-page-subheader")
       end
 
       def open_theme_menu(theme)


### PR DESCRIPTION
### What is this change?

- Add subheader with install button to match the <kbd>Components</kbd> tab.
- Remove the "special" card with the install button from the end of the list.

**Screenshot:**

<img width="343" alt="Screenshot 2025-05-29 at 10 32 01 AM" src="https://github.com/user-attachments/assets/d40c9b12-690f-4311-a15a-70b1a44a8daf" />
