### PR TITLE
UX: ensure mobile setting filter is always reachable on mobile

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -39,9 +39,7 @@ export default class AdminSiteSettingsController extends Controller {
 
   @action
   toggleMenu() {
-    const adminDetail = document.querySelector(".admin-detail");
-    ["mobile-closed", "mobile-open"].forEach((state) => {
-      adminDetail.classList.toggle(state);
-    });
+    const adminDetail = document.querySelector(".admin-nav__wrapper");
+    adminDetail.classList.toggle("mobile-open");
   }
 }

--- a/app/assets/javascripts/admin/addon/templates/site-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.gjs
@@ -30,37 +30,37 @@ export default RouteTemplate(
       @onToggleMenu={{@controller.toggleMenu}}
     />
 
-    <div class="admin-nav admin-site-settings-category-nav pull-left">
-      <ul class="nav nav-stacked">
-        {{#each @controller.visibleSiteSettings as |category|}}
-          <li
-            class={{concatClass
-              "admin-site-settings-category-nav__item"
-              category.nameKey
-            }}
-          >
-            <LinkTo
-              @route="adminSiteSettingsCategory"
-              @model={{category.nameKey}}
-              class={{category.nameKey}}
-              title={{category.name}}
+    <div class="admin-nav__wrapper">
+      <div class="admin-nav admin-site-settings-category-nav">
+        <ul class="nav nav-stacked">
+          {{#each @controller.visibleSiteSettings as |category|}}
+            <li
+              class={{concatClass
+                "admin-site-settings-category-nav__item"
+                category.nameKey
+              }}
             >
-              {{category.name}}
-              {{#if @controller.filtersApplied}}
-                <span class="count">({{category.count}})</span>
-              {{/if}}
-            </LinkTo>
-          </li>
-        {{/each}}
-      </ul>
+              <LinkTo
+                @route="adminSiteSettingsCategory"
+                @model={{category.nameKey}}
+                class={{category.nameKey}}
+                title={{category.name}}
+              >
+                {{category.name}}
+                {{#if @controller.filtersApplied}}
+                  <span class="count">({{category.count}})</span>
+                {{/if}}
+              </LinkTo>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+
+      <div class="admin-detail mobile-closed">
+        {{outlet}}
+      </div>
+
     </div>
-
-    <div class="admin-detail pull-left mobile-closed">
-      {{outlet}}
-    </div>
-
-    <div class="clearfix"></div>
-
     <AdminSiteSettingsChangesBanner />
   </template>
 );

--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -825,14 +825,19 @@ $mobile-breakpoint: 700px;
   box-sizing: border-box;
   position: relative; // The admin-nav becomes a slide-out menu at the mobile-nav breakpoint
 
-  @media (max-width: $mobile-breakpoint) {
-    position: absolute;
-    z-index: z("base") - 1;
-    width: 250px;
+  @include viewport.until(sm) {
+    width: 0;
+    transition: width 0.3s ease;
   }
 
-  @media (width <= 500px) {
-    width: 50%;
+  &__wrapper {
+    display: flex;
+
+    &.mobile-open {
+      .admin-nav {
+        width: 50%;
+      }
+    }
   }
 
   .nav-stacked {
@@ -859,18 +864,6 @@ $mobile-breakpoint: 700px;
   @media (max-width: $mobile-breakpoint) {
     width: 100%;
     border: none;
-  }
-}
-
-.admin-detail.mobile-open {
-  @media (max-width: $mobile-breakpoint) {
-    transition: transform 0.3s ease;
-    transform: translateX(250px);
-  }
-
-  @media (width <= 500px) {
-    transition: transform 0.3s ease;
-    transform: translateX(50%);
   }
 }
 


### PR DESCRIPTION
As reported here https://meta.discourse.org/t/site-setting-menu-limited-by-results-page-size/372904

If you filter the 'all site settings' list and try to scroll down, you're limited by the height of the settings... and can't scroll down to reach other categories.

Can't scroll past "backups" here:

<img  height="500" alt="image" src="https://github.com/user-attachments/assets/08f7543f-e704-415d-9191-4ce2551fef27" />

This is because of how overflow is hidden and the menu is absolutely positioned. 

This PR adds a new wrapper and applies flex so the menu doesn't have to be absolutely positioned and gets included in the height calculation... so now we can scroll fully: 

<img height="500" alt="image" src="https://github.com/user-attachments/assets/bd7654c3-f6c0-42b8-aa27-043300ae4075" />

This menu needs more refactoring in general, but at least makes it more usable on mobile. 

