### PR TITLE
DEV: Support 'cors origins' site setting for message-bus

### DIFF
--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -27,8 +27,15 @@ def setup_message_bus_env(env)
 
   host = RailsMultisite::ConnectionManagement.host(env)
   RailsMultisite::ConnectionManagement.with_hostname(host) do
+    cors_origin = Discourse.base_url_no_prefix
+
+    if GlobalSetting.enable_cors && SiteSetting.cors_origins.present?
+      allowed_origins = SiteSetting.cors_origins.split("|")
+      cors_origin = env["HTTP_ORIGIN"] if allowed_origins.include?(env["HTTP_ORIGIN"])
+    end
+
     extra_headers = {
-      "Access-Control-Allow-Origin" => Discourse.base_url_no_prefix,
+      "Access-Control-Allow-Origin" => cors_origin,
       "Access-Control-Allow-Methods" => "GET, POST",
       "Access-Control-Allow-Headers" =>
         "X-SILENCE-LOGGER, X-Shared-Session-Key, Dont-Chunk, Discourse-Present, Discourse-Deferred-Track-View",

--- a/spec/integration/message_bus_spec.rb
+++ b/spec/integration/message_bus_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe "message bus integration" do
     expect(response.status).to eq(200)
   end
 
+  it "allows custom cors origins" do
+    global_setting :enable_cors, true
+    SiteSetting.cors_origins = "https://allowed.example.com"
+
+    post "/message-bus/poll"
+    expect(response.headers["Access-Control-Allow-Origin"]).to eq(Discourse.base_url_no_prefix)
+
+    post "/message-bus/poll", headers: { origin: "https://allowed.example.com" }
+    expect(response.headers["Access-Control-Allow-Origin"]).to eq("https://allowed.example.com")
+
+    post "/message-bus/poll", headers: { origin: "https://not-allowed.example.com" }
+    expect(response.headers["Access-Control-Allow-Origin"]).to eq(Discourse.base_url_no_prefix)
+  end
+
   context "with login_required" do
     before { SiteSetting.login_required = true }
 


### PR DESCRIPTION
Discourse message-bus traffic is not considered a 'public api' for general consumption. However, it does make sense to have consistency with the CORS behavior of the rest of the app, so that people can use it at their own risk.