### PR TITLE
FIX: Don’t create empty event dates in calendar

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -397,6 +397,7 @@ module DiscoursePostEvent
           recurrence:,
           recurrence_until:,
         ).first
+      return unless next_starts_at
 
       if original_ends_at
         difference = original_ends_at - original_starts_at

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -501,4 +501,25 @@ describe DiscoursePostEvent::Event do
       expect(event_1.missing_users.pluck(:id)).to match_array([user_1.id, user_2.id])
     end
   end
+
+  describe "#calculate_next_date" do
+    subject(:next_date) { event.calculate_next_date }
+
+    context "when the event is recurring" do
+      context "when the recurring ends on the next day" do
+        let(:event) do
+          Fabricate(
+            :event,
+            recurrence: "every_day",
+            recurrence_until: "2020-04-25 06:59",
+            original_starts_at: "2020-04-20 13:00",
+          )
+        end
+
+        it "returns nothing" do
+          expect(next_date).to be_blank
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, there’s an edge case in the calendar plugin: when a recurring event (typically a daily one) ends on the next day, it can happen that we create a `event_date` record with no `starts_at` attribute.

This is because `Event#calculate_next_date` doesn’t check the result from `RRuleGenerator.generate`.

This PR addresses the issue simply by checking the value of `RRuleGenerator.generate` and returns early if the value is `nil`.