### PR TITLE
FIX: include icon for private messages in non message filtered searches

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -121,6 +121,15 @@ export default class SearchMenu extends Component {
     );
   }
 
+  get isPMOnly() {
+    // Check if search is filtered to private messages only
+    const searchTerm = this.search.activeGlobalSearchTerm || "";
+    return (
+      this.inPMInboxContext ||
+      /\bin:(personal|messages|personal-direct|all-pms)\b/i.test(searchTerm)
+    );
+  }
+
   @action
   onKeydown(event) {
     if (event.key === "Escape") {
@@ -472,6 +481,7 @@ export default class SearchMenu extends Component {
           @suggestionResults={{this.suggestionResults}}
           @searchTopics={{this.includesTopics}}
           @inPMInboxContext={{this.inPMInboxContext}}
+          @isPMOnly={{this.isPMOnly}}
           @triggerSearch={{this.triggerSearch}}
           @updateTypeFilter={{this.updateTypeFilter}}
           @closeSearchMenu={{this.close}}
@@ -488,6 +498,7 @@ export default class SearchMenu extends Component {
             @suggestionResults={{this.suggestionResults}}
             @searchTopics={{this.includesTopics}}
             @inPMInboxContext={{this.inPMInboxContext}}
+            @isPMOnly={{this.isPMOnly}}
             @triggerSearch={{this.triggerSearch}}
             @updateTypeFilter={{this.updateTypeFilter}}
             @closeSearchMenu={{this.close}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results.gjs
@@ -109,6 +109,7 @@ export default class Results extends Component {
                 @topicResultsOnly={{true}}
                 @closeSearchMenu={{@closeSearchMenu}}
                 @searchLogId={{this.searchLogId}}
+                @isPMOnly={{@isPMOnly}}
               />
               <MoreLink
                 @updateTypeFilter={{@updateTypeFilter}}
@@ -130,6 +131,7 @@ export default class Results extends Component {
                 @searchTermChanged={{@searchTermChanged}}
                 @displayNameWithUser={{true}}
                 @searchLogId={{this.searchLogId}}
+                @isPMOnly={{@isPMOnly}}
               />
             {{/if}}
             <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/type/topic.gjs
@@ -14,6 +14,11 @@ import replaceEmoji from "discourse/helpers/replace-emoji";
 export default class Results extends Component {
   @service siteSettings;
 
+  get shouldShowPrivateMessageIcon() {
+    // Only show PM icon if this is a PM AND we're not in a PM-only search
+    return this.args.result.topic.isPrivateMessage && !this.args.isPMOnly;
+  }
+
   <template>
     <span class="topic">
       <span class="first-line">
@@ -21,6 +26,7 @@ export default class Results extends Component {
           @topic={{@result.topic}}
           @disableActions={{true}}
           @context="topic-view-title"
+          @showPrivateMessageIcon={{this.shouldShowPrivateMessageIcon}}
         />
         <span class="topic-title" data-topic-id={{@result.topic.id}}>
           {{#if

--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
@@ -104,6 +104,7 @@ export default class Types extends Component {
                 <resultType.component
                   @result={{result}}
                   @displayNameWithUser={{@displayNameWithUser}}
+                  @isPMOnly={{@isPMOnly}}
                 />
               </a>
             </li>

--- a/app/assets/javascripts/discourse/app/components/search-result-entries.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-result-entries.gjs
@@ -13,6 +13,7 @@ export default class SearchResultEntries extends Component {
           @selected={{this.selected}}
           @highlightQuery={{this.highlightQuery}}
           @searchLogId={{this.searchLogId}}
+          @isPMOnly={{this.isPMOnly}}
         />
       {{/each}}
     </div>

--- a/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.gjs
@@ -29,6 +29,11 @@ import { logSearchLinkClick } from "discourse/lib/search";
 export default class SearchResultEntry extends Component {
   role = "listitem";
 
+  get shouldShowPrivateMessageIcon() {
+    // Only show PM icon if this is a PM AND we're not in a PM-only search
+    return this.post.topic.isPrivateMessage && !this.isPMOnly;
+  }
+
   @action
   logClick(topicId, event) {
     // Avoid click logging when any modifier keys are pressed.
@@ -79,7 +84,7 @@ export default class SearchResultEntry extends Component {
           <TopicStatus
             @topic={{this.post.topic}}
             @disableActions={{true}}
-            @showPrivateMessageIcon={{true}}
+            @showPrivateMessageIcon={{this.shouldShowPrivateMessageIcon}}
           />
 
           <span class="topic-title">

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -287,6 +287,12 @@ export default class FullPageSearchController extends Controller {
     );
   }
 
+  @discourseComputed("q")
+  isPMOnly(q) {
+    // Check if search is filtered to private messages only
+    return q && /\bin:(personal|messages|personal-direct|all-pms)\b/i.test(q);
+  }
+
   @discourseComputed("resultCount", "noSortQ")
   resultCountLabel(count, term) {
     const plus = count % 50 === 0 ? "+" : "";

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.gjs
@@ -226,6 +226,7 @@ export default RouteTemplate(
                   @selected={{@controller.bulkSelectHelper.selected}}
                   @highlightQuery={{@controller.highlightQuery}}
                   @searchLogId={{@controller.model.grouped_search_result.search_log_id}}
+                  @isPMOnly={{@controller.isPMOnly}}
                 />
 
                 <ConditionalLoadingSpinner @condition={{@controller.loading}}>

--- a/app/assets/javascripts/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
@@ -1,0 +1,79 @@
+import { hash } from "@ember/helper";
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import TopicResultComponent from "discourse/components/search-menu/results/type/topic";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module(
+  "Integration | Component | search-menu/results/type/topic",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("shows PM icon for PM topic in regular search", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const pmTopic = store.createRecord("topic", {
+        id: 1,
+        title: "Private Message Topic",
+        archetype: "private_message",
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent
+            @result={{hash topic=pmTopic}}
+            @isPMOnly={{false}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".topic-status .d-icon-envelope")
+        .exists("PM icon shows for PM topic in regular search");
+    });
+
+    test("hides PM icon for PM topic in PM-only search", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const pmTopic = store.createRecord("topic", {
+        id: 2,
+        title: "Private Message Topic 2",
+        archetype: "private_message",
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent
+            @result={{hash topic=pmTopic}}
+            @isPMOnly={{true}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".topic-status .d-icon-envelope")
+        .doesNotExist("PM icon hidden for PM topic in PM-only search");
+    });
+
+    test("does not show PM icon for regular topic", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const regularTopic = store.createRecord("topic", {
+        id: 3,
+        title: "Regular Topic",
+        archetype: "regular",
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent
+            @result={{hash topic=regularTopic}}
+            @isPMOnly={{false}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".topic-status .d-icon-envelope")
+        .doesNotExist("PM icon not shown for regular topic");
+    });
+  }
+);

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -243,4 +243,58 @@ describe "Search", type: :system do
       ).to have_content(tag1.name)
     end
   end
+
+  describe "Private Message Icon in Search Results" do
+    fab!(:user)
+    fab!(:other_user) { Fabricate(:user) }
+    fab!(:pm_topic) do
+      Fabricate(
+        :private_message_topic,
+        user: user,
+        recipient: other_user,
+        title: "PM about searchable things",
+      )
+    end
+    fab!(:pm_post) do
+      Fabricate(:post, topic: pm_topic, user: user, raw: "Secret PM content searchable")
+    end
+    fab!(:regular_topic) { Fabricate(:topic, title: "Regular topic about searchable things") }
+    fab!(:regular_post) do
+      Fabricate(:post, topic: regular_topic, raw: "Regular post content searchable")
+    end
+
+    before do
+      SearchIndexer.enable
+      SearchIndexer.index(pm_topic, force: true)
+      SearchIndexer.index(regular_topic, force: true)
+      sign_in(user)
+    end
+
+    after { SearchIndexer.disable }
+
+    it "handles different PM search filters correctly" do
+      pm_filters = %w[in:messages in:personal in:personal-direct in:all-pms]
+
+      pm_filters.each do |filter|
+        visit("/search?q=searchable%20#{filter}")
+        if page.has_css?(".fps-result", minimum: 1)
+          expect(page).to have_css(".fps-result .topic-status .d-icon-envelope", count: 0),
+          "Expected no PM icons for filter: #{filter}"
+        end
+      end
+    end
+
+    it "shows PM envelope icon in mixed search results with in:all filter" do
+      # Search with in:all filter to get mixed results (both PM and public topics)
+      visit("/search?q=searchable%20in:all")
+
+      # The PM envelope icon should be on the PM topic specifically
+      pm_result = page.find(".fps-result", text: "PM about searchable things")
+      expect(pm_result).to have_css(".topic-status .d-icon-envelope")
+
+      # The regular topic should NOT have the PM envelope icon
+      regular_result = page.find(".fps-result", text: "Regular topic about searchable things")
+      expect(regular_result).to have_no_css(".topic-status .d-icon-envelope")
+    end
+  end
 end


### PR DESCRIPTION
Context: https://meta.discourse.org/t/missing-pm-icon-in-in-all-searches/365094

This ensures PMs are marked as such with the PM icon in searches where there might be other types of results.


### Testing

#### Search Menu:
<img width="500" height="500" alt="non-pm-search-menu" src="https://github.com/user-attachments/assets/c31c3fd7-c81c-4102-a99f-44202d25b52d" />
<img width="500" height="500" alt="pm-only-search-menu" src="https://github.com/user-attachments/assets/505bfbd9-83ae-421f-b7ff-0b841f0c7135" />

#### Full page search:
<img width="500" height="500" alt="pm-only-full-page-search" src="https://github.com/user-attachments/assets/4617a74b-1454-4e54-b557-8aa239d7fbc5" />
<img width="500" height="500" alt="non-pm-full-page-search" src="https://github.com/user-attachments/assets/f701298b-b9b8-4540-ba58-171ee26929f6" />
