### PR TITLE
FIX: Serialize time objects properly in calendar plugin

### DIFF
--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -238,10 +238,11 @@ after_initialize do
         SiteSetting.display_post_event_date_on_topic_title &&
         object.topic.custom_fields.keys.include?(DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT)
     end,
-  ) { object.topic.custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT] }
+  ) { object.topic.event_starts_at }
 
   add_to_class(:topic, :event_starts_at) do
-    @event_starts_at ||= custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT]
+    @event_starts_at ||=
+      Time.zone.parse(custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_STARTS_AT].to_s)
   end
 
   add_to_serializer(
@@ -263,10 +264,11 @@ after_initialize do
         SiteSetting.display_post_event_date_on_topic_title &&
         object.topic.custom_fields.keys.include?(DiscoursePostEvent::TOPIC_POST_EVENT_ENDS_AT)
     end,
-  ) { object.topic.custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_ENDS_AT] }
+  ) { object.topic.event_ends_at }
 
   add_to_class(:topic, :event_ends_at) do
-    @event_ends_at ||= custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_ENDS_AT]
+    @event_ends_at ||=
+      Time.zone.parse(custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_ENDS_AT].to_s)
   end
 
   add_to_serializer(

--- a/plugins/discourse-calendar/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_list_item_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicListItemSerializer do
+  subject(:serializer) { described_class.new(topic, scope: Guardian.new, root: false) }
+
+  let(:topic) { Fabricate(:topic) }
+  let(:first_post) { Fabricate(:post, topic:) }
+  let(:parsed_json) { JSON.parse(serializer.to_json) }
+
+  before do
+    freeze_time("2020-04-24 14:10")
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    DiscoursePostEvent::Event.create!(
+      id: first_post.id,
+      original_starts_at: 1.hour.from_now,
+      original_ends_at: 2.hours.from_now,
+    )
+  end
+
+  describe "#event_starts_at" do
+    it "returns the start time of the event in proper format" do
+      expect(parsed_json["event_starts_at"]).to eq("2020-04-24T15:10:00.000Z")
+    end
+  end
+
+  describe "#event_ends_at" do
+    it "returns the end time of the event in proper format" do
+      expect(parsed_json["event_ends_at"]).to eq("2020-04-24T16:10:00.000Z")
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicViewSerializer do
+  subject(:serializer) do
+    described_class.new(TopicView.new(topic), scope: Guardian.new, root: false)
+  end
+
+  let(:topic) { Fabricate(:topic) }
+  let(:first_post) { Fabricate(:post, topic:) }
+  let(:parsed_json) { JSON.parse(serializer.to_json) }
+
+  before do
+    freeze_time("2020-04-24 14:10")
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    DiscoursePostEvent::Event.create!(
+      id: first_post.id,
+      original_starts_at: 1.hour.from_now,
+      original_ends_at: 2.hours.from_now,
+    )
+  end
+
+  describe "#event_starts_at" do
+    it "returns the start time of the event in proper format" do
+      expect(parsed_json["event_starts_at"]).to eq("2020-04-24T15:10:00.000Z")
+    end
+  end
+
+  describe "#event_ends_at" do
+    it "returns the end time of the event in proper format" do
+      expect(parsed_json["event_ends_at"]).to eq("2020-04-24T16:10:00.000Z")
+    end
+  end
+end


### PR DESCRIPTION
Currently, `#event_starts_at` and `#event_ends_at` are not properly serialized: we just output the string we have in the custom fields, which is not necessarily a time string JS can deserialize. Until now it worked by chance.

With Rails 8, the string format changes a bit to include the timezone, breaking the deserializing process on the JS side.

This PR addresses the issue by converting the value stored in the custom fields to a proper time object. Then the serializers, when rendering JSON, will output a proper ISO8601 formatted string.