### PR TITLE
FIX: Return the post's raw when GET /post

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -454,8 +454,6 @@ createWidget("post-date", {
 
 // glimmer-post-stream: has glimmer version
 createWidget("post-language", {
-  tagName: "div.post-info.post-language",
-
   html(attrs) {
     return [
       new RenderGlimmer(this, "div", PostMetaDataLanguage, {

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -672,11 +672,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def raw
-    if ContentLocalization.show_translated_post?(object, scope)
-      object.get_localization(I18n.locale)&.raw || object.raw
-    else
-      object.raw
-    end
+    object.raw
   end
 
   def include_locale?

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -711,15 +711,6 @@ RSpec.describe PostSerializer do
     it "returns the post's raw" do
       expect(json[:raw]).to eq(post.raw)
     end
-
-    it "returns the localized raw" do
-      SiteSetting.content_localization_enabled = true
-      Fabricate(:post_localization, post: post, raw: "raw", locale: "ja")
-      I18n.locale = "ja"
-      post.update!(locale: "en")
-
-      expect(json[:raw]).to eq("raw")
-    end
   end
 
   describe "#locale" do

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -3,12 +3,12 @@
 describe "Content Localization" do
   fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
   fab!(:site_local_user) { Fabricate(:user, locale: "en") }
-  fab!(:author) { Fabricate(:user) }
+  fab!(:admin)
 
   fab!(:jap_group) { Fabricate(:group).tap { |g| g.add(japanese_user) } }
 
   fab!(:topic) do
-    Fabricate(:topic, title: "Life strategies from The Art of War", locale: "en", user: author)
+    Fabricate(:topic, title: "Life strategies from The Art of War", locale: "en", user: admin)
   end
   fab!(:post_1) do
     Fabricate(
@@ -31,7 +31,7 @@ describe "Content Localization" do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:topic_list) { PageObjects::Components::TopicList.new }
   let(:composer) { PageObjects::Components::Composer.new }
-  let(:post_1_obj) { PageObjects::Components::Post.new(1) }
+  let(:post_4_obj) { PageObjects::Components::Post.new(4) }
 
   before do
     Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "孫子兵法からの人生戦略")
@@ -40,6 +40,7 @@ describe "Content Localization" do
     Fabricate(:post_localization, post: post_1, locale: "ja", cooked: "傑作は単なる軍事戦略についてではありません")
     Fabricate(:post_localization, post: post_2, locale: "ja", cooked: "最大の勝利は戦いを必要としないものです")
     Fabricate(:post_localization, post: post_3, locale: "en", cooked: "A general is one who ..")
+    SiteSetting.approve_unless_allowed_groups = Group::AUTO_GROUPS[:everyone]
   end
 
   context "when the feature is enabled for English and Japanese" do
@@ -84,12 +85,34 @@ describe "Content Localization" do
       expect(composer.locale.text.gsub(/\u200B/, "")).to be_blank
 
       composer.set_locale("日本語")
-      composer.fill_content("新しい投稿の内容 をここに入力します。")
+      composer.fill_content("この小説は、名前のない猫の視点から明治時代の人間社会を風刺的に描いています。")
       composer.create
+      try_until_success do
+        new_post = Post.find_by(post_number: 4, topic_id: topic.id)
+        expect(new_post).to_not be_nil
+        # simulates a localization that would have been automatically created
+        Fabricate(
+          :post_localization,
+          post: new_post,
+          locale: "en",
+          cooked:
+            "This novel satirically depicts Meiji-era human society from the perspective of a nameless cat.",
+        )
+      end
 
       sign_in(site_local_user)
+
       topic_page.visit_topic(topic)
-      expect(post_1_obj).to have_css(".post-info.post-language")
+      expect(post_4_obj.post_language).to have_content("日本語")
+    end
+
+    it "allows editing original content when post is localized" do
+      sign_in(admin)
+
+      topic_page.visit_topic(topic)
+      topic_page.expand_post_actions(post_3)
+      topic_page.click_post_action_button(post_3, :edit)
+      expect(composer).to have_content(post_3.raw)
     end
   end
 end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -131,7 +131,7 @@ module PageObjects
 
       def set_locale(locale)
         Components::DMenu.new(POST_LANGUAGE_SELECTOR).expand
-        find("#{POST_LANGUAGE_SELECTOR} button", text: locale)
+        find("#{POST_LANGUAGE_SELECTOR} button", text: locale).click
       end
 
       def switch_category(category_name)

--- a/spec/system/page_objects/components/post.rb
+++ b/spec/system/page_objects/components/post.rb
@@ -60,6 +60,11 @@ module PageObjects
         find("#embedded-posts__top--#{@post_number}").has_no_content?(content)
       end
 
+      def post_language
+        post.find(".post-info.post-language").hover
+        find(".post-language-content")
+      end
+
       private
 
       def post_id


### PR DESCRIPTION
Previously, there was no way to edit post localizations, so the `post.raw` was always returning the localized value. With localization UI and endpoints now, we want to always return the original raw and the composer to reflect the original value.

https://github.com/discourse/discourse/pull/33184 will handle the decision to show the post edit composer or the post localization composer.