### PR TITLE
Add category-custom-images plugin outlet to category page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-images.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-images.gjs
@@ -1,6 +1,8 @@
 import EmberObject, { action } from "@ember/object";
 import { buildCategoryPanel } from "discourse/components/edit-category-panel";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import UppyImageUploader from "discourse/components/uppy-image-uploader";
+import lazyHash from "discourse/helpers/lazy-hash";
 import discourseComputed from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 
@@ -135,6 +137,13 @@ export default class EditCategoryImages extends buildCategoryPanel("images") {
         @onUploadDeleted={{this.backgroundDarkUploadDeleted}}
         @type="category_background_dark"
         @id="category-dark-background-uploader"
+      />
+    </section>
+
+    <section>
+      <PluginOutlet
+        @name="category-custom-images"
+        @outletArgs={{lazyHash category=this.category}}
       />
     </section>
   </template>


### PR DESCRIPTION
The new `category-custom-images` plugin outlet will allow theme and plugin developers to easily inject custom images, UI components, or contextual elements that will relate to a specific category. This will provide greater flexibility for enhancing and customizing the appearance and functionality of category pages.