### PR TITLE
DEV: Bump aws-sdk-core in prep for aws-sdk-mediaconvert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,13 +57,14 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1053.0)
-    aws-sdk-core (3.219.0)
+    aws-partitions (1.1117.0)
+    aws-sdk-core (3.226.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
+      logger
     aws-sdk-kms (1.99.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
@@ -74,7 +75,7 @@ GEM
     aws-sdk-sns (1.96.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sigv4 (1.11.0)
+    aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.4.1)
@@ -815,12 +816,12 @@ CHECKSUMS
   annotate (3.2.0) sha256=9a61baa1fb13880aa3a8d9f62553889bb2a3b7970f88bbc66d3ac75a567780d3
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1053.0) sha256=6f06634f719c745929d671909919e608d2b3c9072df85f6c074823f4a79d11ca
-  aws-sdk-core (3.219.0) sha256=d10c3832ece1f1de8edb7cbbcd737dd49b2789fae8744537943e86fdd822c649
+  aws-partitions (1.1117.0) sha256=fe6469ff7426b449c0c6d0aa43e45f387a4b26992bf48f6897c0b730b205a8a3
+  aws-sdk-core (3.226.0) sha256=6b2dca6576d965b8c7ddf393fe49dac6aea2b6f4a07ead0c35306bba2b0c90f5
   aws-sdk-kms (1.99.0) sha256=ba292fc3ffd672532aae2601fe55ff424eee78da8e23c23ba6ce4037138275a8
   aws-sdk-s3 (1.182.0) sha256=d0fc3579395cb6cb69bf6e975240ce031fc673190e74c8dddbdd6c18572b450d
   aws-sdk-sns (1.96.0) sha256=f92b3c7203c53181b1cafb3dbbea85f330002ad696175bda829cfef359fa6dd4
-  aws-sigv4 (1.11.0) sha256=50a8796991a862324442036ad7a395920572b84bb6cd29b945e5e1800e8da1db
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   better_errors (2.10.1) sha256=f798f1bac93f3e775925b7fcb24cffbcf0bb62ee2210f5350f161a6b75fc0a73

--- a/spec/lib/backup_restore/s3_backup_store_spec.rb
+++ b/spec/lib/backup_restore/s3_backup_store_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe BackupRestore::S3BackupStore do
         expect do @objects.delete_if { |obj| obj[:key] == context.params[:key] } end.to change {
           @objects
         }
+
+        { delete_marker: true }
       end,
     )
 

--- a/spec/lib/backup_restore/s3_backup_store_spec.rb
+++ b/spec/lib/backup_restore/s3_backup_store_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe BackupRestore::S3BackupStore do
           size: context.params[:body].size,
           last_modified: Time.zone.now,
         }
+
+        { etag: "test-etag" }
       end,
     )
 

--- a/spec/lib/s3_helper_spec.rb
+++ b/spec/lib/s3_helper_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe "S3Helper" do
       expect(put_object_tagging_request[:context].params[:bucket]).to eq("some-bucket")
       expect(put_object_tagging_request[:context].params[:key]).to eq("some-path/some/key")
 
-      expect(put_object_tagging_request[:context].params[:tagging][:tag_set]).to eq(
+      expect(put_object_tagging_request[:context].params[:tagging][:tag_set].map(&:to_h)).to eq(
         [{ key: "tag1", value: "newvalue" }, { key: "tag2", value: "value2" }],
       )
     end
@@ -391,7 +391,7 @@ RSpec.describe "S3Helper" do
       expect(put_object_tagging_request[:context].params[:bucket]).to eq("some-bucket")
       expect(put_object_tagging_request[:context].params[:key]).to eq("some-path/some/key")
 
-      expect(put_object_tagging_request[:context].params[:tagging][:tag_set]).to eq(
+      expect(put_object_tagging_request[:context].params[:tagging][:tag_set].map(&:to_h)).to eq(
         [
           { key: "tag1", value: "value1" },
           { key: "tag2", value: "value2" },

--- a/spec/support/fake_s3.rb
+++ b/spec/support/fake_s3.rb
@@ -120,7 +120,7 @@ class FakeS3
         log_operation(context)
 
         find_bucket(context.params)&.delete_object(context.params[:key])
-        nil
+        { delete_marker: true }
       end,
     )
 


### PR DESCRIPTION
In an upcoming pr #33092 that adds support for aws-sdk-mediaconvert it requires
that we bump aws-sdk-core to 3.225.0

```
+    aws-sdk-mediaconvert (1.160.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
```

but in doing so there are apparently some api changes and it requires changes
in core to support the new version. I thought it would best to break out these
changes in a separate PR as to not muddy up the mediaconvert pr that is already
quite large.
