### PR TITLE
UX: make navigation container full-width again

### DIFF
--- a/app/assets/stylesheets/common/base/list-controls.scss
+++ b/app/assets/stylesheets/common/base/list-controls.scss
@@ -32,7 +32,7 @@
 }
 
 .navigation-container {
-  width: calc(100% - var(--nav-horizontal-padding) * 2);
+  width: 100%;
   font-size: var(--d-nav-font-size);
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Looks like this regressed in 20f57aec12a5d2291c79a447d18eb3f164877c61, this gets it fixed


Before:
<img width="758" height="224" alt="image" src="https://github.com/user-attachments/assets/cecef214-b547-4bf2-a41c-fc9f8f0031d1" />


After:
<img width="764" height="210" alt="image" src="https://github.com/user-attachments/assets/731ddc08-4c7d-4edf-85b3-64fffd741eb2" />
