### PR TITLE
DEV: Switch to `type="module"` for translation files

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,14 +151,14 @@ module ApplicationHelper
       .html_safe
   end
 
-  def preload_script_url(url, entrypoint: nil)
+  def preload_script_url(url, entrypoint: nil, type_module: false)
     entrypoint_attribute = entrypoint ? "data-discourse-entrypoint=\"#{entrypoint}\"" : ""
     nonce_attribute = "nonce=\"#{csp_nonce_placeholder}\""
 
     add_resource_preload_list(url, "script")
 
     <<~HTML.html_safe
-      <script defer src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
+      <script #{type_module ? 'type="module"' : "defer"} src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
     HTML
   end
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 89
+  BASE_COMPILER_VERSION = 90
 
   class SettingsMigrationError < StandardError
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -340,7 +340,7 @@ class ThemeField < ActiveRecord::Base
 
     doc = ""
     doc = <<~HTML.html_safe if javascript_cache.content.present?
-          <script defer src="#{javascript_cache.url}" data-theme-id="#{theme_id}" nonce="#{ThemeField::CSP_NONCE_PLACEHOLDER}"></script>
+          <script type="module" src="#{javascript_cache.url}" data-theme-id="#{theme_id}" nonce="#{ThemeField::CSP_NONCE_PLACEHOLDER}"></script>
         HTML
     [doc, errors&.join("\n")]
   rescue ThemeTranslationParser::InvalidYaml => e

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,19 +36,19 @@
       <%= preload_script file %>
     <%- end %>
 
-    <%= preload_script_url ExtraLocalesController.url("main") %>
-    <%= preload_script_url ExtraLocalesController.url("mf") %>
+    <%= preload_script_url ExtraLocalesController.url("main"), type_module: true %>
+    <%= preload_script_url ExtraLocalesController.url("mf"), type_module: true %>
     <%- if ExtraLocalesController.client_overrides_exist? %>
-      <%= preload_script_url ExtraLocalesController.url("overrides") %>
+      <%= preload_script_url ExtraLocalesController.url("overrides"), type_module: true %>
     <%- end %>
 
     <%- if staff? %>
-      <%= preload_script_url ExtraLocalesController.url("admin") %>
+      <%= preload_script_url ExtraLocalesController.url("admin"), type_module: true %>
       <%= preload_script "admin" %>
     <%- end %>
 
     <%- if admin? %>
-      <%= preload_script_url ExtraLocalesController.url("wizard") %>
+      <%= preload_script_url ExtraLocalesController.url("wizard"), type_module: true %>
     <%- end %>
 
     <%- unless customization_disabled? %>


### PR DESCRIPTION
We will be moving towards `type="module"` for all of Discourse's JS bundles in the near future. This commit makes a start by applying the change to translation bundles.