### PR TITLE
UX: more consistent search menu spacing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/assistant-item.gjs
@@ -144,7 +144,7 @@ export default class AssistantItem extends Component {
       data-usage={{@usage}}
     >
       <a class={{concatClass @typeClass "search-link"}} href={{this.href}}>
-        <span aria-label={{i18n "search.title"}}>
+        <span class="search-icon-wrapper" aria-label={{i18n "search.title"}}>
           {{icon (or @icon "magnifying-glass")}}
         </span>
         <span class="search-item-wrapper">

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -40,7 +40,7 @@
 
     .search-menu-panel & {
       @include viewport.from(sm) {
-        padding: 0.75em 1rem 0.25em;
+        padding: 0.75rem 1rem 0;
       }
     }
   }
@@ -135,6 +135,7 @@
     display: flex;
     flex-direction: column;
     border-radius: var(--d-border-radius);
+    padding-top: 0.75rem;
 
     .heading {
       padding: 0.5em 0 0 1rem;
@@ -415,13 +416,9 @@
 }
 
 .search-random-quick-tip {
-  padding: max(0.75rem, 0.75em) 1rem;
+  padding: 0 1rem 0.75rem;
   font-size: var(--font-down-2);
   color: var(--primary-medium);
-
-  .search-menu-panel & {
-    padding: 0.5rem 1rem max(0.75rem, 0.75em);
-  }
 
   .tip-label {
     background-color: rgb(var(--tertiary-rgb), 0.1);

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -124,7 +124,7 @@
       }
     }
 
-    .results {
+    .search-menu-container .results {
       @include float-down;
       box-sizing: border-box;
       border-radius: var(--d-border-radius);
@@ -133,9 +133,14 @@
       left: 0;
       top: 100%;
       right: 0;
+      padding-top: 0;
 
       @include viewport.until(sm) {
         width: 100%;
+      }
+
+      .search-random-quick-tip {
+        padding-top: 0.75rem;
       }
 
       ul,
@@ -144,7 +149,7 @@
         margin: 0;
       }
 
-      .d-icon-magnifying-glass {
+      .search-icon-wrapper {
         display: none;
       }
     }


### PR DESCRIPTION
This gives the search input in the header dropdown consistent spacing by adding top padding to the results wrapper (always present), which avoids issues like this (too little space below while loading):

![image](https://github.com/user-attachments/assets/2b9c0ff2-b0fe-4334-a69c-d3e47cfd86fc)

Also fixes this slight misalignment (`test in all topics and posts` has an extra space on the left):

![image](https://github.com/user-attachments/assets/831efebd-6fbc-4274-b6a7-dad4c3aebb34)

![image](https://github.com/user-attachments/assets/740b318c-6098-4b05-aad2-cc4feb35e79b)
