### PR TITLE
DEV: Add event trigger on sign up user creation

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -466,6 +466,10 @@ export default class SignupPageController extends Controller {
     this.set("formSubmitted", true);
     return User.createAccount(attrs).then(
       (result) => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+
         this.isDeveloper = false;
         if (result.success) {
           this.appEvents.trigger("signup:user-created", result);

--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -27,6 +27,7 @@ export default class SignupPageController extends Controller {
   @service site;
   @service siteSettings;
   @service login;
+  @service appEvents;
 
   @tracked accountName;
   @tracked accountPassword;
@@ -465,12 +466,9 @@ export default class SignupPageController extends Controller {
     this.set("formSubmitted", true);
     return User.createAccount(attrs).then(
       (result) => {
-        if (this.isDestroying || this.isDestroyed) {
-          return;
-        }
-
         this.isDeveloper = false;
         if (result.success) {
+          this.appEvents.trigger("signup:user-created", result);
           // invalidate honeypot
           this._challengeExpiry = 1;
 


### PR DESCRIPTION
On the signup controller, when a user is successfully created, if we have an app event, we can use it in plugins or other
Places to run side effects that require the user to be created first.