### PR TITLE
DEV: Have about page extra groups depend on groups selected

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/about.gjs
@@ -60,10 +60,6 @@ export default class AdminConfigAreasAbout extends Component {
     };
   }
 
-  get showExtraGroups() {
-    return this.siteSettings.show_additional_about_groups === true;
-  }
-
   @action
   setSavingStatus(status) {
     this.saving = status;
@@ -116,22 +112,20 @@ export default class AdminConfigAreasAbout extends Component {
             />
           </:content>
         </AdminConfigAreaCard>
-        {{#if this.showExtraGroups}}
-          <AdminConfigAreaCard
-            @heading="admin.config_areas.about.extra_groups.heading"
-            @description="admin.config_areas.about.extra_groups.description"
-            @collapsable={{true}}
-            class="admin-config-area-about__extra-groups-section"
-          >
-            <:content>
-              <AdminConfigAreasAboutExtraGroups
-                @extraGroups={{this.extraGroups}}
-                @setGlobalSavingStatus={{this.setSavingStatus}}
-                @globalSavingStatus={{this.saving}}
-              />
-            </:content>
-          </AdminConfigAreaCard>
-        {{/if}}
+        <AdminConfigAreaCard
+          @heading="admin.config_areas.about.extra_groups.heading"
+          @description="admin.config_areas.about.extra_groups.description"
+          @collapsable={{true}}
+          class="admin-config-area-about__extra-groups-section"
+        >
+          <:content>
+            <AdminConfigAreasAboutExtraGroups
+              @extraGroups={{this.extraGroups}}
+              @setGlobalSavingStatus={{this.setSavingStatus}}
+              @globalSavingStatus={{this.saving}}
+            />
+          </:content>
+        </AdminConfigAreaCard>
       </div>
     </div>
   </template>

--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -233,10 +233,7 @@ export default class AboutPage extends Component {
   }
 
   get showExtraGroups() {
-    return (
-      this.siteSettings.show_additional_about_groups === true &&
-      !isBlank(this.siteSettings.about_page_extra_groups)
-    );
+    return !isBlank(this.siteSettings.about_page_extra_groups);
   }
 
   <template>

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1021,10 +1021,6 @@ groups:
   max_automatic_membership_email_domains:
     default: 50
     hidden: true
-  show_additional_about_groups:
-    client: true
-    default: false
-    hidden: true
 
 posting:
   min_post_length:

--- a/spec/system/about_page_spec.rb
+++ b/spec/system/about_page_spec.rb
@@ -386,7 +386,6 @@ describe "About page", type: :system do
 
     before do
       SiteSetting.about_banner_image = nil
-      SiteSetting.show_additional_about_groups = true
       SiteSetting.about_page_extra_groups = extra_groups_setting
       SiteSetting.about_page_extra_groups_order = order
 

--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -10,11 +10,7 @@ describe "Admin About Config Area Page", type: :system do
   let!(:extra_group_2) { Fabricate(:group, name: "extra2") }
   let!(:extra_group_3) { Fabricate(:group, name: "extra3") }
 
-  before do
-    SiteSetting.show_additional_about_groups = true
-
-    sign_in(admin)
-  end
+  before { sign_in(admin) }
 
   context "when all fields have existing values" do
     before do


### PR DESCRIPTION
### What is this change?

When we ported over the about page extra groups theme component, we used a hidden site setting to control this as per MO.

We don't need this any more. We can simply rely on the presence of any configured groups to decide.