### PR TITLE
DEV: Make admin search data source tests more reliable

### DIFF
--- a/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
+++ b/app/assets/javascripts/admin/addon/services/admin-search-data-source.js
@@ -229,7 +229,7 @@ export default class AdminSearchDataSource extends Service {
 
   async buildMap() {
     if (this.isLoaded) {
-      return;
+      return Promise.resolve();
     }
 
     ADMIN_NAV_MAP.forEach((navMapSection) => {
@@ -347,7 +347,7 @@ export default class AdminSearchDataSource extends Service {
 
     // Cache the setting area + category URLs for later use
     // when building the setting list via #processSettings.
-    if (link.settings_area && !this.settingPageMap.areas[this.settings_area]) {
+    if (link.settings_area && !this.settingPageMap.areas[link.settings_area]) {
       this.settingPageMap.areas[link.settings_area] = link.multi_tabbed
         ? `${formattedPageLink.url}/settings`
         : formattedPageLink.url;

--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -1,4 +1,5 @@
 import { getOwner } from "@ember/owner";
+import { settled } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
@@ -119,6 +120,7 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
 
   test("buildMap - labels are correct for top-level, second-level, and third-level nav", async function (assert) {
     await this.subject.buildMap();
+    await settled();
 
     const firstPage = this.subject.pageDataSourceItems.find(
       (page) => page.url === "/admin"


### PR DESCRIPTION
Also fix some issues in the source, wasn't returning a promise
with the early return.

Saw this in the CI log failures:

> ℹ️ Hint: when the assertion failed, the Ember runloop was not in a settled state. Maybe you missed an `await` further up the test? Or maybe you need to manually add `await settled()` before your assertion? (hasPendingTimers, hasRunLoop, isRenderPending)