### PR TITLE
FIX: use translatedTitle for moderator icon title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/poster-name.gjs
@@ -157,7 +157,10 @@ export default class PostMetaDataPosterName extends Component {
               {{this.name}}
               {{#if this.showGlyph}}
                 {{#if (or @post.moderator @post.group_moderator)}}
-                  {{icon "shield-halved" title=(i18n "user.moderator_tooltip")}}
+                  {{icon
+                    "shield-halved"
+                    translatedTitle=(i18n "user.moderator_tooltip")
+                  }}
                 {{/if}}
               {{/if}}
             </UserLink>


### PR DESCRIPTION
We were passing already translated text for the moderator shield icon and trying to re-translate it... 


before:
<img width="634" height="138" alt="image" src="https://github.com/user-attachments/assets/6c7dc0e3-1ed8-4c14-907f-ef8bd0587a12" />



after:
<img width="728" height="122" alt="image" src="https://github.com/user-attachments/assets/36573302-1a04-4620-9531-5d0b2f78e628" />
