### PR TITLE
DEV: Update colors for flag reasons in new reviewable UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/flag-reason.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/flag-reason.gjs
@@ -1,12 +1,27 @@
+import Component from "@glimmer/component";
 import { gt } from "truth-helpers";
 
-<template>
-  <span class="review-item__flag-reason --{{@score.type}}">
-    {{#if (gt @score.count 0)}}
-      <span class="review-item__flag-count --{{@score.type}}">
-        {{@score.count}}
-      </span>
-    {{/if}}
-    {{@score.title}}
-  </span>
-</template>
+const SCORE_TYPE_TO_CSS_CLASS_MAP = {
+  illegal: "illegal",
+  inappropriate: "inappropriate",
+  needs_approval: "needs-approval",
+  off_topic: "off-topic",
+  spam: "spam",
+};
+
+export default class ReviewableFlagReason extends Component {
+  get scoreCSSClass() {
+    return SCORE_TYPE_TO_CSS_CLASS_MAP[this.args.type] || "other";
+  }
+
+  <template>
+    <span class="review-item__flag-reason --{{this.scoreCSSClass}}">
+      {{#if (gt @count 0)}}
+        <span class="review-item__flag-count --{{this.scoreCSSClass}}">
+          {{@count}}
+        </span>
+      {{/if}}
+      {{@title}}
+    </span>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/item.gjs
@@ -593,7 +593,11 @@ export default class ReviewableItem extends Component {
 
                 <div class="review-item__flag-badges">
                   {{#each this.scoreSummary as |score|}}
-                    <ReviewableFlagReason @score={{score}} />
+                    <ReviewableFlagReason
+                      @type={{score.type}}
+                      @count={{score.count}}
+                      @title={{score.title}}
+                    />
                   {{/each}}
                 </div>
               </div>

--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -3,14 +3,14 @@
   --d-review-reason-spam-text: #b91c1c;
   --d-review-reason-spam-count-bg: #b91c1c;
   --d-review-reason-spam-count-text: #fee2e2;
-  --d-review-reason-offtopic-bg: #dbeafe;
-  --d-review-reason-offtopic-text: #1d4ed8;
-  --d-review-reason-offtopic-count-bg: #1d4ed8;
-  --d-review-reason-offtopic-count-text: #dbeafe;
-  --d-review-reason-illegal-bg: #d1fae5;
-  --d-review-reason-illegal-text: #065f46;
-  --d-review-reason-illegal-count-bg: #065f46;
-  --d-review-reason-illegal-count-text: #d1fae5;
+  --d-review-reason-off-topic-bg: #fff7dc;
+  --d-review-reason-off-topic-text: #5e450c;
+  --d-review-reason-off-topic-count-bg: #5e450c;
+  --d-review-reason-off-topic-count-text: #fff7dc;
+  --d-review-reason-illegal-bg: #fff5f5;
+  --d-review-reason-illegal-text: #4b0000;
+  --d-review-reason-illegal-count-bg: #4b0000;
+  --d-review-reason-illegal-count-text: #fff5f5;
   --d-review-reason-inappropriate-bg: #ffedd5;
   --d-review-reason-inappropriate-text: #c2410c;
   --d-review-reason-inappropriate-count-bg: #c2410c;
@@ -175,9 +175,9 @@
     color: var(--d-review-reason-spam-text);
   }
 
-  &.--offtopic {
-    background-color: var(--d-review-reason-offtopic-bg);
-    color: var(--d-review-reason-offtopic-text);
+  &.--off-topic {
+    background-color: var(--d-review-reason-off-topic-bg);
+    color: var(--d-review-reason-off-topic-text);
   }
 
   &.--illegal {
@@ -216,9 +216,9 @@
     color: var(--d-review-reason-spam-count-text);
   }
 
-  &.--offtopic {
-    background-color: var(--d-review-reason-offtopic-count-bg);
-    color: var(--d-review-reason-offtopic-count-text);
+  &.--off-topic {
+    background-color: var(--d-review-reason-off-topic-count-bg);
+    color: var(--d-review-reason-off-topic-count-text);
   }
 
   &.--illegal {

--- a/spec/system/page_objects/components/review/flag_reason.rb
+++ b/spec/system/page_objects/components/review/flag_reason.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    module Review
+      class FlagReason < PageObjects::Components::Base
+        def has_spam_flag_reason?(reviewable, count: 1)
+          has_flag_reason?(reviewable, css_class: "spam", type: :spam, count:)
+        end
+
+        def has_off_topic_flag_reason?(reviewable, count: 1)
+          has_flag_reason?(reviewable, css_class: "off-topic", type: :off_topic, count:)
+        end
+
+        def has_illegal_flag_reason?(reviewable, count: 1)
+          has_flag_reason?(reviewable, css_class: "illegal", type: :illegal, count:)
+        end
+
+        def has_inappropriate_flag_reason?(reviewable, count: 1)
+          has_flag_reason?(reviewable, css_class: "inappropriate", type: :inappropriate, count:)
+        end
+
+        def has_needs_approval_flag_reason?(reviewable, count: 1)
+          has_flag_reason?(reviewable, css_class: "needs-approval", type: :needs_approval, count:)
+        end
+
+        private
+
+        def has_flag_reason?(reviewable, css_class:, type:, count: 1)
+          within_reviewable_item(reviewable) do
+            expect(find(".review-item__flag-reason.--#{css_class}").text.gsub(/\s+/, " ")).to eq(
+              "#{count} #{ReviewableScore.type_title(type)}",
+            )
+
+            expect(page).to have_css(".review-item__flag-count.--#{css_class}")
+          end
+        end
+
+        def within_reviewable_item(reviewable)
+          within(".review-item[data-reviewable-id='#{reviewable.id}']") { yield }
+        end
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -146,6 +146,10 @@ module PageObjects
         find(".reviewable-claimed-topic .unclaim").click
       end
 
+      def flag_reason_component
+        PageObjects::Components::Review::FlagReason.new
+      end
+
       private
 
       def reviewable_action_dropdown

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -331,22 +331,4 @@ describe "Reviewables", type: :system do
       expect(review_page).to have_no_information_about_unknown_reviewables_visible
     end
   end
-
-  describe "when user is part of the groups list of the `reviewable_ui_refresh` site setting" do
-    fab!(:reviewable_flagged_post)
-    fab!(:group)
-
-    before do
-      SiteSetting.reviewable_ui_refresh = group.name
-      group.add(admin)
-    end
-
-    it "shows the new reviewable UI" do
-      sign_in(admin)
-
-      visit "/review/#{reviewable_flagged_post.id}"
-
-      expect(page).to have_selector(".review-container")
-    end
-  end
 end

--- a/spec/system/viewing_reviewable_spec.rb
+++ b/spec/system/viewing_reviewable_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe "Viewing reviewable item", type: :system do
+  fab!(:admin)
+  fab!(:group)
+  fab!(:reviewable_flagged_post)
+
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  describe "when user is part of the groups list of the `reviewable_ui_refresh` site setting" do
+    before do
+      SiteSetting.reviewable_ui_refresh = group.name
+      group.add(admin)
+      sign_in(admin)
+    end
+
+    it "shows the new reviewable UI" do
+      review_page.visit_reviewable(reviewable_flagged_post)
+
+      expect(page).to have_selector(".review-container")
+    end
+
+    it "shows the reviewable item with badges stating the flag reason and count" do
+      _spam_reviewable_score =
+        Fabricate(
+          :reviewable_score,
+          reviewable: reviewable_flagged_post,
+          reviewable_score_type: ReviewableScore.types[:spam],
+        )
+
+      _off_topic_reviewable_score =
+        Fabricate(
+          :reviewable_score,
+          reviewable: reviewable_flagged_post,
+          reviewable_score_type: ReviewableScore.types[:off_topic],
+        )
+
+      _illegal_reviewable_score =
+        Fabricate(
+          :reviewable_score,
+          reviewable: reviewable_flagged_post,
+          reviewable_score_type: ReviewableScore.types[:illegal],
+        )
+
+      _inappropriate_reviewable_score =
+        Fabricate(
+          :reviewable_score,
+          reviewable: reviewable_flagged_post,
+          reviewable_score_type: ReviewableScore.types[:inappropriate],
+        )
+
+      _needs_approval_reviewable_score =
+        Fabricate(
+          :reviewable_score,
+          reviewable: reviewable_flagged_post,
+          reviewable_score_type: ReviewableScore.types[:needs_approval],
+        )
+
+      flag_reason_component =
+        review_page.visit_reviewable(reviewable_flagged_post).flag_reason_component
+
+      expect(flag_reason_component).to have_spam_flag_reason(reviewable_flagged_post, count: 1)
+      expect(flag_reason_component).to have_off_topic_flag_reason(reviewable_flagged_post, count: 1)
+      expect(flag_reason_component).to have_illegal_flag_reason(reviewable_flagged_post, count: 1)
+
+      expect(flag_reason_component).to have_inappropriate_flag_reason(
+        reviewable_flagged_post,
+        count: 2,
+      )
+
+      expect(flag_reason_component).to have_needs_approval_flag_reason(
+        reviewable_flagged_post,
+        count: 1,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Prior to this change, off topic and something else flags did not have
the right CSS classes set resulting in the right colors not being set
for the badges used to display the flag reasons.

This commit also updates the colors used for the off topic and illegal
flags to reflect the severity. Before this change, the badge color for
illegal was green while the badge color for off topic is blue. Those
colors are too "positive".

### Screenshots

#### Before

<img width="718" alt="Screenshot 2025-07-03 at 3 22 49 PM" src="https://github.com/user-attachments/assets/cc10d078-fe58-41aa-8c15-4bba86eb90e5" />

#### After

<img width="715" alt="Screenshot 2025-07-03 at 3 23 02 PM" src="https://github.com/user-attachments/assets/e039e042-68ae-4e76-bd5a-62116ef020a3" />
