### PR TITLE
FIX: Unclaim reviewables when an action modal is cancelled.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.gjs
@@ -528,17 +528,19 @@ export default class ReviewableItem extends Component {
         this.dialog.confirm({
           message,
           didConfirm: () => this._performConfirmed(performableAction),
+          didCancel: () => this.#unclaimAutomaticReviewable(),
         });
       }
     } else if (actionModalClass) {
       if (await this.#claimReviewable()) {
-        this.modal.show(actionModalClass, {
+        await this.modal.show(actionModalClass, {
           model: {
             reviewable: this.reviewable,
             performConfirmed: this._performConfirmed,
             action: performableAction,
           },
         });
+        await this.#unclaimAutomaticReviewable();
       }
     } else {
       return this._performConfirmed(performableAction);


### PR DESCRIPTION
## ✨ What's This?

When a modal is opened as part of a reviewable action, we automatically mark a reviewable as claimed, so that other site staff won't accidentally start working on that reviewable. If the modal is cancelled out of, however, we weren't removing the claimed flag.

## 👑 Testing

**Setup**
- Add a "Require Approval" watched word.
- As a non-admin, reply to an existing topic, using that watched word.

**Test 1**
- In the reviewable that appears in the review queue, click the "Revise Post..." button.
- Cancel (or Escape) out of the modal that pops up.
- Confirm that the reviewable is not marked as claimed.

**Setup**
- As an admin, mark the original topic as closed.
- Refresh the review queue or reviewable page.

**Test 2**
- On the reviewable, click the "Approve Post" button.
- Cancel (or Escape) out of the confirmation dialog that pops up.
- Confirm that the reviewable is not marked as claimed.