### PR TITLE
FIX: convert invalid mentions in composer rich text mode to text

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -9,7 +9,7 @@ const INVALID_MENTIONS = new Set();
 const extension = {
   nodeSpec: {
     mention: {
-      attrs: { name: {}, valid: { default: true } },
+      attrs: { name: {} },
       inline: true,
       group: "inline",
       draggable: true,
@@ -21,7 +21,6 @@ const extension = {
           getAttrs: (dom) => {
             return {
               name: dom.getAttribute("data-name"),
-              valid: dom.getAttribute("data-valid"),
             };
           },
         },
@@ -32,7 +31,6 @@ const extension = {
           {
             class: "mention",
             "data-name": node.attrs.name,
-            "data-valid": node.attrs.valid,
           },
           `@${node.attrs.name}`,
         ];

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -108,7 +108,7 @@ const extension = {
             this._processingMentionNodes = true;
 
             view.state.doc.descendants((node, pos) => {
-              if (node.type.name !== "mention" || !node.attrs.valid) {
+              if (node.type.name !== "mention") {
                 return;
               }
 
@@ -130,11 +130,10 @@ const extension = {
                   continue;
                 }
 
+                // insert invalid mentions as text nodes
+                const textNode = view.state.schema.text(`@${name}`);
                 view.dispatch(
-                  view.state.tr.setNodeMarkup(pos, null, {
-                    ...node.attrs,
-                    valid: false,
-                  })
+                  view.state.tr.replaceWith(pos, pos + node.nodeSize, textNode)
                 );
               }
             };

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
@@ -51,7 +51,7 @@ module(
       ],
       "invalid mention": [
         "Hello @invalid, how are you?",
-        '<p>Hello <a class="mention" data-name="invalid" data-valid="false" contenteditable="false" draggable="true">@invalid</a>, how are you?</p>',
+        "<p>Hello @invalid, how are you?</p>",
         "Hello @invalid, how are you?",
       ],
     };

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/mention-test.js
@@ -26,27 +26,27 @@ module(
     const testCases = {
       mention: [
         "@eviltrout",
-        '<p><a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<p><a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "@eviltrout",
       ],
       "text with mention": [
         "Hello @eviltrout",
-        '<p>Hello <a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<p>Hello <a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "Hello @eviltrout",
       ],
       "mention after heading": [
         "## Hello\n\n@eviltrout",
-        '<h2>Hello</h2><p><a class="mention" data-name="eviltrout" data-valid="true" contenteditable="false" draggable="true">@eviltrout</a></p>',
+        '<h2>Hello</h2><p><a class="mention" data-name="eviltrout" contenteditable="false" draggable="true">@eviltrout</a></p>',
         "## Hello\n\n@eviltrout",
       ],
       "group mention": [
         "Maybe @support can help",
-        '<p>Maybe <a class="mention" data-name="support" data-valid="true" contenteditable="false" draggable="true">@support</a> can help</p>',
+        '<p>Maybe <a class="mention" data-name="support" contenteditable="false" draggable="true">@support</a> can help</p>',
         "Maybe @support can help",
       ],
       "group and user mention": [
         "Hey @john, I think @support can help here",
-        '<p>Hey <a class="mention" data-name="john" data-valid="true" contenteditable="false" draggable="true">@john</a>, I think <a class="mention" data-name="support" data-valid="true" contenteditable="false" draggable="true">@support</a> can help here</p>',
+        '<p>Hey <a class="mention" data-name="john" contenteditable="false" draggable="true">@john</a>, I think <a class="mention" data-name="support" contenteditable="false" draggable="true">@support</a> can help here</p>',
         "Hey @john, I think @support can help here",
       ],
       "invalid mention": [

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -901,7 +901,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("Hey @#{user.username} ")
 
-      expect(rich).to have_css("a.mention[data-valid='true']", text: user.username)
+      expect(rich).to have_css("a.mention", text: user.username)
 
       composer.type_content("and @invalid_user - how are you?")
 
@@ -919,7 +919,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.toggle_rich_editor
 
-      expect(rich).to have_css("a.mention[data-valid='true']", text: user.username)
+      expect(rich).to have_css("a.mention", text: user.username)
       expect(rich).to have_no_css("a.mention", text: "@unknown")
     end
 
@@ -928,8 +928,8 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("Hey @testuser_123 and @TESTUSER_123 ")
 
-      expect(rich).to have_css("a.mention[data-valid='true']", text: "testuser_123")
-      expect(rich).to have_css("a.mention[data-valid='true']", text: "TESTUSER_123")
+      expect(rich).to have_css("a.mention", text: "testuser_123")
+      expect(rich).to have_css("a.mention", text: "TESTUSER_123")
 
       composer.type_content("and @InvalidUser ")
 
@@ -941,8 +941,8 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("Hey @testgroup_abc and @TESTGROUP_ABC ")
 
-      expect(rich).to have_css("a.mention[data-valid='true']", text: "testgroup_abc")
-      expect(rich).to have_css("a.mention[data-valid='true']", text: "TESTGROUP_ABC")
+      expect(rich).to have_css("a.mention", text: "testgroup_abc")
+      expect(rich).to have_css("a.mention", text: "TESTGROUP_ABC")
 
       composer.type_content("and @InvalidGroup ")
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -905,7 +905,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("and @invalid_user - how are you?")
 
-      expect(rich).to have_css("a.mention[data-valid='false']", text: "@invalid_user")
+      expect(rich).to have_no_css("a.mention", text: "@invalid_user")
 
       composer.toggle_rich_editor
 
@@ -920,7 +920,7 @@ describe "Composer - ProseMirror editor", type: :system do
       composer.toggle_rich_editor
 
       expect(rich).to have_css("a.mention[data-valid='true']", text: user.username)
-      expect(rich).to have_css("a.mention[data-valid='false']", text: "@unknown")
+      expect(rich).to have_no_css("a.mention", text: "@unknown")
     end
 
     it "validates mentions case-insensitively" do
@@ -933,7 +933,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("and @InvalidUser ")
 
-      expect(rich).to have_css("a.mention[data-valid='false']", text: "@InvalidUser")
+      expect(rich).to have_no_css("a.mention", text: "@InvalidUser")
     end
 
     it "validates group mentions case-insensitively" do
@@ -946,7 +946,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       composer.type_content("and @InvalidGroup ")
 
-      expect(rich).to have_css("a.mention[data-valid='false']", text: "@InvalidGroup")
+      expect(rich).to have_no_css("a.mention", text: "@InvalidGroup")
     end
   end
 


### PR DESCRIPTION
This change makes it easier to edit typos when adding mentions to composer's rich text mode. Previously we would keep invalid mentions as mention nodes and use a data attribute to identify if they were valid or not and style them based on that. This would mean that pressing backspace would delete the entire mention and you would have to type again from scratch.

The updated approach is to replace the invalid mention node with text and in turn removes the need to use the data attribute to identify valid/invalid mentions.

Internal ref: /t/-/149988/37