### PR TITLE
FIX: Also update topic locale on creation

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -134,7 +134,7 @@ class TopicCreator
       visible: @opts[:visible],
     }
 
-    %i[subtype archetype import_mode advance_draft].each do |key|
+    %i[subtype archetype import_mode advance_draft locale].each do |key|
       topic_params[key] = @opts[key] if @opts[key].present?
     end
 

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe TopicCreator do
             )
           expect(topic.participant_count).to eq(3)
         end
+
+        describe "locale" do
+          it "updates the locale of the topic" do
+            topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(locale: "ja"))
+            expect(topic.locale).to eq("ja")
+          end
+
+          it "sets the locale of the topic to nil if blank" do
+            topic1 = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(locale: ""))
+            expect(topic1.locale).to eq(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
When a user creates a new topic via the composer and sets the locale, we currently set the post's locale but not the topic's. This PR updates that.