### PR TITLE
FIX: prevent login loop when logging out when only one idp

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -663,8 +663,15 @@ class SessionController < ApplicationController
   end
 
   def destroy
-    redirect_url = params[:return_url].presence
-    redirect_url ||= SiteSetting.logout_redirect.presence
+    redirect_url = params[:return_url].presence || SiteSetting.logout_redirect.presence
+
+    redirect_url ||=
+      if SiteSetting.login_required
+        uses_sso = SiteSetting.enable_discourse_connect
+        has_one_auth = !SiteSetting.enable_local_logins && Discourse.enabled_authenticators.uniq?
+        path("/login-required") if uses_sso || has_one_auth
+      end
+
     redirect_url ||= path("/")
 
     data = {

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -668,7 +668,7 @@ class SessionController < ApplicationController
     redirect_url ||=
       if SiteSetting.login_required
         uses_sso = SiteSetting.enable_discourse_connect
-        has_one_auth = !SiteSetting.enable_local_logins && Discourse.enabled_authenticators.uniq?
+        has_one_auth = !SiteSetting.enable_local_logins && Discourse.enabled_authenticators.one?
         path("/login-required") if uses_sso || has_one_auth
       end
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -13,9 +13,6 @@ module Discourse
   class Utils
     URI_REGEXP = URI.regexp(%w[http https])
 
-    # TODO: Remove this once we drop support for Ruby 2.
-    EMPTY_KEYWORDS = {}
-
     # Usage:
     #   Discourse::Utils.execute_command("pwd", chdir: 'mydirectory')
     # or with a block

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2515,7 +2515,7 @@ RSpec.describe SessionController do
       expect(response.parsed_body["redirect_url"]).to eq("/")
     end
 
-    it "redirects to /login when SSO and login_required" do
+    it "redirects to / when SSO and login_required" do
       SiteSetting.discourse_connect_url = "https://example.com/sso"
       SiteSetting.enable_discourse_connect = true
 
@@ -2530,7 +2530,7 @@ RSpec.describe SessionController do
       delete "/session/#{user.username}.json", xhr: true
       expect(response.status).to eq(200)
       expect(response.parsed_body["error"]).not_to be_present
-      expect(response.parsed_body["redirect_url"]).to eq("/login")
+      expect(response.parsed_body["redirect_url"]).to eq("/")
     end
 
     it "allows plugins to manipulate redirect URL" do

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2515,7 +2515,7 @@ RSpec.describe SessionController do
       expect(response.parsed_body["redirect_url"]).to eq("/")
     end
 
-    it "redirects to / when SSO and login_required" do
+    it "redirects to /login-required when SSO and login_required" do
       SiteSetting.discourse_connect_url = "https://example.com/sso"
       SiteSetting.enable_discourse_connect = true
 
@@ -2530,7 +2530,7 @@ RSpec.describe SessionController do
       delete "/session/#{user.username}.json", xhr: true
       expect(response.status).to eq(200)
       expect(response.parsed_body["error"]).not_to be_present
-      expect(response.parsed_body["redirect_url"]).to eq("/")
+      expect(response.parsed_body["redirect_url"]).to eq("/login-required")
     end
 
     it "allows plugins to manipulate redirect URL" do


### PR DESCRIPTION
When we migrated to the full page /login, we added a nice feature that will automatically redirect a user to the idp if it's the only way they can log in, thus avoiding unecessary click.

But when logging out, we would redirect to the /login page which would start the /login process by automatically redirecting the user to the idp...

The fix is easy, redirect back to `/login-required` after logging out instead. This will show the "splash" screen that asks the user to either log in or sign up.

Note: I also removed the `Discourse::Utils::EMPTY_KEYWORDS` since it was its last occurence and I'm pretty sure we dropped support for Ruby 2 a while ago...

Internal ref - t/156834