### PR TITLE
DEV: Enable the Glimmer Post Stream automatically

### DIFF
--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -6,11 +6,6 @@ const DEPRECATION_WORKFLOW = [
     handler: "silence",
     matchId: "discourse.decorate-widget.hamburger-widget-links",
   },
-  // TODO (glimmer-post-stream): remove the silence once upgrade notes are ready and we start rolling out the new version
-  {
-    handler: "silence",
-    matchId: "discourse.post-stream-widget-overrides",
-  },
 ];
 
 export default DEPRECATION_WORKFLOW;

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4061,7 +4061,7 @@ experimental:
       - disabled
       - auto
       - enabled
-    default: disabled
+    default: "auto"
   enable_rich_text_paste:
     client: true
     default: true


### PR DESCRIPTION
This PR enables the Glimmer Post Stream automatically on compatible sites.

- Set the default value for `glimmer_post_stream_mode` to "auto"
- Unsilences the deprecation message in the console.