### PR TITLE
FIX: escapes display:none for subheader in welcome banner for Horizon

### DIFF
--- a/themes/horizon/scss/welcome-banner.scss
+++ b/themes/horizon/scss/welcome-banner.scss
@@ -47,7 +47,7 @@
       }
     }
 
-    p {
+    p:not(.welcome-banner__subheader) {
       display: none;
     }
   }


### PR DESCRIPTION
In Horizon theme all paragraphs in welcome banner are hidden (for some reason).

Adding exception for `.welcome-banner__subheader` subheader, if it is in the DOM.