### PR TITLE
FIX: when new new is enabled, filter dismiss modal to correct type

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
@@ -44,19 +44,11 @@ export default class DismissNew extends Component {
   }
 
   get showDismissNewTopics() {
-    if (this.partialDismiss) {
-      return this.countNewTopics > 0;
-    }
-
-    return this.subset === TOPICS_SUBSET || !this.subset;
+    return this.partialDismiss ? this.countNewTopics > 0 : true;
   }
 
   get showDismissNewReplies() {
-    if (this.partialDismiss) {
-      return this.countNewReplies > 0;
-    }
-
-    return this.subset === REPLIES_SUBSET || !this.subset;
+    return this.partialDismiss ? this.countNewReplies > 0 : true;
   }
 
   get countNewTopics() {
@@ -107,18 +99,22 @@ export default class DismissNew extends Component {
     >
       <:body>
         <p>
-          <PreferenceCheckbox
-            @labelKey={{this.dismissNewTopicsLabel}}
-            @labelCount={{this.countNewTopics}}
-            @checked={{this.dismissTopics}}
-            class="dismiss-topics"
-          />
-          <PreferenceCheckbox
-            @labelKey={{this.dismissNewRepliesLabel}}
-            @labelCount={{this.countNewReplies}}
-            @checked={{this.dismissPosts}}
-            class="dismiss-posts"
-          />
+          {{#if this.showDismissNewTopics}}
+            <PreferenceCheckbox
+              @labelKey={{this.dismissNewTopicsLabel}}
+              @labelCount={{this.countNewTopics}}
+              @checked={{this.dismissTopics}}
+              class="dismiss-topics"
+            />
+          {{/if}}
+          {{#if this.showDismissNewReplies}}
+            <PreferenceCheckbox
+              @labelKey={{this.dismissNewRepliesLabel}}
+              @labelCount={{this.countNewReplies}}
+              @checked={{this.dismissPosts}}
+              class="dismiss-posts"
+            />
+          {{/if}}
           <PreferenceCheckbox
             @labelKey="topics.bulk.dismiss_new_modal.untrack"
             @checked={{this.untrack}}

--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
@@ -6,9 +6,6 @@ import DModal from "discourse/components/d-modal";
 import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import { i18n } from "discourse-i18n";
 
-const REPLIES_SUBSET = "replies";
-const TOPICS_SUBSET = "topics";
-
 export default class DismissNew extends Component {
   @tracked untrack = false;
   @tracked dismissTopics = true;

--- a/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/dismiss-new.gjs
@@ -107,22 +107,18 @@ export default class DismissNew extends Component {
     >
       <:body>
         <p>
-          {{#if this.showDismissNewTopics}}
-            <PreferenceCheckbox
-              @labelKey={{this.dismissNewTopicsLabel}}
-              @labelCount={{this.countNewTopics}}
-              @checked={{this.dismissTopics}}
-              class="dismiss-topics"
-            />
-          {{/if}}
-          {{#if this.showDismissNewReplies}}
-            <PreferenceCheckbox
-              @labelKey={{this.dismissNewRepliesLabel}}
-              @labelCount={{this.countNewReplies}}
-              @checked={{this.dismissPosts}}
-              class="dismiss-posts"
-            />
-          {{/if}}
+          <PreferenceCheckbox
+            @labelKey={{this.dismissNewTopicsLabel}}
+            @labelCount={{this.countNewTopics}}
+            @checked={{this.dismissTopics}}
+            class="dismiss-topics"
+          />
+          <PreferenceCheckbox
+            @labelKey={{this.dismissNewRepliesLabel}}
+            @labelCount={{this.countNewReplies}}
+            @checked={{this.dismissPosts}}
+            class="dismiss-posts"
+          />
           <PreferenceCheckbox
             @labelKey="topics.bulk.dismiss_new_modal.untrack"
             @checked={{this.untrack}}

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -154,7 +154,7 @@ export default class DiscoveryListController extends Controller {
     this.modal.show(DismissNew, {
       model: {
         selectedTopics: this.bulkSelectHelper.selected,
-        subset: this.model.listParams?.subset,
+        subset: this.model.list?.listParams?.subset,
         dismissCallback: ({ dismissPosts, dismissTopics, untrack }) => {
           this.callResetNew(dismissPosts, dismissTopics, untrack);
         },

--- a/app/assets/javascripts/discourse/tests/integration/components/dismiss-new-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/dismiss-new-test.gjs
@@ -77,7 +77,7 @@ module("Integration | Component | modal/dismiss-new", function (hooks) {
       );
   });
 
-  test("no selected topics with topics subset", async function (assert) {
+  test("selected replies unchecked with topics subset", async function (assert) {
     const self = this;
 
     this.model.subset = "topics";
@@ -86,13 +86,13 @@ module("Integration | Component | modal/dismiss-new", function (hooks) {
       <template><DismissNew @inline={{true}} @model={{self.model}} /></template>
     );
 
-    assert.dom(".dismiss-posts").doesNotExist();
+    assert.dom(".dismiss-posts").isNotChecked();
     assert
       .dom(".dismiss-topics")
       .hasText(i18n("topics.bulk.dismiss_new_modal.topics"));
   });
 
-  test("no selected topics with replies subset", async function (assert) {
+  test("selected topics unchecked with replies subset", async function (assert) {
     const self = this;
 
     this.model.subset = "replies";
@@ -101,7 +101,7 @@ module("Integration | Component | modal/dismiss-new", function (hooks) {
       <template><DismissNew @inline={{true}} @model={{self.model}} /></template>
     );
 
-    assert.dom(".dismiss-topics").doesNotExist();
+    assert.dom(".dismiss-topics").isNotChecked();
     assert
       .dom(".dismiss-posts")
       .hasText(i18n("topics.bulk.dismiss_new_modal.replies"));

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Dismissing New", type: :system do
 
       visit("/new?subset=topics")
 
-      expect(topic_list).to have_topic(post1.topic)
+      expect(topic_list).to have_topic(new_topic)
 
       topic_list_controls.dismiss_new
 

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -142,6 +142,42 @@ RSpec.describe "Dismissing New", type: :system do
       expect(topic_list).to have_no_topics
     end
 
+    it "displays confirmation modal with preselected options" do
+      sign_in(user)
+
+      visit("/new?subset=replies")
+
+      expect(topic_list).to have_topic(post1.topic)
+
+      topic_list_controls.dismiss_new
+
+      expect(dismiss_new_modal).to have_dismiss_topics_unchecked
+      expect(dismiss_new_modal).to have_dismiss_posts_checked
+      expect(dismiss_new_modal).to have_untrack_unchecked
+
+      dismiss_new_modal.click_dismiss
+
+      expect(topic_list).to have_no_topics
+    end
+
+    it "displays confirmation modal with preselected options" do
+      sign_in(user)
+
+      visit("/new?subset=topics")
+
+      expect(topic_list).to have_topic(post1.topic)
+
+      topic_list_controls.dismiss_new
+
+      expect(dismiss_new_modal).to have_dismiss_topics_checked
+      expect(dismiss_new_modal).to have_dismiss_posts_unchecked
+      expect(dismiss_new_modal).to have_untrack_unchecked
+
+      dismiss_new_modal.click_dismiss
+
+      expect(topic_list).to have_no_topics
+    end
+
     context "with a tagged topic" do
       fab!(:tag)
       fab!(:tagged_topic) { Fabricate(:topic, tags: [tag]) }

--- a/spec/system/dismissing_new_spec.rb
+++ b/spec/system/dismissing_new_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Dismissing New", type: :system do
       expect(topic_list).to have_no_topics
     end
 
-    it "displays confirmation modal with preselected options" do
+    it "displays confirmation modal with replies preselected" do
       sign_in(user)
 
       visit("/new?subset=replies")
@@ -160,7 +160,7 @@ RSpec.describe "Dismissing New", type: :system do
       expect(topic_list).to have_no_topics
     end
 
-    it "displays confirmation modal with preselected options" do
+    it "displays confirmation modal with topics preselected" do
       sign_in(user)
 
       visit("/new?subset=topics")

--- a/spec/system/page_objects/modals/dismiss_new.rb
+++ b/spec/system/page_objects/modals/dismiss_new.rb
@@ -11,6 +11,14 @@ module PageObjects
         find(".dismiss-posts label").has_checked_field?
       end
 
+      def has_dismiss_topics_unchecked?
+        find(".dismiss-topics label").has_no_checked_field?
+      end
+
+      def has_dismiss_posts_unchecked?
+        find(".dismiss-posts label").has_no_checked_field?
+      end
+
       def has_untrack_unchecked?
         find(".untrack label").has_no_checked_field?
       end


### PR DESCRIPTION
Currently both boxes are always checked, even if you're filtered to new topics or new posts. 

You must have the site setting `Experimental new new view groups` set to your user's group to see this mode. 


![image](https://github.com/user-attachments/assets/f485ad66-7491-4f52-a812-4b5f9dba6d63)

This allows both options to appear, but only selects the current filter: 

![image](https://github.com/user-attachments/assets/6a3c1a91-1638-440f-80e3-4d74711d8064)

Turns out this was already implemented, but `subset` was always undefined. This fixes the arg and adds a couple new specs to cover it. 

see /t/155039 for reference