### PR TITLE
DEV: Remove now-redundant is_staff check from PostGuardian

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -405,7 +405,7 @@ module PostGuardian
   end
 
   def trusted_with_post_edits?
-    is_staff? || @user.in_any_groups?(SiteSetting.edit_post_allowed_groups_map)
+    @user.in_any_groups?(SiteSetting.edit_post_allowed_groups_map)
   end
 
   private


### PR DESCRIPTION
### What is this change?

A while back we replaced hard-coded `#is_staff?` checks with group based permissions.

The `edit_post_allowed_groups` setting has `admins` and `moderators` (i.e. `staff`) as mandatory values, and so we no longer need the explicit staff check.