### PR TITLE
UX: Update theme cards min width

### DIFF
--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -5,7 +5,7 @@
 
 .themes-cards-container {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 1em;
   align-items: stretch;
 }


### PR DESCRIPTION
This PR allows for three cards per row at medium screen sizes and placeholder images go all the way to the edges.

### Before
<img src="https://github.com/user-attachments/assets/4526b39a-dcf8-4d38-ac6f-2179ef920144" width="400"/>

### After
<img src="https://github.com/user-attachments/assets/cc81853b-b99e-488b-9244-efc1cb803211" width="400"/>
