### PR TITLE
FIX: Wrong argument error in `FileStore::S3Store#update_access_control`

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -494,14 +494,7 @@ class Upload < ActiveRecord::Base
     self.update(secure_params(mark_secure, reason, source))
 
     if secure_status_did_change && SiteSetting.s3_use_acls && Discourse.store.external?
-      begin
-        Discourse.store.update_upload_access_control(self)
-      rescue Aws::S3::Errors::NotImplemented => err
-        Discourse.warn_exception(
-          err,
-          message: "The file store object storage provider does not support setting ACLs",
-        )
-      end
+      Discourse.store.update_upload_access_control(self)
     end
 
     secure_status_did_change


### PR DESCRIPTION
This commit is a follow up to b02bc707dec12c607511d4a95c7d791f63131b49.
When the `s3_enable_access_control_tags` site setting is enabled,
calling `FileStore::S3Store#update_access_control` will result in a
argument error.
