### PR TITLE
FIX: Wrap theme translations in IIFE

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 89
+  BASE_COMPILER_VERSION = 90
 
   class SettingsMigrationError < StandardError
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -322,16 +322,18 @@ class ThemeField < ActiveRecord::Base
     data = translation_data
 
     js = <<~JS
-      /* Translation data for theme #{self.theme_id} (#{self.name})*/
-      const data = #{data.to_json};
+      (function(){
+        /* Translation data for theme #{self.theme_id} (#{self.name})*/
+        const data = #{data.to_json};
 
-      for (let lang in data){
-        let cursor = I18n.translations;
-        for (let key of [lang, "js", "theme_translations"]){
-          cursor = cursor[key] ??= {};
+        for (let lang in data){
+          let cursor = I18n.translations;
+          for (let key of [lang, "js", "theme_translations"]){
+            cursor = cursor[key] ??= {};
+          }
+          cursor[#{self.theme_id}] = data[lang];
         }
-        cursor[#{self.theme_id}] = data[lang];
-      }
+      })()
     JS
 
     javascript_cache.content = js


### PR DESCRIPTION
Without this wrapper, `data` is defined in the global scope and clashes when there are multiple themes with translations.

Followup to 033cccdf17a56b43f9f243bb549abe0a41a0de63

We can remove the wrapper once we land https://github.com/discourse/discourse/pull/33107