### PR TITLE
FIX: bug when silence user and do nothing to post

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/penalize-user.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/penalize-user.gjs
@@ -112,8 +112,8 @@ export default class PenalizeUser extends Component {
       if (this.successCallback) {
         await this.successCallback(result);
       }
-    } catch {
-      this.flash = extractError(result);
+    } catch (error) {
+      this.flash = result ? extractError(result) : extractError(error);
     } finally {
       this.penalizing = false;
     }

--- a/app/services/user/action/trigger_post_action.rb
+++ b/app/services/user/action/trigger_post_action.rb
@@ -9,7 +9,7 @@ class User::Action::TriggerPostAction < Service::ActionBase
   delegate :user, to: :guardian, private: true
 
   def call
-    return if post.blank? || post_action.blank?
+    return if post.blank? || post_action.blank? || post_action == "none"
     send(post_action)
   rescue NoMethodError
   end

--- a/app/services/user/silence.rb
+++ b/app/services/user/silence.rb
@@ -17,7 +17,11 @@ class User::Silence
     validates :reason, presence: true, length: { maximum: 300 }
     validates :silenced_till, presence: true
     validates :other_user_ids, length: { maximum: User::MAX_SIMILAR_USERS }
-    validates :post_action, inclusion: { in: %w[delete delete_replies edit] }, allow_blank: true
+    validates :post_action,
+              inclusion: {
+                in: %w[delete delete_replies edit none],
+              },
+              allow_blank: true
   end
 
   model :user

--- a/app/services/user/suspend.rb
+++ b/app/services/user/suspend.rb
@@ -17,7 +17,11 @@ class User::Suspend
     validates :reason, presence: true, length: { maximum: 300 }
     validates :suspend_until, presence: true
     validates :other_user_ids, length: { maximum: User::MAX_SIMILAR_USERS }
-    validates :post_action, inclusion: { in: %w[delete delete_replies edit] }, allow_blank: true
+    validates :post_action,
+              inclusion: {
+                in: %w[delete delete_replies edit none],
+              },
+              allow_blank: true
   end
 
   model :user

--- a/spec/services/user/action/trigger_post_action_spec.rb
+++ b/spec/services/user/action/trigger_post_action_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe User::Action::TriggerPostAction do
       end
     end
 
+    context "when post_action is 'none'" do
+      let(:post_action) { "none" }
+      it "does nothing" do
+        expect { action }.not_to change { Post.count }
+      end
+    end
+
     context "when post and post_action are defined" do
       context "when post_action is 'delete'" do
         let(:post_action) { "delete" }

--- a/spec/services/user/silence_spec.rb
+++ b/spec/services/user/silence_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User::Silence do
     end
     it do
       is_expected.to validate_inclusion_of(:post_action).in_array(
-        %w[delete delete_replies edit],
+        %w[delete delete_replies edit none],
       ).allow_blank
     end
   end

--- a/spec/services/user/suspend_spec.rb
+++ b/spec/services/user/suspend_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User::Suspend do
     end
     it do
       is_expected.to validate_inclusion_of(:post_action).in_array(
-        %w[delete delete_replies edit],
+        %w[delete delete_replies edit none],
       ).allow_blank
     end
   end

--- a/spec/system/page_objects/modals/penalize_user.rb
+++ b/spec/system/page_objects/modals/penalize_user.rb
@@ -14,6 +14,24 @@ module PageObjects
       def modal
         find(".d-modal.#{@penalty_type}-user-modal")
       end
+
+      def fill_in_reason(reason)
+        find("input.suspend-reason").fill_in with: reason
+      end
+
+      def set_future_date(date)
+        select = PageObjects::Components::SelectKit.new(".future-date-input details")
+        select.expand
+        select.select_row_by_value(date)
+      end
+
+      def perform
+        find(".perform-penalize").click
+      end
+
+      def has_error_message?(message)
+        expect(find("#modal-alert").text).to eq(message)
+      end
     end
   end
 end


### PR DESCRIPTION
When the user was silenced or suspended by accepting a flag, and the action on the post was `Do Nothing`, it was throwing a silent error.

That was fixed, but in addition, ensured that errors are always displayed on the modal to inform the user that something went wrong.

<img width="779" height="1188" alt="Screenshot 2025-07-24 at 3 07 52 pm" src="https://github.com/user-attachments/assets/ecf88898-4865-43ab-8b7c-e142968237a1" />
