### PR TITLE
DEV: Add `--reset` option to `import` command

### DIFF
--- a/migrations/bin/cli
+++ b/migrations/bin/cli
@@ -20,6 +20,7 @@ module Migrations
       end
 
       desc "import", "Import a file"
+      option :reset, type: :boolean, desc: "Reset MappingsDB before importing data"
       def import
         ::Migrations::CLI::ImportCommand.new(options).execute
       end

--- a/migrations/lib/cli/import_command.rb
+++ b/migrations/lib/cli/import_command.rb
@@ -9,7 +9,7 @@ module Migrations::CLI
     def execute
       ::Migrations.load_rails_environment(quiet: true)
 
-      ::Migrations::Importer.execute
+      ::Migrations::Importer.execute(@options)
     end
   end
 end

--- a/migrations/lib/importer.rb
+++ b/migrations/lib/importer.rb
@@ -2,11 +2,11 @@
 
 module Migrations
   module Importer
-    def self.execute
+    def self.execute(options)
       config_path = File.join(::Migrations.root_path, "config", "importer.yml")
       config = YAML.load_file(config_path, symbolize_names: true)
 
-      executor = Executor.new(config)
+      executor = Executor.new(config, options)
       executor.start
     end
   end

--- a/migrations/lib/importer/executor.rb
+++ b/migrations/lib/importer/executor.rb
@@ -2,12 +2,12 @@
 
 module Migrations::Importer
   class Executor
-    def initialize(config)
+    def initialize(config, options)
       @intermediate_db = ::Migrations::Database.connect(config[:intermediate_db])
       @discourse_db = DiscourseDB.new
       @shared_data = SharedData.new(@discourse_db)
 
-      attach_mappings_db(config[:mappings_db])
+      attach_mappings_db(config[:mappings_db], options[:reset])
       attach_uploads_db(config[:uploads_db])
     end
 
@@ -24,7 +24,8 @@ module Migrations::Importer
 
     private
 
-    def attach_mappings_db(db_path)
+    def attach_mappings_db(db_path, reset)
+      ::Migrations::Database.reset!(db_path) if reset
       migrate_and_attach(db_path, ::Migrations::Database::MAPPINGS_DB_SCHEMA_PATH, "mapped")
     end
 


### PR DESCRIPTION
It deletes the MappingDB before executing the import. That's useful during development when you repeat the import multiple times.