### PR TITLE
UX: move rich_editor setting from experimental to posting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2729,7 +2729,7 @@ en:
     about_page_extra_groups_order: "Ordering of the extra groups on the about page."
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
-    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition. The rich text editor is under active development, so not all features are supported yet — <a href='https://meta.discourse.org/t/test-our-new-composer/352347' target='_blank'>see Meta for more details</a>."
+    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition."
     viewport_based_mobile_mode: "EXPERIMENTAL: Disable the user-agent-based mobile/desktop modes and use viewport width instead."
     reviewable_ui_refresh: "Groups that can use the experimental new UI in the review queue."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1595,6 +1595,9 @@ posting:
     type: integer
     min: 1
     hidden: true
+  rich_editor:
+    client: true
+    default: false
 
 content_localization:
   content_localization_enabled:
@@ -4046,9 +4049,6 @@ experimental:
     default: false
     hidden: true
     client: true
-  rich_editor:
-    client: true
-    default: false
   reviewable_ui_refresh:
     client: true
     type: group_list


### PR DESCRIPTION
Moves the `rich_editor` site setting from the experimental to the posting section, and updates its copy.