### PR TITLE
DEV: Handle null theme id

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -327,6 +327,8 @@ class Theme < ActiveRecord::Base
       .each do |theme_id|
         Discourse.cache.delete(SiteSettingExtension.theme_site_settings_cache_key(theme_id))
       end
+
+    Discourse.cache.delete(SiteSettingExtension.theme_site_settings_cache_key(nil))
   end
 
   def self.clear_default!

--- a/app/models/theme_site_setting.rb
+++ b/app/models/theme_site_setting.rb
@@ -99,6 +99,14 @@ class ThemeSiteSetting < ActiveRecord::Base
     theme_site_setting_values_map
   end
 
+  def self.generate_defaults_map
+    SiteSetting
+      .themeable_site_settings
+      .each_with_object({}) do |setting_name, map|
+        map[setting_name] = SiteSetting.defaults[setting_name]
+      end
+  end
+
   def setting_rb_value
     SiteSetting.type_supervisor.to_rb_value(self.name, self.value, self.data_type)
   end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1055,6 +1055,13 @@ RSpec.describe SiteSettingExtension do
           %Q|{"enable_welcome_banner":false,"search_experience":"search_icon"}|,
         )
       end
+
+      it "returns default JSON when the theme_id is null" do
+        SiteSetting.refresh!
+        expect(SiteSetting.theme_site_settings_json_uncached(nil)).to eq(
+          %Q|{"enable_welcome_banner":true,"search_experience":"search_icon"}|,
+        )
+      end
     end
   end
 


### PR DESCRIPTION
There are a few legit scenarios where the current
theme ID may be blank, such as safe mode. In this
case it will be better to return default site setting
values rather than to cause random/undefined behaviour
in the UI.

Also clears the theme site setting cache when the
theme ID is null, along with the other fix here this
was probably causing issues in system spec runs
