### PR TITLE
FIX: Broken admin user profile bounce score link

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -59,7 +59,7 @@ export default class AdminUser extends User {
 
   @discourseComputed
   bounceLink() {
-    return getURL("/admin/email/bounced");
+    return getURL("/admin/email-logs/bounced");
   }
 
   resetBounceScore() {


### PR DESCRIPTION
### What is the problem?

When we introduced a dedicated admin page for e-mail logs under a new route, this link remained un-updated.