### PR TITLE
FEATURE: Add utilities for importing and exporting backups

### DIFF
--- a/app/models/backup_file.rb
+++ b/app/models/backup_file.rb
@@ -16,18 +16,6 @@ class BackupFile
     attributes == other.attributes
   end
 
-  def self.download(url)
-    FileHelper.download(
-      url,
-      max_file_size: Float::INFINITY,
-      tmp_file_name: File.basename(URI.parse(url).path),
-      follow_redirect: true,
-      skip_rate_limit: true,
-      validate_uri: false,
-      verbose: true,
-    )
-  end
-
   protected
 
   def attributes

--- a/app/models/backup_file.rb
+++ b/app/models/backup_file.rb
@@ -16,6 +16,18 @@ class BackupFile
     attributes == other.attributes
   end
 
+  def self.download(url)
+    FileHelper.download(
+      url,
+      max_file_size: Float::INFINITY,
+      tmp_file_name: File.basename(URI.parse(url).path),
+      follow_redirect: true,
+      skip_rate_limit: true,
+      validate_uri: false,
+      verbose: true,
+    )
+  end
+
   protected
 
   def attributes

--- a/lib/backup_restore/backup_file_handler.rb
+++ b/lib/backup_restore/backup_file_handler.rb
@@ -71,7 +71,7 @@ module BackupRestore
           verbose: true,
         )
 
-      Discourse::Utils.execute_command("cp", tmpfile.path, @archive_path)
+      Discourse::Utils.execute_command("mv", tmpfile.path, @archive_path)
     ensure
       tmpfile&.unlink
     end

--- a/lib/backup_restore/backup_file_handler.rb
+++ b/lib/backup_restore/backup_file_handler.rb
@@ -46,6 +46,18 @@ module BackupRestore
       log "Something went wrong while removing the following tmp directory: #{@tmp_directory}", ex
     end
 
+    def self.download(url)
+      FileHelper.download(
+        url,
+        max_file_size: Float::INFINITY,
+        tmp_file_name: File.basename(URI.parse(url).path),
+        follow_redirect: true,
+        skip_rate_limit: true,
+        validate_uri: false,
+        verbose: true,
+      )
+    end
+
     protected
 
     def create_tmp_directory
@@ -61,7 +73,7 @@ module BackupRestore
 
     def download_archive_to_tmp_directory
       log "Downloading archive from URL to tmp directory..."
-      tmpfile = BackupFile.download(@url)
+      tmpfile = self.class.download(@url)
       Discourse::Utils.execute_command("mv", tmpfile.path, @archive_path)
     ensure
       tmpfile&.unlink

--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -49,7 +49,7 @@ module BackupRestore
 
       @system.listen_for_shutdown_signal
 
-      @tmp_directory, db_dump_path = @backup_file_handler.decompress
+      @filename, @tmp_directory, db_dump_path = @backup_file_handler.decompress
       validate_backup_metadata
 
       @system.enable_readonly_mode

--- a/script/discourse
+++ b/script/discourse
@@ -174,7 +174,7 @@ class DiscourseCLI < Thor
     end
 
     puts "Downloading backup file from #{url}..."
-    tmpfile = BackupFile.download(url)
+    tmpfile = BackupRestore::BackupFileHandler.download(url)
 
     if store.remote?
       puts "Uploading backup file to remote store..."

--- a/script/discourse
+++ b/script/discourse
@@ -173,16 +173,7 @@ class DiscourseCLI < Thor
     end
 
     puts "Downloading backup file from #{url}..."
-    tmpfile =
-      FileHelper.download(
-        url,
-        max_file_size: Float::INFINITY,
-        tmp_file_name: filename,
-        follow_redirect: true,
-        skip_rate_limit: true,
-        validate_uri: false,
-        verbose: true,
-      )
+    tmpfile = BackupFile.download(url)
 
     if store.remote?
       puts "Uploading backup file to remote store..."

--- a/script/discourse
+++ b/script/discourse
@@ -140,6 +140,66 @@ class DiscourseCLI < Thor
     end
   end
 
