### PR TITLE
FIX: Make Ctrl+K link shortcut in RTE work on platforms other than macOS

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link.js
@@ -1,4 +1,5 @@
 import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
+import { PLATFORM_KEY_MODIFIER } from "discourse/lib/keyboard-shortcuts";
 import {
   getChangedRanges,
   markInputRule,
@@ -131,9 +132,11 @@ const extension = {
     new Plugin({
       props: {
         handleKeyDown(view, event) {
-          if (event.key === "k" && event.metaKey) {
-            // Avoids propagating this event to the chat global keydown handler
+          if (event.key === "k" && event[`${PLATFORM_KEY_MODIFIER}Key`]) {
+            // Avoids propagating this event to the chat global keydown handler,
+            // and avoids Ctrl+K from being handled by the browser to open the search bar.
             event.stopPropagation();
+            event.preventDefault();
             return false;
           }
         },

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -399,8 +399,11 @@ describe "Composer - ProseMirror editor", type: :system do
     end
 
     it "supports Ctrl + K to create a link" do
+      hyperlink_modal = PageObjects::Modals::Base.new
       open_composer_and_toggle_rich_editor
       page.send_keys([PLATFORM_KEY_MODIFIER, "k"])
+      expect(hyperlink_modal).to be_open
+      expect(hyperlink_modal.header).to have_content(I18n.t("js.composer.link_dialog_title"))
       page.send_keys("https://www.example.com")
       page.send_keys(:tab)
       page.send_keys("This is a link")


### PR DESCRIPTION
Followup fb7fa2902cf685ee9d4002e5448b4817f2dbef98, use the
PLATFORM_KEY_MODIFIER constant to ensure the Ctrl+K shortcut
works across all platforms.

Also ensure the browser's default behavior of opening the search
bar is not triggered when the Ctrl+K shortcut is used.
