### PR TITLE
UX: reload the page when the default theme is changed

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -83,6 +83,8 @@ export default class ThemeCard extends Component {
       },
       duration: "short",
     });
+
+    window.location.reload();
   }
 
   @action

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -47,6 +47,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     config_area.mark_as_active(theme_2)
     expect(config_area).to have_badge(theme_2, "--active")
     expect(config_area).to have_no_badge(foundation_theme, "--active")
+    expect(find(".theme-card", match: :first).find(".theme-card__title")).to have_text(theme_2.name)
   end
 
   it "allows to make theme selectable by users" do


### PR DESCRIPTION
When the default theme is changed, reload the page to present new theme to the admin.

https://github.com/user-attachments/assets/d127ea36-6960-419e-820e-265321dad0cd



