### PR TITLE
DEV: Improve layout of flagged post in new reviewable UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/post.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/post.gjs
@@ -1,51 +1,13 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
-import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ReviewablePostEdits from "discourse/components/reviewable-post-edits";
 import ReviewableCreatedBy from "discourse/components/reviewable-refresh/created-by";
 import ReviewableTopicLink from "discourse/components/reviewable-refresh/topic-link";
 import lazyHash from "discourse/helpers/lazy-hash";
-import { bind } from "discourse/lib/decorators";
 import highlightWatchedWords from "discourse/lib/highlight-watched-words";
 import { i18n } from "discourse-i18n";
 
 export default class ReviewablePost extends Component {
-  @tracked isCollapsed = false;
-  @tracked isLongPost = false;
-  maxPostHeight = 300;
-
-  @action
-  toggleContent() {
-    this.isCollapsed = !this.isCollapsed;
-  }
-
-  @bind
-  calculatePostBodySize(element) {
-    if (element?.offsetHeight > this.maxPostHeight) {
-      this.isCollapsed = true;
-      this.isLongPost = true;
-    } else {
-      this.isCollapsed = false;
-      this.isLongPost = false;
-    }
-  }
-
-  get collapseButtonProps() {
-    if (this.isCollapsed) {
-      return {
-        label: "review.show_more",
-        icon: "chevron-down",
-      };
-    }
-    return {
-      label: "review.show_less",
-      icon: "chevron-up",
-    };
-  }
-
   get metaLabel() {
     return this.args.metaLabel || i18n("review.posted_in");
   }
@@ -75,36 +37,24 @@ export default class ReviewablePost extends Component {
     </div>
 
     <div class="review-item__post">
-      <div class="review-item__post-content">
-        <div
-          class="post-body{{if this.isCollapsed ' is-collapsed'}}"
-          {{didInsert this.calculatePostBodySize @reviewable}}
-        >
+      <div class="review-item__post-content-wrapper">
+        <div class="review-item__post-content">
           {{#if @reviewable.blank_post}}
             <p>{{i18n "review.deleted_post"}}</p>
           {{else}}
             {{highlightWatchedWords @reviewable.cooked @reviewable}}
           {{/if}}
+
+          <span>
+            <PluginOutlet
+              @name={{this.pluginOutletName}}
+              @connectorTagName="div"
+              @outletArgs={{lazyHash model=@reviewable}}
+            />
+          </span>
+
+          {{yield}}
         </div>
-
-        {{#if this.isLongPost}}
-          <DButton
-            @action={{this.toggleContent}}
-            @label={{this.collapseButtonProps.label}}
-            @icon={{this.collapseButtonProps.icon}}
-            class="btn-default btn-icon post-body__toggle-btn"
-          />
-        {{/if}}
-
-        <span>
-          <PluginOutlet
-            @name={{this.pluginOutletName}}
-            @connectorTagName="div"
-            @outletArgs={{lazyHash model=@reviewable}}
-          />
-        </span>
-
-        {{yield}}
       </div>
     </div>
   </template>

--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -97,7 +97,9 @@
 
   &__meta-content {
     display: grid;
-    grid-template-columns: auto auto;
+    grid-template-columns: auto 1fr;
+    row-gap: var(--space-4);
+    column-gap: var(--space-4);
     padding: var(--space-4);
 
     .badge-category__wrapper {
@@ -120,12 +122,39 @@
   }
 
   &__post {
+    display: flex;
     padding: var(--space-4);
 
+    &-content-wrapper {
+      padding-top: var(--space-4);
+      border-top: 4px solid var(--primary-low);
+    }
+
     &-content {
-      max-height: 200px;
-      overflow: hidden;
-      position: relative;
+      max-height: 300px;
+      overflow: auto;
+      scrollbar-color: var(--primary-low) transparent;
+      transition: scrollbar-color 0.25s ease-in-out;
+      transition-delay: 0.5s;
+
+      --scrollbarWidth: 0.5em;
+
+      &::-webkit-scrollbar {
+        width: var(--scrollbarWidth);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: transparent;
+        border-radius: calc(var(--scrollbarWidth) / 2);
+      }
+
+      &::-webkit-scrollbar-track {
+        background-color: transparent;
+      }
+
+      p:first-of-type {
+        margin-top: 0;
+      }
     }
   }
 


### PR DESCRIPTION
This commit makes a UX pass at the layout when displaying a reviewable
of `ReviewableFlaggedPost` type.

### Screenshots/Recordings

#### Before

<img width="773" alt="Screenshot 2025-07-03 at 4 21 09 PM" src="https://github.com/user-attachments/assets/3a7cb59b-a582-4ed4-a8d3-0e72fe438e2f" />

#### After

![Kapture 2025-07-03 at 16 20 00](https://github.com/user-attachments/assets/fe3c0f99-c84f-4349-b0bd-21bc7b547f2f)
