### PR TITLE
DEV: Render username in quote posts marked as not found

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -5,7 +5,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { modifier as modifierFn } from "ember-modifier";
-import { eq, or } from "truth-helpers";
+import { eq } from "truth-helpers";
 import AsyncContent from "discourse/components/async-content";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
@@ -95,11 +95,26 @@ export default class PostQuotedContent extends Component {
   }
 
   get shouldDisplayNavigateToPostButton() {
-    return this.quotedPostUrl && !this.isQuotedPostIgnored;
+    return (
+      !this.args.quotedPostNotFound &&
+      this.quotedPostUrl &&
+      !this.isQuotedPostIgnored
+    );
+  }
+
+  get shouldDisplayQuoteControls() {
+    return (
+      this.shouldDisplayNavigateToPostButton || this.shouldDisplayToggleButton
+    );
   }
 
   get shouldDisplayToggleButton() {
-    return this.args.id && !this.args.fullQuote && !this.isQuotedPostIgnored;
+    return (
+      !this.args.quotedPostNotFound &&
+      this.args.id &&
+      !this.args.fullQuote &&
+      !this.isQuotedPostIgnored
+    );
   }
 
   get stateExpandedId() {
@@ -181,11 +196,9 @@ export default class PostQuotedContent extends Component {
       {{/if}}
       <div
         class="title"
-        data-has-quote-controls={{or
-          this.shouldDisplayToggleButton
-          this.shouldDisplayNavigateToPostButton
-        }}
+        data-has-quote-controls={{this.shouldDisplayQuoteControls}}
         data-can-toggle-quote={{this.shouldDisplayToggleButton}}
+        data-can-navigate-to-post={{this.shouldDisplayNavigateToPostButton}}
         {{(if
           this.shouldDisplayToggleButton (modifier on "click" this.onClickTitle)
         )}}
@@ -207,34 +220,36 @@ export default class PostQuotedContent extends Component {
             {{~@title~}}
           {{~/if~}}
         {{~/if~}}
-        <div class="quote-controls">
-          {{~#if this.shouldDisplayToggleButton~}}
-            <DButton
-              class="btn-flat quote-toggle"
-              @action={{this.toggleExpanded}}
-              @ariaControls={{@id}}
-              @ariaExpanded={{this.expanded}}
-              @ariaLabel={{if this.expanded "post.collapse" "expand"}}
-              @title={{if this.expanded "post.collapse" "expand"}}
-            >
-              {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
-                  extra whitespace that will interfere with the text captured when quoting a quoted content }}
-              {{~icon this.toggleIcon~}}
-            </DButton>
-          {{~/if~}}
-          {{~#if this.shouldDisplayNavigateToPostButton~}}
-            <DButton
-              class="btn-flat back"
-              @href={{this.quotedPostUrl}}
-              @title="post.follow_quote"
-              @ariaLabel="post.follow_quote"
-            >
-              {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
-                  extra whitespace that will interfere with the text captured when quoting a quoted content }}
-              {{~icon this.navigateToPostIcon~}}
-            </DButton>
-          {{~/if~}}
-        </div>
+        {{~#if this.shouldDisplayQuoteControls~}}
+          <div class="quote-controls">
+            {{~#if this.shouldDisplayToggleButton~}}
+              <DButton
+                class="btn-flat quote-toggle"
+                @action={{this.toggleExpanded}}
+                @ariaControls={{@id}}
+                @ariaExpanded={{this.expanded}}
+                @ariaLabel={{if this.expanded "post.collapse" "expand"}}
+                @title={{if this.expanded "post.collapse" "expand"}}
+              >
+                {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
+                    extra whitespace that will interfere with the text captured when quoting a quoted content }}
+                {{~icon this.toggleIcon~}}
+              </DButton>
+            {{~/if~}}
+            {{~#if this.shouldDisplayNavigateToPostButton~}}
+              <DButton
+                class="btn-flat back"
+                @href={{this.quotedPostUrl}}
+                @title="post.follow_quote"
+                @ariaLabel="post.follow_quote"
+              >
+                {{! rendering the icon in the block instead of using the parameter `@icon` prevents DButton from adding
+                    extra whitespace that will interfere with the text captured when quoting a quoted content }}
+                {{~icon this.navigateToPostIcon~}}
+              </DButton>
+            {{~/if~}}
+          </div>
+        {{~/if~}}
       </div>
       <blockquote id={{@id}}>
         {{~#unless this.isQuotedPostIgnored~}}

--- a/app/assets/javascripts/discourse/app/lib/post-cooked-html-decorators/quote-controls.gjs
+++ b/app/assets/javascripts/discourse/app/lib/post-cooked-html-decorators/quote-controls.gjs
@@ -67,9 +67,9 @@ export default function quoteControls(element, context) {
       quotedPostNotFound: aside.classList.contains("quote-post-not-found"),
       quotedPostNumber,
       quotedTopicId,
+      quotedUsername: username,
       streamElement,
       title,
-      username,
       wrapperElement: aside,
     };
 

--- a/app/assets/javascripts/discourse/tests/integration/components/post/cooked-html-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/cooked-html-test.gjs
@@ -32,10 +32,17 @@ module("Integration | Component | Post | PostCookedHtml", function (hooks) {
   });
 
   test("quotes with no username and no valid topic", async function (assert) {
-    this.post.cooked = `<aside class=\"quote no-group quote-post-not-found\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`;
+    this.post.cooked = `<aside class=\"quote no-group quote-post-not-found\" data-username=\"unknown\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`;
 
     await renderComponent(this.post);
 
+    assert
+      .dom("aside.quote .title")
+      .hasText("unknown")
+      .doesNotHaveAttribute("data-has-quote-controls")
+      .doesNotHaveAttribute("data-can-toggle-quote")
+      .doesNotHaveAttribute("data-can-navigate-to-post");
+    assert.dom(".quote-controls").doesNotExist();
     assert.dom("blockquote").hasText("abcd");
   });
 });


### PR DESCRIPTION
This change improves the handling of quote components when the referenced post cannot be found in the Glimmer Post Stream. 
Previously, quotes marked as "not found" would not display any username information, making them difficult to understand contextually.

**Key Changes:**
- Added conditional logic to hide quote controls (toggle and navigate buttons) when `quotedPostNotFound` is true
- Introduced `shouldDisplayQuoteControls` getter to centralize control visibility logic
- Modified the quote controls template to only render when appropriate
- Updated data attributes to include `data-can-navigate-to-post` for better semantic meaning
- Ensured the username from `quotedUsername` is properly displayed even for not-found quotes
- Added comprehensive test coverage for the new behavior

The quote component now gracefully handles missing posts by showing the username while hiding interactive controls that would not function properly.