### PR TITLE
FIX: FormKit textarea value attribute binding

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -38,9 +38,10 @@ export default class FKControlTextarea extends Component {
       class="form-kit__control-textarea"
       style={{this.style}}
       disabled={{@field.disabled}}
+      value={{@field.value}}
       ...attributes
       {{this.resizeObserver}}
       {{on "input" this.handleInput}}
-    >{{@field.value}}</textarea>
+    />
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { hash } from "@ember/helper";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -47,6 +48,49 @@ module(
       );
 
       assert.dom(".form-kit__control-textarea").hasAttribute("disabled");
+    });
+
+    test("dynamically updates textarea value", async function (assert) {
+      let formApi;
+      const registerApi = (api) => (formApi = api);
+
+      await render(
+        <template>
+          <Form
+            @data={{hash content="initial value"}}
+            @onRegisterApi={{registerApi}}
+            as |form|
+          >
+            <form.Field @name="content" @title="Content" as |field|>
+              <field.Textarea />
+            </form.Field>
+          </Form>
+        </template>
+      );
+
+      assert.form().field("content").hasValue("initial value");
+      assert.dom(".form-kit__control-textarea").hasValue("initial value");
+
+      // Dynamically update the value through the form API
+      formApi.set("content", "updated value");
+      await settled();
+
+      assert.form().field("content").hasValue("updated value");
+      assert.dom(".form-kit__control-textarea").hasValue("updated value");
+
+      // Update to empty string
+      formApi.set("content", "");
+      await settled();
+
+      assert.form().field("content").hasValue("");
+      assert.dom(".form-kit__control-textarea").hasValue("");
+
+      // Update to another value
+      formApi.set("content", "final value");
+      await settled();
+
+      assert.form().field("content").hasValue("final value");
+      assert.dom(".form-kit__control-textarea").hasValue("final value");
     });
   }
 );


### PR DESCRIPTION
## ✨ What's This?

The FormKit textarea component was using `@field.value` as inner content, preventing dynamic updates to the `textarea` value through the form API.

This change moves the `textarea` value to being set in the `value` attribute, instead.

## 👑 Testing

Confirm that the automated tests cover expected behaviour.