### PR TITLE
DEV: Add test coverage for PostGuardian methods

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -212,7 +212,11 @@ module PostGuardian
   end
 
   def can_delete_post_or_topic?(post)
-    post.is_first_post? ? post.topic && can_delete_topic?(post.topic) : can_delete_post?(post)
+    if post.is_first_post?
+      post.topic && can_delete_topic?(post.topic)
+    else
+      can_delete_post?(post)
+    end
   end
 
   def can_delete_post?(post)


### PR DESCRIPTION
### What is this change?

In #33587 we moved `PostGuardian` related tests from `guardian_spec` to `post_guardian_spec`. When doing so we also added stubs for missing tests.

This PR implements those missing tests.