### PR TITLE
FIX: Rename the reviewable notes route to match existing reviewable routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/note-form.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/note-form.gjs
@@ -55,17 +55,14 @@ export default class ReviewableNoteForm extends Component {
     this.isSubmitting = true;
 
     try {
-      const response = await ajax(
-        `/reviewables/${this.args.reviewable.id}/notes`,
-        {
-          type: "POST",
-          data: {
-            reviewable_note: {
-              content: data.content.trim(),
-            },
+      const response = await ajax(`/review/${this.args.reviewable.id}/notes`, {
+        type: "POST",
+        data: {
+          reviewable_note: {
+            content: data.content.trim(),
           },
-        }
-      );
+        },
+      });
 
       // Clear the submitted content
       await this.formApi.set("content", "");

--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/timeline.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/timeline.gjs
@@ -209,12 +209,10 @@ export default class ReviewableTimeline extends Component {
 
   <template>
     <div class="reviewable-timeline">
-      {{#if this.currentUser.staff}}
-        <ReviewableNoteForm
-          @reviewable={{@reviewable}}
-          @onNoteCreated={{this.onNoteCreated}}
-        />
-      {{/if}}
+      <ReviewableNoteForm
+        @reviewable={{@reviewable}}
+        @onNoteCreated={{this.onNoteCreated}}
+      />
 
       {{#if this.timelineEvents}}
         <div class="timeline-events">

--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/timeline.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/timeline.gjs
@@ -194,7 +194,7 @@ export default class ReviewableTimeline extends Component {
   @action
   async deleteNote(noteId) {
     try {
-      await ajax(`/reviewables/${this.args.reviewable.id}/notes/${noteId}`, {
+      await ajax(`/review/${this.args.reviewable.id}/notes/${noteId}`, {
         type: "DELETE",
       });
 

--- a/app/controllers/reviewable_notes_controller.rb
+++ b/app/controllers/reviewable_notes_controller.rb
@@ -2,6 +2,7 @@
 
 class ReviewableNotesController < ApplicationController
   before_action :find_reviewable
+  before_action :ensure_can_see
 
   def create
     note = @reviewable.reviewable_notes.build(note_params)
@@ -17,7 +18,7 @@ class ReviewableNotesController < ApplicationController
   end
 
   def destroy
-    note = @reviewable.reviewable_notes.find(params[:id])
+    note = @reviewable.reviewable_notes.find(params[:note_id])
 
     # Only allow the author or admin to delete notes
     raise Discourse::InvalidAccess unless note.user == current_user || current_user.admin?
@@ -34,5 +35,9 @@ class ReviewableNotesController < ApplicationController
 
   def note_params
     params.require(:reviewable_note).permit(:content)
+  end
+
+  def ensure_can_see
+    Guardian.new(current_user).ensure_can_see_review_queue!
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -521,19 +521,21 @@ Discourse::Application.routes.draw do
         :constraints => {
           reviewable_id: /\d+/,
         }
+    post "review/:reviewable_id/notes" => "reviewable_notes#create",
+         :constraints => {
+           reviewable_id: /\d+/,
+         }
     delete "review/:reviewable_id" => "reviewables#destroy",
            :constraints => {
              reviewable_id: /\d+/,
            }
+    delete "review/:reviewable_id/notes/:note_id" => "reviewable_notes#destroy",
+           :constraints => {
+             reviewable_id: /\d+/,
+             note_id: /\d+/,
+           }
 
     resources :reviewable_claimed_topics, only: %i[create destroy]
-
-    resources :reviewables, only: [] do
-      resources :reviewable_notes,
-                only: %i[create destroy],
-                path: "notes",
-                constraints: StaffConstraint.new
-    end
 
     get "session/sso" => "session#sso"
     get "session/sso_login" => "session#sso_login"


### PR DESCRIPTION
## ✨ What's This?

The reviewable notes route was originally created at `/reviewables/:reviewable_id/notes`, which didn't match the existing reviewable routes at `/review/:reviewable_id`.

This change fixes the naming inconsistency, and tidies up some of the endpoint permission checks.