### PR TITLE
FIX: Error in shadowed global settings for deprecated settings

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -738,11 +738,11 @@ module SiteSettingExtension
   def setup_shadowed_methods(name, value)
     clean_name = name.to_s.sub("?", "").to_sym
 
-    define_singleton_method clean_name do
+    define_singleton_method clean_name do |scoped_to = nil|
       value
     end
 
-    define_singleton_method "#{clean_name}?" do
+    define_singleton_method "#{clean_name}?" do |scoped_to = nil|
       value
     end
 

--- a/spec/lib/site_settings/deprecated_settings_spec.rb
+++ b/spec/lib/site_settings/deprecated_settings_spec.rb
@@ -50,4 +50,46 @@ RSpec.describe SiteSettings::DeprecatedSettings do
       end
     end
   end
+
+  describe "when deprecating global settings" do
+    describe "when not overriding deprecated settings" do
+      it "can access the old method and does not act as a proxy to the new method" do
+        global_setting(:old_one, true)
+
+        SiteSetting.send(:setting, :old_one, true)
+
+        stub_deprecated_settings!(override: false) do
+          SiteSetting.old_one = true
+
+          expect(SiteSetting.old_one).to eq(true)
+          expect(SiteSetting.old_one?).to eq(true)
+
+          expect(SiteSetting.new_one).to eq(false)
+          expect(SiteSetting.new_one?).to eq(false)
+        end
+      end
+
+      after { SiteSetting.remove_instance_variable(:@shadowed_settings) }
+    end
+
+    describe "when overriding deprecated settings" do
+      it "can access the old method and acts as a proxy to the new method" do
+        global_setting(:old_one, true)
+
+        SiteSetting.send(:setting, :old_one, true)
+
+        stub_deprecated_settings!(override: true) do
+          SiteSetting.old_one = true
+
+          expect(SiteSetting.old_one).to eq(true)
+          expect(SiteSetting.old_one?).to eq(true)
+
+          expect(SiteSetting.new_one).to eq(true)
+          expect(SiteSetting.new_one?).to eq(true)
+        end
+      end
+
+      after { SiteSetting.remove_instance_variable(:@shadowed_settings) }
+    end
+  end
 end


### PR DESCRIPTION
Followup 19af83d39e6c06cdc31df2c203623b47bef9c252

There was another edge case here, where this scenario happened:

* A site setting is deprecated _without_ an override
* This site setting is being shadowed by a global setting
* This would cause an argument error when getting the deprecated
  setting value in SiteSetting.client_settings_json_uncached

An example of this setting was `external_system_avatars_enabled`.
The shadowed setting was blowing up because it was missing the
`scoped_to` argument that was added for themeable site settings
in the referenced commit.

This commit fixes the issue and adds a spec to cover this scenario,
followup commit will add stronger handling of shadowed global
settings for theme site settings...this is not allowed.
