### PR TITLE
FIX: Don't overwrite translated titles when updating badge

### DIFF
--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -214,10 +214,10 @@ class Admin::BadgesController < Admin::AdminController
       badge.save!
     end
 
-    if opts[:new].blank?
+    if opts[:new].blank? && badge.name_previously_changed?
       Jobs.enqueue(
         :bulk_user_title_update,
-        new_title: badge.name,
+        new_title: badge.display_name,
         granted_badge_id: badge.id,
         action: Jobs::BulkUserTitleUpdate::UPDATE_ACTION,
       )


### PR DESCRIPTION
### What is the issue?

When using a non-English default locale and editing a badge, the titles for all badge holders using it is reset to the English name.

### Why is this happening?

1. We don't check if the badge name was actually changed before firing the bulk title update job.
2. We fire the job with `Badge#name` which is the English name, instead of `Badge#display_name` which is the localized name.