### PR TITLE
UX: Move to regular border radius variable

### DIFF
--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -46,7 +46,7 @@
     cursor: pointer;
     border: 1px solid var(--primary-low);
     color: var(--primary);
-    border-radius: var(--d-button-border-radius);
+    border-radius: var(--d-border-radius);
 
     .discourse-no-touch & {
       &:hover {


### PR DESCRIPTION
Using the button border radius variable can make these cards edges look too rounded.