### PR TITLE
FIX: chat btn order on user profile

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -19,7 +19,7 @@
     order: -2;
   }
 
-  li.user-profile-controls-outlet.chat-button {
+  li.chat-button {
     order: -1;
 
     &:empty {


### PR DESCRIPTION
A recent regression caused the incorrect order of the chat button which makes the profile controls look visually incorrect.

### Before

<img width="171" alt="Screenshot 2025-07-07 at 6 34 07 PM" src="https://github.com/user-attachments/assets/ef425af3-041f-4ba4-9daf-737cf009dce3" />


### After

<img width="161" alt="Screenshot 2025-07-07 at 6 38 12 PM" src="https://github.com/user-attachments/assets/ccd6b7a8-95b4-43df-8c8b-864765ee36c4" />
