### PR TITLE
FIX: Add @disabled parameter support to FormKit Submit component

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/submit.gjs
@@ -14,6 +14,7 @@ export default class FKSubmit extends Component {
       class="btn-primary form-kit__button"
       type="submit"
       @isLoading={{@isLoading}}
+      @disabled={{@disabled}}
       ...attributes
     />
   </template>

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/submit-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/layout/submit-test.gjs
@@ -54,4 +54,18 @@ module("Integration | Component | FormKit | Layout | Submit", function (hooks) {
 
     assert.dom(".form-kit__button .d-icon-spinner").exists();
   });
+
+  test("@disabled", async function (assert) {
+    await render(
+      <template>
+        <Form as |form|>
+          <form.Submit @label="submit" @disabled={{true}} />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom(".form-kit__button")
+      .isDisabled("submit button is disabled when @disabled is true");
+  });
 });


### PR DESCRIPTION
## ✨ What's This?

When the `@disabled` parameter is set a on `<Submit>` component, the component now passes it through to the underlying `<DButton>`.
