### PR TITLE
UX: raise chat composer when topic composer is open

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -127,6 +127,6 @@
   }
 }
 
-body:not(.peek-mode-active) .chat-composer__outer-container {
+body.has-full-page-chat:not(.peek-mode-active) .chat-composer__outer-container {
   padding-bottom: var(--composer-height);
 }


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="2276" height="1822" alt="CleanShot 2025-07-17 at 11 55 40@2x" src="https://github.com/user-attachments/assets/09c4c3e3-fb2f-4984-8a56-216d253e0a95" />|<img width="2242" height="1806" alt="CleanShot 2025-07-17 at 11 52 22@2x" src="https://github.com/user-attachments/assets/b382d04f-297b-4aca-8ea0-09728b72cf77" />|
|<img width="2276" height="1814" alt="CleanShot 2025-07-17 at 11 55 25@2x" src="https://github.com/user-attachments/assets/7026091a-c3e6-4cf4-9270-be41e9f03663" />|<img width="2250" height="1814" alt="CleanShot 2025-07-17 at 11 54 22@2x" src="https://github.com/user-attachments/assets/a3794b2f-2a29-4ee1-a36c-139af00e813b" />|
