### PR TITLE
FEAT: Add clipboard button to new palette UI

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -6,6 +6,7 @@ import DButton from "discourse/components/d-button";
 import Form from "discourse/components/form";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
+import { clipboardCopy } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import AdminConfigAreaCard from "admin/components/admin-config-area-card";
 import ColorPaletteEditor, {
@@ -123,6 +124,28 @@ export default class AdminConfigAreasColorPalette extends Component {
   @action
   onEditorTabSwitch(newMode) {
     this.editorMode = newMode;
+  }
+
+  @action
+  async copy_to_clipboard() {
+    try {
+      await clipboardCopy(this.args.colorPalette.dump());
+      this.toasts.success({
+        data: {
+          message: i18n(
+            "admin.config_areas.color_palettes.copied_to_clipboard"
+          ),
+        },
+      });
+    } catch {
+      this.toasts.error({
+        data: {
+          message: i18n(
+            "admin.config_areas.color_palettes.copy_to_clipboard_error"
+          ),
+        },
+      });
+    }
   }
 
   @action
@@ -320,6 +343,11 @@ export default class AdminConfigAreasColorPalette extends Component {
                   {{i18n "admin.config_areas.color_palettes.unsaved_changes"}}
                 </span>
               {{/if}}
+              <DButton
+                class="copy-to-clipboard"
+                @label="admin.config_areas.color_palettes.copy_to_clipboard"
+                @action={{this.copy_to_clipboard}}
+              />
               <form.Submit
                 @isLoading={{this.saving}}
                 @label="admin.config_areas.color_palettes.save_changes"

--- a/app/assets/javascripts/admin/addon/models/color-scheme.js
+++ b/app/assets/javascripts/admin/addon/models/color-scheme.js
@@ -88,6 +88,28 @@ export default class ColorScheme extends EmberObject {
     return [`"${this.name}": {`, buffer.join(",\n"), "}"].join("\n");
   }
 
+  schemeObject() {
+    const extractColors = (property) =>
+      Object.fromEntries(
+        this.colors.map((color) => [color.get("name"), color.get(property)])
+      );
+    return {
+      dark: extractColors("dark_hex"),
+      light: extractColors("hex"),
+    };
+  }
+
+  /**
+   * @returns a JSON representation of the color scheme.
+   */
+  dump() {
+    return (
+      JSON.stringify(this.name) +
+      ": " +
+      JSON.stringify(this.schemeObject(), null, 2)
+    );
+  }
+
   copy() {
     const newScheme = ColorScheme.create({
       name: this.name,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6426,6 +6426,9 @@ en:
           save_successful: "User field saved."
         color_palettes:
           palette_name: "Name"
+          copy_to_clipboard: "Copy to Clipboard"
+          copied_to_clipboard: "Copied to Clipboard"
+          copy_to_clipboard_error: "Error copying data to Clipboard"
           duplicate: "Duplicate"
           delete: "Delete"
           color_options:


### PR DESCRIPTION
The current colour palette editor has a ‘Copy to clipboard’ button on it that copies a JSON object of the current palette’s colours. This commit adds the button to the new colour palette UI.