### PR TITLE
FIX: Chat video thumbnails in Safari

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
@@ -9,6 +9,7 @@ import { isAudio, isImage, isVideo } from "discourse/lib/uploads";
 
 export default class ChatUpload extends Component {
   @service siteSettings;
+  @service capabilities;
 
   @tracked loaded = false;
 
@@ -54,6 +55,11 @@ export default class ChatUpload extends Component {
     }
   }
 
+  get videoSourceUrl() {
+    const baseUrl = this.args.upload.url;
+    return (this.capabilities.isIOS || this.capabilities.isSafari) ? `${baseUrl}#t=0.001` : baseUrl;
+  }
+
   @action
   imageLoaded() {
     this.loaded = true;
@@ -76,7 +82,7 @@ export default class ChatUpload extends Component {
       />
     {{else if (eq this.type this.VIDEO_TYPE)}}
       <video class="chat-video-upload" preload="metadata" height="150" controls>
-        <source src={{@upload.url}} />
+        <source src={{this.videoSourceUrl}} />
       </video>
     {{else if (eq this.type this.AUDIO_TYPE)}}
       <audio class="chat-audio-upload" preload="metadata" controls>

--- a/plugins/chat/test/javascripts/components/chat-upload-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-upload-test.gjs
@@ -2,6 +2,7 @@ import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatUpload from "discourse/plugins/chat/discourse/components/chat-upload";
+import { setOwner } from "@ember/application";
 
 const IMAGE_FIXTURE = {
   id: 290,
@@ -143,5 +144,58 @@ module("Discourse Chat | Component | chat-upload", function (hooks) {
     assert
       .dom("a.chat-other-upload")
       .hasAttribute("href", TXT_FIXTURE.url, "has the correct URL");
+  });
+
+  module("video source URL", function (hooks) {
+    let mockCapabilities;
+
+    hooks.beforeEach(function () {
+      mockCapabilities = {
+        isIOS: false,
+        isSafari: false,
+      };
+
+      // Override the capabilities service
+      this.owner.register("service:capabilities", mockCapabilities, {
+        instantiate: false,
+      });
+    });
+
+    test("adds timestamp parameter for iOS", async function (assert) {
+      const self = this;
+      this.set("upload", { ...VIDEO_FIXTURE, url: "https://example.com/video.mp4" });
+      mockCapabilities.isIOS = true;
+
+      await render(<template><ChatUpload @upload={{self.upload}} /></template>);
+
+      assert
+        .dom("video.chat-video-upload source")
+        .hasAttribute("src", "https://example.com/video.mp4#t=0.001", "adds timestamp for iOS");
+    });
+
+    test("adds timestamp parameter for Safari", async function (assert) {
+      const self = this;
+      this.set("upload", { ...VIDEO_FIXTURE, url: "https://example.com/video.mp4" });
+      mockCapabilities.isSafari = true;
+
+      await render(<template><ChatUpload @upload={{self.upload}} /></template>);
+
+      assert
+        .dom("video.chat-video-upload source")
+        .hasAttribute("src", "https://example.com/video.mp4#t=0.001", "adds timestamp for Safari");
+    });
+
+    test("does not add timestamp parameter for other browsers", async function (assert) {
+      const self = this;
+      this.set("upload", { ...VIDEO_FIXTURE, url: "https://example.com/video.mp4" });
+      mockCapabilities.isIOS = false;
+      mockCapabilities.isSafari = false;
+
+      await render(<template><ChatUpload @upload={{self.upload}} /></template>);
+
+      assert
+        .dom("video.chat-video-upload source")
+        .hasAttribute("src", "https://example.com/video.mp4", "does not add timestamp for other browsers");
+    });
   });
 });


### PR DESCRIPTION
When uploading videos in chat using Safari the thumbnail isn't being displayed
so we need to trick the browser to by adding the timestamp property so that it
will fetch the metedata the html5 video tag needs to render the thumbnail.
