### PR TITLE
FEATURE: pass email to external auth on signup

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/preload-store.js
+++ b/app/assets/javascripts/discourse/app/lib/preload-store.js
@@ -40,6 +40,10 @@ export default {
     return Promise.resolve(null);
   },
 
+  has(key) {
+    return this.data.has(key);
+  },
+
   get(key) {
     return this.data.get(key);
   },

--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -8,7 +8,7 @@ import Site from "discourse/models/site";
 import { i18n } from "discourse-i18n";
 
 export default class LoginMethod extends EmberObject {
-  static buildPostForm(url) {
+  static buildPostForm(url, params = {}) {
     // Login always happens in an anonymous context, with no CSRF token
     // So we need to fetch it before sending a POST request
     return updateCsrfToken().then(() => {
@@ -17,10 +17,17 @@ export default class LoginMethod extends EmberObject {
       form.setAttribute("method", "post");
       form.setAttribute("action", url);
 
-      const input = document.createElement("input");
-      input.setAttribute("name", "authenticity_token");
-      input.setAttribute("value", Session.currentProp("csrfToken"));
-      form.appendChild(input);
+      const csrfInput = document.createElement("input");
+      csrfInput.setAttribute("name", "authenticity_token");
+      csrfInput.setAttribute("value", Session.currentProp("csrfToken"));
+      form.appendChild(csrfInput);
+
+      Object.keys(params).forEach((key) => {
+        const input = document.createElement("input");
+        input.setAttribute("name", key);
+        input.setAttribute("value", params[key]);
+        form.appendChild(input);
+      });
 
       document.body.appendChild(form);
 
@@ -57,25 +64,22 @@ export default class LoginMethod extends EmberObject {
       return Promise.resolve();
     }
 
-    let authUrl = getURL(`/auth/${this.name}`);
-
     if (reconnect) {
-      params["reconnect"] = true;
+      params.reconnect = true;
     }
 
     if (signup) {
-      params["signup"] = true;
+      params.signup = true;
+
+      const email = Session.currentProp("email");
+      if (email) {
+        params.email = email;
+      }
     }
 
-    const paramKeys = Object.keys(params);
-    if (paramKeys.length > 0) {
-      authUrl += "?";
-      authUrl += paramKeys
-        .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
-        .join("&");
-    }
-
-    return LoginMethod.buildPostForm(authUrl).then((form) => form.submit());
+    return LoginMethod.buildPostForm(getURL(`/auth/${this.name}`), params).then(
+      (form) => form.submit()
+    );
   }
 }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
@@ -19,6 +19,11 @@ module("Unit | Utility | preload-store", function (hooks) {
     );
   });
 
+  test("has", function (assert) {
+    assert.false(PreloadStore.has("joker"), "returns false for a missing key");
+    assert.true(PreloadStore.has("bane"), "returns true for an existing key");
+  });
+
   test("remove", function (assert) {
     PreloadStore.remove("bane");
     assert.blank(

--- a/lib/auth/discourse_id_authenticator.rb
+++ b/lib/auth/discourse_id_authenticator.rb
@@ -7,7 +7,12 @@ class Auth::DiscourseIdAuthenticator < Auth::ManagedAuthenticator
     option :client_options, auth_scheme: :basic_auth
 
     def authorize_params
-      super.tap { _1[:intent] = "signup" if request.params["signup"] == "true" }
+      super.tap do |params|
+        if request.params["signup"] == "true"
+          params[:intent] = "signup"
+          params[:email] = request.params["email"] if request.params["email"].present?
+        end
+      end
     end
 
     def callback_url

--- a/spec/lib/auth/discourse_id_authenticator_spec.rb
+++ b/spec/lib/auth/discourse_id_authenticator_spec.rb
@@ -81,6 +81,66 @@ describe Auth::DiscourseIdAuthenticator do
     it "defines callback_url" do
       expect(strategy.callback_url).to eq("http://test.localhost/auth/discourse_id/callback")
     end
+
+    describe "#authorize_params" do
+      let(:env) { Rack::MockRequest.env_for("http://example.com/auth/discourse_id", params:) }
+      let(:request) { Rack::Request.new(env) }
+      let(:strategy) do
+        strategy = Auth::DiscourseIdAuthenticator::DiscourseIdStrategy.new({})
+        allow(strategy).to receive(:request).and_return(request)
+        strategy
+      end
+
+      before do
+        allow_any_instance_of(OmniAuth::Strategies::OAuth2).to receive(
+          :authorize_params,
+        ).and_return({})
+      end
+
+      context "when just email parameter is present" do
+        let(:params) { { "email" => "test@example.com" } }
+
+        it "does not include email in authorize params" do
+          expect(strategy.authorize_params[:email]).to be_nil
+        end
+      end
+
+      context "when signup parameter is true" do
+        let(:params) { { "signup" => "true" } }
+
+        it "includes signup intent in authorize params" do
+          expect(strategy.authorize_params[:intent]).to eq("signup")
+        end
+      end
+
+      context "when signup parameter is false" do
+        let(:params) { { "signup" => "false" } }
+
+        it "does not include signup intent in authorize params" do
+          expect(strategy.authorize_params[:intent]).to be_nil
+        end
+      end
+
+      context "when signup is false and email is present" do
+        let(:params) { { "email" => "test@example.com", "signup" => "false" } }
+
+        it "does not include anything in authorize params" do
+          params = strategy.authorize_params
+          expect(params[:email]).to be_nil
+          expect(params[:intent]).to be_nil
+        end
+      end
+
+      context "when signup is true and email is present" do
+        let(:params) { { "email" => "test@example.com", "signup" => "true" } }
+
+        it "includes both email and intent in authorize params" do
+          params = strategy.authorize_params
+          expect(params[:email]).to eq("test@example.com")
+          expect(params[:intent]).to eq("signup")
+        end
+      end
+    end
   end
 
   let(:hash) do

--- a/spec/system/discourse_id_spec.rb
+++ b/spec/system/discourse_id_spec.rb
@@ -18,8 +18,6 @@ describe "discourse login client auth" do
           username: OmniauthHelpers::USERNAME,
         ),
     )
-
-    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:github]
   end
 
   after { reset_omniauth_config(:discourse_id) }


### PR DESCRIPTION
And forward them in "discourse id" so we can pre-fill the email field on the signup page.

Also added `PreloadStore.has("key")` so we can quickly check a key is present in the "preload store" without actually retrieving it.

Internal ref - t/154880