### PR TITLE
DEV: remove redundant composer tips site settings

### DIFF
--- a/db/migrate/20250609115711_remove_composer_tips_site_settings.rb
+++ b/db/migrate/20250609115711_remove_composer_tips_site_settings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RemoveComposerTipsSiteSettings < ActiveRecord::Migration[7.2]
+  def up
+    execute "DELETE FROM site_settings WHERE name='disable_avatar_education_message'"
+    execute "DELETE FROM site_settings WHERE name='sequential_replies_threshold'"
+    execute "DELETE FROM site_settings WHERE name='warn_reviving_old_topic_age'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
In #33012 we phased out the site settings for:

- `disable_avatar_education_message`
- `sequential_replies_threshold`
- `warn_reviving_old_topic_age`

This change is a follow up migration to delete the site settings from the database.