### PR TITLE
FIX: add channel hashtag color when lazy load is disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-decorator.js
@@ -80,7 +80,7 @@ export function generatePlaceholderHashtagHTML(type, spanEl, data) {
   link.dataset.type = type;
   link.dataset.id = data.id;
   link.dataset.slug = data.slug;
-  link.dataset.style_type = data.style_type;
+  link.dataset.styleType = data.style_type;
 
   if (data.style_type === "icon") {
     link.dataset.icon = data.icon;
@@ -109,7 +109,7 @@ export function decorateHashtags(element, site) {
         icon: site.hashtag_icons[hashtagType],
         id: hashtagEl.dataset.id,
         slug: hashtagEl.dataset.slug,
-        style_type: hashtagEl.dataset.styleType || "square",
+        style_type: hashtagEl.dataset?.styleType || "square",
       };
 
       if (opts.style_type === "icon") {

--- a/plugins/chat/assets/javascripts/discourse/lib/hashtag-types/channel.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/hashtag-types/channel.js
@@ -38,6 +38,6 @@ export default class ChannelHashtagType extends HashtagTypeBase {
   }
 
   isLoaded(id) {
-    return !this.site.lazy_load_categories || super.isLoaded(id);
+    return super.isLoaded(id);
   }
 }


### PR DESCRIPTION
When category lazy loading was disabled, chat channel CSS classes were not being inserted into the page markup. This meant that they would not be styled correctly in the markdown editor preview.

### Before

<img width="506" alt="Screenshot 2025-06-19 at 4 11 45 PM" src="https://github.com/user-attachments/assets/0cd4ddf0-4c69-4dcb-a41b-74576f7d7f28" />


### After

<img width="501" alt="Screenshot 2025-06-19 at 4 12 34 PM" src="https://github.com/user-attachments/assets/46b6f73c-7da6-423b-9f20-e513d2b33446" />

