### PR TITLE
DEV: Correct `reviewable_flagged_post` fabricator

### DIFF
--- a/spec/fabricators/reviewable_fabricator.rb
+++ b/spec/fabricators/reviewable_fabricator.rb
@@ -99,8 +99,8 @@ Fabricator(:reviewable_flagged_post) do
   target_created_by { Fabricate(:user) }
   topic
   target_type "Post"
-  target { Fabricate(:post) }
-  reviewable_scores { |p| [Fabricate.build(:reviewable_score, reviewable_id: p[:id])] }
+  target { |attrs| Fabricate(:post, topic: attrs[:topic]) }
+  reviewable_scores { |attrs| [Fabricate.build(:reviewable_score, reviewable_id: attrs[:id])] }
 end
 
 Fabricator(:reviewable_user) do


### PR DESCRIPTION
For a reviewable of `ReviewableFlaggedPost` type, the reviewable's
`topic_id` should be set to the target post's `topic_id`.
