### PR TITLE
UX: edit category description layout fix

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -258,8 +258,10 @@ export default class EditCategoryGeneral extends Component {
 
       {{#if this.showDescription}}
         <@form.Section @title={{i18n "category.description"}}>
+          <span class="readonly-field">{{this.categoryDescription}}</span>
+
           {{#if @category.topic_url}}
-            <@form.Container @subtitle={{this.categoryDescription}}>
+            <@form.Container>
               <@form.Button
                 @action={{this.showCategoryTopic}}
                 @icon="pencil"


### PR DESCRIPTION
The `form-kit` container subtitle doesn't play well with the category description. The issue experienced appears to be due to the flex direction.

Since we can only update the category description from the topic and not within the edit category page, I have moved the description to a read-only span which follows a similar pattern that we use on other forms.

### Before

<img width="890" height="151" alt="Screenshot 2025-07-10 at 5 00 29 PM" src="https://github.com/user-attachments/assets/99174b48-6ffe-456d-aaed-f41192836973" />


### After

<img width="894" height="175" alt="Screenshot 2025-07-10 at 5 00 18 PM" src="https://github.com/user-attachments/assets/486cb87f-ab3a-478a-a8ea-6de3fcb12e79" />

Internal ref: /t/-/158283