### PR TITLE
FIX: render emojis in cooked hashtag text for composer rich text mode

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/hashtag.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/hashtag.js
@@ -1,5 +1,6 @@
 import { ajax } from "discourse/lib/ajax";
 import { getHashtagTypeClasses } from "discourse/lib/hashtag-type-registry";
+import { emojiUnescape } from "discourse/lib/text";
 import { isBoundary } from "discourse/static/prosemirror/lib/markdown-it";
 
 const VALID_HASHTAGS = new Map();
@@ -161,7 +162,7 @@ const extension = {
                 }
 
                 // decorate valid hashtags based on their type
-                const tagText = validHashtag?.text || name;
+                const tagText = emojiUnescape(validHashtag?.text || name);
                 const hashtagTypeClass =
                   getHashtagTypeClasses()[validHashtag.type];
                 const hashtagIconHTML = hashtagTypeClass

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
@@ -32,6 +32,13 @@ module(
               style_type: "icon",
               id: 4,
             },
+            {
+              type: "category",
+              ref: "welcome",
+              text: "hello :wave:",
+              style_type: "square",
+              id: 5,
+            },
           ],
           tags: [
             {
@@ -80,6 +87,11 @@ module(
         "Lets #discuss",
         '<p>Lets <a class="hashtag-cooked" data-name="discuss" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-icon hashtag-color--category-4\"><svg class=\"fa d-icon d-icon-comment svg-icon svg-string\" aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\"><use href=\"#comment\"></use></svg></span>discuss</a></p>',
         "Lets #discuss",
+      ],
+      "hashtag with emoji in text": [
+        "#welcome",
+        '<p><a class="hashtag-cooked" data-name="welcome" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-5\"></span>hello <img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/wave.png?v=14\" title=\"wave\" alt=\"wave\" class=\"emoji\"></a></p>',
+        "#welcome",
       ],
     };
 


### PR DESCRIPTION
Correctly renders emojis within hashtag text (ie. chat channel titles) in composer rich text mode.

### Before

<img width="534" alt="Screenshot 2025-06-30 at 12 45 50 PM" src="https://github.com/user-attachments/assets/372e6275-3b21-47ff-9dd8-bebeeaa39ea6" />

### After

<img width="482" alt="Screenshot 2025-06-30 at 12 42 21 PM" src="https://github.com/user-attachments/assets/61e73a15-b10d-44c5-8404-2d8918d3c05a" />

