### PR TITLE
UX: Remove duplicate class from time-gap in post-stream widget

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -284,7 +284,7 @@ export default createWidget("post-stream", {
           result.push(
             new RenderGlimmer(
               this,
-              "div.time-gap.small-action",
+              "div.time-gap",
               hbs`<Post::TimeGap @daysSince={{@data.daysSince}} />`,
               { daysSince }
             )


### PR DESCRIPTION
Follow-up to 66564434330e52958cf3a4e90ca1b500b7f40f4c, to fix issue reported here: https://meta.discourse.org/t/super-long-line-in-topic-causing-page-to-be-sidescrolled-a-lot/369637

The addition of the class in the glimmer template resulted in double-classes in the post stream widget. Removing the small-action class fixes this in the widget post-stream without breaking the glimmer post-stream.

Before (note the timegap line going through the timeline):
![image](https://github.com/user-attachments/assets/fefa9d5c-2352-4616-9689-0023d24b3cfe)



After (widget):
![image](https://github.com/user-attachments/assets/66b65943-a2d3-4514-a90d-376b024f0a9b)


After (glimmer):
![image](https://github.com/user-attachments/assets/0cb22ada-14bb-4a4d-92ae-f6b6786c762a)
