### PR TITLE
DEV: Add hysteresis to post-stream uncloaking to prevent layout shift flicker

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-stream.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-stream.gjs
@@ -197,6 +197,11 @@ export default class PostStream extends Component {
     // requesting an animation frame to update the cloaking boundaries prevents Chrome from logging
     // [Violation] 'setTimeout' handler took <N>ms when scrolling fast
     requestAnimationFrame(() => {
+      if (this.cloakAbove === above && this.cloakBelow === below) {
+        // prevent Ember from trying to rerender the cloaking logic if the boundaries did not change
+        return;
+      }
+
       this.cloakAbove = above;
       this.cloakBelow = below;
     });

--- a/app/assets/javascripts/discourse/app/modifiers/post-stream-viewport-tracker.js
+++ b/app/assets/javascripts/discourse/app/modifiers/post-stream-viewport-tracker.js
@@ -40,6 +40,16 @@ const SCROLL_BATCH_INTERVAL_MS = 10;
 // system feeling sluggish.
 const SLACK_FACTOR = 1;
 
+// Number of pixels of intersection required before a post is uncloaked when entering the visibility area.
+// If a post intersects by at least the amount of pixels specified, it will be uncloaked even if the ratio
+// threshold is not met
+const UNCLOAKING_HYSTERESIS_THRESHOLD_PX = 5;
+
+// Percentage of intersection required before a post is uncloaked when entering the visibility area.
+// Post must have at least the specified ratio of its area intersecting to be uncloaked.
+// Works together with pixel threshold - whichever condition is met first will trigger uncloaking
+const UNCLOAKING_HYSTERESIS_RATIO = 0.05;
+
 // Set to true to visualize the eyeline position with a red line
 const DEBUG_EYELINE = false;
 
@@ -99,7 +109,7 @@ export default class PostStreamViewportTracker {
   /**
    * Map of post IDs to their styles when cloaked
    * Used to maintain correct scroll position when posts are cloaked
-   * @type {Object<number, number>}
+   * @type {Object<number, {height: number, margin: string}>}
    */
   #cloakedPostsStyle = {};
 
@@ -393,7 +403,12 @@ export default class PostStreamViewportTracker {
    */
   @bind
   getCloakingData(post, { above, below }) {
-    if (!cloakingEnabled || !post || cloakingPrevented.posts.has(post.id)) {
+    if (
+      !cloakingEnabled ||
+      !post ||
+      cloakingPrevented.posts.has(post.id) ||
+      this.#postsOnScreen[post.post_number]
+    ) {
       return { active: false };
     }
 
@@ -425,7 +440,8 @@ export default class PostStreamViewportTracker {
    */
   @bind
   trackCloakedPosts(entry) {
-    const { target, isIntersecting } = entry;
+    const { target, isIntersecting, intersectionRect, intersectionRatio } =
+      entry;
     const post = elementsToPost.get(target);
 
     if (!post) {
@@ -435,9 +451,20 @@ export default class PostStreamViewportTracker {
     const postNumber = post.post_number;
 
     if (isIntersecting) {
-      // entering the visibility area
-      this.#uncloakedPostNumbers.add(postNumber);
-      delete this.#cloakedPostsStyle[post.id];
+      // Uncloaks a post if either: 1) it has a significant portion (UNCLOAKING_HYSTERESIS_RATIO)
+      // visible and at least 1px height intersection, or 2) it intersects by at least
+      // UNCLOAKING_HYSTERESIS_THRESHOLD_PX pixels height-wise. This dual-condition hysteresis
+      // prevents rapid cloaking/uncloaking causing layout shifts and flickering when posts are near visibility
+      // thresholds.
+      if (
+        (intersectionRect.height >= 1 &&
+          intersectionRatio >= UNCLOAKING_HYSTERESIS_RATIO) ||
+        intersectionRect.height >= UNCLOAKING_HYSTERESIS_THRESHOLD_PX
+      ) {
+        // entering the visibility area
+        this.#uncloakedPostNumbers.add(postNumber);
+        delete this.#cloakedPostsStyle[post.id];
+      }
     } else {
       // entering the cloaking area
       this.#uncloakedPostNumbers.delete(postNumber);
@@ -661,7 +688,12 @@ export default class PostStreamViewportTracker {
 
     this.#cloakingObserver = this.#initializeObserver(this.trackCloakedPosts, {
       rootMargin: `${this.#cloakOffset}px 0px`,
-      threshold: [0, 1],
+      // Adding UNCLOAKING_HYSTERESIS_RATIO provides a threshold between completely cloaked (0) and fully visible (1)
+      // states. Without this threshold, the intersection observer would only trigger when the element entered or exited
+      // the cloaking viewport. The values are clamped between 0 and 1.
+      threshold: Array.from(new Set([0, UNCLOAKING_HYSTERESIS_RATIO, 1]))
+        .map((n) => Math.max(0, Math.min(n, 1)))
+        .sort(),
     });
     this.#viewportObserver = this.#initializeObserver(this.trackVisiblePosts, {
       rootMargin: `${headerMargin}px 0px 0px 0px`,


### PR DESCRIPTION
This PR enhances the accuracy of post height calculations during cloaking and uncloaking in the Discourse post stream. The main improvements include:

- Capturing and restoring the full set of post styles (height, margin, etc.) instead of only the height, reducing rounding errors and visual glitches when posts are cloaked or uncloaked.
- Introducing a hysteresis mechanism to the uncloaking logic. This means posts now require a more significant and sustained intersection with the viewport before being uncloaked, preventing rapid toggling or flickering when a post is near the edge of the viewport.
- Refactoring the style application and visibility tracking logic to support these improvements and ensure smoother post rendering and scrolling performance.

There are no tests added because reproducing the flickering bug is incredibly hard and I can't reproduce it in a system test.