### PR TITLE
FIX: Use the max_tag_search_results setting as the default limit for tag groups search

### DIFF
--- a/app/controllers/tag_groups_controller.rb
+++ b/app/controllers/tag_groups_controller.rb
@@ -92,7 +92,10 @@ class TagGroupsController < ApplicationController
 
     matches =
       matches.order("name").limit(
-        fetch_limit_from_params(default: 5, max: SiteSetting.max_tag_search_results),
+        fetch_limit_from_params(
+          default: SiteSetting.max_tag_search_results,
+          max: SiteSetting.max_tag_search_results,
+        ),
       )
 
     render json: {

--- a/spec/requests/tag_groups_controller_spec.rb
+++ b/spec/requests/tag_groups_controller_spec.rb
@@ -54,6 +54,17 @@ RSpec.describe TagGroupsController do
                        SiteSetting.max_tag_search_results
     end
 
+    it "doesn't error when the max_tag_search_results setting is lowered from its default" do
+      tag_group = tag_group_with_permission(everyone, readonly)
+
+      SiteSetting.max_tag_search_results = 4
+
+      get "/tag_groups/filter/search.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["results"].size).to eq(1)
+      expect(response.parsed_body["results"].first["name"]).to eq(tag_group.name)
+    end
+
     context "for anons" do
       it "returns the tag group with the associated tag names" do
         tag_group = tag_group_with_permission(everyone, readonly)


### PR DESCRIPTION
Hardcoding the default limit and using a setting for the max value could result in an error if the setting is changed to anything lower than the hardcoded value for the default limit. It's better to use the setting for both the default limit and maximum limit.

Internal topic: t/156246.