### PR TITLE
UX: fix mobile positioning for content editable (rich editor)

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1018,7 +1018,8 @@ div.ac-wrap {
   //
   // Source https://gist.github.com/kiding/72721a0553fa93198ae2bb6eefaa3299
   input:focus,
-  textarea:focus {
+  textarea:focus,
+  [contenteditable="true"]:focus-within {
     animation: blink_input_opacity_to_prevent_scrolling_when_focus 0.01s;
   }
 }


### PR DESCRIPTION
Uses the same hack that the markdown editor (`textarea`) uses to avoid iOS shifting the mobile composer, when using the rich editor/ a content editable.