### PR TITLE
UX: use correct name for PMs in user admin stats

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7628,7 +7628,7 @@ en:
         activity: Activity
         like_count: Likes Given / Received
         last_100_days: "in the last 100 days"
-        private_topics_count: Private Topics
+        private_topics_count: Personal Messages
         posts_read_count: Posts Read
         post_count: Posts Created
         second_factor_enabled: Two-Factor Authentication Enabled


### PR DESCRIPTION
When admin'ing an account, we have a very old "private topics" text — this should use the current term, "personal messages" 

Reported: https://meta.discourse.org/t/rename-private-topics-to-personal-message-topics/374264