### PR TITLE
FIX: ensures we have a cooked to work with

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -245,6 +245,10 @@ export default class PostTextSelection extends Component {
       ".cooked"
     );
 
+    if (!cooked) {
+      return;
+    }
+
     if (cooked.closest(".small-action")) {
       return;
     }


### PR DESCRIPTION
At this point cooked could be null and checking if it's inside a small action is useless and would generate an error which wouldn't break anything but is something we want to avoid.