### PR TITLE
DEV: Prevent N+1 for localizations on topic show

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1326,7 +1326,7 @@ class Post < ActiveRecord::Base
   end
 
   def has_localization?(locale = I18n.locale)
-    post_localizations.exists?(locale: locale.to_s.sub("-", "_"))
+    get_localization(locale).present?
   end
 
   def in_user_locale?
@@ -1334,7 +1334,8 @@ class Post < ActiveRecord::Base
   end
 
   def get_localization(locale = I18n.locale)
-    post_localizations.find_by(locale: locale.to_s.sub("-", "_"))
+    locale_string = locale.to_s.sub("-", "_")
+    post_localizations.find { |tl| tl.locale == locale_string }
   end
 
   private

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -660,7 +660,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def post_localizations_count
-    object.post_localizations.count
+    object.post_localizations.size
   end
 
   def include_has_post_localizations?

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2517,6 +2517,28 @@ RSpec.describe TopicsController do
       expect(user_options_queries.size).to eq(1) # for all mentioned users
     end
 
+    context "when content_localization_enabled true" do
+      before do
+        SiteSetting.content_localization_enabled = true
+        SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      end
+
+      it "does not result in N+1 queries when loading a localized post" do
+        3.times do
+          Fabricate(:post_localization, post: Fabricate(:post, topic:, locale: "ja"), locale: "en")
+        end
+
+        queries =
+          track_sql_queries do
+            sign_in(admin)
+            get "/t/#{topic.slug}/#{topic.id}.json"
+          end
+
+        queries = queries.filter { |q| q =~ /FROM "?post_localizations"?/ }
+        expect(queries.size).to eq(2)
+      end
+    end
+
     context "with serialize_post_user_badges" do
       fab!(:badge)
       before do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2535,7 +2535,7 @@ RSpec.describe TopicsController do
           end
 
         queries = queries.filter { |q| q =~ /FROM "?post_localizations"?/ }
-        expect(queries.size).to eq(2)
+        expect(queries.size).to eq(1)
       end
     end
 


### PR DESCRIPTION
`post_localizations` are preloaded, but using `find_by`, `exists?`, and `count` will hit the db.

Use alternatives instead that can make use of the loaded records.

The two records below in mini profiler shares the caller:
<img width="1241" height="807" alt="Screenshot 2025-07-17 at 8 41 37 PM" src="https://github.com/user-attachments/assets/b015fd42-b89f-472f-bfbc-b87e97c06f28" />
