### PR TITLE
UX: make sure search context is kept when navigating

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -218,7 +218,7 @@ export default class SearchMenu extends Component {
 
   @action
   clearPMInboxContext() {
-    this.inPMInboxContext = false;
+    this.search.searchContext = null;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -44,8 +44,6 @@ export default class SearchMenu extends Component {
   @service appEvents;
 
   @tracked loading = false;
-  @tracked
-  inPMInboxContext = this.search.searchContext?.type === "private_messages";
   @tracked typeFilter = DEFAULT_TYPE_FILTER;
   @tracked suggestionKeyword = false;
   @tracked suggestionResults = [];
@@ -112,6 +110,10 @@ export default class SearchMenu extends Component {
     }
 
     return false;
+  }
+
+  get inPMInboxContext() {
+    return this.search.searchContext?.type === "private_messages";
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -51,6 +51,9 @@ export default class SearchMenu extends Component {
   @tracked menuPanelOpen = false;
 
   searchInputId = this.args.searchInputId ?? "search-term";
+
+  @tracked isPMInboxCleared = false;
+
   _debouncer = null;
   _activeSearch = null;
 
@@ -113,7 +116,10 @@ export default class SearchMenu extends Component {
   }
 
   get inPMInboxContext() {
-    return this.search.searchContext?.type === "private_messages";
+    return (
+      !this.isPMInboxCleared &&
+      this.search.searchContext?.type === "private_messages"
+    );
   }
 
   @action
@@ -218,7 +224,7 @@ export default class SearchMenu extends Component {
 
   @action
   clearPMInboxContext() {
-    this.search.searchContext = null;
+    this.isPMInboxCleared = true;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -203,6 +203,9 @@ export default class SearchMenu extends Component {
     if (opts.setTopicContext) {
       this.search.inTopicContext = true;
     }
+    if (opts.setPMInboxContext) {
+      this.isPMInboxCleared = false;
+    }
     this.search.activeGlobalSearchTerm = term;
     this.triggerSearch();
   }

--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -44,6 +44,7 @@ export default class SearchMenu extends Component {
   @service appEvents;
 
   @tracked loading = false;
+  @tracked isPMInboxCleared = false;
   @tracked typeFilter = DEFAULT_TYPE_FILTER;
   @tracked suggestionKeyword = false;
   @tracked suggestionResults = [];
@@ -51,8 +52,6 @@ export default class SearchMenu extends Component {
   @tracked menuPanelOpen = false;
 
   searchInputId = this.args.searchInputId ?? "search-term";
-
-  @tracked isPMInboxCleared = false;
 
   _debouncer = null;
   _activeSearch = null;

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -122,10 +122,14 @@ export default class AssistantItem extends Component {
       return;
     }
 
+    const inPMInboxContext =
+      this.search.searchContext?.type === "private_messages";
     this.args.searchTermChanged(updatedTerm, {
       searchTopics,
       ...(inTopicContext &&
         !this.args.searchAllTopics && { setTopicContext: true }),
+      ...(!this.args.searchAllTopics &&
+        inPMInboxContext && { setPMInboxContext: true }),
     });
     this.search.focusSearchInput();
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
@@ -1,4 +1,10 @@
-import { click, fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
+import {
+  click,
+  fillIn,
+  render,
+  settled,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import SearchMenu, {
   DEFAULT_TYPE_FILTER,
@@ -105,5 +111,35 @@ module("Integration | Component | search-menu", function (hooks) {
     assert
       .dom("#search-term.search-term__input")
       .exists("input defaults to id of search-term");
+  });
+
+  test("search-context state changes updates the UI", async function (assert) {
+    const searchService = this.owner.lookup("service:search");
+
+    searchService.searchContext = null;
+    searchService.inTopicContext = false;
+    await render(<template><SearchMenu @location="test" /></template>);
+
+    assert
+      .dom(".search-context")
+      .doesNotExist("no search context button when searchContext is null");
+
+    searchService.searchContext = { type: "private_messages" };
+    await settled();
+
+    assert
+      .dom(".search-context")
+      .exists(
+        "PM context button appears when searchContext.type changes to private_messages"
+      );
+
+    searchService.searchContext = null;
+    await settled();
+
+    assert
+      .dom(".search-context")
+      .doesNotExist(
+        "PM context button disappears when searchContext changes back to null"
+      );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
@@ -133,13 +133,10 @@ module("Integration | Component | search-menu", function (hooks) {
         "PM context button appears when searchContext.type changes to private_messages"
       );
 
-    searchService.searchContext = null;
-    await settled();
+    await click(".search-context");
 
     assert
       .dom(".search-context")
-      .doesNotExist(
-        "PM context button disappears when searchContext changes back to null"
-      );
+      .doesNotExist("PM context button disappears when clear btn is pressed");
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu-test.gjs
@@ -139,4 +139,30 @@ module("Integration | Component | search-menu", function (hooks) {
       .dom(".search-context")
       .doesNotExist("PM context button disappears when clear btn is pressed");
   });
+
+  test("PM inbox context can be restored after being cleared", async function (assert) {
+    const searchService = this.owner.lookup("service:search");
+
+    searchService.searchContext = { type: "private_messages" };
+    searchService.inTopicContext = false;
+
+    await render(<template><SearchMenu @location="test" /></template>);
+
+    assert.dom(".search-context").exists("PM context button appears initially");
+
+    await click(".search-context");
+    assert
+      .dom(".search-context")
+      .doesNotExist("PM context button disappears when cleared");
+
+    await click("#search-term");
+
+    await click(".search-menu-assistant-item .search-item-slug");
+
+    assert
+      .dom(".search-context")
+      .exists(
+        "PM context button reappears after selecting 'in:messages' suggestion"
+      );
+  });
 });


### PR DESCRIPTION
Uses a getter to reactively re-render the search context (eg. "in messages").

Also fixes an issue where although the in:messages suggestion appeared, it didn't work to add the PM context.