### PR TITLE
noneItem

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/enum.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/enum.gjs
@@ -10,7 +10,11 @@ export default class Enum extends Component {
       @onChange={{fn (mut this.value)}}
       @valueProperty={{this.setting.computedValueProperty}}
       @nameProperty={{this.setting.computedNameProperty}}
-      @options={{hash castInteger=true allowAny=this.setting.allowsNone}}
+      @options={{hash
+        castInteger=true
+        allowAny=this.setting.allowsNone
+        none=this.setting.noneItem
+      }}
     />
 
     {{this.preview}}

--- a/app/assets/javascripts/admin/addon/lib/setting-object-helper.js
+++ b/app/assets/javascripts/admin/addon/lib/setting-object-helper.js
@@ -48,16 +48,27 @@ export default class SettingObjectHelper {
   }
 
   @dependentKeyCompat
+  get noneItem() {
+    const originalValidValues = this.settingObj.get("valid_values");
+    return (
+      Array.isArray(originalValidValues) &&
+      originalValidValues.find((item) => item.value === "")
+    );
+  }
+
+  @dependentKeyCompat
   get validValues() {
     const originalValidValues = this.settingObj.get("valid_values");
     const values = [];
     const translateNames = this.settingObj.translate_names;
 
     (originalValidValues || []).forEach((v) => {
-      if (v.name && v.name.length > 0 && translateNames) {
-        values.addObject({ name: i18n(v.name), value: v.value });
-      } else {
-        values.addObject(v);
+      if (v.value !== "") {
+        if (v.name && v.name.length > 0 && translateNames) {
+          values.addObject({ name: i18n(v.name), value: v.value });
+        } else {
+          values.addObject(v);
+        }
       }
     });
     return values;

--- a/app/assets/javascripts/admin/addon/models/site-setting.js
+++ b/app/assets/javascripts/admin/addon/models/site-setting.js
@@ -79,6 +79,7 @@ export default class SiteSetting extends EmberObject {
   @alias("settingObjectHelper.validValues") validValues;
   @alias("settingObjectHelper.allowsNone") allowsNone;
   @alias("settingObjectHelper.anyValue") anyValue;
+  @alias("settingObjectHelper.noneItem") noneItem;
 
   constructor() {
     super(...arguments);


### PR DESCRIPTION
- **DEV: Introduce `reviewable_ui_refresh` site setting (#33404)**
- **Build(deps): Bump a11y-dialog from 8.1.3 to 8.1.4 (#33398)**
- **DEV: Add various APIs and outlets to the themes config area (#33385)**
- **DEV: Spacing variables (#33383)**
- **DEV: Add `include_raw` to list of forwarded topic query params (#33412)**
- **UX: avoid suppressing non-click events when dragging the grippie (#33415)**
- **DEV: Add scss var back (#33417)**
- **FIX: UppyUploader issues when authorized_extensions setting is blank but authorized_extensions_for_staff is not (#33423)**
- **Build(deps): Bump @faker-js/faker from 9.8.0 to 9.9.0 (#33426)**
- **Build(deps-dev): Bump puppeteer-core from 24.11.1 to 24.11.2 (#33427)**
- **Build(deps-dev): Bump @swc/core from 1.12.7 to 1.12.9 (#33425)**
- **FIX: Show tip for required selectable field on signup when not selected (#33401)**
- **UI: improvement for the admin system theme (#33406)**
- **FIX: escapes display:none for subheader in welcome banner for Horizon (#33411)**
- **FIX: Ensure client-side reviewable claiming data is set correctly (#33405)**
- **UX: remove messages section from sidebar (#33358)**
- **DEV: Display flag reasons and count for reviewable in refreshed UI (#33408)**
- **FIX: Horizon default color scheme must be user selectable (#33428)**
- **FIX: ensures small actions don't trigger post toolbar (#33422)**
- **FIX: render emojis in cooked hashtag text for composer rich text mode (#33395)**
- **FIX: ensures we have a cooked to work with (#33439)**
- **DEV: Move `AdminConfigAreaCard` back to the admin bundle (#33429)**
- **FIX: Run post-adopt decorators correctly in glimmer post-stream (#33440)**
- **A11Y: autofocus topic map DMenu contents for links, likes, and users - fix links (#33419)**
- **UX: fix title status icon size (#33442)**
- **DEV: adds support for startsWith/endsWith validation (#33446)**
- **DEV: add login-required wrapper plugin outlet (#33435)**
- **Update translations (#33409)**
- **A11Y: make in-reply-to keyboard accessible (#33447)**
- **UX: Shrink YouTube thumbnail in chat transcript (#33433)**
- **DEV: Replace toolbar popup menu with DMenu (#33247)**
- **UX: Update badge colors for illegal and offtopic reviewables (#33456)**
- **Build(deps): Bump ace-builds from 1.43.0 to 1.43.1 (#33454)**
- **UX: Improve invite list (#33253)**
- **FIX: Make hide_new_user_profiles work with manually upgraded users (#33458)**
- **FEAT: Add clipboard button to new palette UI (#33430)**
- **Revert "UX: Update badge colors for illegal and offtopic reviewables (#33456)"**
- **Revert "DEV: Display flag reasons and count for reviewable in refreshed UI (#33408)"**
- **Revert "DEV: Introduce `reviewable_ui_refresh` site setting (#33404)"**
- **DEV: First pass of review queue redesign**
- **DEV: Add `CurrentUserSerializer#use_reviewable_ui_refresh` attribute (#33460)**
- **DEV: Update colors for flag reasons in new reviewable UI (#33462)**
- **DEV: Move all admin sidebar code to admin bundle (#33416)**
- **DEV: allows to load full calendar 6 as an async bundle (#33448)**
- **FIX: resets quote state when reseting text selection (#33463)**
- **Revert "DEV: Move all admin sidebar code to admin bundle (#33416)" (#33466)**
- **DEV: Make outlet argument stringification more robust (#33465)**
- **FIX: clear selection on expand popup menu (#33467)**
- **REFACTOR: merge mobile and desktop menu-panel CSS into common (#33350)**
- **UX: increase chat avatar & icon sizing in sidebar (#33468)**
- **FEATURE: Display locale change in post history modal (#33469)**
- **UX: Remove unnecessary border (#33472)**
- **Add category moderation groups and more attributes to generic importer (#32561)**
- **fix/ Added default values for category color and text_color (#33479)**
- **DEV: Improve layout of flagged post in new reviewable UI (#33464)**
- **FIX: Rename the reviewable notes route to match existing reviewable routes (#33480)**
- **DEV: Deprecate external_system_avatars_enabled (#33436)**
- **FIX: Prevent saving empty string as a locale (#33481)**
- **DEV: smarter output message when running bin/turbo_rspec (#33484)**
- **Build(deps-dev): Bump ember-cli-deprecation-workflow from 3.3.0 to 3.4.0 (#33478)**
- **Build(deps-dev): Bump lefthook from 1.11.14 to 1.11.16 (#33477)**
- **Build(deps): Bump rdoc from 6.14.1 to 6.14.2 (#33476)**
- **Build(deps): Bump @floating-ui/dom from 1.7.1 to 1.7.2 (#33389)**
- **Build(deps-dev): Bump mime-types-data from 3.2025.0624 to 3.2025.0701 (#33420)**
- **Build(deps): Bump the babel group with 3 updates (#33452)**
- **UX: Title label adjustments for new new view (#33489)**
- **FIX: Sidebar messages link updates (#33444)**
- **DEV: Add locale files from themes to Crowdin (#33471)**
- **DEV: Add apply_modifier to invite upload_csv (#33470)**
- ** DEV: Prevent test "leakage" in cooked post processor specs (#33493)**
- **Build(deps-dev): Bump sqlite3 from 2.7.1 to 2.7.2 (#33486)**
- **Build(deps-dev): Bump @ember/test-waiters from 4.1.0 to 4.1.1 (#33488)**
- **Build(deps): Bump faraday from 2.13.1 to 2.13.2 (#33487)**
- **FEATURE: rich editor image toolbar for scale/alt text/delete (#33381)**
- **DEV: Refactors digest/summary email into partials (#33451)**
- **Build(deps-dev): Bump faker from 3.5.1 to 3.5.2 (#33421)**
- **FIX: Handle restore URLs ending with query params (#33384)**
- **FIX: chat btn order on user profile (#33494)**
- **FIX: convert invalid mentions in composer rich text mode to text (#33437)**
- **FIX: convert invalid hashtags in composer to text (#33441)**
- **UX: move rich_editor setting from experimental to posting (#33496)**
- **DEV: Remove broken button in admin badge show template (#33499)**
- **UX: Add info alert for built-in themes (#33497)**
- **DEV: Add limit on localized descriptions (#33492)**
- **FIX: Escape URL when inserting/editing links in composer modal (#33501)**
- **FIX: Badge grouping for system badges should be editable (#33504)**
- **DEV: Remove flush_timings_secs setting (#33505)**
- **DEV: Hide some highly technical site settings in the UI (#33511)**
- **UX: Horizon: adjust emoji size in topic-excerpt (#33491)**
- **DEV: Correct `reviewable_flagged_post` fabricator (#33515)**
- **Build(deps-dev): Bump esbuild from 0.25.5 to 0.25.6 (#33500)**
- **Build(deps-dev): Bump puppeteer-core from 24.11.2 to 24.12.0 (#33502)**
- **Build(deps): Bump core-js from 3.43.0 to 3.44.0 (#33503)**
- **FIX: Formkit calendar date setting back one day (#33238)**
- **UX: Do not round emoji img borders in RTE (#33509)**
- **FIX: emptying a text field should nullify it (#33520)**
- **DEV: Fix PMs user/group removal in the Glimmer Post Stream (#33514)**
- **DEV: Enhance the Glimmer Post Stream with new extension points (#33396)**
- **FEATURE: image input rule when typing on rich editor (#33498)**
- **DEV: Add hysteresis to post-stream uncloaking to prevent layout shift flicker (#33483)**
- **UX: remove topic status actions from composer more menu (#33369)**
- **Build(deps-dev): Bump rubocop from 1.77.0 to 1.78.0 (#33525)**
- **Build(deps-dev): Bump mime-types-data from 3.2025.0701 to 3.2025.0708 (#33526)**
- **UX: allow parens on rich editor img input rule (#33524)**
- **DEV: Use FormKit APIs for reviewable note validation. (#33528)**
- **Build(deps-dev): Bump lefthook from 1.11.16 to 1.12.0 (#33529)**
- **Build(deps-dev): Bump @swc/core from 1.12.9 to 1.12.11 (#33530)**
- **DEV: Fix topic link component for reviewabled flagged post in new UI (#33518)**
- **DEV: enhances rubocop to catch pause_test on commit (#33532)**
- **FIX: Use the max_tag_search_results setting as the default limit for tag groups search (#33485)**
- **DEV: Force full refresh from language switcher (#33522)**
- **FIX: allow descriptions on empty enum setting**
