### PR TITLE
UX: Followup fix dmenu zindex

### DIFF
--- a/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
@@ -10,8 +10,10 @@
     }
   }
 
-  .discourse-touch & {
-    z-index: calc(z("mobile-composer") + 1);
+  &.fk-d-menu {
+    @include viewport.until(sm) {
+      z-index: calc(z("mobile-composer") + 1);
+    }
   }
 
   .fullscreen-composer & {


### PR DESCRIPTION
followup for #33545 

The `z-index: calc(z("mobile-composer") + 1);` (1101) was lower dan the modal overlay on mobile (1300), which made the menu inaccessible.

it's now scoped to the desktop version of dmenu only, which should suffice for desktop/tablet usecases.