### PR TITLE
DEV: Simplify theme translation JS generation

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 88
+  BASE_COMPILER_VERSION = 89
 
   class SettingsMigrationError < StandardError
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -318,40 +318,27 @@ class ThemeField < ActiveRecord::Base
   def process_translation
     errors = []
     javascript_cache || build_javascript_cache
-    js_compiler = ThemeJavascriptCompiler.new(theme_id, self.theme.name)
     begin
       data = translation_data
 
       js = <<~JS
-        export default {
-          name: "theme-#{theme_id}-translations",
-          initialize() {
-            /* Translation data for theme #{self.theme_id} (#{self.name})*/
-            const data = #{data.to_json};
+        /* Translation data for theme #{self.theme_id} (#{self.name})*/
+        const data = #{data.to_json};
 
-            for (let lang in data){
-              let cursor = I18n.translations;
-              for (let key of [lang, "js", "theme_translations"]){
-                cursor = cursor[key] = cursor[key] || {};
-              }
-              cursor[#{self.theme_id}] = data[lang];
-            }
+        for (let lang in data){
+          let cursor = I18n.translations;
+          for (let key of [lang, "js", "theme_translations"]){
+            cursor = cursor[key] ??= {};
           }
-        };
+          cursor[#{self.theme_id}] = data[lang];
+        }
       JS
-
-      js_compiler.append_module(
-        js,
-        "discourse/pre-initializers/theme-#{theme_id}-translations",
-        "js",
-        include_variables: false,
-      )
     rescue ThemeTranslationParser::InvalidYaml => e
       errors << e.message
     end
 
-    javascript_cache.content = js_compiler.content
-    javascript_cache.source_map = js_compiler.source_map
+    javascript_cache.content = js
+    javascript_cache.source_map = nil
     javascript_cache.save!
     doc = ""
     doc = <<~HTML.html_safe if javascript_cache.content.present?

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -318,33 +318,33 @@ class ThemeField < ActiveRecord::Base
   def process_translation
     errors = []
     javascript_cache || build_javascript_cache
-    begin
-      data = translation_data
 
-      js = <<~JS
-        /* Translation data for theme #{self.theme_id} (#{self.name})*/
-        const data = #{data.to_json};
+    data = translation_data
 
-        for (let lang in data){
-          let cursor = I18n.translations;
-          for (let key of [lang, "js", "theme_translations"]){
-            cursor = cursor[key] ??= {};
-          }
-          cursor[#{self.theme_id}] = data[lang];
+    js = <<~JS
+      /* Translation data for theme #{self.theme_id} (#{self.name})*/
+      const data = #{data.to_json};
+
+      for (let lang in data){
+        let cursor = I18n.translations;
+        for (let key of [lang, "js", "theme_translations"]){
+          cursor = cursor[key] ??= {};
         }
-      JS
-    rescue ThemeTranslationParser::InvalidYaml => e
-      errors << e.message
-    end
+        cursor[#{self.theme_id}] = data[lang];
+      }
+    JS
 
     javascript_cache.content = js
     javascript_cache.source_map = nil
     javascript_cache.save!
+
     doc = ""
     doc = <<~HTML.html_safe if javascript_cache.content.present?
           <script defer src="#{javascript_cache.url}" data-theme-id="#{theme_id}" nonce="#{ThemeField::CSP_NONCE_PLACEHOLDER}"></script>
         HTML
     [doc, errors&.join("\n")]
+  rescue ThemeTranslationParser::InvalidYaml => e
+    ["", e.message]
   end
 
   def validate_yaml!


### PR DESCRIPTION
Theme translations are very simple JS, and do not need to be run through the theme transpiler. This brings their format in-line with core/plugin translations.

Extracted from https://github.com/discourse/discourse/pull/33103