### PR TITLE
DEV: Enable `auth_skip_create_confirm` on new sites

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
@@ -25,7 +25,8 @@ acceptance("Create Account - external auth", function (needs) {
     document.getElementById("data-authentication").remove();
   });
 
-  test("when skip is disabled (default)", async function (assert) {
+  test("when skip is disabled", async function (assert) {
+    this.siteSettings.auth_skip_create_confirm = false;
     await visit("/");
 
     assert.dom(".signup-fullpage").exists("it shows the signup page");
@@ -37,8 +38,7 @@ acceptance("Create Account - external auth", function (needs) {
       .doesNotExist("it does not show the associate link");
   });
 
-  test("when skip is enabled", async function (assert) {
-    this.siteSettings.auth_skip_create_confirm = true;
+  test("when skip is enabled (default)", async function (assert) {
     await visit("/");
 
     assert.dom(".signup-fullpage").exists("it shows the signup page");
@@ -58,6 +58,7 @@ acceptance("Create account - with associate link", function (needs) {
   });
 
   test("displays associate link when allowed", async function (assert) {
+    this.siteSettings.auth_skip_create_confirm = false;
     await visit("/");
 
     assert.dom(".signup-fullpage").exists("it shows the signup page");

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -665,7 +665,7 @@ login:
     regex: "^[a-zA-Z0-9_=\\.]+$"
     secret: true
   auth_skip_create_confirm:
-    default: false
+    default: true
     client: true
   auth_immediately:
     default: true

--- a/db/migrate/20250604181345_disable_auth_skip_create_confirm_existing_sites.rb
+++ b/db/migrate/20250604181345_disable_auth_skip_create_confirm_existing_sites.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DisableAuthSkipCreateConfirmExistingSites < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL if Migration::Helpers.existing_site?
+        INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+        VALUES('auth_skip_create_confirm', 5, 'f', NOW(), NOW())
+        ON CONFLICT (name) DO NOTHING
+      SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Changes the default to `true` without affecting existing instances. 