### PR TITLE
FIX: typo in translated title for audio file types list

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings/file-types-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-settings/file-types-list.gjs
@@ -129,7 +129,7 @@ export default class FileTypesList extends Component {
       @action={{fn this.insertDefaultTypes "audio"}}
       @label="admin.site_settings.file_types_list.add_audio_types"
       @translatedTitle={{i18n
-        "admin.site_settings.file_types_list.add_types_title audio"
+        "admin.site_settings.file_types_list.add_types_title"
         types=AUDIO_TYPES_STRING
       }}
       class="btn btn-small btn-default file-types-list__button"


### PR DESCRIPTION
"audio" shouldn't be here and was breaking the translation 


before:
<img width="854" height="240" alt="image" src="https://github.com/user-attachments/assets/737e2270-7c6d-402b-8838-fddd285ef0ed" />



after: 
<img width="614" height="198" alt="image" src="https://github.com/user-attachments/assets/7db3bf9d-ed49-44f6-801b-fbcd6e815405" />
