### PR TITLE
DEV: Add Plugin modifier for reviewable creation (bot posts)

### DIFF
--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -384,7 +384,16 @@ class PostActionCreator
 
   def create_reviewable(result)
     return unless flagging_post?
-    return if @post.user_id.to_i < 0
+
+    # Return early if the reviewable is being created for a user with a negative user_id. Plugin apply_modifier
+    # can remove this early return for special cases.
+    return_early_for_bot =
+      DiscoursePluginRegistry.apply_modifier(
+        :post_action_creator_block_reviewable_for_bot,
+        @post.user_id.to_i < 0,
+        @post,
+      )
+    return if return_early_for_bot
 
     result.reviewable =
       ReviewableFlaggedPost.needs_review!(

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -387,10 +387,10 @@ class PostActionCreator
 
     # Return early if the reviewable is being created for a user with a negative user_id.
     # Plugin apply_modifier can remove this early return for special cases.
-    is_non_human_creator = @post.user_id.to_i < 0
+    is_bot_post = @post.user_id.to_i < 0
     if DiscoursePluginRegistry.apply_modifier(
          :post_action_creator_block_reviewable_for_bot,
-         is_non_human_creator,
+         is_bot_post,
          @post,
        )
       return

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -387,13 +387,13 @@ class PostActionCreator
 
     # Return early if the reviewable is being created for a user with a negative user_id. Plugin apply_modifier
     # can remove this early return for special cases.
-    return_early_for_bot =
+    block_reviewable_creation_for_nonhuman =
       DiscoursePluginRegistry.apply_modifier(
         :post_action_creator_block_reviewable_for_bot,
         @post.user_id.to_i < 0,
         @post,
       )
-    return if return_early_for_bot
+    return if block_reviewable_creation_for_nonhuman
 
     result.reviewable =
       ReviewableFlaggedPost.needs_review!(

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -385,15 +385,16 @@ class PostActionCreator
   def create_reviewable(result)
     return unless flagging_post?
 
-    # Return early if the reviewable is being created for a user with a negative user_id. Plugin apply_modifier
-    # can remove this early return for special cases.
-    block_reviewable_creation_for_nonhuman =
-      DiscoursePluginRegistry.apply_modifier(
-        :post_action_creator_block_reviewable_for_bot,
-        @post.user_id.to_i < 0,
-        @post,
-      )
-    return if block_reviewable_creation_for_nonhuman
+    # Return early if the reviewable is being created for a user with a negative user_id.
+    # Plugin apply_modifier can remove this early return for special cases.
+    is_non_human_creator = @post.user_id.to_i < 0
+    if DiscoursePluginRegistry.apply_modifier(
+         :post_action_creator_block_reviewable_for_bot,
+         is_non_human_creator,
+         @post,
+       )
+      return
+    end
 
     result.reviewable =
       ReviewableFlaggedPost.needs_review!(

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe PostActionCreator do
         expect(result.reviewable).to be_blank
       end
 
-      it "applies modifier and can allow flagging for non-human users" do
+      it "applies modifier and can allow reviewable creation for non-human users" do
         plugin = Plugin::Instance.new
         modifier = :post_action_creator_block_reviewable_for_bot
         proc = Proc.new { false }


### PR DESCRIPTION
I need reviewables to be created for bot users in a private plugin. This allows me to do that.