### PR TITLE
DEV: Fix topic link component for reviewabled flagged post in new UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/topic-link.gjs
@@ -8,20 +8,20 @@ import { i18n } from "discourse-i18n";
 
 <template>
   <div class="post-topic">
-    {{#if this.reviewable.topic}}
+    {{#if @reviewable.topic}}
       <TopicStatus
-        @topic={{this.reviewable.topic}}
+        @topic={{@reviewable.topic}}
         @showPrivateMessageIcon={{true}}
       />
+
       <a
-        href={{this.reviewable.target_url}}
+        href={{@reviewable.target_url}}
         class="title-text"
-      >{{highlightWatchedWords
-          this.reviewable.topic.fancyTitle
-          this.reviewable
-        }}</a>
-      {{categoryBadge this.reviewable.category}}
-      <ReviewableTags @tags={{this.reviewable.topic_tags}} @tagName="" />
+      >{{highlightWatchedWords @reviewable.topic.fancyTitle @reviewable}}</a>
+
+      {{categoryBadge @reviewable.category}}
+
+      <ReviewableTags @tags={{@reviewable.topic_tags}} @tagName="" />
     {{else if (has-block)}}
       {{yield}}
     {{else}}
@@ -29,7 +29,7 @@ import { i18n } from "discourse-i18n";
         {{i18n "review.topics.deleted"}}
         <LinkTo
           @route="topic"
-          @models={{array "-" this.reviewable.removed_topic_id}}
+          @models={{array "-" @reviewable.removed_topic_id}}
         >{{i18n "review.topics.original"}}</LinkTo>
       </span>
     {{/if}}

--- a/spec/system/page_objects/components/review/topic_link.rb
+++ b/spec/system/page_objects/components/review/topic_link.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    module Review
+      class TopicLink < PageObjects::Components::Base
+        WRAPPER_CSS = ".post-topic"
+
+        def has_closed_topic_status?
+          within(WRAPPER_CSS) { has_css?(".topic-status .d-icon-lock") }
+        end
+
+        def has_topic_link?(topic_title:, post_url:)
+          within(WRAPPER_CSS) { expect(page).to have_link(topic_title, href: post_url) }
+        end
+
+        def has_category_badge?(category_name)
+          within(WRAPPER_CSS) do
+            expect(page).to have_css(".badge-category__name", text: category_name)
+          end
+        end
+
+        def has_tag_link?(tag_name:, tag_url:)
+          within(WRAPPER_CSS) { expect(page).to have_link(tag_name, href: tag_url) }
+        end
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -150,6 +150,10 @@ module PageObjects
         PageObjects::Components::Review::FlagReason.new
       end
 
+      def topic_link_component
+        PageObjects::Components::Review::TopicLink.new
+      end
+
       private
 
       def reviewable_action_dropdown

--- a/spec/system/viewing_reviewable_spec.rb
+++ b/spec/system/viewing_reviewable_spec.rb
@@ -14,64 +14,97 @@ describe "Viewing reviewable item", type: :system do
       sign_in(admin)
     end
 
-    it "shows the new reviewable UI" do
-      review_page.visit_reviewable(reviewable_flagged_post)
+    describe "when the reviewable item is a flagged post" do
+      it "shows the new reviewable UI" do
+        review_page.visit_reviewable(reviewable_flagged_post)
 
-      expect(page).to have_selector(".review-container")
-    end
+        expect(page).to have_selector(".review-container")
+      end
 
-    it "shows the reviewable item with badges stating the flag reason and count" do
-      _spam_reviewable_score =
-        Fabricate(
-          :reviewable_score,
-          reviewable: reviewable_flagged_post,
-          reviewable_score_type: ReviewableScore.types[:spam],
+      it "shows the reviewable item with badges stating the flag reason and count" do
+        _spam_reviewable_score =
+          Fabricate(
+            :reviewable_score,
+            reviewable: reviewable_flagged_post,
+            reviewable_score_type: ReviewableScore.types[:spam],
+          )
+
+        _off_topic_reviewable_score =
+          Fabricate(
+            :reviewable_score,
+            reviewable: reviewable_flagged_post,
+            reviewable_score_type: ReviewableScore.types[:off_topic],
+          )
+
+        _illegal_reviewable_score =
+          Fabricate(
+            :reviewable_score,
+            reviewable: reviewable_flagged_post,
+            reviewable_score_type: ReviewableScore.types[:illegal],
+          )
+
+        _inappropriate_reviewable_score =
+          Fabricate(
+            :reviewable_score,
+            reviewable: reviewable_flagged_post,
+            reviewable_score_type: ReviewableScore.types[:inappropriate],
+          )
+
+        _needs_approval_reviewable_score =
+          Fabricate(
+            :reviewable_score,
+            reviewable: reviewable_flagged_post,
+            reviewable_score_type: ReviewableScore.types[:needs_approval],
+          )
+
+        flag_reason_component =
+          review_page.visit_reviewable(reviewable_flagged_post).flag_reason_component
+
+        expect(flag_reason_component).to have_spam_flag_reason(reviewable_flagged_post, count: 1)
+        expect(flag_reason_component).to have_off_topic_flag_reason(
+          reviewable_flagged_post,
+          count: 1,
+        )
+        expect(flag_reason_component).to have_illegal_flag_reason(reviewable_flagged_post, count: 1)
+
+        expect(flag_reason_component).to have_inappropriate_flag_reason(
+          reviewable_flagged_post,
+          count: 2,
         )
 
-      _off_topic_reviewable_score =
-        Fabricate(
-          :reviewable_score,
-          reviewable: reviewable_flagged_post,
-          reviewable_score_type: ReviewableScore.types[:off_topic],
+        expect(flag_reason_component).to have_needs_approval_flag_reason(
+          reviewable_flagged_post,
+          count: 1,
+        )
+      end
+
+      it "shows the topic status, title link, category badge and tags of the topic associated with the reviewable item correctly" do
+        post = reviewable_flagged_post.post
+        topic = reviewable_flagged_post.topic
+        category = Fabricate(:category)
+        topic.change_category_to_id(category.id)
+        tag_1 = Fabricate(:tag)
+        tag_2 = Fabricate(:tag)
+        topic.tags = [tag_1, tag_2]
+        topic.closed = true
+        topic.save!
+
+        topic_link_component =
+          review_page.visit_reviewable(reviewable_flagged_post).topic_link_component
+
+        expect(topic_link_component).to have_closed_topic_status
+
+        expect(topic_link_component).to have_topic_link(
+          topic_title: topic.title,
+          post_url: post.full_url,
         )
 
-      _illegal_reviewable_score =
-        Fabricate(
-          :reviewable_score,
-          reviewable: reviewable_flagged_post,
-          reviewable_score_type: ReviewableScore.types[:illegal],
-        )
+        expect(topic_link_component).to have_category_badge(category.name)
+        expect(topic_link_component).to have_tag_link(tag_name: tag_1.name, tag_url: tag_1.url)
+        expect(topic_link_component).to have_tag_link(tag_name: tag_2.name, tag_url: tag_2.url)
 
-      _inappropriate_reviewable_score =
-        Fabricate(
-          :reviewable_score,
-          reviewable: reviewable_flagged_post,
-          reviewable_score_type: ReviewableScore.types[:inappropriate],
-        )
-
-      _needs_approval_reviewable_score =
-        Fabricate(
-          :reviewable_score,
-          reviewable: reviewable_flagged_post,
-          reviewable_score_type: ReviewableScore.types[:needs_approval],
-        )
-
-      flag_reason_component =
-        review_page.visit_reviewable(reviewable_flagged_post).flag_reason_component
-
-      expect(flag_reason_component).to have_spam_flag_reason(reviewable_flagged_post, count: 1)
-      expect(flag_reason_component).to have_off_topic_flag_reason(reviewable_flagged_post, count: 1)
-      expect(flag_reason_component).to have_illegal_flag_reason(reviewable_flagged_post, count: 1)
-
-      expect(flag_reason_component).to have_inappropriate_flag_reason(
-        reviewable_flagged_post,
-        count: 2,
-      )
-
-      expect(flag_reason_component).to have_needs_approval_flag_reason(
-        reviewable_flagged_post,
-        count: 1,
-      )
+        # TODO: Add test for watched words highlighting
+      end
     end
   end
 end


### PR DESCRIPTION
This commit fixes a problem in the new reviewable item template that uses the `reviewable-refresh/topic-link` component where a topic is always shown as deleted even if the topic is present.

### Before 

<img width="723" alt="Screenshot 2025-07-08 at 9 22 33 PM" src="https://github.com/user-attachments/assets/a9cf8e56-5ccf-46ad-93aa-debb3eb97641" />

### After

<img width="726" alt="Screenshot 2025-07-08 at 9 23 24 PM" src="https://github.com/user-attachments/assets/4d348675-6c1d-43bc-9a0a-58bb682b4dec" />
