### PR TITLE
UI: ensures the textarea is not too small

### DIFF
--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -288,6 +288,21 @@
     }
   }
 
+  .d-editor .d-editor-container {
+    display: flex;
+    flex: 1;
+    justify-content: space-between;
+
+    .d-editor-textarea-wrapper {
+      box-sizing: border-box;
+      min-width: 300px;
+
+      .d-editor-input {
+        min-height: 200px;
+      }
+    }
+  }
+
   .field-wrapper {
     display: flex;
     flex-direction: column;
@@ -342,22 +357,6 @@
           margin: 0;
         }
       }
-
-      .d-editor,
-      .d-editor-container {
-        display: flex;
-        flex: 1;
-        justify-content: space-between;
-
-        .d-editor-input {
-          min-height: 200px;
-        }
-      }
-    }
-
-    .d-editor-textarea-wrapper {
-      box-sizing: border-box;
-      min-width: 300px;
     }
 
     .pm-field:not(:last-child) {
@@ -371,7 +370,6 @@
     .pm-textarea {
       width: 100%;
       box-sizing: border-box;
-      height: 200px;
     }
 
     .no-pm {


### PR DESCRIPTION
Ideally we should move all these fields to form-kit but that should improve the situation for now.

Before: 

<img width="1051" height="190" alt="Screenshot 2025-07-12 at 00 36 35" src="https://github.com/user-attachments/assets/327c1180-2fda-42e7-b6f0-8be73f7a0ac0" />

After:

<img width="1048" height="324" alt="Screenshot 2025-07-12 at 00 36 43" src="https://github.com/user-attachments/assets/6eb4291a-121f-4a34-bef8-769fbe49bb54" />