### PR TITLE
FEATURE: Add X-Discourse-Sender Header to outgoing mail

### DIFF
--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -269,7 +269,7 @@ module Email
       result["X-Discourse-Topic-Id"] = @opts[:topic_id].to_s if @opts[:topic_id]
       result["X-Discourse-Topic-Ids"] = @opts[:topic_ids].join(",") if @opts[:topic_ids].present?
 
-      # at this point these have been filtered by the recipient's guardian for visibility,
+      # At this point these have been filtered by the recipient's guardian for visibility,
       # see UserNotifications#send_notification_email
       result["X-Discourse-Tags"] = @template_args[:show_tags_in_subject] if @opts[
         :show_tags_in_subject
@@ -278,7 +278,11 @@ module Email
         :show_category_in_subject
       ]
 
-      # please, don't send us automatic responses...
+      # Mimics X-GitHub-Sender, which identifies the GitHub user that originated the message,
+      # useful to filter and prioritize mail.
+      result["X-Discourse-Sender"] = @opts[:username] if @opts[:username].present?
+
+      # Please, don't send us automatic responses...
       result["X-Auto-Response-Suppress"] = "All"
 
       if !allow_reply_by_email?

--- a/spec/lib/email/message_builder_spec.rb
+++ b/spec/lib/email/message_builder_spec.rb
@@ -380,6 +380,7 @@ RSpec.describe Email::MessageBuilder do
           post_id: 4567,
           show_tags_in_subject: "foo bar baz",
           show_category_in_subject: "random",
+          username: "elbarto",
         }.merge(additional_opts),
       )
     end
@@ -404,6 +405,10 @@ RSpec.describe Email::MessageBuilder do
 
     it "passes through the topic category" do
       expect(message_with_header_args.header_args["X-Discourse-Category"]).to eq("random")
+    end
+
+    it "passes through the username" do
+      expect(message_with_header_args.header_args["X-Discourse-Sender"]).to eq("elbarto")
     end
 
     context "when allow_reply_by_email is enabled " do


### PR DESCRIPTION
When there is a relevant `username` associated with an outgoing email,
like in the case of post notifications, the `X-Discourse-Sender` header
will be added to the email, indicating the sender's username.

This mimics the `X-GitHub-Sender` header used by GitHub, which is useful
for filtering and categorizing emails based on the sender.
