### PR TITLE
DEV: Update `uploads:sync_access_control` rake task to remove ACLs

### DIFF
--- a/app/jobs/regular/sync_access_control_for_uploads.rb
+++ b/app/jobs/regular/sync_access_control_for_uploads.rb
@@ -16,11 +16,11 @@ module Jobs
         .find_in_batches do |uploads|
           uploads.each do |upload|
             begin
-              Discourse.store.update_upload_access_control(upload)
+              Discourse.store.update_upload_access_control(upload, remove_existing_acl: true)
             rescue => err
               Discourse.warn_exception(
                 err,
-                message: "Failed to update upload ACL",
+                message: "Failed to update upload access control",
                 env: {
                   upload_id: upload.id,
                   filename: upload.original_filename,

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -309,21 +309,29 @@ module FileStore
       end
     end
 
-    def update_upload_access_control(upload)
+    def update_upload_access_control(upload, remove_existing_acl: false)
       key = get_upload_key(upload)
-      update_access_control(key, upload.secure?)
+      update_access_control(key, upload.secure?, remove_existing_acl:)
 
       upload.optimized_images.each do |optimized_image|
-        update_optimized_image_access_control(optimized_image, secure: upload.secure)
+        update_optimized_image_access_control(
+          optimized_image,
+          secure: upload.secure,
+          remove_existing_acl:,
+        )
       end
 
       true
     end
 
-    def update_optimized_image_access_control(optimized_image, secure: false)
+    def update_optimized_image_access_control(
+      optimized_image,
+      secure: false,
+      remove_existing_acl: false
+    )
       optimized_image_key = get_path_for_optimized_image(optimized_image)
       optimized_image_key.prepend(File.join(upload_path, "/")) if Rails.configuration.multisite
-      update_access_control(optimized_image_key, secure)
+      update_access_control(optimized_image_key, secure, remove_existing_acl:)
     end
 
     def download_file(upload, destination_path)
@@ -441,8 +449,10 @@ module FileStore
       end
     end
 
-    def update_access_control(key, secure)
-      if acl = self.class.acl_option_value(secure:)
+    def update_access_control(key, secure, remove_existing_acl: false)
+      acl = self.class.acl_option_value(secure:)
+
+      if acl.present? || remove_existing_acl
         begin
           object = object_from_path(key).acl.put(acl:)
         rescue Aws::S3::Errors::NotImplemented => err

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -545,7 +545,7 @@ def sync_access_control(async: true, concurrency: 10)
           Concurrent::Future.execute(executor:) do
             RailsMultisite::ConnectionManagement.with_connection(current_db) do
               begin
-                Discourse.store.update_upload_access_control(upload)
+                Discourse.store.update_upload_access_control(upload, remove_existing_acl: true)
               rescue => error
                 errors << "Error updating access control for upload #{upload.url}: #{error.message}"
               end

--- a/spec/lib/file_store/s3_store_spec.rb
+++ b/spec/lib/file_store/s3_store_spec.rb
@@ -601,6 +601,21 @@ RSpec.describe FileStore::S3Store do
         expect(s3_helper.s3_client.api_requests).to be_empty
       end
 
+      it "removes acl when `s3_use_acls` site setting is disabled and the `remove_existing_acl` kwarg is true" do
+        SiteSetting.s3_use_acls = false
+
+        upload.update!(secure: true)
+
+        expect(store.update_upload_access_control(upload, remove_existing_acl: true)).to be_truthy
+
+        put_object_acl_request =
+          store.s3_helper.s3_client.api_requests.find do |api_request|
+            api_request[:operation_name] == :put_object_acl
+          end
+
+        expect(put_object_acl_request[:context].params[:acl]).to eq(nil)
+      end
+
       describe "when `s3_enable_access_control_tags` site setting is enabled" do
         before { SiteSetting.s3_enable_access_control_tags = true }
 


### PR DESCRIPTION
The `uploads:sync_access_control` rake task should reset the access control
of all s3 objects linked to an upload record. This means that if the
`s3_use_acls` site setting has been disabled, the rake task should
remove the existing ACL that has been set previously.
