### PR TITLE
missing orders

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -112,7 +112,12 @@ export default class FullPageSearchController extends Controller {
 
     this.sortOrders = [
       { name: i18n("search.relevance"), id: 0 },
-      { name: i18n("search.latest_post"), id: 1, term: "order:latest" },
+      {
+        name: i18n("search.latest_post"),
+        id: 1,
+        term: "order:latest",
+        alias: "l",
+      },
       { name: i18n("search.most_liked"), id: 2, term: "order:likes" },
       { name: i18n("search.most_viewed"), id: 3, term: "order:views" },
       {
@@ -121,6 +126,15 @@ export default class FullPageSearchController extends Controller {
         term: "order:latest_topic",
       },
     ];
+
+    if (this.currentUser) {
+      this.sortOrders.push({
+        name: i18n("search.last_read"),
+        id: 5,
+        term: "order:read",
+        alias: "r",
+      });
+    }
 
     this.bulkSelectHelper = new BulkSelectHelper(this);
   }
@@ -203,10 +217,15 @@ export default class FullPageSearchController extends Controller {
     if (term) {
       this.sortOrders.forEach((order) => {
         if (order.term) {
-          let matches = term.match(new RegExp(`${order.term}\\b`));
+          let word = order.term;
+          let matches = term.match(new RegExp(`${word}\\b`));
+          if (!matches && order.alias) {
+            word = order.alias;
+            matches = term.match(new RegExp(`${word}\\b`));
+          }
           if (matches) {
             this.set("sortOrder", order.id);
-            term = term.replace(new RegExp(`${order.term}\\b`, "g"), "");
+            term = term.replace(new RegExp(`${word}\\b`, "g"), "");
             term = term.trim();
           }
         }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3035,6 +3035,7 @@ en:
       relevance: "Relevance"
       latest_post: "Latest Post"
       latest_topic: "Latest Topic"
+      last_read: "Last Read"
       most_viewed: "Most Viewed"
       most_liked: "Most Liked"
       select_all: "Select All"

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -545,6 +545,19 @@ class TopicsFilter
     "views" => {
       column: "topics.views",
     },
+    "read" => {
+      column: "tu.last_visited_at",
+      scope: -> do
+        if @guardian.user
+          @scope.joins(
+            "JOIN topic_users tu ON tu.topic_id = topics.id AND tu.user_id = #{@guardian.user.id.to_i}",
+          ).where("tu.last_visited_at IS NOT NULL")
+        else
+          # make sure this works for anon
+          @scope.joins("LEFT JOIN topic_users tu ON 1 = 0")
+        end
+      end,
+    },
   }
   private_constant :ORDER_BY_MAPPINGS
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -3136,7 +3136,7 @@ RSpec.describe Search do
     end
   end
 
-  it "can order by read" do
+  it "orders posts by the timestamp of the user's last visit to each topic" do
     user = Fabricate(:user)
 
     post2 = nil
@@ -3160,5 +3160,10 @@ RSpec.describe Search do
 
     # also allow for the r shortcul like we have l
     expect(result.posts.map(&:id)).to eq([post1.id, post2.id])
+
+    result = Search.execute("Read order term r", guardian: Guardian.new)
+
+    # no op on anon - all included
+    expect(result.posts.map(&:id).length).to eq(3)
   end
 end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -3135,4 +3135,30 @@ RSpec.describe Search do
       expect(results.posts).to contain_exactly(regular_post)
     end
   end
+
+  it "can order by read" do
+    user = Fabricate(:user)
+
+    post2 = nil
+    freeze_time 2.hours.ago do
+      post2 = Fabricate(:post, raw: "Read order term")
+      TopicUser.update_last_read(user, post2.topic.id, post2.post_number, 1, 0)
+    end
+
+    post1 = nil
+    freeze_time 1.hour.ago do
+      post1 = Fabricate(:post, raw: "Read order term")
+      TopicUser.update_last_read(user, post1.topic.id, post1.post_number, 1, 0)
+    end
+
+    _unread_post = Fabricate(:post, raw: "Read order term")
+
+    result = Search.execute("Read order term order:read", guardian: Guardian.new(user))
+    expect(result.posts.map(&:id)).to eq([post1.id, post2.id])
+
+    result = Search.execute("Read order term r", guardian: Guardian.new(user))
+
+    # also allow for the r shortcul like we have l
+    expect(result.posts.map(&:id)).to eq([post1.id, post2.id])
+  end
 end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1530,6 +1530,59 @@ RSpec.describe TopicsFilter do
         include_examples "ordering topics filters", "title", "topic's title"
       end
 
+      describe "when ordering by user's last visit to topics" do
+        fab!(:user)
+        fab!(:topic)
+        fab!(:topic2) { Fabricate(:topic) }
+        fab!(:topic3) { Fabricate(:topic) }
+
+        before do
+          freeze_time 3.hours.ago do
+            TopicUser.update_last_read(user, topic3.id, 1, 1, 0)
+          end
+
+          freeze_time 2.hours.ago do
+            TopicUser.update_last_read(user, topic.id, 1, 1, 0)
+          end
+
+          freeze_time 1.hour.ago do
+            TopicUser.update_last_read(user, topic2.id, 1, 1, 0)
+          end
+        end
+
+        describe "when query string is `order:read`" do
+          it "should return topics ordered by last visited date in descending order for logged in users" do
+            expect(
+              TopicsFilter
+                .new(guardian: Guardian.new(user))
+                .filter_from_query_string("order:read")
+                .pluck(:id),
+            ).to eq([topic2.id, topic.id, topic3.id])
+          end
+
+          it "should not apply any special ordering for anonymous users" do
+            topics =
+              TopicsFilter
+                .new(guardian: Guardian.new)
+                .filter_from_query_string("order:read")
+                .where(id: [topic.id, topic2.id, topic3.id])
+
+            expect(topics.pluck(:id)).to contain_exactly(topic.id, topic2.id, topic3.id)
+          end
+        end
+
+        describe "when query string is `order:read-asc`" do
+          it "should return topics ordered by last visited date in ascending order for logged in users" do
+            expect(
+              TopicsFilter
+                .new(guardian: Guardian.new(user))
+                .filter_from_query_string("order:read-asc")
+                .pluck(:id),
+            ).to eq([topic3.id, topic.id, topic2.id])
+          end
+        end
+      end
+
       describe "composing multiple order filters" do
         fab!(:topic) { Fabricate(:topic, created_at: Time.zone.local(2023, 1, 1), views: 2) }
         fab!(:topic2) { Fabricate(:topic, created_at: Time.zone.local(2024, 1, 1), views: 2) }

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -16,6 +16,10 @@ module PageObjects
         self
       end
 
+      def sort_order
+        PageObjects::Components::SelectKit.new("#search-sort-by")
+      end
+
       def click_search_menu_link
         find(".search-menu .results .search-link").click
       end
@@ -23,6 +27,10 @@ module PageObjects
       def clear_search_input
         find("input.full-page-search").set("")
         self
+      end
+
+      def search_input
+        find("input.full-page-search")
       end
 
       def has_heading_text?(text)

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -19,6 +19,24 @@ describe "Search", type: :system do
 
     after { SearchIndexer.disable }
 
+    it "handles search term cleaning and ordering for aliases" do
+      # we need to be logged in for last read to show up
+      sign_in(post.user)
+      TopicUser.update_last_read(post.user, post.topic.id, 1, 1, 0)
+
+      visit("/search?q=test%20r")
+
+      expect(search_page.search_input.value).to eq("test")
+      # read sort order is set to 5
+      expect(search_page.sort_order.value).to eq("5")
+
+      visit("/search?q=test%20l")
+
+      expect(search_page.search_input.value).to eq("test")
+      # latest sort order is set to 1
+      expect(search_page.sort_order.value).to eq("1")
+    end
+
     it "works and clears search page state", mobile: true do
       visit("/search")
 


### PR DESCRIPTION
- **FEATURE: new search order for read topics**
- **implement on filter as well**
- **FIX: add missing last read sort order to full page search**
