### PR TITLE
FEATURE: Add reusable AdminFilterControls component, apply to plugins and reports

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-filter-controls.gjs
@@ -1,0 +1,167 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { schedule } from "@ember/runloop";
+import { and, eq } from "truth-helpers";
+import DButton from "discourse/components/d-button";
+import DSelect from "discourse/components/d-select";
+import FilterInput from "discourse/components/filter-input";
+
+/**
+ *  admin filter controls component for filtering
+ *
+ * @component AdminFilterControls
+ * @param {Array} array - The dataset to filter (must be an array)
+ * @param {Array} searchableProps - Array of property names to search in for text filtering
+ * @param {Array} dropdownOptions - Array of dropdown options [{value: "all", label: "All", filterFn: (item) => boolean}, ...]
+ * @param {String} inputPlaceholder - Placeholder text for search input
+ * @param {String} defaultDropdown - Default dropdown value (default: "all")
+ * @param {String} noResultsMessage - Message to show when no results found (optional)
+ */
+
+export default class AdminFilterControls extends Component {
+  @tracked textFilter = "";
+  @tracked dropdownFilter = "all";
+
+  get array() {
+    return Array.isArray(this.args.array) ? this.args.array : [];
+  }
+
+  get searchableProps() {
+    return Array.isArray(this.args.searchableProps)
+      ? this.args.searchableProps
+      : [];
+  }
+
+  get dropdownOptions() {
+    return Array.isArray(this.args.dropdownOptions)
+      ? this.args.dropdownOptions
+      : [];
+  }
+
+  get showDropdownFilter() {
+    return this.dropdownOptions.length > 1;
+  }
+
+  get defaultDropdown() {
+    return this.args.defaultDropdown || "all";
+  }
+
+  get hasActiveFilters() {
+    return (
+      this.textFilter.length > 0 || this.dropdownFilter !== this.defaultDropdown
+    );
+  }
+
+  get filteredData() {
+    let filtered = [...this.array];
+
+    if (this.textFilter.length > 0) {
+      const term = this.textFilter.toLowerCase();
+      filtered = filtered.filter((item) => {
+        return this.searchableProps.some((key) => {
+          const value = this.getNestedValue(item, key);
+          return value && value.toString().toLowerCase().includes(term);
+        });
+      });
+    }
+
+    if (this.dropdownFilter !== this.defaultDropdown) {
+      const selectedOption = this.dropdownOptions.find(
+        (option) => option.value === this.dropdownFilter
+      );
+      if (selectedOption?.filterFn) {
+        filtered = filtered.filter(selectedOption.filterFn);
+      }
+    }
+
+    return filtered;
+  }
+
+  /**
+   * get nested value
+   * @param {Object} obj - The object to get value from
+   * @param {String} path - The property path (e.g. "user.name")
+   * @returns {*} The value at the path
+   */
+  getNestedValue(obj, path) {
+    return path.split(".").reduce((current, key) => current?.[key], obj);
+  }
+
+  @action
+  setupComponent() {
+    this.dropdownFilter = this.defaultDropdown;
+  }
+
+  @action
+  onTextFilterChange(event) {
+    this.textFilter = event.target?.value || "";
+  }
+
+  @action
+  onDropdownFilterChange(value) {
+    this.dropdownFilter = value;
+  }
+
+  @action
+  resetFilters() {
+    this.textFilter = "";
+    this.dropdownFilter = this.defaultDropdown;
+
+    schedule("afterRender", () => {
+      document
+        .querySelector(".admin-filter-controls .admin-filter__input")
+        ?.focus();
+    });
+  }
+
+  <template>
+    <div class="admin-filter-controls" {{didInsert this.setupComponent}}>
+      <FilterInput
+        placeholder={{@inputPlaceholder}}
+        @filterAction={{this.onTextFilterChange}}
+        @value={{this.textFilter}}
+        class="admin-filter-controls__input"
+        @icons={{hash left="magnifying-glass"}}
+      />
+
+      {{#if this.showDropdownFilter}}
+        <DSelect
+          @value={{this.dropdownFilter}}
+          @includeNone={{false}}
+          @onChange={{this.onDropdownFilterChange}}
+          class="admin-filter-controls__dropdown"
+          as |select|
+        >
+          {{#each this.dropdownOptions as |option|}}
+            <select.Option @value={{option.value}}>
+              {{option.label}}
+            </select.Option>
+          {{/each}}
+        </DSelect>
+      {{/if}}
+
+    </div>
+
+    {{#if this.filteredData.length}}
+      {{yield this.filteredData}}
+    {{else}}
+
+      {{#if (and this.hasActiveFilters (eq this.filteredData.length 0))}}
+        <div class="admin-filter-controls__no-results">
+          {{#if @noResultsMessage}}
+            <p>{{@noResultsMessage}}</p>
+          {{/if}}
+          <DButton
+            @icon="arrow-rotate-left"
+            @label="admin.plugins.filters.reset"
+            @action={{this.resetFilters}}
+            class="btn-default admin-filter-controls__reset"
+          />
+        </div>
+      {{/if}}
+    {{/if}}
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/admin-reports.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-reports.gjs
@@ -1,21 +1,16 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
-import { fn } from "@ember/helper";
-import { on } from "@ember/modifier";
+import { array } from "@ember/helper";
 import { service } from "@ember/service";
 import AsyncContent from "discourse/components/async-content";
-import withEventValue from "discourse/helpers/with-event-value";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
+import AdminFilterControls from "admin/components/admin-filter-controls";
 import AdminSectionLandingItem from "admin/components/admin-section-landing-item";
 import AdminSectionLandingWrapper from "admin/components/admin-section-landing-wrapper";
 
 export default class AdminReports extends Component {
   @service siteSettings;
-
-  @tracked reports;
-  @tracked filter = "";
 
   @bind
   async loadReports() {
@@ -24,56 +19,38 @@ export default class AdminReports extends Component {
   }
 
   @bind
-  filterReports(reports, filter) {
+  filterReports(reports) {
     if (!reports) {
       return [];
-    }
-
-    let filteredReports = reports;
-    if (filter) {
-      const lowerCaseFilter = filter.toLowerCase();
-      filteredReports = filteredReports.filter((report) => {
-        return (
-          (report.title || "").toLowerCase().includes(lowerCaseFilter) ||
-          (report.description || "").toLowerCase().includes(lowerCaseFilter)
-        );
-      });
     }
 
     const hiddenReports = (this.siteSettings.dashboard_hidden_reports || "")
       .split("|")
       .filter(Boolean);
-    filteredReports = filteredReports.filter(
-      (report) => !hiddenReports.includes(report.type)
-    );
-
-    return filteredReports;
+    return reports.filter((report) => !hiddenReports.includes(report.type));
   }
 
   <template>
     <AsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
-        <div class="d-admin-filter admin-reports-header">
-          <div class="admin-filter__input-container">
-            <input
-              type="text"
-              class="admin-filter__input admin-reports-header__filter"
-              placeholder={{i18n "admin.filter_reports"}}
-              value={{this.filter}}
-              {{on "input" (withEventValue (fn (mut this.filter)))}}
-            />
-          </div>
-        </div>
-        <AdminSectionLandingWrapper class="admin-reports-list">
-          {{#each (this.filterReports reports this.filter) as |report|}}
-            <AdminSectionLandingItem
-              @titleLabelTranslated={{report.title}}
-              @descriptionLabelTranslated={{report.description}}
-              @titleRoute="adminReports.show"
-              @titleRouteModel={{report.type}}
-            />
-          {{/each}}
-        </AdminSectionLandingWrapper>
+        <AdminFilterControls
+          @array={{this.filterReports reports}}
+          @searchableProps={{array "title" "description"}}
+          @inputPlaceholder={{i18n "admin.filter_reports"}}
+          @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
+          as |filteredReports|
+        >
+          <AdminSectionLandingWrapper class="admin-reports-list">
+            {{#each filteredReports as |report|}}
+              <AdminSectionLandingItem
+                @titleLabelTranslated={{report.title}}
+                @descriptionLabelTranslated={{report.description}}
+                @titleRoute="adminReports.show"
+                @titleRouteModel={{report.type}}
+              />
+            {{/each}}
+          </AdminSectionLandingWrapper>
+        </AdminFilterControls>
       </:content>
     </AsyncContent>
   </template>

--- a/app/assets/javascripts/admin/addon/controllers/admin-plugins-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-plugins-index.js
@@ -3,12 +3,39 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { adminRouteValid } from "discourse/lib/admin-utilities";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { i18n } from "discourse-i18n";
 import SiteSetting from "admin/models/site-setting";
 
 export default class AdminPluginsIndexController extends Controller {
   @service session;
   @service adminPluginNavManager;
   @service router;
+
+  get searchableProps() {
+    return ["nameTitleized", "author", "about"];
+  }
+
+  get dropdownOptions() {
+    return [
+      { value: "all", label: i18n("admin.plugins.filters.all") },
+      {
+        value: "enabled",
+        label: i18n("admin.plugins.filters.enabled"),
+        filterFn: (item) => item.enabled,
+      },
+      {
+        value: "disabled",
+        label: i18n("admin.plugins.filters.disabled"),
+        filterFn: (item) => !item.enabled,
+      },
+      {
+        value: "preinstalled",
+        label: i18n("admin.plugins.filters.preinstalled"),
+        filterFn: (item) =>
+          item.url?.includes("/discourse/discourse/tree/main/plugins/"),
+      },
+    ];
+  }
 
   @action
   async togglePluginEnabled(plugin) {

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -6,6 +6,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
+import AdminFilterControls from "admin/components/admin-filter-controls";
 import AdminPluginsList from "admin/components/admin-plugins-list";
 
 export default RouteTemplate(
@@ -55,7 +56,16 @@ export default RouteTemplate(
       </div>
 
       {{#if @controller.model.length}}
-        <AdminPluginsList @plugins={{@controller.model}} />
+        <AdminFilterControls
+          @array={{@controller.model}}
+          @searchableProps={{@controller.searchableProps}}
+          @dropdownOptions={{@controller.dropdownOptions}}
+          @inputPlaceholder={{i18n "admin.plugins.filters.search_placeholder"}}
+          @noResultsMessage={{i18n "admin.plugins.filters.no_results"}}
+          as |filteredPlugins|
+        >
+          <AdminPluginsList @plugins={{filteredPlugins}} />
+        </AdminFilterControls>
       {{else}}
         <p>{{i18n "admin.plugins.none_installed"}}</p>
       {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -81,7 +81,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       .dom(".admin-reports-list .admin-section-landing-item__content")
       .exists({ count: 1 });
 
-    await fillIn(".admin-reports-header__filter", "flags");
+    await fillIn(".admin-filter-controls__input", "flags");
 
     assert
       .dom(".admin-reports-list .admin-section-landing-item__content")
@@ -96,7 +96,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       .dom(".admin-reports-list .admin-section-landing-item__content")
       .exists({ count: 1 }, "navigating back and forth resets filter");
 
-    await fillIn(".admin-reports-header__filter", "activities");
+    await fillIn(".admin-filter-controls__input", "activities");
 
     assert
       .dom(".admin-reports-list .admin-section-landing-item__content")

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -79,7 +79,7 @@ acceptance("Dashboard", function (needs) {
       )
       .exists({ count: 1 });
 
-    await fillIn(".dashboard .admin-reports-header__filter", "flags");
+    await fillIn(".dashboard .admin-filter-controls__input", "flags");
 
     assert
       .dom(
@@ -96,7 +96,7 @@ acceptance("Dashboard", function (needs) {
       )
       .exists({ count: 1 }, "navigating back and forth resets filter");
 
-    await fillIn(".dashboard .admin-reports-header__filter", "activities");
+    await fillIn(".dashboard .admin-filter-controls__input", "activities");
 
     assert
       .dom(

--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1253,6 +1253,7 @@ a.inline-editable-field {
 @import "admin/search";
 @import "admin/admin_table";
 @import "admin/admin_filter";
+@import "admin/admin_filter_controls";
 @import "admin/admin_reports";
 @import "admin/admin_report";
 @import "admin/admin_report_counters";

--- a/app/assets/stylesheets/admin/admin_filter_controls.scss
+++ b/app/assets/stylesheets/admin/admin_filter_controls.scss
@@ -1,0 +1,27 @@
+.admin-filter-controls {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+
+  .filter-input-container {
+    flex: 1 1 auto;
+  }
+
+  &__dropdown {
+    max-width: 10em;
+    flex: 1 1 auto;
+  }
+
+  &__no-results {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    justify-content: center;
+    padding: var(--space-4);
+    gap: var(--space-2);
+
+    .btn {
+      align-self: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/admin/plugins.scss
+++ b/app/assets/stylesheets/admin/plugins.scss
@@ -146,8 +146,6 @@
 }
 
 .admin-plugins-howto {
-  margin: var(--space-2) 0 0;
-
   a {
     display: inline-block;
     width: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5459,6 +5459,7 @@ en:
       title: "Discourse Admin"
       moderator: "Moderator"
       filter_reports: Filter reports
+      filter_reports_no_results: "No reports match your filter"
 
       tags:
         remove_muted_tags_from_latest:
@@ -5793,7 +5794,7 @@ en:
               header_description: "View a log of searches that have been performed"
         plugins:
           title: "Installed plugins"
-          header_description: "Any Discourse plugins that you have installed, or plugins that come preinstalled with Discourse hosting, will appear in this list"
+          header_description: "Plugins enhance your community with additional features. Both preinstalled and custom plugins are listed below."
         api_keys:
           title: "API keys"
           header_description: "The API keys feature lets you securely integrate Discourse with external systems and automate actions. Admins can create keys with specific scopes to control access to resources and sensitive data. Scopes limit functionality, ensuring enhanced security."
@@ -6500,7 +6501,7 @@ en:
           install: "Install"
           themes:
             title: "Themes"
-            description: "Site-wide themes that change the overall look and feel of your site for all users. Want to check which site settings your themes override? <a href=\"%{themeSiteSettingsUrl}\">View theme site settings</a>"
+            description: 'Site-wide themes that change the overall look and feel of your site for all users. Want to check which site settings your themes override? <a href="%{themeSiteSettingsUrl}">View theme site settings</a>'
             themes_intro: "Install a new theme to get started, or create your own from scratch using these resources."
             new_theme: "New theme"
             back: "Back to themes"
@@ -6593,6 +6594,14 @@ en:
         experimental_badge: "experimental"
         learn_more: "Learn more"
         preinstalled: "Preinstalled"
+        filters:
+          all: "All"
+          enabled: "Enabled"
+          disabled: "Disabled"
+          preinstalled: "Preinstalled"
+          search_placeholder: "Search plugins..."
+          reset: "Reset"
+          no_results: "No plugins found matching your filters"
 
       navigation_menu:
         sidebar: "Sidebar"

--- a/spec/system/admin_filter_controls_spec.rb
+++ b/spec/system/admin_filter_controls_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+describe "AdminFilterControls", type: :system do
+  fab!(:admin)
+
+  let(:filter_controls) do
+    PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
+  end
+
+  before do
+    sign_in(admin)
+
+    poll_plugin =
+      Plugin::Instance.parse_from_source(File.join(Rails.root, "plugins", "poll", "plugin.rb"))
+
+    spoiler_alert_plugin =
+      Plugin::Instance.parse_from_source(
+        File.join(Rails.root, "plugins", "spoiler-alert", "plugin.rb"),
+      )
+
+    Discourse.stubs(:plugins_sorted_by_name).returns([poll_plugin, spoiler_alert_plugin])
+  end
+
+  describe "text filtering" do
+    it "filters plugins by text input" do
+      page.visit("/admin/plugins")
+
+      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".admin-plugins-list__row", count: 2)
+
+      filter_controls.type_in_search("poll")
+      expect(page).to have_css(".admin-plugins-list__row", count: 1)
+
+      filter_controls.clear_search
+      expect(page).to have_css(".admin-plugins-list__row", count: 2)
+    end
+  end
+
+  describe "dropdown filtering" do
+    it "filters plugins by dropdown selection" do
+      page.visit("/admin/plugins")
+
+      expect(page).to have_css(".admin-filter-controls")
+
+      filter_controls.select_dropdown_option("Enabled")
+      expect(page).to have_css(".admin-plugins-list__row", count: 2)
+
+      filter_controls.select_dropdown_option("Disabled")
+      expect(page).to have_css(".admin-plugins-list__row", count: 0)
+
+      filter_controls.select_dropdown_option("All")
+      expect(page).to have_css(".admin-plugins-list__row", count: 2)
+    end
+  end
+
+  describe "reset functionality" do
+    it "shows reset button when filters are active and no results" do
+      page.visit("/admin/plugins")
+
+      expect(page).to have_css(".admin-filter-controls")
+
+      filter_controls.type_in_search("xyznonexistent")
+      expect(page).to have_css(".admin-plugins-list__row", count: 0)
+      expect(filter_controls).to have_reset_button
+
+      filter_controls.click_reset_button
+      expect(filter_controls.search_input_value).to eq("")
+      expect(page).to have_css(".admin-plugins-list__row", count: 2)
+    end
+
+    it "does not show reset button when there are results" do
+      page.visit("/admin/plugins")
+
+      expect(page).to have_css(".admin-filter-controls")
+
+      filter_controls.type_in_search("poll")
+      expect(page).to have_css(".admin-plugins-list__row", count: 1)
+      expect(filter_controls).to have_no_reset_button
+    end
+  end
+
+  describe "no results message" do
+    it "shows configurable no results message" do
+      page.visit("/admin/plugins")
+
+      expect(page).to have_css(".admin-filter-controls")
+
+      filter_controls.type_in_search("xyznonexistent")
+      expect(page).to have_css(".admin-plugins-list__row", count: 0)
+      expect(filter_controls).to have_no_results_message
+    end
+  end
+end

--- a/spec/system/page_objects/components/admin_filter_controls.rb
+++ b/spec/system/page_objects/components/admin_filter_controls.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AdminFilterControls < PageObjects::Components::Base
+      def initialize(component_selector)
+        @component_selector = component_selector
+      end
+
+      def component
+        find(@component_selector)
+      end
+
+      def type_in_search(input)
+        component.find(".admin-filter-controls__input").send_keys(input)
+      end
+
+      def clear_search
+        component.find(".admin-filter-controls__input").set("")
+      end
+
+      def select_dropdown_option(text)
+        component.find(".admin-filter-controls__dropdown").select(text)
+      end
+
+      def has_reset_button?
+        page.has_css?(".admin-filter-controls__reset")
+      end
+
+      def click_reset_button
+        page.find(".admin-filter-controls__reset").click
+      end
+
+      def has_no_reset_button?
+        component.has_no_css?(".admin-filter-controls__reset")
+      end
+
+      def has_no_results_message?
+        page.has_css?(".admin-filter-controls__no-results")
+      end
+
+      def search_input_value
+        component.find(".admin-filter-controls__input").value
+      end
+
+      def dropdown_value
+        component.find(".admin-filter-controls__dropdown option:checked").text
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates a reusable filter component for admin areas that includes a text filter and dropdown. 

The component accepts an array to filter, an array of searchable property names, and optional dropdown values. An additional option is available if you'd like the default dropdown value to be something other than "all." 




It looks like this: 

<img width="2204" height="876" alt="image" src="https://github.com/user-attachments/assets/48693634-6752-4078-8639-42fb1ac77679" />

The dropdown is optional, without it: 

<img width="1756" height="900" alt="image" src="https://github.com/user-attachments/assets/ea9a7ae6-ae86-4cd8-8b99-4afc082f2ce5" />

When there are no matching filters, it provides a reset button: 

<img width="2188" height="394" alt="image" src="https://github.com/user-attachments/assets/9e59218e-8040-41db-ba81-1dc2628429bb" />

I'll use this to replace occurrences of similar filters, we've added a couple to the AI plugin. 
