### PR TITLE
UI: improvement for the admin system theme

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show-index.gjs
@@ -1,5 +1,6 @@
 import { fn, hash } from "@ember/helper";
 import RouteTemplate from "ember-route-template";
+import { and, not } from "truth-helpers";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -74,8 +75,10 @@ export default RouteTemplate(
             </span>
           {{/if}}
         </div>
-      {{else}}
-        <span class="heading">{{i18n "admin.customize.theme.creator"}}</span>
+      {{else if (not @controller.model.system)}}
+        <span class="heading created-by">{{i18n
+            "admin.customize.theme.creator"
+          }}</span>
         <span>
           <UserLink @user={{@controller.model.user}}>
             {{formatUsername @controller.model.user.username}}
@@ -255,8 +258,8 @@ export default RouteTemplate(
       </div>
     {{/unless}}
 
-    {{#if @controller.extraFiles.length}}
-      <div class="control-unit">
+    {{#if (and @controller.extraFiles.length (not @controller.model.system))}}
+      <div class="control-unit extra-files">
         <div class="mini-title">{{i18n
             "admin.customize.theme.extra_files"
           }}</div>
@@ -279,7 +282,7 @@ export default RouteTemplate(
     {{/if}}
 
     {{#if @controller.hasSettings}}
-      <div class="control-unit">
+      <div class="control-unit theme-settings">
         <div class="mini-title">{{i18n
             "admin.customize.theme.theme_settings"
           }}</div>
@@ -344,12 +347,14 @@ export default RouteTemplate(
         target="_blank"
         class="btn btn-default"
       >{{icon "desktop"}}{{i18n "admin.customize.theme.preview"}}</a>
-      <a
-        class="btn btn-default export"
-        rel="noopener noreferrer"
-        target="_blank"
-        href={{@controller.downloadUrl}}
-      >{{icon "download"}} {{i18n "admin.export_json.button_text"}}</a>
+      {{#unless @controller.model.system}}
+        <a
+          class="btn btn-default export"
+          rel="noopener noreferrer"
+          target="_blank"
+          href={{@controller.downloadUrl}}
+        >{{icon "download"}} {{i18n "admin.export_json.button_text"}}</a>
+      {{/unless}}
 
       {{#if @controller.showConvert}}
         <DButton
@@ -378,7 +383,7 @@ export default RouteTemplate(
           />
         {{/if}}
       {{/if}}
-      {{#if @controller.hasSettings}}
+      {{#if (and @controller.hasSettings (not @controller.model.system))}}
         <DButton
           @action={{@controller.showThemeSettingsEditor}}
           @label="admin.customize.theme.settings_editor"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -229,6 +229,9 @@ en:
       broken_theme_alert: "Your site may not work because a theme / component has errors."
       error_caused_by: "Caused by '%{name}'. <a target='blank' href='%{path}'>Click here</a> to update, reconfigure or disable."
       only_admins: "(this message is only shown to site administrators)"
+      horizon:
+        topic_pinned: "Pinned"
+        topic_hot: "Hot"
 
     broken_decorator_alert: "Posts may not display correctly because one of the post content decorators on your site raised an error."
     broken_page_change_alert: "An onPageChange handler raised an error. Check the browser developer tools for more information."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -229,9 +229,6 @@ en:
       broken_theme_alert: "Your site may not work because a theme / component has errors."
       error_caused_by: "Caused by '%{name}'. <a target='blank' href='%{path}'>Click here</a> to update, reconfigure or disable."
       only_admins: "(this message is only shown to site administrators)"
-      horizon:
-        topic_pinned: "Pinned"
-        topic_hot: "Hot"
 
     broken_decorator_alert: "Posts may not display correctly because one of the post content decorators on your site raised an error."
     broken_page_change_alert: "An onPageChange handler raised an error. Check the browser developer tools for more information."
@@ -4452,6 +4449,8 @@ en:
       pinned:
         title: "Pinned"
         help: "This topic is pinned for you; it will display at the top of its category"
+      hot:
+        title: "Hot"
       unlisted:
         help: "This topic is unlisted; it will not be displayed in topic lists, and can only be accessed via a direct link. %{unlistedReason}"
       personal_message:

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -72,6 +72,34 @@ describe "Admin Customize Themes", type: :system do
     expect(page).not_to have_css(".delete")
   end
 
+  it "hides unecessary sections and buttons for system themes" do
+    theme.theme_fields.create!(
+      name: "js",
+      target_id: Theme.targets[:extra_js],
+      value: "console.log('second test')",
+    )
+    yaml = <<~YAML
+      enable_welcome_banner:
+        default: true
+        description: "Overrides the core `enable welcome banner` site setting"
+    YAML
+    theme.set_field(target: :settings, name: "yaml", value: yaml)
+    theme.save!
+
+    visit("/admin/customize/themes/#{theme.id}")
+    expect(page).to have_css(".created-by")
+    expect(page).to have_css(".export")
+    expect(page).to have_css(".extra-files")
+    expect(page).to have_css(".theme-settings")
+
+    theme.stubs(:system?).returns(true)
+    visit("/admin/customize/themes/#{theme.id}")
+    expect(page).not_to have_css(".created-by")
+    expect(page).not_to have_css(".export")
+    expect(page).not_to have_css(".extra-files")
+    expect(page).not_to have_css(".theme-settings")
+  end
+
   describe "when editing theme translations" do
     it "should allow admin to edit and save the theme translations" do
       theme.set_field(

--- a/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -10,7 +10,6 @@ export default class TopicActivityColumn extends Component {
       return {
         user: undefined,
         username: undefined,
-        activityText: "user_updated",
         class: "--updated",
       };
     }
@@ -19,7 +18,6 @@ export default class TopicActivityColumn extends Component {
       return {
         user: this.args.topic.lastPosterUser,
         username: this.args.topic.last_poster_username,
-        activityText: "user_replied",
         class: "--replied",
       };
     } else if (this.args.topic.posts_count === 1) {

--- a/themes/horizon/javascripts/discourse/components/card/topic-status-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-status-column.gjs
@@ -10,7 +10,7 @@ export default class TopicStatusColumn extends Component {
     if (this.args.topic.is_hot) {
       return {
         icon: "fire",
-        text: "themes.horizon.topic_hot",
+        text: "topic_statuses.hot.title",
         className: "--hot",
       };
     }
@@ -18,7 +18,7 @@ export default class TopicStatusColumn extends Component {
     if (this.args.topic.pinned) {
       return {
         icon: "thumbtack",
-        text: "themes.horizon.topic_pinned",
+        text: "topic_statuses.pinned.title",
         className: "--pinned",
       };
     }

--- a/themes/horizon/javascripts/discourse/components/card/topic-status-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-status-column.gjs
@@ -10,7 +10,7 @@ export default class TopicStatusColumn extends Component {
     if (this.args.topic.is_hot) {
       return {
         icon: "fire",
-        text: "topic_hot",
+        text: "themes.horizon.topic_hot",
         className: "--hot",
       };
     }
@@ -18,7 +18,7 @@ export default class TopicStatusColumn extends Component {
     if (this.args.topic.pinned) {
       return {
         icon: "thumbtack",
-        text: "topic_pinned",
+        text: "themes.horizon.topic_pinned",
         className: "--pinned",
       };
     }
@@ -30,9 +30,7 @@ export default class TopicStatusColumn extends Component {
     {{#if this.badge}}
       <span class="topic-status-card {{this.badge.className}}">{{icon
           this.badge.icon
-        }}<p class="topic-status-card__name">{{i18n
-            (themePrefix this.badge.text)
-          }}</p></span>
+        }}<p class="topic-status-card__name">{{i18n this.badge.text}}</p></span>
     {{/if}}
   </template>
 }

--- a/themes/horizon/locales/en.yml
+++ b/themes/horizon/locales/en.yml
@@ -1,8 +1,3 @@
 en:
   theme_metadata:
     description: "A simple, beautiful theme that improves the out of the box experience for Discourse sites."
-  topic_pinned: "Pinned"
-  topic_hot: "Hot"
-  user_replied: "replied"
-  user_posted: "posted"
-  user_updated: "updated"


### PR DESCRIPTION
List of small changes for the system Horizon theme:
- Remove"Created by: system"
- Remove All Extra Files section
- Move translation to core
- Remove settings editor button
- Remove export button

<img width="1203" alt="Screenshot 2025-07-01 at 3 02 22 pm" src="https://github.com/user-attachments/assets/39659f5d-13ae-453d-b4b9-911381aaa8e3" />
