### PR TITLE
FIX: Add @enabled arg to <LoadMore /> component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/load-more.gjs
+++ b/app/assets/javascripts/discourse/app/components/load-more.gjs
@@ -23,6 +23,12 @@ export function enableLoadMoreObserver() {
  * in additional options to customize the observer's behavior;
  * Refer to https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options for a full list.
  *
+ * Additionally, an @enabled boolean can be passed to allow for cases where
+ * the element is visible in the viewport but you don't want to allow the `loadMore`
+ * behaviour. A use case for this is when our controllers return some `canLoadMore`
+ * boolean. There is no use attempting to load more from the server in this case,
+ * there will be nothing else.
+ *
  * @example Basic usage with a block:
  * ```gjs
  * <LoadMore @action={{this.loadMoreTopics}}>
@@ -57,10 +63,11 @@ export default class LoadMore extends Component {
   root = this.args.root || null;
   rootMargin = this.args.rootMargin || "0px 0px 0px 0px";
   threshold = this.args.threshold || 0.0;
+  enabled = this.args.enabled ?? true;
 
   @action
   onIntersection(entry) {
-    if (ENABLE_LOAD_MORE_OBSERVER && entry.isIntersecting) {
+    if (ENABLE_LOAD_MORE_OBSERVER && entry.isIntersecting && this.enabled) {
       discourseDebounce(this, this.args.action, 100);
     }
   }
@@ -78,7 +85,6 @@ export default class LoadMore extends Component {
           }}
           class="load-more-sentinel"
           aria-hidden="true"
-          style="height: 0px; width: 100%; margin: 0; padding: 0; pointer-events: none; user-select: none; visibility: hidden; position: relative;"
         />
       </Wrapper>
     {{/let}}

--- a/app/assets/javascripts/discourse/app/templates/users.gjs
+++ b/app/assets/javascripts/discourse/app/templates/users.gjs
@@ -25,7 +25,10 @@ export default RouteTemplate(
 
     {{bodyClass "users-page"}}
     <section>
-      <LoadMore @action={{@controller.loadMore}}>
+      <LoadMore
+        @action={{@controller.loadMore}}
+        @enabled={{@controller.model.canLoadMore}}
+      >
         <div class="container">
           <div class="users-directory directory">
             <span>

--- a/app/assets/javascripts/discourse/tests/integration/components/load-more-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/load-more-test.gjs
@@ -70,4 +70,33 @@ module("Integration | Component | load-more", function (hooks) {
       "loadMore action should be called once"
     );
   });
+
+  test("does not call loadMore action if intersection occurs and this is not enabled", async function (assert) {
+    let actionCalled = 0;
+    const performLoadMore = () => {
+      actionCalled++;
+    };
+
+    await render(
+      <template>
+        <LoadMore
+          @action={{performLoadMore}}
+          @root="#ember-testing"
+          @enabled={{false}}
+        >
+          <table class="numbers">
+            <tbody>
+              <tr />
+            </tbody>
+          </table>
+        </LoadMore>
+      </template>
+    );
+
+    assert.strictEqual(
+      actionCalled,
+      0,
+      "loadMore action should be called never"
+    );
+  });
 });

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -31,6 +31,7 @@
 @import "iframed-html";
 @import "ignored-user-list";
 @import "keyboard_shortcuts";
+@import "load-more";
 @import "more-topics";
 @import "navs";
 @import "offline-indicator";

--- a/app/assets/stylesheets/common/components/load-more.scss
+++ b/app/assets/stylesheets/common/components/load-more.scss
@@ -1,0 +1,10 @@
+.load-more-sentinel {
+  height: 0;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  user-select: none;
+  visibility: hidden;
+  position: relative;
+}


### PR DESCRIPTION
This commit adds an @enabled boolean to `<LoadMore />` to allow for
cases where the element is visible in the viewport but you don't want to
allow the `loadMore` behaviour. A use case for this is when our
controllers return some `canLoadMore` boolean. There is no use
attempting to load more from the server in this case, there will be
nothing else.

I also moved the CSS styles for the `<LoadMore />` component into
a new file.

This also fixes a bug in the users list shown here
https://meta.discourse.org/t/users-list-only-partial/368793
