### PR TITLE
FEATURE: Add option to make <AceEditor /> resizable

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
@@ -406,6 +406,7 @@ export default class AdminBadgesShow extends Component {
               @name="query"
               @title={{i18n "admin.badges.query"}}
               @disabled={{this.readOnly}}
+              @format="full"
               as |field|
             >
               <field.Code @lang="sql" />

--- a/app/assets/javascripts/discourse/app/components/ace-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/ace-editor.gjs
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import { buildWaiter } from "@ember/test-waiters";
 import { modifier } from "ember-modifier";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import concatClass from "discourse/helpers/concat-class";
 import { bind } from "discourse/lib/decorators";
 import { isTesting } from "discourse/lib/environment";
 import loadAce from "discourse/lib/load-ace-editor";
@@ -169,6 +170,14 @@ export default class AceEditor extends Component {
     return this.args.mode || "css";
   }
 
+  get cssClasses() {
+    let cssClasses = ["ace"];
+    if (this.args.resizable) {
+      cssClasses.push("ace_editor--resizable");
+    }
+    return cssClasses.join(" ");
+  }
+
   @bind
   editorIdChanged() {
     if (this.autofocus) {
@@ -265,7 +274,7 @@ export default class AceEditor extends Component {
           {{didUpdate this.modeChanged @mode}}
           {{didUpdate this.placeholderChanged @placeholder}}
           {{didUpdate this.changeDisabledState @disabled}}
-          class="ace"
+          class={{concatClass this.cssClasses}}
           ...attributes
         >
         </div>

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/code.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/code.gjs
@@ -28,6 +28,7 @@ export default class FKControlCode extends Component {
       @onChange={{this.handleInput}}
       @mode={{@lang}}
       @disabled={{@field.disabled}}
+      @resizable={{true}}
       class="form-kit__control-code"
       style={{this.style}}
       ...attributes

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import AceEditor from "discourse/components/ace-editor";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | ace-editor", function (hooks) {
+module("Integration | Component | AceEditor", function (hooks) {
   setupRenderingTest(hooks);
 
   test("css editor", async function (assert) {
@@ -83,5 +83,23 @@ module("Integration | Component | ace-editor", function (hooks) {
     assert
       .dom(".ace-wrapper")
       .hasAttribute("data-disabled", "true", "it has a data-disabled attr");
+  });
+
+  test("resizable editor", async function (assert) {
+    await render(
+      <template>
+        <AceEditor
+          @mode="sql"
+          @content="SELECT * FROM users"
+          style="width: 300px; height: 200px"
+          @resizable={{true}}
+        />
+      </template>
+    );
+
+    assert.dom(".ace_editor").exists("it renders the ace editor");
+    assert
+      .dom(".ace-wrapper .ace_editor--resizable")
+      .exists("it has the resizable class");
   });
 });

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -1,3 +1,4 @@
+@import "ace-editor";
 @import "badges";
 @import "banner";
 @import "d-breadcrumbs";

--- a/app/assets/stylesheets/common/components/ace-editor.scss
+++ b/app/assets/stylesheets/common/components/ace-editor.scss
@@ -1,0 +1,3 @@
+.ace_editor--resizable {
+  resize: vertical;
+}

--- a/app/assets/stylesheets/common/form-kit/_control-code.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-code.scss
@@ -29,7 +29,7 @@
 }
 
 .form-kit__control-code {
-  height: 250px !important;
+  min-height: 250px !important;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid var(--primary-400);


### PR DESCRIPTION
This commit adds a `@resizable` argument to `<AceEditor />`
and sets it to true always for the FormKit code control.
This allows the user to vertically resize the editor inside
FormKit forms. Horizontal resizing is not allowed at this
time, it's more unpredictable for layout, and the vertical
resizing is mostly what's needed anyway.

Also changes the FormKit code control to use min-height of
250px so the inline style height takes precedence, before
it was a hardcoded !important height.

![image](https://github.com/user-attachments/assets/a1fedc6d-5231-4ab1-9d99-45a58bbbbaf1)
