### PR TITLE
DEV: Extract theme script tags into their own JS files

### DIFF
--- a/app/assets/javascripts/theme-transpiler/transpiler.js
+++ b/app/assets/javascripts/theme-transpiler/transpiler.js
@@ -54,7 +54,8 @@ function buildTemplateCompilerBabelPlugins({ extension, themeId }) {
 }
 
 globalThis.transpile = function (source, options = {}) {
-  const { moduleId, filename, extension, skipModule, themeId } = options;
+  const { moduleId, filename, extension, skipModule, themeId, generateMap } =
+    options;
 
   if (extension === "gjs") {
     const preprocessor = new Preprocessor();
@@ -69,7 +70,7 @@ globalThis.transpile = function (source, options = {}) {
   plugins.push([DecoratorTransforms, { runEarly: true }]);
 
   try {
-    return babelTransform(source, {
+    const result = babelTransform(source, {
       moduleId,
       filename,
       ast: false,
@@ -85,7 +86,16 @@ globalThis.transpile = function (source, options = {}) {
           },
         ],
       ],
-    }).code;
+      sourceMaps: generateMap,
+    });
+    if (generateMap) {
+      return {
+        code: result.code,
+        map: JSON.stringify(result.map),
+      };
+    } else {
+      return result.code;
+    }
   } catch (error) {
     // Workaround for https://github.com/rubyjs/mini_racer/issues/262
     error.message = JSON.stringify(error.message);

--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -45,12 +45,13 @@ end
 #  updated_at     :datetime         not null
 #  theme_id       :bigint
 #  source_map     :text
+#  name           :string
 #
 # Indexes
 #
-#  index_javascript_caches_on_digest          (digest)
-#  index_javascript_caches_on_theme_field_id  (theme_field_id) UNIQUE
-#  index_javascript_caches_on_theme_id        (theme_id) UNIQUE
+#  index_javascript_caches_on_digest                   (digest)
+#  index_javascript_caches_on_theme_field_id_and_name  (theme_field_id,name) UNIQUE WHERE (theme_field_id IS NOT NULL)
+#  index_javascript_caches_on_theme_id                 (theme_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 91
+  BASE_COMPILER_VERSION = 92
   CORE_THEMES = { "foundation" => -1, "horizon" => -2 }
   EDITABLE_SYSTEM_ATTRIBUTES = %w[
     child_theme_ids

--- a/db/migrate/20250715094001_update_javascript_cache.rb
+++ b/db/migrate/20250715094001_update_javascript_cache.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class UpdateJavascriptCache < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :javascript_caches,
+                 column: :theme_field_id,
+                 name: :index_javascript_caches_on_theme_field_id,
+                 unique: true
+    add_column :javascript_caches, :name, :string
+    add_index :javascript_caches,
+              %i[theme_field_id name],
+              unique: true,
+              nulls_not_distinct: true,
+              where: "theme_field_id IS NOT NULL"
+  end
+end

--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -109,7 +109,14 @@ class DiscourseJsProcessor
       @skip_module = skip_module
     end
 
-    def perform(source, root_path = nil, logical_path = nil, theme_id: nil, extension: nil)
+    def perform(
+      source,
+      root_path = nil,
+      logical_path = nil,
+      theme_id: nil,
+      extension: nil,
+      generate_map: false
+    )
       self.class.v8_call(
         "transpile",
         source,
@@ -119,6 +126,7 @@ class DiscourseJsProcessor
           filename: logical_path || "unknown",
           extension: extension,
           themeId: theme_id,
+          generateMap: generate_map,
         },
       )
     end

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -1188,18 +1188,18 @@ RSpec.describe Admin::ThemesController do
         )
         theme.save!
 
-        javascript_cache =
+        javascript_caches =
           theme
             .theme_fields
             .find_by(target_id: Theme.targets[:common], name: :header)
-            .javascript_cache
-        expect(javascript_cache).to_not eq(nil)
+            .raw_javascript_caches
+        expect(javascript_caches.length).to eq(1)
 
         delete "/admin/themes/#{theme.id}.json"
 
         expect(response.status).to eq(204)
         expect { theme.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { javascript_cache.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { javascript_caches[0].reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 


### PR DESCRIPTION
Previously, all script tags in a theme field would be combined into a single `.js` bundle along with the `text/discourse-plugin` modules. This led to some unexpected run order, and also makes it hard to implement the `type=module` change being developed in #33103.

This commit refactors things so that each raw script gets extracted into its own `.js` bundle, which is then placed in exactly the same place in the HTML.