### PR TITLE
FEATURE: Allow Ctrl/Cmd+Enter to submit a form from a textarea

### DIFF
--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -26,7 +26,7 @@ export default class FKControlTextarea extends Component {
   }
 
   /**
-   * Handles keyboard shortcuts in the textarea
+   * Handles keyboard shortcuts in the textarea.
    *
    * @param {KeyboardEvent} event - Keyboard event
    */

--- a/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -25,6 +25,26 @@ export default class FKControlTextarea extends Component {
     this.args.field.set(event.target.value);
   }
 
+  /**
+   * Handles keyboard shortcuts in the textarea
+   *
+   * @param {KeyboardEvent} event - Keyboard event
+   */
+  @action
+  onKeyDown(event) {
+    // Ctrl/Cmd + Enter to submit
+    if (
+      (event.ctrlKey || event.metaKey) &&
+      event.key === "Enter" &&
+      !event.repeat
+    ) {
+      event.preventDefault();
+      event.target.form?.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true })
+      );
+    }
+  }
+
   get style() {
     if (!this.args.height) {
       return;
@@ -42,6 +62,7 @@ export default class FKControlTextarea extends Component {
       ...attributes
       {{this.resizeObserver}}
       {{on "input" this.handleInput}}
+      {{on "keydown" this.onKeyDown}}
     />
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
@@ -15,11 +15,36 @@ class Field {
     return this.element.dataset.controlType;
   }
 
+  /**
+   * For elements that have a single input element, this returns that element.
+   *
+   * @throws {Error} If the control type does not have a single input element.
+   * @returns {HTMLElement} The input element for the control.
+   */
+  get inputElement() {
+    switch (this.controlType) {
+      case "input-text":
+      case "input-number":
+      case "password":
+      case "checkbox":
+        return this.element.querySelector("input");
+      case "code":
+      case "textarea":
+      case "composer":
+        return this.element.querySelector("textarea");
+      case "toggle":
+        return this.element.querySelector("button");
+      case "select":
+        return this.element.querySelector("select");
+      default:
+        throw new Error(`Unsupported control type: ${this.controlType}`);
+    }
+  }
+
   value() {
     switch (this.controlType) {
       case "input-text":
-        const input = this.element.querySelector("input");
-        return parseInt(input.value, 10);
+        return parseInt(this.inputElement.value, 10);
     }
   }
 
@@ -33,24 +58,7 @@ class Field {
   }
 
   async fillIn(value) {
-    let element;
-
-    switch (this.controlType) {
-      case "input-text":
-      case "input-number":
-      case "password":
-        element = this.element.querySelector("input");
-        break;
-      case "code":
-      case "textarea":
-      case "composer":
-        element = this.element.querySelector("textarea");
-        break;
-      default:
-        throw new Error(`Unsupported control type: ${this.controlType}`);
-    }
-
-    await fillIn(element, value);
+    await fillIn(this.inputElement, value);
   }
 
   async toggle() {
@@ -61,10 +69,10 @@ class Field {
         );
         break;
       case "checkbox":
-        await click(this.element.querySelector("input"));
+        await click(this.inputElement);
         break;
       case "toggle":
-        await click(this.element.querySelector("button"));
+        await click(this.inputElement);
         break;
       default:
         throw new Error(`Unsupported control type: ${this.controlType}`);
@@ -119,9 +127,8 @@ class Field {
         await picker.selectRowByValue(value);
         break;
       case "select":
-        const select = this.element.querySelector("select");
-        select.value = value;
-        await triggerEvent(select, "input");
+        this.inputElement.value = value;
+        await triggerEvent(this.inputElement, "input");
         break;
       case "menu":
         const trigger = this.element.querySelector(
@@ -145,6 +152,10 @@ class Field {
       default:
         throw new Error("Unsupported field type");
     }
+  }
+
+  async triggerEvent(eventName, options = {}) {
+    await triggerEvent(this.inputElement, eventName, options);
   }
 }
 

--- a/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/form-kit-helper.js
@@ -154,6 +154,12 @@ class Field {
     }
   }
 
+  /**
+   * Triggers any event on the input element of the field.
+   *
+   * @param {string} eventName - The name of the event to trigger.
+   * @param {Object} [options={}] - Additional options for the event.
+   */
   async triggerEvent(eventName, options = {}) {
     await triggerEvent(this.inputElement, eventName, options);
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/password-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/password-test.gjs
@@ -48,13 +48,13 @@ module(
       );
 
       assert
-        .dom(formKit().field("foo").element.querySelector("input"))
+        .dom(formKit().field("foo").inputElement)
         .hasAttribute("type", "password");
 
       await formKit().field("foo").toggle();
 
       assert
-        .dom(formKit().field("foo").element.querySelector("input"))
+        .dom(formKit().field("foo").inputElement)
         .hasAttribute("type", "text");
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
@@ -92,5 +92,29 @@ module(
       assert.form().field("content").hasValue("final value");
       assert.dom(".form-kit__control-textarea").hasValue("final value");
     });
+
+    test("Ctrl/Cmd + Enter submits the form", async function (assert) {
+      let data = { foo: null };
+      const mutateData = (x) => (data = x);
+
+      await render(
+        <template>
+          <Form @onSubmit={{mutateData}} as |form|>
+            <form.Field @name="foo" @title="Foo" as |field|>
+              <field.Textarea />
+            </form.Field>
+          </Form>
+        </template>
+      );
+
+      await formKit().field("foo").fillIn("bar");
+      await formKit().field("foo").triggerEvent("keydown", {
+        key: "Enter",
+        ctrlKey: true,
+      });
+      await settled();
+
+      assert.deepEqual(data, { foo: "bar" });
+    });
   }
 );


### PR DESCRIPTION
## ✨ What's This?

When a FormKit textarea is focussed, there's currently no way to submit the form using the keyboard without tabbing out of the textarea.

This change lets the form be submitted using the Ctrl/Cmd+Enter key combination, bringing consistency with the post and chat composers.