### PR TITLE
DEV: Add `CurrentUserSerializer#use_reviewable_ui_refresh` attribute

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/review-show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/review-show.gjs
@@ -26,41 +26,15 @@ export default RouteTemplate(
     }
 
     /**
-     * Determines if the current user can use the refreshed reviewable UI.
-     *
-     * @returns {boolean} True if the current user can access the refreshed UI, false otherwise
-     */
-    get canUseRefreshUI() {
-      if (!this.currentUser) {
-        return false;
-      }
-
-      const allowedGroupIds =
-        this.args.controller.siteSettings.reviewable_ui_refresh;
-      if (!allowedGroupIds) {
-        return false;
-      }
-
-      // Convert comma-separated string to array of numbers
-      const groupIds = allowedGroupIds
-        .toString()
-        .split(",")
-        .map((id) => parseInt(id.trim(), 10))
-        .filter((id) => !isNaN(id));
-
-      // Check if current user is in any of the specified groups
-      return this.currentUser.groups.some((userGroup) =>
-        groupIds.includes(userGroup.id)
-      );
-    }
-
-    /**
      * Determines whether to use the refreshed reviewable UI component.
      *
      * @returns {boolean} True if both conditions are met: user has permission and component exists
      */
     get shouldUseRefreshUI() {
-      return this.canUseRefreshUI && this.refreshedReviewableComponentExists;
+      return (
+        this.currentUser.use_reviewable_ui_refresh &&
+        this.refreshedReviewableComponentExists
+      );
     }
 
     <template>

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -78,7 +78,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_see_emails,
              :use_glimmer_post_stream_mode_auto_mode,
              :can_localize_content?,
-             :effective_locale
+             :effective_locale,
+             :use_reviewable_ui_refresh
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -341,5 +342,13 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def include_effective_locale?
     SiteSetting.content_localization_enabled
+  end
+
+  def use_reviewable_ui_refresh
+    scope.can_see_reviewable_ui_refresh?
+  end
+
+  def include_use_reviewable_ui_refresh?
+    scope.can_see_review_queue?
   end
 end

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -331,4 +331,22 @@ describe "Reviewables", type: :system do
       expect(review_page).to have_no_information_about_unknown_reviewables_visible
     end
   end
+
+  describe "when user is part of the groups list of the `reviewable_ui_refresh` site setting" do
+    fab!(:reviewable_flagged_post)
+    fab!(:group)
+
+    before do
+      SiteSetting.reviewable_ui_refresh = group.name
+      group.add(admin)
+    end
+
+    it "shows the new reviewable UI" do
+      sign_in(admin)
+
+      visit "/review/#{reviewable_flagged_post.id}"
+
+      expect(page).to have_selector(".review-container")
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a `use_reviewable_ui_refresh` attribute to the
`CurrentUserSerializer` and updates the client side to use this
attribute as a feature flag to determine when the new reviewable UI
should be shown.
