### PR TITLE
FIX: Run post-adopt decorators correctly in glimmer post-stream

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
@@ -134,7 +134,7 @@ export default class PostCookedHtml extends Component {
 
   @bind
   decorateAfterAdopt(element, helper) {
-    if (this.isStreamElement) {
+    if (!this.isStreamElement) {
       return;
     }
 


### PR DESCRIPTION
This will fix the `lib/lazy-load-images` decorator, which sets the background color of images while they're loading