### PR TITLE
FIX: Clicking send invites and export button on admin users page

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-users-list.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users-list.js
@@ -1,25 +1,8 @@
 import { action } from "@ember/object";
-import { service } from "@ember/service";
-import { exportEntity } from "discourse/lib/export-csv";
-import { outputExportResult } from "discourse/lib/export-result";
 import DiscourseRoute from "discourse/routes/discourse";
 import AdminUser from "admin/models/admin-user";
 
 export default class AdminUsersListRoute extends DiscourseRoute {
-  @service router;
-
-  @action
-  exportUsers() {
-    exportEntity("user_list", {
-      trust_level: this.controllerFor("admin-users-list-show").get("query"),
-    }).then(outputExportResult);
-  }
-
-  @action
-  sendInvites() {
-    this.router.transitionTo("userInvited", this.currentUser);
-  }
-
   @action
   deleteUser(user) {
     AdminUser.create(user).destroy({ deletePosts: true });

--- a/app/assets/javascripts/admin/addon/routes/admin-users.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-users.js
@@ -1,8 +1,26 @@
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import { exportEntity } from "discourse/lib/export-csv";
+import { outputExportResult } from "discourse/lib/export-result";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
 export default class AdminUsersRoute extends DiscourseRoute {
+  @service router;
+
   titleToken() {
     return i18n("admin.config.users.title");
+  }
+
+  @action
+  exportUsers() {
+    exportEntity("user_list", {
+      trust_level: this.controllerFor("admin-users-list-show").get("query"),
+    }).then(outputExportResult);
+  }
+
+  @action
+  sendInvites() {
+    this.router.transitionTo("userInvited", this.currentUser);
   }
 }

--- a/spec/system/admin_users_list_spec.rb
+++ b/spec/system/admin_users_list_spec.rb
@@ -219,13 +219,17 @@ describe "Admin Users Page", type: :system do
 
     it "redirect to invites page" do
       admin_users_page.visit
+      admin_users_page.click_tab("settings")
       admin_users_page.click_send_invites
+
       expect(page).to have_current_path("/u/#{current_user.username}/invited/pending")
     end
 
     it "allows to export users" do
       admin_users_page.visit
+      admin_users_page.click_tab("settings")
       admin_users_page.click_export
+
       expect(page).to have_css(".dialog-body")
       expect(page).to have_content(I18n.t("admin_js.admin.export_csv.success"))
     end


### PR DESCRIPTION
The actions are defined on the `AdminUsersIndexRoute` when it should be
the `AdminUsersRoute` as the action is called from the `admin/users`
template.
