### PR TITLE
DEV: Fix a d-assign spec

### DIFF
--- a/plugins/discourse-assign/spec/system/assign_topic_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_topic_spec.rb
@@ -69,13 +69,13 @@ describe "Assign | Assigning topics", type: :system do
           it "show the user's username if there is no name" do
             visit "/t/#{topic.id}"
             staff_user.name = nil
-            staff_user.save
+            staff_user.save!
             staff_user.reload
 
             topic_page.click_assign_topic
             assign_modal.assignee = staff_user
             assign_modal.confirm
-            expect(find("#topic .assigned-to")).to have_content(staff_user.name)
+            expect(find("#topic .assigned-to")).to have_content(staff_user.username)
           end
         end
 


### PR DESCRIPTION
fixes warnings, and now the spec does what it says it does