### PR TITLE
FIX: Header horizontal padding on mobile

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -57,8 +57,9 @@
   --d-category-boxes-gap: var(--space-6);
   --category-boxes-title-font-size: var(--font-up-2);
   --d-category-boxes-margin-top: var(--space-4);
-  --d-header-padding-v: 0;
+  --d-header-padding-v: 0.67em;
   --d-table-border-top-height: 3px;
+  --d-wrap-padding-h: 0.67em;
   --topic-title-font-weight: 400;
   --topic-title-font-weight--visited: 400;
   --topic-list-item-background-color: var(--secondary);
@@ -507,7 +508,6 @@ textarea {
 }
 
 .wrap {
-  --d-wrap-padding-h: 0.67em;
   max-width: var(--d-max-width);
   margin-right: auto;
   margin-left: auto;


### PR DESCRIPTION
Followup 20f57aec12a5d2291c79a447d18eb3f164877c61

Fixes header horizontal padding on mobile devices by
setting a value for `--d-header-padding-v` instead of 0.
Used the same value as `--d-wrap-padding-h` since that
is what it was previous to the referenced commit.

**Before**

![image](https://github.com/user-attachments/assets/248263f2-5865-4338-a769-f810aa4b3239)

**After**

![image](https://github.com/user-attachments/assets/8e857699-7afb-4315-8d35-0bc3c21e85eb)
