### PR TITLE
DEV: Fix sidekiq requires in test env

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/api"
+
 module Jobs
   def self.queued
     Sidekiq::Stats.new.enqueued

--- a/lib/backup_restore/system_interface.rb
+++ b/lib/backup_restore/system_interface.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "sidekiq/api"
+
 module BackupRestore
   class RunningSidekiqJobsError < RuntimeError
     def initialize

--- a/lib/discourse_dev/topic.rb
+++ b/lib/discourse_dev/topic.rb
@@ -2,6 +2,7 @@
 
 require "discourse_dev/record"
 require "faker"
+require "sidekiq/api"
 
 module DiscourseDev
   class Topic < Record


### PR DESCRIPTION
When in test env, we can get errors because the "sidekiq/api" file isn’t properly loaded.