### PR TITLE
FEATURE: Allow flagging posts from negative ID users

### DIFF
--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -384,7 +384,6 @@ class PostActionCreator
 
   def create_reviewable(result)
     return unless flagging_post?
-    return if @post.user_id.to_i < 0
 
     result.reviewable =
       ReviewableFlaggedPost.needs_review!(

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -346,13 +346,6 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(pending_count).to eq(0)
     end
 
-    it "should not review non-human users" do
-      post = create_post(user: Discourse.system_user)
-      reviewable = PostActionCreator.off_topic(user, post).reviewable
-      expect(reviewable).to be_blank
-      expect(pending_count).to eq(0)
-    end
-
     it "should ignore handled flags" do
       post = create_post
       reviewable = PostActionCreator.off_topic(user, post).reviewable


### PR DESCRIPTION
At the moment posts from AI Bot users or system user cannot be flagged. Not sure why that is. Very simple PR here to allow it.