### PR TITLE
FIX: handle redirect issue with categoryId rewriting page number

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -422,7 +422,10 @@ class ListController < ApplicationController
     end
     real_slug = @category.full_slug("/")
     if CGI.unescape(current_slug) != CGI.unescape(real_slug)
-      url = CGI.unescape(request.fullpath).gsub(current_slug, real_slug)
+      path = CGI.unescape(request.path)
+      query = request.query_string
+      new_path = path.gsub(current_slug, real_slug)
+      url = query.present? ? "#{new_path}?#{query}" : new_path
       if ActionController::Base.config.relative_url_root
         url = url.sub(ActionController::Base.config.relative_url_root, "")
       end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1208,6 +1208,13 @@ RSpec.describe ListController do
       expect(response.status).to eq(200)
     end
 
+    it "redirects to the canonical slug without altering query parameters" do
+      # Simulate a request with just the category ID in the path, and a query param that matches the ID
+      get "/c/#{category.id}.json?page=#{category.id}"
+      expect(response.status).to eq(301)
+      expect(response).to redirect_to("/c/#{category.slug}/#{category.id}.json?page=#{category.id}")
+    end
+
     it "redirects to URL with correct case slug" do
       category.update!(slug: "hello")
 


### PR DESCRIPTION
### Description
When accessing a category via `<baseUrl>/c/<categoryId>.json?page={pageNumber}`, it issues a redirect to `<baseUrl>/c/<categorySlug>/<categoryId>.json?.....`. During this redirect, any numeric occurrence matching the categoryId in the query string is also rewritten - including the page parameter - causing incorrect behavior (e.g., `page=5` becoming `page=community/5`).

This PR fixes the logic ensuring that the query parameters remain intact.

### How to reproduce?
Try opening this link https://meta.discourse.org/c/10.json?page=10 in the browser. It will throw a 400 Bad Request error. When we inspect the url, we will notice the page number has been replaced by the `slug/categoryId`