### PR TITLE
DEV: add additional icon aliases for lock

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -82,7 +82,7 @@ export default class BulkSelectTopicsDropdown extends Component {
       },
       {
         id: "close-topics",
-        icon: "lock",
+        icon: "topic.closed",
         name: i18n("topic_bulk_actions.close_topics.name"),
       },
       {

--- a/app/assets/javascripts/discourse/app/components/categories-boxes-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-topic.gjs
@@ -13,7 +13,7 @@ export default class CategoriesBoxesTopic extends Component {
       return "thumbtack";
     }
     if (closed || archived) {
-      return "lock";
+      return "category.restricted";
     }
     return "far-file-lines";
   }

--- a/app/assets/javascripts/discourse/app/components/post/small-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/small-action.gjs
@@ -17,10 +17,10 @@ export const GROUP_ACTION_CODES = ["invited_group", "removed_group"];
 export const customGroupActionCodes = [];
 
 export const ICONS = {
-  "closed.enabled": "lock",
-  "closed.disabled": "unlock-keyhole",
-  "autoclosed.enabled": "lock",
-  "autoclosed.disabled": "unlock-keyhole",
+  "closed.enabled": "topic.closed",
+  "closed.disabled": "topic.opened",
+  "autoclosed.enabled": "topic.closed",
+  "autoclosed.disabled": "topic.opened",
   "archived.enabled": "folder",
   "archived.disabled": "folder-open",
   "pinned.enabled": "thumbtack",

--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -152,7 +152,7 @@ export default class TopicAdminMenu extends Component {
                     "topic.actions.close"
                   }}
                   @action={{fn this.onButtonAction "toggleClosed"}}
-                  @icon={{if @topic.closed "unlock" "lock"}}
+                  @icon={{if @topic.closed "topic.opened" "topic.closed"}}
                 />
               </dropdown.item>
             {{/if}}

--- a/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-label-content.gjs
@@ -26,7 +26,7 @@ const TopicLabelButton = <template>
 
           {{#if @topic.closed}}
             <span class="topic-status">
-              {{icon "lock"}}
+              {{icon "topic.closed"}}
             </span>
           {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-status.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-status.gjs
@@ -43,17 +43,17 @@ export default class TopicStatus extends Component {
         <span
           title={{i18n "topic_statuses.locked_and_archived.help"}}
           class="topic-status"
-        >{{icon "lock"}}</span>
+        >{{icon "topic.closed"}}</span>
       {{~else if @topic.closed~}}
         <span
           title={{i18n "topic_statuses.locked.help"}}
           class="topic-status"
-        >{{icon "lock"}}</span>
+        >{{icon "topic.closed"}}</span>
       {{~else if @topic.archived~}}
         <span
           title={{i18n "topic_statuses.archived.help"}}
           class="topic-status"
-        >{{icon "lock"}}</span>
+        >{{icon "topic.closed"}}</span>
       {{~/if~}}
 
       {{~#if @topic.is_warning~}}

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -200,7 +200,7 @@ export function defaultCategoryLinkRenderer(category, opts) {
   }
 
   if (restricted) {
-    html += iconHTML("lock");
+    html += iconHTML("category.restricted");
   }
   _extraIconRenderers.forEach((renderer) => {
     const iconName = renderer(category);

--- a/app/assets/javascripts/discourse/app/lib/icon-library.js
+++ b/app/assets/javascripts/discourse/app/lib/icon-library.js
@@ -55,6 +55,9 @@ export const REPLACEMENTS = {
   "user_menu.replies": "reply",
   "user_menu.drafts": "pencil",
   "sidebar.all_categories": "list",
+  "topic.closed": "lock",
+  "topic.opened": "unlock",
+  "category.restricted": "lock",
 };
 
 export function replaceIcon(source, destination) {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -230,7 +230,7 @@ export default class CategorySectionLink {
 
   get prefixBadge() {
     if (this.category.read_restricted) {
-      return customCategoryLockIcon || "lock";
+      return customCategoryLockIcon || "category.restricted";
     }
   }
 


### PR DESCRIPTION
This adds some new icon aliases so the lock icon can be overridden in specific scenarios without applying globally to all locks:

* "topic.closed"
* "topic.opened"
* "category.restricted"

This enables customizations like:

![image](https://github.com/user-attachments/assets/e7dc62ce-98ed-49ad-b127-97cf928f3371)

```
import { apiInitializer } from "discourse/lib/api";

export default apiInitializer((api) => {
  api.replaceIcon("topic.closed", "xmark");
  api.replaceIcon("category.restricted", "shield-halved");
});
```

More documentation on this feature in https://meta.discourse.org/t/change-icons-globally/87751