### PR TITLE
FIX: UppyUploader issues when authorized_extensions setting is blank but authorized_extensions_for_staff is not

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
@@ -163,7 +163,6 @@ export default class UppyUpload {
           },
           this.config.validateUploadedFilesOptions
         );
-
         const isValid =
           validateUploadedFile(currentFile, validationOpts) &&
           this.config.isUploadedFileAllowed(currentFile);

--- a/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/uppy-upload.js
@@ -89,6 +89,7 @@ export default class UppyUpload {
   @service siteSettings;
   @service capabilities;
   @service session;
+  @service currentUser;
 
   @tracked uploading = false;
   @tracked processing = false;
@@ -162,6 +163,7 @@ export default class UppyUpload {
           },
           this.config.validateUploadedFilesOptions
         );
+
         const isValid =
           validateUploadedFile(currentFile, validationOpts) &&
           this.config.isUploadedFileAllowed(currentFile);

--- a/spec/system/edit_category_images_spec.rb
+++ b/spec/system/edit_category_images_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "Edit Category Images", type: :system do
+  fab!(:admin)
+  fab!(:category)
+  fab!(:upload) { Fabricate(:upload, user: admin) }
+  let(:category_page) { PageObjects::Pages::Category.new }
+
+  context "when trying to upload an image" do
+    before { sign_in(admin) }
+
+    context "when authorized_extensions blank and authorized_extensions_for_staff have restrictions" do
+      before do
+        SiteSetting.authorized_extensions = ""
+        SiteSetting.authorized_extensions_for_staff = "jpg|jpeg|png"
+        SiteSetting.enable_s3_uploads = false
+      end
+
+      it "displays and updates new counter" do
+        category_page.visit_images(category)
+
+        logo = file_from_fixtures("logo.png", "images").path
+
+        find("#category-logo-uploader .image-upload-controls").click
+        attach_file(
+          "category-logo-uploader__input",
+          "#{Rails.root}/spec/fixtures/images/logo.png",
+          make_visible: true,
+        )
+
+        expect(page).to have_content("uploaded successfully").or have_css(
+               ".uploaded-image-preview.input-xxlarge",
+             )
+      end
+    end
+  end
+end

--- a/spec/system/edit_category_images_spec.rb
+++ b/spec/system/edit_category_images_spec.rb
@@ -3,7 +3,6 @@
 describe "Edit Category Images", type: :system do
   fab!(:admin)
   fab!(:category)
-  fab!(:upload) { Fabricate(:upload, user: admin) }
   let(:category_page) { PageObjects::Pages::Category.new }
 
   context "when trying to upload an image" do
@@ -19,8 +18,6 @@ describe "Edit Category Images", type: :system do
       it "displays and updates new counter" do
         category_page.visit_images(category)
 
-        logo = file_from_fixtures("logo.png", "images").path
-
         find("#category-logo-uploader .image-upload-controls").click
         attach_file(
           "category-logo-uploader__input",
@@ -31,6 +28,10 @@ describe "Edit Category Images", type: :system do
         expect(page).to have_content("uploaded successfully").or have_css(
                ".uploaded-image-preview.input-xxlarge",
              )
+
+        upload = Upload.last
+        expect(upload.user_id).to eq(admin.id)
+        expect(upload.original_filename).to eq("logo.png")
       end
     end
   end

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -39,6 +39,11 @@ module PageObjects
         self
       end
 
+      def visit_images(category)
+        page.visit("/c/#{category.slug}/edit/images")
+        self
+      end
+
       def back_to_category
         find(".edit-category-title-bar span", text: "Back to category").click
         self


### PR DESCRIPTION
**Problem**
An error is showing up for staff members when trying to upload images and `SiteSetting.authorized_extensions = ""` and  `SiteSetting.authorized_extensions_for_staff != ""` because `this.currentUser` is not defined in the `UppyUploader` component

