### PR TITLE
FIX: Apply diversity preferences to emoji search results.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
@@ -7,7 +7,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { cancel, next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
-import { emojiSearch } from "pretty-text/emoji";
+import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
 import { eq, gt, includes, notEq } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import FilterInput from "discourse/components/filter-input";
@@ -181,7 +181,7 @@ export default class EmojiPicker extends Component {
       this.filteredEmojis = results.map((emoji) => {
         return {
           name: emoji,
-          url: emojiUrlFor(emoji),
+          tonable: isSkinTonableEmoji(emoji),
         };
       });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.gjs
@@ -96,6 +96,15 @@ module("Integration | Component | emoji-picker-content", function (hooks) {
     assert
       .dom('.emoji-picker__section.filtered > img[alt="grinning_face"]')
       .exists("it filters the correct emoji using search alias");
+
+    await emojiPicker(".emoji-picker").tone(2);
+    await fillIn(".filter-input", "fist");
+
+    assert
+      .dom(
+        `.emoji-picker__section.filtered > img[src="/images/emoji/twitter/raised_fist/2.png?v=${v}"]`
+      )
+      .exists("it uses the selected skin tone in search results");
   });
 
   test("When selecting an emoji", async function (assert) {


### PR DESCRIPTION
## ✨ What's This?

This change ensures that emoji search results have the appropriate skin tone applied, when a diversity option has been selected.

## 📺 Screenshots

![](https://github.com/user-attachments/assets/aebce497-5df2-4d84-a6cf-3498c2e3530d)

## 👑 Testing

Check that the emoji selector uses the correct skin tone when a diversity option is set, and no skin tone when no diversity option is set.