### PR TITLE
DEV: Allow using `%{base_path}` in theme setting descriptions

### DIFF
--- a/app/serializers/theme_settings_serializer.rb
+++ b/app/serializers/theme_settings_serializer.rb
@@ -37,11 +37,10 @@ class ThemeSettingsSerializer < ApplicationSerializer
     resolved_description = locale_file_description || object.description
 
     if resolved_description
-      begin
-        I18n.interpolate(resolved_description, base_path: Discourse.base_path)
-      rescue I18n::MissingInterpolationArgument
-        resolved_description
+      catch(:exception) do
+        return I18n.interpolate(resolved_description, base_path: Discourse.base_path)
       end
+      resolved_description
     end
   end
 

--- a/config/initializers/100-i18n.rb
+++ b/config/initializers/100-i18n.rb
@@ -9,6 +9,7 @@ require "i18n/backend/fallback_locale_list"
 Rails.application.reloader.to_prepare do
   I18n.backend = I18n::Backend::DiscourseI18n.new
   I18n.fallbacks = I18n::Backend::FallbackLocaleList.new
+  I18n.config.missing_interpolation_argument_handler = proc { throw(:exception) }
   I18n.reload!
   I18n.init_accelerator!(overrides_enabled: ENV["DISABLE_TRANSLATION_OVERRIDES"] != "1")
 


### PR DESCRIPTION
This brings them in line with site setting descriptions