### PR TITLE
DEV: smarter output message when running bin/turbo_rspec

### DIFF
--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -110,7 +110,11 @@ formatters << { name: "progress", outputs: [] } if formatters.empty?
 formatters.each { |formatter| formatter[:outputs] << "-" if formatter[:outputs].empty? }
 
 puts "::group::Run turbo_rspec" if ENV["GITHUB_ACTIONS"]
-puts "Running turbo_rspec (seed: #{seed}) using files in: #{files}"
+if files.size > 5
+  puts "Running turbo_rspec on #{files.size} files"
+else
+  puts "Running turbo_rspec on: #{files.join(", ")}"
+end
 puts "::endgroup::" if ENV["GITHUB_ACTIONS"]
 
 success =


### PR DESCRIPTION
When more than 5 files are run via `turbo_rspec`, we'll show the count. When less than 5 files, we'll list them.

This is slightly better DX as it avoids spamming the console with unecessary information.