### PR TITLE
FIX: Do not show header search icon if welcome banner search shown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
 import { and, eq, not, or } from "truth-helpers";
@@ -142,12 +141,6 @@ export default class GlimmerHeader extends Component {
       case "hamburger":
         this.toggleNavigationMenu();
         break;
-      case "page-search":
-        if (!this.togglePageSearch()) {
-          msg.event.preventDefault();
-          msg.event.stopPropagation();
-        }
-        break;
     }
   }
 
@@ -175,38 +168,6 @@ export default class GlimmerHeader extends Component {
       this.search.inTopicContext = false;
       document.getElementById(SEARCH_BUTTON_ID)?.focus();
     }
-  }
-
-  @action
-  togglePageSearch() {
-    this.search.inTopicContext = false;
-
-    let showSearch = this.router.currentRouteName.startsWith("topic.");
-    // If we're viewing a topic, only intercept search if there are cloaked posts
-    if (showSearch) {
-      const container = getOwner(this);
-      const topic = container.lookup("controller:topic");
-      const total = topic.get("model.postStream.stream.length") || 0;
-      const chunkSize = topic.get("model.chunk_size") || 0;
-      showSearch =
-        total > chunkSize &&
-        document.querySelectorAll(
-          ".topic-post .cooked, .small-action:not(.time-gap)"
-        )?.length < total;
-    }
-
-    if (this.search.visible) {
-      this.toggleSearchMenu();
-      return showSearch;
-    }
-
-    if (showSearch) {
-      this.search.inTopicContext = true;
-      this.toggleSearchMenu();
-      return false;
-    }
-
-    return true;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/header/header-search.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/header-search.gjs
@@ -17,7 +17,7 @@ export default class HeaderSearch extends Component {
 
   handleKeyboardShortcut = modifier(() => {
     const cb = (appEvent) => {
-      if (appEvent.type === "search" || appEvent.type === "page-search") {
+      if (appEvent.type === "search") {
         this.search.focusSearchInput();
         appEvent.event.preventDefault();
       }

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -60,7 +60,8 @@ export default class Icons extends Component {
 
     return (
       this.site.mobileView ||
-      this.search.searchExperience === "search_icon" ||
+      (this.search.searchExperience === "search_icon" &&
+        !this.search.welcomeBannerSearchInViewport) ||
       this.args.topicInfoVisible ||
       this.args.narrowDesktop
     );

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -36,7 +36,7 @@ export default class WelcomeBanner extends Component {
   handleKeyboardShortcut = modifier(() => {
     const cb = (appEvent) => {
       if (
-        (appEvent.type === "search" || appEvent.type === "page-search") &&
+        appEvent.type === "search" &&
         this.search.welcomeBannerSearchInViewport
       ) {
         this.search.focusSearchInput();

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -446,15 +446,6 @@ export default {
     this._changeSection(-1);
   },
 
-  showPageSearch(event) {
-    run(() => {
-      this.appEvents.trigger("header:keyboard-trigger", {
-        type: "page-search",
-        event,
-      });
-    });
-  },
-
   printTopic(event) {
     run(() => {
       if (document.querySelector(".container.posts")) {

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -37,23 +37,48 @@ describe "Welcome banner", type: :system do
       expect(banner).to be_hidden
     end
 
-    it "hides welcome banner and shows header search on scroll, and vice-versa" do
-      SiteSetting.search_experience = "search_field"
-      Fabricate(:topic)
+    context "when using search_field search_experience" do
+      before { SiteSetting.search_experience = "search_field" }
 
-      sign_in(current_user)
-      visit "/"
-      expect(banner).to be_visible
-      expect(search_page).to have_no_search_field
+      it "hides welcome banner and shows header search on scroll, and vice-versa" do
+        Fabricate(:topic)
 
-      fake_scroll_down_long
+        sign_in(current_user)
+        visit "/"
+        expect(banner).to be_visible
+        expect(search_page).to have_no_search_field
 
-      expect(banner).to be_invisible
-      expect(search_page).to have_search_field
+        fake_scroll_down_long
 
-      page.scroll_to(0, 0)
-      expect(banner).to be_visible
-      expect(search_page).to have_no_search_field
+        expect(banner).to be_invisible
+        expect(search_page).to have_search_field
+
+        page.scroll_to(0, 0)
+        expect(banner).to be_visible
+        expect(search_page).to have_no_search_field
+      end
+    end
+
+    context "when using search_icon search_experience" do
+      before { SiteSetting.search_experience = "search_icon" }
+
+      it "hides welcome banner and shows header search on scroll, and vice-versa" do
+        Fabricate(:topic)
+
+        sign_in(current_user)
+        visit "/"
+        expect(banner).to be_visible
+        expect(search_page).to have_no_search_icon
+
+        fake_scroll_down_long
+
+        expect(banner).to be_invisible
+        expect(search_page).to have_search_icon
+
+        page.scroll_to(0, 0)
+        expect(banner).to be_visible
+        expect(search_page).to have_no_search_icon
+      end
     end
   end
 


### PR DESCRIPTION
This brings the search_icon header search mode to parity with the
search_field mode. We don't want to show either of these if the welcome
banner is showing, since it has a search field, this is redundant.

If you scroll the page and the welcome banner is hidden, then we
show the header search icon.

This commit also cleans up some code related to the page-search
shortcut, which we no longer use, including limiting showing search
on topic only if there are > 20 posts.
