### PR TITLE
FIX: Make sure theme site setting cache is set on theme import

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -486,6 +486,8 @@ class RemoteTheme < ActiveRecord::Base
         guardian: Discourse.system_user.guardian,
       ) { |result| }
     end
+
+    SiteSetting.refresh!(refresh_site_settings: false, refresh_theme_site_settings: true)
   end
 
   def github_diff_link

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -600,6 +600,28 @@ RSpec.describe RemoteTheme do
 
         expect(theme.theme_site_settings.first.value).to eq("search_field")
       end
+
+      it "makes sure to refresh the site setting theme site setting cache so we have full data there for each theme" do
+        add_to_git_repo(
+          initial_repo,
+          "about.json" =>
+            JSON
+              .parse(about_json)
+              .merge("theme_site_settings" => { "enable_welcome_banner" => false })
+              .to_json,
+        )
+        theme = RemoteTheme.import_theme(initial_repo_url)
+
+        expect(SiteSetting.theme_site_settings[theme.id][:enable_welcome_banner]).to eq(false)
+        expect(SiteSetting.theme_site_settings[theme.id][:search_experience]).to eq("search_icon")
+      end
+
+      it "makes sure to set the theme site setting cache with defaults correctly when the theme has no theme_site_settings overrides defined" do
+        theme = RemoteTheme.import_theme(initial_repo_url)
+
+        expect(SiteSetting.theme_site_settings[theme.id][:enable_welcome_banner]).to eq(true)
+        expect(SiteSetting.theme_site_settings[theme.id][:search_experience]).to eq("search_icon")
+      end
     end
   end
 


### PR DESCRIPTION
This fixes an issue identified in specs where the theme site setting
cache was not being set correctly when importing themes, leading
to an incomplete list of settings being sent down to the client
via the `themeSiteSettingOverrides` preload store.

For example, a theme might have something like this:

```
496=>{:enable_welcome_banner=>false}}
```

Which is missing the `search_experience` theme site setting.

We can address this properly by refreshing the SiteSetting theme
site setting cache after importing themes, ensuring that all
properties are correctly set.
