### PR TITLE
DEV: Update eye icon behavior for secret site settings

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -406,7 +406,7 @@ export default class SiteSettingComponent extends Component {
         {{#if this.setting.secret}}
           <DButton
             @action={{this.toggleSecret}}
-            @icon="far-eye-slash"
+            @icon={{if this.isSecret "far-eye" "far-eye-slash"}}
             @ariaLabel="admin.settings.unmask"
             class="setting-toggle-secret"
           />

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
@@ -172,10 +172,13 @@ module("Integration | Component | site-setting", function (hooks) {
       <template><SiteSettingComponent @setting={{self.setting}} /></template>
     );
     assert.dom(".input-setting-string").hasAttribute("type", "password");
+    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
     await click(".setting-toggle-secret");
     assert.dom(".input-setting-string").hasAttribute("type", "text");
+    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye-slash");
     await click(".setting-toggle-secret");
     assert.dom(".input-setting-string").hasAttribute("type", "password");
+    assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
   });
 });
 


### PR DESCRIPTION
Previously it always had a slash through it. Now it has a slash if clicking it will hide the site setting, and no slash if clicking it will show the site setting.

![image](https://github.com/user-attachments/assets/28dbed34-7a1a-4932-99c2-58f0f5f215a5)
![image](https://github.com/user-attachments/assets/d55069d6-065e-4522-b615-71a8c69f82bc)
