### PR TITLE
FIX: Respect category/tag filtering for reviewable webhooks

### DIFF
--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -75,16 +75,31 @@ end
 
 %i[reviewable_created reviewable_score_updated].each do |event|
   DiscourseEvent.on(event) do |reviewable|
-    WebHook.enqueue_object_hooks(:reviewable, reviewable, event, reviewable.serializer)
+    category_id = reviewable.category_id
+    tag_ids = reviewable.topic&.tag_ids
+
+    WebHook.enqueue_object_hooks(
+      :reviewable,
+      reviewable,
+      event,
+      reviewable.serializer,
+      category_id:,
+      tag_ids:,
+    )
   end
 end
 
 DiscourseEvent.on(:reviewable_transitioned_to) do |status, reviewable|
+  category_id = reviewable.category_id
+  tag_ids = reviewable.topic&.tag_ids
+
   WebHook.enqueue_object_hooks(
     :reviewable,
     reviewable,
     :reviewable_transitioned_to,
     reviewable.serializer,
+    category_id:,
+    tag_ids:,
   )
 end
 

--- a/spec/initializers/web_hook_events_spec.rb
+++ b/spec/initializers/web_hook_events_spec.rb
@@ -28,4 +28,47 @@ RSpec.describe "Webhook event handlers" do
       expect(job_args["event_name"]).to eq("user_badge_revoked")
     end
   end
+
+  describe "reviewable events" do
+    fab!(:reviewable_webhook) do
+      wh = Fabricate(:web_hook, categories: [post.topic.category])
+      wh.web_hook_event_types = [WebHookEventType.find_by(name: "reviewable_created")]
+      wh.save!
+      wh
+    end
+
+    it "includes category_id in the job arguments" do
+      reviewable = nil
+      expect do
+        reviewable =
+          ReviewableFlaggedPost.needs_review!(target: post, created_by: Discourse.system_user)
+      end.to change { Jobs::EmitWebHookEvent.jobs.size }.by(1)
+
+      job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
+      expect(job_args["id"]).to eq(reviewable.id)
+      expect(job_args["event_name"]).to eq("reviewable_created")
+      expect(reviewable.category_id).to be_present
+      expect(job_args["category_id"]).to eq(reviewable.category_id)
+    end
+
+    it "includes tag_ids in the job arguments" do
+      tag = Fabricate(:tag)
+      post.topic.tags << tag
+      post.topic.save!
+
+      reviewable_webhook.tag_ids = [tag.id]
+      reviewable_webhook.save!
+
+      reviewable = nil
+      expect do
+        reviewable =
+          ReviewableFlaggedPost.needs_review!(target: post, created_by: Discourse.system_user)
+      end.to change { Jobs::EmitWebHookEvent.jobs.size }.by(1)
+
+      job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
+      expect(job_args["id"]).to eq(reviewable.id)
+      expect(job_args["event_name"]).to eq("reviewable_created")
+      expect(job_args["tag_ids"]).to eq([tag.id])
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you configure a webhook with reviewable events and apply categories/tags filtering, no webhook gets fired for reviewable events. This is because when we schedule the `EmitWebHookEvent` job, we don't pass to it the reviewable's category or tags, making it seem like the reviewable doesn't belong to the filtering category/tags that webhook specifies.

Internal topic: t/155369.