### PR TITLE
DEV: Add get() method to the FormKit API

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/form.gjs
@@ -45,6 +45,7 @@ class FKForm extends Component {
     this.args.onRegisterApi?.({
       set: this.set,
       setProperties: this.setProperties,
+      get: this.get,
       submit: this.onSubmit,
       reset: this.onReset,
       addError: this.addError,
@@ -177,6 +178,17 @@ class FKForm extends Component {
     for (const [name, value] of Object.entries(object)) {
       await this.set(name, value);
     }
+  }
+
+  /**
+   * Retrieves the current value of a form field by name.
+   *
+   * @param {string} name - The name of the form field to retrieve.
+   * @returns {any} The current value of the field.
+   */
+  @action
+  get(name) {
+    return this.formData.get(name);
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -147,15 +147,30 @@ module("Integration | Component | FormKit | Form", function (hooks) {
     );
 
     await formApi.set("bar", 2);
+    assert.strictEqual(
+      formApi.get("bar"),
+      2,
+      "get() returns the current value"
+    );
     await formApi.submit();
 
     assert.dom(".bar").hasText("2");
 
     await formApi.set("bar", 1);
+    assert.strictEqual(
+      formApi.get("bar"),
+      1,
+      "get() returns the updated value"
+    );
     await formApi.reset();
     await formApi.submit();
 
     assert.dom(".bar").hasText("2");
+    assert.strictEqual(
+      formApi.get("bar"),
+      2,
+      "get() returns the correct value after reset"
+    );
 
     formApi.addError("bar", { title: "Bar", message: "error_foo" });
     // assert on the next tick


### PR DESCRIPTION
## ✨ What's This?

This change adds an API for retrieving the current value of a component within a FormKit form. It makes use of the existing `@onRegisterApi` parameter, adding a `get()` method to match the existing `set()` method.
