### PR TITLE
FIX: Allow setting blank secret on an existing webhook

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-form.gjs
@@ -42,7 +42,7 @@ export default class AdminConfigAreasWebhookForm extends Component {
     return {
       payload_url: this.webhook.payload_url,
       content_type: this.webhook.content_type,
-      secret: this.webhook.secret === "" ? null : this.webhook.secret,
+      secret: this.webhook.secret,
       categories: this.webhook.categories,
       group_names: this.webhook.group_names,
       tag_names: this.webhook.tag_names,

--- a/app/assets/javascripts/admin/addon/models/web-hook.js
+++ b/app/assets/javascripts/admin/addon/models/web-hook.js
@@ -113,7 +113,7 @@ export default class WebHook extends RestModel {
     return {
       payload_url: this.payload_url,
       content_type: this.content_type,
-      secret: this.secret,
+      secret: this.secret ?? "",
       wildcard_web_hook: this.wildcard_web_hook,
       verify_certificate: this.verify_certificate,
       active: this.active,


### PR DESCRIPTION
### What is this change?

We had a regression where you can no longer update an existing webhook to have a blank secret field.

The problem is the blank field will return a value of `undefined`, which is ignored by the store when sending the request to the back-end.

This fixes that by using the nullish coalescing operator to replace `undefined` with an empty string.

**In action:**

![webhook-secret-fix](https://github.com/user-attachments/assets/0b861fdd-93a0-4690-a5b4-2984eb5e5077)
