### PR TITLE
UX: show chat in plugin list

### DIFF
--- a/plugins/chat/assets/stylesheets/common/core-extensions.scss
+++ b/plugins/chat/assets/stylesheets/common/core-extensions.scss
@@ -5,12 +5,6 @@
   }
 }
 
-.admin-plugins {
-  [data-plugin-name="chat"] {
-    display: none;
-  }
-}
-
 .user-summary-page .details .controls ul,
 .user-main .details .controls ul {
   flex-direction: column;


### PR DESCRIPTION
follow-up to 2d111e2a9a0a8dcc87691c7a4725597af8bc9a3f, we're showing all plugins now but chat was hidden via CSS