### PR TITLE
DEV: Incorrect site setting modifications in specs

### DIFF
--- a/spec/lib/email/processor_spec.rb
+++ b/spec/lib/email/processor_spec.rb
@@ -162,6 +162,9 @@ RSpec.describe Email::Processor do
 
   describe "mailinglist mirror" do
     before do
+      SiteSetting.reply_by_email_address = "reply+%{reply_key}@bar.com"
+      SiteSetting.manual_polling_enabled = true
+      SiteSetting.reply_by_email_enabled = true
       SiteSetting.email_in = true
       Fabricate(:mailinglist_mirror_category)
     end

--- a/spec/lib/email/processor_spec.rb
+++ b/spec/lib/email/processor_spec.rb
@@ -140,9 +140,11 @@ RSpec.describe Email::Processor do
   end
 
   describe "from reply to email address" do
-    SiteSetting.reply_by_email_address = "reply+%{reply_key}@bar.com"
-    SiteSetting.manual_polling_enabled = true
-    SiteSetting.reply_by_email_enabled = true
+    before do
+      SiteSetting.reply_by_email_address = "reply+%{reply_key}@bar.com"
+      SiteSetting.manual_polling_enabled = true
+      SiteSetting.reply_by_email_enabled = true
+    end
 
     let(:mail) do
       "Date: Fri, 15 Jan 2016 00:12:43 +0100\nFrom: reply@bar.com\nTo: reply@bar.com\nSubject: FOO BAR\n\nFoo foo bar bar?"


### PR DESCRIPTION
Modifying site settings outside of an example (or `before/after` blocks) results in corrupting those settings in the test database.

(the was issue introduced in e05ef50c709afb9b4777223e22881b695868d4c2)