### PR TITLE
FEATURE: Indicate if a localization might be outdated based on version number

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/language.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/language.gjs
@@ -3,17 +3,31 @@ import { i18n } from "discourse-i18n";
 import DTooltip from "float-kit/components/d-tooltip";
 
 export default class PostMetaDataLanguage extends Component {
+  // once we switch to glimmer, we can remove `this.args.data.x` from the following 2 getters
+
+  get language() {
+    return this.args.data?.language || this.args.post?.language;
+  }
+
+  get outdated() {
+    return (
+      this.args.data?.localization_outdated ||
+      this.args.post?.localization_outdated
+    );
+  }
+
   get tooltip() {
-    // once we switch to glimmer, we can remove `this.args.data.language`
-    const language = this.args.data?.language || this.args.post?.language;
-    return i18n("post.original_language", {
-      language,
-    });
+    const i18nKey = this.outdated
+      ? "post.original_language_and_outdated"
+      : "post.original_language";
+
+    return i18n(i18nKey, { language: this.language });
   }
 
   <template>
     <div class="post-info post-language">
       <DTooltip
+        class={{if this.outdated "heatmap-low"}}
         @identifier="post-language"
         @icon="language"
         @content={{this.tooltip}}

--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -94,6 +94,7 @@ export function transformBasicPost(post) {
     locale: post.locale,
     is_localized: post.is_localized,
     language: post.language,
+    localization_outdated: post.localization_outdated,
   };
 
   _additionalAttributes.forEach((a) => (postAtts[a] = post[a]));

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -460,6 +460,7 @@ createWidget("post-language", {
     return [
       new RenderGlimmer(this, "div", PostMetaDataLanguage, {
         language: attrs.language,
+        localization_outdated: attrs.localization_outdated,
       }),
     ];
   },

--- a/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
@@ -281,7 +281,27 @@ module("Integration | Component | Post", function (hooks) {
 
     await renderComponent(this.post);
 
-    assert.dom(".post-language").exists();
+    await triggerEvent(".fk-d-tooltip__trigger", "pointermove");
+    assert.dom(".post-language").hasText(
+      i18n("post.original_language", {
+        language: "English",
+      })
+    );
+  });
+
+  test("outdated localization", async function (assert) {
+    this.post.is_localized = true;
+    this.post.language = "English";
+    this.post.localization_outdated = true;
+
+    await renderComponent(this.post);
+
+    await triggerEvent(".fk-d-tooltip__trigger", "pointermove");
+    assert.dom(".post-language").hasText(
+      i18n("post.original_language_and_outdated", {
+        language: "English",
+      })
+    );
   });
 
   test("read indicator", async function (assert) {

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -703,7 +703,7 @@ class PostSerializer < BasicPostSerializer
     object.has_localization? && object.get_localization.post_version != object.version
   end
 
-  def include_localization_outdated
+  def include_localization_outdated?
     include_is_localized? && is_localized
   end
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -99,7 +99,8 @@ class PostSerializer < BasicPostSerializer
              :post_localizations_count,
              :locale,
              :is_localized,
-             :language
+             :language,
+             :localization_outdated
 
   def initialize(object, opts)
     super(object, opts)
@@ -696,6 +697,14 @@ class PostSerializer < BasicPostSerializer
 
   def include_language?
     SiteSetting.experimental_content_localization && object.locale.present?
+  end
+
+  def localization_outdated
+    object.has_localization? && object.get_localization.post_version != object.version
+  end
+
+  def include_localization_outdated
+    include_is_localized? && is_localized
   end
 
   private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4136,6 +4136,7 @@ en:
         instructions: "Share a link to this post:"
 
       original_language: "This post was originally written in %{language}"
+      original_language_and_outdated: "This post was originally written in %{language}. Translation may be outdated"
 
     category:
       none: "(no category)"


### PR DESCRIPTION
We will not update localization on every edit for now. To compensate, the existing indicator will also add information if a translation might be outdated.

Related: https://github.com/discourse/discourse-ai/pull/1422

<img width="897" alt="Screenshot 2025-06-11 at 1 34 04 AM" src="https://github.com/user-attachments/assets/dc1a9a77-659b-40c3-8e95-fce63d03d984" />

/t/156185