### PR TITLE
A11Y: "in reply to" indicator should work with keyboard nav

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/reply-to-tab.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/reply-to-tab.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
 import avatar from "discourse/helpers/avatar";
 import icon from "discourse/helpers/d-icon";
@@ -19,6 +20,13 @@ export default class PostMetaDataReplyToTab extends Component {
 
   @service site;
 
+  @action
+  keyDown(event) {
+    if (event.key === "Enter") {
+      this.args.toggleReplyAbove();
+    }
+  }
+
   <template>
     <a
       class="reply-to-tab"
@@ -32,6 +40,7 @@ export default class PostMetaDataReplyToTab extends Component {
       tabindex="0"
       title="post.in_reply_to"
       {{on "click" @toggleReplyAbove}}
+      {{on "keydown" this.keyDown}}
     >
       {{#if @repliesAbove.isPending}}
         <div class="spinner small"></div>

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -207,6 +207,12 @@ createWidget("reply-to-tab", {
       () => (this.state.loading = false)
     );
   },
+
+  keyDown(event) {
+    if (event.key === "Enter") {
+      this.click();
+    }
+  },
 });
 
 createWidget("post-avatar-user-info", {

--- a/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
@@ -1,5 +1,5 @@
 import { getOwner } from "@ember/owner";
-import { click, render, triggerEvent } from "@ember/test-helpers";
+import { click, render, triggerEvent, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Post from "discourse/components/post";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -381,6 +381,28 @@ module("Integration | Component | Post", function (hooks) {
     await click("a.reply-to-tab");
     assert.strictEqual(count("section.embedded-posts.top .cooked"), 1);
     assert.strictEqual(count("section.embedded-posts .d-icon-arrow-up"), 1);
+  });
+
+  test("reply-to-tab keyboard accessibility", async function (assert) {
+    this.siteSettings.suppress_reply_directly_above = false;
+    this.post.reply_to_user = {
+      username: "eviltrout",
+      avatar_template: "/images/avatar.png",
+    };
+    this.post.post_number = 2;
+    this.post.reply_to_post_number = 1;
+
+    const prevPost = this.store.createRecord("post", {
+      id: 122,
+      post_number: 1,
+      topic: this.post.topic,
+    });
+
+    await renderComponent(this.post, { prevPost });
+
+    assert.dom("a.reply-to-tab").exists("shows the tab");
+    await triggerKeyEvent("a.reply-to-tab", "keydown", "Enter");
+    assert.strictEqual(count("section.embedded-posts.top .cooked"), 1, "toggles replies with Enter key");
   });
 
   test("cooked content hidden", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/post-test.gjs
@@ -1,5 +1,10 @@
 import { getOwner } from "@ember/owner";
-import { click, render, triggerEvent, triggerKeyEvent } from "@ember/test-helpers";
+import {
+  click,
+  render,
+  triggerEvent,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Post from "discourse/components/post";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -402,7 +407,11 @@ module("Integration | Component | Post", function (hooks) {
 
     assert.dom("a.reply-to-tab").exists("shows the tab");
     await triggerKeyEvent("a.reply-to-tab", "keydown", "Enter");
-    assert.strictEqual(count("section.embedded-posts.top .cooked"), 1, "toggles replies with Enter key");
+    assert.strictEqual(
+      count("section.embedded-posts.top .cooked"),
+      1,
+      "toggles in-reply-to with Enter key"
+    );
   });
 
   test("cooked content hidden", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.gjs
@@ -1,6 +1,11 @@
 import EmberObject from "@ember/object";
 import { getOwner } from "@ember/owner";
-import { click, render, triggerEvent, triggerKeyEvent } from "@ember/test-helpers";
+import {
+  click,
+  render,
+  triggerEvent,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import MountWidget from "discourse/components/mount-widget";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -384,7 +389,9 @@ module("Integration | Component | Widget | post", function (hooks) {
 
     assert.dom("a.reply-to-tab").exists("shows the tab");
     await triggerKeyEvent("a.reply-to-tab", "keydown", "Enter");
-    assert.dom("section.embedded-posts.top .cooked").exists("toggles replies with Enter key");
+    assert
+      .dom("section.embedded-posts.top .cooked")
+      .exists("toggles in-reply-to with Enter key");
   });
 
   test("cooked content hidden", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.gjs
@@ -1,6 +1,6 @@
 import EmberObject from "@ember/object";
 import { getOwner } from "@ember/owner";
-import { click, render, triggerEvent } from "@ember/test-helpers";
+import { click, render, triggerEvent, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import MountWidget from "discourse/components/mount-widget";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -364,6 +364,27 @@ module("Integration | Component | Widget | post", function (hooks) {
     await click("a.reply-to-tab");
     assert.dom("section.embedded-posts.top .cooked").exists();
     assert.dom("section.embedded-posts .d-icon-arrow-up").exists();
+  });
+
+  test("reply-to-tab keyboard accessibility", async function (assert) {
+    const self = this;
+
+    this.set("args", {
+      replyToUsername: "eviltrout",
+      replyToAvatarTemplate: "/images/avatar.png",
+      replyDirectlyAbove: true,
+    });
+    this.siteSettings.suppress_reply_directly_above = false;
+
+    await render(
+      <template>
+        <MountWidget @widget="post" @model={{self.post}} @args={{self.args}} />
+      </template>
+    );
+
+    assert.dom("a.reply-to-tab").exists("shows the tab");
+    await triggerKeyEvent("a.reply-to-tab", "keydown", "Enter");
+    assert.dom("section.embedded-posts.top .cooked").exists("toggles replies with Enter key");
   });
 
   test("cooked content hidden", async function (assert) {


### PR DESCRIPTION
The "in reply to" indicator, as seen below, is not currently accessible using your keyboard. This will make it functional on enter key press in both the widget and glimmer versions of the topic. I've also added tests for each. 

![image](https://github.com/user-attachments/assets/89c55078-cb92-4454-a408-ac2eaac1eb2b)
