### PR TITLE
FIX: broken link in admin quick start guide

### DIFF
--- a/docs/ADMIN-QUICK-START-GUIDE.md
+++ b/docs/ADMIN-QUICK-START-GUIDE.md
@@ -4,7 +4,7 @@
 
 Email is required for new account signups and notifications.
 
-→ Send a **[<kbd>test email</kbd>](%{base_url}7D/admin/email/server-settings)**.
+→ Send a **[<kbd>test email</kbd>](%{base_url}/admin/email/server-settings)**.
 
 → Email didn’t arrive? Read our guide on [email providers](https://github.com/discourse/discourse/blob/main/docs/INSTALL-email.md).
 


### PR DESCRIPTION
As reported in https://meta.discourse.org/t/self-hosted-discourse-instance-appending-7d-to-the-fqdn/371144, there was an extra "7D" in the URL which caused the link to break.