### PR TITLE
FIX: ensures small actions don't trigger post toolbar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -241,7 +241,15 @@ export default class PostTextSelection extends Component {
       return;
     }
 
-    return getElement(range.commonAncestorContainer)?.closest?.(".cooked");
+    const cooked = getElement(range.commonAncestorContainer)?.closest?.(
+      ".cooked"
+    );
+
+    if (cooked.closest(".small-action")) {
+      return;
+    }
+
+    return cooked;
   }
 
   get post() {


### PR DESCRIPTION
Prior to this fix you could select the text of a small action (after closing a topic with a message for example) and it would show the toolbar.

This commit will now ensure the common ancestor of the text range has no ".small-action" node as parent.

No test as it's currently very hard to test this behavior due to the debouncing delay causing the check for "no_css" to always be true, I need to re-think few parts of the toolbar to make it reliable. We also have other tests in the codebase which are currently not testing the reality for the same reason: spec/system/post_selection_copy_quote_spec.rb