### PR TITLE
FIX: Ensure `copy_data` callbacks run even when all rows are skipped

### DIFF
--- a/migrations/lib/importer/copy_step.rb
+++ b/migrations/lib/importer/copy_step.rb
@@ -91,14 +91,18 @@ module Migrations::Importer
     end
 
     def fetch_rows
+      skip_row_marker = ::Migrations::Importer::DiscourseDB::SKIP_ROW_MARKER
+
       Enumerator.new do |enumerator|
         query, parameters = self.class.rows_query
+
         @intermediate_db.query(query, *parameters) do |row|
           if (transformed_row = transform_row(row))
-            enumerator << { data: transformed_row, skip: false }
+            enumerator << transformed_row
             @stats.reset
           else
-            enumerator << { data: row, skip: true }
+            row[skip_row_marker] = true
+            enumerator << row
             @stats.reset(skip_count: 1)
           end
 

--- a/migrations/lib/importer/copy_step.rb
+++ b/migrations/lib/importer/copy_step.rb
@@ -75,35 +75,30 @@ module Migrations::Importer
     def copy_data
       table_name = self.class.table_name || self.class.name&.demodulize&.underscore
       column_names = self.class.column_names || @discourse_db.column_names(table_name)
-      skipped_rows = []
 
       if self.class.store_mapped_ids?
         @last_id = @discourse_db.last_id_of(table_name)
         @mapping_type = find_mapping_type(table_name)
       end
 
-      @discourse_db.copy_data(table_name, column_names, fetch_rows(skipped_rows)) do |inserted_rows|
-        after_commit_of_inserted_rows(inserted_rows)
-
-        if skipped_rows.any?
-          after_commit_of_skipped_rows(skipped_rows)
-          skipped_rows.clear
-        end
+      @discourse_db.copy_data(table_name, column_names, fetch_rows) do |inserted_rows, skipped_rows|
+        after_commit_of_inserted_rows(inserted_rows) if inserted_rows.any?
+        after_commit_of_skipped_rows(skipped_rows) if skipped_rows.any?
       end
 
       @discourse_db.fix_last_id_of(table_name) if self.class.store_mapped_ids?
       @intermediate_db.commit_transaction
     end
 
-    def fetch_rows(skipped_rows)
+    def fetch_rows
       Enumerator.new do |enumerator|
         query, parameters = self.class.rows_query
         @intermediate_db.query(query, *parameters) do |row|
           if (transformed_row = transform_row(row))
-            enumerator << transformed_row
+            enumerator << { data: transformed_row, skip: false }
             @stats.reset
           else
-            skipped_rows << row
+            enumerator << { data: row, skip: true }
             @stats.reset(skip_count: 1)
           end
 


### PR DESCRIPTION
Currently, if a  batch "copy" of an import step results in all rows being skipped, the `after_commit_of_skipped_rows` callback is never triggered. This happens because the callback is nested inside a block that only runs when at least one row is inserted.

This change ensures the DB copy operation returns both inserted and skipped rows, allowing the caller to respond appropriately in either case.