### PR TITLE
DEV: enhances rubocop to catch pause_test on commit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,9 @@ Discourse/Plugins/NoMonkeyPatching:
 Lint/Debugger:
   Exclude:
     - script/**/*
+  DebuggerMethods:
+    SystemHelpers:
+      - pause_test
 
 RSpec/InstanceVariable:
   Enabled: true


### PR DESCRIPTION
Enhances `rubocop` to catch custom `pause_test` on pre-commit stage, like it catches `debugger`, `binding.pry`, and `byebug`.