### PR TITLE
FIX: correctly allow to translate my messages

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
@@ -15,12 +15,14 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return i18n("sidebar.sections.community.links.my_messages.content");
+    return i18n("sidebar.sections.community.links.my_messages.title");
   }
 
   get text() {
     return i18n(
-      `sidebar.sections.community.links.${this.overridenName.toLowerCase()}.content`,
+      `sidebar.sections.community.links.${this.overridenName
+        .toLowerCase()
+        .replace(" ", "_")}.content`,
       { defaultValue: this.overridenName }
     );
   }

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -78,10 +78,10 @@ module PageObjects
           I18n.t("js.sidebar.sections.community.links.my_messages.content")
         end
 
-        def has_my_messages_link?
+        def has_my_messages_link?(text = my_messages)
           page.has_css?(
             ".sidebar-section-link[data-link-name='#{my_messages.downcase.parameterize}']",
-            text: my_messages,
+            text:,
           )
         end
 

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -3,7 +3,7 @@
 describe "Viewing sidebar", type: :system do
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
-  context "as logged in user", type: :system do
+  context "as logged in user" do
     fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
     fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:category_sidebar_section_link) { Fabricate(:category_sidebar_section_link, user: user) }
@@ -36,7 +36,7 @@ describe "Viewing sidebar", type: :system do
       end
     end
 
-    describe "Community sidebar section", type: :system do
+    describe "Community sidebar section" do
       fab!(:user) { Fabricate(:user, locale: "pl_PL") }
       fab!(:translation_override) do
         TranslationOverride.create!(
@@ -180,6 +180,22 @@ describe "Viewing sidebar", type: :system do
         visit("/")
         expect(sidebar).to have_no_my_messages_link
       end
+
+      context "with translation override" do
+        fab!(:translation_override) do
+          TranslationOverride.create!(
+            locale: "en",
+            translation_key: "js.sidebar.sections.community.links.my_messages.content",
+            value: "Overrided",
+          )
+        end
+
+        it "is translated" do
+          sign_in(admin)
+          visit("/")
+          expect(sidebar).to have_my_messages_link("Overrided")
+        end
+      end
     end
 
     it "shouldn't display the panel header for the main sidebar" do
@@ -189,7 +205,7 @@ describe "Viewing sidebar", type: :system do
     end
   end
 
-  context "as anonymous user", type: :system do
+  context "as anonymous user" do
     describe "My messages sidebar link" do
       it "shouldn't show for anonymous user" do
         visit("/")


### PR DESCRIPTION
We were not correctly converting the key, it was outputting "my messages" instead of "my_messages".