### PR TITLE
UX: minor fullscreen composer adjustments

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1199,6 +1199,10 @@ div.ac-wrap {
         height: calc(var(--composer-vh, 1vh) * 100) !important;
       }
 
+      .grippie {
+        display: none;
+      }
+
       .d-editor-preview-wrapper {
         margin-top: 1%;
       }
@@ -1221,10 +1225,6 @@ div.ac-wrap {
       #file-uploading {
         margin-left: 0;
         text-align: initial;
-      }
-
-      .composer-popup {
-        top: 30px;
       }
 
       &::before {


### PR DESCRIPTION
1. The grippie shouldn't appear in full-screen mode, as reported here: https://meta.discourse.org/t/grip-not-hidden-in-composer-full-screen-mode/373303

2. Composer education popups are tool tall (post the change from c8482635230359c29e8ef7b405943eeed890c9ef): https://meta.discourse.org/t/your-topic-is-similar-to-pop-up-in-full-screen-composer/373304

Before:
<img width="3018" height="1718" alt="image" src="https://github.com/user-attachments/assets/6001ff9c-1774-428c-8367-6dc9d4193336" />


After:
<img width="3014" height="1708" alt="image" src="https://github.com/user-attachments/assets/bdf7b099-209e-4c9b-9c79-cb9e1412a0f8" />
