### PR TITLE
FEAUTRE: Hide messages count in sidebar with feature flag

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
@@ -31,6 +31,10 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get totalCount() {
+    if (!this.currentUser?.use_experimental_sidebar_messages_count) {
+      return 0;
+    }
+
     const newUserMsgs = this._lookupCount({ type: "new", inboxFilter: "user" });
     const unreadUserMsgs = this._lookupCount({
       type: "unread",
@@ -66,7 +70,10 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get showCount() {
-    return this.currentUser?.sidebarShowCountOfNewItems;
+    return (
+      this.currentUser?.use_experimental_sidebar_messages_count &&
+      this.currentUser?.sidebarShowCountOfNewItems
+    );
   }
 
   get badgeText() {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -79,7 +79,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :use_glimmer_post_stream_mode_auto_mode,
              :can_localize_content?,
              :effective_locale,
-             :use_reviewable_ui_refresh
+             :use_reviewable_ui_refresh,
+             :use_experimental_sidebar_messages_count
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -346,6 +347,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def use_reviewable_ui_refresh
     scope.can_see_reviewable_ui_refresh?
+  end
+
+  def use_experimental_sidebar_messages_count
+    scope.user.in_any_groups?(SiteSetting.experimental_sidebar_messages_count_enabled_groups_map)
   end
 
   def include_use_reviewable_ui_refresh?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2724,6 +2724,7 @@ en:
     show_preview_for_form_templates: "Enable the preview for form templates feature"
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."
     experimental_auto_grid_images: "Automatically wraps images in [grid] tags when 3 or more images are uploaded in the composer."
+    experimental_sidebar_messages_count_enabled_groups: "Show an unread indicator or count next to the 'My messages' sidebar link, depending on the user's Navigation preferences"
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     about_page_hidden_groups: "Do not show members of specific groups on the /about page."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4089,3 +4089,10 @@ experimental:
     client: true
     type: group_list
     default: ""
+  experimental_sidebar_messages_count_enabled_groups:
+    client: true
+    type: group_list
+    list_type: compact
+    default: ""
+    allow_any: false
+    refresh: true

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -203,6 +203,11 @@ describe "Viewing sidebar", type: :system do
         end
         let(:user_private_messages_page) { PageObjects::Pages::UserPrivateMessages.new }
 
+        before do
+          SiteSetting.experimental_sidebar_messages_count_enabled_groups =
+            Group::AUTO_GROUPS[:trust_level_0]
+        end
+
         it "should show new messages indicator" do
           sign_in(admin)
           visit("/")
@@ -222,6 +227,16 @@ describe "Viewing sidebar", type: :system do
           user_private_messages_page.click_unseen_private_mesage(private_message.id)
           expect(sidebar).to have_my_messages_link_with_unread_icon
           try_until_success { expect(sidebar).to have_my_messages_link_without_unread_icon }
+        end
+
+        context "when user does not belong to experimental_sidebar_messages_count_enabled_groups" do
+          before { SiteSetting.experimental_sidebar_messages_count_enabled_groups = "" }
+
+          it "does not show new messages indicator" do
+            sign_in(admin)
+            visit("/")
+            expect(sidebar).to have_my_messages_link_without_unread_icon
+          end
         end
       end
     end


### PR DESCRIPTION
Followup 037670fe73cb208e9ed02d401d6e8ba80f0ae73a

This commit adds a experimental_sidebar_messages_count_enabled_groups
site setting feature flag to control the visibility of the messages count/
icon in the sidebar while we work out some kinks with the
functionality. By default this feature is disabled.
