### PR TITLE
UX: adjust bookmark hover and active states

### DIFF
--- a/app/assets/stylesheets/common/components/bookmark-menu.scss
+++ b/app/assets/stylesheets/common/components/bookmark-menu.scss
@@ -23,7 +23,7 @@
 
     &:hover,
     &:focus {
-      background: var(--tertiary-very-low);
+      background: var(--d-hover);
 
       &.--remove {
         background: var(--danger-low);

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -40,8 +40,6 @@
   .bookmark-options-button {
     margin-left: 0.5em;
     margin-bottom: 0.5em;
-    background: transparent;
-    padding: 6px;
   }
 
   .bookmark-options-panel {

--- a/app/assets/stylesheets/common/components/tap-tile.scss
+++ b/app/assets/stylesheets/common/components/tap-tile.scss
@@ -16,11 +16,11 @@
     }
 
     &:hover {
-      background-color: var(--tertiary-low);
+      background-color: var(--d-hover);
     }
 
     &.active {
-      background-color: var(--highlight-bg);
+      background-color: var(--d-selected);
     }
 
     .d-icon {


### PR DESCRIPTION
These were some old hover and active states, this updates to use the proper color variables 


Before (yellow active, blue hover):

![image](https://github.com/user-attachments/assets/f81afd39-0dca-49e3-b1e8-f44b2e035bdd)


![image](https://github.com/user-attachments/assets/013a8258-e6b6-49bf-8add-8ad57125de3b)



After (blue active, grey hover): 
![image](https://github.com/user-attachments/assets/081e9650-db71-49ce-bd7f-e5aebebdea84)

![image](https://github.com/user-attachments/assets/8e6fefaa-815b-4ebb-b111-dbebe7eaa93d)
