### PR TITLE
DEV: Require `created_at` on `users`

### DIFF
--- a/migrations/config/intermediate_db.yml
+++ b/migrations/config/intermediate_db.yml
@@ -19,6 +19,9 @@ schema:
       primary_key_column_names: [ "user_id" ]
     users:
       columns:
+        modify:
+          - name: "created_at"
+            nullable: false
         add:
           - name: "original_username"
             datatype: text

--- a/migrations/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/db/intermediate_db_schema/100-base-schema.sql
@@ -80,7 +80,7 @@ CREATE TABLE users
     approved                  BOOLEAN,
     approved_at               DATETIME,
     approved_by_id            NUMERIC,
-    created_at                DATETIME,
+    created_at                DATETIME  NOT NULL,
     date_of_birth             DATE,
     first_seen_at             DATETIME,
     flair_group_id            NUMERIC,

--- a/migrations/lib/database/intermediate_db/user.rb
+++ b/migrations/lib/database/intermediate_db/user.rb
@@ -48,7 +48,7 @@ module Migrations::Database::IntermediateDB
       approved: nil,
       approved_at: nil,
       approved_by_id: nil,
-      created_at: nil,
+      created_at:,
       date_of_birth: nil,
       first_seen_at: nil,
       flair_group_id: nil,


### PR DESCRIPTION
Add a table-level override to require `created_at` on `users` table