### PR TITLE
FIX: Make hide_new_user_profiles work with manually upgraded users

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -137,7 +137,8 @@ module UserGuardian
 
     if SiteSetting.hide_new_user_profiles && !SiteSetting.invite_only &&
          !SiteSetting.must_approve_users
-      if user.user_stat.blank? || user.user_stat.post_count == 0
+      if (user.user_stat.blank? || user.user_stat.post_count == 0) &&
+           !user.has_trust_level?(TrustLevel[2])
         return false if anonymous? || !@user.has_trust_level?(TrustLevel[2])
       end
 

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -156,6 +156,8 @@ RSpec.describe UserGuardian do
     fab!(:tl0_user) { Fabricate(:user, trust_level: 0) }
     fab!(:tl1_user) { Fabricate(:user, trust_level: 1) }
     fab!(:tl2_user) { Fabricate(:user, trust_level: 2) }
+    # Admins can manually upgrade users without them meeting the criteria.
+    fab!(:vip_tl2_user) { Fabricate(:user, trust_level: 2) }
 
     before { tl2_user.user_stat.update!(post_count: 1) }
 
@@ -166,6 +168,13 @@ RSpec.describe UserGuardian do
         it "allows anonymous to see any profile" do
           SiteSetting.hide_new_user_profiles = false
           expect(Guardian.new.can_see_profile?(user)).to eq(true)
+        end
+      end
+
+      context "when hide_new_user_profiles is enabled" do
+        it "allows anonymous to see a no-posts (manually upgraded) TL2 user's profile" do
+          SiteSetting.hide_new_user_profiles = true
+          expect(Guardian.new.can_see_profile?(vip_tl2_user)).to eq(true)
         end
       end
 


### PR DESCRIPTION
### What is the problem?

The site setting `hide_new_user_profiles` states:

> Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time.

This implies that TL2 and above should be visible.

However, the actual logic encodes the assumption that TL2 have posted at some point. This fails to account for the fact that admins can manually upgrade a user without posts to a higher TL. This PR covers for that scenario.