### PR TITLE
DEV: Improve deprecation warning banner

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -120,36 +120,34 @@ export default class DeprecationWarningHandler extends Service {
 
     this.#adminWarned = true;
 
-    let notice = i18n("critical_deprecation.notice") + " ";
-
-    if (url) {
-      notice += i18n("critical_deprecation.linked_id", {
-        id: escapeExpression(id),
-        url: escapeExpression(url),
+    let sourceString;
+    if (source?.type === "theme") {
+      sourceString = i18n("critical_deprecation.theme_source", {
+        name: escapeExpression(source.name),
+        path: source.path,
+      });
+    } else if (source?.type === "plugin") {
+      sourceString = i18n("critical_deprecation.plugin_source", {
+        name: escapeExpression(source.name),
       });
     } else {
-      notice += i18n("critical_deprecation.id", {
-        id: escapeExpression(id),
+      sourceString = i18n("critical_deprecation.unknown_source");
+    }
+
+    let notice =
+      i18n("critical_deprecation.notice", {
+        source: sourceString,
+        id,
+      }) + " ";
+
+    if (url) {
+      notice += i18n("critical_deprecation.learn_more_link", {
+        url,
       });
     }
 
     if (this.siteSettings.warn_critical_js_deprecations_message) {
       notice += " " + this.siteSettings.warn_critical_js_deprecations_message;
-    }
-
-    if (source?.type === "theme") {
-      notice +=
-        " " +
-        i18n("critical_deprecation.theme_source", {
-          name: escapeExpression(source.name),
-          path: source.path,
-        });
-    } else if (source?.type === "plugin") {
-      notice +=
-        " " +
-        i18n("critical_deprecation.plugin_source", {
-          name: escapeExpression(source.name),
-        });
     }
 
     addGlobalNotice(notice, "critical-deprecation", {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -240,11 +240,11 @@ en:
     broken_transformer_alert: "There was an error. Your site may not work properly."
 
     critical_deprecation:
-      notice: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes."
-      id: "(id:<em>%{id}</em>)"
-      linked_id: "(id:<a href='%{url}' target='_blank'><em>%{id}</em></a>)"
-      theme_source: "Identified theme: <a target='_blank' href='%{path}'>'%{name}'</a>."
-      plugin_source: "Identified plugin: '%{name}'"
+      notice: "<b>[Admin Notice]</b> %{source} contains code which needs updating. (id:%{id})"
+      learn_more_link: "(<a href='%{url}' target='_blank'><em>learn more</em></a>)"
+      theme_source: "Theme <a target='_blank' href='%{path}'>'%{name}'</a>"
+      plugin_source: "Plugin: '%{name}'"
+      unknown_source: "One of your themes or plugins"
 
     s3:
       regions:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -243,7 +243,7 @@ en:
       notice: "<b>[Admin Notice]</b> %{source} contains code which needs updating. (id:%{id})"
       learn_more_link: "(<a href='%{url}' target='_blank'><em>learn more</em></a>)"
       theme_source: "Theme <a target='_blank' href='%{path}'>'%{name}'</a>"
-      plugin_source: "Plugin: '%{name}'"
+      plugin_source: "Plugin '%{name}'"
       unknown_source: "One of your themes or plugins"
 
     s3:

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -43,9 +43,7 @@ describe "JS Deprecation Handling", type: :system do
     JS
 
     message = find("#global-notice-critical-deprecation")
-    expect(message).to have_text(
-      "One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes",
-    )
+    expect(message).to have_text("One of your themes or plugins contains code which needs updating")
     expect(message).to have_text(SiteSetting.warn_critical_js_deprecations_message)
   end
 


### PR DESCRIPTION
- Make the message shorter
- Make it clearer that the theme/plugin code needs to be updated
- Add explicit 'learn more', because the linked ID was often missed

Before:
<img width="687" height="115" alt="SCR-20250716-kjkm" src="https://github.com/user-attachments/assets/51fe786f-daba-4103-8a09-9276fc6c3278" />

After:
<img width="686" height="98" alt="SCR-20250716-kjhe" src="https://github.com/user-attachments/assets/3460e4b3-8449-439d-abe8-47da413de8b0" />
