### PR TITLE
FIX: removes + from RTE toggle tooltip

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toggle-switch.gjs
@@ -15,7 +15,7 @@ export default class ComposerToggleSwitch extends Component {
   }
 
   get label() {
-    const keyboardShortcut = `${translateModKey("ctrl")}+M`;
+    const keyboardShortcut = `${translateModKey("ctrl")}M`;
     if (this.args.state) {
       return i18n("composer.switch_to_markdown", { keyboardShortcut });
     } else {


### PR DESCRIPTION
It will show `^M` instead of `^+M` on mac for example. The `+` is not supposed to be there.