### PR TITLE
UX: Fix active menu item bottom border

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -205,6 +205,8 @@
       border-top: 1px solid var(--primary-low);
       border-left: 1px solid var(--primary-low);
       border-right: 1px solid var(--primary-low);
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
 
       > .d-icon {
         color: var(--primary-medium);


### PR DESCRIPTION
The border radius should not be present at the bottom of menu icons.