### PR TITLE
 FIX: Catch fast edit selections that are too massive to edit. 

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-text-selection.gjs
@@ -315,15 +315,21 @@ export default class PostTextSelection extends Component {
 
     if (supportsFastEdit) {
       const regexp = new RegExp(escapeRegExp(quoteState.buffer), "gi");
-      const matches = cooked.innerHTML.match(regexp);
+      try {
+        const matches = cooked.innerHTML.match(regexp);
 
-      if (
-        quoteState.buffer.length === 0 ||
-        quoteState.buffer.includes("|") || // tables are too complex
-        quoteState.buffer.match(/\n/g) || // linebreaks are too complex
-        quoteState.buffer.match(/[‚‘’„“”«»‹›™±…→←↔¶]/g) || // typopgraphic characters are too complex
-        matches?.length !== 1 // duplicates are too complex
-      ) {
+        if (
+          quoteState.buffer.length === 0 ||
+          quoteState.buffer.includes("|") || // tables are too complex
+          quoteState.buffer.match(/\n/g) || // linebreaks are too complex
+          quoteState.buffer.match(/[‚‘’„“”«»‹›™±…→←↔¶]/g) || // typopgraphic characters are too complex
+          matches?.length !== 1 // duplicates are too complex
+        ) {
+          supportsFastEdit = false;
+        }
+      } catch {
+        // If the regex is too large, it will throw an error.
+        // In this case, we just disable fast edit.
         supportsFastEdit = false;
       }
     }


### PR DESCRIPTION
## ✨ What's This?

Ref: t/159279, #33776

Given a suitably massive text selection, the `PostTextSelection` component will attempt to create an even bigger regex when determining whether fast edit is supported. When the regex becomes too big to compile, it'll throw an error.

This change catches that error, and fails gracefully.