### PR TITLE
DEV: Use FormKit APIs for reviewable note validation.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/note-form.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/note-form.gjs
@@ -1,10 +1,7 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { not } from "truth-helpers";
 import Form from "discourse/components/form";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -23,13 +20,6 @@ import { i18n } from "discourse-i18n";
 export default class ReviewableNoteForm extends Component {
   @service appEvents;
   @service currentUser;
-
-  /**
-   * Whether the form is currently being submitted.
-   *
-   * @type {boolean}
-   */
-  @tracked isSubmitting = false;
 
   /**
    * Registers the Form API reference.
@@ -51,8 +41,6 @@ export default class ReviewableNoteForm extends Component {
     if (!data.content?.trim()) {
       return;
     }
-
-    this.isSubmitting = true;
 
     try {
       const response = await ajax(`/review/${this.args.reviewable.id}/notes`, {
@@ -81,53 +69,7 @@ export default class ReviewableNoteForm extends Component {
       }
     } catch (error) {
       popupAjaxError(error);
-    } finally {
-      this.isSubmitting = false;
     }
-  }
-
-  /**
-   * Handles keyboard shortcuts in the textarea
-   *
-   * @param {KeyboardEvent} event - Keyboard event
-   */
-  @action
-  onKeyDown(event) {
-    // Ctrl/Cmd + Enter to submit
-    if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
-      event.preventDefault();
-      this.formApi.submit();
-    }
-  }
-
-  /**
-   * Whether the form has valid content to submit
-   *
-   * @returns {boolean} True if content is not empty after trimming
-   */
-  get isValid() {
-    const content = this.formApi.get("content") || "";
-    return content.trim().length > 0;
-  }
-
-  /**
-   * Number of characters remaining before hitting the limit
-   *
-   * @returns {number} Characters remaining out of 2000 max
-   */
-  get remainingChars() {
-    const maxLength = 2000;
-    const content = this.formApi.get("content") || "";
-    return maxLength - content.trim().length;
-  }
-
-  /**
-   * Whether the user is approaching the character limit
-   *
-   * @returns {boolean} True if less than 100 characters remaining
-   */
-  get isNearLimit() {
-    return this.remainingChars < 100;
   }
 
   <template>
@@ -137,38 +79,21 @@ export default class ReviewableNoteForm extends Component {
         @onSubmit={{this.onSubmit}}
         @onRegisterApi={{this.registerApi}}
         class="reviewable-note-form__form"
-        as |form data|
+        as |form|
       >
         <form.Field
           @name="content"
           @title={{i18n "review.notes.add_note_description"}}
           @format="full"
-          @validation="required"
+          @validation="required:trim|length:1,2000"
           as |field|
         >
           <div class="reviewable-note-form__textarea-wrapper">
             <field.Textarea
-              {{on "keydown" this.onKeyDown}}
               placeholder={{i18n "review.notes.placeholder"}}
               class="reviewable-note-form__textarea"
               rows="4"
-              maxlength="2000"
-              disabled={{this.isSubmitting}}
             />
-
-            {{#if data.content}}
-              <div
-                class="reviewable-note-form__char-count{{if
-                    this.isNearLimit
-                    ' warning'
-                  }}"
-              >
-                {{i18n
-                  "review.notes.chars_remaining"
-                  count=this.remainingChars
-                }}
-              </div>
-            {{/if}}
           </div>
         </form.Field>
 
@@ -180,8 +105,6 @@ export default class ReviewableNoteForm extends Component {
 
         <form.Actions>
           <form.Submit
-            @disabled={{not this.isValid}}
-            @isLoading={{this.isSubmitting}}
             @label="review.notes.add_note_button"
             class="btn-primary"
           />

--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -474,16 +474,4 @@
   textarea {
     resize: vertical;
   }
-
-  &__char-count {
-    position: absolute;
-    right: var(--space-2);
-    font-size: var(--font-down-2);
-    color: var(--primary-medium);
-
-    &.warning {
-      color: var(--danger);
-      font-weight: 500;
-    }
-  }
 }


### PR DESCRIPTION
## ✨ What's This?

This is a general clean-up of the reviewable note form component, including these changes:
- Hands off the note validation to FormKit validation checks (thanks @jjaffeux and @lis2 for pointing these out).
- Removes the keyboard shortcut for form submission, in favour of putting it into FormKit (#33527)
- Removes the check that disables the submit button when no note content is entered.

I initially experimented with adding stripped down validation checks to all FormKit forms that would disable the submit button until all required fields were set, matching the previous behaviour of the note form. I got it working quite well, avoiding the potential performance issues of running all form validation checks on large forms whenever a value changed. However, I decided not to go ahead with it for two reasons:

1. Despite it only being a single validation requirement, it wasn't visually obvious why the submit button was disabled on forms with multiple required fields. This could possibly be addressed by marking required fields (as opposed to the current practice of marking optional fields), but it didn't feel like that would be enough.
2. Disabling submit buttons is generally considered to be an accessibility issue, since it stops the button from being focussed with the keyboard, and messes with screen reader behaviour.
