### PR TITLE
FIX: correctly follow enable_emoji_shortcuts in chat

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -214,7 +214,6 @@ module Chat
       chat-transcript
       discourse-local-dates
       emoji
-      emojiShortcuts
       inlineEmoji
       html-img
       hashtag-autocomplete
@@ -253,6 +252,7 @@ module Chat
 
       features = MARKDOWN_FEATURES.dup
       features << "image-grid" if bot
+      features << "emojiShortcuts" if SiteSetting.enable_emoji_shortcuts
 
       rules = MARKDOWN_IT_RULES.dup
       rules << "heading" if bot

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -198,6 +198,34 @@ describe Chat::Message do
   end
 
   describe ".cook" do
+    context "with enable_emoji_shortcuts site setting" do
+      context "when enabled" do
+        before { SiteSetting.enable_emoji_shortcuts = true }
+
+        it "converts emoji shortcuts to emoji" do
+          cooked = described_class.cook <<~MD
+            emoji shortcut :)
+          MD
+
+          expected =
+            "<p>emoji shortcut <img src=\"/images/emoji/twitter/slight_smile.png?v=#{Emoji::EMOJI_VERSION}\" title=\":slight_smile:\" class=\"emoji\" alt=\":slight_smile:\" loading=\"lazy\" width=\"20\" height=\"20\"></p>"
+          expect(cooked).to match(expected)
+        end
+      end
+
+      context "when disabled" do
+        before { SiteSetting.enable_emoji_shortcuts = false }
+
+        it "does not convert emoji shortcuts" do
+          cooked = described_class.cook <<~MD
+            emoji shortcut :)
+          MD
+
+          expect(cooked).to match("<p>emoji shortcut :)</p>")
+        end
+      end
+    end
+
     it "does not support HTML tags" do
       cooked = described_class.cook("<h1>test</h1>")
 


### PR DESCRIPTION
Prior to this fix, this setting would have no effect in chat.