### PR TITLE
FEATURE: Hide topic if OP is hidden

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -635,7 +635,7 @@ class Post < ActiveRecord::Base
       any_visible_posts_in_topic =
         Post.exists?(topic_id: topic_id, hidden: false, post_type: Post.types[:regular])
 
-      if !any_visible_posts_in_topic
+      if is_first_post? || !any_visible_posts_in_topic
         self.topic.update_status(
           "visible",
           false,

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1549,6 +1549,16 @@ RSpec.describe Post do
         post_2.user.user_stat.reload.post_count
       }.from(1).to(0)
     end
+
+    it "should change topic visible status to false if it is the first post" do
+      t = post.topic
+      expect(t.visible).to eq(true)
+
+      post.hide!(PostActionType.types[:off_topic])
+
+      t.reload
+      expect(t.visible).to eq(false)
+    end
   end
 
   describe "#unhide!" do


### PR DESCRIPTION
Before this change, topics with a hidden OP were still visible, we only checked if all posts were hidden to change visibility of the topic.

With this change, if the OP is flagged and is hidden the topic will also be hidden.