### PR TITLE
FIX: default channel name to topic title

### DIFF
--- a/plugins/discourse-calendar/app/services/discourse_post_event/chat_channel_sync.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/chat_channel_sync.rb
@@ -48,7 +48,7 @@ module DiscoursePostEvent
     end
 
     def self.ensure_chat_channel!(event, guardian:)
-      name = event.name
+      name = event.name || event.post.topic.title
 
       channel = nil
       Chat::CreateCategoryChannel.call(

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
@@ -29,8 +29,7 @@ describe DiscoursePostEvent::ChatChannelSync do
   end
 
   it "defaults event name to post title" do
-    post = Fabricate(:post, user: Fabricate(:admin))
-    event = Fabricate(:event, chat_enabled: true, post: post)
+    event = Fabricate(:event, chat_enabled: true, post: admin_post)
 
     expect(event.chat_channel.name).to eq(post.topic.title)
   end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
@@ -8,7 +8,7 @@ describe DiscoursePostEvent::ChatChannelSync do
   fab!(:admin_post) { Fabricate(:post, user: admin) }
 
   it "is able to create a chat channel and sync members" do
-    event = Fabricate(:event, chat_enabled: true, post: admin_post)
+    event = Fabricate(:event, chat_enabled: true, post: admin_post, name: "Test Event")
 
     expect(event.chat_channel_id).to be_present
     expect(event.chat_channel.name).to eq(event.name)
@@ -26,5 +26,12 @@ describe DiscoursePostEvent::ChatChannelSync do
     event = Fabricate(:event, chat_enabled: true, post: post)
 
     expect(event.chat_channel_id).to be_nil
+  end
+
+  it "defaults event name to post title" do
+    post = Fabricate(:post, user: Fabricate(:admin))
+    event = Fabricate(:event, chat_enabled: true, post: post)
+
+    expect(event.chat_channel.name).to eq(post.topic.title)
   end
 end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/chat_channel_sync_spec.rb
@@ -31,6 +31,6 @@ describe DiscoursePostEvent::ChatChannelSync do
   it "defaults event name to post title" do
     event = Fabricate(:event, chat_enabled: true, post: admin_post)
 
-    expect(event.chat_channel.name).to eq(post.topic.title)
+    expect(event.chat_channel.name).to eq(admin_post.topic.title)
   end
 end


### PR DESCRIPTION
We added few weeks ago the possibility to create a channel with the post event, however if the event name was not set we could create an event with no name. This change ensures we will use the topic title in this case, as we do for the event.

Channel name max length is using the topic title max length so that shouldn't be a problem.