### PR TITLE
DEV: remove sso_destination_url and use destination_url cookie instead

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -150,12 +150,7 @@ export default class LoginPageController extends Controller {
 
         if (authResult && !authResult.error) {
           const destinationUrl = cookie("destination_url");
-          const ssoDestinationUrl = cookie("sso_destination_url");
-
-          if (ssoDestinationUrl) {
-            removeCookie("sso_destination_url");
-            window.location.assign(ssoDestinationUrl);
-          } else if (destinationUrl) {
+          if (destinationUrl) {
             removeCookie("destination_url");
             window.location.assign(destinationUrl);
           } else if (this.referrerTopicUrl) {
@@ -322,20 +317,12 @@ export default class LoginPageController extends Controller {
           hiddenLoginForm.querySelector(`input[name=${key}]`).value = value;
         };
 
-        const destinationUrl = cookie("destination_url");
-        const ssoDestinationUrl = cookie("sso_destination_url");
-
         applyHiddenFormInputValue(this.loginName, "username");
         applyHiddenFormInputValue(this.loginPassword, "password");
 
-        if (ssoDestinationUrl) {
-          removeCookie("sso_destination_url");
-          window.location.assign(ssoDestinationUrl);
-          return;
-        } else if (destinationUrl) {
-          // redirect client to the original URL
+        const destinationUrl = cookie("destination_url");
+        if (destinationUrl) {
           removeCookie("destination_url");
-
           applyHiddenFormInputValue(destinationUrl, "redirect");
         } else if (this.referrerTopicUrl) {
           applyHiddenFormInputValue(this.referrerTopicUrl, "redirect");

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -73,16 +73,14 @@ class SessionController < ApplicationController
       end
 
       if request.xhr?
-        # for the login modal
-        cookies[:sso_destination_url] = data[:sso_redirect_url]
+        cookies[:destination_url] = data[:sso_redirect_url]
         render json: success_json.merge(redirect_url: data[:sso_redirect_url])
       else
         redirect_to data[:sso_redirect_url], allow_other_host: true
       end
     elsif result.no_second_factors_enabled?
       if request.xhr?
-        # for the login modal
-        cookies[:sso_destination_url] = result.data[:sso_redirect_url]
+        cookies[:destination_url] = result.data[:sso_redirect_url]
       else
         redirect_to result.data[:sso_redirect_url], allow_other_host: true
       end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1484,7 +1484,7 @@ RSpec.describe SessionController do
              xhr: true,
              headers: headers
 
-        location = response.cookies["sso_destination_url"]
+        location = response.cookies["destination_url"]
         # javascript code will handle redirection of user to return_sso_url
         expect(location).to match(%r{^http://somewhere.over.rainbow/sso})
 
@@ -1809,7 +1809,7 @@ RSpec.describe SessionController do
                headers: headers
           expect(response.status).to eq(200)
           # the frontend will take care of actually redirecting the user
-          redirect_url = response.cookies["sso_destination_url"]
+          redirect_url = response.cookies["destination_url"]
           expect(redirect_url).to start_with("http://somewhere.over.rainbow/sso?sso=")
           sso = DiscourseConnectProvider.parse(URI(redirect_url).query)
           expect(sso.confirmed_2fa).to eq(true)
@@ -1831,7 +1831,7 @@ RSpec.describe SessionController do
                },
                xhr: true,
                headers: headers
-          redirect_url = response.cookies["sso_destination_url"]
+          redirect_url = response.cookies["destination_url"]
           expect(redirect_url).to start_with("http://somewhere.over.rainbow/sso?sso=")
           sso = DiscourseConnectProvider.parse(URI(redirect_url).query)
           expect(sso.confirmed_2fa).to eq(nil)


### PR DESCRIPTION
Looks like this cookie was introduced in c28843e87b about 10 years ago but I couldn't find any reasons why it's any different than the already existing and well-tested destination_url cookie.

This commit replaces the use of the 'sso_destination_url' cookie with the generic 'destination_url' cookie, mainly in order to reduce code complexity.

This was extracted from #33072