### PR TITLE
DEV: Replace staff auto-group in settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -932,7 +932,7 @@ users:
     client: true
     hidden: true
   anonymous_posting_allowed_groups:
-    default: "3|11" # auto group staff and trust_level_1
+    default: "1|2|11" # auto group admins, moderators and trust_level_1
     type: group_list
     allow_any: false
     refresh: true
@@ -1224,7 +1224,7 @@ posting:
     enum: "TrustLevelAndStaffSetting"
     hidden: true
   shared_drafts_allowed_groups:
-    default: "3" # auto group staff
+    default: "1|2" # auto group admins and moderators
     type: group_list
     allow_any: false
     refresh: true


### PR DESCRIPTION
### What is this change?

In all group based access site settings we use `admins` and `moderators` explicitly, except these two. This PR updates them to match the rest.