### PR TITLE
DEV: allows to set timezone and color scheme

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -457,47 +457,6 @@ RSpec.configure do |config|
       end
     end
 
-    driver_options = {
-      browser_type: :chromium,
-      channel: :chromium,
-      headless: (ENV["PLAYWRIGHT_HEADLESS"].presence || ENV["SELENIUM_HEADLESS"].presence) != "0",
-      args: apply_base_chrome_args,
-      acceptDownloads: true,
-      downloadsPath: Downloads::FOLDER,
-      slowMo: ENV["PLAYWRIGHT_SLOW_MO_MS"].to_i, # https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-slow-mo
-      playwright_cli_executable_path: "./node_modules/.bin/playwright",
-      logger: Logger.new(IO::NULL),
-    }
-
-    if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
-      driver_options[:browser] = :remote
-      driver_options[:url] = ENV["CAPYBARA_REMOTE_DRIVER_URL"]
-    end
-
-    Capybara.register_driver(:playwright_chrome) do |app|
-      Capybara::Playwright::Driver.new(
-        app,
-        **driver_options,
-        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 1400, height: 1400 },
-      )
-    end
-
-    Capybara.register_driver(:playwright_mobile_chrome) do |app|
-      Capybara::Playwright::Driver.new(
-        app,
-        **driver_options,
-        deviceScaleFactor: 3,
-        isMobile: true,
-        hasTouch: true,
-        userAgent:
-          "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1",
-        defaultBrowserType: "webkit",
-        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 390, height: 664 },
-      )
-    end
-
-    Capybara.default_driver = :playwright_chrome
-
     [
       [PostAction, :post_action_type_id],
       [Reviewable, :target_id],
@@ -681,6 +640,49 @@ RSpec.configure do |config|
 
       system_tests_initialized = true
     end
+
+    driver_options = {
+      browser_type: :chromium,
+      channel: :chromium,
+      headless: (ENV["PLAYWRIGHT_HEADLESS"].presence || ENV["SELENIUM_HEADLESS"].presence) != "0",
+      args: apply_base_chrome_args,
+      acceptDownloads: true,
+      downloadsPath: Downloads::FOLDER,
+      slowMo: ENV["PLAYWRIGHT_SLOW_MO_MS"].to_i, # https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-slow-mo
+      playwright_cli_executable_path: "./node_modules/.bin/playwright",
+      logger: Logger.new(IO::NULL),
+      timezoneId: example.metadata[:timezone],
+      colorScheme: example.metadata[:color_scheme],
+    }
+
+    if ENV["CAPYBARA_REMOTE_DRIVER_URL"].present?
+      driver_options[:browser] = :remote
+      driver_options[:url] = ENV["CAPYBARA_REMOTE_DRIVER_URL"]
+    end
+
+    Capybara.register_driver(:playwright_mobile_chrome) do |app|
+      Capybara::Playwright::Driver.new(
+        app,
+        **driver_options,
+        deviceScaleFactor: 3,
+        isMobile: true,
+        hasTouch: true,
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1",
+        defaultBrowserType: "webkit",
+        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 390, height: 664 },
+      )
+    end
+
+    Capybara.register_driver(:playwright_chrome) do |app|
+      Capybara::Playwright::Driver.new(
+        app,
+        **driver_options,
+        viewport: ENV["PLAYWRIGHT_NO_VIEWPORT"] == "1" ? nil : { width: 1400, height: 1400 },
+      )
+    end
+
+    Capybara.default_driver = :playwright_chrome
 
     driver = [:playwright]
     driver << :mobile if example.metadata[:mobile]


### PR DESCRIPTION
As defined in: https://playwright.dev/docs/emulation

Example:

```ruby
context "xxxx", color_scheme: "dark", timezone: "Australia/Brisbane" do
  # ...
end
```