### PR TITLE
UX: make all preference icons unique

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.gjs
@@ -18,7 +18,7 @@ export default RouteTemplate(
           @ariaCurrentContext="subNav"
           class="user-nav__preferences-account"
         >
-          {{icon "user"}}
+          {{icon "circle-user"}}
           <span>{{i18n "user.preferences_nav.account"}}</span>
         </DNavigationItem>
 
@@ -36,7 +36,7 @@ export default RouteTemplate(
           @ariaCurrentContext="subNav"
           class="user-nav__preferences-profile"
         >
-          {{icon "user"}}
+          {{icon "address-card"}}
           <span>{{i18n "user.preferences_nav.profile"}}</span>
         </DNavigationItem>
 

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -5,6 +5,7 @@ module SvgSprite
       %w[
         a
         address-book
+        address-card
         align-left
         anchor
         angle-down
@@ -120,6 +121,7 @@ module SvgSprite
         fab-x-twitter
         fab-wikipedia-w
         fab-windows
+        face-smile
         far-bell
         far-bell-slash
         far-calendar-plus

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -121,7 +121,6 @@ module SvgSprite
         fab-x-twitter
         fab-wikipedia-w
         fab-windows
-        face-smile
         far-bell
         far-bell-slash
         far-calendar-plus


### PR DESCRIPTION
We repeat the user icon here, making the icons kind of pointless.

This changes the account and profile icons to potentially be a little more useful. 

Before:
![image](https://github.com/user-attachments/assets/2fce16fb-5ddf-4cd2-9053-c5a946f9500c)

After:
![image](https://github.com/user-attachments/assets/729962c9-c466-456a-95a6-04a767d95ed3)

Mentioned here: https://meta.discourse.org/t/ux-improvements-on-header-dropdown-notifications/370110