### PR TITLE
DEV: Use canonical hostname for omniauth callbacks

### DIFF
--- a/config/initializers/009-omniauth.rb
+++ b/config/initializers/009-omniauth.rb
@@ -52,3 +52,5 @@ OmniAuth.config.on_failure do |env|
 
   OmniAuth::FailureEndpoint.call(env)
 end
+
+OmniAuth.config.full_host = Proc.new { Discourse.base_url_no_prefix }


### PR DESCRIPTION
In production, the enforce_hostname middleware overwrites the HTTP_HOST env using `Discourse.base_url_no_prefix`, which takes into account any configured protocol/hostname/post overrides.

That middleware is not used in development, so if we want omniauth to respect any host/port overrides, we need to configure the 'full host' directly.