### PR TITLE
UX: Horizon > apply small styling fixes for discotoc plugin

### DIFF
--- a/themes/horizon/scss/buttons.scss
+++ b/themes/horizon/scss/buttons.scss
@@ -108,3 +108,15 @@
     );
   }
 }
+
+// DiscoToc plugin
+.d-toc-main,
+.timeline-footer-controls {
+  .btn.timeline-toggle {
+    border-top-right-radius: 8px;
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    bottom: var(--main-grid-gap);
+  }
+}

--- a/themes/horizon/scss/topic.scss
+++ b/themes/horizon/scss/topic.scss
@@ -51,9 +51,13 @@
   }
 }
 
-.container.posts {
-  grid-template-columns: auto 8em;
+body:not(.d-toc-installed) {
+  .container.posts {
+    grid-template-columns: auto 8em;
+  }
+}
 
+.container.posts {
   @media screen and (width <= 924px) {
     grid-template-columns: auto auto;
   }


### PR DESCRIPTION
Reset the `.container .post` grid to default, so the discotoc area isn't too cramped. [only applies when the discotoc plugin is active]
Also applies some fixes (mini reposition + removal/reduction of border-radius) to the timeline toggle button.

<img width="1128" height="780" alt="CleanShot 2025-07-24 at 16 56 38@2x" src="https://github.com/user-attachments/assets/b3d8d37f-44e0-4ba1-b21a-68788a573d6f" />

⬇️ 

<img width="1128" height="780" alt="CleanShot 2025-07-24 at 16 55 15@2x" src="https://github.com/user-attachments/assets/143aa58d-d578-4d77-a861-de45f3cd5fcc" />


