### PR TITLE
FIX: Chat video thumbnails on iOS

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
@@ -57,7 +57,9 @@ export default class ChatUpload extends Component {
 
   get videoSourceUrl() {
     const baseUrl = this.args.upload.url;
-    return this.capabilities.isSafari ? `${baseUrl}#t=0.001` : baseUrl;
+    return this.capabilities.isIOS || this.capabilities.isSafari
+      ? `${baseUrl}#t=0.001`
+      : baseUrl;
   }
 
   @action


### PR DESCRIPTION
Turns out we do need the iOS check, not just the safari check.

Follow up to: #33199
