### PR TITLE
FIX: uses text selection when using hide details

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -105,7 +105,10 @@ export default class ProsemirrorTextManipulation {
       return;
     }
 
-    const text = head + i18n(`composer.${exampleKey}`) + tail;
+    const text =
+      head +
+      (sel.value?.length ? sel.value : i18n(`composer.${exampleKey}`)) +
+      tail;
     const doc = this.convertFromMarkdown(text);
 
     this.view.dispatch(

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -105,11 +105,22 @@ export default class ProsemirrorTextManipulation {
       return;
     }
 
-    const text =
-      head +
-      (sel.value?.length ? sel.value : i18n(`composer.${exampleKey}`)) +
-      tail;
-    const doc = this.convertFromMarkdown(text);
+    const { state } = this.view; // your EditorView instance
+    const { from, to, empty } = state.selection;
+
+    let text;
+    if (empty) {
+      text = i18n(`composer.${exampleKey}`);
+    } else {
+      const selectedFragment = state.doc.slice(from, to).content;
+      const temporaryDoc = state.schema.nodes.doc.create(
+        null,
+        selectedFragment
+      );
+      text = this.convertToMarkdown(temporaryDoc);
+    }
+
+    const doc = this.convertFromMarkdown(head + text + tail);
 
     this.view.dispatch(
       this.view.state.tr.replaceWith(sel.start, sel.end, doc.content.firstChild)

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -105,7 +105,7 @@ export default class ProsemirrorTextManipulation {
       return;
     }
 
-    const { state } = this.view; // your EditorView instance
+    const { state } = this.view;
     const { from, to, empty } = state.selection;
 
     let text;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -113,11 +113,7 @@ export default class ProsemirrorTextManipulation {
       text = i18n(`composer.${exampleKey}`);
     } else {
       const selectedFragment = state.doc.slice(from, to).content;
-      const temporaryDoc = state.schema.nodes.doc.create(
-        null,
-        selectedFragment
-      );
-      text = this.convertToMarkdown(temporaryDoc);
+      text = this.convertToMarkdown(selectedFragment);
     }
 
     const doc = this.convertFromMarkdown(head + text + tail);

--- a/plugins/discourse-details/spec/system/details_spec.rb
+++ b/plugins/discourse-details/spec/system/details_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe "Details button", type: :system do
+  fab!(:admin)
+
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:rich) { composer.rich_editor }
+
+  context "with rich editor" do
+    before do
+      SiteSetting.rich_editor = true
+      sign_in(admin)
+    end
+
+    it "uses the text selection for content" do
+      visit("/new-topic")
+      composer.fill_content("test :+1:").toggle_rich_editor.select_all
+      find(".toolbar-popup-menu-options").click
+      find(".select-kit-row[data-name='Hide Details']").click
+      rich.click(x: 22, y: 30) # hack for pseudo element
+
+      expect(rich).to have_css(
+        "details img.emoji[src=\"/images/emoji/twitter/+1.png?v=#{Emoji::EMOJI_VERSION}\"]",
+      )
+    end
+  end
+end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -274,11 +274,7 @@ module PageObjects
       end
 
       def select_all
-        execute_script(<<~JS, text)
-          const composer = document.querySelector("#{COMPOSER_ID} .d-editor-input");
-          composer.focus();
-          composer.setSelectionRange(0, composer.value.length);
-        JS
+        find(COMPOSER_INPUT_SELECTOR).send_keys([PLATFORM_KEY_MODIFIER, "a"])
       end
 
       def select_range(start_index, length)


### PR DESCRIPTION
When hiding details if the user has currently a text selection we want to use it as the content of the details element.

/t/-/154716/30