### PR TITLE
FIX: Add humanized setting names for theme setting serializer

### DIFF
--- a/app/serializers/theme_settings_serializer.rb
+++ b/app/serializers/theme_settings_serializer.rb
@@ -2,6 +2,7 @@
 
 class ThemeSettingsSerializer < ApplicationSerializer
   attributes :setting,
+             :humanized_name,
              :type,
              :default,
              :value,
@@ -14,6 +15,10 @@ class ThemeSettingsSerializer < ApplicationSerializer
 
   def setting
     object.name
+  end
+
+  def humanized_name
+    SiteSetting.humanized_name(object.name)
   end
 
   def type


### PR DESCRIPTION
Followup 5b236ccc0774e3b0f5e0b34c99c1c36d9ea9604e, a change here
made it so the theme setting name was no longer showing on the
UI, this commit fixes the issue by making sure it's sent from
the server in the same way as site setting humanized names.
