### PR TITLE
FIX: Multiple video uploads in composer failed

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -369,14 +369,17 @@ export default class UppyComposerUpload {
           getUploadMarkdown(upload)
         );
 
-        // Only remove in progress after async resolvers finish:
-        this.#removeInProgressUpload(file.id);
         cacheShortUploadUrl(upload.short_url, upload);
 
         new ComposerVideoThumbnailUppy(getOwner(this)).generateVideoThumbnail(
           file,
           upload.url,
+
+          // This callback is fired even if the thumbnail callnot be generated,
+          // e.g. if video_thumbnails_enabled is false or if the file is not a video.
           () => {
+            this.#removeInProgressUpload(file.id);
+
             this.placeholderHandler.success(file, markdown);
 
             this.appEvents.trigger(

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -40,7 +40,7 @@ describe "Uploading files in the composer", type: :system do
   context "when video thumbnails are enabled" do
     before do
       SiteSetting.video_thumbnails_enabled = true
-      SiteSetting.authorized_extensions += "|webm"
+      SiteSetting.authorized_extensions += "|webm|mp4"
     end
 
     it "generates a topic preview thumbnail from the video" do
@@ -136,6 +136,19 @@ describe "Uploading files in the composer", type: :system do
 
       expect(composer).to have_no_in_progress_uploads
       expect(composer.preview).to have_css(".onebox-placeholder-container")
+    end
+
+    it "handles multiple video uploads" do
+      visit "/new-topic"
+      expect(composer).to be_opened
+      topic.fill_in_composer_title("Video upload test")
+
+      file_path_1 = file_from_fixtures("small.webm", "media").path
+      file_path_2 = file_from_fixtures("small.mp4", "media").path
+      attach_file([file_path_1, file_path_2]) { composer.click_toolbar_button("upload") }
+
+      expect(composer).to have_no_in_progress_uploads
+      expect(composer.preview).to have_css(".onebox-placeholder-container", count: 2)
     end
   end
 


### PR DESCRIPTION
When uploading > 1 video in the composer, any upload after
the first one would fail silently, and not show anything in
the composer.

This was happening because we were removing uploads before the video
thumbnail callback was fired, but that had code like this `if
(this.#inProgressUploads.length === 0) { this.#reset() }`, which meant
that before the second upload was completely done we were resetting the
state.

Instead, we can remove the in progress upload file inside the video
thumbnail callback, which will ensure that the state is not reset
until all uploads are done.
