### PR TITLE
UX: Do not round emoji img borders in RTE

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -55,6 +55,10 @@
     max-width: 100%;
     border-radius: var(--d-border-radius);
 
+    &.emoji {
+      border-radius: 0;
+    }
+
     &[data-placeholder="true"] {
       animation: placeholder 1.5s infinite;
 


### PR DESCRIPTION
Minor followup to d07443a721224b16d74eb52ba72fda50d562e6cb

Makes it so emojis do not have rounded borders in the RTE,
this affects the appearance of some of them (like floppy disk)

**Before**

![image](https://github.com/user-attachments/assets/5c8cadde-ac8e-409d-8a7a-4df625cdcccd)

**After**

![image](https://github.com/user-attachments/assets/63fe2b25-8247-4ffd-ac26-1f264dd68718)
