### PR TITLE
FIX: Broken links to site settings under Content section

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-config-content-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-config-content-settings.js
@@ -1,0 +1,3 @@
+import AdminAreaSettingsBaseController from "admin/controllers/admin-area-settings-base";
+
+export default class AdminConfigContentSettingsController extends AdminAreaSettingsBaseController {}

--- a/app/assets/javascripts/admin/addon/routes/admin-config-content-settings.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-config-content-settings.js
@@ -1,0 +1,14 @@
+import { service } from "@ember/service";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default class AdminConfigContentSettingsRoute extends DiscourseRoute {
+  @service router;
+
+  beforeModel(transition) {
+    let { queryParams } = transition.to;
+
+    if (transition.to.name !== "adminConfig.content") {
+      this.router.replaceWith("adminConfig.content", { queryParams });
+    }
+  }
+}

--- a/app/assets/javascripts/admin/addon/routes/admin-route-map.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-route-map.js
@@ -251,6 +251,7 @@ export default function () {
         );
         this.route("content", function () {
           this.route("categoriesAndTags", { path: "/" });
+          this.route("settings");
           this.route("sharing");
           this.route("postsAndTopics", { path: "/posts-and-topics" });
           this.route("statsAndThresholds", { path: "/stats-and-thresholds" });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -409,6 +409,7 @@ Discourse::Application.routes.draw do
         resources :site_settings, only: %i[index]
         get "analytics-and-seo" => "site_settings#index"
         get "content" => "site_settings#index"
+        get "content/settings" => "site_settings#index"
         get "content/sharing" => "site_settings#index"
         get "content/posts-and-topics" => "site_settings#index"
         get "content/stats-and-thresholds" => "site_settings#index"

--- a/spec/system/admin_search_spec.rb
+++ b/spec/system/admin_search_spec.rb
@@ -78,4 +78,15 @@ describe "Admin Search", type: :system do
     send_keys([SystemHelpers::PLATFORM_KEY_MODIFIER, "/"])
     expect(search_modal).to be_open
   end
+
+  it "works with sections which have a redirect instead of explicit /settings route" do
+    visit "/admin"
+
+    sidebar.click_search_input
+
+    search_modal.search("tags tag style")
+    search_modal.find_result("setting", 0).click
+
+    expect(page).to have_current_path("/admin/config/content?filter=tag_style")
+  end
 end


### PR DESCRIPTION
### What is the problem?

The <kbd>Content</kbd> section in particular has four tabs which are all site setting pages. It does not have one under `/settings`, like other sections.

The admin search functionality will automatically use `/settings` for multi-tabbed sections. This results in a 404 when searching for <kbd>Content</kbd> site settings.

### How does this fix it?

I think it's a bit early to say how this should ultimately work. This PR adds a front-end redirect (`replaceWith`) for `/content/settings` to fix the immediate issue.