### PR TITLE
FIX: Handle restore URLs ending with query params

### DIFF
--- a/lib/backup_restore/backup_file_handler.rb
+++ b/lib/backup_restore/backup_file_handler.rb
@@ -8,7 +8,12 @@ module BackupRestore
 
     def initialize(logger, filename, current_db, root_tmp_directory: Rails.root, location: nil)
       @logger = logger
-      @filename = filename
+      if filename.start_with?("http://", "https://")
+        @url = filename
+        @filename = File.basename(URI.parse(@url).path)
+      else
+        @filename = filename
+      end
       @current_db = current_db
       @root_tmp_directory = root_tmp_directory
       @is_archive = !(@filename =~ /\.sql\.gz\z/)
@@ -17,11 +22,6 @@ module BackupRestore
 
     def decompress
       create_tmp_directory
-
-      if @filename.start_with?("http://", "https://")
-        @url = @filename
-        @filename = File.basename(URI.parse(@url).path)
-      end
 
       @archive_path = File.join(@tmp_directory, @filename)
 

--- a/spec/lib/backup_restore/backup_file_handler_spec.rb
+++ b/spec/lib/backup_restore/backup_file_handler_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BackupRestore::BackupFileHandler do
   it "works with URLs" do
     expect_decompress_and_clean_up_to_work(
       backup_filename: "backup_since_v1.6.tar.gz",
-      url: "https://example.com/backups/backup_since_v1.6.tar.gz",
+      url: "https://example.com/backups/backup_since_v1.6.tar.gz?",
       require_metadata_file: false,
       require_uploads: true,
     )


### PR DESCRIPTION
Moving parsing the URL to the constructor ensures that is_archive is correctly initialized. This allows .sql.gz backups to be restored.