### PR TITLE
FEATURE: Add a hidden setting to limit number of content localization locales

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2806,6 +2806,7 @@ en:
       delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than %{max}"
       invalid_uncategorized_category_setting: 'The "Uncategorized" category cannot be selected if ''allow uncategorized topics'' is not enabled.'
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
+      content_localization_locale_limit: "The number of supported locales cannot exceed %{max}."
       content_localization_anon_language_switcher_requirements: "The language switcher requires the `set locale from cookie` site setting to be enabled, and the `content localization supported locales` to have at least one language."
 
     keywords:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1616,6 +1616,11 @@ content_localization:
     allow_any: false
     choices: "LocaleSiteSetting.values"
     area: "localization"
+    validator: "ContentLocalizationLocalesValidator"
+  content_localization_max_locales:
+    default: 10
+    type: integer
+    hidden: true
   content_localization_anon_language_switcher:
     default: false
     client: true

--- a/lib/validators/content_localization_locales_validator.rb
+++ b/lib/validators/content_localization_locales_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ContentLocalizationLocalesValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == ""
+    count = val.split("|").length
+    SiteSetting.content_localization_max_locales >= count
+  end
+
+  def error_message
+    I18n.t(
+      "site_settings.errors.content_localization_locale_limit",
+      max: SiteSetting.content_localization_max_locales,
+    )
+  end
+end

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -115,4 +115,24 @@ describe "Content Localization" do
       expect(composer).to have_content(post_3.raw)
     end
   end
+
+  context "for site settings" do
+    let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+    let(:banner) { PageObjects::Components::AdminChangesBanner.new }
+
+    it "does not allow more than the maximum number of locales" do
+      SiteSetting.content_localization_max_locales = 2
+      sign_in(admin)
+
+      settings_page.visit("content_localization_supported_locales")
+      settings_page.select_list_values("content_localization_supported_locales", %w[en ja es])
+      settings_page.save_setting("content_localization_supported_locales")
+      expect(settings_page.error_message("content_localization_supported_locales")).to have_content(
+        I18n.t(
+          "site_settings.errors.content_localization_locale_limit",
+          max: SiteSetting.content_localization_max_locales,
+        ),
+      )
+    end
+  end
 end

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -31,6 +31,16 @@ module PageObjects
         ".row.setting[data-setting='#{setting_name}']"
       end
 
+      def select_list_values(setting_name, values)
+        setting =
+          PageObjects::Components::SelectKit.new(
+            ".row.setting[data-setting='#{setting_name}'] .list-setting",
+          )
+        setting.expand
+        values.each { |value| setting.select_row_by_value(value) }
+        self
+      end
+
       def has_setting?(setting_name)
         has_css?(".row.setting[data-setting=\"#{setting_name}\"]")
       end
@@ -65,8 +75,10 @@ module PageObjects
         save_setting(setting) if save_changes
       end
 
-      def save_setting(setting_element)
-        setting_element.find(".setting-controls button.ok").click
+      def save_setting(setting)
+        setting = find_setting(setting) if setting.is_a?(String)
+        setting.find(".setting-controls button.ok").click
+        self
       end
 
       def has_overridden_setting?(setting_name, value: nil)
@@ -113,6 +125,11 @@ module PageObjects
 
       def has_greater_than_n_results?(count)
         assert_selector(".admin-detail .row.setting", minimum: count)
+      end
+
+      def error_message(setting_name)
+        setting = find_setting(setting_name)
+        setting.find(".setting-value .validation-error").text
       end
     end
   end


### PR DESCRIPTION
We want to add a hidden limit to the number of locales an admin can set for localization. This is a safe limit to prevent excessive localization (if each post can be localized to 10 locales, that's 10x the amount of storage and tokens needed).

<img width="609" alt="Screenshot 2025-06-27 at 5 56 32 PM" src="https://github.com/user-attachments/assets/38733831-5e8a-4389-880c-410feecbd529" />

t/157677