### PR TITLE
PERF: Speed up embedding text preparation.

### DIFF
--- a/plugins/discourse-ai/lib/embeddings/strategies/truncation.rb
+++ b/plugins/discourse-ai/lib/embeddings/strategies/truncation.rb
@@ -72,11 +72,18 @@ module DiscourseAi
             text << "\n\n"
           end
 
+          posts_text = +""
+          posts_text_size = 0
+
           topic.posts.find_each do |post|
-            text << Nokogiri::HTML5.fragment(post.cooked).text
-            break if tokenizer.size(text) >= max_length #maybe keep a partial counter to speed this up?
+            posts_text_size += tokenizer.size(post.cooked)
+            posts_text << post.cooked
+            break if posts_text_size >= max_length
+
             text << "\n\n"
           end
+
+          text << Nokogiri::HTML5.fragment(posts_text).text
 
           tokenizer.truncate(text, max_length, strict: SiteSetting.ai_strict_token_counting)
         end


### PR DESCRIPTION
When collecting text for vectorizing a topic, we iterate over as many posts as possible within the context window, parsing their cooked attribute using Nokogiri. We noticed this method doesn't scale well when working with larger contexts.

Instead, we'll collect as much unparsed cooked text as we can, then parse it all in a single Nokogiri call.

I ran this a hundred times in a benchmark, and the perf gains are significant:

```
user     system total        real
prepare_target_text:           114.887620   3.731693 118.619313 (118.952465)
prepare_target_text_bis:        10.264950   0.186204  10.451154 ( 10.465957)
```

Tried running it 1k times, but the old method took too long.