### PR TITLE
FIX: resets quote state when reseting text selection

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -201,6 +201,7 @@ export default class PostTextSelection extends Component {
 
   @bind
   async hideToolbar() {
+    this.args.quoteState.clear();
     await this.menuInstance?.close();
     await this.menuInstance?.destroy();
   }

--- a/spec/system/post_selection_copy_quote_spec.rb
+++ b/spec/system/post_selection_copy_quote_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Post selection | Copy quote", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer) { PageObjects::Components::Composer.new }
   let(:cdp) { PageObjects::CDP.new }
 
   fab!(:topic)
@@ -31,6 +32,18 @@ describe "Post selection | Copy quote", type: :system do
 
       select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
       expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+    end
+
+    it "resets the quote state when the toolbar is hidden" do
+      topic_page.visit_topic(topic)
+      select_text_range("#{topic_page.post_by_number_selector(1)} .cooked p", 0, 10)
+
+      expect(page).to have_css(topic_page.copy_quote_button_selector)
+
+      select_text_range(".topic-map__stat-label", 0, 1) # select non cooked content
+      topic_page.click_reply_button
+
+      expect(composer).to have_value("")
     end
   end
 


### PR DESCRIPTION
In the follow cases:
- no text selection
- invalid text selection (outside of the cooked of a post)

The quote state should be cleared. This commit also adds a spec to prevent similar regressions.