### PR TITLE
FEATURE: Reset bump date when deleting a post 

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -554,6 +554,10 @@ class Post < ActiveRecord::Base
     post_number.blank? ? topic.try(:highest_post_number) == 0 : post_number == 1
   end
 
+  def is_last_reply?
+    topic.try(:highest_post_number) == post_number && post_number != 1
+  end
+
   def is_category_description?
     topic.present? && topic.is_category_topic? && is_first_post?
   end

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -75,6 +75,8 @@ class PostDestroyer
     delete_removed_posts_after =
       @opts[:delete_removed_posts_after] || SiteSetting.delete_removed_posts_after
 
+    should_reset_bumped_at = @post.is_last_reply? && !@post.whisper?
+
     if delete_removed_posts_after < 1 || post_is_reviewable? ||
          Guardian.new(@user).can_moderate_topic?(@topic) || permanent?
       perform_delete
@@ -105,6 +107,8 @@ class PostDestroyer
         Discourse.clear_urls!
       end
     end
+
+    @topic.reset_bumped_at if should_reset_bumped_at
   end
 
   def recover


### PR DESCRIPTION
Necro-posting by spammers will bump the topic, and once you delete them, those topics will still sit in `/latest` without any benifit.

This commit implements automatic resetting of topic bump date when a post is deleted, so the topic will go to the correct place it belongs on `/latest` based on its last public post.
