### PR TITLE
DEV: Add support for ActiveRecord::QueryLogs.prepend_comment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -224,7 +224,10 @@ module Discourse
 
     require "rbtrace" if ENV["RBTRACE"] == "1"
 
-    config.active_record.query_log_tags_enabled = true if ENV["RAILS_QUERY_LOG_TAGS"] == "1"
+    if ENV["RAILS_QUERY_LOG_TAGS"] == "1"
+      config.active_record.query_log_tags_enabled = true
+      ActiveRecord::QueryLogs.prepend_comment = true if ENV["RAILS_QUERY_LOG_PREPEND_COMMENT"] == "1"
+    end
 
     config.generators { |g| g.test_framework :rspec, fixture: false }
   end


### PR DESCRIPTION
**What?**
Propose adding support for `ActiveRecord::QueryLogs.prepend_comment` as a natural extension to the existing `config.active_record.query_log_tags_enabled` feature behind `RAILS_QUERY_LOG_TAGS`.

**Why?**
This setting will help with debugging long, complex queries that get cut off in logs. With prepend comment enabled, we will be able to see query logs even the queries gets truncated in the logs.

**How?**
This would be opt-in via `RAILS_QUERY_LOG_PREPEND_COMMENT` environment variable following Discourse's pattern