### PR TITLE
DEV: Prevent N+1s when topic list (e.g. /latest) has localized titles

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2143,7 +2143,8 @@ class Topic < ActiveRecord::Base
   end
 
   def get_localization(locale = I18n.locale)
-    topic_localizations.find_by(locale: locale.to_s.sub("-", "_"))
+    locale_string = locale.to_s.sub("-", "_")
+    topic_localizations.find { |tl| tl.locale == locale_string }
   end
 
   private


### PR DESCRIPTION
Currently visible on <https://meta.discourse.org/tag/chinese-translation> for `Developers`, we see an N+1 when loading /latest or any other topic lists due to `topic_localizations.find_by` which will hit the db.

This PR switches us to use `find` instead as the associations have been loaded already, and includes a test.