### PR TITLE
DEV: adds support for startsWith/endsWith validation

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validation-parser.js
@@ -37,6 +37,14 @@ export default class ValidationParser {
     };
   }
 
+  startsWithRule(prefix) {
+    return { prefix };
+  }
+
+  endsWithRule(suffix) {
+    return { suffix };
+  }
+
   betweenRule(args) {
     if (!args) {
       throw new Error("`between` rule expects min/max, eg: between:1,10");

--- a/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
+++ b/app/assets/javascripts/discourse/app/form-kit/lib/validator.js
@@ -145,4 +145,52 @@ export default class Validator {
       return i18n("form_kit.errors.required");
     }
   }
+
+  startsWithValidator(value, rule, type) {
+    let error = false;
+
+    if (isBlank(value)) {
+      return;
+    }
+
+    switch (type) {
+      case "input":
+      case "input-text":
+      case "text":
+        if (!value.startsWith(rule.prefix)) {
+          error = true;
+        }
+        break;
+    }
+
+    if (error) {
+      return i18n("form_kit.errors.starts_with", {
+        prefix: rule.prefix,
+      });
+    }
+  }
+
+  endsWithValidator(value, rule, type) {
+    let error = false;
+
+    if (isBlank(value)) {
+      return;
+    }
+
+    switch (type) {
+      case "input":
+      case "input-text":
+      case "text":
+        if (!value.endsWith(rule.suffix)) {
+          error = true;
+        }
+        break;
+    }
+
+    if (error) {
+      return i18n("form_kit.errors.ends_with", {
+        suffix: rule.suffix,
+      });
+    }
+  }
 }

--- a/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validation-parser-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validation-parser-test.js
@@ -18,6 +18,18 @@ module("Unit | Lib | FormKit | ValidationParser", function (hooks) {
     assert.deepEqual(rules.required, { trim: false });
   });
 
+  test("startsWith", function (assert) {
+    const rules = ValidationParser.parse("startsWith:@");
+
+    assert.deepEqual(rules.startsWith, { prefix: "@" });
+  });
+
+  test("endsWith", function (assert) {
+    const rules = ValidationParser.parse("endsWith:.com");
+
+    assert.deepEqual(rules.endsWith, { suffix: ".com" });
+  });
+
   test("url", function (assert) {
     const rules = ValidationParser.parse("url");
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
@@ -206,6 +206,98 @@ module("Unit | Lib | FormKit | Validator", function (hooks) {
     );
   });
 
+  ["input", "input-text", "text"].forEach(async (type) => {
+    test(`${type} - startsWith`, async function (assert) {
+      let errors = await new Validator("xxx", {
+        startsWith: { prefix: "@" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [i18n("form_kit.errors.starts_with", { prefix: "@" })],
+        "it returns an error when the value does not start with the prefix"
+      );
+
+      errors = await new Validator("@gmail.com", {
+        startsWith: { prefix: "@" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [],
+        "it returns no error when the value starts with the prefix"
+      );
+
+      errors = await new Validator("", {
+        startsWith: { prefix: "@" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [],
+        "it returns no error when the value is blank"
+      );
+    });
+  });
+
+  ["input", "input-text", "text"].forEach(async (type) => {
+    test(`${type} - endsWith`, async function (assert) {
+      let errors = await new Validator("xxx", {
+        endsWith: { suffix: "@" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [i18n("form_kit.errors.ends_with", { suffix: "@" })],
+        "it returns an error when the value does not end with the suffix"
+      );
+
+      errors = await new Validator("@gmail.com", {
+        endsWith: { suffix: ".com" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [],
+        "it returns no error when the value ends with the suffix"
+      );
+
+      errors = await new Validator("", {
+        endsWith: { suffix: ".com" },
+      }).validate(type);
+
+      assert.deepEqual(
+        errors,
+        [],
+        "it returns no error when the value is blank"
+      );
+    });
+  });
+
+  test(`unsupported type - endsWith`, async function (assert) {
+    let errors = await new Validator("xxx", {
+      endsWith: { suffix: "@" },
+    }).validate("icon");
+
+    assert.deepEqual(
+      errors,
+      [],
+      "it returns no error when the type is unsupported"
+    );
+  });
+
+  test(`unsupported type - startsWith`, async function (assert) {
+    let errors = await new Validator("xxx", {
+      startsWith: { prefix: "@" },
+    }).validate("icon");
+
+    assert.deepEqual(
+      errors,
+      [],
+      "it returns no error when the type is unsupported"
+    );
+  });
+
   test("required", async function (assert) {
     let errors = await new Validator(" ", {
       required: { trim: true },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2266,6 +2266,8 @@ en:
       errors_summary_title: "This form contains errors:"
       dirty_form: "You didn't submit your changes! Are you sure you want to leave?"
       errors:
+        starts_with: "Must start with %{prefix}"
+        ends_with: "Must end with %{suffix}"
         required: "Required"
         date_before_or_equal: "Must be before or equal to %{date}"
         date_after_or_equal: "Must be after or equal to %{date}"


### PR DESCRIPTION
Usage:

```gjs
<form.Field
  @title="Name
  @name="name"
  @validation="startsWith:foo|endsWith:bar"
  as |field|>
    <field.Input />
</form.Field>
```