### PR TITLE
FIX: Badge grouping for system badges should be editable

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-badges-show.gjs
@@ -471,7 +471,6 @@ export default class AdminBadgesShow extends Component {
         <form.Section @title="Settings">
           <form.Field
             @name="badge_grouping_id"
-            @disabled={{this.readOnly}}
             @validation="required"
             @title={{i18n "admin.badges.badge_grouping"}}
             as |field|

--- a/spec/system/admin_badges_spec.rb
+++ b/spec/system/admin_badges_spec.rb
@@ -19,7 +19,6 @@ describe "Admin Badges Page", type: :system do
       expect(form.field("enabled")).to be_enabled
       expect(form.field("badge_type_id")).to be_disabled
       expect(form.field("badge_type_id")).to have_value(BadgeType::Bronze.to_s)
-      expect(form.field("badge_grouping_id")).to be_disabled
       expect(form.field("badge_grouping_id")).to have_value(BadgeGrouping::GettingStarted.to_s)
       expect(form.field("allow_title")).to be_enabled
       expect(form.field("allow_title")).to be_unchecked


### PR DESCRIPTION
This is mostly a fix for the UI which incorrectly disables the badge
grouping field for system badges. However, nothing in the backend
suggests that the badge grouping for system badges is disallowed. This
is confirmed by the fact that `Badge.protected_system_fields` do not
list the `badge_grouping_id` column as protected.
