### PR TITLE
UX: Fix copy for theme site setting description

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6878,7 +6878,7 @@ en:
           theme_site_settings: "Settings the theme can override"
           edit_objects_theme_setting: "Objects setting editor"
           overriden_settings_explanation: "Changes from the default are marked with a dot and highlight. Click Reset to reset to the default."
-          overriden_site_settings_explanation: "Site settings the theme can customize. Click Reset to restore the theme’s default. If none is set, the site setting default is used. You can see all site settings being overridden by themes at <a href='%{themeSiteSettingsConfigUrl}'>the theme site settings config page</a>."
+          overriden_site_settings_explanation: "Site settings the theme can customize. Click Reset to restore to the site setting's default value. You can see all site settings being overridden by themes at <a href='%{themeSiteSettingsConfigUrl}'>the theme site settings config page</a>."
           no_settings: "This theme has no settings."
           theme_translations: "Theme translations"
           empty: "No items"


### PR DESCRIPTION
Admins resetting the theme site setting values are
resetting to the site setting default, not whatever
the theme had in about.json, because we do not store
this latter value in the database.

<img width="1316" height="413" alt="image" src="https://github.com/user-attachments/assets/c0a0fdc5-81a1-4471-9b6d-f2e1b8b82d86" />
