### PR TITLE
FIX: clear selection on expand popup menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -866,6 +866,8 @@ export default class ComposerEditor extends Component {
     const selected = toolbarEvent.selected;
     toolbarEvent.selectText(selected.start, selected.end - selected.start);
     this.composer.storeToolbarState(toolbarEvent);
+
+    window.getSelection().removeAllRanges();
   }
 
   showPreview() {


### PR DESCRIPTION
Having a text selection can cause issues on iOS where the caret will show over any other element. The state is already stored in the toolbar state so we don't need to keep it actually selected.

No test as it's a very specific behavior and a whole system spec for this seems heavy.