### PR TITLE
DEV: Remove 'experimental' prefix from settings

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-action-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-action-title.gjs
@@ -73,7 +73,7 @@ export default class ComposerActionTitle extends Component {
     const allowedActions = [CREATE_TOPIC, EDIT, REPLY];
     if (
       this.currentUser &&
-      this.siteSettings.experimental_content_localization &&
+      this.siteSettings.content_localization_enabled &&
       this.currentUser.can_localize_content &&
       allowedActions.includes(this.model.action)
     ) {

--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -963,7 +963,7 @@ export default class ComposerEditor extends Component {
 
   get showTranslationEditor() {
     if (
-      !this.siteSettings.experimental_content_localization ||
+      !this.siteSettings.content_localization_enabled ||
       !this.currentUser.can_localize_content
     ) {
       return false;

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -70,8 +70,8 @@ export default class Icons extends Component {
   get showLanguageSwitcher() {
     return (
       !this.currentUser &&
-      this.siteSettings.experimental_anon_language_switcher &&
-      this.siteSettings.experimental_content_localization_supported_locales
+      this.siteSettings.content_localization_anon_language_switcher &&
+      this.siteSettings.content_localization_supported_locales
     );
   }
 

--- a/app/assets/javascripts/discourse/app/components/modal/post-translations.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/post-translations.gjs
@@ -60,7 +60,7 @@ export default class PostTranslationsModal extends Component {
   async editLocalization(locale) {
     if (
       !this.currentUser ||
-      !this.siteSettings.experimental_content_localization ||
+      !this.siteSettings.content_localization_enabled ||
       !this.currentUser.can_localize_content
     ) {
       return;

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/add-translation.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/add-translation.gjs
@@ -36,7 +36,7 @@ export default class PostMenuAddTranslationButton extends Component {
   get showTranslationButton() {
     return (
       this.currentUser &&
-      this.siteSettings.experimental_content_localization &&
+      this.siteSettings.content_localization_enabled &&
       this.currentUser.can_localize_content
     );
   }
@@ -60,7 +60,7 @@ export default class PostMenuAddTranslationButton extends Component {
   async addTranslation() {
     if (
       !this.currentUser ||
-      !this.siteSettings.experimental_content_localization ||
+      !this.siteSettings.content_localization_enabled ||
       !this.currentUser.can_localize_content
     ) {
       return;

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -782,7 +782,7 @@ export default class Category extends RestModel {
         style_type: this.style_type,
         emoji: this.emoji,
         icon: this.icon,
-        ...(this.siteSettings.experimental_content_localization && {
+        ...(this.siteSettings.content_localization_enabled && {
           category_localizations_attributes: this._buildUpdatedLocalizations(),
         }),
       }),

--- a/app/assets/javascripts/discourse/app/templates/edit-category-tabs.gjs
+++ b/app/assets/javascripts/discourse/app/templates/edit-category-tabs.gjs
@@ -79,7 +79,7 @@ export default RouteTemplate(
             />
           {{/if}}
 
-          {{#if @controller.siteSettings.experimental_content_localization}}
+          {{#if @controller.siteSettings.content_localization_enabled}}
             <EditCategoryTab
               @panels={{@controller.panels}}
               @selectedTab={{@controller.selectedTab}}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -540,7 +540,7 @@ class CategoriesController < ApplicationController
           conditional_param_keys << { moderating_group_ids: [] }
         end
 
-        if SiteSetting.experimental_content_localization?
+        if SiteSetting.content_localization_enabled?
           conditional_param_keys << {
             category_localizations_attributes: %i[id category_id locale name description _destroy],
           }

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -140,7 +140,7 @@ class CategoryList
   def find_categories
     query = Category.includes(CategoryList.included_associations).secured(@guardian)
 
-    if SiteSetting.experimental_content_localization
+    if SiteSetting.content_localization_enabled
       locale = I18n.locale.to_s
       query =
         query.joins(
@@ -173,7 +173,7 @@ class CategoryList
     query =
       DiscoursePluginRegistry.apply_modifier(:category_list_find_categories_query, query, self)
 
-    if SiteSetting.experimental_content_localization
+    if SiteSetting.content_localization_enabled
       query =
         query.group("categories.id").select(
           "categories.*,

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,7 +84,7 @@ class Site
                 category_required_tag_groups: :tag_group,
               ).joins("LEFT JOIN topics t on t.id = categories.topic_id")
 
-            if SiteSetting.experimental_content_localization
+            if SiteSetting.content_localization_enabled
               locale = I18n.locale.to_s
               query =
                 query.joins(
@@ -232,7 +232,7 @@ class Site
     end
 
     seq = nil
-    use_localized_anon_cache = SiteSetting.experimental_content_localization && guardian.anonymous?
+    use_localized_anon_cache = SiteSetting.content_localization_enabled && guardian.anonymous?
 
     locale = I18n.locale
     cache_key = "site_json"

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -118,9 +118,9 @@ class SiteSetting < ActiveRecord::Base
   client_settings << :available_content_localization_locales
 
   def self.available_content_localization_locales
-    return [] if !SiteSetting.experimental_content_localization?
+    return [] if !SiteSetting.content_localization_enabled?
 
-    supported_locales = SiteSetting.experimental_content_localization_supported_locales.split("|")
+    supported_locales = SiteSetting.content_localization_supported_locales.split("|")
     default_locale = SiteSetting.default_locale
     if default_locale.present? && !supported_locales.include?(default_locale)
       supported_locales << default_locale

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -138,9 +138,7 @@ class TopicList
       { category: :parent_category },
     ]
 
-    if SiteSetting.experimental_content_localization
-      topic_preloader_associations << :topic_localizations
-    end
+    topic_preloader_associations << :topic_localizations if SiteSetting.content_localization_enabled
 
     DiscoursePluginRegistry.topic_preloader_associations.each do |a|
       fields = a[:fields]

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -332,7 +332,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_can_localize_content?
-    SiteSetting.experimental_content_localization
+    SiteSetting.content_localization_enabled
   end
 
   def effective_locale
@@ -340,6 +340,6 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_effective_locale?
-    SiteSetting.experimental_content_localization
+    SiteSetting.content_localization_enabled
   end
 end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -680,7 +680,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def include_locale?
-    SiteSetting.experimental_content_localization
+    SiteSetting.content_localization_enabled
   end
 
   def is_localized
@@ -688,7 +688,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def include_is_localized?
-    SiteSetting.experimental_content_localization
+    SiteSetting.content_localization_enabled
   end
 
   def language
@@ -696,7 +696,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def include_language?
-    SiteSetting.experimental_content_localization && object.locale.present?
+    SiteSetting.content_localization_enabled && object.locale.present?
   end
 
   def localization_outdated

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -337,6 +337,6 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_has_localized_content?
-    SiteSetting.experimental_content_localization
+    SiteSetting.content_localization_enabled
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7814,6 +7814,7 @@ en:
           basic: "Basic Setup"
           users: "Users"
           posting: "Posting"
+          content_localization: "Content Localization"
           email: "Email"
           files: "Files"
           trust: "Trust Levels"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2727,12 +2727,14 @@ en:
     about_page_extra_groups_order: "Ordering of the extra groups on the about page."
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
-    experimental_content_localization: "Displays localized content for users based on their language preferences. Such content may include categories, tags, posts, and topics. This feature is under heavy development."
     rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer/352347' target='_blank'>see Meta for more details</a>."
-    experimental_content_localization_allowed_groups: 'Groups allowed to update localized content. Requires "experimental content localization" to be enabled.'
-    experimental_content_localization_supported_locales: "List of supported locales that user content can be translated to. Requires `experimental_content_localization` to be enabled to take effect."
     viewport_based_mobile_mode: "EXPERIMENTAL: Disable the user-agent-based mobile/desktop modes and use viewport width instead."
-    experimental_anon_language_switcher: "Enable experimental language switcher. This will allow site visitors who are not logged in to switch between translated versions of Discourse and user-contributed content in topics."
+
+    content_localization_enabled: "Displays localized content for users based on their browser or user language preferences. Such content may include categories, tags, posts, and topics. Supported locales are set in 'content localization supported locales'."
+    content_localization_supported_locales: "List of supported locales that user content can be translated to. Requires 'content localization enabled'."
+    content_localization_allowed_groups: "Groups allowed to update localized content. Requires 'content localization enabled'."
+    content_localization_anon_language_switcher: "Enable language switcher which allows site visitors who are not logged in to switch between translated versions of Discourse and user-contributed content. Depends on the list of languages defined in 'content localization supported locales'"
+
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."
@@ -2802,7 +2804,7 @@ en:
       delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than %{max}"
       invalid_uncategorized_category_setting: 'The "Uncategorized" category cannot be selected if ''allow uncategorized topics'' is not enabled.'
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
-      experimental_anon_language_switcher_requirements: "The experimental language switcher requires the `set locale from cookie` site setting to be enabled, and the `automatic translation target languages` to have at least one language."
+      content_localization_anon_language_switcher_requirements: "The language switcher requires the `set locale from cookie` site setting to be enabled, and the `content localization supported locales` to have at least one language."
 
     keywords:
       clean_up_inactive_users_after_days: "deactivated|inactive|unactivated"
@@ -5775,6 +5777,3 @@ en:
       duplicate_ids: "has duplicate ids"
       reserved_id: "has a reserved keyword as id: %{id}"
       unsafe_description: "has an unsafe HTML description"
-
-  content_localization:
-    not_allowed: "You are not allowed to localize this content."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1580,6 +1580,31 @@ posting:
     min: 1
     hidden: true
 
+content_localization:
+  content_localization_enabled:
+    client: true
+    default: false
+    area: "localization"
+  content_localization_allowed_groups:
+    type: group_list
+    list_type: compact
+    allow_any: false
+    client: true
+    default: "1|2" # admin, moderator
+    area: "localization"
+  content_localization_supported_locales:
+    default: ""
+    type: list
+    client: true
+    list_type: named
+    allow_any: false
+    choices: "LocaleSiteSetting.values"
+    area: "localization"
+  content_localization_anon_language_switcher:
+    default: false
+    client: true
+    validator: "LanguageSwitcherSettingValidator"
+
 email:
   email_time_window_mins:
     default: 10
@@ -4002,29 +4027,6 @@ experimental:
   rich_editor:
     client: true
     default: false
-  experimental_content_localization:
-    client: true
-    default: false
-    area: "localization"
-  experimental_content_localization_allowed_groups:
-    type: group_list
-    list_type: compact
-    allow_any: false
-    client: true
-    default: "1|2" # admin, moderator
-    area: "localization"
-  experimental_content_localization_supported_locales:
-    default: ""
-    type: list
-    client: true
-    list_type: named
-    allow_any: false
-    choices: "LocaleSiteSetting.values"
-    area: "localization"
-  experimental_anon_language_switcher:
-    default: false
-    client: true
-    validator: "LanguageSwitcherSettingValidator"
   experimental_system_themes:
     type: list
     default: ""

--- a/db/migrate/20250617085536_remove_experimental_from_content_localization_settings.rb
+++ b/db/migrate/20250617085536_remove_experimental_from_content_localization_settings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveExperimentalFromContentLocalizationSettings < ActiveRecord::Migration[7.2]
+  def up
+    execute "UPDATE site_settings SET name = 'content_localization_enabled' WHERE name = 'experimental_content_localization'"
+    execute "UPDATE site_settings SET name = 'content_localization_allowed_groups' WHERE name = 'experimental_content_localization_allowed_groups'"
+    execute "UPDATE site_settings SET name = 'content_localization_supported_locales' WHERE name = 'experimental_content_localization_supported_locales'"
+    execute "UPDATE site_settings SET name = 'content_localization_anon_language_switcher' WHERE name = 'experimental_anon_language_switcher'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -14,7 +14,7 @@ class ContentLocalization
   # @param post [Post] The post object
   # @return [Boolean]
   def self.show_translated_post?(post, scope)
-    SiteSetting.experimental_content_localization && post.raw.present? && post.locale.present? &&
+    SiteSetting.content_localization_enabled && post.raw.present? && post.locale.present? &&
       !post.in_user_locale? && !show_original?(scope)
   end
 
@@ -23,7 +23,7 @@ class ContentLocalization
   # @param topic [Topic] The topic record
   # @return [Boolean]
   def self.show_translated_topic?(topic, scope)
-    SiteSetting.experimental_content_localization && topic.locale.present? &&
-      !topic.in_user_locale? && !show_original?(scope)
+    SiteSetting.content_localization_enabled && topic.locale.present? && !topic.in_user_locale? &&
+      !show_original?(scope)
   end
 end

--- a/lib/guardian/localization_guardian.rb
+++ b/lib/guardian/localization_guardian.rb
@@ -2,7 +2,7 @@
 
 module LocalizationGuardian
   def can_localize_content?
-    return false if !SiteSetting.experimental_content_localization
-    user.in_any_groups?(SiteSetting.experimental_content_localization_allowed_groups_map)
+    return false if !SiteSetting.content_localization_enabled
+    user.in_any_groups?(SiteSetting.content_localization_allowed_groups_map)
   end
 end

--- a/lib/validators/language_switcher_setting_validator.rb
+++ b/lib/validators/language_switcher_setting_validator.rb
@@ -8,10 +8,10 @@ class LanguageSwitcherSettingValidator
   def valid_value?(val)
     return true if val == "f" || val == "false"
     SiteSetting.set_locale_from_cookie &&
-      SiteSetting.experimental_content_localization_supported_locales.present?
+      SiteSetting.content_localization_supported_locales.present?
   end
 
   def error_message
-    I18n.t("site_settings.errors.experimental_anon_language_switcher_requirements")
+    I18n.t("site_settings.errors.content_localization_anon_language_switcher_requirements")
   end
 end

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -24,7 +24,7 @@ describe ContentLocalization do
     fab!(:post)
 
     it "returns true when criteria met" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "ja")
       I18n.locale = "de"
       scope = create_scope
@@ -34,13 +34,13 @@ describe ContentLocalization do
 
     context "when criteria not met" do
       before do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
         post.update!(locale: "ja")
         I18n.locale = "de"
       end
 
-      it "returns false when experimental_content_localization is false" do
-        SiteSetting.experimental_content_localization = false
+      it "returns false when content_localization_enabled is false" do
+        SiteSetting.content_localization_enabled = false
         scope = create_scope
 
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
@@ -79,7 +79,7 @@ describe ContentLocalization do
     fab!(:topic)
 
     it "returns true when criteria met" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       topic.update!(locale: "ja")
       I18n.locale = "de"
       scope = create_scope
@@ -89,13 +89,13 @@ describe ContentLocalization do
 
     context "when criteria not met" do
       before do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
         topic.update!(locale: "ja")
         I18n.locale = "de"
       end
 
-      it "returns false when experimental_content_localization is false" do
-        SiteSetting.experimental_content_localization = false
+      it "returns false when content_localization_enabled is false" do
+        SiteSetting.content_localization_enabled = false
         scope = create_scope
 
         expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false

--- a/spec/lib/post_localization_creator_spec.rb
+++ b/spec/lib/post_localization_creator_spec.rb
@@ -9,8 +9,8 @@ describe PostLocalizationCreator do
   let(:raw) { "これは翻訳です。" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/lib/post_localization_destroyer_spec.rb
+++ b/spec/lib/post_localization_destroyer_spec.rb
@@ -9,8 +9,8 @@ describe PostLocalizationDestroyer do
   let(:locale) { "ja" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/lib/post_localization_updater_spec.rb
+++ b/spec/lib/post_localization_updater_spec.rb
@@ -12,8 +12,8 @@ describe PostLocalizationUpdater do
   let(:new_raw) { "新しいバージョンです" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/lib/topic_localization_creator_spec.rb
+++ b/spec/lib/topic_localization_creator_spec.rb
@@ -9,8 +9,8 @@ describe TopicLocalizationCreator do
   let(:title) { "これは翻訳です" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/lib/topic_localization_destroyer_spec.rb
+++ b/spec/lib/topic_localization_destroyer_spec.rb
@@ -9,8 +9,8 @@ describe TopicLocalizationDestroyer do
   let(:locale) { "ja" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/lib/topic_localization_updater_spec.rb
+++ b/spec/lib/topic_localization_updater_spec.rb
@@ -12,8 +12,8 @@ describe TopicLocalizationUpdater do
   let(:new_title) { "新しいバージョンです" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
   end
 

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -499,14 +499,14 @@ RSpec.describe CategoryList do
     end
   end
 
-  context "with experimental_content_localization enabled" do
+  context "with content_localization_enabled enabled" do
     fab!(:category) { Fabricate(:category, name: "Original Name", description: "Original Desc") }
     fab!(:category_localization) { Fabricate(:category_localization, category:, locale: "ja") }
 
     let(:locale) { "ja" }
 
     before do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       I18n.locale = locale
     end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -345,9 +345,9 @@ RSpec.describe Site do
       )
     end
 
-    describe "experimental_content_localization" do
+    describe "content_localization_enabled" do
       it "returns localized category names when enabled" do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
 
         localization = Fabricate(:category_localization)
         category = localization.category
@@ -362,7 +362,7 @@ RSpec.describe Site do
       end
 
       it "returns original names when enabled" do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
 
         category = Fabricate(:category, name: "derp", description: "derp derp")
 
@@ -390,8 +390,8 @@ RSpec.describe Site do
       I18n.locale = original_locale
     end
 
-    context "when experimental_content_localization is disabled" do
-      before { SiteSetting.experimental_content_localization = false }
+    context "when content_localization_enabled is disabled" do
+      before { SiteSetting.content_localization_enabled = false }
 
       it "caches anon site json with a global key (not locale scoped)" do
         expect(Discourse.redis.get("site_json")).to be_nil
@@ -410,8 +410,8 @@ RSpec.describe Site do
       end
     end
 
-    context "when experimental_content_localization is enabled" do
-      before { SiteSetting.experimental_content_localization = true }
+    context "when content_localization_enabled is enabled" do
+      before { SiteSetting.content_localization_enabled = true }
 
       it "caches anon site json separately for each locale" do
         expect(Discourse.redis.get("site_json_en")).to be_nil

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1714,7 +1714,7 @@ describe Topic do
       end
 
       it "returns a localized banner" do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
 
         first_post.update!(locale: "en")
         I18n.locale = :ja

--- a/spec/requests/post_localizations_controller_spec.rb
+++ b/spec/requests/post_localizations_controller_spec.rb
@@ -9,8 +9,8 @@ describe PostLocalizationsController do
   let(:raw) { "これは翻訳です。" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
     sign_in(user)
   end

--- a/spec/requests/topic_localizations_controller_spec.rb
+++ b/spec/requests/topic_localizations_controller_spec.rb
@@ -9,8 +9,8 @@ describe TopicLocalizationsController do
   let(:title) { "これはトピックの翻訳です。" }
 
   before do
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = group.id.to_s
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = group.id.to_s
     group.add(user)
     sign_in(user)
   end

--- a/spec/serializers/basic_post_serializer_spec.rb
+++ b/spec/serializers/basic_post_serializer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BasicPostSerializer do
       end
 
       it "returns the localized cooked" do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
         Fabricate(:post_localization, post: post, cooked: "X", locale: "ja")
         I18n.locale = "ja"
         post.update!(locale: "en")

--- a/spec/serializers/basic_topic_serializer_spec.rb
+++ b/spec/serializers/basic_topic_serializer_spec.rb
@@ -11,7 +11,7 @@ describe BasicTopicSerializer do
     end
 
     it "returns the fancy title with a modifier" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       Fabricate(:topic_localization, topic:, fancy_title: "X", locale: "ja")
       I18n.locale = "ja"
       topic.update!(locale: "en")

--- a/spec/serializers/listable_topic_serializer_spec.rb
+++ b/spec/serializers/listable_topic_serializer_spec.rb
@@ -46,7 +46,7 @@ describe ListableTopicSerializer do
       topic.update!(locale: "en")
       Fabricate(:topic_localization, topic:, excerpt: "X", locale: "ja")
 
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       SiteSetting.always_include_topic_excerpts = true
 
       json = ListableTopicSerializer.new(topic, scope: Guardian.new).as_json

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe PostSerializer do
     end
 
     it "returns the localized raw" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       Fabricate(:post_localization, post: post, raw: "raw", locale: "ja")
       I18n.locale = "ja"
       post.update!(locale: "en")
@@ -726,15 +726,15 @@ RSpec.describe PostSerializer do
     let(:serializer) { serialized_post }
     let(:json) { serializer.as_json }
 
-    it "is included when experimental_content_localization is enabled" do
-      SiteSetting.experimental_content_localization = true
+    it "is included when content_localization_enabled is enabled" do
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "ja")
 
       expect(json[:locale]).to eq("ja")
     end
 
-    it "is excluded when experimental_content_localization is disabled" do
-      SiteSetting.experimental_content_localization = false
+    it "is excluded when content_localization_enabled is disabled" do
+      SiteSetting.content_localization_enabled = false
       post.update!(locale: "ja")
 
       expect(json[:locale]).to eq(nil)
@@ -745,15 +745,15 @@ RSpec.describe PostSerializer do
     let(:serializer) { serialized_post }
     let(:json) { serializer.as_json }
 
-    it "is excluded when experimental_content_localization is disabled" do
-      SiteSetting.experimental_content_localization = false
+    it "is excluded when content_localization_enabled is disabled" do
+      SiteSetting.content_localization_enabled = false
 
       expect(json[:is_localized]).to eq(nil)
     end
 
     describe "content localization enabled" do
       before do
-        SiteSetting.experimental_content_localization = true
+        SiteSetting.content_localization_enabled = true
         I18n.locale = "en"
       end
 
@@ -783,25 +783,25 @@ RSpec.describe PostSerializer do
     let(:serializer) { serialized_post }
     let(:json) { serializer.as_json }
 
-    it "is excluded when experimental_content_localization is disabled or no locale" do
-      SiteSetting.experimental_content_localization = false
+    it "is excluded when content_localization_enabled is disabled or no locale" do
+      SiteSetting.content_localization_enabled = false
       post.update!(locale: "ja")
       expect(serializer.as_json[:language]).to eq(nil)
 
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: nil)
       expect(serializer.as_json[:language]).to eq(nil)
     end
 
     it "shows the language of the post based on locale" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "ja")
 
       expect(json[:language]).to eq("日本語")
     end
 
     it "defaults to locale if language does not exist" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "aa")
 
       expect(json[:language]).to eq("aa")
@@ -812,13 +812,13 @@ RSpec.describe PostSerializer do
     let(:serializer) { serialized_post }
     let(:json) { serializer.as_json }
 
-    it "is excluded when experimental_content_localization is disabled" do
-      SiteSetting.experimental_content_localization = false
+    it "is excluded when content_localization_enabled is disabled" do
+      SiteSetting.content_localization_enabled = false
       expect(json[:localization_outdated]).to eq(nil)
     end
 
     it "is true when the post is localized and the localization is outdated" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "ja", version: 3)
       Fabricate(:post_localization, post:, locale: "en", post_version: 2)
 
@@ -826,7 +826,7 @@ RSpec.describe PostSerializer do
     end
 
     it "is false when the post is localized and the localization is not outdated" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       post.update!(locale: "ja", version: 10)
       Fabricate(:post_localization, post:, locale: "en", post_version: 10)
 

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -655,7 +655,7 @@ RSpec.describe TopicViewSerializer do
     end
 
     it "returns the localized fancy_title" do
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
       Fabricate(:topic_localization, topic:, fancy_title: "X", locale: "ja")
       I18n.locale = "ja"
       topic.update!(locale: "en")
@@ -666,7 +666,7 @@ RSpec.describe TopicViewSerializer do
   end
 
   describe "#has_localized_content" do
-    before { SiteSetting.experimental_content_localization = true }
+    before { SiteSetting.content_localization_enabled = true }
 
     it "returns true if the topic has localization" do
       Fabricate(:topic_localization, topic:, locale: "ja")
@@ -692,7 +692,7 @@ RSpec.describe TopicViewSerializer do
     end
 
     it "does not return attribute if setting is disabled" do
-      SiteSetting.experimental_content_localization = false
+      SiteSetting.content_localization_enabled = false
 
       json = serialize_topic(topic, user)
       expect(json[:has_localized_content]).to eq(nil)

--- a/spec/system/anon_language_switcher_spec.rb
+++ b/spec/system/anon_language_switcher_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe "Anonymous user language switcher", type: :system do
 
   before do
     SiteSetting.default_locale = "en"
-    SiteSetting.experimental_content_localization_supported_locales = "es|ja"
-    SiteSetting.experimental_content_localization = true
+    SiteSetting.content_localization_supported_locales = "es|ja"
+    SiteSetting.content_localization_enabled = true
     SiteSetting.allow_user_locale = true
     SiteSetting.set_locale_from_cookie = true
   end
 
   it "only shows the language switcher based on what is in target languages" do
-    SiteSetting.experimental_anon_language_switcher = false
+    SiteSetting.content_localization_anon_language_switcher = false
     visit("/")
 
     expect(page).not_to have_css(SWITCHER_SELECTOR)
 
-    SiteSetting.experimental_anon_language_switcher = true
+    SiteSetting.content_localization_anon_language_switcher = true
     visit("/")
 
     switcher.expand
@@ -35,7 +35,7 @@ RSpec.describe "Anonymous user language switcher", type: :system do
     expect(switcher).to have_content("日本語")
     expect(switcher).to have_content("Español")
 
-    SiteSetting.experimental_content_localization_supported_locales = "es"
+    SiteSetting.content_localization_supported_locales = "es"
     visit("/")
 
     switcher.expand

--- a/spec/system/edit_category_localizations_spec.rb
+++ b/spec/system/edit_category_localizations_spec.rb
@@ -11,7 +11,7 @@ describe "Edit Category Localizations", type: :system do
   before { sign_in(admin) }
 
   context "when content localization setting is disabled" do
-    before { SiteSetting.experimental_content_localization = false }
+    before { SiteSetting.content_localization_enabled = false }
 
     it "should not show the localization tab" do
       category_page.visit_settings(category)
@@ -22,9 +22,9 @@ describe "Edit Category Localizations", type: :system do
   context "when content localization setting is enabled" do
     before do
       SiteSetting.default_locale = "en"
-      SiteSetting.experimental_content_localization = true
-      SiteSetting.experimental_content_localization_supported_locales = "es|fr"
-      SiteSetting.experimental_content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_supported_locales = "es|fr"
+      SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
 
       if SiteSetting.client_settings.exclude?(:available_content_localization_locales)
         SiteSetting.client_settings << :available_content_localization_locales

--- a/spec/system/post_translation_spec.rb
+++ b/spec/system/post_translation_spec.rb
@@ -19,9 +19,9 @@ describe "Post translations", type: :system do
   before do
     sign_in(admin)
     SiteSetting.default_locale = "en"
-    SiteSetting.experimental_content_localization_supported_locales = "fr|es|pt_BR"
-    SiteSetting.experimental_content_localization = true
-    SiteSetting.experimental_content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    SiteSetting.content_localization_supported_locales = "fr|es|pt_BR"
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
     SiteSetting.post_menu =
       "read|like|copyLink|flag|edit|bookmark|delete|admin|reply|addTranslation"
   end

--- a/spec/system/topic_view/localized_content_spec.rb
+++ b/spec/system/topic_view/localized_content_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Localized topic" do
   context "when the feature is enabled" do
     before do
       SiteSetting.allow_user_locale = true
-      SiteSetting.experimental_content_localization = true
+      SiteSetting.content_localization_enabled = true
     end
 
     it "shows the correct language based on the selected language and login status" do


### PR DESCRIPTION
This PR takes the localization features out of "experimental" to prep for the announcement
- rename settings and gives them its own area
  - `experimental_content_localization` to `content_localization_enabled`
  - `experimental_content_localization_allowed_groups` to `content_localization_allowed_groups`
  - `experimental_content_localization_supported_locales` to `content_localization_supported_locales`
  - `experimental_anon_language_switcher` to `content_localization_anon_language_switcher`
- migration
- related to https://github.com/discourse/discourse-ai/pull/1439

| screenshot 📸 |
|---|
| <img width="964" alt="Screenshot 2025-06-17 at 5 06 32 PM" src="https://github.com/user-attachments/assets/9a8b2c38-c846-4fc9-8ddd-815c45cc3d0e" /> |