### PR TITLE
UX: show all preinstalled plugins and label them as such

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -58,6 +58,12 @@ export default class AdminPluginsListItem extends Component {
     return "";
   }
 
+  get isPreinstalled() {
+    return this.args.plugin.url?.includes(
+      "/discourse/discourse/tree/main/plugins/"
+    );
+  }
+
   <template>
     <tr
       data-plugin-name={{@plugin.name}}
@@ -96,9 +102,10 @@ export default class AdminPluginsListItem extends Component {
               href={{@plugin.linkUrl}}
               rel="noopener noreferrer"
               target="_blank"
+              class="admin-plugins-list__about-link"
             >
-              {{i18n "admin.plugins.learn_more"}}
               {{icon "up-right-from-square"}}
+              {{i18n "admin.plugins.learn_more"}}
             </a>
           {{/if}}
         </div>
@@ -113,7 +120,18 @@ export default class AdminPluginsListItem extends Component {
             @outletArgs={{lazyHash plugin=@plugin}}
           >
             {{@plugin.version}}<br />
-            <PluginCommitHash @plugin={{@plugin}} />
+            {{#if this.isPreinstalled}}
+              <a
+                href="https://meta.discourse.org/t/bundling-more-popular-plugins-with-discourse-core/373574"
+                rel="noopener noreferrer"
+                target="_blank"
+                class="admin-plugins-list__preinstalled-link"
+              >
+                {{i18n "admin.plugins.preinstalled"}}
+              </a>
+            {{else}}
+              <PluginCommitHash @plugin={{@plugin}} />
+            {{/if}}
           </PluginOutlet>
         </div>
       </td>

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -47,9 +47,9 @@ export default RouteTemplate(
         </:tabs>
       </DPageHeader>
 
-      <div class="alert alert-info -top-margin admin-plugins-howto">
-        {{icon "circle-info"}}
+      <div class="alert alert-info admin-plugins-howto">
         <a href="https://meta.discourse.org/t/install-a-plugin/19157">
+          {{icon "circle-info"}}
           {{i18n "admin.plugins.howto"}}
         </a>
       </div>

--- a/app/assets/stylesheets/admin/admin_table.scss
+++ b/app/assets/stylesheets/admin/admin_table.scss
@@ -149,16 +149,18 @@
   &-name {
     font-weight: 700;
     max-width: 80%;
-    margin-bottom: var(--space-1);
+    margin-bottom: 0;
   }
 
   &-author {
     font-size: var(--font-down-1);
     margin-bottom: var(--space-1);
+    color: var(--primary-high);
   }
 
   &-about {
     padding-right: var(--space-4);
+    max-width: 75ch;
 
     @include viewport.until(md) {
       padding-top: var(--space-1);

--- a/app/assets/stylesheets/admin/plugins.scss
+++ b/app/assets/stylesheets/admin/plugins.scss
@@ -58,6 +58,11 @@
         margin-right: var(--space-1);
       }
     }
+
+    &__about-link {
+      white-space: nowrap;
+      display: block;
+    }
   }
 }
 
@@ -136,6 +141,15 @@
 
 .admin-plugin-filtered-site-settings {
   &__filter {
+    width: 100%;
+  }
+}
+
+.admin-plugins-howto {
+  margin: var(--space-2) 0 0;
+
+  a {
+    display: inline-block;
     width: 100%;
   }
 }

--- a/app/assets/stylesheets/common/base/alert.scss
+++ b/app/assets/stylesheets/common/base/alert.scss
@@ -46,10 +46,6 @@
       }
     }
   }
