### PR TITLE
UX: Properly center-align buttons in login-required screen

### DIFF
--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -47,6 +47,7 @@
 
   button {
     margin-right: 1em;
+
     &:last-child {
       margin-right: 0;
     }

--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -46,7 +46,7 @@
   display: flex;
 
   button {
-    margin-right: 1em;
+    margin-right: 1rem;
 
     &:last-child {
       margin-right: 0;

--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -46,6 +46,9 @@
   display: flex;
 
   button {
-    margin-right: 0.75em;
+    margin-right: 1em;
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }


### PR DESCRIPTION
Hard to take a screenshot, the "Log In" button having a right margin forced the rest of the block to be slightly misaligned. It's not visible on the default screen, but quite visible when adding other centre-aligned elements to the page. 