### PR TITLE
UX: Update composer placeholder for RTE

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.gjs
@@ -134,12 +134,20 @@ export default class ComposerEditor extends Component {
     let placeholder = "composer.reply_placeholder_choose_category";
 
     if (!requiredCategoryMissing) {
-      const key = authorizesOneOrMoreImageExtensions(
+      const allowImages = authorizesOneOrMoreImageExtensions(
         this.currentUser.staff,
         this.siteSettings
-      )
-        ? "reply_placeholder"
-        : "reply_placeholder_no_images";
+      );
+
+      let key;
+      if (this.siteSettings.rich_editor) {
+        key = allowImages
+          ? "reply_placeholder_rte"
+          : "reply_placeholder_rte_no_images";
+      } else {
+        key = allowImages ? "reply_placeholder" : "reply_placeholder_no_images";
+      }
+
       placeholder = `composer.${key}`;
     }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2847,6 +2847,8 @@ en:
       remove_featured_link: "Remove link from topic."
       reply_placeholder: "Type here. Use Markdown, BBCode, or HTML to format. Drag or paste images."
       reply_placeholder_no_images: "Type here. Use Markdown, BBCode, or HTML to format."
+      reply_placeholder_rte: "Type here, use the toolbar or Markdown for formatting. Drag or paste images."
+      reply_placeholder_rte_no_images: "Type here, use the toolbar or Markdown for formatting."
       reply_placeholder_choose_category: "Select a category before typing here."
       view_new_post: "View your new post."
       saving: "Saving"


### PR DESCRIPTION
We don't really want to encourage HTML in the RTE,
and BBCode is pretty technical too, so this commit
simplifies the copy of the placeholder for the RTE

<img width="541" height="159" alt="image" src="https://github.com/user-attachments/assets/49126f5d-6d28-452f-acae-a952db0dedbb" />
