### PR TITLE
UX: fix admin reports breadcrumb link

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/reports.gjs
+++ b/app/assets/javascripts/admin/addon/templates/reports.gjs
@@ -15,7 +15,7 @@ export default RouteTemplate(
       <:breadcrumbs>
         <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
         <DBreadcrumbsItem
-          @path="/admin.config.reports"
+          @path="/admin/reports"
           @label={{i18n "admin.config.reports.title"}}
         />
       </:breadcrumbs>


### PR DESCRIPTION
`/admin.config.reports` does not exist

Reported here: https://meta.discourse.org/t/breadcrumb-link-on-admin-reports-returns-404/368982