### PR TITLE
UX: consistent sizing for configure default nav links

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -12,7 +12,7 @@
 
   &[data-list-item-name="all-categories"],
   &[data-list-item-name="all-tags"],
-  &[data-list-item-name="configure-default-navigation-menu-tags"] {
+  &[data-list-item-name*="configure-default-navigation-menu-"] {
     font-size: var(--font-down-1-rem);
   }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f01356eb-c6ca-4fdd-910e-61cc25eff49c)


After: 
![image](https://github.com/user-attachments/assets/a048f018-e198-43cd-9ce7-8cbf57f4f492)


To match the sizing with tags: 

![image](https://github.com/user-attachments/assets/d6071d33-00d2-4460-9338-6eb3e53dd92f)
