### PR TITLE
DEV: allow custom community sidebar links to pass models for route params 

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/custom-community-section-links.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/custom-community-section-links.js
@@ -49,6 +49,10 @@ export function addSectionLink(args, secondary) {
       get prefixValue() {
         return args.icon || super.prefixValue;
       }
+
+      get models() {
+        return args.models;
+      }
     };
 
     links.push(klass);


### PR DESCRIPTION
Without this, you can't add a custom link like this...

```js
api.addCommunitySectionLink({
 name: "tag-link",
 route: "tag.show",
 title: "foo",
 text: "bar",
 models: ["baz"]
})
```

...because the route needs a model