### PR TITLE
FIX: Horizon bulk select sometimes not sticky in Safari

### DIFF
--- a/themes/horizon/scss/desktop-horizon-fixes.scss
+++ b/themes/horizon/scss/desktop-horizon-fixes.scss
@@ -8,7 +8,6 @@
     position: sticky;
     top: 8em;
     height: 0;
-    display: block;
   }
 
   .topic-author-avatar-data {


### PR DESCRIPTION
For some reason `display: block;` here was causing Safari to not always stick the bulk controls in the Horizon theme on scroll. Fortunately we don't need it and removing it seems to fix the issue. Follow-up to https://github.com/discourse/discourse/commit/4987ae6c495fd43b9015b23ddb5e05c6bafc13aa