### PR TITLE
DEV: Update migration to add index to run first

### DIFF
--- a/plugins/discourse-ai/db/migrate/20241230153301_add_index_to_ai_topics_embeddings.rb
+++ b/plugins/discourse-ai/db/migrate/20241230153301_add_index_to_ai_topics_embeddings.rb
@@ -2,7 +2,7 @@
 
 class AddIndexToAiTopicsEmbeddings < ActiveRecord::Migration[7.2]
   def up
-    add_index :ai_topics_embeddings, %i[topic_id model_id]
+    add_index :ai_topics_embeddings, %i[topic_id model_id], if_not_exists: true
   end
 
   def down


### PR DESCRIPTION
This updates the timestamp of the `AddIndexToAiTopicsEmbeddings`
migration to `20241230153301` so that it runs before all recent
migrations. This is required because the lack of this index is causing
core migrations to fail as queries against the `ai_topics_embeddings`
table are running for too long and causing lock timeouts to happen.

This is a follow-up to cc77e73cfdc381a2cdce18e9e1afa869c16dcd16
