### PR TITLE
A11Y: add aria-label to quote expansion button, jump to post

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -214,7 +214,8 @@ export default class PostQuotedContent extends Component {
               @action={{this.toggleExpanded}}
               @ariaControls={{@id}}
               @ariaExpanded={{this.expanded}}
-              @title="post.expand_collapse"
+              @ariaLabel={{if this.expanded "post.collapse" "expand"}}
+              @title={{if this.expanded "post.collapse" "expand"}}
             >
               {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
                   extra whitespace that will interfere with the text captured when quoting a quoted content }}
@@ -226,6 +227,7 @@ export default class PostQuotedContent extends Component {
               class="btn-flat back"
               @href={{this.quotedPostUrl}}
               @title="post.follow_quote"
+              @ariaLabel="post.follow_quote"
             >
               {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
                   extra whitespace that will interfere with the text captured when quoting a quoted content }}

--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -269,7 +269,7 @@ export default class PostCooked {
       const icon = iconHTML("arrow-up");
       navLink = `<a href='${this._urlForPostNumber(
         postNumber
-      )}' title='${quoteTitle}' class='btn-flat back'>${icon}</a>`;
+      )}' title='${quoteTitle}' aria-label='${quoteTitle}' class='btn-flat back'>${icon}</a>`;
     }
 
     // Only add the expand/contract control if it's not a full post
@@ -277,12 +277,13 @@ export default class PostCooked {
     let expandContract = "";
 
     if (!aside.dataset.full) {
-      const icon = iconHTML(desc, { title: "post.expand_collapse" });
+      const icon = iconHTML(desc);
       const quoteId = aside.querySelector("blockquote")?.id;
 
       if (quoteId) {
         const isExpanded = aside.dataset.expanded === "true";
-        expandContract = `<button aria-controls="${quoteId}" aria-expanded="${isExpanded}" class="quote-toggle btn-flat">${icon}</button>`;
+        const toggleLabel = isExpanded ? i18n("post.collapse") : i18n("expand");
+        expandContract = `<button aria-controls="${quoteId}" aria-expanded="${isExpanded}" aria-label="${toggleLabel}" title="${toggleLabel}" class="quote-toggle btn-flat">${icon}</button>`;
 
         if (titleElement) {
           titleElement.style.cursor = "pointer";


### PR DESCRIPTION
Concerns the quote controls: 

![quote](https://github.com/user-attachments/assets/a9d21286-1f44-4f9f-a1cb-6fc4fdb8c350)

This improves the title so rather than "expand/collapse" for both states it represents the current action "expand" or "collapse". This is also added for aria-label. 

I've also added aria-label to the "go to the quoted post" arrow. 