### PR TITLE
FIX: Horizon default color scheme must be user selectable

### DIFF
--- a/lib/system_themes_manager.rb
+++ b/lib/system_themes_manager.rb
@@ -11,7 +11,8 @@ class SystemThemesManager
 
     theme_dir = "#{Rails.root}/themes/#{theme_name}"
 
-    RemoteTheme.import_theme_from_directory(theme_dir, theme_id: theme_id)
+    remote_theme = RemoteTheme.import_theme_from_directory(theme_dir, theme_id: theme_id)
+    remote_theme.color_scheme&.update!(user_selectable: true)
     Stylesheet::Manager.clear_theme_cache!
   end
 end

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -353,13 +353,6 @@ task "themes:deduplicate_horizon" => :environment do |task, args|
           }
           map
         end
-    if remote_horizon_theme.color_scheme.theme_id == remote_horizon_theme.id
-      system_horizon_theme.update!(
-        color_scheme_id: color_schemes_map[remote_horizon_theme.color_scheme_id][:id],
-      )
-    elsif remote_horizon_theme.color_scheme_id
-      system_horizon_theme.update!(color_scheme_id: remote_horizon_theme.color_scheme_id)
-    end
     system_horizon_theme.color_schemes.find_each do |color_scheme|
       color_scheme.update!(
         user_selectable:
@@ -369,6 +362,14 @@ task "themes:deduplicate_horizon" => :environment do |task, args|
             &.dig(:user_selectable),
       )
     end
+    if remote_horizon_theme.color_scheme.theme_id == remote_horizon_theme.id
+      system_horizon_theme.update!(
+        color_scheme_id: color_schemes_map[remote_horizon_theme.color_scheme_id][:id],
+      )
+    elsif remote_horizon_theme.color_scheme_id
+      system_horizon_theme.update!(color_scheme_id: remote_horizon_theme.color_scheme_id)
+    end
+    system_horizon_theme.color_scheme.update!(user_selectable: true)
     puts "Theme color palette is updated"
     UserOption
       .where(color_scheme_id: color_schemes_map.keys)

--- a/spec/lib/system_themes_manager_spec.rb
+++ b/spec/lib/system_themes_manager_spec.rb
@@ -5,5 +5,8 @@ RSpec.describe SystemThemesManager do
     Theme.delete_all
     expect { SystemThemesManager.sync! }.to change { Theme.system.count }.by(2)
     expect { SystemThemesManager.sync! }.not_to change { Theme.count }
+    expect(Theme.horizon_theme.color_scheme.user_selectable).to be true
+    expect(Theme.horizon_theme.color_schemes.where(user_selectable: true).count).to eq(1)
+    expect(Theme.horizon_theme.color_schemes.where(user_selectable: false).count).to eq(11)
   end
 end

--- a/spec/tasks/themes_spec.rb
+++ b/spec/tasks/themes_spec.rb
@@ -151,6 +151,13 @@ RSpec.describe "tasks/themes" do
       remote_horizon_theme.color_schemes.create!(
         name: "Lily Dark",
         theme_id: remote_horizon_theme.id,
+        user_selectable: false,
+      )
+    end
+    fab!(:remote_color_scheme_2) do
+      remote_horizon_theme.color_schemes.create!(
+        name: "Violet Dark",
+        theme_id: remote_horizon_theme.id,
         user_selectable: true,
       )
     end
@@ -165,6 +172,9 @@ RSpec.describe "tasks/themes" do
 
     let!(:system_horizon_theme) { Theme.horizon_theme }
     let!(:system_color_scheme) { system_horizon_theme.color_schemes.where(name: "Lily Dark").first }
+    let!(:system_color_scheme_2) do
+      system_horizon_theme.color_schemes.where(name: "Violet Dark").first
+    end
 
     before do
       remote_horizon_theme.update!(color_scheme: remote_color_scheme)
@@ -237,6 +247,7 @@ RSpec.describe "tasks/themes" do
         )
         expect(system_horizon_theme.color_scheme).to eq(system_color_scheme)
         expect(system_color_scheme.reload.user_selectable).to be true
+        expect(system_color_scheme_2.reload.user_selectable).to be true
       end
 
       it "logs that remote theme was deleted" do


### PR DESCRIPTION
Two improvements:
- When import Horizon theme, ensure that default color scheme is marked as `user_selectable`
- When merge remote Horizon into system Horizon, also ensure that default color scheme is marked as `user_selectable`