### PR TITLE
FEATURE: Add site setting to allow comments to be disabled in discourse-post-voting plugin

### DIFF
--- a/plugins/discourse-post-voting/app/models/post_voting_comment.rb
+++ b/plugins/discourse-post-voting/app/models/post_voting_comment.rb
@@ -51,7 +51,9 @@ class PostVotingComment < ActiveRecord::Base
   end
 
   def ensure_can_comment
-    if !post.is_post_voting_topic?
+    if !SiteSetting.post_voting_comment_enabled
+      errors.add(:base, I18n.t("post_voting.comment.errors.disabled"))
+    elsif !post.is_post_voting_topic?
       errors.add(:base, I18n.t("post_voting.comment.errors.post_voting_not_enabled"))
     elsif post.reply_to_post_number.present?
       errors.add(:base, I18n.t("post_voting.comment.errors.not_permitted"))

--- a/plugins/discourse-post-voting/assets/javascripts/discourse/initializers/post-voting-edits.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/initializers/post-voting-edits.gjs
@@ -229,6 +229,10 @@ function customizePostMenu(api, container) {
     "post-menu__after",
     class extends Component {
       static shouldRender(args) {
+        if (!siteSettings.post_voting_comment_enabled) {
+          return false;
+        }
+
         return (
           args.post.post_voting_has_votes !== undefined &&
           !args.post.reply_to_post_number &&

--- a/plugins/discourse-post-voting/config/locales/server.en.yml
+++ b/plugins/discourse-post-voting/config/locales/server.en.yml
@@ -27,6 +27,7 @@ en:
     post_voting_comment_limit_per_post: "Number of comments allowed on each post"
     min_trust_to_flag_posts_voting_comments: "Minimum trust level to flag a post voting comment"
     flag_posts_voting_comments_allowed_groups: "Groups allowed to flag a post voting comment"
+    post_voting_comment_enabled: "Enable comments on Post in Post Voting topics"
 
     keywords:
       flag_posts_voting_comments_allowed_groups: "min_trust_to_flag_posts_voting_comments"
@@ -58,6 +59,7 @@ en:
         limit_exceeded: "Limit of %{limit} comments per post has been reached."
         perform: "Post Voting Comment flagged with score high enough to silence user."
         auto_silence_from_flags: "Automatically silenced due to flagging."
+        disabled: "Commenting on a post is not permitted."
       reviewables:
         comment_already_handled: "Thanks, but we've already reviewed this comment and determined it does not need to be flagged again."
         actions:

--- a/plugins/discourse-post-voting/config/settings.yml
+++ b/plugins/discourse-post-voting/config/settings.yml
@@ -4,6 +4,9 @@ plugins:
     default: false
   post_voting_undo_vote_action_window:
     default: 10
+  post_voting_comment_enabled:
+    client: true
+    default: true
   post_voting_comment_limit_per_post:
     default: 10
     min: 1

--- a/plugins/discourse-post-voting/spec/models/post_voting_comment_spec.rb
+++ b/plugins/discourse-post-voting/spec/models/post_voting_comment_spec.rb
@@ -11,6 +11,20 @@ describe PostVotingComment do
   before { SiteSetting.post_voting_enabled = true }
 
   describe "validations" do
+    it "does not allow comments to be created when `post_voting_comment_enabled` site setting is false" do
+      SiteSetting.post_voting_comment_enabled = false
+
+      post_2 = Fabricate(:post, topic:)
+
+      comment = PostVotingComment.new(raw: "this is a **post**", post: post_2, user:)
+
+      expect(comment.valid?).to eq(false)
+
+      expect(comment.errors.full_messages).to contain_exactly(
+        I18n.t("post_voting.comment.errors.disabled"),
+      )
+    end
+
     it "does not allow comments to be created when post is in reply to another post" do
       post_2 = Fabricate(:post, topic: topic)
 

--- a/plugins/discourse-post-voting/spec/system/page_objects/pages/post_voting_topic.rb
+++ b/plugins/discourse-post-voting/spec/system/page_objects/pages/post_voting_topic.rb
@@ -6,6 +6,10 @@ module PageObjects
       COMMENT_VOTE_BUTTON = ".post-voting-comment-actions-vote button"
       POST_VOTE_BUTTON = ".post-voting-post button"
       COMMENT_ACTIONS = ".post-voting-comment-actions"
+
+      def has_no_comment_menu?
+        has_no_css?(".post-voting-comments-menu")
+      end
     end
   end
 end

--- a/plugins/discourse-post-voting/spec/system/post_voting_spec.rb
+++ b/plugins/discourse-post-voting/spec/system/post_voting_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe "Post voting", type: :system do
     before { SiteSetting.glimmer_post_stream_mode = value }
 
     context "when glimmer_post_stream_mode=#{value}" do
+      it "does not display button to add a comment and does not show comments when `post_voting_comment_enabled` site setting is false" do
+        SiteSetting.post_voting_comment_enabled = false
+        SiteSetting.post_voting_enabled = true
+
+        topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: user2)
+        post_1 = Fabricate(:post, topic: topic)
+        post_2 = Fabricate(:post, topic: topic)
+
+        sign_in(user1)
+
+        topic_page.visit_topic(topic)
+
+        expect(topic_page).to have_no_comment_menu
+      end
+
       it "disallows voting on archived or closed topics" do
         SiteSetting.post_voting_enabled = true
         topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: user2, archived: true)


### PR DESCRIPTION
This commit introduces a post_voting_comment_enabled site setting to
control whether comments are allowed on posts.
