### PR TITLE
DEV: Add apply_modifier to invite upload_csv

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -491,6 +491,13 @@ class InvitesController < ApplicationController
         end
 
         if invites.present?
+          custom_error =
+            DiscoursePluginRegistry.apply_modifier(:invite_bulk_csv_custom_error, nil, invites)
+
+          if custom_error.present?
+            return render json: failed_json.merge(errors: [custom_error]), status: 422
+          end
+
           Jobs.enqueue(:bulk_invite, invites: invites, current_user_id: current_user.id)
 
           if invites.count >= SiteSetting.max_bulk_invites

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -1806,6 +1806,24 @@ RSpec.describe InvitesController do
         user2 = User.where(staged: true).find_by_email("test2@example.com")
         expect(user2.locale).to eq("pl")
       end
+
+      describe "invite_bulk_csv_custom_error modifier" do
+        let!(:plugin) { Plugin::Instance.new }
+        let!(:modifier) { :invite_bulk_csv_custom_error }
+        let!(:block) { Proc.new { "Custom error message" } }
+
+        before { DiscoursePluginRegistry.register_modifier(plugin, modifier, &block) }
+        after { DiscoursePluginRegistry.unregister_modifier(plugin, modifier, &block) }
+
+        it "applies custom errors" do
+          sign_in(admin)
+
+          post "/invites/upload_csv.json", params: { file: file, name: "discourse.csv" }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to include("Custom error message")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Changes 

This PR adds an `invite_bulk_csv_custom_error` apply_modifier to the invite_controller's `upload_csv` method.
This change lets plugins to add custom error message when bulk invite is created.