### PR TITLE
FEATURE: Show legacy pageview report for sites using legacy pageviews

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
@@ -56,6 +56,20 @@ export default class AdminReportsShowRoute extends DiscourseRoute {
     return super.serializeQueryParam(value, urlKey, defaultValueType);
   }
 
+  redirect(params) {
+    if (
+      params.type === "site_traffic" &&
+      this.siteSettings.use_legacy_pageviews
+    ) {
+      this.router.transitionTo("adminReports.show", "consolidated_page_views", {
+        queryParams: {
+          ...params,
+          type: "consolidated_page_views",
+        },
+      });
+    }
+  }
+
   @action
   onParamsChange(params) {
     const queryParams = {

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe "Admin Reports", type: :system do
+  fab!(:current_user, :admin)
+  before { sign_in(current_user) }
+
+  context "when use_legacy_pageviews is true" do
+    before { SiteSetting.use_legacy_pageviews = true }
+
+    it "redirects from site_traffic to consolidated_page_views" do
+      visit "/admin/reports/site_traffic"
+      expect(page).to have_current_path("/admin/reports/consolidated_page_views")
+    end
+  end
+end

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -12,4 +12,13 @@ describe "Admin Reports", type: :system do
       expect(page).to have_current_path("/admin/reports/consolidated_page_views")
     end
   end
+
+  context "when use_legacy_pageviews is false" do
+    before { SiteSetting.use_legacy_pageviews = false }
+
+    it "redirects from site_traffic to consolidated_page_views" do
+      visit "/admin/reports/site_traffic"
+      expect(page).to have_current_path("/admin/reports/site_traffic")
+    end
+  end
 end

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -16,7 +16,7 @@ describe "Admin Reports", type: :system do
   context "when use_legacy_pageviews is false" do
     before { SiteSetting.use_legacy_pageviews = false }
 
-    it "redirects from site_traffic to consolidated_page_views" do
+    it "won't redirects from site_traffic to consolidated_page_views" do
       visit "/admin/reports/site_traffic"
       expect(page).to have_current_path("/admin/reports/site_traffic")
     end


### PR DESCRIPTION
This commit redirects the new site traffic report URL to the legacy one on sites where `use_legacy_pageviews = true`.

- New URL: /admin/reports/site_traffic
- Legacy URL: /admin/reports/consolidated_page_views