### PR TITLE
FIX: Error in client site settings JSON

### DIFF
--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -921,6 +921,12 @@ RSpec.describe SiteSettingExtension do
 
       expect(client_settings["with_html"]).to eq("<script></script>rest")
     end
+
+    it "does not include themeable site settings" do
+      SiteSetting.refresh!
+      expect(SiteSetting.client_settings_json_uncached).not_to include("enable_welcome_banner")
+      expect(SiteSetting.client_settings_json_uncached).not_to include("search_experience")
+    end
   end
 
   describe ".setup_methods" do
@@ -1040,6 +1046,15 @@ RSpec.describe SiteSettingExtension do
       expect(SiteSetting.enable_welcome_banner(theme_id: theme_2.id)).to eq(true)
       expect(SiteSetting.search_experience(theme_id: theme_1.id)).to eq("search_icon")
       expect(SiteSetting.search_experience(theme_id: theme_2.id)).to eq("search_field")
+    end
+
+    describe ".theme_site_settings_json_uncached" do
+      it "returns the correct JSON" do
+        SiteSetting.refresh!
+        expect(SiteSetting.theme_site_settings_json_uncached(theme_1.id)).to eq(
+          %Q|{"enable_welcome_banner":false,"search_experience":"search_icon"}|,
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Followup 19af83d39e6c06cdc31df2c203623b47bef9c252

In some scenarios, the client_settings_json_uncached
was silently failing and returning "", which caused
problems down the line in mini_racer when this code
was produced:

```
__optInput = {};
__optInput.siteSettings = ;
```

The problem was only happening in rare cases with interaction
between core and other plugins, because the length of the
array we were trying to make a Hash with wasn't an even length.

To address this, we can use filter_map to ensure correct behavior,
and add some specs and also raise errors when parsing client settings JSON
in specs, so we don't miss this in the future.
