### PR TITLE
FEATURE: Enable rich composer by default for new sites

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1617,7 +1617,7 @@ posting:
     hidden: true
   rich_editor:
     client: true
-    default: false
+    default: true
 
 content_localization:
   content_localization_enabled:

--- a/db/migrate/20250716051519_enable_rich_composer_by_default_new_sites.rb
+++ b/db/migrate/20250716051519_enable_rich_composer_by_default_new_sites.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class EnableRichComposerByDefaultNewSites < ActiveRecord::Migration[7.2]
+  def change
+    return if !Migration::Helpers.existing_site?
+
+    current_val =
+      DB.query_single("SELECT value FROM site_settings WHERE name = 'rich_editor'").first
+
+    # We don't want to change whatever the admin already put in the DB
+    return if !current_val.nil?
+
+    # Set the old default value in the DB
+    # 5 is bool type
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      VALUES ('rich_editor', 5, 'f', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Now that we have announced our new composer, we would like
to enable this by default for all new sites. Existing sites
will have the old default of `false` inserted into the DB,
or if there already was a value, it will remain unchanged.

https://meta.discourse.org/t/introducing-our-new-composer-making-writing-on-discourse-easier-than-ever/369779
