### PR TITLE
DEV: Switch to `type="module"` for translation files

### DIFF
--- a/app/controllers/extra_locales_controller.rb
+++ b/app/controllers/extra_locales_controller.rb
@@ -9,12 +9,15 @@ class ExtraLocalesController < ApplicationController
                      :redirect_to_profile_if_required,
                      :verify_authenticity_token
 
+  before_action :is_asset_path, :apply_cdn_headers
+
   OVERRIDES_BUNDLE = "overrides"
   SHA1_HASH_LENGTH = 40
   MAIN_BUNDLE = "main"
   MF_BUNDLE = "mf"
   ADMIN_BUNDLE = "admin"
   WIZARD_BUNDLE = "wizard"
+  CACHE_VERSION = 1
 
   SITE_SPECIFIC_BUNDLES = [OVERRIDES_BUNDLE, MF_BUNDLE]
   SHARED_BUNDLES = [MAIN_BUNDLE, ADMIN_BUNDLE, WIZARD_BUNDLE]
@@ -88,7 +91,7 @@ class ExtraLocalesController < ApplicationController
     end
 
     def digest_for_content(js)
-      Digest::SHA1.hexdigest(js)
+      Digest::SHA1.hexdigest("#{CACHE_VERSION}|#{js}")
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,14 +151,14 @@ module ApplicationHelper
       .html_safe
   end
 
-  def preload_script_url(url, entrypoint: nil)
+  def preload_script_url(url, entrypoint: nil, type_module: false)
     entrypoint_attribute = entrypoint ? "data-discourse-entrypoint=\"#{entrypoint}\"" : ""
     nonce_attribute = "nonce=\"#{csp_nonce_placeholder}\""
 
     add_resource_preload_list(url, "script")
 
     <<~HTML.html_safe
-      <script defer src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
+      <script #{type_module ? 'type="module"' : "defer"} src="#{url}" #{entrypoint_attribute} #{nonce_attribute}></script>
     HTML
   end
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 90
+  BASE_COMPILER_VERSION = 91
 
   class SettingsMigrationError < StandardError
   end

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -322,18 +322,16 @@ class ThemeField < ActiveRecord::Base
     data = translation_data
 
     js = <<~JS
