### PR TITLE
UX: avoid presence layout shift

### DIFF
--- a/plugins/discourse-presence/assets/stylesheets/presence.scss
+++ b/plugins/discourse-presence/assets/stylesheets/presence.scss
@@ -1,5 +1,5 @@
 .topic-above-footer-buttons-outlet.presence {
-  min-height: 2.5em; // height of the avatars, prevents layout shift
+  min-height: 2.55em; // height of the avatars, prevents layout shift
   margin: var(--below-topic-margin) 0;
 }
 


### PR DESCRIPTION
The space reserved for presence was just slightly too short, which was causing a layout shift when the indicator appears, this fixes it. 

![image](https://github.com/user-attachments/assets/d729c941-09c2-42ec-8e26-11b598697c94)
