### PR TITLE
FIX: Emoji.exists? method to support complex aliased emoji lookups

### DIFF
--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe Emoji do
       expect(Emoji.exists?(aliases_list[0][0])).to be(true)
       expect(Emoji.exists?(aliases_list[1][0])).to be(true)
       expect(Emoji.exists?(aliases_list[2][0])).to be(true)
+      expect(Emoji.exists?(":#{aliases_list[2][0]}:")).to be(true)
+      expect(Emoji.exists?(":wave:t2:")).to be(true)
     end
   end
 


### PR DESCRIPTION
Currently, `Emoji.exists?` only checks if the alias name exists using `Emoji.aliases_values.include?(name)`. This leads to incorrect false returns for certain variations.

For example, the emoji `waving_hand` has an alias `wave`.  
- `Emoji.exists?("waving_hand")`, `Emoji.exists?(":waving_hand:")`, and `Emoji.exists?(":waving_hand:t2:")` all return true.  
- However, `Emoji.exists?(":wave:")` and `Emoji.exists?(":wave:t2:")` return false, while only `Emoji.exists?("wave")` returns true.

![image](https://github.com/user-attachments/assets/cd9f1713-3116-4bb2-84ec-d3cbc944ef04)

This PR attempts to resolve this by replacing the alias with the original name and then checking if the emoji exists again.