### PR TITLE
UX: Overrule specific z-index for case of dmenu in conjuction with mobile composer

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -892,6 +892,7 @@ div.ac-wrap {
   // the interactive-widget=resizes-content in the viewport meta tag
   // for maximum browser compatibility (including Firefox on Android)
   // see https://developer.chrome.com/blog/viewport-resize-behavior for context
+  .discourse-touch,
   .mobile-device {
     #reply-control {
       // this might be overkill


### PR DESCRIPTION
 `discourse-touch` does not equal mobile by default: setting the composer z-index this high causes issues on tablets, which has the `discouse-touch` class, but does not use mobile composer nor mobile dmenu when in desktop mode:

<img width="1272" height="924" alt="CleanShot 2025-07-15 at 18 08 35@2x" src="https://github.com/user-attachments/assets/5a927e69-67e6-49fb-bb31-440238f12ddb" />

Unfortunately, touching this is too risky, so I'm instead adjusting for this specific (wrong) usecase in tablet-desktop mode
