### PR TITLE
DEV: Improvements to post language selector

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-language-selector.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-language-selector.gjs
@@ -9,6 +9,14 @@ import DMenu from "float-kit/components/d-menu";
 export default class PostLanguageSelector extends Component {
   @service siteSettings;
 
+  get selectedLanguage() {
+    return (
+      this.siteSettings.available_content_localization_locales.find(
+        (locale) => locale.value === this.args.composerModel.locale
+      )?.value || ""
+    );
+  }
+
   @action
   selectPostLanguage(locale) {
     this.args.composerModel.locale = locale;
@@ -25,7 +33,7 @@ export default class PostLanguageSelector extends Component {
       @identifier="post-language-selector"
       @title="Post Language"
       @icon="globe"
-      @label={{@selectedLanguage}}
+      @label={{this.selectedLanguage}}
       @modalForMobile={{true}}
       @onRegisterApi={{this.onRegisterApi}}
       @class="btn-transparent btn-small post-language-selector"
@@ -37,7 +45,7 @@ export default class PostLanguageSelector extends Component {
             as |locale|
           }}
             <dropdown.item
-              class="locale=options"
+              class="locale-options"
               data-menu-option-id={{locale.value}}
             >
               <DButton
@@ -47,6 +55,13 @@ export default class PostLanguageSelector extends Component {
               />
             </dropdown.item>
           {{/each}}
+          <dropdown.divider />
+          <dropdown.item>
+            <DButton
+              @label="post.localizations.post_language_selector.none"
+              @action={{fn this.selectPostLanguage ""}}
+            />
+          </dropdown.item>
         </DropdownMenu>
       </:content>
     </DMenu>

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -77,7 +77,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :has_unseen_features,
              :can_see_emails,
              :use_glimmer_post_stream_mode_auto_mode,
-             :can_localize_content?
+             :can_localize_content?,
+             :effective_locale
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -331,6 +332,14 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_can_localize_content?
+    SiteSetting.experimental_content_localization
+  end
+
+  def effective_locale
+    scope.user.effective_locale
+  end
+
+  def include_effective_locale?
     SiteSetting.experimental_content_localization
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3936,6 +3936,8 @@ en:
           title: "Translations for post"
           confirm_delete: "Are you sure you want to delete translations for '%{languageCode}'?"
         success: "Translations have been updated successfully"
+        post_language_selector:
+          none: "None"
 
       errors:
         create: "Sorry, there was an error creating your post. Please try again."


### PR DESCRIPTION
## :mag: Overview
Sometimes users may overlook that there is a post translations selector when writing posts. This could lead to the site's default locale being used when a post is written in the user's preferred language.

This update ensures that:
- the user's `effective_locale` is used as the default for the `PostLanguageSelector` in the composer
- when the user's `effective_locale` is not one of the `experimental_content_localization_supported_locales`, we default to blank so that the `post.locale` doesn't get set
- we also allow for setting a "none" option in the language selector for cases where the user wants to post in a language that is not part of `experimental_content_localization_supported_locales`

## 📷 Screenshots
<img width="216" alt="Screenshot 2025-06-12 at 07 03 56" src="https://github.com/user-attachments/assets/651b9387-de57-408f-9445-92501bd47567" />
