### PR TITLE
DEV: Add modifier for restricting theme creation endpoints

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -7,6 +7,7 @@ class Admin::ThemesController < Admin::AdminController
 
   skip_before_action :check_xhr, only: %i[show preview export]
   before_action :ensure_admin
+  before_action :ensure_theme_creation_is_allowed, only: %i[create import]
 
   def preview
     theme = Theme.find_by(id: params[:id])
@@ -505,5 +506,9 @@ class Admin::ThemesController < Admin::AdminController
   # Overridden by theme-creator plugin
   def theme_user
     current_user
+  end
+
+  def ensure_theme_creation_is_allowed
+    guardian.ensure_can_create_theme!(current_user)
   end
 end

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -509,6 +509,6 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def ensure_theme_creation_is_allowed
-    guardian.ensure_can_create_theme!(current_user)
+    guardian.ensure_can_create_theme!
   end
 end

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -225,10 +225,11 @@ module UserGuardian
     (SiteSetting.allow_changing_staged_user_tracking || !user.staged) && can_edit_user?(user)
   end
 
-  def can_create_theme?(admin)
+  def can_create_theme?
+    return false if !is_admin?
     # this modifier is used to further restrict theme creation, it's not
     # possible to use this modifier to open up theme creation permissions (e.g.
     # to non-admins)
-    DiscoursePluginRegistry.apply_modifier(:user_guardian_can_create_theme, true, admin, self)
+    DiscoursePluginRegistry.apply_modifier(:user_guardian_can_create_theme, true, self)
   end
 end

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -224,4 +224,11 @@ module UserGuardian
   def can_change_tracking_preferences?(user)
     (SiteSetting.allow_changing_staged_user_tracking || !user.staged) && can_edit_user?(user)
   end
+
+  def can_create_theme?(admin)
+    # this modifier is used to further restrict theme creation, it's not
+    # possible to use this modifier to open up theme creation permissions (e.g.
+    # to non-admins)
+    DiscoursePluginRegistry.apply_modifier(:user_guardian_can_create_theme, true, admin, self)
+  end
 end

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -403,6 +403,42 @@ RSpec.describe Admin::ThemesController do
         expect(json["theme"]["auto_update"]).to eq(false)
         expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
       end
+
+      context "with registered user_guardian_can_create_theme" do
+        it "doesn't allow importing a theme if the modifier returns false" do
+          plugin_instance = Plugin::Instance.new
+          i = 0
+          plugin_instance.register_modifier(
+            :user_guardian_can_create_theme,
+          ) do |val, admin_user, guardian|
+            expect(admin_user).to eq(admin)
+            expect(guardian.user).to eq(admin)
+            i += 1
+            i % 2 == 1
+          end
+
+          RemoteTheme.stubs(:import_theme).returns(Fabricate(:theme))
+          post "/admin/themes/import.json",
+               params: {
+                 remote: "https://github.com/discourse/discourse-brand-header.git",
+               }
+          expect(i).to eq(1)
+          expect(response.status).to eq(201)
+
+          json = response.parsed_body
+
+          expect(json["theme"]).to be_present
+
+          expect do
+            post "/admin/themes/import.json",
+                 params: {
+                   remote: "https://github.com/discourse/discourse-brand-header-2.git",
+                 }
+          end.not_to change { Theme.count }
+          expect(i).to eq(2)
+          expect(response.status).to eq(403)
+        end
+      end
     end
 
     shared_examples "theme import not allowed" do
@@ -632,6 +668,47 @@ RSpec.describe Admin::ThemesController do
           expect(json["errors"]).to include(
             "No type could be guessed for field blahblah for target common",
           )
+        end
+      end
+
+      context "with registered user_guardian_can_create_theme" do
+        it "doesn't allow theme creation if the modifier returns false" do
+          plugin_instance = Plugin::Instance.new
+          i = 0
+          plugin_instance.register_modifier(
+            :user_guardian_can_create_theme,
+          ) do |val, admin_user, guardian|
+            expect(admin_user).to eq(admin)
+            expect(guardian.user).to eq(admin)
+            i += 1
+            i % 2 == 1
+          end
+
+          post "/admin/themes.json",
+               params: {
+                 theme: {
+                   name: "my test name",
+                   theme_fields: [name: "scss", target: "common", value: "body{color: red;}"],
+                 },
+               }
+          expect(i).to eq(1)
+          expect(response.status).to eq(201)
+
+          json = response.parsed_body
+
+          expect(json["theme"]).to be_present
+
+          expect do
+            post "/admin/themes.json",
+                 params: {
+                   theme: {
+                     name: "my test name 2",
+                     theme_fields: [name: "scss", target: "common", value: "body{color: red;}"],
+                   },
+                 }
+          end.not_to change { Theme.count }
+          expect(i).to eq(2)
+          expect(response.status).to eq(403)
         end
       end
     end


### PR DESCRIPTION
This PR adds a new modifier that plugins can hook into to add further restriction to who install themes and components via the admin UI. It isn't possible to use this modifier to open up the theme installation permissions to more than core allows, e.g. this modifier can't be used to allow moderators to install themes on the site.

Internal topic: t/156924.