### PR TITLE
UX: Add classes to read/unread user menu messages items 

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/message-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/message-item.js
@@ -11,7 +11,11 @@ export default class UserMenuMessageItem extends UserMenuBaseItem {
   }
 
   get className() {
-    return "message";
+    let classNames = ["message"];
+
+    classNames.push(this.message.unread ? "unread" : "read");
+
+    return classNames.join(" ");
   }
 
   get linkHref() {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -681,6 +681,7 @@
     &.pending {
       .icon-avatar__icon-wrapper {
         background: var(--tertiary);
+        font-size: var(--font-down-1);
 
         .d-icon {
           color: var(--secondary);

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -681,7 +681,6 @@
     &.pending {
       .icon-avatar__icon-wrapper {
         background: var(--tertiary);
-        font-size: var(--font-down-1);
 
         .d-icon {
           color: var(--secondary);


### PR DESCRIPTION
The messages in the message tab did not include a class to show whether it was read or unread.