### PR TITLE
UX: allow horizontal scrolling for the editor toolbar on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -710,41 +710,45 @@ export default class DEditor extends Component {
             {{if this.disabled 'disabled'}}
             {{if this.isEditorFocused 'in-focus'}}"
         >
-
-          {{#if this.replacedToolbarInstance}}
-            <div class="d-editor-button-bar --replaced-toolbar" role="toolbar">
-              <DButton
-                @action={{this.resetToolbar}}
-                @icon="angle-left"
-                @preventFocus={{true}}
-                @onKeyDown={{this.rovingButtonBar}}
-                class="d-editor-button-bar__back"
-              />
-              <ToolbarButtons
-                @data={{this.replacedToolbarInstance}}
-                @rovingButtonBar={{this.rovingButtonBar}}
-                @isFirst={{false}}
-              />
-            </div>
-          {{else}}
-            <div class="d-editor-button-bar" role="toolbar">
-              {{#if this.siteSettings.rich_editor}}
-                <ToggleSwitch
+          <div class="d-editor-button-bar__wrapper">
+            {{#if this.replacedToolbarInstance}}
+              <div
+                class="d-editor-button-bar --replaced-toolbar"
+                role="toolbar"
+              >
+                <DButton
+                  @action={{this.resetToolbar}}
+                  @icon="angle-left"
                   @preventFocus={{true}}
-                  @disabled={{@disableSubmit}}
-                  @state={{this.isRichEditorEnabled}}
-                  {{on "click" this.toggleRichEditor}}
-                  {{on "keydown" this.rovingButtonBar}}
+                  @onKeyDown={{this.rovingButtonBar}}
+                  class="d-editor-button-bar__back"
                 />
-              {{/if}}
+                <ToolbarButtons
+                  @data={{this.replacedToolbarInstance}}
+                  @rovingButtonBar={{this.rovingButtonBar}}
+                  @isFirst={{false}}
+                />
+              </div>
+            {{else}}
+              <div class="d-editor-button-bar" role="toolbar">
+                {{#if this.siteSettings.rich_editor}}
+                  <ToggleSwitch
+                    @preventFocus={{true}}
+                    @disabled={{@disableSubmit}}
+                    @state={{this.isRichEditorEnabled}}
+                    {{on "click" this.toggleRichEditor}}
+                    {{on "keydown" this.rovingButtonBar}}
+                  />
+                {{/if}}
 
-              <ToolbarButtons
-                @data={{this.toolbar}}
-                @rovingButtonBar={{this.rovingButtonBar}}
-                @isFirst={{not this.siteSettings.rich_editor}}
-              />
-            </div>
-          {{/if}}
+                <ToolbarButtons
+                  @data={{this.toolbar}}
+                  @rovingButtonBar={{this.rovingButtonBar}}
+                  @isFirst={{not this.siteSettings.rich_editor}}
+                />
+              </div>
+            {{/if}}
+          </div>
 
           <ConditionalLoadingSpinner @condition={{this.loading}} />
           <this.editorComponent

--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -710,45 +710,41 @@ export default class DEditor extends Component {
             {{if this.disabled 'disabled'}}
             {{if this.isEditorFocused 'in-focus'}}"
         >
-          <div class="d-editor-button-bar__wrapper">
-            {{#if this.replacedToolbarInstance}}
-              <div
-                class="d-editor-button-bar --replaced-toolbar"
-                role="toolbar"
-              >
-                <DButton
-                  @action={{this.resetToolbar}}
-                  @icon="angle-left"
-                  @preventFocus={{true}}
-                  @onKeyDown={{this.rovingButtonBar}}
-                  class="d-editor-button-bar__back"
-                />
-                <ToolbarButtons
-                  @data={{this.replacedToolbarInstance}}
-                  @rovingButtonBar={{this.rovingButtonBar}}
-                  @isFirst={{false}}
-                />
-              </div>
-            {{else}}
-              <div class="d-editor-button-bar" role="toolbar">
-                {{#if this.siteSettings.rich_editor}}
-                  <ToggleSwitch
-                    @preventFocus={{true}}
-                    @disabled={{@disableSubmit}}
-                    @state={{this.isRichEditorEnabled}}
-                    {{on "click" this.toggleRichEditor}}
-                    {{on "keydown" this.rovingButtonBar}}
-                  />
-                {{/if}}
 
-                <ToolbarButtons
-                  @data={{this.toolbar}}
-                  @rovingButtonBar={{this.rovingButtonBar}}
-                  @isFirst={{not this.siteSettings.rich_editor}}
+          {{#if this.replacedToolbarInstance}}
+            <div class="d-editor-button-bar --replaced-toolbar" role="toolbar">
+              <DButton
+                @action={{this.resetToolbar}}
+                @icon="angle-left"
+                @preventFocus={{true}}
+                @onKeyDown={{this.rovingButtonBar}}
+                class="d-editor-button-bar__back"
+              />
+              <ToolbarButtons
+                @data={{this.replacedToolbarInstance}}
+                @rovingButtonBar={{this.rovingButtonBar}}
+                @isFirst={{false}}
+              />
+            </div>
+          {{else}}
+            <div class="d-editor-button-bar" role="toolbar">
+              {{#if this.siteSettings.rich_editor}}
+                <ToggleSwitch
+                  @preventFocus={{true}}
+                  @disabled={{@disableSubmit}}
+                  @state={{this.isRichEditorEnabled}}
+                  {{on "click" this.toggleRichEditor}}
+                  {{on "keydown" this.rovingButtonBar}}
                 />
-              </div>
-            {{/if}}
-          </div>
+              {{/if}}
+
+              <ToolbarButtons
+                @data={{this.toolbar}}
+                @rovingButtonBar={{this.rovingButtonBar}}
+                @isFirst={{not this.siteSettings.rich_editor}}
+              />
+            </div>
+          {{/if}}
 
           <ConditionalLoadingSpinner @condition={{this.loading}} />
           <this.editorComponent

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -912,8 +912,7 @@ div.ac-wrap {
       }
 
       .submit-panel,
-      .composer-fields,
-      .d-editor-button-bar {
+      .composer-fields {
         // this prevents touch events (i.e. accidental scrolls) from bubbling up
         touch-action: none;
       }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -333,26 +333,6 @@
     }
   }
 
-  &__wrapper {
-    position: relative;
-
-    @include viewport.until(sm) {
-      &::after {
-        content: "";
-        position: absolute;
-        right: 0;
-        top: 3px; // avoiding overlapping with border-radius
-        bottom: 0;
-        width: var(--space-2);
-        background: linear-gradient(
-          to right,
-          transparent,
-          var(--secondary) 100%
-        );
-      }
-    }
-  }
-
   .composer-toggle-switch {
     padding: 0 0.5rem;
   }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -320,12 +320,41 @@
   gap: var(--space-2);
   margin: 0.25rem 0;
 
-  .composer-toggle-switch {
-    padding: 0 0.5rem;
+  @include viewport.until(sm) {
+    flex-wrap: nowrap;
+    padding-block: var(--space-1);
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    max-width: 100%;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
-  @include viewport.until(sm) {
-    font-size: var(--font-down-1-rem);
+  &__wrapper {
+    position: relative;
+
+    @include viewport.until(sm) {
+      &::after {
+        content: "";
+        position: absolute;
+        right: 0;
+        top: 3px; // avoiding overlapping with border-radius
+        bottom: 0;
+        width: var(--space-2);
+        background: linear-gradient(
+          to right,
+          transparent,
+          var(--secondary) 100%
+        );
+      }
+    }
+  }
+
+  .composer-toggle-switch {
+    padding: 0 0.5rem;
   }
 
   .btn:focus-visible {


### PR DESCRIPTION
To prevent the toolbar to wrap onto 2 lines and eat into the precious writing space on mobile, this commit aims to allow horizontal scrolling.

### Before
<img width="716" height="1504" alt="CleanShot 2025-07-18 at 13 08 37@2x" src="https://github.com/user-attachments/assets/c996d0c2-f0ab-4eee-bcad-f9ccd30a35e6" />

### New

<img width="716" height="1504" alt="CleanShot 2025-07-18 at 13 08 16@2x" src="https://github.com/user-attachments/assets/579a2f76-a41a-4e7b-919a-7457de8f8822" />

#### Notes
This is a very basic implementation; I'd like to follow-up later with fade-out and arrow-scrolling
