### PR TITLE
DEV: Add validator for `enable_discourse_id` setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2803,6 +2803,7 @@ en:
         other: "The list must contain exactly %{count} values."
       markdown_linkify_tlds: "You cannot include a value of '*'."
       google_oauth2_hd_groups: "You must configure all 'google oauth2 hd' settings before enabling this setting."
+      discourse_id_credentials: "You must configure Discourse ID credentials ('discourse_id_client_id' and 'discourse_id_client_secret') before enabling this setting."
       linkedin_oidc_credentials: "You must configure LinkedIn OIDC credentials ('linkedin_oidc_client_id' and 'linkedin_oidc_client_secret') before enabling this setting."
       search_tokenize_chinese_enabled: "You must disable 'search_tokenize_chinese' before enabling this setting."
       search_tokenize_japanese_enabled: "You must disable 'search_tokenize_japanese' before enabling this setting."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -603,6 +603,7 @@ login:
   enable_discourse_id:
     default: false
     hidden: true
+    validator: "EnableDiscourseIdValidator"
   discourse_id_client_id:
     default: ""
     hidden: true

--- a/lib/validators/enable_discourse_id_validator.rb
+++ b/lib/validators/enable_discourse_id_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class EnableDiscourseIdValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == "f"
+    return false if credentials_missing?
+    true
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.discourse_id_credentials") if credentials_missing?
+  end
+
+  private
+
+  def credentials_missing?
+    SiteSetting.discourse_id_client_id.blank? || SiteSetting.discourse_id_client_secret.blank?
+  end
+end

--- a/spec/lib/validators/enable_discourse_id_validator_spec.rb
+++ b/spec/lib/validators/enable_discourse_id_validator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe EnableDiscourseIdValidator do
+  subject(:validator) { described_class.new }
+
+  describe "#valid_value?" do
+    describe "when credentials are configured" do
+      before do
+        SiteSetting.discourse_id_client_id = "foo"
+        SiteSetting.discourse_id_client_secret = "bar"
+      end
+
+      describe "when value is false" do
+        it "should be valid" do
+          expect(validator.valid_value?("f")).to eq(true)
+        end
+      end
+
+      describe "when value is true" do
+        it "should be valid" do
+          expect(validator.valid_value?("t")).to eq(true)
+        end
+      end
+    end
+
+    describe "when discourse_id_client_id is not set" do
+      before { SiteSetting.discourse_id_client_id = "" }
+
+      describe "when value is false" do
+        it "should be valid" do
+          expect(validator.valid_value?("f")).to eq(true)
+        end
+      end
+
+      describe "when value is true" do
+        it "should not be valid" do
+          expect(validator.valid_value?("t")).to eq(false)
+
+          expect(validator.error_message).to eq(
+            I18n.t("site_settings.errors.discourse_id_credentials"),
+          )
+        end
+      end
+    end
+
+    describe "when discourse_id_client_secret is not set" do
+      before { SiteSetting.discourse_id_client_secret = "" }
+
+      describe "when value is false" do
+        it "should be valid" do
+          expect(validator.valid_value?("f")).to eq(true)
+        end
+      end
+
+      describe "when value is true" do
+        it "should not be valid" do
+          expect(validator.valid_value?("t")).to eq(false)
+
+          expect(validator.error_message).to eq(
+            I18n.t("site_settings.errors.discourse_id_credentials"),
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Still an internal beta feature, but without an id and a secret, the authenticator shouldn't be enabled.