### PR TITLE
UX: Make the theme title fully clickable + accessible

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
@@ -45,26 +45,32 @@ export default RouteTemplate(
 
       <div class="title">
         {{#if @controller.editingName}}
-          <TextField @value={{@controller.model.name}} @autofocus="true" />
-          <DButton
-            @action={{@controller.finishedEditingName}}
-            @icon="check"
-            class="btn-primary btn-small submit-edit"
-          />
-          <DButton
-            @action={{@controller.cancelEditingName}}
-            @icon="xmark"
-            class="btn-small cancel-edit"
-          />
-        {{else}}
-          <span>{{@controller.model.name}}</span>
-          {{#unless @controller.model.system}}
+          <div class="container-edit-title">
+            <TextField @value={{@controller.model.name}} @autofocus="true" />
             <DButton
-              @action={{@controller.startEditingName}}
-              @icon="pencil"
-              class="btn-small"
+              @action={{@controller.finishedEditingName}}
+              @icon="check"
+              class="btn-primary btn-small submit-edit"
             />
-          {{/unless}}
+            <DButton
+              @action={{@controller.cancelEditingName}}
+              @icon="xmark"
+              class="btn-small cancel-edit"
+            />
+          </div>
+        {{else}}
+          <DButton
+            @action={{@controller.startEditingName}}
+            class="btn-transparent title-button"
+            role="heading"
+            aria-level="2"
+            aria-label="Edit theme name: {{@controller.model.name}}"
+          >
+            <span>{{@controller.model.name}}</span>
+            {{#unless @controller.model.system}}
+              {{icon "pencil" class="inline-icon"}}
+            {{/unless}}
+          </DButton>
         {{/if}}
       </div>
 

--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -153,27 +153,51 @@
     vertical-align: top;
 
     .title {
-      font-size: var(--font-up-1);
+      font-family: var(--heading-font-family);
+      font-size: var(--font-up-2-rem);
       font-weight: bold;
-      margin-bottom: 0.25em;
       display: flex;
       align-items: center;
 
-      span {
-        min-width: 0;
-        overflow-wrap: anywhere;
-      }
-
-      input {
+      .title-button {
         margin: 0;
+        padding: 0;
+        border-radius: 0;
+        border: none;
+        text-align: left;
+        font-weight: bold;
+        gap: var(--space-2);
+
+        &:hover {
+          color: inherit;
+
+          .d-icon-pencil {
+            display: block;
+            font-size: var(--font-down-2);
+          }
+        }
+
+        span {
+          margin-top: var(--space-2);
+          margin-bottom: var(--space-1);
+        }
       }
 
-      .btn {
-        margin-left: 0.5em;
+      .d-icon-pencil {
+        display: none;
       }
 
-      a {
-        font-size: var(--font-down-2);
+      .container-edit-title {
+        margin: 0;
+        width: 100%;
+
+        input {
+          font-size: var(--font-up-1-rem);
+        }
+
+        .btn-small {
+          font-size: var(--font-down-3);
+        }
       }
     }
 


### PR DESCRIPTION
### What I changed

- Wrapped the theme title and the pencil icon in a single `DButton` so the whole thing is clickable
- Added ARIA stuff: heading role, level, and label to help screen readers know it’s both a title and editable

### Why

Changed it so the entire title acts as the edit trigger, instead of just the icon.

[Kapture 2025-06-13 at 16.34.12.webm](https://github.com/user-attachments/assets/c44049a0-bfd0-455a-94a3-fe9ec4d387ff)
