### PR TITLE
FIX: ensures we show an error when description is too long

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -5,6 +5,8 @@ module DiscoursePostEvent
     PUBLIC_GROUP = "trust_level_0"
     MIN_NAME_LENGTH = 5
     MAX_NAME_LENGTH = 255
+    MAX_DESCRIPTION_LENGTH = 1000
+
     self.table_name = "discourse_post_event_events"
     self.ignored_columns = %w[starts_at ends_at]
 
@@ -27,6 +29,7 @@ module DiscoursePostEvent
                 in: MIN_NAME_LENGTH..MAX_NAME_LENGTH,
               },
               unless: ->(event) { event.name.blank? }
+    validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
 
     validate :raw_invitees_length
     validate :ends_before_start

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -8,6 +8,18 @@ describe DiscoursePostEvent::Event do
     SiteSetting.discourse_post_event_enabled = true
   end
 
+  it do
+    is_expected.to validate_length_of(:description).is_at_most(
+      DiscoursePostEvent::Event::MAX_DESCRIPTION_LENGTH,
+    )
+  end
+
+  it do
+    is_expected.to validate_length_of(:name).is_at_least(
+      DiscoursePostEvent::Event::MIN_NAME_LENGTH,
+    ).is_at_most(DiscoursePostEvent::Event::MAX_NAME_LENGTH)
+  end
+
   describe "topic custom fields callback" do
     let(:user) { Fabricate(:user, admin: true) }
     let!(:notified_user) { Fabricate(:user) }


### PR DESCRIPTION
Sadly we can't do much better ATM, and the post will still be created. The lifecycles of a the post and the event are separated. A post can be valid while the event is invalid, resulting in a post being created but not the event. At least will now show the correct description length error instead of a 500.