### PR TITLE
FIX: Formkit calendar date setting back one day

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
@@ -35,12 +35,9 @@ export default class FKControlCalendar extends Component {
   @action
   setDate(date) {
     let [year, month, day] = date.split("-").map(Number);
-    // JS Date months are 0-based
     month -= 1;
 
     const updatedDate = new Date(year, month, day);
-    //const updatedDate = new Date(date);
-
     const currentDate = this.args.field.value || new Date();
 
     updatedDate.setHours(

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
@@ -34,12 +34,13 @@ export default class FKControlCalendar extends Component {
 
   @action
   setDate(date) {
-    let year, month, day;
-    [year, month, day] = date.split("-").map(Number);
+    let [year, month, day] = date.split("-").map(Number);
     // JS Date months are 0-based
     month -= 1;
 
     const updatedDate = new Date(year, month, day);
+    //const updatedDate = new Date(date);
+
     const currentDate = this.args.field.value || new Date();
 
     updatedDate.setHours(

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/calendar.gjs
@@ -34,7 +34,12 @@ export default class FKControlCalendar extends Component {
 
   @action
   setDate(date) {
-    const updatedDate = new Date(date);
+    let year, month, day;
+    [year, month, day] = date.split("-").map(Number);
+    // JS Date months are 0-based
+    month -= 1;
+
+    const updatedDate = new Date(year, month, day);
     const currentDate = this.args.field.value || new Date();
 
     updatedDate.setHours(

--- a/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
@@ -32,8 +32,8 @@ export default class ValidationParser {
 
   parseDateString(input) {
     let [year, month, day] = input.split("-").map(Number);
-    // JS Date months are 0-based
     month -= 1;
+
     return new Date(year, month, day);
   }
 

--- a/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
@@ -20,14 +20,21 @@ export default class ValidationParser {
 
   dateBeforeOrEqualRule(input) {
     return {
-      date: new Date(input),
+      date: this.parseDateString(input),
     };
   }
 
   dateAfterOrEqualRule(input) {
     return {
-      date: new Date(input),
+      date: this.parseDateString(input),
     };
+  }
+
+  parseDateString(input) {
+    let [year, month, day] = input.split("-").map(Number);
+    // JS Date months are 0-based
+    month -= 1;
+    return new Date(year, month, day);
   }
 
   requiredRule(args = "") {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/calendar-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/calendar-test.gjs
@@ -13,7 +13,7 @@ module(
 
     let clock = null;
     hooks.beforeEach(() => {
-      clock = fakeTime("2025-05-03T08:00:00", "America/Chicago", true); // Monday morning
+      clock = fakeTime("2025-05-03T08:00:00", "America/Chicago", true);
     });
 
     hooks.afterEach(() => {

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/calendar-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/calendar-test.gjs
@@ -3,12 +3,22 @@ import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 module(
   "Integration | Component | FormKit | Controls | Calendar",
   function (hooks) {
     setupRenderingTest(hooks);
+
+    let clock = null;
+    hooks.beforeEach(() => {
+      clock = fakeTime("2025-05-03T08:00:00", "America/Chicago", true); // Monday morning
+    });
+
+    hooks.afterEach(() => {
+      clock.restore();
+    });
 
     test("default", async function (assert) {
       let data = { foo: null };


### PR DESCRIPTION
I ran into an issue where the date was being set back 1 day. This is due to Midnight in Kansas being the past day in UTC. Check this out:

![Screenshot 2025-06-17 at 2 37 52 PM](https://github.com/user-attachments/assets/1022d0cc-ef3d-4e31-86f1-b7a79543289d)

![Screenshot 2025-06-17 at 2 42 10 PM](https://github.com/user-attachments/assets/51953b6c-333c-4c56-9561-1f3f166f0b94)

___

This change does a simple parsing of the date string, and extracts the year/month/days out, so that picking a date from any timezone will keep it at that date (the time is separate -- this is OK!)