### PR TITLE
UX: fix title status icon size

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -536,15 +536,15 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--space-4);
+  width: 1em;
   background-color: var(--secondary);
   border-radius: 50%;
-  height: var(--space-4);
+  height: 1em;
   box-shadow: 0 0 0 2px var(--secondary);
 
   .d-icon.d-icon-discourse-dnd {
     color: var(--header_primary-medium) !important;
-    font-size: var(--space-4);
+    font-size: 1em;
     height: 1em;
     width: 1em;
   }
@@ -917,8 +917,8 @@ form {
     margin-right: 0.2em;
 
     .d-icon {
-      height: 0.75rem;
-      width: 0.75rem;
+      height: 0.75em;
+      width: 0.75em;
     }
   }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -917,8 +917,8 @@ form {
     margin-right: 0.2em;
 
     .d-icon {
-      height: 0.75em;
-      width: 0.75em;
+      height: 0.74em;
+      width: 0.74em;
     }
   }
 


### PR DESCRIPTION
follow-up to https://github.com/discourse/discourse/commit/e4be2df16a86c29837ee082f0fb0e09ef0edc6a1

The switch to rem made these based on the document font size, but they should scale with the title font size 


Before:
![image](https://github.com/user-attachments/assets/0bc70cb4-1073-427e-b1e1-1021db0e4fc9)


After:
![image](https://github.com/user-attachments/assets/9daf8a12-a733-4a4a-bda4-98d1910c9915)
