### PR TITLE
UX: show calendar month

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/upcoming-events-calendar.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/upcoming-events-calendar.scss
@@ -39,10 +39,6 @@
       padding: 3px 3px 3px 0.5em;
     }
 
-    .fc-center {
-      display: none;
-    }
-
     .fc-button {
       border-radius: 0;
       box-shadow: none;


### PR DESCRIPTION
The month currently isn't showing, making the calendar difficult to use 

Before: 

<img width="1556" height="1280" alt="image" src="https://github.com/user-attachments/assets/5bc24083-4c4a-449a-8a4c-b90134ab3d2a" />


After: 

<img width="1574" height="1396" alt="image" src="https://github.com/user-attachments/assets/d67889e4-01b6-46b7-a75f-75aa1d615d23" />
