### PR TITLE
FIX: ensures post toolbar text can't be selected

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -737,6 +737,10 @@ aside.quote {
   opacity: 0.4;
 }
 
+.fk-d-menu[data-identifier="post-text-selection-toolbar"] {
+  @include user-select(none);
+}
+
 .quote-button {
   flex-direction: column;
 


### PR DESCRIPTION
We suspect it might interfere with text selection of posts on android.