### PR TITLE
FIX: Correct new_user_posting_on_first_day? logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1003,11 +1003,12 @@ class User < ActiveRecord::Base
   end
 
   def new_user_posting_on_first_day?
-    !staff? && trust_level < TrustLevel[2] &&
-      (
-        trust_level == TrustLevel[0] || self.first_post_created_at.nil? ||
-          self.first_post_created_at >= 24.hours.ago
-      )
+    return false if staff?
+    return false if trust_level >= TrustLevel[2]
+    if self.first_post_created_at.present? && self.first_post_created_at <= 24.hours.ago
+      return false
+    end
+    true
   end
 
   def new_user?


### PR DESCRIPTION
All the way back in bc52bdfa1280ba08e6fb1931c26e18aa7fee9f7f we changed
the definition of new_user_posting_on_first_day? to return true if the
user was TL0 unconditionally. However this changes the logic of
the method, and essentially makes it "lie". Yes TL0 may be considered
a new user in other places, but in this method specifically we want
to check it's their "first day" of posting, not just that they are TL0.

The intent per these commits:

* 487c20959c874666db726d69c00abe139ba1aeab
* 5aa1272f05fc0de0b08577707d3370d10fafdd51
* 9834d1150300de26ffc35cb6af9a3ac91666e216

Was consider any user < TL2 who hadn't made their first post yet
as a new user posting on their first day. If they had made a post
>= 24 hours ago, they were no longer considered a new user posting
on their first day.

This commit restores that logic and also cleans up the spec and
guardian check to be clearer.
