### PR TITLE
UX: scroll to top of form on error

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -4,6 +4,7 @@ import { array, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import curryComponent from "ember-curry-component";
 import DButton from "discourse/components/d-button";
@@ -22,7 +23,9 @@ import FKSection from "discourse/form-kit/components/fk/section";
 import FKSubmit from "discourse/form-kit/components/fk/submit";
 import { VALIDATION_TYPES } from "discourse/form-kit/lib/constants";
 import FKFormData from "discourse/form-kit/lib/fk-form-data";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { i18n } from "discourse-i18n";
+import { getScrollParent } from "float-kit/lib/get-scroll-parent";
 
 class FKForm extends Component {
   @service dialog;
@@ -134,6 +137,11 @@ class FKForm extends Component {
   }
 
   @action
+  registerFormElement(element) {
+    this.formElement = element;
+  }
+
+  @action
   async addItemToCollection(name, value = {}) {
     const current = this.formData.get(name) ?? [];
     this.formData.set(name, current.concat(value));
@@ -211,6 +219,11 @@ class FKForm extends Component {
         this.formData.save();
 
         await this.args.onSubmit?.(this.formData.draftData);
+      } else {
+        const elementPosition = this.formElement.getBoundingClientRect().top;
+        const scrollable = getScrollParent(this.formElement);
+        const top = elementPosition + scrollable.scrollY - headerOffset();
+        scrollable.scrollTo({ top });
       }
     } finally {
       this.isSubmitting = false;
@@ -273,6 +286,7 @@ class FKForm extends Component {
       ...attributes
       {{on "submit" this.onSubmit}}
       {{on "reset" this.onReset}}
+      {{didInsert this.registerFormElement}}
     >
       <FKErrorsSummary @errors={{this.formData.errors}} />
 

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -2,9 +2,9 @@ import { array, fn, hash } from "@ember/helper";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
-import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+import { query } from "discourse/tests/helpers/qunit-helpers";
 
 module("Integration | Component | FormKit | Form", function (hooks) {
   setupRenderingTest(hooks);
@@ -340,15 +340,14 @@ module("Integration | Component | FormKit | Form", function (hooks) {
 
     await render(
       <template>
-        <Form @data={{hash foo=1 bar=2}} @validate={{validate}} as |form|>
-          <form.Field @name="foo" @title="Foo" />
-          <div class="spacer" style="height: 1000px;"></div>
+        <Form @validate={{validate}} as |form|>
+          <div style="height: 1000px;"></div>
           <form.Submit />
         </Form>
       </template>
     );
 
-    document.querySelector(".form-kit__button").scrollIntoView();
+    query(".form-kit__button").scrollIntoView();
 
     await formKit().submit();
 

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -2,6 +2,7 @@ import { array, fn, hash } from "@ember/helper";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
+import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 
@@ -330,5 +331,30 @@ module("Integration | Component | FormKit | Form", function (hooks) {
     await click(".test");
 
     assert.form().hasNoErrors("remove the errors associated with this field");
+  });
+
+  test("scroll to top on error", async function (assert) {
+    const validate = async (data, { addError }) => {
+      addError("bar", { title: "Foo", message: "error" });
+    };
+
+    await render(
+      <template>
+        <Form @data={{hash foo=1 bar=2}} @validate={{validate}} as |form|>
+          <form.Field @name="foo" @title="Foo" />
+          <div class="spacer" style="height: 1000px;"></div>
+          <form.Submit />
+        </Form>
+      </template>
+    );
+
+    document.querySelector(".form-kit__button").scrollIntoView();
+
+    await formKit().submit();
+
+    assert.strictEqual(
+      document.querySelector("#ember-testing-container").scrollTop,
+      0
+    );
   });
 });


### PR DESCRIPTION
This commit ensures the form errors summary is visible on error.