### PR TITLE
FEATURE: Make it easier for staff to see if a profile is silenced

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
@@ -71,7 +71,8 @@ export default class UserCardContents extends CardContentsBase {
   @gt("moreBadgesCount", 0) showMoreBadges;
   @and("viewingAdmin", "showName", "user.canBeDeleted") showDelete;
   @not("user.isBasic") linkWebsite;
-  @or("user.suspend_reason", "user.bio_excerpt") isSuspendedOrHasBio;
+  @or("user.suspend_reason", "user.silence_reason") isRestricted;
+  @or("isRestricted", "user.bio_excerpt") isRestrictedOrHasBio;
   @and("user.staged", "canCheckEmails") showCheckEmail;
 
   user = null;
@@ -551,7 +552,7 @@ export default class UserCardContents extends CardContentsBase {
             </div>
           {{/if}}
 
-          {{#if this.isSuspendedOrHasBio}}
+          {{#if this.isRestrictedOrHasBio}}
             <div class="card-row second-row">
               {{#if this.user.suspend_reason}}
                 <div class="suspended">
@@ -575,39 +576,37 @@ export default class UserCardContents extends CardContentsBase {
                     >{{this.user.suspend_reason}}</span>
                   </div>
                 </div>
-              {{else}}
-                {{#if this.user.silence_reason}}
-                  <div class="silenced">
-                    <div class="silence-date">
-                      {{icon "microphone-slash"}}
-                      {{#if this.user.silencedForever}}
-                        {{i18n "user.silenced_permanently"}}
-                      {{else}}
-                        {{i18n
-                          "user.silenced_notice"
-                          date=this.user.silencedTillDate
-                        }}
-                      {{/if}}
-                    </div>
-                    <div class="silence-reason">
-                      <span class="silence-reason-title">{{i18n
-                          "user.silenced_reason"
-                        }}</span>
-                      <span
-                        class="silence-reason-description"
-                      >{{this.user.silence_reason}}</span>
-                    </div>
-                  </div>
-                {{else}}
-                  {{#if this.user.bio_excerpt}}
-                    <div class="bio">
-                      <HtmlWithLinks>
-                        {{htmlSafe this.user.bio_excerpt}}
-                      </HtmlWithLinks>
-                    </div>
-                  {{/if}}
-                {{/if}}
               {{/if}}
+              {{#if this.user.silence_reason}}
+                <div class="silenced">
+                  <div class="silence-date">
+                    {{icon "microphone-slash"}}
+                    {{#if this.user.silencedForever}}
+                      {{i18n "user.silenced_permanently"}}
+                    {{else}}
+                      {{i18n
+                        "user.silenced_notice"
+                        date=this.user.silencedTillDate
+                      }}
+                    {{/if}}
+                  </div>
+                  <div class="silence-reason">
+                    <span class="silence-reason-title">{{i18n
+                        "user.silenced_reason"
+                      }}</span>
+                    <span
+                      class="silence-reason-description"
+                    >{{this.user.silence_reason}}</span>
+                  </div>
+                </div>
+              {{/if}}
+              {{#unless this.isRestricted}}
+                <div class="bio">
+                  <HtmlWithLinks>
+                    {{htmlSafe this.user.bio_excerpt}}
+                  </HtmlWithLinks>
+                </div>
+              {{/unless}}
             </div>
           {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
@@ -576,12 +576,36 @@ export default class UserCardContents extends CardContentsBase {
                   </div>
                 </div>
               {{else}}
-                {{#if this.user.bio_excerpt}}
-                  <div class="bio">
-                    <HtmlWithLinks>
-                      {{htmlSafe this.user.bio_excerpt}}
-                    </HtmlWithLinks>
+                {{#if this.user.silence_reason}}
+                  <div class="silenced">
+                    <div class="silence-date">
+                      {{icon "microphone-slash"}}
+                      {{#if this.user.silencedForever}}
+                        {{i18n "user.silenced_permanently"}}
+                      {{else}}
+                        {{i18n
+                          "user.silenced_notice"
+                          date=this.user.silencedTillDate
+                        }}
+                      {{/if}}
+                    </div>
+                    <div class="silence-reason">
+                      <span class="silence-reason-title">{{i18n
+                          "user.silenced_reason"
+                        }}</span>
+                      <span
+                        class="silence-reason-description"
+                      >{{this.user.silence_reason}}</span>
+                    </div>
                   </div>
+                {{else}}
+                  {{#if this.user.bio_excerpt}}
+                    <div class="bio">
+                      <HtmlWithLinks>
+                        {{htmlSafe this.user.bio_excerpt}}
+                      </HtmlWithLinks>
+                    </div>
+                  {{/if}}
                 {{/if}}
               {{/if}}
             </div>

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -212,22 +212,22 @@ export default class UserController extends Controller {
     return this.site.desktopView;
   }
 
-  @action
-  showSilencings(event) {
-    event?.preventDefault();
-    this.adminTools.showActionLogs(this, {
-      target_user: this.get("model.username"),
-      action_name: "silence_user",
-    });
+  get silencingsRouteQuery() {
+    return {
+      filters: {
+        target_user: this.get("model.username"),
+        action_name: "silence_user",
+      },
+    };
   }
 
-  @action
-  showSuspensions(event) {
-    event?.preventDefault();
-    this.adminTools.showActionLogs(this, {
-      target_user: this.get("model.username"),
-      action_name: "suspend_user",
-    });
+  get suspensionsRouteQuery() {
+    return {
+      filters: {
+        target_user: this.get("model.username"),
+        action_name: "suspend_user",
+      },
+    };
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -94,7 +94,7 @@ export default class UserController extends Controller {
   }
 
   @discourseComputed("model.suspended", "model.silenced", "currentUser.staff")
-  isNotSuspendedOrIsStaff(suspended, silenced, isStaff) {
+  isNotRestrictedOrIsStaff(suspended, silenced, isStaff) {
     return (!suspended && !silenced) || isStaff;
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -27,6 +27,7 @@ export default class UserController extends Controller {
   @gt("model.number_of_flags_given", 0) hasGivenFlags;
   @gt("model.number_of_flagged_posts", 0) hasFlaggedPosts;
   @gt("model.number_of_deleted_posts", 0) hasDeletedPosts;
+  @gt("model.number_of_silencings", 0) hasBeenSilenced;
   @gt("model.number_of_suspensions", 0) hasBeenSuspended;
   @gt("model.warnings_received_count", 0) hasReceivedWarnings;
   @gt("model.number_of_rejected_posts", 0) hasRejectedPosts;
@@ -36,6 +37,7 @@ export default class UserController extends Controller {
     "hasGivenFlags",
     "hasFlaggedPosts",
     "hasDeletedPosts",
+    "hasBeenSilenced",
     "hasBeenSuspended",
     "hasReceivedWarnings",
     "hasRejectedPosts"
@@ -91,9 +93,9 @@ export default class UserController extends Controller {
     };
   }
 
-  @discourseComputed("model.suspended", "currentUser.staff")
-  isNotSuspendedOrIsStaff(suspended, isStaff) {
-    return !suspended || isStaff;
+  @discourseComputed("model.suspended", "model.silenced", "currentUser.staff")
+  isNotSuspendedOrIsStaff(suspended, silenced, isStaff) {
+    return (!suspended && !silenced) || isStaff;
   }
 
   @discourseComputed("model.trust_level")
@@ -208,6 +210,15 @@ export default class UserController extends Controller {
     }
 
     return this.site.desktopView;
+  }
+
+  @action
+  showSilencings(event) {
+    event?.preventDefault();
+    this.adminTools.showActionLogs(this, {
+      target_user: this.get("model.username"),
+      action_name: "silence_user",
+    });
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -432,6 +432,11 @@ export default class User extends RestModel.extend(Evented) {
   }
 
   @discourseComputed("silenced_till")
+  silenced(silencedTill) {
+    return silencedTill && moment(silencedTill).isAfter();
+  }
+
+  @discourseComputed("silenced_till")
   silencedForever(silencedTill) {
     return isForever(silencedTill);
   }

--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -1,5 +1,4 @@
 import { array, concat, fn, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";
@@ -122,7 +121,10 @@ export default RouteTemplate(
                 {{/if}}
                 {{#if @controller.model.number_of_silencings}}
                   <div>
-                    <a href {{on "click" @controller.showSilencings}}>
+                    <LinkTo
+                      @route="adminLogs.staffActionLogs"
+                      @query={{@controller.silencingsRouteQuery}}
+                    >
                       {{htmlSafe
                         (i18n
                           "user.staff_counters.silencings"
@@ -130,12 +132,15 @@ export default RouteTemplate(
                           count=@controller.model.number_of_silencings
                         )
                       }}
-                    </a>
+                    </LinkTo>
                   </div>
                 {{/if}}
                 {{#if @controller.model.number_of_suspensions}}
                   <div>
-                    <a href {{on "click" @controller.showSuspensions}}>
+                    <LinkTo
+                      @route="adminLogs.staffActionLogs"
+                      @query={{@controller.suspensionsRouteQuery}}
+                    >
                       {{htmlSafe
                         (i18n
                           "user.staff_counters.suspensions"
@@ -143,7 +148,7 @@ export default RouteTemplate(
                           count=@controller.model.number_of_suspensions
                         )
                       }}
-                    </a>
+                    </LinkTo>
                   </div>
                 {{/if}}
                 {{#if @controller.model.warnings_received_count}}

--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -329,7 +329,7 @@ export default RouteTemplate(
                       {{/if}}
                     </div>
                   {{/if}}
-                  {{#if @controller.isNotSuspendedOrIsStaff}}
+                  {{#if @controller.isNotRestrictedOrIsStaff}}
                     <HtmlWithLinks>
                       {{htmlSafe @controller.model.bio_cooked}}
                     </HtmlWithLinks>

--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -296,41 +296,47 @@ export default RouteTemplate(
                 <div class="bio">
                   {{#if @controller.model.suspended}}
                     <div class="suspended">
-                      {{icon "ban"}}
-                      <b>
-                        {{#if @controller.model.suspendedForever}}
-                          {{i18n "user.suspended_permanently"}}
-                        {{else}}
-                          {{i18n
-                            "user.suspended_notice"
-                            date=@controller.model.suspendedTillDate
-                          }}
-                        {{/if}}
-                      </b>
-                      <br />
+                      <div class="suspension-date">
+                        {{icon "ban"}}
+                        <b>
+                          {{#if @controller.model.suspendedForever}}
+                            {{i18n "user.suspended_permanently"}}
+                          {{else}}
+                            {{i18n
+                              "user.suspended_notice"
+                              date=@controller.model.suspendedTillDate
+                            }}
+                          {{/if}}
+                        </b>
+                      </div>
                       {{#if @controller.model.suspend_reason}}
-                        <b>{{i18n "user.suspended_reason"}}</b>
-                        {{@controller.model.suspend_reason}}
+                        <div class="suspension-reason">
+                          <b>{{i18n "user.suspended_reason"}}</b>
+                          {{@controller.model.suspend_reason}}
+                        </div>
                       {{/if}}
                     </div>
                   {{/if}}
                   {{#if @controller.model.silenced}}
                     <div class="silenced">
-                      {{icon "microphone-slash"}}
-                      <b>
-                        {{#if @controller.model.silencedForever}}
-                          {{i18n "user.silenced_permanently"}}
-                        {{else}}
-                          {{i18n
-                            "user.silenced_notice"
-                            date=@controller.model.silencedTillDate
-                          }}
-                        {{/if}}
-                      </b>
-                      <br />
+                      <div class="silence-date">
+                        {{icon "microphone-slash"}}
+                        <b>
+                          {{#if @controller.model.silencedForever}}
+                            {{i18n "user.silenced_permanently"}}
+                          {{else}}
+                            {{i18n
+                              "user.silenced_notice"
+                              date=@controller.model.silencedTillDate
+                            }}
+                          {{/if}}
+                        </b>
+                      </div>
                       {{#if @controller.model.silence_reason}}
-                        <b>{{i18n "user.silenced_reason"}}</b>
-                        {{@controller.model.silence_reason}}
+                        <div class="silence-reason">
+                          <b>{{i18n "user.silenced_reason"}}</b>
+                          {{@controller.model.silence_reason}}
+                        </div>
                       {{/if}}
                     </div>
                   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -120,6 +120,19 @@ export default RouteTemplate(
                     </LinkTo>
                   </div>
                 {{/if}}
+                {{#if @controller.model.number_of_silencings}}
+                  <div>
+                    <a href {{on "click" @controller.showSilencings}}>
+                      {{htmlSafe
+                        (i18n
+                          "user.staff_counters.silencings"
+                          className="silencings"
+                          count=@controller.model.number_of_silencings
+                        )
+                      }}
+                    </a>
+                  </div>
+                {{/if}}
                 {{#if @controller.model.number_of_suspensions}}
                   <div>
                     <a href {{on "click" @controller.showSuspensions}}>
@@ -293,6 +306,26 @@ export default RouteTemplate(
                       {{#if @controller.model.suspend_reason}}
                         <b>{{i18n "user.suspended_reason"}}</b>
                         {{@controller.model.suspend_reason}}
+                      {{/if}}
+                    </div>
+                  {{/if}}
+                  {{#if @controller.model.silenced}}
+                    <div class="silenced">
+                      {{icon "microphone-slash"}}
+                      <b>
+                        {{#if @controller.model.silencedForever}}
+                          {{i18n "user.silenced_permanently"}}
+                        {{else}}
+                          {{i18n
+                            "user.silenced_notice"
+                            date=@controller.model.silencedTillDate
+                          }}
+                        {{/if}}
+                      </b>
+                      <br />
+                      {{#if @controller.model.silence_reason}}
+                        <b>{{i18n "user.silenced_reason"}}</b>
+                        {{@controller.model.silence_reason}}
                       {{/if}}
                     </div>
                   {{/if}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -212,6 +212,10 @@
         color: var(--danger);
       }
 
+      .silenced {
+        color: var(--danger);
+      }
+
       .primary {
         width: 100%;
         position: relative;
@@ -335,6 +339,10 @@
   }
 
   .deleted-posts {
+    background-color: var(--danger-medium);
+  }
+
+  .silencings {
     background-color: var(--danger-medium);
   }
 

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -225,6 +225,15 @@
       }
     }
 
+    .silenced {
+      color: var(--danger);
+
+      .silence-reason-title,
+      .silence-date {
+        font-weight: bold;
+      }
+    }
+
     .profile-hidden,
     .inactive-user {
       font-size: var(--font-up-1);

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1522,6 +1522,7 @@ class UsersController < ApplicationController
       number_of_deleted_posts
       number_of_flagged_posts
       number_of_flags_given
+      number_of_silencings
       number_of_suspensions
       warnings_received_count
       number_of_rejected_posts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1632,6 +1632,10 @@ class User < ActiveRecord::Base
       .count
   end
 
+  def number_of_silencings
+    UserHistory.for(self, :silence_user).count
+  end
+
   def number_of_suspensions
     UserHistory.for(self, :suspend_user).count
   end

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -20,7 +20,6 @@ class AdminUserListSerializer < BasicUserSerializer
              :approved,
              :suspended_at,
              :suspended_till,
-             :silenced,
              :silenced_till,
              :time_read,
              :staged,
@@ -43,14 +42,6 @@ class AdminUserListSerializer < BasicUserSerializer
 
   alias_method :include_secondary_emails?, :include_email?
   alias_method :include_associated_accounts?, :include_email?
-
-  def silenced
-    object.silenced?
-  end
-
-  def include_silenced?
-    object.silenced?
-  end
 
   def silenced_till
     object.silenced_till

--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -62,6 +62,8 @@ class UserCardSerializer < BasicUserSerializer
              :title,
              :suspend_reason,
              :suspended_till,
+             :silence_reason,
+             :silenced_till,
              :badge_count,
              :user_fields,
              :custom_fields,
@@ -156,6 +158,14 @@ class UserCardSerializer < BasicUserSerializer
 
   def include_suspended_till?
     object.suspended?
+  end
+
+  def include_silence_reason?
+    scope.can_see_silencing_reason?(object) && object.silenced?
+  end
+
+  def include_silenced_till?
+    object.silenced?
   end
 
   def user_fields

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1555,8 +1555,8 @@ en:
           one: '<span class="%{className}">%{count}</span> deleted post'
           other: '<span class="%{className}">%{count}</span> deleted posts'
         silencings:
-          one: '<span class="%{className}">%{count}</span> silencing'
-          other: '<span class="%{className}">%{count}</span> silencings'
+          one: '<span class="%{className}">%{count}</span> silenced'
+          other: '<span class="%{className}">%{count}</span> silenced'
         suspensions:
           one: '<span class="%{className}">%{count}</span> suspension'
           other: '<span class="%{className}">%{count}</span> suspensions'

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1479,6 +1479,9 @@ en:
       suspended_notice: "This user is suspended until %{date}."
       suspended_permanently: "This user is suspended."
       suspended_reason: "Reason: "
+      silenced_notice: "This user is silenced until %{date}."
+      silenced_permanently: "This user is silenced."
+      silenced_reason: "Reason: "
       github_profile: "GitHub"
       email_activity_summary: "Activity Summary"
       mailing_list_mode:
@@ -1551,6 +1554,9 @@ en:
         deleted_posts:
           one: '<span class="%{className}">%{count}</span> deleted post'
           other: '<span class="%{className}">%{count}</span> deleted posts'
+        silencings:
+          one: '<span class="%{className}">%{count}</span> silencing'
+          other: '<span class="%{className}">%{count}</span> silencings'
         suspensions:
           one: '<span class="%{className}">%{count}</span> suspension'
           other: '<span class="%{className}">%{count}</span> suspensions'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2428,6 +2428,8 @@ en:
 
     show_inactive_accounts: "Allow logged in users to browse profiles of inactive accounts."
 
+    hide_silencing_reasons: "Don't display silencing reasons publically on user profiles."
+
     hide_suspension_reasons: "Don't display suspension reasons publically on user profiles."
 
     log_personal_messages_views: "Log personal message views by Admin for other users/groups."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -960,6 +960,10 @@ users:
     default: false
     client: true
     area: "users"
+  hide_silencing_reasons:
+    default: false
+    client: true
+    area: "users"
   log_personal_messages_views:
     default: false
     area: "users"

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -115,6 +115,11 @@ module UserGuardian
     user == @user || is_staff?
   end
 
+  def can_see_silencing_reason?(user)
+    return true unless SiteSetting.hide_silencing_reasons?
+    user == @user || is_staff?
+  end
+
   def can_disable_second_factor?(user)
     user && can_administer_user?(user)
   end

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/user-about.gjs
@@ -289,6 +289,11 @@ const UserAbout = <template>
             </a>
           </div>
           <div>
+            <span class="silencings">
+              {{@dummy.user.num_of_silencings}}
+            </span>&nbsp;{{i18n "user.staff_counters.silencings"}}
+          </div>
+          <div>
             <span class="suspensions">
               {{@dummy.user.number_of_suspensions}}
             </span>&nbsp;{{i18n "user.staff_counters.suspensions"}}

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -4227,6 +4227,28 @@ RSpec.describe Guardian do
     end
   end
 
+  describe "silencing reasons" do
+    it "will be shown by default" do
+      expect(Guardian.new.can_see_silencing_reason?(user)).to eq(true)
+    end
+
+    context "with hide silencing reason enabled" do
+      before { SiteSetting.hide_silencing_reasons = true }
+
+      it "will not be shown to anonymous users" do
+        expect(Guardian.new.can_see_silencing_reason?(user)).to eq(false)
+      end
+
+      it "users can see their own silencings" do
+        expect(Guardian.new(user).can_see_silencing_reason?(user)).to eq(true)
+      end
+
+      it "staff can see silencings" do
+        expect(Guardian.new(moderator).can_see_silencing_reason?(user)).to eq(true)
+      end
+    end
+  end
+
   describe "#can_remove_allowed_users?" do
     context "with staff users" do
       it "should be true" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2126,6 +2126,15 @@ RSpec.describe User do
         expect(user.number_of_flagged_posts).to eq(0)
       end
     end
+
+    describe "#number_of_silencings" do
+      it "counts the number of silencings" do
+        3.times do
+          Fabricate(:user_history, action: UserHistory.actions[:silence_user], target_user: user)
+        end
+        expect(user.number_of_silencings).to eq(3)
+      end
+    end
   end
 
   describe "new_user?" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7828,6 +7828,56 @@ RSpec.describe UsersController do
     end
   end
 
+  describe "#staff_info" do
+    context "when logged out" do
+      it "responds with 403" do
+        get "/u/#{user.username}/staff-info.json"
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when logged in" do
+      it "responds with 403 for normal users" do
+        sign_in(user)
+        get "/u/#{user.username}/staff-info.json"
+        expect(response.status).to eq(403)
+      end
+
+      it "responds with 200 for moderators" do
+        sign_in(moderator)
+
+        get "/u/#{user.username}/staff-info.json"
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with 200 for admins" do
+        sign_in(admin)
+
+        get "/u/#{user.username}/staff-info.json"
+        expect(response.status).to eq(200)
+      end
+
+      it "delegates work to `User`" do
+        user_instance = mock
+        UsersController.any_instance.stubs(:fetch_user_from_params).returns(user_instance)
+
+        %i[
+          number_of_deleted_posts
+          number_of_flagged_posts
+          number_of_flags_given
+          number_of_silencings
+          number_of_suspensions
+          warnings_received_count
+          number_of_rejected_posts
+        ].each { |info| user_instance.expects(info) }
+
+        sign_in(admin)
+
+        get "/u/#{user.username}/staff-info.json"
+      end
+    end
+  end
+
   def create_second_factor_security_key
     sign_in(user1)
     stub_secure_session_confirmed

--- a/spec/system/page_objects/pages/user.rb
+++ b/spec/system/page_objects/pages/user.rb
@@ -46,6 +46,12 @@ module PageObjects
         self
       end
 
+      def click_staff_info_silencings_link
+        staff_counters = page.find(".staff-counters")
+        staff_counters.find("a:has(.silencings)").click
+        self
+      end
+
       def expand_info_panel
         button = page.find("button[aria-controls='collapsed-info-panel']")
         button.click if button["aria-expanded"] == "false"

--- a/spec/system/user_page/staff_info_spec.rb
+++ b/spec/system/user_page/staff_info_spec.rb
@@ -17,4 +17,25 @@ describe "Viewing user staff info as an admin", type: :system do
       expect(user_page).to have_warning_messages_path(user)
     end
   end
+
+  context "for silencings" do
+    fab!(:silencing) do
+      Fabricate(:user_history, action: UserHistory.actions[:silence_user], target_user: user)
+    end
+    it "should display the right link to user's silencings with the right count in text" do
+      user_page.visit(user)
+      silencings_counters = page.find(".staff-counters .silencings")
+      expect(silencings_counters).to have_text("1")
+
+      user_page.click_staff_info_silencings_link
+      expect(user_page).to have_current_path("/admin/logs/staff_action_logs", ignore_query: true)
+
+      current_url = user_page.current_url
+      uri = URI.parse(current_url)
+      filters = JSON.parse(URI.decode_www_form(uri.query).to_h["filters"])
+
+      expect(filters["target_user"]).to eq(user.username)
+      expect(filters["action_name"]).to eq("silence_user")
+    end
+  end
 end


### PR DESCRIPTION
This commit make it easier for staff to see if a profile is silenced by aligning it with how suspended notices are shown.

- The number of times a profile has been silenced is shown in the staff counters banner at the top of the public user profiles.
- Clicking on the silenced note in the staff counters banner goes to a filtered view of the staff action logs for the user and the silenced action.
- The profile indicates if a user is silenced and shows the date they are silenced until. This looks exactly the same as how it currently displays for suspended users, with the added info of the date. This is also displayed on the user card, the same as suspended notices currently are.

## Screenshots

![image](https://github.com/user-attachments/assets/43cf8134-3391-43ff-98fe-fcba07c9e3dd)
![image](https://github.com/user-attachments/assets/2804dcba-70b2-4cf2-8a93-63433a23b481)
