### PR TITLE
UX: avoid suppressing non-click events when dragging the grippie

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/grippie-drag-resize.js
+++ b/app/assets/javascripts/discourse/app/modifiers/grippie-drag-resize.js
@@ -45,7 +45,7 @@ export default class GrippieDragResize extends Modifier {
 
     // Only allow left-click dragging
     // c.f. https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value
-    if (event.button !== 0) {
+    if (event.type === "mousedown" && event.button !== 0) {
       return;
     }
 


### PR DESCRIPTION
Scopes a check introduced on https://github.com/discourse/discourse/pull/33046 to `mousedown` events, it was preventing touch events to be used to drag the grippie.

Reported on [meta.discourse.org](https://meta.discourse.org/t/composer-resizing-problems-while-using-a-tablet/370706).