### PR TITLE
DEV: Add outlet wrapper for post avatar flair

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/avatar.gjs
@@ -47,6 +47,12 @@ export default class PostAvatar extends Component {
               @user={{this.user}}
             />
             <UserAvatarFlair @user={{@post}} />
+            <div>
+              <PluginOutlet
+                @name="post-avatar-flair"
+                @outletArgs={{lazyHash user=this.user}}
+              />
+            <div>
           {{/if}}
           {{#if @displayPosterName}}
             <div class="post-avatar-user-info"></div>

--- a/app/assets/javascripts/discourse/app/components/post/avatar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/avatar.gjs
@@ -52,7 +52,7 @@ export default class PostAvatar extends Component {
                 @name="post-avatar-flair"
                 @outletArgs={{lazyHash user=this.user}}
               />
-            <div>
+            </div>
           {{/if}}
           {{#if @displayPosterName}}
             <div class="post-avatar-user-info"></div>


### PR DESCRIPTION
This adds an outlet wrapper for post avatar flair to keep in line with the existing pattern we see with user card and profile avatar flair:

https://github.com/discourse/discourse/blob/8cc009ceebe55a6650cf424b003878279fe276c0/app/assets/javascripts/discourse/app/components/user-card-contents.gjs#L391-L399

https://github.com/discourse/discourse/blob/8cc009ceebe55a6650cf424b003878279fe276c0/app/assets/javascripts/discourse/app/components/user-profile-avatar.gjs#L21-L27