### PR TITLE
UX: Adjust inconsistent spacing in search drop down

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -12,7 +12,7 @@
 }
 
 :root {
-  --search-result-element-padding: 0.5em 1rem;
+  --search-result-element-padding: 0.75em 1rem;
 }
 
 .search-menu.glimmer-search-menu .search-input-wrapper {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -84,7 +84,10 @@
   }
 
   .menu-panel {
-    padding: 0; // overrule generic menu panels to achieve full width hover effect
+    padding: 0; // overrule generic menu panels to achieve full width hover
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-border-radius);
+    max-height: calc(100vh - var(--header-offset));
 
     @include viewport.from(sm) {
       // alignment adjustment for search menu panel (within topic) on desktop to align with results
@@ -135,7 +138,6 @@
     display: flex;
     flex-direction: column;
     border-radius: var(--d-border-radius);
-    padding-top: 0.75rem;
 
     .heading {
       padding: 0.5em 0 0 1rem;
@@ -166,6 +168,7 @@
 
   .search-link {
     padding: var(--search-result-element-padding);
+    font-size: var(--font-down-1);
 
     &.category,
     &.user,
@@ -285,7 +288,6 @@
           word-break: break-word;
           hyphens: auto;
           color: var(--primary-high);
-          font-size: var(--font-down-1);
         }
       }
     }
@@ -416,14 +418,14 @@
 }
 
 .search-random-quick-tip {
-  padding: 0 1rem 0.75rem;
-  font-size: var(--font-down-2);
+  padding: var(--search-result-element-padding);
+  font-size: var(--font-down-1);
   color: var(--primary-medium);
 
   .tip-label {
     background-color: rgb(var(--tertiary-rgb), 0.1);
     margin-right: 0.25em;
-    padding: 2px 4px;
+    padding: 0 4px;
     display: inline-block;
     border: none;
 
@@ -461,4 +463,5 @@
 
 .no-results {
   padding: var(--search-result-element-padding);
+  font-size: var(--font-down-1);
 }

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -139,10 +139,6 @@
         width: 100%;
       }
 
-      .search-random-quick-tip {
-        padding-top: 0.75rem;
-      }
-
       ul,
       ol {
         list-style-type: none;

--- a/app/assets/stylesheets/desktop/components/header-search.scss
+++ b/app/assets/stylesheets/desktop/components/header-search.scss
@@ -96,13 +96,6 @@
             z-index: 2;
           }
 
-          .search-menu-panel {
-            padding: 0;
-            border: 1px solid var(--primary-low);
-            border-radius: var(--d-border-radius);
-            max-height: calc(100vh - var(--header-offset));
-          }
-
           .search-input {
             display: flex;
             padding: 0 0 0 2em;


### PR DESCRIPTION
This PR makes the spacing consistent for different search states. Previously the hints box would increase in size when a term was entered into search.

I apply border styling to the correct stylesheet in order to have all versions of search dropdown retain consistent styling.

I also changed how padding is applied to keep it consistent.

![CleanShot 2025-06-04 at 16 15 37@2x](https://github.com/user-attachments/assets/50087019-16a5-420e-97b0-e1117588d011)



