### PR TITLE
FIX: Show bulk removal of expired invites 

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
@@ -51,13 +51,9 @@ export default class UserInvitedShowController extends Controller {
     });
   }
 
-  @discourseComputed("filter")
-  showBulkActionButtons(filter) {
-    return (
-      filter === "pending" &&
-      this.model.invites.length > 0 &&
-      this.currentUser.staff
-    );
+  @discourseComputed("model")
+  showBulkActionButtons(model) {
+    return model.invites.length > 0 && this.currentUser.staff;
   }
 
   @discourseComputed("invitesCount", "filter")

--- a/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
@@ -14,6 +14,7 @@ import { i18n } from "discourse-i18n";
 export default class UserInvitedShowController extends Controller {
   @service dialog;
   @service modal;
+  @service toasts;
 
   user = null;
   model = null;
@@ -23,7 +24,6 @@ export default class UserInvitedShowController extends Controller {
   invitesLoading = false;
   hasLoadedInitialInvites = false;
   reinvitedAll = false;
-  removedAll = false;
   searchTerm = "";
 
   @equal("filter", "redeemed") inviteRedeemed;
@@ -87,9 +87,11 @@ export default class UserInvitedShowController extends Controller {
     this.dialog.deleteConfirm({
       message: i18n("user.invited.remove_all_confirm"),
       didConfirm: () => {
-        return Invite.destroyAllExpired()
+        return Invite.destroyAllExpired(this.user)
           .then(() => {
-            this.set("removedAll", true);
+            this.toasts.success({
+              data: { message: i18n("user.invited.removed_all") },
+            });
             this.send("triggerRefresh");
           })
           .catch(popupAjaxError);

--- a/app/assets/javascripts/discourse/app/models/invite.js
+++ b/app/assets/javascripts/discourse/app/models/invite.js
@@ -44,8 +44,11 @@ export default class Invite extends EmberObject {
     return ajax("/invites/reinvite-all", { type: "POST" });
   }
 
-  static destroyAllExpired() {
-    return ajax("/invites/destroy-all-expired", { type: "POST" });
+  static destroyAllExpired(user) {
+    return ajax("/invites/destroy-all-expired", {
+      type: "POST",
+      data: { username: user.username },
+    });
   }
 
   @alias("topics.firstObject.id") topicId;

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.gjs
@@ -70,6 +70,7 @@ export default RouteTemplate(
                   @icon="xmark"
                   @action={{@controller.destroyAllExpired}}
                   @label="user.invited.remove_all"
+                  class="bulk-remove-expired"
                 />
               {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.gjs
@@ -66,17 +66,11 @@ export default RouteTemplate(
             {{/if}}
             {{#if @controller.showBulkActionButtons}}
               {{#if @controller.inviteExpired}}
-                {{#if @controller.removedAll}}
-                  <span class="removed-all">
-                    {{i18n "user.invited.removed_all"}}
-                  </span>
-                {{else}}
-                  <DButton
-                    @icon="xmark"
-                    @action={{@controller.destroyAllExpired}}
-                    @label="user.invited.remove_all"
-                  />
-                {{/if}}
+                <DButton
+                  @icon="xmark"
+                  @action={{@controller.destroyAllExpired}}
+                  @label="user.invited.remove_all"
+                />
               {{/if}}
 
               {{#if @controller.invitePending}}

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -420,9 +420,10 @@ class InvitesController < ApplicationController
 
   def destroy_all_expired
     guardian.ensure_can_destroy_all_invites!(current_user)
+    user = fetch_user_from_params
 
     Invite
-      .where(invited_by: current_user)
+      .where(invited_by: user)
       .where("expires_at < ?", Time.zone.now)
       .find_each { |invite| invite.trash!(current_user) }
 

--- a/spec/system/page_objects/pages/user_invited_expired.rb
+++ b/spec/system/page_objects/pages/user_invited_expired.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class UserInvitedExpired < PageObjects::Pages::Base
+      def visit(user)
+        url = "/u/#{user.username_lower}/invited/expired"
+        page.visit(url)
+        has_css?(".user-content.--loaded")
+      end
+
+      def wait_till_loaded
+        has_css?(".user-content.--loaded")
+      end
+
+      def bulk_remove_expired_button
+        find(".user-content .bulk-remove-expired")
+      end
+
+      def invites_list
+        all(".user-content .user-invite-list tbody tr").map do |row|
+          UserInvitedPending::Invite.new(row)
+        end
+      end
+
+      def empty?
+        has_css?(".empty-state__container")
+      end
+
+      def latest_invite
+        UserInvitedPending::Invite.new(
+          find(".user-content .user-invite-list tbody tr:first-of-type"),
+        )
+      end
+    end
+  end
+end

--- a/spec/system/user_page/user_invites_spec.rb
+++ b/spec/system/user_page/user_invites_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "User invites", type: :system do
+  fab!(:admin)
+  fab!(:user)
+  fab!(:invites_pending) { [1, 2, 3, 4].map { Fabricate(:invite, invited_by: user) } }
+  fab!(:invites_expired) do
+    [1, 2, 3].map { Fabricate(:invite, invited_by: user, expires_at: 2.days.ago) }
+  end
+
+  before do
+    SiteSetting.invite_expiry_days = 1
+    sign_in(admin)
+  end
+
+  describe "expired invites" do
+    let(:user_invite_expired_page) { PageObjects::Pages::UserInvitedExpired.new }
+    it "correctly shows expired invites" do
+      user_invite_expired_page.visit(user)
+      expect(user_invite_expired_page.invites_list.size).to eq(invites_expired.size)
+    end
+
+    it "can remove all expired invites" do
+      user_invite_expired_page.visit(user)
+      user_invite_expired_page.bulk_remove_expired_button.click
+      user_invite_expired_page.find(".btn-danger").click
+      user_invite_expired_page.wait_till_loaded
+
+      expect(user_invite_expired_page).to be_empty
+      invites_expired.each { |invite| expect(invite.reload.deleted_at).to be_present }
+    end
+  end
+end


### PR DESCRIPTION
An existing codepath to bulk delete invites exists, but does not show up. This commit fixes it and also fixes the old code's bug.

Specifically,
- `destroy_all_expired` endpoint only acts on the `current_user` which is absolutely counter-intuitive, when a person visits another person’s profile and is able to see the button, clicking it would delete their own invites and not those of the profile they are visiting.
- In `UserInvitedShowController` the removedAll state is never set to the original state, which results in the link being displayed in the list when the new link expires, but the batch deletion cannot be displayed unless the page is refreshed. It is replaced by a toast.

## Screenshots

<img width="872" height="667" alt="image" src="https://github.com/user-attachments/assets/75bf34ba-8940-4350-b30e-a9db3c27d9c7" />
<img width="854" height="992" alt="image" src="https://github.com/user-attachments/assets/151b3d2d-e35b-4aad-9c3a-2b4a4e20d65f" />
