### PR TITLE
UX: add missing toolbar separator css

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -369,6 +369,12 @@
   }
 }
 
+.toolbar-separator {
+  width: 1px;
+  background-color: var(--primary-low);
+  margin: 0.5rem 0.25rem;
+}
+
 .d-editor #form-template-form {
   overflow: auto;
   background: var(--primary-very-low);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/069b0ce3-2e7b-4b4a-ad60-046fd7a16d47)
