### PR TITLE
DEV: Remove generic exception in model step in services

### DIFF
--- a/lib/service/steps_inspector.rb
+++ b/lib/service/steps_inspector.rb
@@ -75,7 +75,7 @@ class Service::StepsInspector
   class Model < Step
     def error
       return result[name].errors.inspect if step_result.invalid
-      step_result.exception.full_message
+      step_result.exception&.full_message || "Model not found"
     end
   end
 


### PR DESCRIPTION
Currently when a model is not found, we raise an `ArgumentError` exception and that exception is stored in the resulting context object.

However, since we’re also storing unexpected exceptions, this default exception can pollute the context object when we need to inspect it or act on it.

This PR addresses that issue by raising a custom exception instead, and we then discard it from the context object.