### PR TITLE
DEV: Fix lograg `logger` and `log_level` not following rails `log_level`

### DIFF
--- a/config/initializers/101-lograge.rb
+++ b/config/initializers/101-lograge.rb
@@ -154,7 +154,10 @@ if ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
           type: :rails,
           customize_event:
             lambda { |event| event["database"] = RailsMultisite::ConnectionManagement.current_db },
+          level: Rails.application.config.log_level,
         )
+
+      config.lograge.log_level = Rails.application.config.log_level
 
       # Stop broadcasting to Rails' default logger
       Rails.logger.stop_broadcasting_to(

--- a/lib/discourse_logstash_logger.rb
+++ b/lib/discourse_logstash_logger.rb
@@ -22,10 +22,11 @@ class DiscourseLogstashLogger < Logger
   #   The proc is called with a hash of log event data and can be modified in place.
   #
   # @return [Logger] A new logger instance with the specified log device and type.
-  def self.logger(logdev:, type:, customize_event: nil)
+  def self.logger(logdev:, type:, customize_event: nil, level: Logger::INFO)
     logger = self.new(logdev)
     logger.type = type
     logger.customize_event = customize_event if customize_event
+    logger.level = level
     logger
   end
 


### PR DESCRIPTION
Before this change, we were relying on the `lograge`'s gem default
`log_level` of `info`. However, `lograge` should be following
`Rails.application.config.log_level` instead and this commits seeks to
correct that behaviour.
