### PR TITLE
DEV: Enhance `discourse-assign` data tracking for components

### DIFF
--- a/plugins/discourse-assign/assets/javascripts/discourse/components/assign-button.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/assign-button.gjs
@@ -35,6 +35,10 @@ export default class AssignButton extends Component {
 
       await this.taskActions.unassign(post.id, "Post");
       delete post.topic.indirectly_assigned_to[post.id];
+
+      // force the components tracking `topic.indirectly_assigned_to` to update
+      // eslint-disable-next-line no-self-assign
+      post.topic.indirectly_assigned_to = post.topic.indirectly_assigned_to;
     } else {
       this.taskActions.showAssignModal(this.args.post, {
         isAssigned: false,

--- a/plugins/discourse-assign/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -28,18 +28,20 @@ export default {
 
     switch (id) {
       case "unassign": {
-        this.set("topic.assigned_to_user", null);
-        this.set("topic.assigned_to_group", null);
+        this.topic.assigned_to_user = null;
+        this.topic.assigned_to_group = null;
 
         await taskActions.unassign(this.topic.id);
+        // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
         this.appEvents.trigger("post-stream:refresh", { id: firstPostId });
         break;
       }
       case "reassign-self": {
-        this.set("topic.assigned_to_user", null);
-        this.set("topic.assigned_to_group", null);
+        this.topic.assigned_to_user = null;
+        this.topic.assigned_to_group = null;
 
         await taskActions.reassignUserToTopic(this.currentUser, this.topic);
+        // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
         this.appEvents.trigger("post-stream:refresh", { id: firstPostId });
         break;
       }
@@ -49,6 +51,7 @@ export default {
             topic: this.topic,
           },
           onSuccess: () =>
+            // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
             this.appEvents.trigger("post-stream:refresh", { id: firstPostId }),
         });
         break;
@@ -57,7 +60,13 @@ export default {
         if (id.startsWith("unassign-from-post-")) {
           const postId = extractPostId(id);
           await taskActions.unassign(postId, "Post");
+
           delete this.topic.indirectly_assigned_to[postId];
+
+          // force the components tracking `topic.indirectly_assigned_to` to update
+          // eslint-disable-next-line no-self-assign
+          this.topic.indirectly_assigned_to = this.topic.indirectly_assigned_to;
+          // TODO (glimmer-post-stream) the Glimmer Post Stream does not listen to this event
           this.appEvents.trigger("post-stream:refresh", { id: firstPostId });
         }
       }

--- a/plugins/discourse-assign/assets/javascripts/discourse/models/assignment.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/models/assignment.js
@@ -31,12 +31,12 @@ export class Assignment extends EmberObject {
   // to-do rename to groupName, some components use both this model
   // and models from server, that's why we have to call it "group_name" now
   @tracked group_name;
-  @tracked username;
+  @tracked isEdited = false;
   @tracked name;
-  @tracked status;
   @tracked note;
+  @tracked status;
+  @tracked username;
   targetId;
   targetType;
   postNumber;
-  isEdited = false;
 }

--- a/plugins/discourse-assign/assets/javascripts/discourse/models/topic.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/models/topic.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import { Assignment } from "./assignment";
 
 export function extendTopicModel(api) {
@@ -5,6 +6,14 @@ export function extendTopicModel(api) {
     "model:topic",
     (Superclass) =>
       class extends Superclass {
+        @tracked assigned_to_group;
+        @tracked assigned_to_group_id;
+        @tracked assigned_to_user;
+        @tracked assigned_to_user_id;
+        @tracked assignment_note;
+        @tracked assignment_status;
+        @tracked indirectly_assigned_to;
+
         assignees() {
           const result = [];
 

--- a/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/services/task-actions.js
@@ -48,6 +48,10 @@ export default class TaskActions extends Service {
   async unassignPost(post) {
     await this.unassign(post.id, "Post");
     delete post.topic.indirectly_assigned_to[post.id];
+
+    // force the components tracking `topic.indirectly_assigned_to` to update
+    // eslint-disable-next-line no-self-assign
+    post.topic.indirectly_assigned_to = post.topic.indirectly_assigned_to;
   }
 
   showAssignModal(
@@ -85,11 +89,11 @@ export default class TaskActions extends Service {
 
   async assign(model) {
     if (isEmpty(model.username)) {
-      model.target.set("assigned_to_user", null);
+      model.target.assigned_to_user = null;
     }
 
     if (isEmpty(model.group_name)) {
-      model.target.set("assigned_to_group", null);
+      model.target.assigned_to_group = null;
     }
 
     let path = "/assign/assign";

--- a/plugins/discourse-assign/test/javascripts/acceptance/assign-enabled-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/assign-enabled-test.js
@@ -12,40 +12,46 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-acceptance("Discourse Assign | Assign mobile", function (needs) {
-  needs.user();
-  needs.mobileView();
-  needs.settings({ assign_enabled: true });
-
-  needs.pretender((server, helper) => {
-    server.get("/assign/suggestions", () => {
-      return helper.response({
-        success: true,
-        assign_allowed_groups: false,
-        assign_allowed_for_groups: [],
-        suggestions: [
-          {
-            id: 19,
-            username: "eviltrout",
-            name: "Robin Ward",
-            avatar_template:
-              "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
-          },
-        ],
-      });
-    });
-  });
-
-  test("Footer dropdown contains button", async function (assert) {
-    updateCurrentUser({ can_assign: true });
-    await visit("/t/internationalization-localization/280");
-    await click(".topic-footer-mobile-dropdown-trigger");
-    await click(".assign");
-    assert.dom(".assign.d-modal").exists("assign modal opens");
-  });
-});
-
 ["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `Discourse Assign | Assign mobile (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.mobileView();
+      needs.settings({
+        assign_enabled: true,
+        glimmer_post_stream_mode: postStreamMode,
+      });
+
+      needs.pretender((server, helper) => {
+        server.get("/assign/suggestions", () => {
+          return helper.response({
+            success: true,
+            assign_allowed_groups: false,
+            assign_allowed_for_groups: [],
+            suggestions: [
+              {
+                id: 19,
+                username: "eviltrout",
+                name: "Robin Ward",
+                avatar_template:
+                  "/user_avatar/meta.discourse.org/eviltrout/{size}/5275_2.png",
+              },
+            ],
+          });
+        });
+      });
+
+      test("Footer dropdown contains button", async function (assert) {
+        updateCurrentUser({ can_assign: true });
+        await visit("/t/internationalization-localization/280");
+        await click(".topic-footer-mobile-dropdown-trigger");
+        await click(".assign");
+        assert.dom(".assign.d-modal").exists("assign modal opens");
+      });
+    }
+  );
+
   acceptance(
     `Discourse Assign | Assign desktop (glimmer_post_stream_mode = ${postStreamMode})`,
     function (needs) {

--- a/plugins/discourse-assign/test/javascripts/acceptance/edit-assignments-modal-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/edit-assignments-modal-test.js
@@ -12,158 +12,170 @@ const secondReply = topic.post_stream.posts[2];
 const new_assignee_1 = "user_1";
 const new_assignee_2 = "user_2";
 
-acceptance("Discourse Assign | Edit assignments modal", function (needs) {
-  needs.user({ can_assign: true });
-  needs.settings({
-    assign_enabled: true,
-  });
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `Discourse Assign | Edit assignments modal (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user({ can_assign: true });
+      needs.settings({
+        assign_enabled: true,
+        glimmer_post_stream_mode: postStreamMode,
+      });
 
-  needs.pretender((server, helper) => {
-    server.get("/t/44.json", () => helper.response(topic));
-    server.put("/assign/assign", () => {
-      return helper.response({ success: true });
-    });
+      needs.pretender((server, helper) => {
+        server.get("/t/44.json", () => helper.response(topic));
+        server.put("/assign/assign", () => {
+          return helper.response({ success: true });
+        });
 
-    const suggestions = [
-      { username: new_assignee_1 },
-      { username: new_assignee_2 },
-    ];
-    server.get("/assign/suggestions", () =>
-      helper.response({
-        assign_allowed_for_groups: [],
-        suggestions,
-      })
-    );
-    server.get("/u/search/users", () =>
-      helper.response({
-        users: suggestions,
-      })
-    );
-  });
+        const suggestions = [
+          { username: new_assignee_1 },
+          { username: new_assignee_2 },
+        ];
+        server.get("/assign/suggestions", () =>
+          helper.response({
+            assign_allowed_for_groups: [],
+            suggestions,
+          })
+        );
+        server.get("/u/search/users", () =>
+          helper.response({
+            users: suggestions,
+          })
+        );
+      });
 
-  test("reassigning topic", async function (assert) {
-    await visit("/t/assignment-topic/44");
-    await openModal();
-    await selectAssignee(new_assignee_1);
+      test("reassigning topic", async function (assert) {
+        await visit("/t/assignment-topic/44");
+        await openModal();
+        await selectAssignee(new_assignee_1);
 
-    await submitModal();
-    await receiveAssignedMessage(topic, new_assignee_1);
+        await submitModal();
+        await receiveAssignedMessage(topic, new_assignee_1);
 
-    assert
-      .dom(".post-stream article#post_1 .assigned-to .assigned-to--user a")
-      .hasText(new_assignee_1, "The topic is assigned to a new assignee");
-  });
+        assert
+          .dom(".post-stream article#post_1 .assigned-to .assigned-to--user a")
+          .hasText(new_assignee_1, "The topic is assigned to a new assignee");
+      });
 
-  test("reassigning posts", async function (assert) {
-    await visit("/t/assignment-topic/44");
-    await openModal();
+      test("reassigning posts", async function (assert) {
+        await visit("/t/assignment-topic/44");
+        await openModal();
 
-    await selectPost(1);
-    await expandAssigneeChooser();
-    await selectAssignee(new_assignee_1);
+        await selectPost(1);
+        await expandAssigneeChooser();
+        await selectAssignee(new_assignee_1);
 
-    await selectPost(2);
-    await expandAssigneeChooser();
-    await selectAssignee(new_assignee_2);
+        await selectPost(2);
+        await expandAssigneeChooser();
+        await selectAssignee(new_assignee_2);
 
-    await submitModal();
-    await receiveAssignedMessage(firstReply, new_assignee_1);
-    await receiveAssignedMessage(secondReply, new_assignee_2);
+        await submitModal();
+        await receiveAssignedMessage(firstReply, new_assignee_1);
+        await receiveAssignedMessage(secondReply, new_assignee_2);
 
-    assert
-      .dom(".post-stream article#post_2 .assigned-to .assigned-to-username")
-      .hasText(new_assignee_1, "The first reply is assigned to a new assignee");
+        assert
+          .dom(".post-stream article#post_2 .assigned-to .assigned-to-username")
+          .hasText(
+            new_assignee_1,
+            "The first reply is assigned to a new assignee"
+          );
 
-    assert
-      .dom(".post-stream article#post_3 .assigned-to .assigned-to-username")
-      .hasText(
-        new_assignee_2,
-        "The second reply is assigned to a new assignee"
-      );
-  });
+        assert
+          .dom(".post-stream article#post_3 .assigned-to .assigned-to-username")
+          .hasText(
+            new_assignee_2,
+            "The second reply is assigned to a new assignee"
+          );
+      });
 
-  test("reassigning topic and posts in one go", async function (assert) {
-    await visit("/t/assignment-topic/44");
-    await openModal();
-    await selectAssignee(new_assignee_1);
+      test("reassigning topic and posts in one go", async function (assert) {
+        await visit("/t/assignment-topic/44");
+        await openModal();
+        await selectAssignee(new_assignee_1);
 
-    await selectPost(1);
-    await expandAssigneeChooser();
-    await selectAssignee(new_assignee_2);
+        await selectPost(1);
+        await expandAssigneeChooser();
+        await selectAssignee(new_assignee_2);
 
-    await selectPost(2);
-    await expandAssigneeChooser();
-    await selectAssignee(new_assignee_2);
+        await selectPost(2);
+        await expandAssigneeChooser();
+        await selectAssignee(new_assignee_2);
 
-    await submitModal();
-    await receiveAssignedMessage(topic, new_assignee_1);
-    await receiveAssignedMessage(firstReply, new_assignee_2);
-    await receiveAssignedMessage(secondReply, new_assignee_2);
+        await submitModal();
+        await receiveAssignedMessage(topic, new_assignee_1);
+        await receiveAssignedMessage(firstReply, new_assignee_2);
+        await receiveAssignedMessage(secondReply, new_assignee_2);
 
-    assert
-      .dom(".post-stream article#post_1 .assigned-to .assigned-to--user a")
-      .hasText(new_assignee_1, "The topic is assigned to a new assignee");
+        assert
+          .dom(".post-stream article#post_1 .assigned-to .assigned-to--user a")
+          .hasText(new_assignee_1, "The topic is assigned to a new assignee");
 
-    assert
-      .dom(".post-stream article#post_2 .assigned-to .assigned-to-username")
-      .hasText(new_assignee_2, "The first reply is assigned to a new assignee");
+        assert
+          .dom(".post-stream article#post_2 .assigned-to .assigned-to-username")
+          .hasText(
+            new_assignee_2,
+            "The first reply is assigned to a new assignee"
+          );
 
-    assert
-      .dom(".post-stream article#post_3 .assigned-to .assigned-to-username")
-      .hasText(
-        new_assignee_2,
-        "The second reply is assigned to a new assignee"
-      );
-  });
+        assert
+          .dom(".post-stream article#post_3 .assigned-to .assigned-to-username")
+          .hasText(
+            new_assignee_2,
+            "The second reply is assigned to a new assignee"
+          );
+      });
 
-  async function expandAssigneeChooser() {
-    await click(
-      ".modal-container #assignee-chooser-header .select-kit-header-wrapper"
-    );
-  }
+      async function expandAssigneeChooser() {
+        await click(
+          ".modal-container #assignee-chooser-header .select-kit-header-wrapper"
+        );
+      }
 
-  async function openModal() {
-    await click("#topic-footer-dropdown-reassign .btn");
-    await click(`li[data-value='reassign']`);
-  }
+      async function openModal() {
+        await click("#topic-footer-dropdown-reassign .btn");
+        await click(`li[data-value='reassign']`);
+      }
 
-  // todo remove this function and all calls to it after we start updating UI right away
-  // (there is no need to wait for a message bus message in the browser of a user
-  // who did reassignment, but we do that at the moment)
-  async function receiveAssignedMessage(target, newAssignee) {
-    const targetIsAPost = !!target.topic_id;
+      // todo remove this function and all calls to it after we start updating UI right away
+      // (there is no need to wait for a message bus message in the browser of a user
+      // who did reassignment, but we do that at the moment)
+      async function receiveAssignedMessage(target, newAssignee) {
+        const targetIsAPost = !!target.topic_id;
 
-    let topicId, postId;
-    if (targetIsAPost) {
-      topicId = target.topic_id;
-      postId = target.id;
-    } else {
-      topicId = target.id;
-      postId = false;
+        let topicId, postId;
+        if (targetIsAPost) {
+          topicId = target.topic_id;
+          postId = target.id;
+        } else {
+          topicId = target.id;
+          postId = false;
+        }
+
+        await publishToMessageBus("/staff/topic-assignment", {
+          type: "assigned",
+          topic_id: topicId,
+          post_id: postId,
+          assigned_type: "User",
+          assigned_to: {
+            username: newAssignee,
+          },
+        });
+        await settled();
+      }
+
+      async function selectPost(number) {
+        await click(".target .single-select .select-kit-header-wrapper");
+        await click(`li[title='Post #${number}']`);
+      }
+
+      async function selectAssignee(username) {
+        await click(`.email-group-user-chooser-row[data-value='${username}']`);
+      }
+
+      async function submitModal() {
+        await click(".d-modal__footer .btn-primary");
+      }
     }
-
-    await publishToMessageBus("/staff/topic-assignment", {
-      type: "assigned",
-      topic_id: topicId,
-      post_id: postId,
-      assigned_type: "User",
-      assigned_to: {
-        username: newAssignee,
-      },
-    });
-    await settled();
-  }
-
-  async function selectPost(number) {
-    await click(".target .single-select .select-kit-header-wrapper");
-    await click(`li[title='Post #${number}']`);
-  }
-
-  async function selectAssignee(username) {
-    await click(`.email-group-user-chooser-row[data-value='${username}']`);
-  }
-
-  async function submitModal() {
-    await click(".d-modal__footer .btn-primary");
-  }
+  );
 });

--- a/plugins/discourse-assign/test/javascripts/acceptance/topic-level-assign-menu-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/topic-level-assign-menu-test.js
@@ -10,40 +10,46 @@ import topicWithAssignedPosts from "../fixtures/topic-with-assigned-posts";
 const topic = topicWithAssignedPosts();
 const post = topic.post_stream.posts[1];
 
-acceptance("Discourse Assign | Topic level assign menu", function (needs) {
-  needs.user();
-  needs.settings({
-    assign_enabled: true,
-  });
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `Discourse Assign | Topic level assign menu (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        assign_enabled: true,
+        glimmer_post_stream_mode: postStreamMode,
+      });
 
-  needs.pretender((server, helper) => {
-    server.get("/t/44.json", () => helper.response(topic));
-    server.put("/assign/unassign", () => {
-      return helper.response({ success: true });
-    });
-  });
+      needs.pretender((server, helper) => {
+        server.get("/t/44.json", () => helper.response(topic));
+        server.put("/assign/unassign", () => {
+          return helper.response({ success: true });
+        });
+      });
 
-  needs.hooks.beforeEach(() => {
-    updateCurrentUser({ can_assign: true });
-  });
+      needs.hooks.beforeEach(() => {
+        updateCurrentUser({ can_assign: true });
+      });
 
-  test("Unassign button unassigns the post", async function (assert) {
-    await visit("/t/assignment-topic/44");
+      test("Unassign button unassigns the post", async function (assert) {
+        await visit("/t/assignment-topic/44");
 
-    await click("#topic-footer-dropdown-reassign .btn");
-    await click(`li[data-value='unassign-from-post-${post.id}']`);
-    await publishToMessageBus("/staff/topic-assignment", {
-      type: "unassigned",
-      topic_id: topic.id,
-      post_id: post.id,
-      assigned_type: "User",
-    });
+        await click("#topic-footer-dropdown-reassign .btn");
+        await click(`li[data-value='unassign-from-post-${post.id}']`);
+        await publishToMessageBus("/staff/topic-assignment", {
+          type: "unassigned",
+          topic_id: topic.id,
+          post_id: post.id,
+          assigned_type: "User",
+        });
 
-    assert
-      .dom("#topic-footer-dropdown-reassign-body ul[role='menu']")
-      .doesNotExist("The menu is closed");
-    assert
-      .dom(".post-stream article#post_2 .assigned-to")
-      .doesNotExist("The post is unassigned");
-  });
+        assert
+          .dom("#topic-footer-dropdown-reassign-body ul[role='menu']")
+          .doesNotExist("The menu is closed");
+        assert
+          .dom(".post-stream article#post_2 .assigned-to")
+          .doesNotExist("The post is unassigned");
+      });
+    }
+  );
 });


### PR DESCRIPTION
Replaced legacy assignment updates with `@tracked` properties for reactive state management in `Discourse Assign` plugin. Updated methods for modifying assignment-related properties (`assigned_to_user`, `assigned_to_group`, etc.) and ensured compatibility with Glimmer's reactive model.

Also, improved test coverage by parameterizing tests to run with `glimmer_post_stream_mode` both enabled and disabled, ensuring consistent behavior across configurations.