### PR TITLE
UX: add missing subpage title to tracking and users prefs

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/tracking.js
@@ -13,6 +13,8 @@ export default class extends Controller {
   @tracked saved = false;
   @tracked customAttrNames = [];
 
+  subpageTitle = i18n("user.preferences_nav.tracking");
+
   likeNotificationFrequencies = [
     { name: i18n("user.like_notification_frequency.always"), value: 0 },
     {

--- a/app/assets/javascripts/discourse/app/controllers/preferences/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/users.js
@@ -4,6 +4,7 @@ import { and } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse/lib/decorators";
 import { makeArray } from "discourse/lib/helpers";
+import { i18n } from "discourse-i18n";
 
 export default class UsersController extends Controller {
   @and(
@@ -11,6 +12,8 @@ export default class UsersController extends Controller {
     "model.user_option.allow_private_messages"
   )
   allowPmUsersEnabled;
+
+  subpageTitle = i18n("user.preferences_nav.users");
 
   init() {
     super.init(...arguments);


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/title-of-tracking-and-users-preferences-pages/372965

We were missing subpage titles for these user pref pages 

Before:
<img width="426" height="66" alt="image" src="https://github.com/user-attachments/assets/356627c2-c75a-408c-a8fb-21a5218fe449" />


After:
<img width="456" height="94" alt="image" src="https://github.com/user-attachments/assets/1535fb73-586c-4c32-88a9-d844c578ccce" />
