### PR TITLE
FIX: Ignore recent posts offset in search when before/after filters are used

### DIFF
--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1913,6 +1913,22 @@ RSpec.describe Search do
       expect(Search.execute("test after:jan").posts).to contain_exactly(post_1, post_2)
     end
 
+    it "supports before/after filters and is not affected by the `search_recent_regular_posts_offset_post_id` site setting" do
+      post_1 = Fabricate(:post, created_at: Time.zone.parse("2000-06-24"), like_count: 15)
+      post_2 = Fabricate(:post, created_at: Time.zone.parse("2000-06-26"), like_count: 5)
+
+      SiteSetting.search_recent_regular_posts_offset_post_id = post_2.id
+      # Disable pagination as we are only concerned about the posts returned in the first page.
+      SiteSetting.search_page_size = 1
+
+      expect(
+        Search
+          .execute("after:2000-01-01 before:2001-01-01 order:likes", search_type: :full_page)
+          .posts
+          .map(&:id),
+      ).to contain_exactly(post_1.id)
+    end
+
     it "supports in:first, user:, @username" do
       post_1 = Fabricate(:post, raw: "hi this is a test 123 123", topic: topic)
       post_2 = Fabricate(:post, raw: "boom boom shake the room test", topic: topic)


### PR DESCRIPTION
There exists a hidden `search_recent_regular_posts_offset_post_id` site
setting which is used to optimize the searching of recent posts through
the use of a partial index. However, we do not want this optimization to
apply when the `before` and `after` advanced search filters are used
since the partial index only contains the most recent posts 1 million
posts and the `before`/`after` filter may be searching for posts that falls outside of the 
most recent posts range.