### PR TITLE
FIX: improvements for admin search

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -142,8 +142,8 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
       {
         description: "first page",
         icon: "house",
-        keywords: "exact setting",
-        label: "Page about exact setting",
+        keywords: "exact settings",
+        label: "Page about whatever",
         type: "page",
         url: "/admin",
       },
@@ -152,14 +152,14 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
       {
         description: "first setting",
         icon: "house",
-        keywords: "exact setting",
+        keywords: "exact settings",
         label: "exact setting",
         type: "setting",
         url: "/admin",
       },
     ];
-    let results = this.subject.search("exact setting");
-    assert.deepEqual(results[0].label, "Page about exact setting");
+    let results = this.subject.search("exact      setting");
+    assert.deepEqual(results[0].label, "Page about whatever");
   });
 });
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5373,6 +5373,7 @@ en:
 
         logo:
           title: "Logo"
+          header_description: "Configure the logos and icons used throughout your site"
           form:
             saved: "Logo settings are saved."
             logo:
@@ -5437,6 +5438,7 @@ en:
               help_text: "recommended size is at least 280 x 150 pixels. Don't use an SVG image."
         fonts:
           title: "Fonts"
+          header_description: "Configure the fonts used throughout your site, including base font, heading font, and default text size"
           form:
             more_fonts: "More fonts"
             fewer_fonts: "Fewer fonts"


### PR DESCRIPTION
Some adjustments to improve admin search results:
- trim filter phrase and remove multiple spaces
- score for partial label match: "the" should find "Theme and Components"
- partial keyword score: "custom field" should find "custom fields"
- for keyword and fallback searches, ensure the keyword has at least 3 character to not be flooded by "the", "a", "and" etc.
<img width="728" alt="Screenshot 2025-05-30 at 1 52 38 pm" src="https://github.com/user-attachments/assets/4d97800d-6ec1-4a54-8ea5-78ceb75b93b8" />
<img width="730" alt="Screenshot 2025-05-30 at 1 52 46 pm" src="https://github.com/user-attachments/assets/ca7baa4e-f19e-4512-ab35-63e594a571cc" />
<img width="733" alt="Screenshot 2025-05-30 at 1 52 54 pm" src="https://github.com/user-attachments/assets/7f5ea85b-11ca-4f59-a564-72364d2a65be" />
<img width="721" alt="Screenshot 2025-05-30 at 1 56 18 pm" src="https://github.com/user-attachments/assets/eb42a293-f14b-4bfa-ad6b-9f63b5fe3303" />
