### PR TITLE
FIX: emptying a text field should nullify it

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/input.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/input.gjs
@@ -50,7 +50,7 @@ export default class FKControlInput extends Component {
   handleInput(event) {
     const value =
       event.target.value === ""
-        ? undefined
+        ? null
         : this.type === "number"
           ? parseFloat(event.target.value)
           : event.target.value;

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-text-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/input-text-test.gjs
@@ -47,5 +47,25 @@ module(
 
       assert.dom(".form-kit__control-input").hasAttribute("disabled");
     });
+
+    test("when emptied", async function (assert) {
+      let data = { foo: "xxx" };
+      const mutateData = (x) => (data = x);
+
+      await render(
+        <template>
+          <Form @data={{data}} @onSubmit={{mutateData}} as |form|>
+            <form.Field @name="foo" @title="Foo" as |field|>
+              <field.Input />
+            </form.Field>
+          </Form>
+        </template>
+      );
+
+      await formKit().field("foo").fillIn("");
+      await formKit().submit();
+
+      assert.deepEqual(data.foo, null, "it nullifies the value");
+    });
   }
 );

--- a/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/form-kit/validator-test.js
@@ -309,6 +309,26 @@ module("Unit | Lib | FormKit | Validator", function (hooks) {
       "it returns an error when the value is empty spaces with trim"
     );
 
+    errors = await new Validator(undefined, {
+      required: {},
+    }).validate("input-text");
+
+    assert.deepEqual(
+      errors,
+      [i18n("form_kit.errors.required")],
+      "it returns an error when the value is undefined"
+    );
+
+    errors = await new Validator(null, {
+      required: {},
+    }).validate("input-text");
+
+    assert.deepEqual(
+      errors,
+      [i18n("form_kit.errors.required")],
+      "it returns an error when the value is null"
+    );
+
     errors = await new Validator(" ", {
       required: { trim: false },
     }).validate("input-text");


### PR DESCRIPTION
At the moment emptying a input-text is making it `undefined` instead of `null`. It's generally not a big deal but can be harder to work with.

There's also the very specific case of `JSON.stringify(data)` which will remove keys if the value is undefined.