### PR TITLE
DEV: Remove application code from old migration

### DIFF
--- a/db/migrate/20210215231312_fix_group_flair_avatar_upload_security_and_acls.rb
+++ b/db/migrate/20210215231312_fix_group_flair_avatar_upload_security_and_acls.rb
@@ -16,15 +16,6 @@ class FixGroupFlairAvatarUploadSecurityAndAcls < ActiveRecord::Migration[6.0]
         UPDATE uploads SET secure = false, security_last_changed_at = :now, updated_at = :now, security_last_changed_reason = :reason
         WHERE id IN (:upload_ids) AND uploads.secure
       SQL
-
-      if Discourse.store.external?
-        uploads =
-          Upload.where(id: upload_ids, secure: false).where("updated_at = security_last_changed_at")
-        uploads.each do |upload|
-          Discourse.store.update_upload_ACL(upload)
-          upload.touch
-        end
-      end
     end
   end
 

--- a/db/migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
+++ b/db/migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
@@ -17,14 +17,6 @@ class FixBadgeImageAvatarUploadSecurityAndAcls < ActiveRecord::Migration[6.1]
         UPDATE uploads SET secure = false, security_last_changed_at = :now, updated_at = :now, security_last_changed_reason = :reason
         WHERE id IN (:upload_ids)
       SQL
-
-      if Discourse.store.external?
-        uploads = Upload.where(id: upload_ids)
-        uploads.each do |upload|
-          Discourse.store.update_upload_ACL(upload)
-          upload.touch
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Application code should not be used in migrations since we want
migrations to be idempotent. Since these migrations were added 4 years
ago, the application code is safe to be removed.

This will allow me to make changes to the `FileStore::S3Store#update_upload_ACL` method without having to worry about these migrations.