### PR TITLE
DEV: Capture unhandled JS errors in Playwright logs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,18 @@ class PlaywrightLogger
         }
       end,
     )
+
+    page.on(
+      "pageerror",
+      ->(error) do
+        @logs << {
+          level: "error",
+          message: error.message,
+          timestamp: Time.now.to_i * 1000,
+          source: "pageerror-api",
+        }
+      end,
+    )
   end
 end
 


### PR DESCRIPTION
Before this change, even if we were failing rspec tests due to
JS errors, they were not being shown in the "JS LOGS" backed
by the playwright logger in the failure message. Sometimes the
unhandled JS errors are the _cause_ of the failure, so it
is important to see them.
