### PR TITLE
DEV: Change admin site settings filter to be route based

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings-category.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings-category.js
@@ -1,18 +1,6 @@
-import Controller, { inject as controller } from "@ember/controller";
-import discourseComputed from "discourse/lib/decorators";
+import Controller from "@ember/controller";
+import { alias } from "@ember/object/computed";
 
 export default class AdminSiteSettingsCategoryController extends Controller {
-  @controller adminSiteSettings;
-
-  categoryNameKey = null;
-
-  @discourseComputed("adminSiteSettings.visibleSiteSettings", "categoryNameKey")
-  category(categories, nameKey) {
-    return (categories || []).findBy("nameKey", nameKey);
-  }
-
-  @discourseComputed("category")
-  filteredContent(category) {
-    return category ? category.siteSettings : [];
-  }
+  @alias("model") filteredSiteSettings;
 }

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -2,65 +2,31 @@ import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { service } from "@ember/service";
-import { isEmpty } from "@ember/utils";
 import { debounce } from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
-import SiteSettingFilter from "admin/lib/site-setting-filter";
 
 export default class AdminSiteSettingsController extends Controller {
   @service router;
 
-  @alias("model") allSiteSettings;
-
-  filter = "";
-  visibleSiteSettings = null;
-  siteSettingFilter = null;
-
-  filterContentNow(filterData, category) {
-    this.siteSettingFilter ??= new SiteSettingFilter(this.allSiteSettings);
-
-    if (isEmpty(this.allSiteSettings)) {
-      return;
-    }
-
-    this.set("filter", filterData.filter);
-
-    if (isEmpty(filterData.filter) && !filterData.onlyOverridden) {
-      this.set("visibleSiteSettings", this.allSiteSettings);
-      if (this.categoryNameKey === "all_results") {
-        this.router.transitionTo("adminSiteSettings");
-      }
-      return;
-    }
-
-    const matchesGroupedByCategory = this.siteSettingFilter.filterSettings(
-      filterData.filter,
-      { onlyOverridden: filterData.onlyOverridden }
-    );
-
-    const categoryMatches = matchesGroupedByCategory.findBy(
-      "nameKey",
-      category
-    );
-
-    if (!categoryMatches || categoryMatches.count === 0) {
-      category = "all_results";
-    }
-
-    this.set("visibleSiteSettings", matchesGroupedByCategory);
-    this.router.transitionTo(
-      "adminSiteSettingsCategory",
-      category || "all_results"
-    );
-  }
+  @alias("model") visibleSiteSettings;
 
   @debounce(INPUT_DELAY)
   filterContent(filterData) {
     if (this._skipBounce) {
       this.set("_skipBounce", false);
     } else {
-      if (!this.isDestroyed) {
-        this.filterContentNow(filterData, this.categoryNameKey);
+      const currentParams = this.router.currentRoute.queryParams;
+      const queryParams = {
+        filter: filterData.filter || undefined,
+        onlyOverridden: filterData.onlyOverridden || undefined,
+      };
+
+      const paramsChanged =
+        currentParams.filter !== queryParams.filter ||
+        currentParams.onlyOverridden !== queryParams.onlyOverridden;
+
+      if (!this.isDestroyed && paramsChanged) {
+        this.router.transitionTo(this.router.currentRouteName, { queryParams });
       }
     }
   }

--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -8,7 +8,8 @@ import { INPUT_DELAY } from "discourse/lib/environment";
 export default class AdminSiteSettingsController extends Controller {
   @service router;
 
-  @alias("model") visibleSiteSettings;
+  @alias("model.filteredSettings") visibleSiteSettings;
+  @alias("model.filtersApplied") filtersApplied;
 
   @debounce(INPUT_DELAY)
   filterContent(filterData) {

--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -20,26 +20,22 @@ const AUTO_REFRESH_ON_SAVE = [
 ];
 
 export default class SiteSetting extends EmberObject {
-  static findAll(params = {}) {
-    return ajax("/admin/site_settings", { data: params }).then(
-      function (settings) {
-        // Group the results by category
-        const categories = {};
-        settings.site_settings.forEach(function (s) {
-          if (!categories[s.category]) {
-            categories[s.category] = [];
-          }
-          categories[s.category].pushObject(SiteSetting.create(s));
-        });
-        return Object.keys(categories).map(function (n) {
-          return {
-            nameKey: n,
-            name: i18n("admin.site_settings.categories." + n),
-            siteSettings: categories[n],
-          };
-        });
+  static async findAll(params = {}) {
+    let settings = await ajax("/admin/site_settings", { data: params });
+    const categories = {};
+    settings.site_settings.forEach(function (s) {
+      if (!categories[s.category]) {
+        categories[s.category] = [];
       }
-    );
+      categories[s.category].pushObject(SiteSetting.create(s));
+    });
+    return Object.keys(categories).map(function (n) {
+      return {
+        nameKey: n,
+        name: i18n("admin.site_settings.categories." + n),
+        siteSettings: categories[n],
+      };
+    });
   }
 
   static findByName(name) {

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
@@ -3,8 +3,10 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default class AdminSiteSettingsCategoryRoute extends DiscourseRoute {
   model(params) {
     return (
-      this.modelFor("adminSiteSettings").findBy("nameKey", params.category_id)
-        ?.siteSettings || []
+      this.modelFor("adminSiteSettings").filteredSettings.findBy(
+        "nameKey",
+        params.category_id
+      )?.siteSettings || []
     );
   }
 

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
@@ -1,24 +1,19 @@
-import EmberObject from "@ember/object";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 
 export default class AdminSiteSettingsCategoryRoute extends DiscourseRoute {
   model(params) {
-    // The model depends on user input, so let the controller do the work:
-    this.controllerFor("adminSiteSettingsCategory").set(
-      "categoryNameKey",
-      params.category_id
+    return (
+      this.modelFor("adminSiteSettings").findBy("nameKey", params.category_id)
+        ?.siteSettings || []
     );
-    this.controllerFor("adminSiteSettings").set(
-      "categoryNameKey",
-      params.category_id
-    );
-    return EmberObject.create({
-      nameKey: params.category_id,
-      name: i18n("admin.site_settings.categories." + params.category_id),
-      siteSettings: this.controllerFor("adminSiteSettingsCategory").get(
-        "filteredContent"
-      ),
-    });
+  }
+
+  afterModel(model, transition) {
+    if (
+      model.length === 0 &&
+      transition.to.params.category_id !== "all_results"
+    ) {
+      this.router.transitionTo("adminSiteSettingsCategory", "all_results");
+    }
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-category.js
@@ -2,17 +2,15 @@ import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminSiteSettingsCategoryRoute extends DiscourseRoute {
   model(params) {
-    return (
-      this.modelFor("adminSiteSettings").filteredSettings.findBy(
-        "nameKey",
-        params.category_id
-      )?.siteSettings || []
-    );
+    return this.modelFor("adminSiteSettings").filteredSettings.findBy(
+      "nameKey",
+      params.category_id
+    )?.siteSettings;
   }
 
   afterModel(model, transition) {
     if (
-      model.length === 0 &&
+      (!model || model.length === 0) &&
       transition.to.params.category_id !== "all_results"
     ) {
       this.router.transitionTo("adminSiteSettingsCategory", "all_results");

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings-index.js
@@ -9,10 +9,6 @@ export default class AdminSiteSettingsIndexRoute extends DiscourseRoute {
   @service router;
 
   beforeModel() {
-    this.router.replaceWith(
-      "adminSiteSettingsCategory",
-      this.controllerFor("adminSiteSettings").get("visibleSiteSettings")[0]
-        .nameKey
-    );
+    this.router.replaceWith("adminSiteSettingsCategory", "required");
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -15,8 +15,8 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
     return i18n("admin.config.site_settings.title");
   }
 
-  model() {
-    return SiteSetting.findAll();
+  async model() {
+    return await SiteSetting.findAll();
   }
 
   afterModel(siteSettings) {

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -11,12 +11,18 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
     filter: { replace: true },
   };
 
+  _siteSettings = null;
+
   titleToken() {
     return i18n("admin.config.site_settings.title");
   }
 
   async model() {
-    return await SiteSetting.findAll();
+    if (!this._siteSettings) {
+      this._siteSettings = await SiteSetting.findAll();
+    }
+
+    return this._siteSettings;
   }
 
   afterModel(siteSettings) {
@@ -42,10 +48,8 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
   }
 
   @action
-  refreshAll() {
-    SiteSetting.findAll().then((settings) => {
-      this.controllerFor("adminSiteSettings").set("model", settings);
-    });
+  async refreshAll() {
+    this._siteSettings = await SiteSetting.findAll();
   }
 
   resetController(controller, isExiting) {

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -48,11 +48,6 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
   }
 
   @action
-  async refreshAll() {
-    this._siteSettings = await SiteSetting.findAll();
-  }
-
-  @action
   filterSettings(filter, onlyOverridden) {
     const settingFilter = new SiteSettingFilter(this._siteSettings);
 

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -30,7 +30,13 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
       this._siteSettings = await SiteSetting.findAll();
     }
 
-    return this.filterSettings(params.filter, params.onlyOverridden);
+    return {
+      filteredSettings: this.filterSettings(
+        params.filter,
+        params.onlyOverridden
+      ),
+      filtersApplied: params.filter || params.onlyOverridden,
+    };
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-site-settings.js
@@ -26,9 +26,7 @@ export default class AdminSiteSettingsRoute extends DiscourseRoute {
   }
 
   async model(params) {
-    if (!this._siteSettings) {
-      this._siteSettings = await SiteSetting.findAll();
-    }
+    this._siteSettings ??= await SiteSetting.findAll();
 
     return {
       filteredSettings: this.filterSettings(

--- a/app/assets/javascripts/admin/addon/templates/site-settings-category.gjs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings-category.gjs
@@ -4,9 +4,9 @@ import SiteSetting from "admin/components/site-setting";
 
 export default RouteTemplate(
   <template>
-    {{#if @controller.filteredContent}}
+    {{#if @controller.filteredSiteSettings}}
       <section class="form-horizontal settings">
-        {{#each @controller.filteredContent as |setting|}}
+        {{#each @controller.filteredSiteSettings as |setting|}}
           <SiteSetting @setting={{setting}} />
         {{/each}}
         {{#if @controller.category.hasMore}}

--- a/app/assets/javascripts/admin/addon/templates/site-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.gjs
@@ -46,7 +46,7 @@ export default RouteTemplate(
               title={{category.name}}
             >
               {{category.name}}
-              {{#if category.count}}
+              {{#if @controller.filtersApplied}}
                 <span class="count">({{category.count}})</span>
               {{/if}}
             </LinkTo>


### PR DESCRIPTION
### What is this change?

The filtering is currently being done in the controller. This leads to weird things where the filter loop might already be initiated and we get double filtering, as well as the issue that we can't abort like we could with a route transition.

### How does it work?

- Cache the site settings fetched from the server in the route instance.
- Hook up the controller to the query params.
- Use the query params to filter the `model` in the route.