### PR TITLE
FIX: Escape URL when inserting/editing links in composer modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -19,7 +19,7 @@ import ConditionalLoadingSpinner from "discourse/components/conditional-loading-
 import DButton from "discourse/components/d-button";
 import DEditorPreview from "discourse/components/d-editor-preview";
 import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
-import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
+import UpsertHyperlink from "discourse/components/modal/upsert-hyperlink";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import PopupInputTip from "discourse/components/popup-input-tip";
 import { SKIP } from "discourse/lib/autocomplete";
@@ -508,7 +508,7 @@ export default class DEditor extends Component {
       linkText = this._lastSel.value;
     }
 
-    this.modal.show(InsertHyperlink, {
+    this.modal.show(UpsertHyperlink, {
       model: {
         linkText,
         toolbarEvent,

--- a/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
@@ -17,7 +17,7 @@ import { searchForTerm } from "discourse/lib/search";
 import { prefixProtocol } from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 
-export default class InsertHyperlink extends Component {
+export default class UpsertHyperlink extends Component {
   @tracked selectedRow = -1;
   @tracked searchResults = [];
   @tracked searchLoading = false;
@@ -144,7 +144,7 @@ export default class InsertHyperlink extends Component {
   @action
   onFormSubmit(data) {
     const origLink = data.linkUrl;
-    const linkUrl = prefixProtocol(origLink);
+    const linkUrl = encodeURI(prefixProtocol(origLink));
     const sel = this.args.model.toolbarEvent.selected;
 
     if (isEmpty(linkUrl)) {
@@ -197,7 +197,7 @@ export default class InsertHyperlink extends Component {
         )
       }}
       @bodyClass="insert-link"
-      class="insert-hyperlink-modal"
+      class="upsert-hyperlink-modal"
     >
       <:body>
         <div class="inputs">

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link-toolbar.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/link-toolbar.js
@@ -1,7 +1,7 @@
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import ToolbarButtons from "discourse/components/composer/toolbar-buttons";
-import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
+import UpsertHyperlink from "discourse/components/modal/upsert-hyperlink";
 import { ToolbarBase } from "discourse/lib/composer/toolbar";
 import { rovingButtonBar } from "discourse/lib/roving-button-bar";
 import { clipboardCopy } from "discourse/lib/utilities";
@@ -191,11 +191,11 @@ class LinkToolbarPluginView {
       )
     );
 
-    this.#getContext().modal.show(InsertHyperlink, {
+    this.#getContext().modal.show(UpsertHyperlink, {
       model: {
         editing: true,
         linkText: currentLinkText,
-        linkUrl: this.#linkState.href,
+        linkUrl: decodeURI(this.#linkState.href),
         toolbarEvent: {
           addText: (text) => this.#replaceText(text),
           selected: { value: this.#linkState.href },

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -1,6 +1,6 @@
 @use "lib/viewport";
 
-.d-modal.insert-hyperlink-modal {
+.d-modal.upsert-hyperlink-modal {
   .insert-link {
     overflow-y: visible;
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -21,7 +21,7 @@ import { Promise } from "rsvp";
 import { not, or } from "truth-helpers";
 import DTextarea from "discourse/components/d-textarea";
 import EmojiPickerDetached from "discourse/components/emoji-picker/detached";
-import InsertHyperlink from "discourse/components/modal/insert-hyperlink";
+import UpsertHyperlink from "discourse/components/modal/upsert-hyperlink";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -173,7 +173,7 @@ export default class ChatComposer extends Component {
     this.appEvents.on(
       "chat:open-insert-link-modal",
       this,
-      "openInsertLinkModal"
+      "openUpsertLinkModal"
     );
   }
 
@@ -183,7 +183,7 @@ export default class ChatComposer extends Component {
     this.appEvents.off(
       "chat:open-insert-link-modal",
       this,
-      "openInsertLinkModal"
+      "openUpsertLinkModal"
     );
     this.pane.sending = false;
   }
@@ -408,14 +408,14 @@ export default class ChatComposer extends Component {
   }
 
   @action
-  openInsertLinkModal(event, options = { context: null }) {
+  openUpsertLinkModal(event, options = { context: null }) {
     if (options.context !== this.context) {
       return;
     }
 
     const selected = this.composer.textarea.getSelected("", { lineVal: true });
     const linkText = selected?.value;
-    this.modal.show(InsertHyperlink, {
+    this.modal.show(UpsertHyperlink, {
       model: {
         linkText,
         toolbarEvent: {

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -956,7 +956,7 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   describe "link toolbar" do
-    let(:insert_hyperlink_modal) { PageObjects::Modals::InsertHyperlink.new }
+    let(:upsert_hyperlink_modal) { PageObjects::Modals::UpsertHyperlink.new }
 
     it "shows link toolbar when cursor is on a link" do
       open_composer_and_toggle_rich_editor
@@ -980,19 +980,43 @@ describe "Composer - ProseMirror editor", type: :system do
       # Use Tab to navigate to the toolbar and Enter to activate edit
       composer.send_keys(:tab, :enter)
 
-      expect(insert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to be_open
 
-      expect(insert_hyperlink_modal.link_text_value).to eq("Example")
-      expect(insert_hyperlink_modal.link_url_value).to eq("https://example.com")
+      expect(upsert_hyperlink_modal.link_text_value).to eq("Example")
+      expect(upsert_hyperlink_modal.link_url_value).to eq("https://example.com")
 
-      insert_hyperlink_modal.fill_in_link_text("Updated Example")
-      insert_hyperlink_modal.fill_in_link_url("https://updated-example.com")
-      insert_hyperlink_modal.click_primary_button
+      upsert_hyperlink_modal.fill_in_link_text("Updated Example")
+      upsert_hyperlink_modal.fill_in_link_url("https://updated-example.com")
+      upsert_hyperlink_modal.click_primary_button
 
       expect(rich).to have_css("a[href='https://updated-example.com']", text: "Updated Example")
 
       composer.toggle_rich_editor
       expect(composer).to have_value("[Updated Example](https://updated-example.com)")
+    end
+
+    it "escapes URL when editing link via modal" do
+      cdp.allow_clipboard
+      open_composer_and_toggle_rich_editor
+
+      composer.type_content("[Example](https://example.com)")
+      composer.send_keys(:left, :left, :left)
+
+      # Use Tab to navigate to the toolbar and Enter to activate edit
+      composer.send_keys(:tab, :enter)
+
+      expect(upsert_hyperlink_modal).to be_open
+
+      expect(upsert_hyperlink_modal.link_text_value).to eq("Example")
+      expect(upsert_hyperlink_modal.link_url_value).to eq("https://example.com")
+
+      upsert_hyperlink_modal.fill_in_link_url("https://updated-example.com?query=with space")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css(
+        "a[href='https://updated-example.com?query=with%20space']",
+        text: "Example",
+      )
     end
 
     it "allows copying a link URL via toolbar" do
@@ -1101,14 +1125,14 @@ describe "Composer - ProseMirror editor", type: :system do
       # Use Tab to navigate to the toolbar and Enter to activate edit
       composer.send_keys(:tab, :enter)
 
-      expect(insert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to be_open
 
-      expect(insert_hyperlink_modal.link_text_value).to eq("Party :tada: Time")
-      expect(insert_hyperlink_modal.link_url_value).to eq("https://example.com")
+      expect(upsert_hyperlink_modal.link_text_value).to eq("Party :tada: Time")
+      expect(upsert_hyperlink_modal.link_url_value).to eq("https://example.com")
 
-      insert_hyperlink_modal.fill_in_link_text("Updated :tada: Party")
-      insert_hyperlink_modal.fill_in_link_url("https://updated-party.com")
-      insert_hyperlink_modal.click_primary_button
+      upsert_hyperlink_modal.fill_in_link_text("Updated :tada: Party")
+      upsert_hyperlink_modal.fill_in_link_url("https://updated-party.com")
+      upsert_hyperlink_modal.click_primary_button
 
       expect(rich).to have_css("a[href='https://updated-party.com']")
       expect(rich).to have_css("a img[title=':tada:'], a img[alt=':tada:']")
@@ -1126,14 +1150,14 @@ describe "Composer - ProseMirror editor", type: :system do
       # Use Tab to navigate to the toolbar and Enter to activate edit
       composer.send_keys(:tab, :enter)
 
-      expect(insert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to be_open
 
-      expect(insert_hyperlink_modal.link_text_value).to eq("**Bold** and *italic* text")
-      expect(insert_hyperlink_modal.link_url_value).to eq("https://example.com")
+      expect(upsert_hyperlink_modal.link_text_value).to eq("**Bold** and *italic* text")
+      expect(upsert_hyperlink_modal.link_url_value).to eq("https://example.com")
 
-      insert_hyperlink_modal.fill_in_link_text("Updated **bold** and *italic* content")
-      insert_hyperlink_modal.fill_in_link_url("https://updated-example.com")
-      insert_hyperlink_modal.click_primary_button
+      upsert_hyperlink_modal.fill_in_link_text("Updated **bold** and *italic* content")
+      upsert_hyperlink_modal.fill_in_link_url("https://updated-example.com")
+      upsert_hyperlink_modal.click_primary_button
 
       expect(rich).to have_css("a[href='https://updated-example.com']")
       expect(rich).to have_css("strong a", text: "bold")

--- a/spec/system/page_objects/modals/upsert_hyperlink.rb
+++ b/spec/system/page_objects/modals/upsert_hyperlink.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module PageObjects
   module Modals
-    class InsertHyperlink < PageObjects::Modals::Base
-      BODY_SELECTOR = ".insert-hyperlink-modal"
-      MODAL_SELECTOR = ".insert-hyperlink-modal"
+    class UpsertHyperlink < PageObjects::Modals::Base
+      BODY_SELECTOR = ".upsert-hyperlink-modal"
+      MODAL_SELECTOR = ".upsert-hyperlink-modal"
       LINK_TEXT_SELECTOR = ".d-modal__body input.link-text"
       LINK_URL_SELECTOR = ".d-modal__body input.link-url"
 


### PR DESCRIPTION
Fixes an issue where a URL like this:

```
https://meta.discourse.org/admin/site_settings/category/all_results?filter=discourse connect
```

Would appear to be broken when inserting into the composer via the
hyperlink modal. All we have to do is escape it before inserting,
and unescape before editing it in the modal.

Also in this commit I am renaming the InsertHyperlink modal to UpsertHyperlink,
since it is used for both inserting and editing links.
