### PR TITLE
A11Y: SVG icons should be hidden unless a label is provided

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -156,12 +156,10 @@ registerIconRenderer({
     const id = escape(handleIconId(icon));
     let html = `<svg class='${escape(iconClasses(icon, params))} svg-string'`;
 
-    if (params.label) {
+    if (params["aria-label"]) {
+      html += ` aria-hidden='false' aria-label='${escape(params["aria-label"])}'`;
+    } else {
       html += " aria-hidden='true'";
-    } else if (params["aria-label"]) {
-      html += ` aria-hidden='false' aria-label='${escape(
-        params["aria-label"]
-      )}'`;
     }
     html += ` xmlns="${SVG_NAMESPACE}"><use href="#${id}" /></svg>`;
     if (params.label) {


### PR DESCRIPTION
This is fairly minor because usually SVGs aren't focusable, but this adds `aria-hidden='true'` to all SVGs by default unless either an `aria-label` or `label` is provided. 

So now:

1. SVG: `aria-hidden="true"`  (new behavior) 
2. SVG with `label` param: `aria-hidden="true"` and `sr-only` label is provided 
3. SVG with `aria-label` param: `aria-hidden="false"` and `aria-label` is provided 