### PR TITLE
FIX: Missing topic timeline color var

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -143,4 +143,5 @@
   --shadow-focus-danger: 0 0 6px 0 var(--danger);
   --float-kit-arrow-stroke-color: var(--primary-low);
   --float-kit-arrow-fill-color: var(--secondary);
+  --topic-timeline-border-color: #{$tertiary-low-or-tertiary-high};
 }


### PR DESCRIPTION
Followup 20f57aec12a5d2291c79a447d18eb3f164877c61

Adds missing --topic-timeline-border-color CSS var,
otherwise topic timeline vertical line is not shown. Fixes
this:

![image](https://github.com/user-attachments/assets/e29835b6-397f-4c13-847b-a1f8bd2bbc54)

