### PR TITLE
UX: remove old about page CSS

### DIFF
--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -6,17 +6,6 @@
   .about-page & {
     max-width: unset;
 
-    section:not(
-        .admins,
-        .moderators,
-        .category-moderators,
-        .about__admins,
-        .about__moderators,
-        .about__header
-      ) {
-      max-width: 700px;
-    }
-
     .about.category-moderators {
       .badge-category__wrapper .badge-category {
         color: var(--primary);


### PR DESCRIPTION
Fixes the group width issue reported here: https://meta.discourse.org/t/additional-groups-on-about-page-are-not-aligned-with-the-default-groups/374854

<img width="1736" height="1450" alt="image" src="https://github.com/user-attachments/assets/5d5b464a-4359-4459-855a-7e8bb9380c3a" />


Where additional groups aren't the same width. This is because we had a blanket min-width on section elements for the old about page. 

This CSS doesn't seem to be necessary after the about page redesign in https://github.com/discourse/discourse/commit/6039b513fe298521620cbb9bbec2ac9ffa751a37