### PR TITLE
FIX: chat: if empty shows timer placeholder

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.gjs
@@ -1,18 +1,25 @@
 import Component from "@glimmer/component";
+import { or } from "truth-helpers";
 import { i18n } from "discourse-i18n";
 
 export default class ChatChannelMetadata extends Component {
   get lastMessageFormattedDate() {
-    const lastMessageDate = this.showThreadUnreadDate
-      ? this.args.channel.lastUnreadThreadDate
-      : this.args.channel.lastMessage.createdAt;
+    const { createdAt, id } = this.args.channel.lastMessage || {};
 
-    return moment(lastMessageDate).calendar(null, {
-      sameDay: "LT",
-      lastDay: `[${i18n("chat.dates.yesterday")}]`,
-      lastWeek: "dddd",
-      sameElse: "l",
-    });
+    if (id === null) {
+      return null;
+    } else {
+      const lastMessageDate = this.showThreadUnreadDate
+        ? this.args.channel.lastUnreadThreadDate
+        : createdAt;
+
+      return moment(lastMessageDate).calendar(null, {
+        sameDay: "LT",
+        lastDay: `[${i18n("chat.dates.yesterday")}]`,
+        lastWeek: "dddd",
+        sameElse: "l",
+      });
+    }
   }
 
   get showThreadUnreadDate() {
@@ -26,7 +33,7 @@ export default class ChatChannelMetadata extends Component {
     <div class="chat-channel__metadata">
       {{#if @channel.lastMessage}}
         <div class="chat-channel__metadata-date">
-          {{this.lastMessageFormattedDate}}
+          {{or this.lastMessageFormattedDate "–"}}
         </div>
       {{/if}}
     </div>

--- a/plugins/chat/test/javascripts/components/chat-channel-metadata-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-metadata-test.gjs
@@ -8,6 +8,22 @@ import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 module("Discourse Chat | Component | chat-channel-metadata", function (hooks) {
   setupRenderingTest(hooks);
 
+  test("displays created at placeholder for empty chat", async function (assert) {
+    const self = this;
+    this.channel = new ChatFabricators(getOwner(this)).directMessageChannel();
+    this.channel.lastMessage = new ChatFabricators(getOwner(this)).message({
+      channel: this.channel,
+      created_at: Date.now(),
+      id: null,
+    });
+
+    await render(
+      <template><ChatChannelMetadata @channel={{self.channel}} /></template>
+    );
+
+    assert.dom(".chat-channel__metadata-date").hasText("–");
+  });
+
   test("displays last message created at", async function (assert) {
     const self = this;
 


### PR DESCRIPTION
For empty chats, dummy message is still created with `id=null` (an unsaved Ember model).

This change determines by existing `id` to show timer or placeholder.