### PR TITLE
UX: Make the `rich_editor` setting easier to find

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2732,7 +2732,7 @@ en:
     about_page_extra_groups_order: "Ordering of the extra groups on the about page."
     adobe_analytics_tags_url: "Adobe Analytics tags URL (`https://assets.adobedtm.com/...`)"
     view_raw_email_allowed_groups: "Groups which can view the raw email content of a post if it was created by an incoming email. This includes email headers and other technical information."
-    rich_editor: "Enable the rich editor so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition."
+    rich_editor: "Enable the rich editor for the composer so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition."
     viewport_based_mobile_mode: "EXPERIMENTAL: Disable the user-agent-based mobile/desktop modes and use viewport width instead."
     reviewable_ui_refresh: "Groups that can use the experimental new UI in the review queue."
 
@@ -2817,6 +2817,7 @@ en:
       clean_up_inactive_users_after_days: "deactivated|inactive|unactivated"
       navigation_menu: "sidebar|header dropdown"
       purge_unactivated_users_grace_period_days: "deactivated|inactive|unactivated"
+      rich_editor: "rte|rich text|composer"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1618,6 +1618,7 @@ posting:
   rich_editor:
     client: true
     default: false
+    area: "posts_and_topics"
 
 content_localization:
   content_localization_enabled:


### PR DESCRIPTION
Add the `composer` word to keywords and description, and
also put the setting in an appropriate area so it shows
up in `/admin/config/content/posts-and-topics`
