### PR TITLE
PERF: Remove `<details>` polyfill

### DIFF
--- a/plugins/discourse-details/assets/stylesheets/details.scss
+++ b/plugins/discourse-details/assets/stylesheets/details.scss
@@ -31,11 +31,6 @@ details.details__boxed {
   }
 }
 
-details > *,
-details .lightbox-wrapper {
-  display: none;
-}
-
 details,
 summary {
   outline: none;
@@ -58,19 +53,9 @@ summary::before {
   margin-right: 0.25em;
 }
 
-details[open] > *,
-details[open] .lightbox-wrapper {
-  display: block;
-}
-
 details[open] > summary::before,
 details.open > summary::before {
   content: "\25BC";
-}
-
-details[open] > summary:first-of-type ~ *,
-details.open > summary:first-of-type ~ * {
-  display: block;
 }
 
 /* hide native indicator */

--- a/plugins/discourse-details/test/javascripts/integration/prosemirror-editor/details-test.js
+++ b/plugins/discourse-details/test/javascripts/integration/prosemirror-editor/details-test.js
@@ -59,16 +59,16 @@ module(
 
       const detailsCss = ".d-editor-input details";
       const summaryCss = `${detailsCss} summary`;
-      assert.dom(`${detailsCss} p`).isNotVisible();
+      assert.dom(detailsCss).doesNotHaveAttribute("open");
 
-      await click(`${summaryCss}`);
-      assert.dom(`${detailsCss}`).hasAttribute("open");
+      await click(summaryCss);
+      assert.dom(detailsCss).hasAttribute("open");
 
       // click elsewhere first to avoid a double-click being detected
       await click(`${detailsCss} p`);
-      await click(`${summaryCss}`);
+      await click(summaryCss);
 
-      assert.dom(`${detailsCss}`).doesNotHaveAttribute("open");
+      assert.dom(detailsCss).doesNotHaveAttribute("open");
     });
   }
 );

--- a/plugins/discourse-details/test/javascripts/integration/prosemirror-editor/details-test.js
+++ b/plugins/discourse-details/test/javascripts/integration/prosemirror-editor/details-test.js
@@ -63,13 +63,11 @@ module(
 
       await click(`${summaryCss}`);
       assert.dom(`${detailsCss}`).hasAttribute("open");
-      assert.dom(`${detailsCss} p`).isVisible();
 
       // click elsewhere first to avoid a double-click being detected
       await click(`${detailsCss} p`);
       await click(`${summaryCss}`);
 
-      assert.dom(`${detailsCss} p`).isNotVisible();
       assert.dom(`${detailsCss}`).doesNotHaveAttribute("open");
     });
   }


### PR DESCRIPTION
When we first introduced the `discourse-details` plugin, the `<details>` element was not supported in all browsers, so this `display: none`-based polyfill had to be used.

Nowadays, there is no need for this. And in fact, the `details[open] > summary:first-of-type ~ *` selector is showing as our most expensive CSS selector during repaints.

Removing this `display: none` also means that browser find-in-page will now be able to correctly find content inside `<details>` in discourse.

![image](https://github.com/user-attachments/assets/e3d943f3-ec63-4c16-9096-44340a4f7df0)
