### PR TITLE
DEV: use composer mention input rules and invalidate nodes via plugin

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -150,7 +150,10 @@ const extension = {
 };
 
 async function fetchMentions(names) {
-  names = names.uniq().filter((name) => !VALID_MENTIONS.has(name));
+  // only fetch new mentions that are not already validated
+  names = names.uniq().filter((name) => {
+    return !VALID_MENTIONS.has(name) && !INVALID_MENTIONS.has(name);
+  });
 
   if (!names.length) {
     return;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -150,7 +150,7 @@ const extension = {
 };
 
 async function fetchMentions(names) {
-  names.uniq().filter((name) => !VALID_MENTIONS.has(name));
+  names = names.uniq().filter((name) => !VALID_MENTIONS.has(name));
 
   if (!names.length) {
     return;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -108,7 +108,7 @@ const extension = {
             this._processingMentionNodes = true;
 
             view.state.doc.descendants((node, pos) => {
-              if (node.type.name !== "mention") {
+              if (node.type.name !== "mention" || node.attrs.valid === false) {
                 return;
               }
 

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -4,7 +4,6 @@ import { isBoundary } from "discourse/static/prosemirror/lib/markdown-it";
 
 const VALID_MENTIONS = new Set();
 const INVALID_MENTIONS = new Set();
-const MIN_MENTION_LENGTH = 3;
 
 /** @type {RichEditorExtension} */
 const extension = {
@@ -151,9 +150,7 @@ const extension = {
 };
 
 async function fetchMentions(names) {
-  names.uniq().filter((name) => {
-    return !VALID_MENTIONS.has(name) && name.length >= MIN_MENTION_LENGTH;
-  });
+  names.uniq().filter((name) => !VALID_MENTIONS.has(name));
 
   if (!names.length) {
     return;

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -4,6 +4,7 @@ import { isBoundary } from "discourse/static/prosemirror/lib/markdown-it";
 
 const VALID_MENTIONS = new Set();
 const INVALID_MENTIONS = new Set();
+const MIN_MENTION_LENGTH = 3;
 
 /** @type {RichEditorExtension} */
 const extension = {
@@ -108,7 +109,7 @@ const extension = {
             this._processingMentionNodes = true;
 
             view.state.doc.descendants((node, pos) => {
-              if (node.type.name !== "mention" || node.attrs.valid === false) {
+              if (node.type.name !== "mention" || !node.attrs.valid) {
                 return;
               }
 
@@ -150,8 +151,8 @@ const extension = {
 };
 
 async function fetchMentions(names) {
-  names.filter((name) => {
-    return !VALID_MENTIONS.has(name) && !INVALID_MENTIONS.has(name);
+  names.uniq().filter((name) => {
+    return !VALID_MENTIONS.has(name) && name.length >= MIN_MENTION_LENGTH;
   });
 
   if (!names.length) {

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
@@ -26,32 +26,32 @@ module(
     const testCases = {
       mention: [
         "@eviltrout",
-        '<p><a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<p><a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "@eviltrout",
       ],
       "text with mention": [
         "Hello @eviltrout",
-        '<p>Hello <a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<p>Hello <a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "Hello @eviltrout",
       ],
       "mention after heading": [
         "## Hello\n\n@eviltrout",
-        '<h2>Hello</h2><p><a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<h2>Hello</h2><p><a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "## Hello\n\n@eviltrout",
       ],
       "group mention": [
         "Maybe @support can help",
-        '<p>Maybe <a class="mention" data-name="support" contenteditable="false" draggable="true">@support</a> can help</p>',
+        '<p>Maybe <a class="mention" data-name="support" data-valid="true" contenteditable="false" draggable="true">@support</a> can help</p>',
         "Maybe @support can help",
       ],
       "group and user mention": [
         "Hey @john, I think @support can help here",
-        '<p>Hey <a class="mention" data-name="john" contenteditable="false" draggable="true">@john</a>, I think <a class="mention" data-name="support" contenteditable="false" draggable="true">@support</a> can help here</p>',
+        '<p>Hey <a class="mention" data-name="john" data-valid="true" contenteditable="false" draggable="true">@john</a>, I think <a class="mention" data-name="support" data-valid="true" contenteditable="false" draggable="true">@support</a> can help here</p>',
         "Hey @john, I think @support can help here",
       ],
       "invalid mention": [
         "Hello @invalid, how are you?",
-        "<p>Hello @invalid, how are you?</p>",
+        '<p>Hello <a class="mention" data-name="invalid" data-valid="false" contenteditable="false" draggable="true">@invalid</a>, how are you?</p>',
         "Hello @invalid, how are you?",
       ],
     };

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -258,6 +258,11 @@ $hpad: 0.65em;
   text-wrap: nowrap;
   line-height: 1;
 
+  &[data-valid="false"] {
+    background: unset;
+    padding: 0;
+  }
+
   &.--bot {
     background: var(--success-low);
   }

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -862,11 +862,11 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("Hey @#{user.username} ")
 
-      expect(rich).to have_css("a.mention", text: user.username)
+      expect(rich).to have_css("a.mention[data-valid='true']", text: user.username)
 
       composer.type_content("and @invalid_user - how are you?")
 
-      expect(rich).to have_no_css("a.mention", text: "@invalid_user")
+      expect(rich).to have_css("a.mention[data-valid='false']", text: "@invalid_user")
 
       composer.toggle_rich_editor
 
@@ -880,8 +880,8 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.toggle_rich_editor
 
-      expect(rich).to have_css("a.mention", text: user.username)
-      expect(rich).to have_no_css("a.mention", text: "@unknown")
+      expect(rich).to have_css("a.mention[data-valid='true']", text: user.username)
+      expect(rich).to have_css("a.mention[data-valid='false']", text: "@unknown")
     end
   end
 


### PR DESCRIPTION
We recently added validation for mentions in rich text editor mode of composer in #32879.

In an effort to eliminate potential edge cases for non-text nodes, I have restored the input rules and simplified the approach used in the plugin code.

This change means that Instead of finding and inserting mention nodes within text while the user is typing, we let the input rules handle the mention node creation part. This allows the plugin code to focus entirely on validating nodes within the document.

As part of this change we introduced a new data attribute (`data-valid`) which will assume by default that mentions are valid and therefore be `true`, but will proceed to invalidate them by changing to false for mentions that were not found. It also means that invalid mentions are retained as mention nodes, whereas previously we would convert them to text.

### How it looks:

<img width="615" alt="Screenshot 2025-06-12 at 2 12 57 PM" src="https://github.com/user-attachments/assets/4cbf06d2-0ee0-4f50-97af-88d99425f625" />
