### PR TITLE
DEV: remove educational tips and associated site settings

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -697,24 +697,6 @@ en:
 
       For more tips and advice on participating in our community, [check out our community guidelines](%{base_path}/guidelines).
 
-    avatar: |
-      ### How about a picture for your account?
-
-      You’ve posted a few topics and replies, but your profile picture isn’t as unique as you are – it’s just a letter.
-
-      Have you considered **[visiting your user profile](%{profile_path})** and uploading a picture that represents you?
-
-      It’s easier to follow discussions and find interesting people in conversations when everyone has a unique profile picture!
-
-    sequential_replies: |
-      ### Consider replying to several posts at once
-
-      Rather than several replies to a topic in a row, please consider a single reply that includes quotes from previous posts or @name references.
-
-      You can edit your previous reply to add a quote by highlighting text and selecting the <b>quote reply</b> button that appears.
-
-      It’s easier for everyone to read topics that have fewer in-depth replies versus lots of small, individual replies.
-
     dominating_topic: You've posted a lot in this topic! Consider giving others an opportunity to participate, too.
 
     get_a_room:
@@ -725,13 +707,6 @@ en:
 
     too_many_replies: |
       New users are temporarily limited to %{newuser_max_replies_per_topic} replies in the same topic. Please consider visiting other topics to keep getting to know the community.
-
-    reviving_old_topic: |
-      ### Revive this topic?
-
-      The last reply to this topic was **%{time_ago}**. Your reply will bump the topic to the top of its list and notify anyone previously involved in the conversation.
-
-      Are you sure you want to continue this old conversation?
 
   activerecord:
     attributes:
@@ -2472,8 +2447,6 @@ en:
 
     allow_profile_backgrounds: "Allow users to upload profile backgrounds."
 
-    sequential_replies_threshold: "Number of posts a user has to make in a row in a topic before being reminded about too many sequential replies."
-
     get_a_room_threshold: "Number of posts a user has to make to the same person in the same topic before being warned."
 
     dont_feed_the_trolls_threshold: "Number of flags from other users before being warned."
@@ -2481,8 +2454,6 @@ en:
     enable_mobile_theme: "Mobile devices use a mobile-friendly theme, with the ability to switch to the full site. Disable this if you want to use a custom stylesheet that is fully responsive."
 
     dominating_topic_minimum_percent: "What percentage of posts a user has to make in a topic before being reminded about overly dominating a topic."
-
-    disable_avatar_education_message: "Disable education message for changing avatar."
 
     pm_warn_user_last_seen_months_ago: "When creating a new PM warn users when target recepient has not been seen more than n months ago."
 
@@ -2536,7 +2507,6 @@ en:
     show_time_gap_days: "If two posts are made this many days apart, display the time gap in the topic."
     short_progress_text_threshold: "After the number of posts in a topic goes above this number, the progress bar will only show the current post number. If you change the progress bar's width, you may need to change this value."
     default_code_lang: "Default programming language syntax highlighting applied to markdown code blocks (auto, text, ruby, python etc.). This value must also be present in the `highlighted languages` site setting."
-    warn_reviving_old_topic_age: "When someone starts replying to a topic where the last reply is older than this many days, a warning will be displayed. Disable by setting to 0."
     autohighlight_all_code: "Apply syntax highlighting to HTML-authored &lt;code&gt; blocks, even if they didn't specify a language. To configure markdown-authored code blocks, use the 'default code lang' setting."
     highlighted_languages: "Included syntax highlighting rules. (Warning: including too many languages may impact performance) see: <a href='https://highlightjs.org/demo/' target='_blank'>https://highlightjs.org/demo</a> for a demo"
     show_copy_button_on_codeblocks: "Add a button to codeblocks to copy the block contents to the user's clipboard."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1372,9 +1372,6 @@ posting:
     client: true
     default: "auto"
     area: "posts_and_topics"
-  warn_reviving_old_topic_age:
-    default: 180
-    area: "posts_and_topics"
   autohighlight_all_code:
     client: true
     default: false
@@ -3283,9 +3280,6 @@ uncategorized:
   educate_until_posts:
     default: 2
     area: "users"
-  sequential_replies_threshold:
-    default: 2
-    area: "stats_and_thresholds"
   get_a_room_threshold:
     default: 3
     area: "stats_and_thresholds"
@@ -3295,9 +3289,6 @@ uncategorized:
   dominating_topic_minimum_percent:
     default: 40
     area: "stats_and_thresholds"
-  disable_avatar_education_message:
-    default: false
-    area: "users"
   pm_warn_user_last_seen_months_ago:
     default: 24
     area: "users"

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -22,12 +22,11 @@ RSpec.describe ComposerMessagesController do
       end
 
       it "delegates args to the finder" do
-        user.user_stat.update!(post_count: 10)
-
         get "/composer_messages.json", params: args
         expect(response.status).to eq(200)
+
         json = response.parsed_body
-        expect(json["composer_messages"].first["id"]).to eq("reviving_old")
+        expect(json["composer_messages"].first["id"]).to eq("education")
       end
     end
   end

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ComposerMessagesController do
 
       it "delegates args to the finder" do
         user.user_stat.update!(post_count: 10)
-        SiteSetting.disable_avatar_education_message = true
 
         get "/composer_messages.json", params: args
         expect(response.status).to eq(200)

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -66,7 +66,6 @@ module SystemHelpers
     SiteSetting.force_hostname = Capybara.server_host
     SiteSetting.port = Capybara.server_port
     SiteSetting.external_system_avatars_enabled = false
-    SiteSetting.disable_avatar_education_message = true
     SiteSetting.enable_user_tips = false
     SiteSetting.splash_screen = false
     SiteSetting.allowed_internal_hosts =


### PR DESCRIPTION
Removes the composer educational tips for:

- upload avatar
- sequential replies 
- reviving old topic

We are also removing the associated site settings that are now redundant:

- Disable avatar education message
- Sequential replies threshold
- Warn reviving old topic age

Note: we will remove these site settings from the database in a follow up PR.

Internal ref: /t/150274