### PR TITLE
A11Y: autofocus topic map DMenu contents for links, likes, and users - fix links

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -285,6 +285,7 @@ export default class TopicMapSummary extends Component {
           @placement="right"
           @groupIdentifier="topic-map"
           @inline={{true}}
+          @autofocus={{true}}
         >
           <:trigger>
             {{number @topic.like_count noTitle="true"}}
@@ -339,6 +340,7 @@ export default class TopicMapSummary extends Component {
           @groupIdentifier="topic-map"
           @placement="right"
           @inline={{true}}
+          @autofocus={{true}}
         >
           <:trigger>
             {{number this.linksCount maxDisplay=LINKS_THRESHOLD noTitle="true"}}
@@ -386,6 +388,7 @@ export default class TopicMapSummary extends Component {
           @modalForMobile={{true}}
           @groupIdentifier="topic-map"
           @inline={{true}}
+          @autofocus={{true}}
         >
           <:trigger>
             {{number @topic.participant_count noTitle="true"}}

--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -327,7 +327,7 @@ body:not(.archetype-private_message) {
 
       .discourse-no-touch & {
         &:hover,
-        &:focus-within {
+        &:focus-visible {
           outline: 0;
           background: var(--d-hover);
         }

--- a/app/assets/stylesheets/common/components/topic-map.scss
+++ b/app/assets/stylesheets/common/components/topic-map.scss
@@ -326,7 +326,9 @@ body:not(.archetype-private_message) {
       padding: 0.75em 1rem;
 
       .discourse-no-touch & {
-        &:hover {
+        &:hover,
+        &:focus-within {
+          outline: 0;
           background: var(--d-hover);
         }
       }
@@ -389,23 +391,33 @@ body:not(.archetype-private_message) {
       }
 
       .discourse-no-touch & {
-        &:hover {
+        &:hover,
+        &:focus-within {
           background: var(--d-hover);
+
+          a {
+            outline: 0;
+          }
         }
       }
     }
 
     .topic-link {
-      display: contents;
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-row: 1;
+      grid-column: 1 / -1;
 
       .content {
-        grid-area: link;
+        grid-row: 1;
+        grid-column: 2;
       }
     }
 
     .topic-link[data-clicks]::before {
       @include click-counter-badge;
-      grid-area: counter;
+      grid-row: 1;
+      grid-column: 1;
       align-self: start;
       margin-top: 0.35em;
     }
@@ -415,7 +427,8 @@ body:not(.archetype-private_message) {
     }
 
     .domain {
-      grid-area: domain;
+      grid-row: 2;
+      grid-column: 2;
       font-size: var(--font-down-2);
       color: var(--primary-medium);
     }


### PR DESCRIPTION
This traps focus for these topic map menus (links, likes, and users)

![image](https://github.com/user-attachments/assets/c56993e7-03f9-47a4-a8a3-6eece4a5fe77)

and also restructures the links in the link menu to avoid `display: contents;` — unfortunately `display: contents;` can make content within inaccessible with keyboard nav

So instead I've restructured it to use subgrid, which avoid the issue without changing the visuals. 

![image](https://github.com/user-attachments/assets/edf74a0b-6a0d-4f98-a4f5-0151ef327cb6)


