### PR TITLE
FEATURE: image input rule when typing on rich editor

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/image-node-view.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/image-node-view.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
@@ -57,10 +58,12 @@ class ImageToolbar extends ToolbarBase {
 
 export default class ImageNodeView extends Component {
   @service menu;
+  @service siteSettings;
 
   @tracked imageToolbar;
   @tracked menuInstance;
   @tracked altMenuInstance;
+  @tracked imageLoaded = false;
 
   constructor() {
     super(...arguments);
@@ -215,14 +218,18 @@ export default class ImageNodeView extends Component {
   scaleImage(scale) {
     const pos = this.args.getPos();
     const tr = this.args.view.state.tr;
-    this.args.view.dispatch(
-      tr
-        .setNodeMarkup(pos, null, {
-          ...this.args.node.attrs,
-          scale,
-        })
-        .setSelection(NodeSelection.create(tr.doc, pos))
-    );
+
+    if (!this.args.node.attrs.width || !this.args.node.attrs.height) {
+      const dimensions = this.maxDimensions;
+      if (dimensions) {
+        tr.setNodeAttribute(pos, "width", dimensions.width);
+        tr.setNodeAttribute(pos, "height", dimensions.height);
+      }
+    }
+
+    tr.setNodeAttribute(pos, "scale", scale);
+    tr.setSelection(NodeSelection.create(tr.doc, pos));
+    this.args.view.dispatch(tr);
   }
 
   selectNode() {
@@ -245,18 +252,47 @@ export default class ImageNodeView extends Component {
     this.altMenuInstance = null;
   }
 
-  get imageStyle() {
-    if (!this.args.node.attrs.width || !this.args.node.attrs.height) {
+  get maxDimensions() {
+    if (!this.imageLoaded) {
       return null;
+    }
+
+    const widthRatio =
+      this.siteSettings.max_image_width / this.image.naturalWidth;
+    const heightRatio =
+      this.siteSettings.max_image_height / this.image.naturalHeight;
+
+    const ratio = Math.min(widthRatio, heightRatio);
+
+    return {
+      width: Math.floor(this.image.naturalWidth * ratio),
+      height: Math.floor(this.image.naturalHeight * ratio),
+    };
+  }
+
+  get imageStyle() {
+    let width = this.args.node.attrs.width;
+    let height = this.args.node.attrs.height;
+
+    if (!width || !height) {
+      const dimensions = this.maxDimensions;
+
+      if (!dimensions) {
+        return null;
+      }
+
+      width = dimensions.width;
+      height = dimensions.height;
     }
 
     const scale = (this.args.node.attrs.scale || 100) / 100;
 
-    return htmlSafe(
-      `width: ${this.args.node.attrs.width * scale}px; height: ${
-        this.args.node.attrs.height * scale
-      }px;`
-    );
+    return htmlSafe(`width: ${width * scale}px; height: ${height * scale}px;`);
+  }
+
+  @action
+  updateImageLoaded() {
+    this.imageLoaded = true;
   }
 
   <template>
@@ -271,6 +307,7 @@ export default class ImageNodeView extends Component {
       data-thumbnail={{if (eq @node.attrs.extras "thumbnail") "true"}}
       style={{this.imageStyle}}
       {{didInsert this.setupImage}}
+      {{on "load" this.updateImageLoaded}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -177,6 +177,23 @@ const extension = {
     },
   },
 
+  inputRules: ({
+    utils: { convertFromMarkdown },
+    pmState: { NodeSelection },
+  }) => {
+    return {
+      match: /!\[([^\]]*)\]\(([^)\s]+)\)$/,
+      handler: (state, match, start, end) => {
+        const tr = state.tr;
+
+        return tr
+          .replaceWith(start, end, convertFromMarkdown(match[0]))
+          .setSelection(NodeSelection.create(tr.doc, start + 1))
+          .scrollIntoView();
+      },
+    };
+  },
+
   plugins({ pmState: { Plugin, NodeSelection, TextSelection } }) {
     const shortUrlResolver = new Plugin({
       state: {

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -188,7 +188,7 @@ const extension = {
 
         return tr
           .replaceWith(start, end, convertFromMarkdown(match[0]))
-          .setSelection(NodeSelection.create(tr.doc, start + 1))
+          .setSelection(NodeSelection.create(tr.doc, start + 2))
           .scrollIntoView();
       },
     };

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/glimmer-node-view.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/glimmer-node-view.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { next } from "@ember/runloop";
 
 /**
  * @typedef {Object} GlimmerNodeViewArgs
@@ -43,11 +44,11 @@ export default class GlimmerNodeView {
   }
 
   selectNode() {
-    this.#componentInstance?.selectNode?.();
+    next(() => this.#componentInstance?.selectNode?.());
   }
 
   deselectNode() {
-    this.#componentInstance?.deselectNode?.();
+    next(() => this.#componentInstance?.deselectNode?.());
   }
 
   setSelection() {

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -1189,6 +1189,24 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(page).to have_no_css("[data-identifier='composer-image-toolbar']")
     end
+
+    it "sets width and height attributes when scaling external images" do
+      open_composer_and_toggle_rich_editor
+
+      image = Fabricate(:image_upload)
+
+      composer.type_content("![alt text](#{image.url})")
+
+      find(".composer-image-node img").click
+
+      expect(rich).to have_no_css(".composer-image-node img[width]")
+      expect(rich).to have_no_css(".composer-image-node img[height]")
+
+      find(".composer-image-toolbar__zoom-out").click
+
+      expect(rich).to have_css(".composer-image-node img[width]")
+      expect(rich).to have_css(".composer-image-node img[height]")
+    end
   end
 
   describe "image alt text display and editing" do


### PR DESCRIPTION
Adds a `![markdown](image)` input rule that uses the markdown parser to create an image node.

Supporting this format surfaced an issue with dimension-less images, so now the image node view uses the max width/height site settings in addition to the loaded image natural dimensions to determine what a 100% looks like – it's used for display, and also when a zoom-out button action is taken, so we calculate the next step % of the calculated dimensions.