### PR TITLE
FIX: chat message inline onebox url target

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-text.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-text.gjs
@@ -27,7 +27,7 @@ export default class ChatMessageText extends Component {
         <DecoratedHtml
           @html={{htmlSafe @cooked}}
           @decorate={{@decorate}}
-          @className=" chat-cooked"
+          @className="chat-cooked"
         />
       {{/if}}
 

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -114,7 +114,7 @@ export default {
 
   forceLinksToOpenNewTab(element) {
     const links = element.querySelectorAll(
-      ".chat-message-text a:not([target='_blank'])"
+      "a:not([target]), a[target]:not([target='_blank'])"
     );
     for (let linkIndex = 0; linkIndex < links.length; linkIndex++) {
       const link = links[linkIndex];

--- a/plugins/chat/spec/system/chat_message_onebox_spec.rb
+++ b/plugins/chat/spec/system/chat_message_onebox_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Chat message onebox", type: :system do
       chat_page.visit_channel(channel_1)
       channel_page.send_message("test message - https://example.com")
 
-      expect(channel_page).to have_selector(".chat-cooked a[target='_blank']", text: "example.com")
+      expect(page).to have_selector(".chat-cooked a[target='_blank']", text: "example.com")
     end
   end
 end


### PR DESCRIPTION
Chat inline onebox links should open in a new tab with the help of chat decorators by appending the `target="_blank"` attribute. I suspect this may have been accidentally broken during a refactor in #31309 

The issue was that the element that we pass into the decorator has changed, meaning that the selector in the decorator would never find inline links in cooked messages.