### PR TITLE
DEV: Fix displaying the time gap in the Glimmer Post Stream

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-stream.gjs
@@ -119,8 +119,8 @@ export default class PostStream extends Component {
   }
 
   daysBetween(post1, post2) {
-    const time1 = post1 ? new Date(post1.createdAt).getTime() : null;
-    const time2 = post2 ? new Date(post2.createdAt).getTime() : null;
+    const time1 = post1 ? new Date(post1.created_at).getTime() : null;
+    const time2 = post2 ? new Date(post2.created_at).getTime() : null;
 
     if (!time1 || !time2) {
       return null;

--- a/app/assets/javascripts/discourse/app/components/post/time-gap.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/time-gap.gjs
@@ -17,9 +17,11 @@ export default class PostTimeGap extends Component {
   }
 
   <template>
-    <div class="topic-avatar"></div>
-    <div class="small-action-desc timegap">
-      {{this.description}}
+    <div class="time-gap small-action">
+      <div class="topic-avatar"></div>
+      <div class="small-action-desc timegap">
+        {{this.description}}
+      </div>
     </div>
   </template>
 }


### PR DESCRIPTION
Update `time-gap` component structure for improved semantics and consistency. 

Correct the date property reference in `post-stream` from `createdAt` to `created_at` to match the model property.