### PR TITLE
DEV: add class to logout dialog

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-document.js
+++ b/app/assets/javascripts/discourse/app/components/d-document.js
@@ -87,6 +87,7 @@ export default class DDocument extends Component {
       confirmButtonLabel: "refresh",
       didConfirm: () => logout(),
       didCancel: () => logout(),
+      class: "dialog-container__logout-refresh",
     });
   }
 }


### PR DESCRIPTION
This adds a class to the dialog that appears when a user is notified that they were logged out, which will allow some custom styles to be added. 

![image](https://github.com/user-attachments/assets/02b37164-61f1-4663-bcbf-f205e06b22b3)
