### PR TITLE
FEATURE: Add upload type to schema settings

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-setting/field.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-setting/field.gjs
@@ -9,6 +9,7 @@ import GroupsField from "admin/components/schema-setting/types/groups";
 import IntegerField from "admin/components/schema-setting/types/integer";
 import StringField from "admin/components/schema-setting/types/string";
 import TagsField from "admin/components/schema-setting/types/tags";
+import UploadField from "admin/components/schema-setting/types/upload";
 
 export default class SchemaSettingField extends Component {
   get component() {
@@ -31,6 +32,8 @@ export default class SchemaSettingField extends Component {
         return TagsField;
       case "groups":
         return GroupsField;
+      case "upload":
+        return UploadField;
       default:
         throw new Error(`unknown type ${type}`);
     }

--- a/app/assets/javascripts/admin/addon/components/schema-setting/types/upload.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-setting/types/upload.gjs
@@ -1,0 +1,41 @@
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { action } from "@ember/object";
+import { and, not } from "truth-helpers";
+import UppyImageUploader from "discourse/components/uppy-image-uploader";
+import FieldInputDescription from "admin/components/schema-setting/field-input-description";
+import SchemaSettingTypeModels from "admin/components/schema-setting/types/models";
+
+export default class SchemaSettingTypeUpload extends SchemaSettingTypeModels {
+  @tracked value = this.args.value || null;
+  type = "upload";
+
+  @action
+  onChange(upload) {
+    return upload.id;
+  }
+
+  <template>
+
+    <UppyImageUploader
+      @imageUrl={{this.value}}
+      @placeholderUrl={{@setting.placeholder}}
+      @onUploadDone={{this.onInput}}
+      @onUploadDeleted={{fn (mut this.value) null}}
+      @type={{this.type}}
+      @id={{@setting.schema.name}}
+    />
+
+    <div class="schema-field__input-supporting-text">
+      {{#if (and @description (not this.validationErrorMessage))}}
+        <FieldInputDescription @description={{@description}} />
+      {{/if}}
+
+      {{#if this.validationErrorMessage}}
+        <div class="schema-field__input-error">
+          {{this.validationErrorMessage}}
+        </div>
+      {{/if}}
+    </div>
+  </template>
+}


### PR DESCRIPTION
In this PR we introduce `type: upload` to the schema settings, allowing users to upload files in the objects editor.

You now can have lists that include images for example.

Both applies to site_settings and theme settings.