### PR TITLE
UX: fix z-index composer translation dropdown

### DIFF
--- a/app/assets/stylesheets/common/components/post-translations.scss
+++ b/app/assets/stylesheets/common/components/post-translations.scss
@@ -12,6 +12,11 @@
 
 .post-language-selector-content {
   z-index: z("composer", "dropdown");
+
+  // eventho mobile composer shouldnt be used in conjuction with fk-d-menu (floating version), on tablets the possibility unfortunately exists
+  .discourse-touch & {
+    z-index: z("mobile-composer");
+  }
 }
 
 .post-language-selector-trigger {


### PR DESCRIPTION
Reported on meta
https://meta.discourse.org/t/composer-more-menu-partly-hidden-behind-header-and-composer/372859/21

Tablets are using a mobile z-index (which is higher) for composer, even when on desktop "mode" – which conflicts with the default z-index for the dmenu dropdown.

This overrule fixes it.