### PR TITLE
DEV: enable Foundation and stop Default

### DIFF
--- a/app/controllers/admin/color_schemes_controller.rb
+++ b/app/controllers/admin/color_schemes_controller.rb
@@ -4,10 +4,7 @@ class Admin::ColorSchemesController < Admin::AdminController
   before_action :fetch_color_scheme, only: %i[update destroy]
 
   def index
-    schemes =
-      ColorScheme.without_theme_owned_palettes.with_experimental_system_theme_palettes.order(
-        "color_schemes.id ASC",
-      )
+    schemes = ColorScheme.without_theme_owned_palettes.order("color_schemes.id ASC")
 
     schemes = schemes.where(theme_id: nil) if params[:exclude_theme_owned]
 

--- a/app/controllers/admin/config/customize_controller.rb
+++ b/app/controllers/admin/config/customize_controller.rb
@@ -8,7 +8,6 @@ class Admin::Config::CustomizeController < Admin::AdminController
       Theme
         .include_basic_relations
         .includes(:theme_fields, color_scheme: [:color_scheme_colors])
-        .with_experimental_system_themes
         .where(component: false)
         .order(:name)
 

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -170,14 +170,13 @@ class Admin::ThemesController < Admin::AdminController
   end
 
   def index
-    @themes = Theme.with_experimental_system_themes.strict_loading.include_relations.order(:name)
+    @themes = Theme.strict_loading.include_relations.order(:name)
 
     @color_schemes =
       ColorScheme
         .strict_loading
         .all
         .without_theme_owned_palettes
-        .with_experimental_system_theme_palettes
         .includes(:theme, color_scheme_colors: :color_scheme)
         .to_a
 

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -318,14 +318,6 @@ class ColorScheme < ActiveRecord::Base
   scope :without_theme_owned_palettes,
         -> { where("color_schemes.id NOT IN (SELECT color_scheme_id FROM theme_color_schemes)") }
 
-  scope :with_experimental_system_theme_palettes,
-        -> do
-          joins("LEFT JOIN themes on themes.id = color_schemes.theme_id").where(
-            "themes.id is NULL OR themes.id > 0 OR themes.id IN (?)",
-            Theme.experimental_system_theme_ids,
-          )
-        end
-
   validates_associated :color_scheme_colors
 
   BASE_COLORS_FILE = "#{Rails.root}/app/assets/stylesheets/common/foundation/colors.scss"

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -128,8 +128,6 @@ class Theme < ActiveRecord::Base
 
   scope :not_system, -> { where("id > 0") }
   scope :system, -> { where("id < 0") }
-  scope :with_experimental_system_themes,
-        -> { where("id > 0 OR id IN (?)", Theme.experimental_system_theme_ids) }
 
   delegate :remote_url, to: :remote_theme, private: true, allow_nil: true
 
@@ -346,12 +344,6 @@ class Theme < ActiveRecord::Base
 
       all_ids - disabled_ids
     end
-  end
-
-  def self.experimental_system_theme_ids
-    Theme::CORE_THEMES
-      .select { |k, v| SiteSetting.experimental_system_themes_map.include?(k) }
-      .values
   end
 
   def set_default!

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4677,7 +4677,6 @@ en:
     solarized_dark_theme_name: "Solarized Dark"
     wcag_dark: "WCAG Dark"
     wcag_dark_theme_name: "WCAG Dark"
-    default_theme_name: "Default"
     light_theme_name: "Light"
     dark_theme_name: "Dark"
     neutral_theme_name: "Neutral"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4071,11 +4071,3 @@ experimental:
     client: true
     type: group_list
     default: ""
-  experimental_system_themes:
-    type: list
-    default: "horizon|foundation"
-    hidden: true
-    allow_any: false
-    choices:
-      - "foundation"
-      - "horizon"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4073,7 +4073,7 @@ experimental:
     default: ""
   experimental_system_themes:
     type: list
-    default: "horizon"
+    default: "horizon|foundation"
     hidden: true
     allow_any: false
     choices:

--- a/db/fixtures/600_themes.rb
+++ b/db/fixtures/600_themes.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+theme_exists = Theme.exists?
+
+SystemThemesManager.sync!
+
 # we can not guess what to do if customization already started, so skip it
