### PR TITLE
A11Y: hide anchor links from global site banners

### DIFF
--- a/app/assets/stylesheets/common/components/banner.scss
+++ b/app/assets/stylesheets/common/components/banner.scss
@@ -50,4 +50,8 @@
   > p:last-of-type {
     margin-bottom: 0;
   }
+
+  a.anchor {
+    display: none;
+  }
 }


### PR DESCRIPTION
When a topic is pinned as a site banner, we include automatically generated anchor links from the post in the banner's content... but do not include the anchor functionality from the topic (topic seen below)

<img width="246" height="48" alt="image" src="https://github.com/user-attachments/assets/6f145875-97a3-401c-bef6-ffd5cd6a22d1" />

This means we end up with a 0 dimension link in the banner content, which is still reachable via keyboard and other forms of navigation. You can see the outlined link below:

<img width="1097" height="174" alt="image" src="https://github.com/user-attachments/assets/d5d50892-72f3-4ab8-8a33-2f2eb73fdc3d" />

This can be confusing if you're using a screenreader, and the anchor links don't serve much purpose when included in these banners. Hiding them with CSS avoids the issue. 


