### PR TITLE
FEATURE: allow date-based filters to accept a day count

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -145,6 +145,11 @@ class TopicsFilter
         Time.zone.parse(
           "#{match_data[:year].to_i}-#{match_data[:month].to_i}-#{match_data[:day].to_i}",
         )
+      elsif value =~ /\A\d+\z/
+        # Handle integer as number of days ago (0 = today at midnight)
+        days = value.to_i
+        return nil if days < 0
+        days.days.ago.beginning_of_day
       end
     when "likes-min", "likes-max", "likes-op-min", "likes-op-max", "posts-min", "posts-max",
          "posters-min", "posters-max", "views-min", "views-max"

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1331,6 +1331,45 @@ RSpec.describe TopicsFilter do
           ).to eq([])
         end
       end
+
+      describe "when query string is `#{filter}-after:1`" do
+        it "should only return topics with #{description} after 1 day ago" do
+          freeze_time do
+            expect(
+              TopicsFilter
+                .new(guardian: Guardian.new)
+                .filter_from_query_string("#{filter}-after:1")
+                .pluck(:id),
+            ).to contain_exactly(topic2.id)
+          end
+        end
+      end
+
+      describe "when query string is `#{filter}-before:1`" do
+        it "should only return topics with #{description} before 1 day ago" do
+          freeze_time do
+            expect(
+              TopicsFilter
+                .new(guardian: Guardian.new)
+                .filter_from_query_string("#{filter}-before:1")
+                .pluck(:id),
+            ).to contain_exactly(topic.id)
+          end
+        end
+      end
+
+      describe "when query string is `#{filter}-after:0`" do
+        it "should only return topics with #{description} after today" do
+          freeze_time do
+            expect(
+              TopicsFilter
+                .new(guardian: Guardian.new)
+                .filter_from_query_string("#{filter}-after:0")
+                .pluck(:id),
+            ).to contain_exactly(topic.id, topic2.id)
+          end
+        end
+      end
     end
 
     describe "when filtering by activity of topics" do


### PR DESCRIPTION
This allows date based filters to use a count of days as well as the existing date string system (`YYYY-MM-DD`). This is convenient if you want a dynamic list based on the current date, you could use: `created-after:7` to return topics from the past week. 

This will work for: 

 - created-before/after
 - activity-before/after
 - latest-post-before/after
 
This also makes filters consistent with our existing query params like `?before=7`



This came up in: https://meta.discourse.org/t/creating-a-custom-filter-homepage/370062 and we already do this in the query param system so it seems reasonable to add for topic filters. 