### PR TITLE
DEV: Fix theme site setting flakiness part 2

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -364,8 +364,10 @@ class Theme < ActiveRecord::Base
     if component
       raise Discourse::InvalidParameters.new(I18n.t("themes.errors.component_no_default"))
     end
+
+    # NOTE: The cache is expired in the 014-track-setting-changes.rb
+    # initializer, so we don't need to do it here.
     SiteSetting.default_theme_id = id
-    Theme.expire_site_cache!
   end
 
   def default?

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -85,4 +85,6 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
       end
     end
   end
+
+  Theme.expire_site_cache! if name == :default_theme_id
 end


### PR DESCRIPTION
In certain scenarios in the specs, we are ending up in
a situation where the default theme has been changed,
but `Theme.user_theme_ids` does not contain that theme's
ID, even though it should have the default theme ID. This
means that the default theme isn't selected as the
application_controller `@theme_id`, which is usually used
to get the correct theme site setting values from the cache.

This is happening because we need to clear the Theme cache
every time this changes. Usually this would happen via
`theme.set_default!`, but this isn't consistently used,
and we don't want to end up in a bad state when people use
`SiteSetting.default_theme_id=` directly.

This commit fixes the flakiness by moving `Theme.expire_site_cache!`
to the main site setting change tracker, this way it's always called
whenever the setting changes.
