### PR TITLE
FIX: Add Azure communication service endpoint to SMTP authentication override

### DIFF
--- a/lib/smtp_provider_overrides.rb
+++ b/lib/smtp_provider_overrides.rb
@@ -6,7 +6,7 @@ class SmtpProviderOverrides
   # need certain authentication methods. This may need to change when we start to
   # use XOAUTH2 for SMTP.
   def self.authentication_override(host)
-    return "login" if %w[smtp.office365.com smtp-mail.outlook.com].include?(host)
+    return "login" if %w[smtp.office365.com smtp-mail.outlook.com smtp.azurecomm.net].include?(host)
     GlobalSetting.smtp_authentication
   end
 end


### PR DESCRIPTION
Per [this thread](https://meta.discourse.org/t/struggling-to-configure-smtp-in-discourse-with-azure-communication-service/290511), Azure communication service requires the `login` authentication method on their SMTP service.