### PR TITLE
UX: Horizon composer-chat interaction

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -15,6 +15,8 @@ html.composer-open:not(.has-full-page-chat) {
   cursor: row-resize;
   padding: 0.25em 0;
   background: var(--tertiary);
+  border-top-left-radius: var(--d-border-radius-large);
+  border-top-right-radius: var(--d-border-radius-large);
 
   @media (pointer: coarse) {
     padding: 0.35em 0;
@@ -51,6 +53,8 @@ html.composer-open:not(.has-full-page-chat) {
     min-height 0.2s;
   background-color: var(--secondary);
   box-shadow: var(--shadow-composer);
+  border-top-left-radius: var(--d-border-radius-large);
+  border-top-right-radius: var(--d-border-radius-large);
 
   @media screen and (width <= 1200px) {
     min-width: 0;
@@ -119,7 +123,7 @@ html.composer-open:not(.has-full-page-chat) {
 
   &.draft,
   &.saving {
-    height: 40px !important;
+    height: 45px !important;
     align-items: center;
     background: var(--tertiary);
     color: var(--secondary);

--- a/themes/horizon/scss/chat.scss
+++ b/themes/horizon/scss/chat.scss
@@ -5,10 +5,16 @@
 }
 
 .c-navbar-container {
+  background-color: var(--d-content-background);
+
   .full-page-chat & {
     padding: 0 1.5em;
   }
-  background-color: var(--d-content-background);
+
+  .chat-drawer.is-collapsed & {
+    background: var(--tertiary-low);
+    opacity: 0.7;
+  }
 }
 
 body.has-full-page-chat {
@@ -31,15 +37,11 @@ body.has-full-page-chat {
 
 .chat-drawer-outlet-container {
   z-index: z("composer", "content");
+  padding-bottom: 0;
+  right: var(--main-grid-gap);
 
-  .peek-mode-active & {
-    padding-bottom: 0;
-    left: unset;
-    right: var(--main-grid-gap);
-
-    &:has(.is-expanded) {
-      z-index: calc(z("composer", "dropdown") + 1);
-    }
+  &:has(.is-expanded) {
+    z-index: calc(z("composer", "dropdown") + 1);
   }
 }
 

--- a/themes/horizon/scss/composer.scss
+++ b/themes/horizon/scss/composer.scss
@@ -16,13 +16,9 @@
 #reply-control.hide-preview:not(.draft) {
   @include viewport.from(sm) {
     background: var(--d-content-background);
-    border-top-right-radius: var(--d-border-radius);
-    border-top-left-radius: var(--d-border-radius);
 
     .grippie {
       background: var(--tertiary-low);
-      border-top-right-radius: var(--d-border-radius);
-      border-top-left-radius: var(--d-border-radius);
     }
 
     .user-selector,


### PR DESCRIPTION
* relocated the border-radius to core, so it follows the variable settings always, not just in Horizon
* changed the interaction-layout in Horizon for composer-chat where
  * When opened, chat drawer will always be in front of composer, no matter which mode (markdown, RTE, peek)
  * When minimised, chat drawer will always be behind the composer
* also changed the color of the chat-drawer when minimised, to stand out a bit more and to match the de-focussed grippie colour on composer.
* slight change in height of composer when minimised (40 -> 45px) to match height of chat drawer when minimised

<img width="3452" height="1680" alt="CleanShot 2025-07-17 at 17 14 13@2x" src="https://github.com/user-attachments/assets/c524b1d8-dab2-4e89-b971-a91be87cc50d" />


<img width="3452" height="1680" alt="CleanShot 2025-07-17 at 17 14 01@2x" src="https://github.com/user-attachments/assets/cb8b38c2-32f4-43f7-bc90-c45c00d9f102" />
