### PR TITLE
FIX: convert invalid hashtags in composer to text

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/hashtag.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/hashtag.js
@@ -13,7 +13,6 @@ const extension = {
       attrs: {
         name: {},
         processed: { default: false },
-        valid: { default: true },
       },
       inline: true,
       group: "inline",
@@ -27,7 +26,6 @@ const extension = {
             return {
               name: dom.getAttribute("data-name"),
               processed: dom.getAttribute("data-processed"),
-              valid: dom.getAttribute("data-valid"),
             };
           },
         },
@@ -39,7 +37,6 @@ const extension = {
             class: "hashtag-cooked",
             "data-name": node.attrs.name,
             "data-processed": node.attrs.processed,
-            "data-valid": node.attrs.valid,
           },
           `#${node.attrs.name}`,
         ];
@@ -116,11 +113,7 @@ const extension = {
             const hashtagNodes = [];
 
             view.state.doc.descendants((node, pos) => {
-              if (
-                node.type.name !== "hashtag" ||
-                node.attrs.processed ||
-                !node.attrs.valid
-              ) {
+              if (node.type.name !== "hashtag" || node.attrs.processed) {
                 return;
               }
 
@@ -148,13 +141,23 @@ const extension = {
                   continue;
                 }
 
-                view.dispatch(
-                  view.state.tr.setNodeMarkup(pos, null, {
+                let change;
+                if (validHashtag) {
+                  // mark node as processed so we can skip in future
+                  change = view.state.tr.setNodeMarkup(pos, null, {
                     ...node.attrs,
                     processed: true,
-                    valid: !!validHashtag,
-                  })
-                );
+                  });
+                } else {
+                  // replace invalid hashtags with plain text
+                  change = view.state.tr.replaceWith(
+                    pos,
+                    pos + node.nodeSize,
+                    view.state.schema.text(`#${name}`)
+                  );
+                }
+
+                view.dispatch(change);
 
                 const domNode = view.nodeDOM(pos);
                 if (!validHashtag || !domNode) {

--- a/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
@@ -55,42 +55,42 @@ module(
     const testCases = {
       hashtag: [
         "#product",
-        '<p><a class="hashtag-cooked" data-name="product" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
+        '<p><a class="hashtag-cooked" data-name="product" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
         "#product",
       ],
       "text with hashtag": [
         "Hello #product",
-        '<p>Hello <a class="hashtag-cooked" data-name="product" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
+        '<p>Hello <a class="hashtag-cooked" data-name="product" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
         "Hello #product",
       ],
       "hashtag after heading": [
         "## Hello\n\n#product",
-        '<h2>Hello</h2><p><a class="hashtag-cooked" data-name="product" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
+        '<h2>Hello</h2><p><a class="hashtag-cooked" data-name="product" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-2\"></span>product</a></p>',
         "## Hello\n\n#product",
       ],
       "invalid hashtag": [
         "Hello #invalid, how are you?",
-        '<p>Hello <a class="hashtag-cooked" data-name="invalid" data-processed="true" data-valid="false" contenteditable="false" draggable="true">#invalid</a>, how are you?</p>',
+        "<p>Hello #invalid, how are you?</p>",
         "Hello #invalid, how are you?",
       ],
       "with regular tags": [
         "Hello #dev",
-        '<p>Hello <a class="hashtag-cooked" data-name="dev" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><svg class=\"fa d-icon d-icon-tag svg-icon hashtag-color--tag-1 svg-string\" aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\"><use href=\"#tag\"></use></svg>dev</a></p>',
+        '<p>Hello <a class="hashtag-cooked" data-name="dev" data-processed="true" contenteditable="false" draggable="true"><svg class=\"fa d-icon d-icon-tag svg-icon hashtag-color--tag-1 svg-string\" aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\"><use href=\"#tag\"></use></svg>dev</a></p>',
         "Hello #dev",
       ],
       "hashtag with emoji": [
         "Time for #coffee",
-        '<p>Time for <a class="hashtag-cooked" data-name="coffee" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-emoji hashtag-color--category-3\"><img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/coffee.png?v=14\" title=\"coffee\" alt=\"coffee\" class=\"emoji\"></span>coffee</a></p>',
+        '<p>Time for <a class="hashtag-cooked" data-name="coffee" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-emoji hashtag-color--category-3\"><img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/coffee.png?v=14\" title=\"coffee\" alt=\"coffee\" class=\"emoji\"></span>coffee</a></p>',
         "Time for #coffee",
       ],
       "hashtag with icon": [
         "Lets #discuss",
-        '<p>Lets <a class="hashtag-cooked" data-name="discuss" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-icon hashtag-color--category-4\"><svg class=\"fa d-icon d-icon-comment svg-icon svg-string\" aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\"><use href=\"#comment\"></use></svg></span>discuss</a></p>',
+        '<p>Lets <a class="hashtag-cooked" data-name="discuss" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-icon hashtag-color--category-4\"><svg class=\"fa d-icon d-icon-comment svg-icon svg-string\" aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\"><use href=\"#comment\"></use></svg></span>discuss</a></p>',
         "Lets #discuss",
       ],
       "hashtag with emoji in text": [
         "#welcome",
-        '<p><a class="hashtag-cooked" data-name="welcome" data-processed="true" data-valid="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-5\"></span>hello <img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/wave.png?v=14\" title=\"wave\" alt=\"wave\" class=\"emoji\"></a></p>',
+        '<p><a class="hashtag-cooked" data-name="welcome" data-processed="true" contenteditable="false" draggable="true"><span class=\"hashtag-category-square hashtag-color--category-5\"></span>hello <img width=\"20\" height=\"20\" src=\"/images/emoji/twitter/wave.png?v=14\" title=\"wave\" alt=\"wave\" class=\"emoji\"></a></p>',
         "#welcome",
       ],
     };


### PR DESCRIPTION
This change makes it easier to edit typos when adding hashtags to composer's rich text mode. Previously we would keep invalid hashtags as hashtag nodes and use a data attribute to identify if they were valid or not and style them based on that. This would mean that pressing backspace would delete the entire hashtag and you would have to type again from scratch.

The updated approach is to replace the invalid hashtag node with text and in turn removes the need to use the data attribute to identify valid/invalid hashtags.

Internal ref: /t/-/149988/37