### PR TITLE
UI: remove bold font for selected autocomplete items

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -719,12 +719,6 @@ html.composer-open:not(.has-full-page-chat) {
 
         &.selected {
           background-color: var(--d-selected);
-
-          .username,
-          .name,
-          .emoji-shortname {
-            font-weight: bold;
-          }
         }
 
         .avatar {

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -98,10 +98,6 @@ a.hashtag {
     align-items: center;
     display: flex;
 
-    &.selected {
-      font-weight: bold;
-    }
-
     .d-icon {
       margin-right: 0.25em;
     }


### PR DESCRIPTION
This removes the bolded font for an item in the autocomplete menu as they are selected (by keyboard navigation or hover) which originally made the whole text shift as we selected different items.

### Testing

#### Bolded (Current):
<img width="414" height="340" alt="bold-1" src="https://github.com/user-attachments/assets/cfecfa16-7a6a-4fb2-83b4-dfadf7a807fa" />
<img width="414" height="340" alt="bold-2" src="https://github.com/user-attachments/assets/ab190b33-1aeb-4164-9987-a00954da9e8d" />
<img width="369" height="268" alt="bold-3" src="https://github.com/user-attachments/assets/44cf849f-8aba-4d9a-a1a3-ba19105eec2f" />

#### Non-bolded:
<img width="369" height="309" alt="bold-4" src="https://github.com/user-attachments/assets/d06add1d-0d72-4f33-993d-1154fb98e0e8" />
<img width="369" height="309" alt="bold-5" src="https://github.com/user-attachments/assets/41a512c5-195c-459b-b0ee-9bb665381098" />
<img width="369" height="309" alt="bold-6" src="https://github.com/user-attachments/assets/66012b23-60e1-4bd4-a956-0affb6f3b605" />


