### PR TITLE
FIX: external_id param can be an integer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -282,7 +282,7 @@ class ApplicationController < ActionController::Base
 
     show_json_errors =
       (request.format && request.format.json?) || (request.xhr?) ||
-        ((params[:external_id] || "").ends_with? ".json")
+        ((params[:external_id] || "").to_s.ends_with?(".json"))
 
     if type == :not_found && opts[:check_permalinks]
       url = opts[:original_path] || request.fullpath


### PR DESCRIPTION
fixes errors like:

```
Failed to handle exception in exception app middleware : NoMethodError : undefined method `ends_with?' for an instance of Integer
```