### PR TITLE
UX: welcome-banner: adds optional subheader

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -70,6 +70,12 @@ export default class WelcomeBanner extends Component {
     });
   }
 
+  get subheaderText() {
+    return this.currentUser
+      ? i18n("welcome_banner.subheader.logged_in_members")
+      : i18n("welcome_banner.subheader.anonymous_members");
+  }
+
   get shouldDisplay() {
     const enabled = applyValueTransformer(
       "site-setting-enable-welcome-banner",
@@ -104,6 +110,11 @@ export default class WelcomeBanner extends Component {
           <div class="custom-search-banner-wrap welcome-banner__wrap">
             <div class="welcome-banner__title">
               {{htmlSafe this.headerText}}
+              {{#if this.subheaderText}}
+                <p class="welcome-banner__subheader">
+                  {{htmlSafe this.subheaderText}}
+                </p>
+              {{/if}}
             </div>
             <PluginOutlet @name="welcome-banner-below-headline" />
             <div class="search-menu welcome-banner__search-menu">

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -82,6 +82,20 @@
       text-align: center;
     }
 
+    .welcome-banner__subheader {
+      font-size: var(--font-down-6);
+      font-weight: normal;
+      margin-top: 0.25rem;
+
+      @include viewport.until(md) {
+        font-size: var(--font-down-4);
+      }
+
+      @include viewport.until(sm) {
+        font-size: var(--font-down-1);
+      }
+    }
+
     .btn.search-icon {
       z-index: 2;
       background: transparent;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -222,6 +222,9 @@ en:
       header:
         logged_in_members: "Welcome back, %{preferred_display_name}!"
         anonymous_members: "Welcome to %{site_name}!"
+      subheader:
+        logged_in_members: ""
+        anonymous_members: ""
       search: "Search"
 
     themes:


### PR DESCRIPTION
Adds support of an optional subheader to the core welcome banner.

Similarly to header it accepts `logged in` and `anonymous` copies.