### PR TITLE
FIX: z-index issues with new DMenu in composer

### DIFF
--- a/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
@@ -3,6 +3,19 @@
 .toolbar-menu__options-content {
   @include viewport.from(sm) {
     z-index: z("composer", "content");
+
+    // making sure it's only limited in height on floating menu, not mobile menu
+    &.fk-d-menu {
+      max-height: 30vh;
+    }
+  }
+
+  .discourse-touch & {
+    z-index: calc(z("mobile-composer") + 1);
+  }
+
+  .fullscreen-composer & {
+    z-index: z("header") + 1;
   }
 
   .shortcut {


### PR DESCRIPTION
Addressing some z-index issues with the first use of Dmenu within the composer:
* z-index need an adjustment on mobile/tablets
* z-index need an adjustment when in fullscreen on desktop

Also limiting the max height on desktop to 30vh to avoid it potentially scrolling of the page without a way to fix it by resizing composer height.

Meta report: https://meta.discourse.org/t/composer-more-menu-partly-hidden-behind-header-and-composer/372859