### PR TITLE
DEV: Update link to comment in robots.txt as 'allow' is allowed

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -54,11 +54,10 @@ class RobotsTxtController < ApplicationController
       deny_paths_googlebot + DISALLOWED_WITH_HEADER_PATHS.map { |p| Discourse.base_path + p }
     deny_all = ["#{Discourse.base_path}/"]
 
-    result = {
-      header:
-        "# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file",
-      agents: [],
-    }
+    result = { header: <<~ROBOTS, agents: [] }
+              # See https://datatracker.ietf.org/doc/rfc9309 for documentation on how to use the robots.txt file
+              # Google uses the same format as the standard above. More info at https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt
+              ROBOTS
 
     if SiteSetting.allowed_crawler_user_agents.present?
       SiteSetting


### PR DESCRIPTION
The old link http://www.robotstxt.org/robotstxt.html seems to indicate that `allow` is not allowed. 

<img width="1295" alt="Screenshot 2025-06-17 at 11 30 36 AM" src="https://github.com/user-attachments/assets/6611f9d0-654e-4dc2-9eed-581458ec1187" />
