### PR TITLE
FIX: Add missing user custom preferences outlet class in component using connector

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
@@ -1,11 +1,14 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { classNames, tagName } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
 import { i18n } from "discourse-i18n";
 import RegionInput from "../../components/region-input";
 import { TIME_ZONE_TO_REGION } from "../../lib/regions";
 
+@tagName("div")
+@classNames("user-custom-preferences-outlet")
 export default class Region extends Component {
   static shouldRender(args, component) {
     return component.siteSettings.calendar_enabled;

--- a/plugins/discourse-calendar/spec/system/user_preference_spec.rb
+++ b/plugins/discourse-calendar/spec/system/user_preference_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe "User Preferences", system: true do
+  fab!(:user)
+
+  before { SiteSetting.calendar_enabled = true }
+
+  context "when in the user preferences page" do
+    before do
+      sign_in(user)
+      visit("/u/#{user.username_lower}/preferences/profile")
+    end
+
+    it "should show `region` input with `user-custom-preferences-outlet`" do
+      expect(page).to have_selector(".user-custom-preferences-outlet > .control-group.region")
+    end
+  end
+end


### PR DESCRIPTION
For some reason, this specific plugin outlet is not rendering its `div.user-custom-preferences-outlet` HTML.

Cakeday plugin has added `classNames` and `tagName` in their connectors, see:

https://github.com/discourse/discourse-cakeday/blob/main/assets/javascripts/discourse/connectors/user-custom-preferences/user-date-of-birth-input.gjs#L8-L8

In this PR, I'm adding those classes to the `user-custom-preferences` region input