### PR TITLE
FIX: ignore SiteSetting.max_image_size_kb for theme screenshots

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -257,7 +257,7 @@ class RemoteTheme < ActiveRecord::Base
 
     theme_info["assets"]&.each do |name, relative_path|
       if path = importer.real_path(relative_path)
-        upload = RemoteTheme.create_upload(theme, path, relative_path)
+        upload = RemoteTheme.create_upload(theme: theme, path: path, relative_path: relative_path)
         if !upload.errors.empty?
           raise ImportError,
                 I18n.t(
@@ -477,7 +477,7 @@ class RemoteTheme < ActiveRecord::Base
     remote_url.present?
   end
 
-  def self.create_upload(theme, path, relative_path)
+  def self.create_upload(theme:, path:, relative_path:, skip_validations: false)
     new_path = "#{File.dirname(path)}/#{SecureRandom.hex}#{File.extname(path)}"
 
     # OptimizedImage has strict file name restrictions, so rename temporarily
@@ -487,6 +487,7 @@ class RemoteTheme < ActiveRecord::Base
       File.open(new_path),
       File.basename(relative_path),
       for_theme: true,
+      skip_validations: skip_validations,
     ).create_for(theme.user_id)
   end
 end

--- a/lib/theme_screenshots_handler.rb
+++ b/lib/theme_screenshots_handler.rb
@@ -60,7 +60,13 @@ class ThemeScreenshotsHandler
               )
       end
 
-      upload = RemoteTheme.create_upload(@theme, path, relative_path)
+      upload =
+        RemoteTheme.create_upload(
+          theme: @theme,
+          path: path,
+          relative_path: relative_path,
+          skip_validations: true,
+        )
       if !upload.errors.empty?
         raise ThemeScreenshotError,
               I18n.t(

--- a/spec/lib/theme_screenshots_handler_spec.rb
+++ b/spec/lib/theme_screenshots_handler_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe ThemeScreenshotsHandler do
     end
   end
 
+  it "ignore max_image_size_kb site setting" do
+    SiteSetting.max_image_size_kb = 1
+
+    screenshots = ["screenshots/light.jpeg", "screenshots/some Absolutely silly $%&* name --.jpeg"]
+    write_temp_screenshots_for_importer(screenshots)
+    handler.parse_screenshots_as_theme_fields!(screenshots, importer)
+    expect { theme.save! }.not_to raise_error
+  end
+
   it "raises an error if the screenshot has invalid dimensions" do
     screenshots = ["screenshots/light.jpeg"]
     write_temp_screenshots_for_importer(screenshots)


### PR DESCRIPTION
Theme screenshots have their validations: https://github.com/discourse/discourse/blob/main/lib/theme_screenshots_handler.rb#L4

Therefore, validations in `UploadCreator` can be ignored. Currently, the import of system themes is crashing when the value is too low for  `SiteSetting.max_image_size_kb` .