### PR TITLE
DEV: Fix a flaky system test

### DIFF
--- a/spec/system/s3_secure_uploads_spec.rb
+++ b/spec/system/s3_secure_uploads_spec.rb
@@ -18,8 +18,11 @@ describe "Uploading files in the composer to S3", type: :system do
     def expect_first_post_to_have_secure_upload
       img = first_post_img
       expect(img["src"]).to include("/secure-uploads")
-      topic = topic_page.current_topic
-      expect(topic.first_post.uploads.first.secure).to eq(true)
+
+      try_until_success do
+        topic = topic_page.current_topic
+        expect(topic.first_post.uploads.first.secure).to eq(true)
+      end
     end
 
     it "marks uploads inside of private message posts as secure" do


### PR DESCRIPTION
Asserting for the state of the database needs to be wrapped in a
`try_until_success` block as we may need to retry the assertion multiple
times in order to ensure that all inflight requests by the server have
been processed.
