### PR TITLE
DEV: Add tests for the ReviewableFlagReason component.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/flag-reason.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/flag-reason.gjs
@@ -9,19 +9,41 @@ const SCORE_TYPE_TO_CSS_CLASS_MAP = {
   spam: "spam",
 };
 
+/**
+ * Displays a reason for a reviewable flag in the review process.
+ * Renders the flag type, title, and the number of times this flag has been raised.
+ *
+ * @component ReviewableFlagReason
+ *
+ * @template
+ * ```gjs
+ * <ReviewableFlagReason @score={{this.score}} />
+ * ```
+ *
+ * @param {Object} score - The score object containing flag information
+ * @param {String} score.type - The type of flag (illegal, inappropriate, needs_approval, off_topic, spam)
+ * @param {String} score.title - The display title for the flag reason
+ * @param {Number} [score.count] - The number of times this flag has been raised
+ */
 export default class ReviewableFlagReason extends Component {
+  /**
+   * Determines the CSS class to apply based on the score type.
+   * Maps known flag types to their corresponding CSS classes, defaults to "other" for unknown types.
+   *
+   * @returns {String} The CSS class modifier (e.g., "spam", "illegal", "other")
+   */
   get scoreCSSClass() {
-    return SCORE_TYPE_TO_CSS_CLASS_MAP[this.args.type] || "other";
+    return SCORE_TYPE_TO_CSS_CLASS_MAP[this.args.score.type] || "other";
   }
 
   <template>
     <span class="review-item__flag-reason --{{this.scoreCSSClass}}">
-      {{#if (gt @count 0)}}
+      {{#if (gt @score.count 0)}}
         <span class="review-item__flag-count --{{this.scoreCSSClass}}">
-          {{@count}}
+          {{@score.count}}
         </span>
       {{/if}}
-      {{@title}}
+      {{@score.title}}
     </span>
   </template>
 }

--- a/app/assets/javascripts/discourse/app/components/reviewable-refresh/item.gjs
+++ b/app/assets/javascripts/discourse/app/components/reviewable-refresh/item.gjs
@@ -593,11 +593,7 @@ export default class ReviewableItem extends Component {
 
                 <div class="review-item__flag-badges">
                   {{#each this.scoreSummary as |score|}}
-                    <ReviewableFlagReason
-                      @type={{score.type}}
-                      @count={{score.count}}
-                      @title={{score.title}}
-                    />
+                    <ReviewableFlagReason @score={{score}} />
                   {{/each}}
                 </div>
               </div>

--- a/app/assets/javascripts/discourse/tests/integration/components/reviewable-refresh/flag-reason-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/reviewable-refresh/flag-reason-test.gjs
@@ -1,0 +1,137 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import ReviewableFlagReason from "discourse/components/reviewable-refresh/flag-reason";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module(
+  "Integration | Component | reviewable-refresh | flag-reason",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("renders with basic arguments", async function (assert) {
+      const score = { type: "spam", title: "This is spam", count: 3 };
+
+      await render(
+        <template><ReviewableFlagReason @score={{score}} /></template>
+      );
+
+      assert
+        .dom(".review-item__flag-reason")
+        .exists("renders the flag reason container");
+      assert
+        .dom(".review-item__flag-reason")
+        .hasClass("--spam", "applies correct CSS class for spam type");
+      assert
+        .dom(".review-item__flag-reason")
+        .containsText("This is spam", "displays the title");
+      assert
+        .dom(".review-item__flag-count")
+        .exists("renders the flag count element");
+      assert
+        .dom(".review-item__flag-count")
+        .containsText("3", "displays the count value");
+    });
+
+    test("renders count when count is greater than 0", async function (assert) {
+      const score = {
+        type: "inappropriate",
+        title: "Inappropriate content",
+        count: 5,
+      };
+
+      await render(
+        <template><ReviewableFlagReason @score={{score}} /></template>
+      );
+
+      assert
+        .dom(".review-item__flag-count")
+        .exists("renders the flag count element");
+      assert
+        .dom(".review-item__flag-count")
+        .hasClass("--inappropriate", "applies correct CSS class to count");
+      assert
+        .dom(".review-item__flag-count")
+        .containsText("5", "displays the count value");
+    });
+
+    test("does not render count when invalid", async function (assert) {
+      const countScenarios = [
+        { count: 0, title: "Zero count", description: "count is 0" },
+        {
+          count: undefined,
+          title: "Undefined count",
+          description: "count is not provided",
+        },
+        {
+          count: -1,
+          title: "Negative count",
+          description: "count is negative",
+        },
+      ];
+
+      for (const { count, title, description } of countScenarios) {
+        const score = { type: "spam", title, count };
+
+        await render(
+          <template><ReviewableFlagReason @score={{score}} /></template>
+        );
+
+        assert
+          .dom(".review-item__flag-count")
+          .doesNotExist(`does not render count element when ${description}`);
+        assert
+          .dom(".review-item__flag-reason")
+          .containsText(title, `still displays the title when ${description}`);
+      }
+    });
+
+    test("applies correct CSS class for each flag type", async function (assert) {
+      const flagTypes = [
+        { type: "illegal", expectedClass: "--illegal" },
+        { type: "inappropriate", expectedClass: "--inappropriate" },
+        { type: "needs_approval", expectedClass: "--needs-approval" },
+        { type: "off_topic", expectedClass: "--off-topic" },
+        { type: "spam", expectedClass: "--spam" },
+        { type: "unknown_type", expectedClass: "--other" },
+        { type: undefined, expectedClass: "--other" },
+      ];
+
+      for (const { type, expectedClass } of flagTypes) {
+        const typeDescription = type || "undefined";
+        const score = { type, title: "Test content", count: 1 };
+
+        await render(
+          <template><ReviewableFlagReason @score={{score}} /></template>
+        );
+
+        assert
+          .dom(".review-item__flag-reason")
+          .hasClass(
+            expectedClass,
+            `applies ${expectedClass} CSS class for ${typeDescription} type`
+          );
+        assert
+          .dom(".review-item__flag-count")
+          .hasClass(
+            expectedClass,
+            `applies ${expectedClass} CSS class to count for ${typeDescription} type`
+          );
+      }
+    });
+
+    test("renders title even when empty string", async function (assert) {
+      const score = { type: "spam", title: "", count: 1 };
+
+      await render(
+        <template><ReviewableFlagReason @score={{score}} /></template>
+      );
+
+      assert
+        .dom(".review-item__flag-reason")
+        .exists("renders the flag reason container");
+      assert
+        .dom(".review-item__flag-reason")
+        .hasText("1", "only shows the count when title is empty");
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/reviewable-refresh/flag-reason-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/reviewable-refresh/flag-reason-test.gjs
@@ -32,28 +32,6 @@ module(
         .containsText("3", "displays the count value");
     });
 
-    test("renders count when count is greater than 0", async function (assert) {
-      const score = {
-        type: "inappropriate",
-        title: "Inappropriate content",
-        count: 5,
-      };
-
-      await render(
-        <template><ReviewableFlagReason @score={{score}} /></template>
-      );
-
-      assert
-        .dom(".review-item__flag-count")
-        .exists("renders the flag count element");
-      assert
-        .dom(".review-item__flag-count")
-        .hasClass("--inappropriate", "applies correct CSS class to count");
-      assert
-        .dom(".review-item__flag-count")
-        .containsText("5", "displays the count value");
-    });
-
     test("does not render count when invalid", async function (assert) {
       const countScenarios = [
         { count: 0, title: "Zero count", description: "count is 0" },


### PR DESCRIPTION
## ✨ What's This?

This is a follow-up to #32506.

In this change:
- Add JSDocs for the component.
- Add integration tests for the component.
- Standardise on passing a single `@score` parameter to the component, rather than splitting out the parameters.

## 👑 Reviewing

- Read the JSDocs. Do they make sense? Convey the reason for this component as well as its usage?
- Review the tests. Do they cover everything? Do they cover too much?