### PR TITLE
UX: increase chat avatar sizing in sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 :root {
   --d-sidebar-section-link-prefix-margin-right: 0.75em;
   --d-sidebar-section-link-prefix-width: 1.35rem;
@@ -169,6 +171,16 @@
     width: var(--d-sidebar-section-link-prefix-width);
     height: var(--d-sidebar-section-link-prefix-width);
     margin-right: var(--d-sidebar-section-link-prefix-margin-right);
+
+    #sidebar-section-content-chat-dms & {
+      @include viewport.from(sm) {
+        --d-sidebar-section-link-prefix-width: 1.75em;
+
+        .prefix-text {
+          font-size: var(--font-0);
+        }
+      }
+    }
 
     .prefix-image {
       border: 1px solid transparent;


### PR DESCRIPTION
Moving this design experiment into core.

Slight increase of avatar sizing in sidebar:

| Before | After |
|--------|--------|
|![image](https://github.com/user-attachments/assets/894c1c64-30ad-423b-8bc2-685c1b227433)| ![image](https://github.com/user-attachments/assets/ee4d2f26-6707-4532-b3fd-62b6835a9142) | 