-      (function(){
-        /* Translation data for theme #{self.theme_id} (#{self.name})*/
-        const data = #{data.to_json};
+      /* Translation data for theme #{self.theme_id} (#{self.name})*/
+      const data = #{data.to_json};
 
-        for (let lang in data){
-          let cursor = I18n.translations;
-          for (let key of [lang, "js", "theme_translations"]){
-            cursor = cursor[key] ??= {};
-          }
-          cursor[#{self.theme_id}] = data[lang];
+      for (let lang in data){
+        let cursor = I18n.translations;
+        for (let key of [lang, "js", "theme_translations"]){
+          cursor = cursor[key] ??= {};
         }
-      })()
+        cursor[#{self.theme_id}] = data[lang];
+      }
     JS
 
     javascript_cache.content = js
@@ -342,7 +340,7 @@ class ThemeField < ActiveRecord::Base
 
     doc = ""
     doc = <<~HTML.html_safe if javascript_cache.content.present?
-          <script defer src="#{javascript_cache.url}" data-theme-id="#{theme_id}" nonce="#{ThemeField::CSP_NONCE_PLACEHOLDER}"></script>
+          <script type="module" src="#{javascript_cache.url}" data-theme-id="#{theme_id}" nonce="#{ThemeField::CSP_NONCE_PLACEHOLDER}"></script>
         HTML
     [doc, errors&.join("\n")]
   rescue ThemeTranslationParser::InvalidYaml => e

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,19 +36,19 @@
       <%= preload_script file %>
     <%- end %>
 
-    <%= preload_script_url ExtraLocalesController.url("main") %>
-    <%= preload_script_url ExtraLocalesController.url("mf") %>
+    <%= preload_script_url ExtraLocalesController.url("main"), type_module: true %>
+    <%= preload_script_url ExtraLocalesController.url("mf"), type_module: true %>
     <%- if ExtraLocalesController.client_overrides_exist? %>
-      <%= preload_script_url ExtraLocalesController.url("overrides") %>
+      <%= preload_script_url ExtraLocalesController.url("overrides"), type_module: true %>
     <%- end %>
 
     <%- if staff? %>
-      <%= preload_script_url ExtraLocalesController.url("admin") %>
+      <%= preload_script_url ExtraLocalesController.url("admin"), type_module: true %>
       <%= preload_script "admin" %>
     <%- end %>
 
     <%- if admin? %>
-      <%= preload_script_url ExtraLocalesController.url("wizard") %>
+      <%= preload_script_url ExtraLocalesController.url("wizard"), type_module: true %>
     <%- end %>
 
     <%- unless customization_disabled? %>

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -612,7 +612,7 @@ HTML
       it "is generated correctly" do
         fr1.ensure_baked!
         expect(fr1.value_baked).to include(
-          "<script defer src=\"#{fr1.javascript_cache.url}\" data-theme-id=\"#{fr1.theme_id}\" nonce=\"#{ThemeField::CSP_NONCE_PLACEHOLDER}\"></script>",
+          "<script type=\"module\" src=\"#{fr1.javascript_cache.url}\" data-theme-id=\"#{fr1.theme_id}\" nonce=\"#{ThemeField::CSP_NONCE_PLACEHOLDER}\"></script>",
         )
         expect(fr1.javascript_cache.content).to include("bonjourworld")
         expect(fr1.javascript_cache.content).to include("helloworld")

--- a/spec/requests/extra_locales_controller_spec.rb
+++ b/spec/requests/extra_locales_controller_spec.rb
@@ -177,14 +177,14 @@ RSpec.describe ExtraLocalesController do
     it "doesn't call bundle_js more than once for the same locale and bundle" do
       locale = :de
       ExtraLocalesController.expects(:bundle_js).with("admin", locale:).returns("admin_js DE").once
-      expected_hash_de = Digest::SHA1.hexdigest("admin_js DE")
+      expected_hash_de = Digest::SHA1.hexdigest("#{described_class::CACHE_VERSION}|admin_js DE")
 
       expect(ExtraLocalesController.bundle_js_hash("admin", locale:)).to eq(expected_hash_de)
       expect(ExtraLocalesController.bundle_js_hash("admin", locale:)).to eq(expected_hash_de)
 
       locale = :fr
       ExtraLocalesController.expects(:bundle_js).with("admin", locale:).returns("admin_js FR").once
-      expected_hash_fr = Digest::SHA1.hexdigest("admin_js FR")
+      expected_hash_fr = Digest::SHA1.hexdigest("#{described_class::CACHE_VERSION}|admin_js FR")
 
       expect(ExtraLocalesController.bundle_js_hash("admin", locale:)).to eq(expected_hash_fr)
       expect(ExtraLocalesController.bundle_js_hash("admin", locale:)).to eq(expected_hash_fr)
@@ -197,7 +197,7 @@ RSpec.describe ExtraLocalesController do
         .with("wizard", locale:)
         .returns("wizard_js DE")
         .once
-      expected_hash_de = Digest::SHA1.hexdigest("wizard_js DE")
+      expected_hash_de = Digest::SHA1.hexdigest("#{described_class::CACHE_VERSION}|wizard_js DE")
 
       expect(ExtraLocalesController.bundle_js_hash("wizard", locale:)).to eq(expected_hash_de)
       expect(ExtraLocalesController.bundle_js_hash("wizard", locale:)).to eq(expected_hash_de)
@@ -230,7 +230,7 @@ RSpec.describe ExtraLocalesController do
 
     it "returns both JS and its hash for a given bundle" do
       expect(described_class.bundle_js_with_hash("admin", locale: :en)).to eq(
-        ["JS", Digest::SHA1.hexdigest("JS")],
+        ["JS", Digest::SHA1.hexdigest("#{described_class::CACHE_VERSION}|JS")],
       )
     end
   end


### PR DESCRIPTION
We will be moving towards `type="module"` for all of Discourse's JS
bundles in the near future. This commit makes a start by applying the
change to translation bundles.

This was previously merged, but the lack of `apply_cdn_headers` on the locales controller led to CORS errors on sites with CDNs.