### PR TITLE
DEV: Silence `post-stream-widget-overrides` in the checklist plugin

### DIFF
--- a/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
+++ b/plugins/checklist/assets/javascripts/discourse/initializers/checklist.js
@@ -1,5 +1,6 @@
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { withSilencedDeprecations } from "discourse/lib/deprecated";
 import { getOwnerWithFallback } from "discourse/lib/get-owner";
 import { iconHTML } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -58,12 +59,16 @@ export function checklistSyntax(elem, postDecorator) {
   const boxes = [...elem.getElementsByClassName("chcklst-box")];
   addUlClasses(boxes);
 
-  // TODO (glimmer-post-stream): remove this when we remove the legacy post stream code
-  const postWidget = getOwnerWithFallback(this).lookup("service:site")
-    .useGlimmerPostStream
-    ? null
-    : postDecorator?.widget;
   const postModel = postDecorator?.getModel();
+
+  // TODO (glimmer-post-stream): remove this when we remove the legacy post stream code
+  const postWidget = withSilencedDeprecations(
+    "discourse.post-stream-widget-overrides",
+    () =>
+      getOwnerWithFallback(this).lookup("service:site").useGlimmerPostStream
+        ? null
+        : postDecorator?.widget
+  );
 
   if (!postModel?.can_edit) {
     return;


### PR DESCRIPTION
Wraps the post widget lookup in `withSilencedDeprecations` to suppress noisy `post-stream-widget-overrides` warnings when the checklist plugin accesses the legacy post stream widget.

The deprecation warning was being triggered when incompatible extensions forced the use of the legacy widget post-stream, even though the code already properly handles the Glimmer Post Stream case. This change maintains the existing functionality while eliminating unnecessary console noise.