### PR TITLE
FIX: ensures colors are set for tl-growth report

### DIFF
--- a/app/models/concerns/reports/trust_level_growth.rb
+++ b/app/models/concerns/reports/trust_level_growth.rb
@@ -51,10 +51,10 @@ module Reports::TrustLevelGrowth
 
       requests =
         filters.map do |filter|
-          color = report.colors[0]
-          color = report.colors[1] if filter == "tl1_reached"
-          color = report.colors[2] if filter == "tl2_reached"
-          color = report.colors[3] if filter == "tl3_reached"
+          color = report.colors[:purple]
+          color = report.colors[:lime] if filter == "tl1_reached"
+          color = report.colors[:magenta] if filter == "tl2_reached"
+          color = report.colors[:yellow] if filter == "tl3_reached"
 
           {
             req: filter,

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,6 +35,15 @@ class Report
     page_view_logged_in_reqs
   ]
 
+  COLORS = {
+    turquoise: "#1EB8D1",
+    lime: "#9BC53D",
+    purple: "#721D8D",
+    magenta: "#E84A5F",
+    brown: "#8A6916",
+    yellow: "#FFCD56",
+  }
+
   include Reports::Bookmarks
   include Reports::ConsolidatedApiRequests
   include Reports::ConsolidatedPageViews
@@ -475,14 +484,7 @@ class Report
   end
 
   def colors
-    {
-      turquoise: "#1EB8D1",
-      lime: "#9BC53D",
-      purple: "#721D8D",
-      magenta: "#E84A5F",
-      brown: "#8A6916",
-      yellow: "#FFCD56",
-    }
+    COLORS
   end
 
   private

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1643,10 +1643,31 @@ RSpec.describe Report do
         tl3_reached = reports.data.find { |r| r[:req] == "tl3_reached" }
         tl4_reached = reports.data.find { |r| r[:req] == "tl4_reached" }
 
-        expect(tl1_reached[:data][0][:y]).to eql(0)
-        expect(tl2_reached[:data][0][:y]).to eql(1)
-        expect(tl3_reached[:data][0][:y]).to eql(0)
-        expect(tl4_reached[:data][0][:y]).to eql(1)
+        x = Time.now.at_midnight.strftime("%Y-%m-%d")
+        expect(tl1_reached).to eq(
+          color: Report::COLORS[:lime],
+          data: [{ x:, y: 0 }],
+          req: "tl1_reached",
+          label: I18n.t("reports.trust_level_growth.xaxis.tl1_reached"),
+        )
+        expect(tl2_reached).to eq(
+          color: Report::COLORS[:magenta],
+          data: [{ x:, y: 1 }],
+          req: "tl2_reached",
+          label: I18n.t("reports.trust_level_growth.xaxis.tl2_reached"),
+        )
+        expect(tl3_reached).to eq(
+          color: Report::COLORS[:yellow],
+          data: [{ x:, y: 0 }],
+          req: "tl3_reached",
+          label: I18n.t("reports.trust_level_growth.xaxis.tl3_reached"),
+        )
+        expect(tl4_reached).to eq(
+          color: Report::COLORS[:purple],
+          data: [{ x:, y: 1 }],
+          req: "tl4_reached",
+          label: I18n.t("reports.trust_level_growth.xaxis.tl4_reached"),
+        )
       end
     end
   end


### PR DESCRIPTION
A previous refactor change colors from an array to hash and this specific report had not been updated.

This commit correctly uses named colors and improves the existing spec to ensure we check for colors.