### PR TITLE
DEV: Use reusable `d-table` instead of admin-only styles

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.gjs
@@ -5,16 +5,16 @@ import ApiKeyItem from "admin/components/api-key-item";
 const ApiKeysList = <template>
   <div class="container admin-api_keys">
     {{#if @apiKeys}}
-      <table class="d-admin-table admin-api_keys__items">
-        <thead>
-          <th>{{i18n "admin.api.key"}}</th>
-          <th>{{i18n "admin.api.description"}}</th>
-          <th>{{i18n "admin.api.user"}}</th>
-          <th>{{i18n "admin.api.created"}}</th>
-          <th>{{i18n "admin.api.scope"}}</th>
-          <th>{{i18n "admin.api.last_used"}}</th>
+      <table class="d-table admin-api_keys__items">
+        <thead class="d-table__header">
+          <th class="d-table__header-cell">{{i18n "admin.api.key"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.api.description"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.api.user"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.api.created"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.api.scope"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.api.last_used"}}</th>
         </thead>
-        <tbody>
+        <tbody class="d-table__body">
           {{#each @apiKeys as |apiKey|}}
             <ApiKeyItem @apiKey={{apiKey}} />
           {{/each}}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/api-keys-list.gjs
@@ -7,12 +7,14 @@ const ApiKeysList = <template>
     {{#if @apiKeys}}
       <table class="d-table admin-api_keys__items">
         <thead class="d-table__header">
-          <th class="d-table__header-cell">{{i18n "admin.api.key"}}</th>
-          <th class="d-table__header-cell">{{i18n "admin.api.description"}}</th>
-          <th class="d-table__header-cell">{{i18n "admin.api.user"}}</th>
-          <th class="d-table__header-cell">{{i18n "admin.api.created"}}</th>
-          <th class="d-table__header-cell">{{i18n "admin.api.scope"}}</th>
-          <th class="d-table__header-cell">{{i18n "admin.api.last_used"}}</th>
+          <tr class="d-table__row">
+            <th class="d-table__header-cell">{{i18n "admin.api.key"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.api.description"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.api.user"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.api.created"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.api.scope"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.api.last_used"}}</th>
+          </tr>
         </thead>
         <tbody class="d-table__body">
           {{#each @apiKeys as |apiKey|}}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
@@ -234,20 +234,22 @@ export default class AdminConfigAreasComponents extends Component {
       <ConditionalLoadingSpinner @condition={{this.loading}}>
         {{#if this.components.length}}
           <LoadMore @action={{this.loadMore}}>
-            <table class="d-admin-table component-list">
-              <thead>
-                <th>{{i18n
-                    "admin.config_areas.themes_and_components.components.name"
-                  }}</th>
-                <th>{{i18n
-                    "admin.config_areas.themes_and_components.components.used_on"
-                  }}</th>
-                <th>{{i18n
-                    "admin.config_areas.themes_and_components.components.enabled"
-                  }}</th>
-                <th></th>
+            <table class="d-table component-list">
+              <thead class="d-table__header">
+                <tr class="d-table__row">
+                  <th class="d-table__header-cell">{{i18n
+                      "admin.config_areas.themes_and_components.components.name"
+                    }}</th>
+                  <th class="d-table__header-cell">{{i18n
+                      "admin.config_areas.themes_and_components.components.used_on"
+                    }}</th>
+                  <th class="d-table__header-cell">{{i18n
+                      "admin.config_areas.themes_and_components.components.enabled"
+                    }}</th>
+                  <th class="d-table__header-cell"></th>
+                </tr>
               </thead>
-              <tbody>
+              <tbody class="d-table__body">
                 {{#each this.components as |comp|}}
                   <ComponentRow
                     @component={{comp}}
@@ -456,16 +458,16 @@ class ComponentRow extends Component {
   <template>
     <tr
       data-component-id={{@component.id}}
-      class="d-admin-row__content admin-config-components__component-row
+      class="d-table__row admin-config-components__component-row
         {{if this.hasUpdates 'has-update'}}"
     >
-      <td class="d-admin-row__overview">
-        <div class="d-admin-row__overview-name">
+      <td class="d-table__cell --overview">
+        <div class="d-table__overview-name">
           {{@component.name}}
         </div>
         {{#if @component.remote_theme.authors}}
           <div
-            class="d-admin-row__overview-author admin-config-components__author-name"
+            class="d-table__overview-author admin-config-components__author-name"
           >{{i18n
               "admin.config_areas.themes_and_components.components.by_author"
               (hash name=@component.remote_theme.authors)
@@ -473,7 +475,7 @@ class ComponentRow extends Component {
         {{/if}}
         {{#if this.description}}
           <div
-            class="d-admin-row__overview-about admin-config-components__description"
+            class="d-table__overview-about admin-config-components__description"
           >
             {{this.description}}
             {{#if @component.remote_theme.about_url}}
@@ -487,7 +489,7 @@ class ComponentRow extends Component {
         {{/if}}
         {{#if this.hasUpdates}}
           <div
-            class="d-admin-row__overview-about admin-config-components__update-available"
+            class="d-table__overview-about admin-config-components__update-available"
           >
             {{i18n
               "admin.config_areas.themes_and_components.components.update_available"
@@ -495,8 +497,8 @@ class ComponentRow extends Component {
           </div>
         {{/if}}
       </td>
-      <td class="d-admin-row__detail admin-config-components__parent-themes">
-        <div class="d-admin-row__mobile-label">
+      <td class="d-table__cell --detail admin-config-components__parent-themes">
+        <div class="d-table__mobile-label">
           {{i18n "admin.config_areas.themes_and_components.components.used_on"}}
         </div>
         <div class="admin-config-components__parent-themes-list">
@@ -514,8 +516,8 @@ class ComponentRow extends Component {
           {{/if}}
         </div>
       </td>
-      <td class="d-admin-row__detail">
-        <div class="d-admin-row__mobile-label">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
           {{i18n "admin.config_areas.themes_and_components.components.enabled"}}
         </div>
         <DToggleSwitch
@@ -525,8 +527,8 @@ class ComponentRow extends Component {
           {{on "click" this.toggleEnabled}}
         />
       </td>
-      <td class="d-admin-row__controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls">
+        <div class="d-table__cell-actions">
           <DButton
             class="admin-config-components__edit"
             @label="admin.config_areas.themes_and_components.components.edit"

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/emojis-list.gjs
@@ -35,20 +35,20 @@ export default class AdminConfigAreasEmojisList extends Component {
     </div>
 
     {{#if this.emojis}}
-      <table id="custom_emoji" class="d-admin-table">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.emoji.image"}}</th>
-            <th>{{i18n "admin.emoji.name"}}</th>
-            <th>{{i18n "admin.emoji.group"}}</th>
-            <th colspan="3">{{i18n "admin.emoji.created_by"}}</th>
+      <table id="custom_emoji" class="d-table">
+        <thead class="d-table__header">
+          <tr class="d-table__row">
+            <th class="d-table__header-cell">{{i18n "admin.emoji.image"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.emoji.name"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.emoji.group"}}</th>
+            <th class="d-table__header-cell" colspan="3">{{i18n "admin.emoji.created_by"}}</th>
           </tr>
         </thead>
         {{#if this.sortedEmojis}}
-          <tbody>
+          <tbody class="d-table__body">
             {{#each this.sortedEmojis as |emoji|}}
-              <tr class="d-admin-row__content">
-                <td class="d-admin-row__overview">
+              <tr class="d-table__row">
+                <td class="d-table__cell --overview">
                   <img
                     class="emoji emoji-custom"
                     src={{emoji.url}}
@@ -56,25 +56,25 @@ export default class AdminConfigAreasEmojisList extends Component {
                     alt={{i18n "admin.emoji.alt"}}
                   />
                 </td>
-                <td class="d-admin-row__detail">
-                  <div class="d-admin-row__mobile-label">
+                <td class="d-table__cell --detail">
+                  <div class="d-table__mobile-label">
                     {{i18n "admin.emoji.name"}}
                   </div>
                   :{{emoji.name}}:
                 </td>
-                <td class="d-admin-row__detail">
-                  <div class="d-admin-row__mobile-label">
+                <td class="d-table__cell --detail">
+                  <div class="d-table__mobile-label">
                     {{i18n "admin.emoji.group"}}
                   </div>
                   {{emoji.group}}
                 </td>
-                <td class="d-admin-row__detail">
-                  <div class="d-admin-row__mobile-label">
+                <td class="d-table__cell --detail">
+                  <div class="d-table__mobile-label">
                     {{i18n "admin.emoji.created_by"}}
                   </div>
                   {{emoji.created_by}}
                 </td>
-                <td class="d-admin-row__controls action">
+                <td class="d-table__cell --controls action">
                   <DButton
                     @action={{fn this.adminEmojis.destroyEmoji emoji}}
                     @label="admin.emoji.delete"

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/flags.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/flags.gjs
@@ -61,12 +61,12 @@ export default class AdminConfigAreasFlags extends Component {
 
   <template>
     <div class="container admin-flags">
-      <table class="d-admin-table admin-flags__items">
-        <thead>
-          <th>{{i18n "admin.config_areas.flags.description"}}</th>
-          <th>{{i18n "admin.config_areas.flags.enabled"}}</th>
+      <table class="d-table admin-flags__items">
+        <thead class="d-table__header">
+          <th class="d-table__header-cell">{{i18n "admin.config_areas.flags.description"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.config_areas.flags.enabled"}}</th>
         </thead>
-        <tbody>
+        <tbody class="d-table__body">
           {{#each this.flags as |flag|}}
             <AdminFlagItem
               @flag={{flag}}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/user-fields-list.gjs
@@ -75,12 +75,14 @@ export default class AdminConfigAreasUserFieldsList extends Component {
   <template>
     <div class="container admin-user_fields">
       {{#if this.fields}}
-        <table class="d-admin-table admin-flags__items">
-          <thead>
-            <th>{{i18n "admin.config_areas.user_fields.field"}}</th>
-            <th>{{i18n "admin.config_areas.user_fields.type"}}</th>
+        <table class="d-table user-fields">
+          <thead class="d-table__header">
+            <tr class="d-table__row">
+              <th class="d-table__header-cell">{{i18n "admin.config_areas.user_fields.field"}}</th>
+              <th class="d-table__header-cell">{{i18n "admin.config_areas.user_fields.type"}}</th>
+            </tr>
           </thead>
-          <tbody>
+          <tbody class="d-table__body">
             {{#each this.sortedFields as |field|}}
               <AdminUserFieldItem
                 @userField={{field}}

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/webhooks-list.gjs
@@ -30,16 +30,16 @@ export default class AdminConfigAreasWebhooksList extends Component {
   <template>
     <div class="container admin-api_keys">
       {{#if this.webhooks}}
-        <table class="d-admin-table admin-web_hooks__items">
-          <thead>
-            <tr>
-              <th>{{i18n "admin.web_hooks.delivery_status.title"}}</th>
-              <th>{{i18n "admin.web_hooks.payload_url"}}</th>
-              <th>{{i18n "admin.web_hooks.description_label"}}</th>
-              <th>{{i18n "admin.web_hooks.controls"}}</th>
+        <table class="d-table admin-web_hooks__items">
+          <thead class="d-table__header">
+            <tr class="d-table__row">
+              <th class="d-table__header-cell">{{i18n "admin.web_hooks.delivery_status.title"}}</th>
+              <th class="d-table__header-cell">{{i18n "admin.web_hooks.payload_url"}}</th>
+              <th class="d-table__header-cell">{{i18n "admin.web_hooks.description_label"}}</th>
+              <th class="d-table__header-cell">{{i18n "admin.web_hooks.controls"}}</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="d-table__body">
             {{#each this.webhooks as |webhook|}}
               <WebhookItem
                 @webhook={{webhook}}

--- a/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-flag-item.gjs
@@ -121,21 +121,21 @@ export default class AdminFlagItem extends Component {
   <template>
     <tr
       class={{concatClass
-        "d-admin-row__content admin-flag-item"
+        "d-table__row admin-flag-item"
         @flag.name_key
         (if this.isSaved "saved")
       }}
     >
-      <td class="d-admin-row__overview">
+      <td class="d-table__cell --overview">
         <div
-          class="d-admin-row__overview-name admin-flag-item__name"
+          class="d-table__overview-name admin-flag-item__name"
         >{{@flag.name}}</div>
-        <div class="d-admin-row__overview-about">{{htmlSafe
+        <div class="d-table__overview-about">{{htmlSafe
             @flag.description
           }}</div>
       </td>
-      <td class="d-admin-row__detail">
-        <div class="d-admin-row__mobile-label">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
           {{i18n "admin.config_areas.flags.enabled"}}
         </div>
         <DToggleSwitch
@@ -144,8 +144,8 @@ export default class AdminFlagItem extends Component {
           {{on "click" (fn this.toggleFlagEnabled @flag)}}
         />
       </td>
-      <td class="d-admin-row__controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls">
+        <div class="d-table__cell-actions">
 
           <DButton
             class="btn-default btn-small admin-flag-item__edit"

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -62,11 +62,11 @@ export default class AdminPluginsListItem extends Component {
     <tr
       data-plugin-name={{@plugin.name}}
       class={{concat
-        "d-admin-row__content admin-plugins-list__row"
+        "d-table__row admin-plugins-list__row"
         (if this.isAdminSearchFiltered "-admin-search-filtered")
       }}
     >
-      <td class="d-admin-row__overview admin-plugins-list__name-details">
+      <td class="d-table__cell --overview admin-plugins-list__name-details">
         <div class="admin-plugins-list__name-with-badges">
           <div class="d-admin-row__overview-name admin-plugins-list__name">
             {{@plugin.nameTitleized}}
@@ -103,8 +103,8 @@ export default class AdminPluginsListItem extends Component {
           {{/if}}
         </div>
       </td>
-      <td class="d-admin-row__detail admin-plugins-list__version">
-        <div class="d-admin-row__mobile-label">
+      <td class="d-table__cell --detail admin-plugins-list__version">
+        <div class="d-table__mobile-label">
           {{i18n "admin.plugins.version"}}
         </div>
         <div class="plugin-version">
@@ -117,8 +117,8 @@ export default class AdminPluginsListItem extends Component {
           </PluginOutlet>
         </div>
       </td>
-      <td class="d-admin-row__detail admin-plugins-list__enabled">
-        <div class="d-admin-row__mobile-label">
+      <td class="d-table__cell --detail admin-plugins-list__enabled">
+        <div class="d-table__mobile-label">
           {{i18n "admin.plugins.enabled"}}
         </div>
         <PluginOutlet
@@ -135,7 +135,7 @@ export default class AdminPluginsListItem extends Component {
           {{/if}}
         </PluginOutlet>
       </td>
-      <td class="d-admin-row__controls admin-plugins-list__settings">
+      <td class="d-table__cell --controls admin-plugins-list__settings">
         <PluginOutlet
           @name="admin-plugin-list-item-settings"
           @outletArgs={{lazyHash plugin=@plugin}}

--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list.gjs
@@ -2,16 +2,16 @@ import { i18n } from "discourse-i18n";
 import AdminPluginsListItem from "./admin-plugins-list-item";
 
 const AdminPluginsList = <template>
-  <table class="d-admin-table admin-plugins-list">
-    <thead>
-      <tr>
-        <th>{{i18n "admin.plugins.name"}}</th>
-        <th>{{i18n "admin.plugins.version"}}</th>
-        <th>{{i18n "admin.plugins.enabled"}}</th>
-        <th></th>
+  <table class="d-table admin-plugins-list">
+    <thead class="d-table__header">
+      <tr class="d-table__row">
+        <th class="d-table__header-cell">{{i18n "admin.plugins.name"}}</th>
+        <th class="d-table__header-cell">{{i18n "admin.plugins.version"}}</th>
+        <th class="d-table__header-cell">{{i18n "admin.plugins.enabled"}}</th>
+        <th class="d-table__header-cell"></th>
       </tr>
     </thead>
-    <tbody>
+    <tbody class="d-table__body">
       {{#each @plugins as |plugin|}}
         <AdminPluginsListItem @plugin={{plugin}} />
       {{/each}}

--- a/app/assets/javascripts/admin/addon/components/admin-user-field-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-user-field-item.gjs
@@ -66,21 +66,21 @@ export default class AdminUserFieldItem extends Component {
   }
 
   <template>
-    <tr class="d-admin-row__content admin-user_field-item">
-      <td class="d-admin-row__overview">
+    <tr class="d-table__row admin-user_field-item">
+      <td class="d-table__cell --overview">
         <div
-          class="d-admin-row__overview-name admin-user_field-item__name"
+          class="d-table__overview-name admin-user_field-item__name"
         >{{@userField.name}}</div>
-        <div class="d-admin-row__overview-about">{{htmlSafe
+        <div class="d-table__overview-about">{{htmlSafe
             @userField.description
           }}</div>
-        <div class="d-admin-row__overview-flags">{{this.flags}}</div>
+        <div class="d-table__overview-flags">{{this.flags}}</div>
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail">
         {{@userField.fieldTypeName}}
       </td>
-      <td class="d-admin-row__controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls">
+        <div class="d-table__cell-actions">
           <DButton
             class="btn-default btn-small admin-user_field-item__edit"
             @action={{this.edit}}

--- a/app/assets/javascripts/admin/addon/components/api-key-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/api-key-item.gjs
@@ -63,22 +63,22 @@ export default class ApiKeyItem extends Component {
   }
 
   <template>
-    <tr class="d-admin-row__content">
-      <td class="d-admin-row__overview key">
+    <tr class="d-table__row">
+      <td class="d-table__cell --overview key">
         {{this.apiKey.truncatedKey}}
         {{#if this.apiKey.revoked_at}}
-          <span class="d-admin-table__badge">{{i18n
+          <span class="d-table__badge">{{i18n
               "admin.api.revoked"
             }}</span>{{/if}}
       </td>
-      <td class="d-admin-row__detail key-description">
-        <div class="d-admin-row__mobile-label">{{i18n
+      <td class="d-table__cell --detail key-description">
+        <div class="d-table__mobile-label">{{i18n
             "admin.api.description"
           }}</div>
         {{this.apiKey.shortDescription}}
       </td>
-      <td class="d-admin-row__detail key-user">
-        <div class="d-admin-row__mobile-label">{{i18n "admin.api.user"}}</div>
+      <td class="d-table__cell --detail key-user">
+        <div class="d-table__mobile-label">{{i18n "admin.api.user"}}</div>
         {{#if this.apiKey.user}}
           <LinkTo @route="adminUser" @model={{this.apiKey.user}}>
             {{avatar this.apiKey.user imageSize="small"}}
@@ -87,22 +87,26 @@ export default class ApiKeyItem extends Component {
           {{i18n "admin.api.all_users"}}
         {{/if}}
       </td>
-      <td class="d-admin-row__detail key-created">
-        <LinkTo @route="adminUser" @model={{this.apiKey.createdBy}}>
-          {{avatar this.apiKey.createdBy imageSize="small"}}
-        </LinkTo>
-        <div class="d-admin-row__mobile-label">{{i18n
-            "admin.api.created"
-          }}</div>
-        {{formatDate this.apiKey.created_at}}
+      <td class="d-table__cell --detail key-created">
+        <div class="d-table__mobile-label">{{i18n
+          "admin.api.created"
+        }}</div>
+        <div class="d-table__mobile-value-wrapper">
+          <LinkTo @route="adminUser" @model={{this.apiKey.createdBy}}>
+            {{avatar this.apiKey.createdBy imageSize="small"}}
+          </LinkTo>
+          {{formatDate this.apiKey.created_at}}
+        </div>
       </td>
-      <td class="d-admin-row__detail key-scope">
-        <div class="d-admin-row__mobile-label">{{i18n "admin.api.scope"}}</div>
-        {{icon this.scopeIcon}}
-        {{this.scopeName}}
+      <td class="d-table__cell --detail key-scope">
+        <div class="d-table__mobile-label">{{i18n "admin.api.scope"}}</div>
+        <div class="d-table__mobile-value-wrapper">
+          {{icon this.scopeIcon}}
+          {{this.scopeName}}
+        </div>
       </td>
-      <td class="d-admin-row__detail key-last-used">
-        <div class="d-admin-row__mobile-label">{{i18n
+      <td class="d-table__cell --detail key-last-used">
+        <div class="d-table__mobile-label">{{i18n
             "admin.api.last_used"
           }}</div>
         {{#if this.apiKey.last_used_at}}
@@ -111,8 +115,8 @@ export default class ApiKeyItem extends Component {
           {{i18n "admin.api.never_used"}}
         {{/if}}
       </td>
-      <td class="d-admin-row__controls key-controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls key-controls">
+        <div class="d-table__cell-actions">
           <DButton
             @action={{this.edit}}
             @label="admin.api_keys.edit"

--- a/app/assets/javascripts/admin/addon/components/api-key-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/api-key-item.gjs
@@ -65,11 +65,17 @@ export default class ApiKeyItem extends Component {
   <template>
     <tr class="d-table__row">
       <td class="d-table__cell --overview key">
-        {{this.apiKey.truncatedKey}}
-        {{#if this.apiKey.revoked_at}}
-          <span class="d-table__badge">{{i18n
-              "admin.api.revoked"
-            }}</span>{{/if}}
+        <div class="d-table__value-wrapper">
+          {{this.apiKey.truncatedKey}}
+          {{#if this.apiKey.revoked_at}}
+            <div class="status-label --inactive">
+              <div class="status-label-indicator"></div>
+              <div class="status-label-text">
+                {{i18n "admin.api.revoked" }}
+                </div>
+            </div>
+          {{/if}}
+        </div>
       </td>
       <td class="d-table__cell --detail key-description">
         <div class="d-table__mobile-label">{{i18n
@@ -91,7 +97,7 @@ export default class ApiKeyItem extends Component {
         <div class="d-table__mobile-label">{{i18n
           "admin.api.created"
         }}</div>
-        <div class="d-table__mobile-value-wrapper">
+        <div class="d-table__value-wrapper">
           <LinkTo @route="adminUser" @model={{this.apiKey.createdBy}}>
             {{avatar this.apiKey.createdBy imageSize="small"}}
           </LinkTo>
@@ -100,7 +106,7 @@ export default class ApiKeyItem extends Component {
       </td>
       <td class="d-table__cell --detail key-scope">
         <div class="d-table__mobile-label">{{i18n "admin.api.scope"}}</div>
-        <div class="d-table__mobile-value-wrapper">
+        <div class="d-table__value-wrapper">
           {{icon this.scopeIcon}}
           {{this.scopeName}}
         </div>

--- a/app/assets/javascripts/admin/addon/components/embeddable-host.gjs
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.gjs
@@ -42,25 +42,44 @@ export default class EmbeddableHost extends Component {
   }
 
   <template>
-    <tr class="d-admin-row__content">
-      <td class="d-admin-row__detail">
+    <tr class="d-table__row">
+      <td class="d-table__cell --overview">
         {{this.host.host}}
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
+          {{i18n "admin.embedding.allowed_paths"}}
+        </div>
         {{this.host.allowed_paths}}
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
+          {{i18n "admin.embedding.category"}}
+        </div>
         {{categoryBadge this.category allowUncategorized=true}}
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
+          {{i18n "admin.embedding.tags"}}
+        </div>
         {{this.tags}}
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail">
+        <div class="d-table__mobile-label">
+          {{#if @controller.embedding.embed_by_username}}
+            {{i18n
+              "admin.embedding.post_author_with_default"
+              author=@controller.embedding.embed_by_username
+            }}
+          {{else}}
+            {{i18n "admin.embedding.post_author"}}
+          {{/if}}
+        </div>
         {{this.user}}
       </td>
 
-      <td class="d-admin-row__controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls">
+        <div class="d-table__cell-actions">
           <DButton
             class="btn-default btn-small admin-embeddable-host-item__edit"
             @route="adminEmbedding.edit"

--- a/app/assets/javascripts/admin/addon/components/webhook-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/webhook-item.gjs
@@ -32,8 +32,8 @@ export default class WebhookItem extends Component {
   }
 
   <template>
-    <tr class="d-admin-row__content">
-      <td class="d-admin-row__overview key">
+    <tr class="d-table__row">
+      <td class="d-table__cell --overview key">
         <LinkTo @route="adminWebHooks.show" @model={{this.webhook}}>
           <WebhookStatus
             @deliveryStatuses={{this.deliveryStatuses}}
@@ -41,16 +41,16 @@ export default class WebhookItem extends Component {
           />
         </LinkTo>
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail key-url">
         <LinkTo @route="adminWebHooks.edit" @model={{this.webhook}}>
           {{this.webhook.payload_url}}
         </LinkTo>
       </td>
-      <td class="d-admin-row__detail">
+      <td class="d-table__cell --detail key-description">
         {{this.webhook.description}}
       </td>
-      <td class="d-admin-row__controls key-controls">
-        <div class="d-admin-row__controls-options">
+      <td class="d-table__cell --controls key-controls">
+        <div class="d-table__cell-actions">
           <DButton
             @action={{this.edit}}
             @label="admin.web_hooks.edit"

--- a/app/assets/javascripts/admin/addon/templates/backups-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/backups-index.gjs
@@ -46,31 +46,33 @@ export default RouteTemplate(
       </div>
     {{/if}}
 
-    <table class="d-admin-table admin-backups-list">
-      <thead>
-        <th>{{i18n "admin.backups.columns.filename"}}</th>
-        <th class="backup-size">{{i18n "admin.backups.columns.size"}}</th>
-        <th></th>
+    <table class="d-table admin-backups-list">
+      <thead class="d-table__header">
+        <tr class="d-table__row">
+          <th class="d-table__header-cell">{{i18n "admin.backups.columns.filename"}}</th>
+          <th class="backup-size">{{i18n "admin.backups.columns.size"}}</th>
+          <th class="d-table__header-cell"></th>
+        </tr>
       </thead>
-      <tbody>
+      <tbody class="d-table__body">
         {{#each @controller.model as |backup|}}
           <tr
-            class="d-admin-row__content backup-item-row"
+            class="d-table__row backup-item-row"
             data-backup-filename={{backup.filename}}
           >
-            <td class="d-admin-row__overview">
+            <td class="d-table__cell --overview">
               <div class="backup-filename">
                 {{backup.filename}}
               </div>
             </td>
-            <td class="d-admin-row__detail backup-size">
-              <div class="d-admin-row__mobile-label">
+            <td class="d-table__cell --detail backup-size">
+              <div class="d-table__mobile-label">
                 {{i18n "admin.backups.columns.size"}}
               </div>
               {{humanSize backup.size}}
             </td>
-            <td class="d-admin-row__controls backup-controls">
-              <div class="d-admin-row__controls-options">
+            <td class="d-table__cell --controls backup-controls">
+              <div class="d-table__cell-actions">
                 <DButton
                   @action={{fn @controller.download backup}}
                   @title="admin.backups.operations.download.title"

--- a/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/embedding-index.gjs
@@ -25,22 +25,22 @@ export default RouteTemplate(
         </AdminConfigAreaCard>
       {{/if}}
 
-      <table class="d-admin-table">
-        <thead>
-          <th>{{i18n "admin.embedding.host"}}</th>
-          <th>{{i18n "admin.embedding.allowed_paths"}}</th>
-          <th>{{i18n "admin.embedding.category"}}</th>
-          <th>{{i18n "admin.embedding.tags"}}</th>
+      <table class="d-table">
+        <thead class="d-table__header">
+          <th class="d-table__header-cell">{{i18n "admin.embedding.host"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.embedding.allowed_paths"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.embedding.category"}}</th>
+          <th class="d-table__header-cell">{{i18n "admin.embedding.tags"}}</th>
           {{#if @controller.embedding.embed_by_username}}
-            <th>{{i18n
+            <th class="d-table__header-cell">{{i18n
                 "admin.embedding.post_author_with_default"
                 author=@controller.embedding.embed_by_username
               }}</th>
           {{else}}
-            <th>{{i18n "admin.embedding.post_author"}}</th>
+            <th class="d-table__header-cell">{{i18n "admin.embedding.post_author"}}</th>
           {{/if}}
         </thead>
-        <tbody>
+        <tbody class="d-table__body">
           {{#each @controller.embedding.embeddable_hosts as |host|}}
             <EmbeddableHost
               @host={{host}}

--- a/app/assets/javascripts/admin/addon/templates/permalinks-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/permalinks-index.gjs
@@ -31,20 +31,22 @@ export default RouteTemplate(
 
       <div class="permalink-results">
         {{#if @controller.model.length}}
-          <table class="d-admin-table permalinks">
-            <thead>
-              <th>{{i18n "admin.permalink.url"}}</th>
-              <th>{{i18n "admin.permalink.destination"}}</th>
+          <table class="d-table permalinks">
+            <thead class="d-table__header">
+              <tr class="d-table__row">
+                <th class="d-table__header-cell">{{i18n "admin.permalink.url"}}</th>
+                <th class="d-table__header-cell">{{i18n "admin.permalink.destination"}}</th>
+              </tr>
             </thead>
-            <tbody>
+            <tbody class="d-table__body">
               {{#each @controller.model as |pl|}}
                 <tr
                   class={{concatClass
-                    "admin-permalink-item d-admin-row__content"
+                    "d-table__row admin-permalink-item"
                     pl.key
                   }}
                 >
-                  <td class="d-admin-row__overview">
+                  <td class="d-table__cell --overview">
                     <FlatButton
                       @title="admin.permalink.copy_to_clipboard"
                       @icon="far-clipboard"
@@ -56,7 +58,7 @@ export default RouteTemplate(
                       title={{pl.url}}
                     >{{pl.url}}</span>
                   </td>
-                  <td class="d-admin-row__detail destination">
+                  <td class="d-table__cell --detail destination">
                     {{#if pl.topic_id}}
                       <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
                     {{/if}}
@@ -80,8 +82,8 @@ export default RouteTemplate(
                       <a href={{pl.user_url}}>{{pl.username}}</a>
                     {{/if}}
                   </td>
-                  <td class="d-admin-row__controls">
-                    <div class="d-admin-row__controls-options">
+                  <td class="d-table__cell --controls">
+                    <div class="d-table__cell-actions">
                       <DButton
                         class="btn-default btn-small admin-permalink-item__edit"
                         @route="adminPermalinks.edit"

--- a/app/assets/stylesheets/admin/admin_config_components.scss
+++ b/app/assets/stylesheets/admin/admin_config_components.scss
@@ -28,14 +28,3 @@
     }
   }
 }
-
-.d-admin-table.component-list {
-  .has-update {
-    background-color: var(--tertiary-very-low);
-    border-left: solid 3px var(--tertiary);
-  }
-
-  .d-admin-row__overview-about .d-icon {
-    font-size: var(--font-down-3);
-  }
-}

--- a/app/assets/stylesheets/admin/api.scss
+++ b/app/assets/stylesheets/admin/api.scss
@@ -1,26 +1,24 @@
 @use "lib/viewport";
 
-// Styles for admin/api
-.d-admin-table.web-hooks {
-  .d-admin-row__overview.payload-url {
-    word-wrap: break-word;
-    max-width: 20vw;
+// For /admin/api/webhooks
+.d-table.admin-web_hooks__items {
+  .d-table__cell {
+    &.key-url {
+      word-break: break-all;
+      white-space: normal;
+    }
 
-    @include viewport.until(lg) {
-      max-width: 70vw;
+    &.key-description {
+      white-space: pre-wrap;
+      word-break: break-word;
     }
   }
+}
 
-  .d-admin-row__detail.description {
-    @include viewport.until(lg) {
-      display: block;
-    }
-
-    .d-admin-row__mobile-label {
-      @include viewport.until(lg) {
-        display: block;
-      }
-    }
+// For /admin/api/keys
+.d-table.admin-api_keys__items {
+  .d-table__cell.key {
+    display: flex;
   }
 }
 

--- a/app/assets/stylesheets/admin/backups.scss
+++ b/app/assets/stylesheets/admin/backups.scss
@@ -6,13 +6,14 @@
     margin-top: 1em;
   }
 
-  .d-admin-table {
-    .backup-size {
-      text-align: right;
+  .d-table {
+    .d-table__cell.--overview {
+      max-width: 65%;
+      text-wrap: balance;
     }
 
-    .backup-filename {
-      text-wrap: balance;
+    .backup-size {
+      text-align: right;
     }
   }
 }

--- a/app/assets/stylesheets/admin/plugins.scss
+++ b/app/assets/stylesheets/admin/plugins.scss
@@ -8,7 +8,7 @@
     }
   }
 
-  .d-admin-table.admin-plugins-list {
+  .d-table.admin-plugins-list {
     .admin-plugins-list__version {
       width: 14%;
 
@@ -18,7 +18,7 @@
       }
     }
 
-    .d-admin-row__controls {
+    .d-table__cell.--controls {
       width: 10%;
 
       @include viewport.until(md) {

--- a/app/assets/stylesheets/common/components/table-layout.scss
+++ b/app/assets/stylesheets/common/components/table-layout.scss
@@ -57,6 +57,40 @@
     width: auto;
     border-top: 0;
   }
+
+  .d-table__overview-name {
+    font-weight: 700;
+    max-width: 80%;
+    margin-bottom: var(--space-1);
+  }
+
+  .d-table__overview-author {
+    font-size: var(--font-down-1);
+    margin-bottom: var(--space-1);
+  }
+
+  .d-table__overview-about {
+    padding-right: var(--space-4);
+
+    @include viewport.until(md) {
+      padding-top: var(--space-1);
+    }
+
+    .d-icon {
+      font-size: var(--font-down-3);
+      margin-bottom: 0.1em;
+    }
+  }
+
+  &-flags {
+    color: var(--primary-high);
+    font-size: var(--font-down-1);
+    text-transform: lowercase;
+
+    &::first-letter {
+      text-transform: uppercase;
+    }
+  }
 }
 
 .d-table__cell.--detail {
@@ -98,4 +132,17 @@
     display: inline-flex;
     color: var(--primary-high);
   }
+}
+
+.d-table__mobile-value-wrapper {
+  align-items: center;
+}
+
+// Badges
+.d-table__badge {
+  background-color: var(--primary-low);
+  border-radius: var(--d-border-radius);
+  font-size: var(--font-down-1);
+  margin-left: var(--space-1);
+  padding: var(--space-2);
 }

--- a/app/assets/stylesheets/common/components/table-layout.scss
+++ b/app/assets/stylesheets/common/components/table-layout.scss
@@ -5,7 +5,7 @@
 
   @include viewport.until(md) {
     border-collapse: collapse;
-    margin-bottom: var(--space-3);
+    margin-bottom: var(--space-12);
   }
 
   th,
@@ -34,6 +34,11 @@
     display: block;
     margin-bottom: var(--space-3);
     border: 1px solid var(--primary-low);
+  }
+
+  &.has-update {
+    background-color: var(--tertiary-very-low);
+    border-left: solid 3px var(--tertiary);
   }
 }
 
@@ -82,7 +87,7 @@
     }
   }
 
-  &-flags {
+  .d-table__overview-flags {
     color: var(--primary-high);
     font-size: var(--font-down-1);
     text-transform: lowercase;
@@ -134,15 +139,78 @@
   }
 }
 
-.d-table__mobile-value-wrapper {
+.d-table__value-wrapper {
+  display: flex;
   align-items: center;
+  gap: var(--space-1);
 }
 
-// Badges
-.d-table__badge {
-  background-color: var(--primary-low);
-  border-radius: var(--d-border-radius);
-  font-size: var(--font-down-1);
-  margin-left: var(--space-1);
-  padding: var(--space-2);
+// Badges/Statuses
+.d-table {
+  // Default
+  .status-label {
+    --d-border-radius: var(--space-4);
+    --status-icon-diameter: 8px;
+    display: flex;
+    flex-wrap: nowrap;
+    width: fit-content;
+    background-color: var(--primary-low);
+    padding: var(--space-half) var(--space-2);
+    border-radius: var(--d-border-radius);
+
+    .status-label-indicator {
+      display: inline-block;
+      width: var(--status-icon-diameter);
+      height: var(--status-icon-diameter);
+      border-radius: 50%;
+      background-color: var(--primary-high);
+      flex-shrink: 0;
+      margin-right: var(--space-1);
+      margin-top: 0.35rem;
+    }
+
+    .status-label-text {
+      color: var(--primary-high);
+      font-size: var(--font-down-1);
+    }
+  }
+
+  // Success badge
+  .status-label.--success {
+    background-color: var(--success-low);
+
+    .status-label-indicator {
+      background-color: var(--success);
+    }
+
+    .status-label-text {
+      color: var(--success-hover);
+    }
+  }
+
+  // Critical badge
+  .status-label.--critical {
+    background-color: var(--danger-low);
+
+    .status-label-indicator {
+      background-color: var(--danger);
+    }
+
+    .status-label-text {
+      color: var(--danger-hover);
+    }
+  }
+
+  // Inactive badge
+  .status-label.--inactive {
+    background-color: var(--primary-low);
+
+    .status-label-indicator {
+      background-color: var(--primary-high);
+    }
+
+    .status-label-text {
+      color: var(--primary-high);
+    }
+  }
 }


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/33253

Switches to the generic `d-table` class instead of admin-only styles. No visual changes, except the badge/status for the API key.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e4d1a0ad-8e60-4ad8-b3b1-d17b66b878e8) | ![image](https://github.com/user-attachments/assets/5bc41353-c4a0-486b-b730-451b9f737341) |
