### PR TITLE
FIX: make topic optional in render-tags so reviewables can use discourseTags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-queued-post.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-queued-post.gjs
@@ -71,7 +71,7 @@ export default class ReviewableQueuedPost extends Component {
         {{highlightWatchedWords @reviewable.payload.title @reviewable}}
       </div>
       {{categoryBadge @reviewable.category}}
-      <ReviewableTags @tags={{@reviewable.payload.tags}} @tagName="" />
+      <ReviewableTags @tags={{@reviewable.payload.tags}} />
       {{#if @reviewable.payload.via_email}}
         <a href {{on "click" this.showRawEmail}} class="show-raw-email">
           {{icon "envelope" title="post.via_email"}}

--- a/app/assets/javascripts/discourse/app/components/reviewable-tags.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-tags.gjs
@@ -1,13 +1,11 @@
-import Component from "@ember/component";
-import { or } from "truth-helpers";
 import discourseTags from "discourse/helpers/discourse-tags";
 
-export default class ReviewableTags extends Component {
-  <template>
-    {{#if @tags}}
-      <div class="list-tags">
-        {{discourseTags (or @topic null) tags=@tags}}
-      </div>
-    {{/if}}
-  </template>
-}
+const ReviewableTags = <template>
+  {{#if @tags}}
+    <div class="list-tags">
+      {{discourseTags @topic tags=@tags}}
+    </div>
+  {{/if}}
+</template>;
+
+export default ReviewableTags;

--- a/app/assets/javascripts/discourse/app/components/reviewable-topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-topic-link.gjs
@@ -26,7 +26,6 @@ export default class ReviewableTopicLink extends Component {
         <ReviewableTags
           @topic={{this.reviewable.topic}}
           @tags={{this.reviewable.topic_tags}}
-          @tagName=""
         />
       {{else if (has-block)}}
         {{yield}}

--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -30,11 +30,11 @@ export default function (topic, params) {
   let tagsForUser = null;
   let tagName;
 
-  const isPrivateMessage = topic?.get?.("isPrivateMessage");
+  const isPrivateMessage = topic?.get("isPrivateMessage");
 
   if (params) {
     if (params.mode === "list") {
-      tags = topic?.get?.("visibleListTags");
+      tags = topic?.get("visibleListTags");
     }
     if (params.tagsForUser) {
       tagsForUser = params.tagsForUser;


### PR DESCRIPTION
We lost the comma separator for tags in reviewables after 55a3a4e

This gets it back by using `discourseTags` in `ReviewableTags` — to support this I made the topic optional in `renderTags` because queued posts don't pass the full topic 


Before:

![image](https://github.com/user-attachments/assets/2302d946-a3d9-46dc-bf26-8a9b9e720980)

After:

![image](https://github.com/user-attachments/assets/49824676-a4a0-41dd-b6ae-e4d7b419070c)

![image](https://github.com/user-attachments/assets/20493467-15a0-4072-a452-fac319ae222e)


