### PR TITLE
Fix Insecure Mass Assignment tag_groups

### DIFF
--- a/app/controllers/tag_groups_controller.rb
+++ b/app/controllers/tag_groups_controller.rb
@@ -109,7 +109,7 @@ class TagGroupsController < ApplicationController
 
   def tag_groups_params
     tag_group = params.delete(:tag_group)
-    params.merge!(tag_group.permit!) if tag_group
+    params.merge!(tag_group.permit(:name, :one_per_topic, tag_names: [], parent_tag_name: [], permissions: {})) if tag_group
 
     result =
       params.permit(:id, :name, :one_per_topic, tag_names: [], parent_tag_name: [], permissions: {})


### PR DESCRIPTION
https://github.com/discourse/discourse/blob/fb7fa2902cf685ee9d4002e5448b4817f2dbef98/app/controllers/tag_groups_controller.rb#L52-L52

Operations that allow for mass assignment (setting multiple attributes of an object using a hash), such as `ActiveRecord::Base.new`, should take care not to allow arbitrary parameters to be set by the user. Otherwise, unintended attributes may be set, such as an `is_admin` field for a `User` object.



Fix the issue need to remove the use of `permit!` on line 112 and ensure that only explicitly permitted parameters are allowed for mass assignment. This can be achieved by directly merging the permitted attributes of the `tag_group` parameter into the `params` object. The `permit` call on line 115 already specifies the allowed attributes, so we can safely rely on it. The updated `tag_groups_params` method will no longer use `permit!` and will explicitly handle the `tag_group` parameter in a secure manner.


Rails guides: [Strong Parameters](https://guides.rubyonrails.org/action_controller_overview.html#strong-parameters)