### PR TITLE
FIX: improves post toolbar behavior

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection-toolbar.gjs
@@ -35,8 +35,6 @@ export default class PostTextSelectionToolbar extends Component {
   @service appEvents;
   @service toasts;
 
-  @tracked isFastEditing = false;
-
   appEventsListeners = modifier(() => {
     this.appEvents.on("quote-button:edit", this, "toggleFastEdit");
 
@@ -108,32 +106,22 @@ export default class PostTextSelectionToolbar extends Component {
     const text = await this.args.data.buildQuote();
     clipboardCopy(text);
     this.toasts.success({
-      duration: 3000,
+      duration: "short",
       data: { message: i18n("post.quote_copied_to_clibboard") },
     });
     await this.args.data.hideToolbar();
   }
 
   @action
-  async closeFastEdit() {
-    this.isFastEditing = false;
-    await this.args.data.hideToolbar();
-  }
-
-  @action
   async toggleFastEdit() {
     if (this.args.data.supportsFastEdit) {
-      if (this.site.desktopView) {
-        this.isFastEditing = !this.isFastEditing;
-      } else {
-        this.modal.show(FastEditModal, {
-          model: {
-            initialValue: this.args.data.quoteState.buffer,
-            post: this.post,
-          },
-        });
-        this.args.data.hideToolbar();
-      }
+      this.modal.show(FastEditModal, {
+        model: {
+          initialValue: this.args.data.quoteState.buffer,
+          post: this.post,
+        },
+      });
+      this.args.data.hideToolbar();
     } else {
       const result = await ajax(`/posts/${this.post.id}`);
 
@@ -201,11 +189,7 @@ export default class PostTextSelectionToolbar extends Component {
     <div
       {{on "mousedown" this.trapEvents}}
       {{on "mouseup" this.trapEvents}}
-      class={{concatClass
-        "quote-button"
-        "visible"
-        (if this.isFastEditing "fast-editing")
-      }}
+      class={{concatClass "quote-button" "visible"}}
       {{this.appEventsListeners}}
     >
       <div class="buttons">
@@ -282,14 +266,6 @@ export default class PostTextSelectionToolbar extends Component {
       </div>
 
       <div class="extra">
-        {{#if this.isFastEditing}}
-          <FastEdit
-            @initialValue={{@data.quoteState.buffer}}
-            @post={{this.post}}
-            @close={{this.closeFastEdit}}
-          />
-        {{/if}}
-
         <PluginOutlet @name="quote-button-after" @connectorTagName="div" />
       </div>
     </div>

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -122,12 +122,6 @@ export function selectedText() {
         ? range.commonAncestorContainer
         : range.commonAncestorContainer.parentElement;
 
-    // ensure we never quote text in the post menu area
-    const postMenuArea = ancestor.querySelector(".post-menu-area");
-    if (postMenuArea) {
-      range.setEndBefore(postMenuArea);
-    }
-
     const oneboxTest = ancestor.closest("aside.onebox[data-onebox-src]");
     const codeBlockTest = ancestor.closest("pre");
     if (codeBlockTest) {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -742,10 +742,6 @@ aside.quote {
   opacity: 0.4;
 }
 
-.fk-d-menu[data-identifier="post-text-selection-toolbar"] {
-  @include user-select(none);
-}
-
 .quote-button {
   flex-direction: column;
 


### PR DESCRIPTION
This commit is applying different techniques to make selecting text of a
post less error prone:
- ensure we only ever show the toolbar when the common ancestor of a
range is cooked
- ensures the menu is not interfering with text selection

The situation was very bad on android but it should also improve other devices.

Note that one visual change of this commit is that the fast edit menu is now a standalone modal.