### PR TITLE
UX: Update some delete confirmation dialogs

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
@@ -216,8 +216,8 @@ export default class AdminBadgesShow extends Component {
       return this.router.transitionTo("adminBadges.index");
     }
 
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.badges.delete_confirm"),
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.badges.delete_confirm"),
       didConfirm: async () => {
         try {
           await this.formApi.reset();

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -148,8 +148,8 @@ export default class AdminConfigAreasColorPalette extends Component {
 
   @action
   async delete() {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.config_areas.color_palettes.delete_confirm"),
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.config_areas.color_palettes.delete_confirm"),
       didConfirm: async () => {
         await this.args.colorPalette.destroy();
         await this.router.replaceWith("adminConfig.colorPalettes");

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
@@ -376,8 +376,8 @@ class ComponentRow extends Component {
 
   @action
   delete() {
-    return this.dialog.yesNoConfirm({
-      message: i18n(
+    return this.dialog.deleteConfirm({
+      title: i18n(
         "admin.config_areas.themes_and_components.components.delete_confirm",
         { name: this.args.component.name }
       ),

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
@@ -49,8 +49,8 @@ export default class AdminConfigAreasUserFieldsList extends Component {
 
   @action
   destroyField(field) {
-    this.dialog.yesNoConfirm({
-      message: i18n("admin.user_fields.delete_confirm"),
+    this.dialog.deleteConfirm({
+      title: i18n("admin.user_fields.delete_confirm"),
       didConfirm: () => {
         this.#deleteField(field);
       },

--- a/app/assets/javascripts/admin/addon/components/form-template/form.gjs
+++ b/app/assets/javascripts/admin/addon/components/form-template/form.gjs
@@ -99,8 +99,8 @@ export default class FormTemplateForm extends Component {
 
   @action
   onDelete() {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.form_templates.delete_confirm"),
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.form_templates.delete_confirm"),
       didConfirm: () => {
         FormTemplate.deleteTemplate(this.args.model.id)
           .then(() => {

--- a/app/assets/javascripts/admin/addon/components/form-template/row-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/form-template/row-item.gjs
@@ -30,8 +30,8 @@ export default class FormTemplateRowItem extends Component {
 
   @action
   deleteTemplate() {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.form_templates.delete_confirm", {
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.form_templates.delete_confirm", {
         template_name: this.args.template.name,
       }),
       didConfirm: () => {

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
@@ -76,8 +76,8 @@ export default class AdminCustomizeColorsShowController extends Controller {
 
   @action
   destroy() {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.customize.colors.delete_confirm"),
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.customize.colors.delete_confirm"),
       didConfirm: () => {
         return this.model.destroy().then(() => {
           this.allColors.removeObject(this.model);

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -398,8 +398,8 @@ export default class AdminCustomizeThemesShowController extends Controller {
 
   @action
   removeUpload(upload) {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.customize.theme.delete_upload_confirm"),
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.customize.theme.delete_upload_confirm"),
       didConfirm: () => this.model.removeField(upload),
     });
   }
@@ -411,8 +411,8 @@ export default class AdminCustomizeThemesShowController extends Controller {
 
   @action
   destroyTheme() {
-    return this.dialog.yesNoConfirm({
-      message: i18n("admin.customize.delete_confirm", {
+    return this.dialog.deleteConfirm({
+      title: i18n("admin.customize.delete_confirm", {
         theme_name: this.get("model.name"),
       }),
       didConfirm: () => {

--- a/app/assets/javascripts/admin/addon/controllers/admin-permalinks-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-permalinks-index.js
@@ -44,8 +44,8 @@ export default class AdminPermalinksIndexController extends Controller {
 
   @action
   destroyRecord(permalink) {
-    this.dialog.yesNoConfirm({
-      message: i18n("admin.permalink.delete_confirm"),
+    this.dialog.deleteConfirm({
+      title: i18n("admin.permalink.delete_confirm"),
       didConfirm: async () => {
         try {
           await this.store.destroyRecord("permalink", permalink);

--- a/app/assets/javascripts/admin/addon/services/admin-emojis.js
+++ b/app/assets/javascripts/admin/addon/services/admin-emojis.js
@@ -53,8 +53,8 @@ export default class AdminEmojis extends Service {
 
   @action
   destroyEmoji(emoji) {
-    this.dialog.yesNoConfirm({
-      message: i18n("admin.emoji.delete_confirm", {
+    this.dialog.deleteConfirm({
+      title: i18n("admin.emoji.delete_confirm", {
         name: emoji.get("name"),
       }),
       didConfirm: () => this.#destroyEmoji(emoji),

--- a/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/sidebar-section-form.gjs
@@ -507,8 +507,8 @@ export default class SidebarSectionForm extends Component {
 
   @action
   delete() {
-    return this.dialog.yesNoConfirm({
-      message: this.model.section.public
+    return this.dialog.deleteConfirm({
+      title: this.model.section.public
         ? i18n("sidebar.sections.custom.delete_public_confirm")
         : i18n("sidebar.sections.custom.delete_confirm"),
       didConfirm: () => {

--- a/app/assets/javascripts/discourse/app/components/user-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-stream.gjs
@@ -80,8 +80,8 @@ export default class UserStreamComponent extends Component {
 
   @action
   removeDraft(draft) {
-    this.dialog.yesNoConfirm({
-      message: i18n("drafts.remove_confirmation"),
+    this.dialog.deleteConfirm({
+      title: i18n("drafts.remove_confirmation"),
       didConfirm: async () => {
         try {
           await Draft.clear(draft.draft_key, draft.sequence);

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -160,8 +160,8 @@ export default class EditCategoryTabsController extends Controller {
   @action
   deleteCategory() {
     this.set("deleting", true);
-    this.dialog.yesNoConfirm({
-      message: i18n("category.delete_confirm"),
+    this.dialog.deleteConfirm({
+      title: i18n("category.delete_confirm"),
       didConfirm: () => {
         this.model
           .destroy()

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -15,9 +15,9 @@ acceptance("User Drafts", function (needs) {
       .doesNotExist("Draft doesn't show expand button");
 
     await click(".user-stream-item:first-child .remove-draft");
-    assert.dom(".dialog-body").exists();
+    assert.dom(".dialog-header").exists();
 
-    await click(".dialog-footer .btn-primary");
+    await click(".dialog-footer .btn-danger");
     assert
       .dom(".user-stream-item")
       .exists({ count: 2 }, "draft removed, list length diminished by one");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4988,7 +4988,7 @@ en:
           save: "Save"
           delete: "Delete"
           delete_confirm: "Are you sure you want to delete this section?"
-          delete_public_confirm: "This section is <strong>visible to everyone</strong>, are you sure you want to delete it?"
+          delete_public_confirm: "This section is visible to everyone, are you sure you want to delete it?"
           update_public_confirm: "Changes will be <strong>visible to everyone</strong> on this site. Are you sure?"
           mark_as_private_confirm: "This section is <strong>visible to everyone</strong>. After the update, it will be <strong>visible only to you</strong>. Are you sure?"
           reset_confirm: "Are you sure you want to reset this section to default?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6404,7 +6404,7 @@ en:
           copy_of: "Copy of %{name}"
           copy_created: 'A new copy of "%{name}" has been created'
           illegal_character_in_color: "Colors consist of hexadecimal characters only"
-          delete_confirm: "Delete this color palette?"
+          delete_confirm: "Are you sure you want to delete this color palette?"
       plugins:
         title: "Plugins"
         name: "Name"
@@ -6785,7 +6785,7 @@ en:
           about: "Modify the colors used by your themes. Create a new color palette to start."
           new_name: "New color palette"
           copy_name_prefix: "Copy of"
-          delete_confirm: "Delete this color palette?"
+          delete_confirm: "Are you sure you want to delete this color palette?"
           undo: "Undo"
           undo_title: "Undo your changes to this color since the last time it was saved."
           revert: "Revert"

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -119,7 +119,7 @@ describe "Admin Badges Page", type: :system do
       expect(badges_page).to have_saved_form
       badges_page.form.field("name").fill_in("another name")
       badges_page.delete_badge
-      dialog.click_yes
+      dialog.click_danger
 
       expect(page).to have_current_path("/admin/badges")
     end

--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -146,7 +146,7 @@ describe "Admin Color Palette Config Area Page", type: :system do
 
     config_area.delete_button.click
 
-    dialog.click_yes
+    dialog.click_danger
 
     expect(page).to have_current_path("/admin/config/colors")
 

--- a/spec/system/admin_customize_components_config_area_spec.rb
+++ b/spec/system/admin_customize_components_config_area_spec.rb
@@ -217,7 +217,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
       config_area.component(disabled_component.id).more_actions_menu.expand
       config_area.component(disabled_component.id).delete_button.click
 
-      dialog.click_yes
+      dialog.click_danger
 
       expect(toasts).to have_success(
         I18n.t(

--- a/spec/system/admin_customize_emojis_spec.rb
+++ b/spec/system/admin_customize_emojis_spec.rb
@@ -21,7 +21,7 @@ describe "Admin Customize Emoji Page", type: :system do
   it "can delete a custom emoji" do
     emojis_page.visit_page
     emojis_page.delete_emoji("joffrey_facepalm")
-    dialog.click_yes
+    dialog.click_danger
     expect(emojis_page).to have_no_emoji_listed("joffrey_facepalm")
   end
 

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -29,7 +29,7 @@ module PageObjects
       end
 
       def confirm_delete
-        find(".dialog-container .btn-primary").click
+        find(".dialog-container .btn-danger").click
         closed?
       end
 

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -118,7 +118,7 @@ module PageObjects
       end
 
       def confirm_delete
-        find(".dialog-footer .btn-primary").click
+        find(".dialog-footer .btn-danger").click
       end
 
       private

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -27,7 +27,7 @@ module PageObjects
       def click_delete_permalink(url)
         open_permalink_menu(url)
         find(".admin-permalink-item__delete").click
-        find(".dialog-footer .btn-primary").click
+        find(".dialog-footer .btn-danger").click
         expect(page).to have_no_css(".dialog-body")
         has_closed_permalink_menu?
         self


### PR DESCRIPTION
More consistent format.

Before
![CleanShot 2025-05-30 at 14 28 19@2x](https://github.com/user-attachments/assets/38c94292-3099-44a1-9b44-c1f294af0512)


After 

![CleanShot 2025-05-30 at 14 27 38@2x](https://github.com/user-attachments/assets/6c2332cc-4650-45d0-8b4d-56a6d147eaa1)
