### PR TITLE
DEV: Drop `fakeweb` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,6 @@ gem "digest", require: false
 group :test do
   gem "capybara", require: false
   gem "webmock", require: false
-  gem "fakeweb", require: false
   gem "simplecov", require: false
   gem "test-prof"
   gem "rails-dom-testing", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,6 @@ GEM
     fabrication (3.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    fakeweb (1.3.0)
     faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -699,7 +698,6 @@ DEPENDENCIES
   extralite-bundle
   fabrication
   faker
-  fakeweb
   faraday
   faraday-retry
   fast_blank
@@ -870,7 +868,6 @@ CHECKSUMS
   extralite-bundle (2.12) sha256=9c9912b7ab592e7064089ee608cf86ab9edd81d20065acb87d1f4fed06052987
   fabrication (3.0.0) sha256=a6a0bfad9071348ad3cb1701df788524b888c0cdd044b988893e7509f7463be3
   faker (3.5.1) sha256=1ad1fbea279d882f486059c23fe3ddb816ccd1d7052c05a45014b4450d859bfc
-  fakeweb (1.3.0) sha256=1ec996be13020a00b3464560c09180b424477c698f59f82edf2b99b16cfa09a8
   faraday (2.13.1) sha256=cc531eb5467e7d74d4517630fa96f1a7003647cbf20a9a3e067d098941217b75
   faraday-net_http (3.4.0) sha256=a1f1e4cd6a2cf21599c8221595e27582d9936819977bbd4089a601f24c64e54a
   faraday-retry (2.3.1) sha256=4004faa21f41fc5360d359bc79889fc58fb7fae0ce93bfb737a784ac76805c03


### PR DESCRIPTION
This was only be `require`'d by one official plugin (discourse-perspective), but was causing failures in specs of unrelated plugins. See https://github.com/discourse/discourse-perspective-api/pull/110