### PR TITLE
Version bumps for main: v3.5.0.beta6, v3.5.0.beta7-dev

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
       # Use the `version_bump:*` rake tasks to update this value
-      STRING = "3.5.0.beta6"
+      STRING = "3.5.0.beta7-dev"
 
       PARTS = STRING.split(".")
       private_constant :PARTS

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -7,7 +7,7 @@ module Discourse
   unless defined?(::Discourse::VERSION)
     module VERSION #:nodoc:
       # Use the `version_bump:*` rake tasks to update this value
-      STRING = "3.5.0.beta6-dev"
+      STRING = "3.5.0.beta6"
 
       PARTS = STRING.split(".")
       private_constant :PARTS


### PR DESCRIPTION
> :warning: This PR should not be merged via the GitHub web interface
>
> It should only be merged (via fast-forward) using the associated `bin/rake version_bump:*` task.