-if !Theme.exists?
+if !theme_exists
   STDERR.puts "> Seeding theme and color schemes"
 
   color_schemes = [
@@ -24,9 +28,7 @@ if !Theme.exists?
       )
   end
 
-  name = I18n.t("color_schemes.default_theme_name")
-  default_theme = Theme.create!(name: name, user_id: Discourse::SYSTEM_USER_ID)
-  default_theme.set_default!
+  Theme.foundation_theme.set_default!
 
   if SiteSetting.default_dark_mode_color_scheme_id ==
        SiteSetting.defaults[:default_dark_mode_color_scheme_id]
@@ -35,5 +37,3 @@ if !Theme.exists?
     SiteSetting.default_dark_mode_color_scheme_id = dark_scheme_id if dark_scheme_id.present?
   end
 end
-
-SystemThemesManager.sync!

--- a/db/migrate/20250714030525_remove_experimental_system_themes_site_setting.rb
+++ b/db/migrate/20250714030525_remove_experimental_system_themes_site_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveExperimentalSystemThemesSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'experimental_system_themes'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -234,7 +234,7 @@ HTML
       f =
         ThemeField.create!(
           target_id: Theme.targets[:mobile],
-          theme_id: 1,
+          theme_id: -1,
           name: "after_header",
           value: html,
         )

--- a/spec/requests/admin/color_schemes_controller_spec.rb
+++ b/spec/requests/admin/color_schemes_controller_spec.rb
@@ -32,20 +32,6 @@ RSpec.describe Admin::ColorSchemesController do
         expect(scheme_colors[0]["hex"]).to eq(base_scheme_colors[0].hex)
       end
 
-      it "filters colors belonging to experimental system themes" do
-        SiteSetting.experimental_system_themes = ""
-        get "/admin/color_schemes.json"
-        expect(response.status).to eq(200)
-        scheme_names = response.parsed_body.map { |scheme| scheme["name"] }
-        expect(scheme_names).not_to include("Horizon")
-
-        SiteSetting.experimental_system_themes = "horizon"
-        get "/admin/color_schemes.json"
-        expect(response.status).to eq(200)
-        scheme_names = response.parsed_body.map { |scheme| scheme["name"] }
-        expect(scheme_names).to include("Horizon")
-      end
-
       it "serializes default colors even when not present in database" do
         scheme = ColorScheme.create_from_base({ name: "my color scheme" })
         scheme.colors.find_by(name: "primary").destroy!

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -510,26 +510,6 @@ RSpec.describe Admin::ThemesController do
         expect(theme_json["remote_theme"]["remote_version"]).to eq("7")
       end
 
-      it "filters experimental system themes" do
-        SiteSetting.experimental_system_themes = ""
-        get "/admin/themes.json"
-        expect(response.status).to eq(200)
-        theme_names = response.parsed_body["themes"].map { |theme| theme[:name] }
-        color_scheme_names =
-          response.parsed_body["extras"]["color_schemes"].map { |scheme| scheme[:name] }
-        expect(theme_names).not_to include("Horizon")
-        expect(color_scheme_names).not_to include("Horizon")
-
-        SiteSetting.experimental_system_themes = "horizon"
-        get "/admin/themes.json"
-        expect(response.status).to eq(200)
-        theme_names = response.parsed_body["themes"].map { |t| t[:name] }
-        color_scheme_names =
-          response.parsed_body["extras"]["color_schemes"].map { |scheme| scheme[:name] }
-        expect(theme_names).to include("Horizon")
-        expect(color_scheme_names).to include("Horizon")
-      end
-
       it "does not result in N+1 queries" do
         # warmup
         get "/admin/themes.json"

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -3,8 +3,8 @@
 describe "Admin Customize Themes Config Area Page", type: :system do
   fab!(:admin)
   fab!(:theme) { Fabricate(:theme, name: "First theme") }
-  fab!(:default_theme) { Theme.where(component: false, name: "Default").first }
   fab!(:foundation_theme) { Theme.foundation_theme }
+  fab!(:horizon_theme) { Theme.horizon_theme }
   fab!(:theme_child_theme) do
     Fabricate(:theme, name: "Child theme", component: true, enabled: true, parent_themes: [theme])
   end
@@ -42,14 +42,11 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
   it "allows to mark theme as active" do
     config_area.visit
