### PR TITLE
FIX: adds missing router service import (explicit)

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channels.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channels.js
@@ -4,6 +4,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default class ChatChannelsRoute extends DiscourseRoute {
   @service chat;
   @service chatChannelsManager;
+  @service router;
   @service siteSettings;
 
   activate() {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-direct-messages.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-direct-messages.js
@@ -4,6 +4,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default class ChatDirectMessagesRoute extends DiscourseRoute {
   @service chat;
   @service chatChannelsManager;
+  @service router;
 
   activate() {
     this.chat.activeChannel = null;


### PR DESCRIPTION
Hotfix to explicitly import `router` service.

This is follow-up change after https://github.com/discourse/discourse/pull/33539.