### PR TITLE
FEATURE: create new topic while viewing restricted category or tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -2,22 +2,12 @@ import Component from "@ember/component";
 import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
 import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
-import { i18n } from "discourse-i18n";
 import DButtonTooltip from "float-kit/components/d-button-tooltip";
-import DTooltip from "float-kit/components/d-tooltip";
 
 @tagName("")
 export default class CreateTopicButton extends Component {
   label = "topic.create";
   btnClass = "btn-default";
-
-  get disallowedReason() {
-    if (this.canCreateTopicOnTag === false) {
-      return "topic.create_disabled_tag";
-    } else if (this.disabled) {
-      return "topic.create_disabled_category";
-    }
-  }
 
   <template>
     {{#if this.canCreateTopic}}
@@ -26,20 +16,11 @@ export default class CreateTopicButton extends Component {
           <DButton
             @action={{this.action}}
             @icon="far-pen-to-square"
-            @disabled={{this.disabled}}
             @label={{this.label}}
             id="create-topic"
             class={{this.btnClass}}
           />
         </:button>
-        <:tooltip>
-          {{#if @disabled}}
-            <DTooltip
-              @icon="circle-info"
-              @content={{i18n this.disallowedReason}}
-            />
-          {{/if}}
-        </:tooltip>
       </DButtonTooltip>
 
       {{#if @showDrafts}}

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -4,7 +4,6 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
 import { and, gt } from "truth-helpers";
 import BreadCrumbs from "discourse/components/bread-crumbs";
@@ -117,26 +116,6 @@ export default class DNavigation extends Component {
     }
   }
 
-  @discourseComputed(
-    "createTopicDisabled",
-    "categoryReadOnlyBanner",
-    "canCreateTopicOnTag",
-    "tag.id"
-  )
-  createTopicButtonDisabled(
-    createTopicDisabled,
-    categoryReadOnlyBanner,
-    canCreateTopicOnTag,
-    tagId
-  ) {
-    if (tagId && !canCreateTopicOnTag) {
-      return true;
-    } else if (categoryReadOnlyBanner) {
-      return false;
-    }
-    return createTopicDisabled;
-  }
-
   @discourseComputed("categoryReadOnlyBanner")
   createTopicClass(categoryReadOnlyBanner) {
     let classNames = ["btn-default"];
@@ -225,11 +204,7 @@ export default class DNavigation extends Component {
 
   @action
   clickCreateTopicButton() {
-    if (this.categoryReadOnlyBanner) {
-      this.dialog.alert({ message: htmlSafe(this.categoryReadOnlyBanner) });
-    } else {
-      this.createTopic();
-    }
+    this.createTopic();
   }
 
   <template>
@@ -333,7 +308,6 @@ export default class DNavigation extends Component {
       <CreateTopicButton
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
-        @disabled={{this.createTopicButtonDisabled}}
         @label={{this.createTopicLabel}}
         @btnClass={{this.createTopicClass}}
         @canCreateTopicOnTag={{this.canCreateTopicOnTag}}

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -300,7 +300,6 @@ export default class DNavigation extends Component {
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
         @label={{this.createTopicLabel}}
-        @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
         @showDrafts={{if (gt this.draftCount 0) true false}}
       />
 

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -116,15 +116,6 @@ export default class DNavigation extends Component {
     }
   }
 
-  @discourseComputed("categoryReadOnlyBanner")
-  createTopicClass(categoryReadOnlyBanner) {
-    let classNames = ["btn-default"];
-    if (categoryReadOnlyBanner) {
-      classNames.push("disabled");
-    }
-    return classNames.join(" ");
-  }
-
   @discourseComputed("category.can_edit")
   showCategoryEdit(canEdit) {
     return canEdit;
@@ -309,7 +300,6 @@ export default class DNavigation extends Component {
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
         @label={{this.createTopicLabel}}
-        @btnClass={{this.createTopicClass}}
         @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
         @showDrafts={{if (gt this.draftCount 0) true false}}
       />

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -50,11 +50,14 @@ acceptance("Category Banners", function (needs) {
     await visit("/c/test-read-only-with-banner");
 
     await click("#create-topic");
-    assert.dom(".dialog-body").exists("pops up a modal");
+    assert.dom(".d-editor").exists("opens composer");
 
-    await click(".dialog-footer .btn-primary");
-    assert.dom(".dialog-body").doesNotExist("closes the modal");
+    assert
+      .dom(".d-editor .selected-name[data-name='test-read-only-with-banner']")
+      .doesNotExist("does not show read-only category in composer");
+
     assert.dom(".category-read-only-banner").exists("shows a banner");
+
     assert
       .dom(".category-read-only-banner .inner")
       .exists({ count: 1 }, "allows staff to embed html in the message");

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -228,14 +228,14 @@ acceptance("Tags listed by group", function (needs) {
       );
   });
 
-  test("new topic button is not available for staff-only tags", async function (assert) {
+  test("new topic button works when viewing staff-only tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/regular-tag");
     assert.dom("#create-topic").isEnabled();
 
     await visit("/tag/staff-only-tag");
-    assert.dom("#create-topic").isDisabled();
+    assert.dom("#create-topic").isEnabled();
 
     updateCurrentUser({ moderator: true });
 

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -41,9 +41,14 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
             end
           end
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "should have the 'New Topic' button enabled and default category set in the composer" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+
+              category_page.new_topic_button.click
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+              expect(select_kit).to have_selected_value(default_latest_category.id)
             end
           end
         end
@@ -66,9 +71,14 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
         end
         describe "Can't post on parent category" do
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "opens composer without a preset topic" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+              category_page.find("#create-topic").click
+
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+              expect(select_kit).to have_selected_name("category&hellip;")
             end
           end
         end
@@ -87,10 +97,18 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
     end
 
     describe "Setting disabled and can't post on parent category" do
-      before { SiteSetting.default_subcategory_on_read_only_category = false }
-      it "should have 'New Topic' button disabled" do
+      before do
+        SiteSetting.default_subcategory_on_read_only_category = false
+        SiteSetting.default_composer_category = default_latest_category.id
+      end
+
+      it "opens composer with default composer category selected" do
         category_page.visit(category)
-        expect(category_page).to have_button("New Topic", disabled: true)
+        expect(category_page).to have_button("New Topic", disabled: false)
+        page.find("#create-topic").click
+
+        select_kit = PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+        expect(select_kit).to have_selected_name(default_latest_category.name)
       end
     end
   end

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Drafts dropdown", type: :system do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:category)
   let(:composer) { PageObjects::Components::Composer.new }
   let(:drafts_dropdown) { PageObjects::Components::DraftsMenu.new }
   let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
@@ -110,10 +111,10 @@ describe "Drafts dropdown", type: :system do
       )
     end
 
-    it "disables the drafts dropdown menu when new topic button is disabled" do
+    it "is still enabled" do
       category_page.visit(category)
 
-      expect(category_page).to have_button("New Topic", disabled: true)
+      expect(category_page).to have_button("New Topic", disabled: false)
       expect(drafts_dropdown).to be_enabled
     end
   end

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -41,30 +41,6 @@ export default class SidebarNewTopicButton extends Component {
     }
   }
 
-  get tagRestricted() {
-    return this.tag?.staff;
-  }
-
-  get createTopicDisabled() {
-    return (
-      (this.category && !this.createTopicTargetCategory) ||
-      (this.tagRestricted && !this.currentUser.staff)
-    );
-  }
-
-  get categoryReadOnlyBanner() {
-    if (this.category && this.currentUser && this.createTopicDisabled) {
-      return this.category.read_only_banner;
-    }
-  }
-
-  get createTopicClass() {
-    const baseClasses = "btn-default sidebar-new-topic-button";
-    return this.categoryReadOnlyBanner
-      ? `${baseClasses} disabled`
-      : baseClasses;
-  }
-
   @action
   createNewTopic() {
     this.composer.openNewTopic({ category: this.category, tags: this.tag?.id });
@@ -104,10 +80,8 @@ export default class SidebarNewTopicButton extends Component {
         <CreateTopicButton
           @canCreateTopic={{this.canCreateTopic}}
           @action={{this.createNewTopic}}
-          @disabled={{this.createTopicDisabled}}
           @label="topic.create"
-          @btnClass={{this.createTopicClass}}
-          @canCreateTopicOnTag={{not this.tagRestricted}}
+          @btnClass="btn-default sidebar-new-topic-button"
           @showDrafts={{gt this.draftCount 0}}
         />
       </div>


### PR DESCRIPTION
When visiting a restricted category or tag where the current user does not have permission to create a topic, we should still allow the user to write a new topic under a different category or tag. This is especially important when using the **new topic** button from the sidebar.

When clicking the **new topic** button when the user does not have permission, the composer category defaults to:

1) Subcategory (if `SiteSetting.default_subcategory_on_read_only_category` is `true` and subcategory exists)
2) Default site category (if `SiteSetting.default_composer_category` has a category id value)
3) Default category chooser value of `Category...` prompting the user to select a category from the dropdown

Internal ref: /t/-/152613