### PR TITLE
DEV: Ensure the collapsed content of quoted posts is decorated

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
@@ -151,6 +151,10 @@ export default class PostCookedHtml extends Component {
     );
   }
 
+  get className() {
+    return this.args.className ?? "cooked";
+  }
+
   get cooked() {
     if (this.isIgnored) {
       return i18n("post.ignored");
@@ -189,7 +193,7 @@ export default class PostCookedHtml extends Component {
 
   <template>
     <DecoratedHtml
-      @className="cooked"
+      @className={{this.className}}
       @decorate={{this.decorateBeforeAdopt}}
       @decorateAfterAdopt={{this.decorateAfterAdopt}}
       @decorateArgs={{lazyHash

--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -250,6 +250,7 @@ export default class PostQuotedContent extends Component {
               <:content as |expandedPost|>
                 <div class="expanded-quote" data-post-id={{expandedPost.id}}>
                   <PostCookedHtml
+                    @className="post__contents-cooked-quote"
                     @post={{expandedPost}}
                     @decoratorState={{@decoratorState}}
                     @extraDecorators={{this.extraDecorators}}
@@ -277,6 +278,7 @@ export default class PostQuotedContent extends Component {
             </AsyncContent>
           {{~else~}}
             <PostCookedHtml
+              @className="post__contents-cooked-quote"
               @post={{@post}}
               @cooked={{@collapsedContent}}
               @decoratorState={{@decoratorState}}

--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -173,7 +173,7 @@ export default class PostQuotedContent extends Component {
     >
       {{#if @wrapperElement}}
         {{! `this.OptionalWrapperComponent` can be empty to render only the children while decorating cooked content.
-        we need to handle the attributtes below in the existing wrapper received as @wrapperElement in this case }}
+      we need to handle the attributtes below in the existing wrapper received as @wrapperElement in this case }}
         {{elementClass
           (if this.isQuotedPostIgnored "ignored-user")
           target=@wrapperElement
@@ -254,6 +254,7 @@ export default class PostQuotedContent extends Component {
                     @decoratorState={{@decoratorState}}
                     @extraDecorators={{this.extraDecorators}}
                     @highlightTerm={{@highlightTerm}}
+                    @selectionBarrier={{false}}
                     @streamElement={{@streamElement}}
                   />
                 </div>
@@ -275,7 +276,15 @@ export default class PostQuotedContent extends Component {
               </:error>
             </AsyncContent>
           {{~else~}}
-            {{~@collapsedContent~}}
+            <PostCookedHtml
+              @post={{@post}}
+              @cooked={{@collapsedContent}}
+              @decoratorState={{@decoratorState}}
+              @extraDecorators={{this.extraDecorators}}
+              @highlightTerm={{@highlightTerm}}
+              @selectionBarrier={{false}}
+              @streamElement={{@streamElement}}
+            />
           {{~/if~}}
         {{~/unless~}}
       </blockquote>

--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -173,7 +173,7 @@ export default class PostQuotedContent extends Component {
     >
       {{#if @wrapperElement}}
         {{! `this.OptionalWrapperComponent` can be empty to render only the children while decorating cooked content.
-      we need to handle the attributtes below in the existing wrapper received as @wrapperElement in this case }}
+        we need to handle the attributtes below in the existing wrapper received as @wrapperElement in this case }}
         {{elementClass
           (if this.isQuotedPostIgnored "ignored-user")
           target=@wrapperElement

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -12,516 +12,584 @@ import {
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
-acceptance("Composer Actions", function (needs) {
-  needs.user({
-    id: 5,
-    username: "kris",
-    whisperer: true,
-  });
-  needs.settings({
-    prioritize_username_in_ux: true,
-    display_name_on_posts: false,
-  });
-  needs.site({ can_tag_topics: true });
-  needs.pretender((server, helper) => {
-    server.put("/u/kris.json", () => helper.response({ user: {} }));
-    const cardResponse = cloneJSON(userFixtures["/u/shade/card.json"]);
-    server.get("/u/shade/card.json", () => helper.response(cardResponse));
-  });
+["enabled", "disabled"].forEach((postStreamMode) => {
+  acceptance(
+    `Composer Actions (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user({
+        id: 5,
+        username: "kris",
+        whisperer: true,
+      });
+      needs.settings({
+        prioritize_username_in_ux: true,
+        display_name_on_posts: false,
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({ can_tag_topics: true });
+      needs.pretender((server, helper) => {
+        server.put("/u/kris.json", () => helper.response({ user: {} }));
+        const cardResponse = cloneJSON(userFixtures["/u/shade/card.json"]);
+        server.get("/u/shade/card.json", () => helper.response(cardResponse));
+      });
 
-  test("replying to post", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await composerActions.expand();
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await composerActions.expand();
 
-    assert.strictEqual(
-      composerActions.rowByIndex(0).value(),
-      "reply_as_new_topic"
-    );
-    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_topic");
-    assert.strictEqual(composerActions.rowByIndex(2).value(), "toggle_whisper");
-    assert.strictEqual(
-      composerActions.rowByIndex(3).value(),
-      "toggle_topic_bump"
-    );
-    assert.strictEqual(composerActions.rowByIndex(4).value(), null);
-  });
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "reply_as_new_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(1).value(),
+          "reply_to_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(2).value(),
+          "toggle_whisper"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(3).value(),
+          "toggle_topic_bump"
+        );
+        assert.strictEqual(composerActions.rowByIndex(4).value(), null);
+      });
 
-  test("replying to post - reply_to_topic", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post - reply_to_topic", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await fillIn(
-      ".d-editor-input",
-      "test replying to topic when initially replied to post"
-    );
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await fillIn(
+          ".d-editor-input",
+          "test replying to topic when initially replied to post"
+        );
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_to_topic");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_to_topic");
 
-    assert
-      .dom(".action-title .topic-link")
-      .hasText("Internationalization / localization");
-    assert
-      .dom(".action-title .topic-link")
-      .hasAttribute("href", "/t/internationalization-localization/280");
-    assert
-      .dom(".d-editor-input")
-      .hasValue("test replying to topic when initially replied to post");
-  });
+        assert
+          .dom(".action-title .topic-link")
+          .hasText("Internationalization / localization");
+        assert
+          .dom(".action-title .topic-link")
+          .hasAttribute("href", "/t/internationalization-localization/280");
+        assert
+          .dom(".d-editor-input")
+          .hasValue("test replying to topic when initially replied to post");
+      });
 
-  test("replying to post - toggle_whisper for whisperers", async function (assert) {
-    updateCurrentUser({ admin: false, moderator: false });
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post - toggle_whisper for whisperers", async function (assert) {
+        updateCurrentUser({ admin: false, moderator: false });
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await fillIn(
-      ".d-editor-input",
-      "test replying as whisper to topic when initially not a whisper"
-    );
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await fillIn(
+          ".d-editor-input",
+          "test replying as whisper to topic when initially not a whisper"
+        );
 
-    assert
-      .dom(".composer-actions svg.d-icon-far-eye-slash")
-      .doesNotExist("whisper icon is not visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .exists("reply icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-far-eye-slash")
+          .doesNotExist("whisper icon is not visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .exists("reply icon is visible");
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("toggle_whisper");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("toggle_whisper");
 
-    assert
-      .dom(".composer-actions svg.d-icon-far-eye-slash")
-      .exists("whisper icon is visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .doesNotExist("reply icon is not visible");
-  });
+        assert
+          .dom(".composer-actions svg.d-icon-far-eye-slash")
+          .exists("whisper icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .doesNotExist("reply icon is not visible");
+      });
 
-  test("replying to post - reply_as_new_topic", async function (assert) {
-    sinon.stub(Draft, "get").resolves({ draft: "", draft_sequence: 0 });
+      test("replying to post - reply_as_new_topic", async function (assert) {
+        sinon.stub(Draft, "get").resolves({ draft: "", draft_sequence: 0 });
 
-    const composerActions = selectKit(".composer-actions");
-    const categoryChooser = selectKit(".title-wrapper .category-chooser");
-    const categoryChooserReplyArea = selectKit(".reply-area .category-chooser");
-    const quote = "test replying as new topic when initially replied to post";
+        const composerActions = selectKit(".composer-actions");
+        const categoryChooser = selectKit(".title-wrapper .category-chooser");
+        const categoryChooserReplyArea = selectKit(
+          ".reply-area .category-chooser"
+        );
+        const quote =
+          "test replying as new topic when initially replied to post";
 
-    await visit("/t/internationalization-localization/280");
+        await visit("/t/internationalization-localization/280");
 
-    await click("#topic-title .d-icon-pencil");
-    await categoryChooser.expand();
-    await categoryChooser.selectRowByValue(4);
-    await click("#topic-title .submit-edit");
+        await click("#topic-title .d-icon-pencil");
+        await categoryChooser.expand();
+        await categoryChooser.selectRowByValue(4);
+        await click("#topic-title .submit-edit");
 
-    await click("article#post_3 button.reply");
-    await fillIn(".d-editor-input", quote);
+        await click("article#post_3 button.reply");
+        await fillIn(".d-editor-input", quote);
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_new_topic");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_as_new_topic");
 
-    assert.strictEqual(categoryChooserReplyArea.header().name(), "faq");
-    assert.dom(".action-title").hasText(i18n("topic.create_long"));
-    assert.dom(".d-editor-input").includesValue(quote);
-  });
+        assert.strictEqual(categoryChooserReplyArea.header().name(), "faq");
+        assert.dom(".action-title").hasText(i18n("topic.create_long"));
+        assert.dom(".d-editor-input").includesValue(quote);
+      });
 
-  test("reply_as_new_topic without a new_topic draft", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    await click(".create.reply");
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_new_topic");
-    assert.dom(".dialog-body").doesNotExist();
-  });
+      test("reply_as_new_topic without a new_topic draft", async function (assert) {
+        await visit("/t/internationalization-localization/280");
+        await click(".create.reply");
+        const composerActions = selectKit(".composer-actions");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_as_new_topic");
+        assert.dom(".dialog-body").doesNotExist();
+      });
 
-  test("reply_as_new_topic without a permission to create topic", async function (assert) {
-    updateCurrentUser({ can_create_topic: false });
-    await visit("/t/internationalization-localization/280");
-    await click(".create.reply");
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    assert
-      .dom(".composer-actions svg.d-icon-plus")
-      .doesNotExist("reply as new topic icon is not visible");
-  });
+      test("reply_as_new_topic without a permission to create topic", async function (assert) {
+        updateCurrentUser({ can_create_topic: false });
+        await visit("/t/internationalization-localization/280");
+        await click(".create.reply");
+        const composerActions = selectKit(".composer-actions");
+        await composerActions.expand();
+        assert
+          .dom(".composer-actions svg.d-icon-plus")
+          .doesNotExist("reply as new topic icon is not visible");
+      });
 
-  test("reply_as_new_group_message", async function (assert) {
-    await visit("/t/lorem-ipsum-dolor-sit-amet/130");
-    await click(".create.reply");
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_new_group_message");
+      test("reply_as_new_group_message", async function (assert) {
+        await visit("/t/lorem-ipsum-dolor-sit-amet/130");
+        await click(".create.reply");
+        const composerActions = selectKit(".composer-actions");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_as_new_group_message");
 
-    const privateMessageUsers = selectKit("#private-message-users");
-    assert.deepEqual(privateMessageUsers.header().value(), "foo,foo_group");
-  });
+        const privateMessageUsers = selectKit("#private-message-users");
+        assert.deepEqual(privateMessageUsers.header().value(), "foo,foo_group");
+      });
 
-  test("interactions", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
-    const quote = "Life is like riding a bicycle.";
+      test("interactions", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
+        const quote = "Life is like riding a bicycle.";
 
-    await visit("/t/short-topic-with-two-posts/54077");
-    await click("article#post_2 button.reply");
-    await fillIn(".d-editor-input", quote);
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_to_topic");
+        await visit("/t/short-topic-with-two-posts/54077");
+        await click("article#post_2 button.reply");
+        await fillIn(".d-editor-input", quote);
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_to_topic");
 
-    assert.dom(".action-title").hasText("Short topic with two posts");
-    assert.dom(".d-editor-input").hasValue(quote);
+        assert.dom(".action-title").hasText("Short topic with two posts");
+        assert.dom(".d-editor-input").hasValue(quote);
 
-    await composerActions.expand();
+        await composerActions.expand();
 
-    assert.strictEqual(
-      composerActions.rowByIndex(0).value(),
-      "reply_as_new_topic"
-    );
-    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_post");
-    assert.strictEqual(composerActions.rowByIndex(2).value(), "toggle_whisper");
-    assert.strictEqual(
-      composerActions.rowByIndex(3).value(),
-      "toggle_topic_bump"
-    );
-    assert.strictEqual(composerActions.rows().length, 4);
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "reply_as_new_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(1).value(),
+          "reply_to_post"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(2).value(),
+          "toggle_whisper"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(3).value(),
+          "toggle_topic_bump"
+        );
+        assert.strictEqual(composerActions.rows().length, 4);
 
-    await composerActions.selectRowByValue("reply_to_post");
-    await composerActions.expand();
+        await composerActions.selectRowByValue("reply_to_post");
+        await composerActions.expand();
 
-    assert.dom(".action-title img.avatar").exists();
-    assert.dom(".action-title .user-link").hasText("tms");
-    assert.dom(".d-editor-input").hasValue(quote);
-    assert.strictEqual(
-      composerActions.rowByIndex(0).value(),
-      "reply_as_new_topic"
-    );
-    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_topic");
-    assert.strictEqual(composerActions.rowByIndex(2).value(), "toggle_whisper");
-    assert.strictEqual(
-      composerActions.rowByIndex(3).value(),
-      "toggle_topic_bump"
-    );
-    assert.strictEqual(composerActions.rows().length, 4);
+        assert.dom(".action-title img.avatar").exists();
+        assert.dom(".action-title .user-link").hasText("tms");
+        assert.dom(".d-editor-input").hasValue(quote);
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "reply_as_new_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(1).value(),
+          "reply_to_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(2).value(),
+          "toggle_whisper"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(3).value(),
+          "toggle_topic_bump"
+        );
+        assert.strictEqual(composerActions.rows().length, 4);
 
-    await composerActions.selectRowByValue("reply_as_new_topic");
-    await composerActions.expand();
+        await composerActions.selectRowByValue("reply_as_new_topic");
+        await composerActions.expand();
 
-    assert.dom(".action-title").hasText(i18n("topic.create_long"));
-    assert.dom(".d-editor-input").includesValue(quote);
-    assert.strictEqual(composerActions.rowByIndex(0).value(), "reply_to_post");
-    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_topic");
-    assert.strictEqual(
-      composerActions.rowByIndex(2).value(),
-      "toggle_unlisted"
-    );
-    assert.strictEqual(composerActions.rowByIndex(3).value(), "shared_draft");
-    assert.strictEqual(composerActions.rows().length, 4);
-  });
+        assert.dom(".action-title").hasText(i18n("topic.create_long"));
+        assert.dom(".d-editor-input").includesValue(quote);
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "reply_to_post"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(1).value(),
+          "reply_to_topic"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(2).value(),
+          "toggle_unlisted"
+        );
+        assert.strictEqual(
+          composerActions.rowByIndex(3).value(),
+          "shared_draft"
+        );
+        assert.strictEqual(composerActions.rows().length, 4);
+      });
 
-  test("interactions - private message", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("interactions - private message", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/internationalization-localization/280");
-    await click('#post_4 a[data-user-card="shade"]');
-    await click(".usercard-controls .compose-pm .btn-primary");
-    await composerActions.expand();
+        await visit("/t/internationalization-localization/280");
+        await click('#post_4 a[data-user-card="shade"]');
+        await click(".usercard-controls .compose-pm .btn-primary");
+        await composerActions.expand();
 
-    assert.dom(".action-title").hasText(i18n("topic.private_message"));
-    assert.strictEqual(composerActions.rowByIndex(0).value(), "create_topic");
-    assert.strictEqual(composerActions.rows().length, 1);
-  });
+        assert.dom(".action-title").hasText(i18n("topic.private_message"));
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "create_topic"
+        );
+        assert.strictEqual(composerActions.rows().length, 1);
+      });
 
-  test("replying to post - toggle_topic_bump", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post - toggle_topic_bump", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/short-topic-with-two-posts/54077");
-    await click("article#post_2 button.reply");
+        await visit("/t/short-topic-with-two-posts/54077");
+        await click("article#post_2 button.reply");
 
-    assert
-      .dom(".composer-actions svg.d-icon-anchor")
-      .doesNotExist("no-bump icon is not visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .exists("reply icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-anchor")
+          .doesNotExist("no-bump icon is not visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .exists("reply icon is visible");
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("toggle_topic_bump");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("toggle_topic_bump");
 
-    assert
-      .dom(".composer-actions svg.d-icon-anchor")
-      .exists("no-bump icon is visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .doesNotExist("reply icon is not visible");
+        assert
+          .dom(".composer-actions svg.d-icon-anchor")
+          .exists("no-bump icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .doesNotExist("reply icon is not visible");
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("toggle_topic_bump");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("toggle_topic_bump");
 
-    assert
-      .dom(".composer-actions svg.d-icon-anchor")
-      .doesNotExist("no-bump icon is not visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .exists("reply icon is visible");
-  });
+        assert
+          .dom(".composer-actions svg.d-icon-anchor")
+          .doesNotExist("no-bump icon is not visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .exists("reply icon is visible");
+      });
 
-  test("replying to post - whisper and no bump", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post - whisper and no bump", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    await visit("/t/short-topic-with-two-posts/54077");
-    await click("article#post_2 button.reply");
+        await visit("/t/short-topic-with-two-posts/54077");
+        await click("article#post_2 button.reply");
 
-    assert
-      .dom(".composer-actions svg.d-icon-far-eye-slash")
-      .doesNotExist("whisper icon is not visible");
-    assert
-      .dom(".reply-details .whisper .d-icon-anchor")
-      .doesNotExist("no-bump icon is not visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .exists("reply icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-far-eye-slash")
+          .doesNotExist("whisper icon is not visible");
+        assert
+          .dom(".reply-details .whisper .d-icon-anchor")
+          .doesNotExist("no-bump icon is not visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .exists("reply icon is visible");
 
-    await composerActions.expand();
-    await composerActions.selectRowByValue("toggle_topic_bump");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("toggle_whisper");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("toggle_topic_bump");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("toggle_whisper");
 
-    assert
-      .dom(".composer-actions svg.d-icon-far-eye-slash")
-      .exists("whisper icon is visible");
-    assert
-      .dom(".reply-details .no-bump .d-icon-anchor")
-      .exists("no-bump icon is visible");
-    assert
-      .dom(".composer-actions svg.d-icon-share")
-      .doesNotExist("reply icon is not visible");
-  });
+        assert
+          .dom(".composer-actions svg.d-icon-far-eye-slash")
+          .exists("whisper icon is visible");
+        assert
+          .dom(".reply-details .no-bump .d-icon-anchor")
+          .exists("no-bump icon is visible");
+        assert
+          .dom(".composer-actions svg.d-icon-share")
+          .doesNotExist("reply icon is not visible");
+      });
 
-  test("replying to post as staff", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post as staff", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    updateCurrentUser({ admin: true });
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await composerActions.expand();
+        updateCurrentUser({ admin: true });
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await composerActions.expand();
 
-    assert.strictEqual(composerActions.rows().length, 4);
-    assert.strictEqual(
-      composerActions.rowByIndex(3).value(),
-      "toggle_topic_bump"
-    );
-  });
+        assert.strictEqual(composerActions.rows().length, 4);
+        assert.strictEqual(
+          composerActions.rowByIndex(3).value(),
+          "toggle_topic_bump"
+        );
+      });
 
-  test("replying to post as TL3 user", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("replying to post as TL3 user", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
 
-    updateCurrentUser({
-      moderator: false,
-      admin: false,
-      trust_level: 3,
-      whisperer: false,
-      groups: [{ id: 13, name: "tl3_group" }],
+        updateCurrentUser({
+          moderator: false,
+          admin: false,
+          trust_level: 3,
+          whisperer: false,
+          groups: [{ id: 13, name: "tl3_group" }],
+        });
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await composerActions.expand();
+
+        assert.strictEqual(composerActions.rows().length, 2);
+        Array.from(composerActions.rows()).forEach((row) => {
+          assert.notStrictEqual(
+            row.value,
+            "toggle_topic_bump",
+            "toggle button is not visible"
+          );
+        });
+      });
+
+      test("replying to post as TL4 user", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
+
+        updateCurrentUser({
+          moderator: false,
+          admin: false,
+          trust_level: 4,
+          whisperer: false,
+          groups: [{ id: 13, name: "tl4_group" }],
+        });
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_3 button.reply");
+        await composerActions.expand();
+
+        assert.strictEqual(composerActions.rows().length, 3);
+        assert.strictEqual(
+          composerActions.rowByIndex(2).value(),
+          "toggle_topic_bump"
+        );
+      });
+
+      test("editing post", async function (assert) {
+        const composerActions = selectKit(".composer-actions");
+
+        await visit("/t/internationalization-localization/280");
+        await click("article#post_1 button.show-more-actions");
+        await click("article#post_1 button.edit");
+        await composerActions.expand();
+
+        assert.strictEqual(composerActions.rows().length, 1);
+        assert.strictEqual(
+          composerActions.rowByIndex(0).value(),
+          "reply_to_post"
+        );
+      });
+    }
+  );
+
+  function stubDraftResponse() {
+    sinon.stub(Draft, "get").resolves({
+      draft:
+        '{"reply":"dum de dum da ba.","action":"createTopic","title":"dum da ba dum dum","categoryId":null,"archetypeId":"regular","metaData":null,"composerTime":540879,"typingTime":3400}',
+      draft_sequence: 0,
     });
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await composerActions.expand();
+  }
 
-    assert.strictEqual(composerActions.rows().length, 2);
-    Array.from(composerActions.rows()).forEach((row) => {
-      assert.notStrictEqual(
-        row.value,
-        "toggle_topic_bump",
-        "toggle button is not visible"
-      );
-    });
-  });
+  acceptance(
+    `Composer Actions With New Topic Draft (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user({ whisperer: true });
+      needs.settings({
+        glimmer_post_stream_mode: postStreamMode,
+      });
+      needs.site({
+        can_tag_topics: true,
+      });
 
-  test("replying to post as TL4 user", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+      test("shared draft", async function (assert) {
+        updateCurrentUser({ draft_count: 1 });
+        stubDraftResponse();
 
-    updateCurrentUser({
-      moderator: false,
-      admin: false,
-      trust_level: 4,
-      whisperer: false,
-      groups: [{ id: 13, name: "tl4_group" }],
-    });
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_3 button.reply");
-    await composerActions.expand();
+        await visit("/");
+        await click("button.topic-drafts-menu-trigger");
+        await click(
+          ".topic-drafts-menu-content .topic-drafts-item:first-child button"
+        );
 
-    assert.strictEqual(composerActions.rows().length, 3);
-    assert.strictEqual(
-      composerActions.rowByIndex(2).value(),
-      "toggle_topic_bump"
-    );
-  });
+        await fillIn(
+          "#reply-title",
+          "This is the new text for the title using 'quotes'"
+        );
+        await fillIn(".d-editor-input", "This is the new text for the post");
 
-  test("editing post", async function (assert) {
-    const composerActions = selectKit(".composer-actions");
+        const tags = selectKit(".mini-tag-chooser");
+        await tags.expand();
+        await tags.selectRowByValue("monkey");
 
-    await visit("/t/internationalization-localization/280");
-    await click("article#post_1 button.show-more-actions");
-    await click("article#post_1 button.edit");
-    await composerActions.expand();
+        const composerActions = selectKit(".composer-actions");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("shared_draft");
 
-    assert.strictEqual(composerActions.rows().length, 1);
-    assert.strictEqual(composerActions.rowByIndex(0).value(), "reply_to_post");
-  });
-});
+        assert.strictEqual(
+          tags.header().value(),
+          "monkey",
+          "tags are not reset"
+        );
+        assert
+          .dom("#reply-title")
+          .hasValue("This is the new text for the title using 'quotes'");
 
-function stubDraftResponse() {
-  sinon.stub(Draft, "get").resolves({
-    draft:
-      '{"reply":"dum de dum da ba.","action":"createTopic","title":"dum da ba dum dum","categoryId":null,"archetypeId":"regular","metaData":null,"composerTime":540879,"typingTime":3400}',
-    draft_sequence: 0,
-  });
-}
+        assert
+          .dom("#reply-control .btn-primary.create .d-button-label")
+          .hasText(i18n("composer.create_shared_draft"));
+        assert
+          .dom(".composer-actions svg.d-icon-far-clipboard")
+          .exists("shared draft icon is visible");
+      });
 
-acceptance("Composer Actions With New Topic Draft", function (needs) {
-  needs.user({ whisperer: true });
-  needs.site({
-    can_tag_topics: true,
-  });
+      test("reply_as_new_topic with new_topic draft", async function (assert) {
+        await visit("/t/internationalization-localization/280");
+        await click(".create.reply");
 
-  test("shared draft", async function (assert) {
-    updateCurrentUser({ draft_count: 1 });
-    stubDraftResponse();
+        stubDraftResponse();
 
-    await visit("/");
-    await click("button.topic-drafts-menu-trigger");
-    await click(
-      ".topic-drafts-menu-content .topic-drafts-item:first-child button"
-    );
+        const composerActions = selectKit(".composer-actions");
+        await composerActions.expand();
+        await composerActions.selectRowByValue("reply_as_new_topic");
 
-    await fillIn(
-      "#reply-title",
-      "This is the new text for the title using 'quotes'"
-    );
-    await fillIn(".d-editor-input", "This is the new text for the post");
+        assert
+          .dom(".dialog-body")
+          .hasText(
+            i18n("composer.composer_actions.reply_as_new_topic.confirm")
+          );
+        await click(".dialog-footer .btn-primary");
 
-    const tags = selectKit(".mini-tag-chooser");
-    await tags.expand();
-    await tags.selectRowByValue("monkey");
+        assert
+          .dom(".d-editor-input")
+          .hasValue(/^Continuing the discussion from/);
+      });
+    }
+  );
 
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("shared_draft");
+  acceptance(
+    `Prioritize Username (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        prioritize_username_in_ux: true,
+        display_name_on_posts: false,
+        glimmer_post_stream_mode: postStreamMode,
+      });
 
-    assert.strictEqual(tags.header().value(), "monkey", "tags are not reset");
-    assert
-      .dom("#reply-title")
-      .hasValue("This is the new text for the title using 'quotes'");
+      test("Reply to post use username", async function (assert) {
+        await visit("/t/short-topic-with-two-posts/54079");
+        await click("article#post_2 button.reply");
 
-    assert
-      .dom("#reply-control .btn-primary.create .d-button-label")
-      .hasText(i18n("composer.create_shared_draft"));
-    assert
-      .dom(".composer-actions svg.d-icon-far-clipboard")
-      .exists("shared draft icon is visible");
-  });
+        assert.dom(".action-title .user-link").hasText("james_john");
+      });
 
-  test("reply_as_new_topic with new_topic draft", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    await click(".create.reply");
+      test("Quotes use username", async function (assert) {
+        await visit("/t/short-topic-with-two-posts/54079");
+        await selectText("#post_2 p");
+        await click(".insert-quote");
+        assert
+          .dom(".d-editor-input")
+          .hasValue(
+            '[quote="james_john, post:2, topic:54079, full:true"]\nThis is a short topic.\n[/quote]\n\n'
+          );
+      });
+    }
+  );
 
-    stubDraftResponse();
+  acceptance(
+    `Prioritize Full Name (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        prioritize_username_in_ux: false,
+        display_name_on_posts: true,
+        glimmer_post_stream_mode: postStreamMode,
+      });
 
-    const composerActions = selectKit(".composer-actions");
-    await composerActions.expand();
-    await composerActions.selectRowByValue("reply_as_new_topic");
+      test("Reply to post use full name", async function (assert) {
+        await visit("/t/short-topic-with-two-posts/54079");
+        await click("article#post_3 button.reply");
 
-    assert
-      .dom(".dialog-body")
-      .hasText(i18n("composer.composer_actions.reply_as_new_topic.confirm"));
-    await click(".dialog-footer .btn-primary");
+        assert
+          .dom(".action-title .user-link")
+          .hasHtml("&lt;h1&gt;Tim Stone&lt;/h1&gt;");
+      });
 
-    assert.dom(".d-editor-input").hasValue(/^Continuing the discussion from/);
-  });
-});
+      test("Quotes use full name", async function (assert) {
+        await visit("/t/short-topic-with-two-posts/54079");
+        await selectText("#post_2 p");
+        await click(".insert-quote");
+        assert
+          .dom(".d-editor-input")
+          .hasValue(
+            '[quote="james, john, the third, post:2, topic:54079, full:true, username:james_john"]\nThis is a short topic.\n[/quote]\n\n'
+          );
+      });
 
-acceptance("Prioritize Username", function (needs) {
-  needs.user();
-  needs.settings({
-    prioritize_username_in_ux: true,
-    display_name_on_posts: false,
-  });
+      test("Quoting a nested quote returns the correct username", async function (assert) {
+        await visit("/t/short-topic-with-two-posts/54079");
+        await selectText("#post_4 p");
+        await click(".insert-quote");
+        assert
+          .dom(".d-editor-input")
+          .hasValue(
+            '[quote="james_john, post:2, topic:54079"]\nThis is a short topic.\n[/quote]\n\n'
+          );
+      });
+    }
+  );
 
-  test("Reply to post use username", async function (assert) {
-    await visit("/t/short-topic-with-two-posts/54079");
-    await click("article#post_2 button.reply");
+  acceptance(
+    `Prioritizing Name fall back (glimmer_post_stream_mode = ${postStreamMode})`,
+    function (needs) {
+      needs.user();
+      needs.settings({
+        prioritize_username_in_ux: false,
+        display_name_on_posts: true,
+        glimmer_post_stream_mode: postStreamMode,
+      });
 
-    assert.dom(".action-title .user-link").hasText("james_john");
-  });
-
-  test("Quotes use username", async function (assert) {
-    await visit("/t/short-topic-with-two-posts/54079");
-    await selectText("#post_2 p");
-    await click(".insert-quote");
-    assert
-      .dom(".d-editor-input")
-      .hasValue(
-        '[quote="james_john, post:2, topic:54079, full:true"]\nThis is a short topic.\n[/quote]\n\n'
-      );
-  });
-});
-
-acceptance("Prioritize Full Name", function (needs) {
-  needs.user();
-  needs.settings({
-    prioritize_username_in_ux: false,
-    display_name_on_posts: true,
-  });
-
-  test("Reply to post use full name", async function (assert) {
-    await visit("/t/short-topic-with-two-posts/54079");
-    await click("article#post_3 button.reply");
-
-    assert
-      .dom(".action-title .user-link")
-      .hasHtml("&lt;h1&gt;Tim Stone&lt;/h1&gt;");
-  });
-
-  test("Quotes use full name", async function (assert) {
-    await visit("/t/short-topic-with-two-posts/54079");
-    await selectText("#post_2 p");
-    await click(".insert-quote");
-    assert
-      .dom(".d-editor-input")
-      .hasValue(
-        '[quote="james, john, the third, post:2, topic:54079, full:true, username:james_john"]\nThis is a short topic.\n[/quote]\n\n'
-      );
-  });
-
-  test("Quoting a nested quote returns the correct username", async function (assert) {
-    await visit("/t/short-topic-with-two-posts/54079");
-    await selectText("#post_4 p");
-    await click(".insert-quote");
-    assert
-      .dom(".d-editor-input")
-      .hasValue(
-        '[quote="james_john, post:2, topic:54079"]\nThis is a short topic.\n[/quote]\n\n'
-      );
-  });
-});
-
-acceptance("Prioritizing Name fall back", function (needs) {
-  needs.user();
-  needs.settings({
-    prioritize_username_in_ux: false,
-    display_name_on_posts: true,
-  });
-
-  test("Quotes fall back to username if name is not present", async function (assert) {
-    await visit("/t/internationalization-localization/130");
-    // select a user with no name
-    await selectText("#post_1 p");
-    await click(".insert-quote");
-    assert
-      .dom(".d-editor-input")
-      .hasValue(
-        '[quote="bianca, post:1, topic:130, full:true"]\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas a varius ipsum. Nunc euismod, metus non vulputate malesuada, ligula metus pharetra tortor, vel sodales arcu lacus sed mauris. Nam semper, orci vitae fringilla placerat, dui tellus convallis felis, ultricies laoreet sapien mi et metus. Mauris facilisis, mi fermentum rhoncus feugiat, dolor est vehicula leo, id porta leo ex non enim. In a ligula vel tellus commodo scelerisque non in ex. Pellentesque semper leo quam, nec varius est viverra eget. Donec vehicula sem et massa faucibus tempus.\n[/quote]\n\n'
-      );
-  });
+      test("Quotes fall back to username if name is not present", async function (assert) {
+        await visit("/t/internationalization-localization/130");
+        // select a user with no name
+        await selectText("#post_1 p");
+        await click(".insert-quote");
+        assert
+          .dom(".d-editor-input")
+          .hasValue(
+            '[quote="bianca, post:1, topic:130, full:true"]\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas a varius ipsum. Nunc euismod, metus non vulputate malesuada, ligula metus pharetra tortor, vel sodales arcu lacus sed mauris. Nam semper, orci vitae fringilla placerat, dui tellus convallis felis, ultricies laoreet sapien mi et metus. Mauris facilisis, mi fermentum rhoncus feugiat, dolor est vehicula leo, id porta leo ex non enim. In a ligula vel tellus commodo scelerisque non in ex. Pellentesque semper leo quam, nec varius est viverra eget. Donec vehicula sem et massa faucibus tempus.\n[/quote]\n\n'
+          );
+      });
+    }
+  );
 });

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -653,6 +653,10 @@ aside.quote {
   blockquote {
     margin-top: 0;
 
+    .cooked {
+      padding: 0;
+    }
+
     .expanded-quote {
       overflow: hidden;
 
@@ -1091,12 +1095,18 @@ kbd {
 
 // we assume blockquotes have their own margins, so all blockquotes
 // will remove margins from first (top) and last (bottom) child elements
-blockquote > *:first-child {
-  margin-top: 0 !important;
+blockquote,
+blockquote .cooked {
+  > *:first-child {
+    margin-top: 0 !important;
+  }
 }
 
-blockquote > *:last-child {
-  margin-bottom: 0 !important;
+blockquote,
+blockquote .cooked {
+  > *:last-child {
+    margin-bottom: 0 !important;
+  }
 }
 
 .gap {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1092,7 +1092,7 @@ kbd {
 // we assume blockquotes have their own margins, so all blockquotes
 // will remove margins from first (top) and last (bottom) child elements
 blockquote,
-blockquote .quote-cooked {
+blockquote .post__contents-cooked-quote {
   > *:first-child {
     margin-top: 0 !important;
   }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -653,10 +653,6 @@ aside.quote {
   blockquote {
     margin-top: 0;
 
-    .cooked {
-      padding: 0;
-    }
-
     .expanded-quote {
       overflow: hidden;
 
@@ -1096,14 +1092,11 @@ kbd {
 // we assume blockquotes have their own margins, so all blockquotes
 // will remove margins from first (top) and last (bottom) child elements
 blockquote,
-blockquote .cooked {
+blockquote .quote-cooked {
   > *:first-child {
     margin-top: 0 !important;
   }
-}
 
-blockquote,
-blockquote .cooked {
   > *:last-child {
     margin-bottom: 0 !important;
   }


### PR DESCRIPTION
This PR refactors the `PostCookedHtml` and `PostQuotedContent` components to enhance how quoted posts are rendered and decorated. It introduces a new `className` prop for customizing the class of cooked HTML, and ensures collapsed quote content is consistently decorated with appropriate styles and structure.

Key changes:
- Adds a `className` argument to `PostCookedHtml`, allowing quoted content to have a distinct class for easier styling.
- Updates `PostQuotedContent` to render collapsed and expanded quoted content through `PostCookedHtml`, ensuring consistent decoration and disabling selection barriers for quoted posts.
- Refines decorator application logic in `PostCookedHtml` to conditionally apply selection barriers.
- Improves CSS by targeting quoted content within blockquotes, ensuring top and bottom margins are correctly removed from child elements.
- Updates acceptance tests to support both classic and glimmer post stream modes, verifying composer actions and quoted content behavior across modes.
