### PR TITLE
FIX: Unread-icon-size

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -681,7 +681,6 @@
     &.pending {
       .icon-avatar__icon-wrapper {
         background: var(--tertiary);
-        font-size: var(--font-down-1);
 
         .d-icon {
           color: var(--secondary);


### PR DESCRIPTION
Two applications of `--font-down-1` are making this icon *slightly* smaller if it is unread. This should not be the case.