### PR TITLE
FIX: timeline shouldn't dock unless all posts are loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.gjs
@@ -427,11 +427,13 @@ export default class TopicTimelineScrollArea extends Component {
     const prevDockAt = this.dockAt;
     const positionTop = headerOffset() + window.pageYOffset;
     const currentPosition = positionTop + timelineHeight;
+    const postStream = this.args.model.postStream;
+    const allPostsLoaded = postStream.loadedAllPosts;
 
     this.dockBottom = false;
     if (positionTop < this.topicTop) {
       this.dockAt = parseInt(this.topicTop, 10);
-    } else if (currentPosition > this.topicBottom) {
+    } else if (allPostsLoaded && currentPosition > this.topicBottom) {
       this.dockAt = parseInt(this.topicBottom - timelineHeight, 10);
       this.dockBottom = true;
       if (this.dockAt < 0) {


### PR DESCRIPTION
Currently the timeline will think it's docked mid-topic if there are enough posts to trigger loading on scroll

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c2b640ef-196b-4714-a053-d3664ec122f0" />

If we check if all posts are loaded, this no longer happens: 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c083a4de-ea73-4769-8e73-eaa002c5bedd" />

and it still docks at the end: 

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/014afdff-3b44-4ed6-be64-7a10313712d5" />

