### PR TITLE
FEATURE: new button in user drafts page to delete all drafts

### DIFF
--- a/app/assets/javascripts/discourse/app/models/draft.js
+++ b/app/assets/javascripts/discourse/app/models/draft.js
@@ -9,6 +9,12 @@ export default class Draft extends EmberObject {
     });
   }
 
+  static clearAll() {
+    return ajax(`/drafts/destroy-all`, {
+      type: "DELETE",
+    });
+  }
+
   static get(key) {
     return ajax(`/drafts/${key}.json`);
   }

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -122,6 +122,12 @@
     width: 100%;
     border-bottom: 0.5px solid var(--primary-low);
   }
+
+  .remove-all-drafts {
+    display: block;
+    margin-left: auto;
+    margin-bottom: 1rem;
+  }
 }
 
 .user-main {

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -154,6 +154,28 @@ class DraftsController < ApplicationController
     render json: success_json
   end
 
+  def destroy_all
+    user =
+      if is_api?
+        if @guardian.is_admin?
+          fetch_user_from_params
+        else
+          raise Discourse::InvalidAccess
+        end
+      else
+        current_user
+      end
+
+    begin
+      Draft.where(user_id: user.id).destroy_all
+      UserStat.update_draft_count(user.id)
+    rescue StandardError => e
+      return render json: failed_json.merge(errors: e), status: 401
+    end
+
+    render json: success_json
+  end
+
   private
 
   def reached_max_drafts_per_user?(params)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -496,9 +496,11 @@ en:
     drafts:
       label: "Drafts"
       label_with_count: "Drafts (%{count})"
+      delete_all_label: "Delete all drafts"
       resume: "Resume"
       remove: "Remove"
       remove_confirmation: "Are you sure you want to delete this draft?"
+      remove_all_confirmation: "Are you sure you want to delete all your drafts?"
       new_topic: "New topic draft"
       new_private_message: "New personal message draft"
       edit_topic: "Edit topic draft"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1602,7 +1602,9 @@ Discourse::Application.routes.draw do
 
     get "message-bus/poll" => "message_bus#poll"
 
-    resources :drafts, only: %i[index create show destroy]
+    resources :drafts, only: %i[index create show destroy] do
+      collection { delete "destroy-all" => "drafts#destroy_all" }
+    end
 
     get "/service-worker.js" => "static#service_worker_asset", :format => :js
 

--- a/spec/system/page_objects/pages/user_activity_drafts.rb
+++ b/spec/system/page_objects/pages/user_activity_drafts.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class UserActivityDrafts < PageObjects::Pages::Base
+      def visit(user)
+        page.visit("/u/#{user.username_lower}/activity/drafts")
+        # Wait for page to load
+        has_css?("body.drafts")
+        self
+      end
+
+      def has_draft?(draft_content)
+        has_content?(draft_content)
+      end
+
+      def has_no_draft?(draft_content)
+        has_no_content?(draft_content)
+      end
+
+      def has_drafts?
+        has_css?(".user-stream-item")
+      end
+
+      def has_no_drafts?
+        has_no_css?(".user-stream-item")
+      end
+
+      def has_clear_all_drafts_button?
+        has_css?(".remove-all-drafts")
+      end
+
+      def has_no_clear_all_drafts_button?
+        has_no_css?(".remove-all-drafts")
+      end
+
+      def click_clear_all_drafts
+        find(".remove-all-drafts").click
+        self
+      end
+
+      def confirm_dialog
+        find(".dialog-footer .btn-danger").click
+        self
+      end
+
+      def remove_first_draft
+        first(".user-stream-item .remove-draft").click
+        self
+      end
+    end
+  end
+end

--- a/spec/system/user_activity_drafts_spec.rb
+++ b/spec/system/user_activity_drafts_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe "User activity drafts", type: :system do
+  let(:user) { Fabricate(:user) }
+  let(:user_activity_drafts) { PageObjects::Pages::UserActivityDrafts.new }
+
+  before do
+    # Clear all drafts to start fresh
+    Draft.delete_all
+    sign_in(user)
+  end
+
+  it "shows clear all drafts button only when multiple drafts exist" do
+    # Start with no drafts - button should not be visible
+    visit "/u/#{user.username_lower}/activity/drafts"
+    expect(user_activity_drafts).to have_no_clear_all_drafts_button
+
+    # Create one draft
+    topic = Fabricate(:topic)
+    Draft.set(user, "topic_#{topic.id}", 0, { reply: "First draft content" }.to_json)
+
+    # Reload page and verify button is not visible with one draft
+    visit "/u/#{user.username_lower}/activity/drafts"
+    expect(user_activity_drafts).to have_drafts
+    expect(user_activity_drafts).to have_no_clear_all_drafts_button
+
+    # Create a second draft with a different key
+    Draft.set(user, Draft::NEW_PRIVATE_MESSAGE, 0, { reply: "Second draft" }.to_json)
+
+    # Reload page and verify button is now visible with multiple drafts
+    visit "/u/#{user.username_lower}/activity/drafts"
+    expect(user_activity_drafts).to have_clear_all_drafts_button
+
+    # Remove one draft
+    user_activity_drafts.remove_first_draft
+    find(".dialog-footer .btn-danger").click
+    page.refresh
+
+    # Button should be hidden again with only one draft left
+    expect(user_activity_drafts).to have_no_clear_all_drafts_button
+  end
+
+  it "can clear all drafts" do
+    # Create multiple drafts
+    topic1 = Fabricate(:topic)
+    topic2 = Fabricate(:topic)
+    Draft.set(user, "topic_#{topic1.id}", 0, { reply: "Draft 1" }.to_json)
+    Draft.set(user, "topic_#{topic2.id}", 0, { reply: "Draft 2" }.to_json)
+
+    # Visit page and verify drafts exist
+    visit "/u/#{user.username_lower}/activity/drafts"
+    expect(page).to have_css(".user-stream-item", count: 2)
+
+    # Click the clear all button and confirm
+    user_activity_drafts.click_clear_all_drafts
+    find(".dialog-footer .btn-danger").click
+
+    # All drafts should be removed
+    expect(page).to have_no_css(".user-stream-item")
+  end
+end


### PR DESCRIPTION
## :mag: Overview
This update adds a new button to the `/u/username/activity/drafts` page which allows users to delete all their drafts at once. The button will only be shown where there is more than one draft.

## :camera_flash: Screenshots

![Screenshot 2025-06-18 at 11 12 35](https://github.com/user-attachments/assets/1564f407-8fc6-45a4-812b-ccfab853fba1)
---
![Screenshot 2025-06-18 at 11 12 16](https://github.com/user-attachments/assets/fe974d78-00cd-456f-a031-da552e4a53ae)
---
![Screenshot 2025-06-18 at 11 12 23](https://github.com/user-attachments/assets/835321ad-e231-409b-ba48-bd38079d7024)
---
