### PR TITLE
FIX: my redirect case insensitive params

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -484,7 +484,7 @@ class UsersController < ApplicationController
   end
 
   def my_redirect
-    raise Discourse::NotFound if params[:path] !~ %r{\A[a-z_\-/]+\z}
+    raise Discourse::NotFound if params[:path] !~ %r{\A[a-zA-Z_\-/]+\z}
 
     if current_user.blank?
       cookies[:destination_url] = path("/my/#{params[:path]}")

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4172,6 +4172,17 @@ RSpec.describe UsersController do
         get "/my/preferences"
         expect(response).to redirect_to("/u/#{user.encoded_username}/preferences")
       end
+
+      it "works with mixed case params" do
+        group = Fabricate(:group, name: "MyGroup")
+        group.add(user1)
+        group.save
+
+        sign_in(user1)
+
+        get "/my/messages/group/#{group.name}"
+        expect(response).to redirect_to("/u/#{user1.username}/messages/group/#{group.name}")
+      end
     end
   end
 


### PR DESCRIPTION
This changes allows the `/my/` prefix redirect to work when the name param contains uppercase letters.

#### For example:

`/my/messages/group/MyGroup` now redirects to `/u/username/messages/group/MyGroup`