### PR TITLE
UX: fix bulk select in Horizon theme

### DIFF
--- a/themes/horizon/scss/desktop-horizon-fixes.scss
+++ b/themes/horizon/scss/desktop-horizon-fixes.scss
@@ -1,8 +1,12 @@
+.topic-list .topic-list-header .topic-list-data:last-of-type {
+  padding: 0;
+}
+
 // Fixing bulk select (only needed for desktop)
 .bulk-select-enabled {
   .topic-list-header {
-    position: relative;
-    top: 0;
+    position: sticky;
+    top: 8em;
     height: 0;
     display: block;
   }
@@ -49,16 +53,15 @@
     }
   }
 
-  // bulk select
   .bulk-select-topics {
     position: absolute;
-    top: 0;
     right: 0;
     background: var(--secondary);
-    border-radius: 0 0 0 var(--d-border-radius);
+    border-radius: var(--d-border-radius);
     display: flex;
     gap: 0.5rem;
-    margin: 0.5rem;
+    margin: var(--space-4) 0;
+    padding: var(--space-1);
 
     button {
       white-space: nowrap;


### PR DESCRIPTION
This regressed at some point on its way into core. The controls were no longer sticky and unreachable on scroll. This makes them sticky again. 

Before:

<img width="1990" height="464" alt="image" src="https://github.com/user-attachments/assets/957f6f37-7e93-4024-89dd-c3093f61b9b9" />


After:

<img width="1760" height="446" alt="image" src="https://github.com/user-attachments/assets/df9433df-2263-4698-8ed4-72fe2c3ab0e3" />
