### PR TITLE
DEV: Add bypass_time_window arg to SendPushNotification job

### DIFF
--- a/app/jobs/regular/send_push_notification.rb
+++ b/app/jobs/regular/send_push_notification.rb
@@ -5,7 +5,13 @@ module Jobs
     def execute(args)
       user = User.find_by(id: args[:user_id])
       push_window = SiteSetting.push_notification_time_window_mins
-      return if !user || (push_window > 0 && user.seen_since?(push_window.minutes.ago))
+      if !user ||
+           (
+             !args[:bypass_time_window] && push_window > 0 &&
+               user.seen_since?(push_window.minutes.ago)
+           )
+        return
+      end
 
       PushNotificationPusher.push(user, args[:payload])
     end

--- a/spec/jobs/send_push_notification_spec.rb
+++ b/spec/jobs/send_push_notification_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Jobs::SendPushNotification do
       Jobs::SendPushNotification.new.execute(user_id: user, payload: payload)
     end
 
+    it "bypasses the online window when bypass_time_window is passed in" do
+      user.update!(last_seen_at: 2.minutes.ago)
+
+      PushNotificationPusher.expects(:push).with(user, payload)
+
+      Jobs::SendPushNotification.new.execute(
+        user_id: user,
+        bypass_time_window: true,
+        payload: payload,
+      )
+    end
+
     it "sends push notification when user is offline" do
       user.update!(last_seen_at: 20.minutes.ago)
 


### PR DESCRIPTION
This PR allows `bypass_time_window` to be passed to the `SendPushNotification` job, to continue sending a PN, even if the user has been active recently.