### PR TITLE
FIX: ensures empty tags field is not storing an empty array

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
@@ -1,10 +1,21 @@
 import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { isBlank } from "@ember/utils";
 import TagChooser from "select-kit/components/tag-chooser";
 import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
 import DAFieldLabel from "./da-field-label";
 
 export default class TagsField extends BaseField {
+  @action
+  onChangeTags(tags) {
+    if (isBlank(tags)) {
+      tags = undefined; // avoids storing [] as value which can complicated logic in the backend
+    }
+
+    this.mutValue(tags);
+  }
+
   <template>
     <section class="field tags-field">
       <div class="control-group">
@@ -12,9 +23,10 @@ export default class TagsField extends BaseField {
 
         <div class="controls">
           <TagChooser
-            @tags={{@field.metadata.value}}
+            @tags={{readonly @field.metadata.value}}
             @everyTag={{true}}
             @options={{hash allowAny=false disabled=@field.isDisabled}}
+            @onChange={{this.onChangeTags}}
           />
 
           <DAFieldDescription @description={{@description}} />

--- a/plugins/automation/test/javascripts/integration/components/da-tags-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-tags-field-test.gjs
@@ -1,5 +1,6 @@
 import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
+import { pauseTest } from "ember-testing/lib/helpers/pause_test";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -33,5 +34,31 @@ module("Integration | Component | da-tags-field", function (hooks) {
     await selectKit().selectRowByValue("monkey");
 
     assert.deepEqual(this.field.metadata.value, ["monkey"]);
+  });
+
+  test("empty tags", async function (assert) {
+    const self = this;
+
+    this.field = new AutomationFabricators(getOwner(this)).field({
+      component: "tags",
+    });
+
+    await render(
+      <template>
+        <AutomationField
+          @automation={{self.automation}}
+          @field={{self.field}}
+        />
+      </template>
+    );
+
+    await selectKit().expand();
+    await selectKit().selectRowByValue("monkey");
+
+    assert.deepEqual(this.field.metadata.value, ["monkey"]);
+
+    await selectKit().deselectItemByName("monkey");
+
+    assert.deepEqual(this.field.metadata.value, undefined);
   });
 });


### PR DESCRIPTION
This would happen in the following scenario:
- select a tag
- save the automation
- unselect the tag
- save the automation

You would end up with a field having `[]` as value instead of `nil`. This can cause issues in the logic of scripts and triggers as they might consider the value as present.