+  desc "export_backup", "Get the URL of a backup file"
+  def export_backup(filename = nil)
+    load_rails
+
+    store = BackupRestore::BackupStore.create
+    raise "Backup URLs are only available for S3 backups" if !store.remote?
+
+    file = store.file(filename, include_download_source: true) if filename
+
+    if !file
+      discourse = File.exist?("/usr/local/bin/discourse") ? "discourse" : "./script/discourse"
+      puts "You must provide a valid filename. Did you mean one of the following?\n\n"
+      store.files.each { |f| puts "#{discourse} export_backup #{f.filename}" }
+      return
+    end
+
+    puts file.source
+  end
+
+  desc "import_backup", "Download a backup file and stores it current backup store"
+  def import_backup(url = nil)
+    load_rails
+
+    store = BackupRestore::BackupStore.create
+    filename = File.basename(URI.parse(url).path)
+
+    file = store.file(filename)
+    if file
+      puts "Backup file already exists in the store"
+      return
+    end
+
+    puts "Downloading backup file from #{url}..."
+    tmpfile =
+      FileHelper.download(
+        url,
+        max_file_size: Float::INFINITY,
+        tmp_file_name: filename,
+        follow_redirect: true,
+        skip_rate_limit: true,
+        validate_uri: false,
+        verbose: true,
+      )
+
+    if store.remote?
+      puts "Uploading backup file to remote store..."
+      content_type = MiniMime.lookup_by_filename(filename).content_type
+      store.upload_file(filename, tmpfile.path, content_type)
+    else
+      puts "Saving backup file to local store..."
+      Discourse::Utils.execute_command(
+        "cp",
+        tmpfile.path,
+        File.join(BackupRestore::LocalBackupStore.base_directory, filename),
+      )
+    end
+  ensure
+    tmpfile&.unlink
+  end
+
   desc "export", "Backup a Discourse forum"
   option :s3_uploads,
          type: :boolean,

--- a/script/discourse
+++ b/script/discourse
@@ -159,7 +159,8 @@ class DiscourseCLI < Thor
     puts file.source
   end
 
-  desc "import_backup_url", "Download a backup file and stores it current backup store"
+  desc "import_backup_url",
+       "Downloads a backup file from a URL and stores it in the current backup store"
   def import_backup_url(url = nil)
     load_rails
 

--- a/script/discourse
+++ b/script/discourse
@@ -140,8 +140,8 @@ class DiscourseCLI < Thor
     end
   end
 
-  desc "export_backup", "Get the URL of a backup file"
-  def export_backup(filename = nil)
+  desc "backup_url", "Get the URL of a backup file"
+  def backup_url(filename = nil)
     load_rails
 
     store = BackupRestore::BackupStore.create
@@ -152,15 +152,15 @@ class DiscourseCLI < Thor
     if !file
       discourse = File.exist?("/usr/local/bin/discourse") ? "discourse" : "./script/discourse"
       puts "You must provide a valid filename. Did you mean one of the following?\n\n"
-      store.files.each { |f| puts "#{discourse} export_backup #{f.filename}" }
+      store.files.each { |f| puts "#{discourse} backup_url #{f.filename}" }
       return
     end
 
     puts file.source
   end
 
-  desc "import_backup", "Download a backup file and stores it current backup store"
-  def import_backup(url = nil)
+  desc "import_backup_url", "Download a backup file and stores it current backup store"
+  def import_backup_url(url = nil)
     load_rails
 
     store = BackupRestore::BackupStore.create

--- a/script/discourse
+++ b/script/discourse
@@ -191,7 +191,7 @@ class DiscourseCLI < Thor
     else
       puts "Saving backup file to local store..."
       Discourse::Utils.execute_command(
-        "cp",
+        "mv",
         tmpfile.path,
         File.join(BackupRestore::LocalBackupStore.base_directory, filename),
       )

--- a/spec/lib/backup_restore/backup_file_handler_spec.rb
+++ b/spec/lib/backup_restore/backup_file_handler_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe BackupRestore::BackupFileHandler do
     )
   end
 
+  it "works with URLs" do
+    expect_decompress_and_clean_up_to_work(
+      backup_filename: "backup_since_v1.6.tar.gz",
+      url: "https://example.com/backups/backup_since_v1.6.tar.gz",
+      require_metadata_file: false,
+      require_uploads: true,
+    )
+  end
+
   it "works with SQL only backup file" do
     expect_decompress_and_clean_up_to_work(
       backup_filename: "sql_only_backup.sql.gz",

--- a/spec/lib/backup_restore/shared_context_for_backup_restore.rb
+++ b/spec/lib/backup_restore/shared_context_for_backup_restore.rb
@@ -88,8 +88,8 @@ RSpec.shared_context "with shared backup restore context" do
           root_tmp_directory: root_directory,
           location: location,
         )
-      tmp_directory, db_dump_path = file_handler.decompress
-
+      filename, tmp_directory, db_dump_path = file_handler.decompress
+      expect(filename).to eq(backup_filename)
       expected_tmp_path = File.join(root_directory, "tmp/restores", current_db, "2019-12-24-143148")
       expect(tmp_directory).to eq(expected_tmp_path)
       expect(db_dump_path).to eq(File.join(expected_tmp_path, expected_dump_filename))


### PR DESCRIPTION
This commit introduces new features and utilities related to the backup
and restore system that make use of remote URLs:

- `discourse restore` accepts a URL to a backup file

- `discourse backup_url` generates a URL of a backup file (S3 only)

- `discourse import_backup_url` downloads a backup file from a URL to
the configured backup store

This can be used to move content between two Discourse instances by
backing up the entire site, copying the backup URL, importing or
restoring it on the other instance.
