### PR TITLE
DEV: Move creation of user archive PM with upload to its own function

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -117,6 +117,7 @@ module Jobs
       )
 
     def execute(args)
+      Rails.logger.warn("User ID?: #{args[:user_id]}")
       @archive_for_user = User.find_by(id: args[:user_id])
 
       if args[:requesting_user_id].present?
@@ -182,8 +183,11 @@ module Jobs
         FileUtils.rm_rf(dirname)
       end
 
+      provide_results(user_export, zip_filename, export_title)
+    end
+
+    def provide_results(user_export, zip_filename, export_title)
       begin
-        # create upload
         create_upload_for_user(user_export, zip_filename)
       ensure
         post = notify_user(user_export, export_title)

--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -117,7 +117,6 @@ module Jobs
       )
 
     def execute(args)
-      Rails.logger.warn("User ID?: #{args[:user_id]}")
       @archive_for_user = User.find_by(id: args[:user_id])
 
       if args[:requesting_user_id].present?


### PR DESCRIPTION
...so I can override it in a customer plugin.

The goal here is to be able to create the same user data export but provide the results by uploading to an s3 bucket instead of sending a PM to the user.