### PR TITLE
UX: Fix new/unread topic banner overlap with topic filter empty state

### DIFF
--- a/app/assets/stylesheets/common/components/empty-states.scss
+++ b/app/assets/stylesheets/common/components/empty-states.scss
@@ -5,6 +5,10 @@
   width: 75%;
   text-align: center;
 
+  @include viewport.from(sm) {
+    padding-top: 7rem;
+  }
+
   &__preferences-hint {
     margin-top: 2rem;
     font-size: var(--font-down-1);
@@ -20,8 +24,6 @@
   }
 
   &__image {
-    margin-top: 6rem;
-
     svg {
       width: 200px;
 
@@ -31,7 +33,7 @@
     }
 
     @include viewport.until(sm) {
-      margin-top: 10vh;
+      margin-top: 8vh;
     }
   }
 


### PR DESCRIPTION
Followup 30b0e38877af703606042cf1a2997a9a06582c32

Changes margin to padding for topic filter empty state to prevent the
"See X new or updated topics" banner from overlapping with the empty state
when there are no topics in the filter.

**BEFORE**

![image](https://github.com/user-attachments/assets/df3c5893-b297-43cd-a1ea-c1f3c67f12e6)

**AFTER**

![image](https://github.com/user-attachments/assets/d90933ee-de78-46ef-9075-c26b6cd25e45)

**Mobile**

![image](https://github.com/user-attachments/assets/57041a2b-c25c-4e71-a4d5-4f129a425eb6)
