### PR TITLE
DEV: Pass additional args to header-content__before PluginOutlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -68,6 +68,9 @@ export default class Contents extends Component {
         @outletArgs={{lazyHash
           topicInfo=@topicInfo
           topicInfoVisible=@topicInfoVisible
+          toggleNavigationMenu=@toggleNavigationMenu
+          showSidebar=@showSidebar
+          sidebarIcon=this.sidebarIcon
         }}
         @deprecatedArgs={{lazyHash
           topic=(deprecatedOutletArgument


### PR DESCRIPTION
This passes a couple additional args to the `header-content__before`. This is used by a private plugin, to append the sidebar hamburger back in a specific case.