### PR TITLE
DEV: Adds `hasNoPreferredMode` to chat state manager

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -148,9 +148,13 @@ export default class ChatStateManager extends Service {
     return !!(
       !this.isFullPagePreferred ||
       (this.site.desktopView &&
-        (!this._store.getObject(PREFERRED_MODE_KEY) ||
+        (this.hasNoPreferredMode ||
           this._store.getObject(PREFERRED_MODE_KEY) === DRAWER_CHAT))
     );
+  }
+
+  get hasNoPreferredMode() {
+    return !this._store.getObject(PREFERRED_MODE_KEY);
   }
 
   get isFullPageActive() {

--- a/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
@@ -50,6 +50,18 @@ module(
       assert.true(this.subject.isDrawerPreferred);
     });
 
+    test("hasNoPreferredMode", async function (assert) {
+      assert.true(this.subject.hasNoPreferredMode);
+
+      this.subject.prefersFullPage();
+
+      assert.false(this.subject.hasNoPreferredMode);
+
+      this.subject.prefersDrawer();
+
+      assert.false(this.subject.hasNoPreferredMode);
+    });
+
     test("lastKnownChatURL", function (assert) {
       assert.strictEqual(this.subject.lastKnownChatURL, "/chat");
 


### PR DESCRIPTION
This commit introduces a new property `hasNoPreferredMode` to the
chat state manager, which represents a user who has not purposely
set chat mode to drawer or full page, meaning they have no LocalStorage
value set.

This can be useful for themes to change the chat mode but only
if the user has no preference already.

c.f. https://meta.discourse.org/t/full-screen-chat-as-default-for-collaboration-setup/369849
