### PR TITLE
A11Y: make in-reply-to keyboard accessible

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/reply-to-tab.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/reply-to-tab.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
 import avatar from "discourse/helpers/avatar";
 import icon from "discourse/helpers/d-icon";
@@ -19,8 +20,15 @@ export default class PostMetaDataReplyToTab extends Component {
 
   @service site;
 
+  @action
+  handleClick(event) {
+    event.preventDefault();
+    this.args.toggleReplyAbove();
+  }
+
   <template>
     <a
+      href
       class="reply-to-tab"
       disabled={{@repliesAbove.isPending}}
       role={{if this.site.desktopView "button"}}
@@ -29,9 +37,8 @@ export default class PostMetaDataReplyToTab extends Component {
         (concat "embedded-posts__top--" @post.post_number)
       }}
       aria-expanded={{if this.site.desktopView @hasRepliesAbove}}
-      tabindex="0"
       title="post.in_reply_to"
-      {{on "click" @toggleReplyAbove}}
+      {{on "click" this.handleClick}}
     >
       {{#if @repliesAbove.isPending}}
         <div class="spinner small"></div>

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -170,7 +170,7 @@ createWidget("reply-to-tab", {
 
   buildAttributes(attrs) {
     let result = {
-      tabindex: "0",
+      href: "",
     };
 
     if (!attrs.mobileView) {
@@ -201,7 +201,8 @@ createWidget("reply-to-tab", {
     ];
   },
 
-  click() {
+  click(event) {
+    event.preventDefault();
     this.state.loading = true;
     this.sendWidgetAction("toggleReplyAbove").then(
       () => (this.state.loading = false)


### PR DESCRIPTION
Adding an empty href to this link makes it keyboard accessible. You can now trigger it with the enter key. This also allows us to remove the tabindex. 

![image](https://github.com/user-attachments/assets/357f7a6e-05fd-46dc-9da7-56520e9ca8f0)


`event.preventDefault();` is neccessary because otherwise `href=""` was resulting in a page refresh, and another work around like `href="#"` was adding an entry to the browser history