### PR TITLE
FIX: Do not set locale when replying and also default to none

### DIFF
--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1817,25 +1817,12 @@ export default class ComposerService extends Service {
       return opts.locale;
     }
 
-    if (opts?.post?.locale) {
+    // inherit post locale when editing, not when replying
+    if (opts?.post?.locale && opts.action === Composer.EDIT) {
       return opts.post.locale;
     }
 
-    if (this.currentUser?.effective_locale) {
-      if (
-        this.siteSettings.available_content_localization_locales.find(
-          (locale) => locale.value === this.currentUser?.effective_locale
-        )
-      ) {
-        return this.currentUser.effective_locale;
-      } else {
-        // If user's effective locale is not part of available locales,
-        // we leave it empty so that a locale value won't be attached to the post.
-        return "";
-      }
-    }
-
-    return this.siteSettings.default_locale;
+    return "";
   }
 }
 

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe "Localized topic" do
+describe "Content Localization" do
   fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
   fab!(:site_local_user) { Fabricate(:user, locale: "en") }
   fab!(:author) { Fabricate(:user) }
+
+  fab!(:jap_group) { Fabricate(:group).tap { |g| g.add(japanese_user) } }
 
   fab!(:topic) do
     Fabricate(:topic, title: "Life strategies from The Art of War", locale: "en", user: author)
@@ -28,6 +30,8 @@ RSpec.describe "Localized topic" do
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:post_1_obj) { PageObjects::Components::Post.new(1) }
 
   before do
     Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "孫子兵法からの人生戦略")
@@ -38,10 +42,13 @@ RSpec.describe "Localized topic" do
     Fabricate(:post_localization, post: post_3, locale: "en", cooked: "A general is one who ..")
   end
 
-  context "when the feature is enabled" do
+  context "when the feature is enabled for English and Japanese" do
     before do
       SiteSetting.allow_user_locale = true
       SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_allowed_groups =
+        "#{Group::AUTO_GROUPS[:admins]}|#{jap_group.id}"
+      SiteSetting.content_localization_supported_locales = "en|ja"
     end
 
     it "shows the correct language based on the selected language and login status" do
@@ -64,6 +71,25 @@ RSpec.describe "Localized topic" do
 
       visit("/")
       topic_list.visit_topic_with_title("Life strategies from The Art of War")
+    end
+
+    it "allows users to set their post's locale when posting" do
+      sign_in(japanese_user)
+
+      visit("/")
+      topic_list.visit_topic_with_title("孫子兵法からの人生戦略")
+
+      topic_page.click_post_action_button(post_1, :reply)
+      expect(composer).to be_opened
+      expect(composer.locale.text.gsub(/\u200B/, "")).to be_blank
+
+      composer.set_locale("日本語")
+      composer.fill_content("新しい投稿の内容 をここに入力します。")
+      composer.create
+
+      sign_in(site_local_user)
+      topic_page.visit_topic(topic)
+      expect(post_1_obj).to have_css(".post-info.post-language")
     end
   end
 end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -8,6 +8,7 @@ module PageObjects
       HASHTAG_MENU = ".autocomplete.hashtag-autocomplete"
       MENTION_MENU = ".autocomplete.ac-user"
       RICH_EDITOR = ".d-editor-input.ProseMirror"
+      POST_LANGUAGE_SELECTOR = ".post-language-selector"
 
       def rich_editor
         find(RICH_EDITOR)
@@ -122,6 +123,15 @@ module PageObjects
 
       def category_chooser
         Components::SelectKit.new(".category-chooser")
+      end
+
+      def locale
+        find("#{COMPOSER_ID} #{POST_LANGUAGE_SELECTOR}")
+      end
+
+      def set_locale(locale)
+        Components::DMenu.new(POST_LANGUAGE_SELECTOR).expand
+        find("#{POST_LANGUAGE_SELECTOR} button", text: locale)
       end
 
       def switch_category(category_name)


### PR DESCRIPTION
This PR relates to the locale setting in the composer and fixes 2 quirks:
- When replying to a post, the composer sets the locale of the new post in composer to the locale of the post being replied. This PR defaults the value to "none"
- When creating a new post, the composer sets the locale to the user's locale. However we are seeing the behaviour that users do not write in the locale they set their profile to. This PR defaults the value to "none"

<img width="904" alt="Screenshot 2025-06-23 at 6 28 39 PM" src="https://github.com/user-attachments/assets/c4973e82-d487-4aa8-828f-d0777de1e630" />
