### PR TITLE
DEV: Supplement updateCategory API doc to include localizations

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -783,25 +783,11 @@ export default class Category extends RestModel {
         emoji: this.emoji,
         icon: this.icon,
         ...(this.siteSettings.content_localization_enabled && {
-          category_localizations_attributes: this._buildUpdatedLocalizations(),
+          category_localizations: this.localizations,
         }),
       }),
       type: id ? "PUT" : "POST",
     });
-  }
-
-  _buildUpdatedLocalizations() {
-    const localizationsToDestroy = this.category_localizations
-      .filter(
-        (original) =>
-          !this.localizations.some((newLoc) => newLoc.id === original.id)
-      )
-      .map((loc) => ({
-        id: loc.id,
-        _destroy: true,
-      }));
-
-    return [...this.localizations, ...localizationsToDestroy];
   }
 
   _permissionsForUpdate() {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -541,9 +541,7 @@ class CategoriesController < ApplicationController
         end
 
         if SiteSetting.content_localization_enabled?
-          conditional_param_keys << {
-            category_localizations_attributes: %i[id category_id locale name description _destroy],
-          }
+          conditional_param_keys << { category_localizations: %i[id locale name description] }
         end
 
         result =

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1275,6 +1275,18 @@ class Category < ActiveRecord::Base
     tags.count > 0 || tag_groups.count > 0
   end
 
+  def category_localizations=(localizations_params)
+    return self.category_localizations_attributes = localizations_params unless persisted?
+
+    incoming_ids = localizations_params.map { |loc| loc["id"] }
+    category_localizations
+      .where.not(id: incoming_ids)
+      .select(:id)
+      .each { |record| localizations_params << { "id" => record.id, "_destroy" => true } }
+
+    self.category_localizations_attributes = localizations_params
+  end
+
   private
 
   def ensure_category_setting

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -9,7 +9,7 @@ class CategorySerializer < SiteCategorySerializer
   end
 
   class CategoryLocalizationSerializer < ApplicationSerializer
-    attributes :id, :category_id, :locale, :name, :description
+    attributes :id, :locale, :name, :description
   end
 
   attributes :read_restricted,

--- a/spec/requests/api/schemas/json/category_create_request.json
+++ b/spec/requests/api/schemas/json/category_create_request.json
@@ -52,6 +52,34 @@
     "form_template_ids": {
       "type": "array",
       "items": {}
+    },
+    "category_localizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The unique identifier for an existing localization. Must be included otherwise the record will be deleted."
+          },
+          "locale": {
+            "type": "string",
+            "description": "The locale for the localization, e.g., 'en', 'zh_CN'. Locale should be in the list of SiteSetting.content_localization_supported_locales."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the category in the specified locale."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description excerpt of the category in the specified locale."
+          }
+        },
+        "required": [
+          "locale",
+          "name"
+        ]
+      }
     }
   },
   "required": [

--- a/spec/system/edit_category_localizations_spec.rb
+++ b/spec/system/edit_category_localizations_spec.rb
@@ -61,7 +61,9 @@ describe "Edit Category Localizations", type: :system do
         category_page.save_settings
         page.refresh
 
-        expect(CategoryLocalization.where(category_id: category.id).count).to eq(2)
+        try_until_success do
+          expect(CategoryLocalization.where(category_id: category.id).count).to eq(2)
+        end
         expect(CategoryLocalization.where(category_id: category.id, locale: "es").count).to eq(1)
         expect(CategoryLocalization.where(category_id: category.id, locale: "fr").count).to eq(1)
         expect(CategoryLocalization.where(category_id: category.id, locale: "es").first.name).to eq(
@@ -82,13 +84,15 @@ describe "Edit Category Localizations", type: :system do
     describe "when editing a category with localizations" do
       fab!(:category_localization) { Fabricate(:category_localization, category: category) }
 
-      it "should allow you to delete localizations" do
+      it "allows you to delete localizations" do
         expect(CategoryLocalization.where(category_id: category.id).count).to eq(1)
         category_page.visit_edit_localizations(category)
         page.find(".edit-category-tab-localizations .remove-localization").click
         category_page.save_settings
         page.refresh
-        expect(CategoryLocalization.where(category_id: category.id).count).to eq(0)
+        try_until_success do
+          expect(CategoryLocalization.where(category_id: category.id).count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
We're moving the `_destroy` logic for localizations to the backend. The `updateCategory` API should look something like this:

```
# Scenario: edit italian, add japanese, delete spanish

# PUT /categories/4
{
  "name": "General",
  "slug": "general",
  "color": "25AAE2",
  #  ...
  "category_localizations": [
    {
      "id": 102
      "locale": "it",
      "name": "generale",
      "description": "Si prega di creare qui argomenti che non rientrano in altre categorie esistenti."
    }
    {
      "locale": "ja",
      "name": "一般",
      "description": "他の既存のカテゴリに該当しないトピックをここに作成してください。"
    }
  ]
}
```