### PR TITLE
UX: decrease font of discourse tags in composer popup

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1122,6 +1122,10 @@ div.ac-wrap {
   &:nth-of-type(2) {
     width: calc(50% - 65px);
   }
+
+  .discourse-tags {
+    font-size: var(--font-down-1);
+  }
 }
 
 .custom-body {


### PR DESCRIPTION
<img width="399" height="438" alt="CleanShot 2025-07-17 at 17 43 14" src="https://github.com/user-attachments/assets/9ec9d4a2-1008-4f04-8a5a-a44c41dedfdc" />
<img width="399" height="438" alt="CleanShot 2025-07-17 at 17 43 24" src="https://github.com/user-attachments/assets/3e7dca2f-2c75-4bbc-b00f-48a551c135c7" />
