### PR TITLE
DEV: Add new color palette page to admin sidebar navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -377,6 +377,13 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
         });
     }
 
+    if (siteSettings.use_overhauled_theme_color_palette) {
+      navMap
+        .find((section) => section.name === "appearance")
+        .links.find((link) => link.name === "admin_color_palettes").route =
+        "adminConfig.colorPalettes";
+    }
+
     navMap.forEach((section) =>
       section.links.forEach((link) => {
         if (link.keywords) {


### PR DESCRIPTION
This PR makes the "Color palettes" link in the admin sidebar points to the new color palettes page at `/admin/config/colors` instead of the legacy one `/admin/customize/colors`.