### PR TITLE
DEV: Add extra permission to allow labeller to work in PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write # Needed for labeler to add labels to PRs: https://github.com/orgs/community/discussions/156181
 
 jobs:
   triage:


### PR DESCRIPTION
Seeing the following in https://github.com/discourse/discourse/actions/runs/16209614945/job/45767099809?pr=33577

```
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: HttpError: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
Error: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
```

Related: https://github.com/orgs/community/discussions/156181