### PR TITLE
DEV: Remove now-redundant is_staff check in can_invite_to_forum

### DIFF
--- a/lib/guardian/invite_guardian.rb
+++ b/lib/guardian/invite_guardian.rb
@@ -10,9 +10,11 @@ module InviteGuardian
   end
 
   def can_invite_to_forum?(groups = nil)
-    authenticated? && (is_staff? || SiteSetting.max_invites_per_day.to_i.positive?) &&
-      (is_staff? || @user.in_any_groups?(SiteSetting.invite_allowed_groups_map)) &&
-      (is_admin? || groups.blank? || groups.all? { |g| can_edit_group?(g) })
+    return false if !authenticated?
+    return false if !@user.in_any_groups?(SiteSetting.invite_allowed_groups_map)
+    return false if !SiteSetting.max_invites_per_day.to_i.positive? && !is_staff?
+
+    groups.blank? || groups.all? { |g| can_edit_group?(g) }
   end
 
   def can_invite_to?(object, groups = nil)


### PR DESCRIPTION
### What is this change?

We check for membership in `invite_allowed_groups`, which has `admins` and `moderators` as a mandatory value, so it's redundant to check `is_staff?` as well.

I also unfurled this one long conditional into multiple guard clauses.

The refactoring is covered by existing tests in `invite_guardian_spec.rb`.