### PR TITLE
FIX: Ensure client-side reviewable claiming data is set correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-claimed-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-claimed-topic.gjs
@@ -33,7 +33,10 @@ export default class ReviewableClaimedTopic extends Component {
 
     try {
       await claim.save({ topic_id: this.args.topicId });
-      this.args.onClaim(this.currentUser);
+      this.args.onClaim({
+        user: this.currentUser,
+        automatic: false,
+      });
     } catch (e) {
       popupAjaxError(e);
     }

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -138,6 +138,14 @@ module PageObjects
         )
       end
 
+      def click_claim_reviewable
+        find(".reviewable-claimed-topic .claim").click
+      end
+
+      def click_unclaim_reviewable
+        find(".reviewable-claimed-topic .unclaim").click
+      end
+
       private
 
       def reviewable_action_dropdown

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -282,6 +282,24 @@ describe "Reviewables", type: :system do
 
         expect(review_page).to have_reviewable_with_rejected_status(queued_post_reviewable)
       end
+
+      context "with reviewable claiming enabled" do
+        before { SiteSetting.reviewable_claiming = "required" }
+
+        it "properly claims and unclaims the reviewable" do
+          review_page.visit_reviewable(queued_post_reviewable)
+
+          expect(review_page).to have_no_reviewable_action_dropdown
+
+          review_page.click_claim_reviewable
+
+          expect(review_page).to have_reviewable_action_dropdown
+
+          review_page.click_unclaim_reviewable
+
+          expect(review_page).to have_no_reviewable_action_dropdown
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## ✨ What's This?

`ReviewableClaimedTopic` has an `onClaim` arg, which is used by the calling components to locally mutate the value of `reviewable.claimed_by`.

This was being incorrectly mutated to a User model, when it in fact needs to match the `ReviewableClaimedTopicSerializer` output.

## 👑 Testing

Claim and unclaim reviewables, confirm that:
- The UI updates correctly as soon as you perform the claim/unclaim (client side updates are correct).
- The UI is displayed correctly after reloading the page (server side updates are correct).