-    expect(config_area).to have_badge(default_theme, "--active")
+    expect(config_area).to have_badge(foundation_theme, "--active")
     expect(config_area).to have_no_badge(theme_2, "--active")
     config_area.mark_as_active(theme_2)
     expect(config_area).to have_badge(theme_2, "--active")
     expect(config_area).to have_no_badge(foundation_theme, "--active")
-    expect(config_area).to have_themes(
-      ["Second theme", "Horizon", "Foundation", "Default", "First theme"],
-    )
   end
 
   it "allows to make theme selectable by users" do
@@ -85,16 +82,14 @@ describe "Admin Customize Themes Config Area Page", type: :system do
   it "allows controlling visibility of system themes with experimental_system_themes setting" do
     SiteSetting.experimental_system_themes = ""
     config_area.visit
-    expect(config_area).to have_themes(["Default", "First theme", "Second theme"])
+    expect(config_area).to have_themes(["First theme", "Second theme"])
 
     SiteSetting.experimental_system_themes = "foundation"
     config_area.visit
-    expect(config_area).to have_themes(["Default", "Foundation", "First theme", "Second theme"])
+    expect(config_area).to have_themes(["Foundation", "First theme", "Second theme"])
 
     SiteSetting.experimental_system_themes = "foundation|horizon"
     config_area.visit
-    expect(config_area).to have_themes(
-      ["Default", "Horizon", "Foundation", "First theme", "Second theme"],
-    )
+    expect(config_area).to have_themes(["Foundation", "Horizon", "First theme", "Second theme"])
   end
 end

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -14,10 +14,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
   let(:install_modal) { PageObjects::Modals::InstallTheme.new }
   let(:admin_customize_themes_page) { PageObjects::Pages::AdminCustomizeThemes.new }
 
-  before do
-    SiteSetting.experimental_system_themes = "foundation|horizon"
-    sign_in(admin)
-  end
+  before { sign_in(admin) }
 
   it "has an install button in the subheader" do
     config_area.visit
@@ -77,19 +74,5 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     expect(page).to have_content(
       I18n.t("admin_js.admin.config_areas.themes_and_components.themes.title"),
     )
-  end
-
-  it "allows controlling visibility of system themes with experimental_system_themes setting" do
-    SiteSetting.experimental_system_themes = ""
-    config_area.visit
-    expect(config_area).to have_themes(["First theme", "Second theme"])
-
-    SiteSetting.experimental_system_themes = "foundation"
-    config_area.visit
-    expect(config_area).to have_themes(["Foundation", "First theme", "Second theme"])
-
-    SiteSetting.experimental_system_themes = "foundation|horizon"
-    config_area.visit
-    expect(config_area).to have_themes(["Foundation", "Horizon", "First theme", "Second theme"])
   end
 end

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -44,6 +44,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     config_area.mark_as_active(theme_2)
     expect(config_area).to have_badge(theme_2, "--active")
     expect(config_area).to have_no_badge(foundation_theme, "--active")
+    expect(config_area).to have_themes(["Second theme", "Horizon", "Foundation", "First theme"])
   end
 
   it "allows to make theme selectable by users" do

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -44,7 +44,6 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     config_area.mark_as_active(theme_2)
     expect(config_area).to have_badge(theme_2, "--active")
     expect(config_area).to have_no_badge(foundation_theme, "--active")
-    expect(config_area).to have_themes(["Second theme", "Horizon", "Foundation", "First theme"])
   end
 
   it "allows to make theme selectable by users" do

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -33,7 +33,7 @@ module PageObjects
       end
 
       def has_themes?(names)
-        expect(all(".theme-card__title").map(&:text)).to eq(names)
+        expect(all(".theme-card__title").map(&:text)).to match_array(names)
       end
 
       def toggle_selectable(theme)

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -33,7 +33,7 @@ module PageObjects
       end
 
       def has_themes?(names)
-        expect(all(".theme-card__title").map(&:text)).to match_array(names)
+        expect(all(".theme-card__title").map(&:text)).to eq(names)
       end
 
       def toggle_selectable(theme)


### PR DESCRIPTION
Reveal Foundation theme and stop creating a Default for new instances. Instead, the Foundation should be set as the default.