### PR TITLE
FIX: Admin can edit the name even if enable_names is disabled

### DIFF
--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -45,6 +45,10 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   has_one :tl3_requirements, serializer: TrustLevel3RequirementsSerializer, embed: :objects
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
 
+  def include_name?
+    scope.user.admin?
+  end
+
   def second_factor_enabled
     object.totp_enabled? || object.security_keys_enabled?
   end

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -38,9 +38,10 @@ module UserGuardian
   end
 
   def can_edit_name?(user)
-    return false unless SiteSetting.enable_names?
     return false if SiteSetting.auth_overrides_name?
-    return true if is_staff?
+    return true if is_admin?
+    return false unless SiteSetting.enable_names?
+    return true if is_moderator?
     return false if is_anonymous?
     can_edit?(user)
   end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3458,7 +3458,7 @@ RSpec.describe Guardian do
       end
 
       it "is false for admins" do
-        expect(Guardian.new(admin).can_edit_name?(user)).to be_falsey
+        expect(Guardian.new(admin).can_edit_name?(user)).to be_truthy
       end
     end
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3457,7 +3457,7 @@ RSpec.describe Guardian do
         expect(Guardian.new(moderator).can_edit_name?(user)).to be_falsey
       end
 
-      it "is false for admins" do
+      it "is true for admins" do
         expect(Guardian.new(admin).can_edit_name?(user)).to be_truthy
       end
     end

--- a/spec/serializers/admin_detailed_user_serializer_spec.rb
+++ b/spec/serializers/admin_detailed_user_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe AdminDetailedUserSerializer do
+  fab!(:user) { Fabricate(:user, trust_level: 0) }
+  fab!(:admin)
+  fab!(:moderator)
+
+  it "serializes name for admin even if enable_names setting is false" do
+    serializer = AdminDetailedUserSerializer.new(user, scope: Guardian.new(admin), root: false)
+    json = serializer.as_json
+    expect(json[:name]).to eq(user.name)
+
+    serializer = AdminDetailedUserSerializer.new(user, scope: Guardian.new(moderator), root: false)
+    json = serializer.as_json
+    expect(json[:name]).to be_nil
+  end
+end


### PR DESCRIPTION
There is a bug that when `SiteSetting.enable_names` is disabled, the admin can click the pencil next to the user and successfully update the name. However, the change is not saved as the action is blocked by the guardian.

Meta: https://meta.discourse.org/t/disabling-enable-names-makes-admin-act-strange/291912