### PR TITLE
DEV: Pass ExportUserArchive job args into provide_results method

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -182,10 +182,10 @@ module Jobs
         FileUtils.rm_rf(dirname)
       end
 
-      provide_results(user_export, zip_filename, export_title)
+      provide_results(user_export, zip_filename, export_title, args)
     end
 
-    def provide_results(user_export, zip_filename, export_title)
+    def provide_results(user_export, zip_filename, export_title, args)
       begin
         create_upload_for_user(user_export, zip_filename)
       ensure


### PR DESCRIPTION
I'm extending this job in a plugin and need to be able to access an additional job arg in the `provide_results` method (see https://github.com/discourse/discourse/pull/33328)