### PR TITLE
DEV: Add a Gravatar enable/disable toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/avatar-selector.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/avatar-selector.gjs
@@ -108,6 +108,10 @@ export default class AvatarSelectorModal extends Component {
     );
   }
 
+  get allowGravatar() {
+    return this.allowAvatarUpload && this.siteSettings.gravatar_enabled;
+  }
+
   @action
   onSelectedChanged(value) {
     this.selected = value;
@@ -210,7 +214,7 @@ export default class AvatarSelectorModal extends Component {
               </label>
             </div>
           {{/if}}
-          <div class="avatar-choice">
+          <div class="avatar-choice avatar-choice--system">
             <RadioButton
               @id="system-avatar"
               @name="avatar"
@@ -223,8 +227,8 @@ export default class AvatarSelectorModal extends Component {
               {{i18n "user.change_avatar.letter_based"}}
             </label>
           </div>
-          {{#if this.allowAvatarUpload}}
-            <div class="avatar-choice">
+          {{#if this.allowGravatar}}
+            <div class="avatar-choice avatar-choice--gravatar">
               <RadioButton
                 @id="gravatar"
                 @name="avatar"
@@ -270,7 +274,9 @@ export default class AvatarSelectorModal extends Component {
                 </p>
               {{/if}}
             </div>
-            <div class="avatar-choice">
+          {{/if}}
+          {{#if this.allowAvatarUpload}}
+            <div class="avatar-choice avatar-choice--upload">
               <RadioButton
                 @id="uploaded-avatar"
                 @name="avatar"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1330,6 +1330,10 @@ class UsersController < ApplicationController
 
     type = params[:type]
 
+    if type == "gravatar" && !SiteSetting.gravatar_enabled?
+      return render json: failed_json, status: 422
+    end
+
     invalid_type = type.present? && !AVATAR_TYPES_WITH_UPLOAD.include?(type) && type != "system"
     return render json: failed_json, status: 422 if invalid_type
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2691,6 +2691,7 @@ en:
     dashboard_visible_tabs: "Choose which dashboard tabs are visible."
     dashboard_general_tab_activity_metrics: "Choose reports to be displayed as activity metrics on the general tab."
 
+    gravatar_enabled: "Use the <a href='https://gravatar.com/'>Gravatar</a> service for user avatars. This will prevent users from switching to Gravatar for their avatars, but will not impact users who already use it."
     gravatar_name: "Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site."
     gravatar_base_url: "Specify the URL for accessing the Gravatar provider's API. This setting is critical for converting email addresses into Gravatar URLs where avatar images are stored."
     gravatar_login_url: "URL relative to `gravatar_base_url`, which provides the user with the login to the Gravatar service."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -992,17 +992,25 @@ users:
     default: 10000
     hidden: true
     area: "notifications"
+  gravatar_enabled:
+    type: "bool"
+    default: true
+    client: true
+    area: "users"
   gravatar_name:
     default: Gravatar
     client: true
+    hidden: true
     area: "users"
   gravatar_base_url:
     default: www.gravatar.com
     client: true
+    hidden: true
     area: "users"
   gravatar_login_url:
     default: /emails
     client: true
+    hidden: true
     area: "users"
   max_bookmarks_per_user:
     default: 2000

--- a/db/post_migrate/20250709051949_disable_gravatar_enabled_if_unconfigured.rb
+++ b/db/post_migrate/20250709051949_disable_gravatar_enabled_if_unconfigured.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DisableGravatarEnabledIfUnconfigured < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'gravatar_enabled', 5, 'f', 'NOW()', 'NOW()'
+      WHERE EXISTS (
+        SELECT 1
+        FROM site_settings
+        WHERE name = 'gravatar_base_url' AND (
+          VALUE = '' OR
+          VALUE IS NULL
+        )
+        LIMIT 1
+      )
+      ON CONFLICT DO NOTHING;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3635,6 +3635,17 @@ RSpec.describe UsersController do
         expect(response.status).to eq(422)
       end
 
+      it "raises an error when trying to pick Gravatar when gravatars are not enabled" do
+        SiteSetting.gravatar_enabled = false
+        put "/u/#{user1.username}/preferences/avatar/pick.json",
+            params: {
+              upload_id: upload.id,
+              type: "gravatar",
+            }
+
+        expect(response.status).to eq(422)
+      end
+
       it "raises an error when selecting the custom/uploaded avatar and uploaded_avatars_allowed_groups is disabled" do
         SiteSetting.uploaded_avatars_allowed_groups = ""
         put "/u/#{user1.username}/preferences/avatar/pick.json",

--- a/spec/system/page_objects/modals/avatar_selector.rb
+++ b/spec/system/page_objects/modals/avatar_selector.rb
@@ -26,6 +26,12 @@ module PageObjects
         has_no_css?(AVATAR_UPLOAD_BUTTON_SELECTOR)
       end
 
+      def has_avatar_options?(*options)
+        ordered_options = options.map { |o| ".avatar-choice--#{o}" }.join(" + ")
+
+        body.has_css?(ordered_options)
+      end
+
       def has_user_avatar_image_uploaded?
         body.has_css?(".avatar[src*='uploads/default']")
       end

--- a/spec/system/user_page/user_preferences_account_spec.rb
+++ b/spec/system/user_page/user_preferences_account_spec.rb
@@ -11,6 +11,7 @@ describe "User preferences | Account", type: :system do
     it "saves custom picture and system assigned pictures" do
       user_account_preferences_page.open_avatar_selector_modal(user)
       expect(avatar_selector_modal).to be_open
+      expect(avatar_selector_modal).to have_avatar_options("system", "gravatar", "upload")
 
       avatar_selector_modal.select_avatar_upload_option
       file_path = File.absolute_path(file_from_fixtures("logo.jpg"))
@@ -32,6 +33,14 @@ describe "User preferences | Account", type: :system do
       user_account_preferences_page.open_avatar_selector_modal(user)
       expect(avatar_selector_modal).to be_open
       expect(avatar_selector_modal).to have_no_avatar_upload_button
+    end
+
+    it "does not show Gravatar option when gravatars are not enabled" do
+      SiteSetting.gravatar_enabled = false
+
+      user_account_preferences_page.open_avatar_selector_modal(user)
+      expect(avatar_selector_modal).to be_open
+      expect(avatar_selector_modal).to have_avatar_options("system", "upload")
     end
   end
 


### PR DESCRIPTION
### What is this change?

We want to add the ability to enable/disable users selecting Gravatar for their avatar.

This change adds a site setting to enable/disable the option (default to enabled.) This will prevent users from configuring Gravatars from that point on. It does not affect already configured avatars.

We're also taking this chance to hide some of the advanced settings from the UI.