### PR TITLE
FIX: apply color palette change when preview is unavailable, warn for dark mode

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -68,9 +68,7 @@ export default class AdminCustomizeColorsController extends Controller {
     // check if user has dark mode available and is using it
     return (
       this.session.darkModeAvailable &&
-      (this.session.userDarkSchemeId ===
-        this.siteSettings.default_dark_mode_color_scheme_id ||
-        this.session.userDarkSchemeId !== -1) &&
+      this.session.userDarkSchemeId !== -1 &&
       window.matchMedia("(prefers-color-scheme: dark)").matches
     );
   }

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -17,6 +17,7 @@ export default class AdminCustomizeColorsController extends Controller {
   @service toasts;
   @service session;
   @service site;
+  @service siteSettings;
 
   @tracked defaultTheme = null;
   @tracked filterValue = "";
@@ -32,7 +33,13 @@ export default class AdminCustomizeColorsController extends Controller {
   _sortedOnce = false;
 
   get canPreviewColorScheme() {
-    return currentThemeId() === this.defaultTheme?.id;
+    const usingDefaultTheme = currentThemeId() === this.defaultTheme?.id;
+    const usingDefaultLightScheme =
+      this._initialUserColorSchemeId === this._initialDefaultThemeColorSchemeId;
+
+    return (
+      usingDefaultTheme && usingDefaultLightScheme && !this.isUsingDarkMode
+    );
   }
 
   get allBaseColorSchemes() {
@@ -55,6 +62,17 @@ export default class AdminCustomizeColorsController extends Controller {
     const changedTheme = this.defaultTheme?.id !== currentThemeId(this.site);
 
     return changedColors || changedTheme;
+  }
+
+  get isUsingDarkMode() {
+    // check if user has dark mode available and is using it
+    return (
+      this.session.darkModeAvailable &&
+      (this.session.userDarkSchemeId ===
+        this.siteSettings.default_dark_mode_color_scheme_id ||
+        this.session.userDarkSchemeId !== -1) &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    );
   }
 
   get filteredColorSchemes() {
@@ -96,7 +114,7 @@ export default class AdminCustomizeColorsController extends Controller {
     if (lightBaseScheme) {
       const builtInDefault = {
         ...lightBaseScheme,
-        id: 0,
+        id: null,
         name: i18n("admin.customize.theme.default_light_scheme"),
         description: i18n("admin.customize.theme.default_light_scheme"),
         is_builtin_default: true,
@@ -195,9 +213,18 @@ export default class AdminCustomizeColorsController extends Controller {
   @action
   async setAsDefaultThemePalette(scheme) {
     try {
-      if (this.canPreviewColorScheme) {
-        this.defaultTheme = await setDefaultColorScheme(scheme, this.store);
+      let previewMode;
+      if (scheme.is_builtin_default) {
+        previewMode = "reload";
+      } else if (this.canPreviewColorScheme) {
+        previewMode = "live";
+      } else {
+        previewMode = "none";
       }
+
+      this.defaultTheme = await setDefaultColorScheme(scheme, this.store, {
+        previewMode,
+      });
 
       if (!this.canPreviewColorScheme) {
         const schemeName = scheme.description || scheme.name;

--- a/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
@@ -8,6 +8,7 @@ import DPageSubheader from "discourse/components/d-page-subheader";
 import DSelect from "discourse/components/d-select";
 import FilterInput from "discourse/components/filter-input";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import getUrl from "discourse/helpers/get-url";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import ColorPaletteListItem from "admin/components/color-palette-list-item";
@@ -76,11 +77,27 @@ export default RouteTemplate(
         {{htmlSafe
           (i18n
             "admin.customize.colors.preference_warning"
-            link="/my/preferences/interface"
+            link=(getUrl "/my/preferences/interface")
           )
         }}
       </div>
     {{/if}}
+
+    {{#unless @controller.changedThemePreferences}}
+      {{! only show one alert at a time, changedThemePreferences takes precedence }}
+      {{#if @controller.isUsingDarkMode}}
+        <div class="alert alert-info">
+          {{htmlSafe
+            (i18n
+              "admin.customize.colors.dark_mode_warning"
+              link=(getUrl
+                "/admin/site_settings/category/all_results?filter=default dark mode"
+              )
+            )
+          }}
+        </div>
+      {{/if}}
+    {{/unless}}
 
     <ul class="color-palette__list">
       {{#each @controller.filteredColorSchemes as |scheme|}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6976,6 +6976,7 @@ en:
             title: "Select base color palette"
             description: "Base palette:"
           preference_warning: "You've changed <a href='%{link}'>your personal theme settings</a>, so palette changes may not be visible to you. Visitors that haven't changed their defaults will still see the changes you make here."
+          dark_mode_warning: "You're currently using dark mode. When setting an active color palette the colors will be applied to the light mode of the theme. If you want to change the default dark mode colors, please edit the <a href='%{link}'>dark mode site setting</a>."
           title: "Colors"
           edit: "Edit"
           set_default: "Set as active on %{theme}"


### PR DESCRIPTION
Follow-up to 8fea4eaaa5aa6c473dfed800b6c51c752ee68120


This fixes an issue where if a live preview wasn't being shown (due to preferences), the color palette wasn't being changed in the theme settings. It's now being applied correctly.

I've also simplified the color-scheme-manager so the logic for handling the default fallback palette is handled in the controller (and determines preview mode in the manager)

This also adds a warning for another case where live previewing isn't available: when the admin is in dark mode. 

This will hopefully be temporary while we simplify how dark mode works. 

<img width="1586" height="964" alt="image" src="https://github.com/user-attachments/assets/8e004836-69c3-47e0-9c2f-b371a17875ea" />
