### PR TITLE
FIX: correctly refreshes associated fields after update

### DIFF
--- a/plugins/automation/app/models/discourse_automation/field.rb
+++ b/plugins/automation/app/models/discourse_automation/field.rb
@@ -18,6 +18,8 @@ module DiscourseAutomation
 
       yield
 
+      automation.fields.reload
+
       automation&.triggerable&.on_update&.call(
         automation,
         automation.serialized_fields,

--- a/plugins/automation/app/models/discourse_automation/field.rb
+++ b/plugins/automation/app/models/discourse_automation/field.rb
@@ -12,6 +12,8 @@ module DiscourseAutomation
     around_save :on_update_callback
 
     def on_update_callback
+      automation.fields.reload
+
       previous_fields = automation.serialized_fields
 
       automation.reset!

--- a/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
+++ b/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
@@ -286,7 +286,7 @@ describe DiscourseAutomation::AdminAutomationsController do
                   ],
                 },
               }
-        }.to change { automation.pending_automations.count }.by(0)
+        }.not_to change { automation.pending_automations.count }
 
         expect(automation.pending_automations.reload.last.execute_at).to be_within_one_minute_of(
           2.hours.from_now,

--- a/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
+++ b/plugins/automation/spec/requests/admin_discourse_automation_automations_spec.rb
@@ -245,6 +245,54 @@ describe DiscourseAutomation::AdminAutomationsController do
         expect(response.status).to eq(404)
       end
     end
+
+    context "when updating a point_in_time automation" do
+      fab!(:automation) do
+        Fabricate(:automation, trigger: DiscourseAutomation::Triggers::POINT_IN_TIME)
+      end
+
+      before do
+        sign_in(Fabricate(:admin))
+
+        automation.upsert_field!(
+          "execute_at",
+          "date_time",
+          { value: 1.hours.from_now },
+          target: "trigger",
+        )
+      end
+
+      it "updates the associated pending automation execute_at" do
+        expect(automation.pending_automations.count).to eq(1)
+        expect(automation.pending_automations.last.execute_at).to be_within_one_minute_of(
+          1.hours.from_now,
+        )
+
+        expect {
+          put "/admin/plugins/automation/automations/#{automation.id}.json",
+              params: {
+                automation: {
+                  script: automation.script,
+                  trigger: automation.trigger,
+                  fields: [
+                    {
+                      name: "execute_at",
+                      component: "date_time",
+                      target: "trigger",
+                      metadata: {
+                        value: 2.hours.from_now,
+                      },
+                    },
+                  ],
+                },
+              }
+        }.to change { automation.pending_automations.count }.by(0)
+
+        expect(automation.pending_automations.reload.last.execute_at).to be_within_one_minute_of(
+          2.hours.from_now,
+        )
+      end
+    end
   end
 
   describe "#index" do


### PR DESCRIPTION
The `on_update` callback of triggers is called with previous fields and new fields, values. However since a recent change: https://github.com/discourse/discourse/pull/32810 this relationship is cached and would cause previous fields to equal new fields. This commit ensures we are refreshing the relationship before calling the `on_update` callback.