### PR TITLE
DEV: remove old unused sidebar section-message component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-message.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-message.gjs
@@ -1,9 +1,0 @@
-const SidebarSectionMessage = <template>
-  <div class="sidebar-section-message-wrapper sidebar-row">
-    <div class="sidebar-section-message">
-      {{yield}}
-    </div>
-  </div>
-</template>;
-
-export default SidebarSectionMessage;


### PR DESCRIPTION
Long ago, we had a sidebar section with text content. We no longer have this section so this component is completely unused. 