### PR TITLE
DEV: Add limit on localized descriptions

### DIFF
--- a/db/migrate/20250707084732_limit_category_localization_descriptions.rb
+++ b/db/migrate/20250707084732_limit_category_localization_descriptions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class LimitCategoryLocalizationDescriptions < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE category_localizations
+      SET description = LEFT(description, 1000)
+      WHERE description IS NOT NULL AND LENGTH(description) > 1000;
+    SQL
+
+    change_column :category_localizations, :description, :string, limit: 1000
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
There are times the LLM returns values that are too large to make sense. This adds a database limit on the column so it prevents the commit. (https://meta.discourse.org/t/category-description-in-french-broken/372397)