### PR TITLE
DEV: Remove redundant user argument in InviteGuardian methods

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -49,7 +49,7 @@ class InvitesController < ApplicationController
   end
 
   def create_multiple
-    guardian.ensure_can_bulk_invite_to_forum!(current_user)
+    guardian.ensure_can_bulk_invite_to_forum!
     emails = params[:email]
     # validate that topics and groups can accept invites.
     if params[:topic_id].present?
@@ -419,7 +419,7 @@ class InvitesController < ApplicationController
   end
 
   def destroy_all_expired
-    guardian.ensure_can_destroy_all_invites!(current_user)
+    guardian.ensure_can_destroy_all_invites!
     user = fetch_user_from_params
 
     Invite
@@ -443,7 +443,7 @@ class InvitesController < ApplicationController
   end
 
   def resend_all_invites
-    guardian.ensure_can_resend_all_invites!(current_user)
+    guardian.ensure_can_resend_all_invites!
 
     begin
       RateLimiter.new(
@@ -466,7 +466,7 @@ class InvitesController < ApplicationController
   end
 
   def upload_csv
-    guardian.ensure_can_bulk_invite_to_forum!(current_user)
+    guardian.ensure_can_bulk_invite_to_forum!
 
     hijack do
       begin

--- a/lib/guardian/invite_guardian.rb
+++ b/lib/guardian/invite_guardian.rb
@@ -46,15 +46,15 @@ module InviteGuardian
       (!SiteSetting.must_approve_users? || is_staff?)
   end
 
-  def can_bulk_invite_to_forum?(user)
-    user.admin?
+  def can_bulk_invite_to_forum?
+    is_admin?
   end
 
-  def can_resend_all_invites?(user)
-    user.staff?
+  def can_resend_all_invites?
+    is_staff?
   end
 
-  def can_destroy_all_invites?(user)
-    user.staff?
+  def can_destroy_all_invites?
+    is_staff?
   end
 end

--- a/spec/lib/guardian/invite_guardian_spec.rb
+++ b/spec/lib/guardian/invite_guardian_spec.rb
@@ -259,15 +259,15 @@ RSpec.describe InviteGuardian do
 
   describe "#can_bulk_invite_to_forum?" do
     it "returns true for admin users" do
-      expect(Guardian.new(admin).can_bulk_invite_to_forum?(admin)).to be_truthy
+      expect(Guardian.new(admin).can_bulk_invite_to_forum?).to be_truthy
     end
 
     it "returns false for moderators" do
-      expect(Guardian.new(moderator).can_bulk_invite_to_forum?(moderator)).to be_falsey
+      expect(Guardian.new(moderator).can_bulk_invite_to_forum?).to be_falsey
     end
 
     it "returns false for regular users" do
-      expect(Guardian.new(user).can_bulk_invite_to_forum?(user)).to be_falsey
+      expect(Guardian.new(user).can_bulk_invite_to_forum?).to be_falsey
     end
   end
 
@@ -275,15 +275,15 @@ RSpec.describe InviteGuardian do
 
   describe "#can_resend_all_invites?" do
     it "returns true for admin users" do
-      expect(Guardian.new(admin).can_resend_all_invites?(admin)).to be_truthy
+      expect(Guardian.new(admin).can_resend_all_invites?).to be_truthy
     end
 
     it "returns true for moderators" do
-      expect(Guardian.new(moderator).can_resend_all_invites?(moderator)).to be_truthy
+      expect(Guardian.new(moderator).can_resend_all_invites?).to be_truthy
     end
 
     it "returns false for regular users" do
-      expect(Guardian.new(user).can_resend_all_invites?(user)).to be_falsey
+      expect(Guardian.new(user).can_resend_all_invites?).to be_falsey
     end
   end
 
@@ -291,15 +291,15 @@ RSpec.describe InviteGuardian do
 
   describe "#can_destroy_all_invites?" do
     it "returns true for admin users" do
-      expect(Guardian.new(admin).can_destroy_all_invites?(admin)).to be_truthy
+      expect(Guardian.new(admin).can_destroy_all_invites?).to be_truthy
     end
 
     it "returns true for moderators" do
-      expect(Guardian.new(moderator).can_destroy_all_invites?(moderator)).to be_truthy
+      expect(Guardian.new(moderator).can_destroy_all_invites?).to be_truthy
     end
 
     it "returns false for regular users" do
-      expect(Guardian.new(user).can_destroy_all_invites?(user)).to be_falsey
+      expect(Guardian.new(user).can_destroy_all_invites?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
### What is this change?

Guardians are initialized with the acting user. Passing acting user as an argument to the methods is redundant and opens up for ambiguity/mistakes.

### Due diligence

- [x] I have searched all our public and private repos for usages of these methods and found nothing.