### PR TITLE
DEV: Added the ability to use users' names in group mention notifications and mentions shown in emails

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/group-mentioned.js
@@ -1,8 +1,19 @@
+import { service } from "@ember/service";
 import NotificationTypeBase from "discourse/lib/notification-types/base";
 
 export default class extends NotificationTypeBase {
+  @service siteSettings;
+
   get label() {
-    return `${this.username} @${this.notification.data.group_name}`;
+    let name;
+
+    if (this.siteSettings.prioritize_full_name_in_ux) {
+      name = this.notification.acting_user_name || this.username;
+    } else {
+      name = this.username;
+    }
+
+    return `${name} @${this.notification.data.group_name}`;
   }
 
   get labelClasses() {

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
@@ -1,3 +1,4 @@
+import Service from "@ember/service";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { deepMerge } from "discourse/lib/object";
@@ -19,12 +20,15 @@ function getNotification(overrides = {}) {
         topic_id: 449,
         fancy_title: "This is fancy title &lt;a&gt;!",
         slug: "this-is-fancy-title",
+        acting_user_name: "Osama Obama",
         data: {
           topic_title: "this is title before it becomes fancy <a>!",
           original_post_id: 112,
           original_post_type: 1,
           original_username: "kolary",
+          original_name: "Osama Obama",
           display_username: "osama",
+          display_name: "Osama Obama",
           group_id: 333,
           group_name: "hikers",
         },
@@ -37,17 +41,48 @@ function getNotification(overrides = {}) {
 module("Unit | Notification Types | group-mentioned", function (hooks) {
   setupTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.owner.register(
+      "service:site-settings",
+      class extends Service {
+        prioritize_full_name_in_ux = false;
+      }
+    );
+
+    this.siteSettings = this.owner.lookup("service:site-settings");
+  });
+
   test("label", function (assert) {
     const notification = getNotification();
+
     const director = createRenderDirector(
       notification,
       "group_mentioned",
       this.siteSettings
     );
+
     assert.strictEqual(
       director.label,
       "osama @hikers",
-      "contains the user who mentioned and the mentioned group"
+      "contains the user's username who mentioned and the mentioned group"
+    );
+  });
+
+  test("label uses the user's name when prioritize_username_in_ux is false", function (assert) {
+    this.siteSettings.prioritize_full_name_in_ux = true;
+
+    const notification = getNotification();
+
+    const director = createRenderDirector(
+      notification,
+      "group_mentioned",
+      this.siteSettings
+    );
+
+    assert.strictEqual(
+      director.label,
+      "Osama Obama @hikers",
+      "contains the user's name who mentioned and the mentioned group"
     );
   });
 });

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -393,6 +393,11 @@ class UserNotifications < ActionMailer::Base
     opts[:use_site_subject] = true
     opts[:show_category_in_subject] = true
     opts[:show_tags_in_subject] = true
+
+    if !SiteSetting.prioritize_username_in_ux
+      opts[:post].cooked = replace_username_with_name_from_post(opts[:post], user)
+    end
+
     notification_email(user, opts)
   end
 
@@ -706,6 +711,7 @@ class UserNotifications < ActionMailer::Base
           (SiteSetting.max_emails_per_day_per_user - 1)
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
+
       if SiteSetting.private_email?
         message = I18n.t("system_messages.contents_hidden")
       else
@@ -871,5 +877,30 @@ class UserNotifications < ActionMailer::Base
         .where("created_at > ?", date)
         .count
         .tap { Discourse.redis.setex(key, 1.day, _1) }
+  end
+
+  def replace_username_with_name_from_post(post, user)
+    alnum = '\p{Alphabetic}\p{Mark}\p{Decimal_Number}'
+    mention_regex =
+      /
+      @(
+        [#{alnum}_]                    
+        [#{alnum}._-]{0,58}            
+        [#{alnum}]                     
+      ) |
+      @([#{alnum}_])                   
+    /ux
+
+    usernames = post.cooked.scan(mention_regex).flatten.compact.uniq
+
+    users = User.where(username: usernames).index_by(&:username)
+
+    post
+      .cooked
+      .gsub(mention_regex) do
+        username = Regexp.last_match[1] || Regexp.last_match[2]
+        user = users[username]
+        user&.name ? "@#{user.name}" : "@#{username}" # fallback to original mention
+      end
   end
 end

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -92,6 +92,24 @@ Fabricator(:mentioned_notification, from: :notification) do
   end
 end
 
+Fabricator(:group_mentioned_notification, from: :notification) do
+  transient :group
+  notification_type Notification.types[:group_mentioned]
+  data do |attrs|
+    {
+      topic_title: attrs[:topic].title,
+      original_post_id: attrs[:post].id,
+      original_post_type: attrs[:post].post_type,
+      original_username: attrs[:post].user.username,
+      revision_number: nil,
+      display_username: attrs[:post].user.username,
+      display_name: attrs[:user].name,
+      group_id: attrs[:group].id,
+      group_name: attrs[:group].name,
+    }.to_json
+  end
+end
+
 Fabricator(:watching_first_post_notification, from: :notification) do
   notification_type Notification.types[:watching_first_post]
   data do |attrs|

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -682,6 +682,152 @@ RSpec.describe UserNotifications do
     end
   end
 
+  describe ".user_mentioned" do
+    let(:response_by_user) { Fabricate(:user, name: "John Doe") }
+    let(:category) { Fabricate(:category, name: "India") }
+
+    let(:topic) { Fabricate(:topic, category: category, title: "Super cool topic") }
+
+    let(:user) { Fabricate(:user) }
+    let(:post) { Fabricate(:post, topic: topic, raw: "This is My super duper cool topic") }
+    let(:response) do
+      Fabricate(
+        :basic_reply,
+        topic: post.topic,
+        user: response_by_user,
+        raw: "@#{user.username} response to post",
+      )
+    end
+    let(:notification) { Fabricate(:mentioned_notification, user: user, post: response) }
+
+    context "when prioritize_username_in_ux is false" do
+      before { SiteSetting.prioritize_username_in_ux = false }
+      context "when user has name" do
+        it "generates a correct email" do
+          mail =
+            UserNotifications.user_mentioned(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+
+          # from should include full user name
+          expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
+
+          # subject should include category name
+          expect(mail.subject).to match(/India/)
+
+          mail_html = mail.html_part.body.to_s
+
+          expect(mail_html.scan(%r{@#{user.name}</a> response to post}).count).to eq(1)
+
+          expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+
+          expect(mail_html.scan(/to respond/).count).to eq(1)
+
+          # 1 unsubscribe
+          expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+
+          # side effect, topic user is updated with post number
+          tu = TopicUser.get(post.topic_id, user)
+          expect(tu.last_emailed_post_number).to eq(response.post_number)
+        end
+      end
+
+      context "when several users are mentioned in the same email" do
+        fab!(:user1) { Fabricate(:user, name: "Cool User1 Name") }
+        fab!(:user2) { Fabricate(:user) }
+        fab!(:user3) { Fabricate(:user, name: "Cool User2 Name") }
+
+        let(:response) do
+          Fabricate(
+            :basic_reply,
+            topic: post.topic,
+            user: response_by_user,
+            raw:
+              "@#{user.username} @#{user1.username} @#{user2.username} @#{user3.username} response to post",
+          )
+        end
+        let(:notification) { Fabricate(:mentioned_notification, user: user, post: response) }
+
+        it "generates a correct email" do
+          user2.name = nil
+          user2.save
+
+          mail =
+            UserNotifications.user_mentioned(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+
+          # from should include full user name
+          expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
+
+          # subject should include category name
+          expect(mail.subject).to match(/India/)
+
+          mail_html = mail.html_part.body.to_s
+
+          expect(mail_html.scan(/@#{user.name}/).count).to eq(1)
+          expect(mail_html.scan(/@#{user1.name}/).count).to eq(1)
+          # Make sure it can handle users without usernames in the same email
+          expect(mail_html.scan(/@#{user2.username}/).count).to eq(1)
+          expect(mail_html.scan(/@#{user3.name}/).count).to eq(1)
+
+          expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+
+          expect(mail_html.scan(/to respond/).count).to eq(1)
+
+          # 1 unsubscribe
+          expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+
+          # side effect, topic user is updated with post number
+          tu = TopicUser.get(post.topic_id, user)
+          expect(tu.last_emailed_post_number).to eq(response.post_number)
+        end
+      end
+
+      context "when user doesn't have a name" do
+        it "generates a correct email" do
+          user.name = nil
+          user.save
+
+          mail =
+            UserNotifications.user_mentioned(
+              user,
+              post: response,
+              notification_type: notification.notification_type,
+              notification_data_hash: notification.data_hash,
+            )
+
+          # from should include full user name
+          expect(mail[:from].display_names).to eql(["John Doe via Discourse"])
+
+          # subject should include category name
+          expect(mail.subject).to match(/India/)
+
+          mail_html = mail.html_part.body.to_s
+
+          expect(mail_html.scan(%r{@#{user.username}</a> response to post}).count).to eq(1)
+
+          expect(mail_html.scan(/Visit Topic/).count).to eq(1)
+
+          expect(mail_html.scan(/to respond/).count).to eq(1)
+
+          # 1 unsubscribe
+          expect(mail_html.scan(/To unsubscribe/).count).to eq(1)
+
+          # side effect, topic user is updated with post number
+          tu = TopicUser.get(post.topic_id, user)
+          expect(tu.last_emailed_post_number).to eq(response.post_number)
+        end
+      end
+    end
+  end
+
   describe ".user_posted" do
     let(:response_by_user) { Fabricate(:user, name: "John Doe", username: "john") }
     let(:topic) { Fabricate(:topic, title: "Super cool topic") }

--- a/spec/system/page_objects/pages/user_notifications.rb
+++ b/spec/system/page_objects/pages/user_notifications.rb
@@ -16,6 +16,10 @@ module PageObjects
         filter_dropdown.select_row_by_value(value)
       end
 
+      def find_notification(notification)
+        find(".notification a[href='#{notification.url}']")
+      end
+
       def has_selected_filter_value?(value)
         expect(filter_dropdown).to have_selected_value(value)
       end

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "User notifications", type: :system do
-  fab!(:user)
+  fab!(:user) { Fabricate(:user, name: "Awesome Name") }
   let(:user_notifications_page) { PageObjects::Pages::UserNotifications.new }
   let(:user_page) { PageObjects::Pages::User.new }
 
@@ -49,6 +49,61 @@ describe "User notifications", type: :system do
       # It is 1 here because we blocked infinite scrolling. Even though the limit is 1,
       # without the callback, we would have 2 items here as it immediately fires another request.
       expect(user_notifications_page).to have_notification_count_of(1)
+    end
+  end
+
+  describe "user group notifications" do
+    fab!(:group) { Fabricate(:group, name: "Awesome_Group") }
+    fab!(:topic) { Fabricate(:topic, title: "Group Mention Notification test") }
+    fab!(:post) do
+      Fabricate(
+        :post,
+        raw: "@#{group.name} this is a post to create a group mention notification",
+        user: user,
+        topic: topic,
+      )
+    end
+    fab!(:user2) { Fabricate(:user) }
+    fab!(:group_mention_notification) do
+      Fabricate(:group_mentioned_notification, post: post, user: user2, group: group)
+    end
+
+    before { group.add(user2) }
+
+    context "when prioritize_username_in_ux is false" do
+      before do
+        SiteSetting.prioritize_full_name_in_ux = true
+        sign_in(user2)
+      end
+
+      it "shows the user name in the notification" do
+        user_notifications_page.visit(user2)
+
+        expect(user_notifications_page).to have_notification(group_mention_notification)
+
+        notification = user_notifications_page.find_notification(group_mention_notification)
+
+        expect(notification).to have_content(group.name)
+        expect(notification).to have_content(user.name)
+      end
+
+      context "when user doesn't have a name" do
+        before do
+          user.name = nil
+          user.save
+        end
+
+        it "shows the username in the notification instead" do
+          user_notifications_page.visit(user2)
+
+          expect(user_notifications_page).to have_notification(group_mention_notification)
+
+          notification = user_notifications_page.find_notification(group_mention_notification)
+
+          expect(notification).to have_content(group.name)
+          expect(notification).to have_content(user.username)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Description**
These changes were introduced in a previous PR but were reverted due to a bug when several users were mentioned in a response. This PR reintroduces the changes along with a fix to the issue.

This is part of a series of changes to allow customers to display users'
names instead of the user's username.

When a user belongs to a group that has been mentioned by another user.
It shows the name of the user that mentioned the group.

[Previous commit](https://github.com/discourse/discourse/commit/e147d2afe6682a85070aecc0775050774f2f81f6)

**Before**

![imagen](https://github.com/user-attachments/assets/b62224fb-9b69-4603-be00-e7aa61d9b33c)

**After**

![imagen](https://github.com/user-attachments/assets/8495cb63-6530-4d86-a51c-f0510d48f6c7)

When a email is sent to the user when mentioned in a post 

**Before**


![imagen](https://github.com/user-attachments/assets/94e674da-085a-41cb-8145-ba6fbe3636ce)

**After**

![imagen](https://github.com/user-attachments/assets/490cb365-bf85-4745-93b9-e47048b2f02e)