### PR TITLE
FEATURE: add emojis to seeded categories

### DIFF
--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -50,6 +50,8 @@ module SeedData
           position: 0,
           color: "0088CC",
           text_color: "FFFFFF",
+          style_type: "emoji",
+          emoji: "card_file_box",
           permissions: {
             everyone: :full,
           },
@@ -63,6 +65,8 @@ module SeedData
           position: 1,
           color: "808281",
           text_color: "FFFFFF",
+          style_type: "emoji",
+          emoji: "thought_balloon",
           permissions: {
             everyone: :full,
           },
@@ -76,6 +80,8 @@ module SeedData
           position: 2,
           color: "E45735",
           text_color: "FFFFFF",
+          style_type: "emoji",
+          emoji: "shield",
           permissions: {
             staff: :full,
           },
@@ -89,6 +95,8 @@ module SeedData
           position: 3,
           color: "25AAE2",
           text_color: "FFFFFF",
+          style_type: "emoji",
+          emoji: "blue_book",
           permissions: {
             everyone: :full,
           },
@@ -112,6 +120,8 @@ module SeedData
       position:,
       color:,
       text_color:,
+      style_type:,
+      emoji:,
       permissions:,
       force_permissions:,
       force_existence: false,
@@ -129,6 +139,8 @@ module SeedData
             position: position,
             color: color,
             text_color: text_color,
+            style_type: style_type,
+            emoji: emoji,
           )
 
         category.skip_category_definition = true if description.blank?

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -99,6 +99,20 @@ RSpec.describe SeedData::Categories do
       expect(SiteSetting.default_composer_category).to eq(Category.last.id)
     end
 
+    it "adds emojis to seeded categories" do
+      create_category("uncategorized_category_id")
+      expect(Category.last.emoji).to eq("card_file_box")
+
+      create_category("meta_category_id")
+      expect(Category.last.emoji).to eq("thought_balloon")
+
+      create_category("staff_category_id")
+      expect(Category.last.emoji).to eq("shield")
+
+      create_category("general_category_id")
+      expect(Category.last.emoji).to eq("blue_book")
+    end
+
     it "does not overwrite permissions on the General category" do
       create_category("general_category_id")
       expect(Category.last.name).to eq("General")

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -100,6 +100,8 @@ RSpec.describe SeedData::Categories do
     end
 
     it "adds emojis to seeded categories" do
+      Category.destroy_all
+
       create_category("uncategorized_category_id")
       expect(Category.last.emoji).to eq("card_file_box")
 


### PR DESCRIPTION
This change adds some flair to the default seeded categories by adding emojis for new sites:

<img width="304" alt="Screenshot 2025-06-18 at 4 00 22 PM" src="https://github.com/user-attachments/assets/f607e779-87ff-45da-8dbb-e90247f0ef39" />

Internal ref: /t/156455