### PR TITLE
UX: Shrink YouTube thumbnail in chat transcript

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-transcript.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-transcript.scss
@@ -63,6 +63,13 @@
     p:last-of-type {
       margin-bottom: 0;
     }
+
+    .lazy-video-container {
+      height: 150px;
+      max-width: calc(150px / 9 * 16);
+      margin: 1em 0 0.5em 0;
+      padding: 0;
+    }
   }
 
   .topic-body .cooked & {


### PR DESCRIPTION
This fixes an issue where the YouTube thumbnail was huge in a chat
transcript, like in this scenario:

* Share a link to a youtube video in channel A
* See it onebox at a reasonable size
* Grab a link to your message
* Share the link to your message in channel B (e.g. a DM to yourself)
* :x: See GIANT youtube image

This commit only fixes the issue visually though -- it does not apply
the LazyYoutube decorations that actually embed the video. We can do
this in a followup commit.

**Before**

![image](https://github.com/user-attachments/assets/b10ec2cd-8d54-4573-aa7b-b50d6789bf96)

**After**

![image](https://github.com/user-attachments/assets/472a4aa4-3e00-4e4e-afd0-2995aeb51f71)
