### PR TITLE
FIX: Admin search labels doubled up with parent label

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -72,13 +72,12 @@ export class PageLinkFormatter {
 
     let label;
     if (this.parentLabel) {
-      label = sectionLabel;
-      if (sectionLabel) {
-        label += ` ${SEPARATOR} `;
-      }
-      label += `${this.parentLabel} ${SEPARATOR} ${linkLabel}`;
+      label = `${this.parentLabel} ${SEPARATOR} ${linkLabel}`;
     } else {
-      label = sectionLabel + (sectionLabel ? ` ${SEPARATOR} ` : "") + linkLabel;
+      label = sectionLabel;
+      if (sectionLabel !== linkLabel) {
+        label = label + (sectionLabel ? ` ${SEPARATOR} ` : "") + linkLabel;
+      }
     }
 
     let keywords = this.link.keywords
@@ -338,7 +337,7 @@ export default class AdminSearchDataSource extends Service {
     return filteredResults.sort((a, b) => b.score - a.score);
   }
 
-  #addPageLink(navMapSection, link, parentLabel = "") {
+  #addPageLink(navMapSection, link, parentLabel = null) {
     const formattedPageLink = new PageLinkFormatter(
       this.router,
       navMapSection,

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -117,6 +117,49 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
     );
   });
 
+  test("buildMap - labels are correct for top-level, second-level, and third-level nav", async function (assert) {
+    await this.subject.buildMap();
+
+    const firstPage = this.subject.pageDataSourceItems.find(
+      (page) => page.url === "/admin"
+    );
+
+    assert.notStrictEqual(firstPage, undefined, "top-level page exists");
+    assert.strictEqual(
+      firstPage.label,
+      i18n("admin.dashboard.title"),
+      "top-level label is correct e.g. Dashboard"
+    );
+
+    const secondPage = this.subject.pageDataSourceItems.find(
+      (page) => page.url === "/admin/config/flags"
+    );
+
+    assert.notStrictEqual(secondPage, undefined, "second-level page exists");
+    assert.strictEqual(
+      secondPage.label,
+      i18n("admin.config_sections.community.title") +
+        " > " +
+        i18n("admin.config.flags.title"),
+      "second-level label is correct e.g. Community > Flags"
+    );
+
+    const thirdPage = this.subject.pageDataSourceItems.find(
+      (page) => page.url === "/admin/backups/logs"
+    );
+
+    assert.notStrictEqual(thirdPage, undefined, "third-level page exists");
+    assert.strictEqual(
+      thirdPage.label,
+      i18n("admin.config_sections.advanced.title") +
+        " > " +
+        i18n("admin.config.backups.title") +
+        " > " +
+        i18n("admin.config.backups.sub_pages.logs.title"),
+      "third-level label is correct e.g. Advanced > Backups > Logs"
+    );
+  });
+
   test("search - returns empty array if the search term is too small", async function (assert) {
     await this.subject.buildMap();
     assert.deepEqual(this.subject.search("a"), []);
@@ -219,7 +262,7 @@ module(
         this.router,
         navMapSection,
         link,
-        i18n("admin.config.backups.title")
+        i18n(navMapSection.label) + " > " + i18n("admin.config.backups.title")
       );
       assert.deepEqual(
         formatter.format().label,
@@ -228,7 +271,7 @@ module(
           i18n("admin.config.backups.title") +
           " > " +
           i18n(link.label),
-        "link uses the section label, parent label, and link label for sub-pages"
+        "link uses the parent label and link label for sub-pages, since the section label is already included in the parent label"
       );
 
       link = {

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-admin-plugin-configuration-nav.js
@@ -15,6 +15,7 @@ export default {
         {
           label: "chat.incoming_webhooks.title",
           route: "adminPlugins.show.discourse-chat-incoming-webhooks",
+          description: "chat.incoming_webhooks.header_description",
         },
       ]);
 

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -554,6 +554,7 @@ en:
         select_emoji: "Choose Emoji"
         system: "system"
         title: "Incoming webhooks"
+        header_description: "Incoming webhooks can be used by external systems to post messages into a designated chat channel as a bot user"
         url: "URL"
         url_instructions: "This URL contains a secret value - keep it safe."
         username: "Username"


### PR DESCRIPTION
Fixes an issue where the admin search results was showing
breadcrumbs with a double up of the parent label. For example,
we would show "Plugins > Plugins > AI > Usage" or
"Advanced > Advanced > Backups > Logs".

Also adds a missing translation for the chat incoming webhooks
page.
