### PR TITLE
DEV: Remove now-redundant is_staff check from PostGuardian

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -3,7 +3,7 @@
 # mixin for all guardian methods dealing with post permissions
 module PostGuardian
   def unrestricted_link_posting?
-    authenticated? && (is_staff? || @user.in_any_groups?(SiteSetting.post_links_allowed_groups_map))
+    authenticated? && @user.in_any_groups?(SiteSetting.post_links_allowed_groups_map)
   end
 
   def link_posting_access


### PR DESCRIPTION
### What is this change?

A while back we replaced hard-coded `#is_staff?` checks with group based permissions.

The `edit_post_allowed_groups` setting has `admins` and `moderators` (i.e. `staff`) as mandatory values, and so we no longer need the explicit staff check.