-
-  &.-top-margin {
-    margin-top: 1em;
-  }
 }
 
 a.alert.clickable {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6592,6 +6592,7 @@ en:
         author: "By %{author}"
         experimental_badge: "experimental"
         learn_more: "Learn more"
+        preinstalled: "Preinstalled"
 
       navigation_menu:
         sidebar: "Sidebar"

--- a/plugins/checklist/plugin.rb
+++ b/plugins/checklist/plugin.rb
@@ -11,4 +11,3 @@ enabled_site_setting :checklist_enabled
 
 register_asset "stylesheets/checklist.scss"
 register_svg_icon "spinner"
-hide_plugin

--- a/plugins/discourse-details/plugin.rb
+++ b/plugins/discourse-details/plugin.rb
@@ -7,7 +7,6 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-details
 
 enabled_site_setting :details_enabled
-hide_plugin
 
 register_asset "stylesheets/details.scss"
 

--- a/plugins/discourse-lazy-videos/plugin.rb
+++ b/plugins/discourse-lazy-videos/plugin.rb
@@ -6,7 +6,6 @@
 # authors: Jan Cernik
 # url: https://github.com/discourse/discourse-lazy-videos
 
-hide_plugin
 enabled_site_setting :lazy_videos_enabled
 
 register_asset "stylesheets/lazy-videos.scss"

--- a/plugins/discourse-local-dates/plugin.rb
+++ b/plugins/discourse-local-dates/plugin.rb
@@ -5,8 +5,6 @@
 # version: 0.1
 # author: Joffrey Jaffeux
 
-hide_plugin
-
 register_asset "stylesheets/common/discourse-local-dates.scss"
 register_asset "moment.js", :vendored_core_pretty_text
 register_asset "moment-timezone.js", :vendored_core_pretty_text

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -7,7 +7,6 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-narrative-bot
 
 enabled_site_setting :discourse_narrative_bot_enabled
-hide_plugin
 
 require_relative "lib/discourse_narrative_bot/welcome_post_type_site_setting"
 register_asset "stylesheets/discourse-narrative-bot.scss"

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -7,7 +7,6 @@
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-presence
 
 enabled_site_setting :presence_enabled
-hide_plugin
 
 register_asset "stylesheets/presence.scss"
 

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -14,7 +14,6 @@ register_asset "stylesheets/common/poll-breakdown.scss"
 register_svg_icon "far-square-check"
 
 enabled_site_setting :poll_enabled
-hide_plugin
 
 after_initialize do
   module ::DiscoursePoll

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -8,7 +8,6 @@
 
 register_asset "stylesheets/styleguide.scss"
 enabled_site_setting :styleguide_enabled
-hide_plugin
 
 require_relative "lib/styleguide/engine"
 

--- a/plugins/styleguide/spec/integration/assets_spec.rb
+++ b/plugins/styleguide/spec/integration/assets_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Styleguide assets" do
   context "when visiting styleguide" do
     it "loads styleguide assets" do
       get "/styleguide"
-      expect(response.body).to include("styleguide.js")
+      expect(response.body).to include('data-target="styleguide"')
     end
   end
 end

--- a/plugins/styleguide/spec/integration/assets_spec.rb
+++ b/plugins/styleguide/spec/integration/assets_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Styleguide assets" do
   context "when visiting styleguide" do
     it "loads styleguide assets" do
       get "/styleguide"
-      expect(response.body).to include("styleguide")
+      expect(response.body).to include("styleguide.js")
     end
   end
 end

--- a/plugins/styleguide/spec/integration/assets_spec.rb
+++ b/plugins/styleguide/spec/integration/assets_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Styleguide assets" do
   context "when visiting homepage" do
     it "doesn't load styleguide assets" do
       get "/"
-      expect(response.body).to_not include("styleguide.js")
+      expect(response.body).to_not include('data-target="styleguide"')
     end
   end
 

--- a/plugins/styleguide/spec/integration/assets_spec.rb
+++ b/plugins/styleguide/spec/integration/assets_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "Styleguide assets" do
   end
 
   context "when visiting homepage" do
-    it "doesn’t load styleguide assets" do
+    it "doesn't load styleguide assets" do
       get "/"
-      expect(response.body).to_not include("styleguide")
+      expect(response.body).to_not include("styleguide.js")
     end
   end
 


### PR DESCRIPTION
Instead of listing the redundant commit hash, this now shows "preinstalled" for the relevant components and links to https://meta.discourse.org/t/bundling-more-popular-plugins-with-discourse-core/373574. This is accomplished by checking the URL of the plugin for `"/discourse/discourse/tree/main/plugins/"` which indicates it's part of the core Discourse repo. 

I've also removed the `hide_plugin` flag from existing preinstalled plugins. Now Discourse admins will have more clarity into what's included. 

I also made some minor layout adjustments: 
* Larger click area for "how to install a plugin" banner
* Moved "Learn more" into a separate line for consistent positioning

Before:
<img width="2182" height="1192" alt="image" src="https://github.com/user-attachments/assets/b2943a7f-5212-4abd-8b80-d0d071378f06" />


After:
<img width="2226" height="1184" alt="image" src="https://github.com/user-attachments/assets/0846a2c9-fc1b-435c-b51f-b966af5ade09" />
