### PR TITLE
UX: Remove category h3 margin

### DIFF
--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -189,8 +189,6 @@
 
   h3 {
     font-size: var(--category-boxes-title-font-size);
-    margin-bottom: 0.5em;
-    margin-top: 0.25em;
     line-height: var(--line-height-medium);
     text-align: var(--category-boxes-text-alignment);
     color: var(--primary);


### PR DESCRIPTION
These margins are not being applied, and then the top one is applied, it is useless.