### PR TITLE
UX: allow parens on rich editor img input rule

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -182,7 +182,7 @@ const extension = {
     pmState: { NodeSelection },
   }) => {
     return {
-      match: /!\[([^\]]*)\]\(([^\s]+)\)$/,
+      match: /!\[[^\]]*\]\([^\s]+\)$/,
       handler: (state, match, start, end) => {
         const tr = state.tr;
 

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -182,7 +182,7 @@ const extension = {
     pmState: { NodeSelection },
   }) => {
     return {
-      match: /!\[([^\]]*)\]\(([^)\s]+)\)$/,
+      match: /!\[([^\]]*)\]\(([^\s]+)\)$/,
       handler: (state, match, start, end) => {
         const tr = state.tr;
 


### PR DESCRIPTION
Changes the regex to be a bit less strict and allow `)`s in the input rule.

For example, `![image](https://upload.wikimedia.org/wikipedia/commons/3/37/Terry_Pratchett\_(3x4_cropped).jpg)` is a valid markdown, but wouldn't get converted with the previous regex.
