### PR TITLE
FIX: Horizon tag background color

### DIFF
--- a/themes/horizon/scss/variables.scss
+++ b/themes/horizon/scss/variables.scss
@@ -3,6 +3,7 @@
   --d-border-radius-large: 20px;
   --d-border-radius: 8px;
   --d-input-border-radius: 6px;
+  --d-tag-background-color: transparent;
 
   // the idea is: block spacing can grow with font-size, but inline spacing should not to maintain horizontal (text) alignment
   --spacing-block-xs: 0.25em;


### PR DESCRIPTION
Followup 20f57aec12a5d2291c79a447d18eb3f164877c61

Makes the tag background color transparent again in
Horizon, using the new core --d-tag-background-color
var.

**Before**

![image](https://github.com/user-attachments/assets/6ea570c1-4114-4c87-aafe-589930210a41)

**After**

![image](https://github.com/user-attachments/assets/779bd770-61cb-45b6-b991-3b6bdb45f639)
