### PR TITLE
UX: minor adjustments to participant group badge

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -261,12 +261,11 @@
 
     .participant-group-wrapper {
       display: flex;
-      margin-left: 0.5em;
       flex-wrap: wrap;
       gap: 0.5em;
 
       .participant-group {
-        padding: 0 5px;
+        padding: 0.1em 0.3em;
         border: 1px solid var(--primary-low);
         border-radius: 0.25em;
         min-width: 3em;
@@ -278,6 +277,7 @@
           align-items: center;
           height: 1.25em;
           color: var(--primary-high);
+          font-size: var(--font-down-1);
 
           .mobile-view & {
             height: 1.1em;
@@ -285,6 +285,7 @@
 
           .d-icon {
             margin-right: 5px;
+            font-size: var(--font-down-1);
           }
         }
       }


### PR DESCRIPTION
These were a bit too large relative to tags and had some extra space...


Before:
![image](https://github.com/user-attachments/assets/f32ba42d-40cd-4ab3-bef4-fa49cd579563)


After:
![image](https://github.com/user-attachments/assets/747f5897-5a48-40e5-ac26-79ad2008ef84)