### PR TITLE
FIX: ensures autogrid works with French spacing

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -640,7 +640,9 @@ export default class UppyComposerUpload {
     }
 
     const uploadingImagePattern = new RegExp(
-      "\\[" + uploadingTextMatch[0].trim() + ": ([^\\]]+?)\\.\\w+…\\]\\(\\)",
+      "\\[" +
+        uploadingTextMatch[0].trim() +
+        "\\s?: ([^\\]]+?)\\.\\w+…\\]\\(\\)",
       "g"
     );
 
@@ -654,7 +656,7 @@ export default class UppyComposerUpload {
       imagePlaceholder = imagePlaceholder.trim();
 
       const filenamePattern = new RegExp(
-        "\\[" + uploadingTextMatch[0].trim() + ": ([^\\]]+?)\\…\\]\\(\\)"
+        "\\[" + uploadingTextMatch[0].trim() + "\\s?: ([^\\]]+?)\\…\\]\\(\\)"
       );
 
       const filenameMatch = imagePlaceholder.match(filenamePattern);

--- a/spec/system/composer_uploads_spec.rb
+++ b/spec/system/composer_uploads_spec.rb
@@ -155,6 +155,25 @@ describe "Uploading files in the composer", type: :system do
   context "when multiple images are uploaded" do
     before { SiteSetting.experimental_auto_grid_images = true }
 
+    context "when the locale is fr" do
+      before { SiteSetting.default_locale = "fr" }
+
+      it "works with the French locale" do
+        visit "/new-topic"
+        expect(composer).to be_opened
+
+        file_path_1 = file_from_fixtures("logo.png", "images").path
+        file_path_2 = file_from_fixtures("logo.jpg", "images").path
+        file_path_3 = file_from_fixtures("downsized.png", "images").path
+        attach_file("file-uploader", [file_path_1, file_path_2, file_path_3], make_visible: true)
+
+        expect(composer).to have_no_in_progress_uploads
+        expect(composer.composer_input.value).to match(
+          %r{\[grid\].*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*!\[.*?\]\(upload://.*?\).*?\[/grid\]}m,
+        )
+      end
+    end
+
     it "automatically wraps images in [grid] tags on 3 or more images" do
       visit "/new-topic"
       expect(composer).to be_opened


### PR DESCRIPTION
French spacing refers to the extra space that comes before many punctuation marks in French.

It's also common in other languages: Italian, Spanish, Catalan, ...

Our regexes were only considering the case without space and as a result auto grid would not work in French.

This regex based parsing is brittle as proven here, but this commit only focuses on fixing the bug and ensuring this case is tested for future improvements.