### PR TITLE
DEV: Don’t check model validity when no changes have been made

### DIFF
--- a/lib/service/base.rb
+++ b/lib/service/base.rb
@@ -196,7 +196,7 @@ module Service
       def run_step
         context[name] = super
         raise NotFound if !optional && (!context[name] || context[name].try(:empty?))
-        if context[name].try(:invalid?)
+        if context[name].try(:has_changes_to_save?) && context[name].try(:invalid?)
           context[result_key].fail(invalid: true)
           context.fail!
         end

--- a/spec/lib/service/runner_spec.rb
+++ b/spec/lib/service/runner_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Service::Runner do
     private
 
     def fetch_fake_model
-      OpenStruct.new(invalid?: true)
+      OpenStruct.new(has_changes_to_save?: true, invalid?: true)
     end
   end
 
@@ -444,7 +444,7 @@ RSpec.describe Service::Runner do
         context "when using the block argument" do
           let(:actions) { <<-BLOCK }
               proc do
-                on_model_errors(:fake_model) { |model| model == OpenStruct.new(invalid?: true) }
+                on_model_errors(:fake_model) { |model| model.invalid? }
               end
             BLOCK
 

--- a/spec/lib/service/steps_inspector_spec.rb
+++ b/spec/lib/service/steps_inspector_spec.rb
@@ -281,7 +281,11 @@ RSpec.describe Service::StepsInspector do
         before do
           class DummyService
             def fetch_model
-              OpenStruct.new(invalid?: true, errors: ActiveModel::Errors.new(nil))
+              OpenStruct.new(
+                has_changes_to_save?: true,
+                invalid?: true,
+                errors: ActiveModel::Errors.new(nil),
+              )
             end
           end
         end


### PR DESCRIPTION
When fetching a model using the `model` step in a service, if that model is an `ActiveRecord` object, we check if it’s in a valid state. While this is useful when manipulating the model or when creating a new one, it’s not the case for a model we just pulled from the DB, as it should be valid.

In some cases, running the validations can be costly (it can lead to N+1 queries if the model validates associated items for example).

This PR introduces a small optimization by checking if the model has any pending changes on it, thus requiring validation. If that’s not the case, we just skip the validation part, as the model should be valid anyway.
