### PR TITLE
UX: Add `flag_post_allowed_groups` site setting to `flags` area

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2317,7 +2317,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
-    area: "group_permissions"
+    area: "flags|group_permissions"
   allow_all_users_to_flag_illegal_content:
     default: false
     area: "flags"


### PR DESCRIPTION
### Screenshot

<img width="1125" alt="Screenshot 2025-07-01 at 11 25 35 AM" src="https://github.com/user-attachments/assets/f0f45d91-8df4-4c6c-ae9d-0eab1ab244bf" />

### Reviewer notes 

No tests are this is mostly a UX change which we don't expect to regress easily.