### PR TITLE
A11Y: add aria-label to advanced search date input

### DIFF
--- a/app/assets/javascripts/discourse/app/components/date-input.gjs
+++ b/app/assets/javascripts/discourse/app/components/date-input.gjs
@@ -193,6 +193,7 @@ export default class DateInput extends Component {
       @value={{readonly this.value}}
       id={{this.inputId}}
       {{on "input" this.onChangeDate}}
+      ...attributes
     />
 
     {{#unless this.useGlobalPickerContainer}}

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.gjs
@@ -955,14 +955,12 @@ export default class SearchAdvancedOptions extends Component {
               @content={{this.postTimeOptions}}
               @value={{this.searchedTerms.time.when}}
               @onChange={{this.onChangeWhenTime}}
-              @options={{hash
-                headerAriaLabel=(i18n "search.advanced.post.time.aria_label")
-              }}
             />
             <DateInput
               @date={{this.searchedTerms.time.days}}
               @onChange={{this.onChangeWhenDate}}
               @inputId="search-post-date"
+              aria-label={{i18n "search.advanced.post.time.aria_label"}}
             />
           </div>
         </div>


### PR DESCRIPTION
The date control here doesn't have a label:

<img width="608" height="170" alt="image" src="https://github.com/user-attachments/assets/5517d5d2-f64b-4cf9-aad0-f14152a85ffd" />

This adds the label, and also removes the headerAriaLabel from the before/after dropdown — the dropdown has a label applied elsewhere so this wasn't doing anything (tested with NVDA)