### PR TITLE
DEV: Preserve ordering of inline script tags

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 91
+  BASE_COMPILER_VERSION = 92
   CORE_THEMES = { "foundation" => -1, "horizon" => -2 }
   EDITABLE_SYSTEM_ATTRIBUTES = %w[
     child_theme_ids

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -840,12 +840,12 @@ HTML
 
     it "recompiles when the hostname changes" do
       theme.set_field(target: :settings, name: :yaml, value: "name: bob")
-      theme_field =
-        theme.set_field(
-          target: :common,
-          name: :after_header,
-          value: '<script>console.log("hello world");</script>',
-        )
+      theme.set_field(
+        target: :common,
+        name: :after_header,
+        value:
+          '<script type="text/discourse-plugin" version="0.1">console.log("hello world");</script>',
+      )
       theme.save!
 
       expect(Theme.lookup_field(theme.id, :common, :after_header)).to include(


### PR DESCRIPTION
Previously, inline `<script>` would be collected together into the JS bundle for the theme field, which is then loaded with a `defer` attribute to match all other script tags in Discourse. While this works in most situations, it can be surprising when inline script tags are used in conjunction with external scripts:

```html
<script>
  window.dataLayer = { foo: "bar" };
</script>
<script src="https://example.com/analytics.js"></script>
```
In this example, the inline script would be collected into the JS bundle for the theme, and would be executed **after** the analytics script. The result would be something like

```html
<script defer src="https://example.com/analytics.js"></script>
<script defer src="/theme-javascripts/...js"> <!-- inline script is here -->
```

---

With our modern strict-dynamic CSP, ideally we would go back to rendering these as simple inline script tags. Unfortunately though, inline scripts do not support the `defer` attribute. `type=module` has the same ordering as `defer`, but the change in scope would cause problems with existing scripts.

Converting each inline script to its own `.js` file could work, but would introduce many new HTTP requests for tiny files, and would complicate the backend implementation.

Therefore, this commit goes for a hybrid approach. For each script tag in a theme, a `type="text/discourse-deferred-inline-js"` attribute is added. This prevents the browser from executing it. Then, a small `<script type="module"` is injected after the original script tag. When that runs, it removes the custom `type` attribute, which causes the inline script to be executed immediately.

That gives us the functionality of inline scripts, but with the timing of `defer` scripts.

---

Note: `<script type="module"` and `type="text/discourse-plugin"` are unaffected by this change. For modern code, `type="module"` is probably the cleanest option, and does not require us to apply this workaround.