### PR TITLE
UX: convert AI admin feature buttons to links

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-features-list.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-features-list.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { concat } from "@ember/helper";
 import { action } from "@ember/object";
+import { LinkTo } from "@ember/routing";
 import DButton from "discourse/components/d-button";
 import { i18n } from "discourse-i18n";
 
@@ -165,15 +166,16 @@ export default class AiFeaturesList extends Component {
                         @maxItemsToShow={{5}}
                         as |persona index isLastItem|
                       >
-                        <DButton
-                          class="btn-flat ai-feature-card__persona-button btn-text"
-                          @translatedLabel={{concat
+                        <LinkTo
+                          @route="adminPlugins.show.discourse-ai-personas.edit"
+                          @model={{persona.id}}
+                          class="ai-feature-card__persona-link"
+                        >
+                          {{concat
                             persona.name
                             (unless (isLastItem index) ", ")
                           }}
-                          @route="adminPlugins.show.discourse-ai-personas.edit"
-                          @routeModels={{persona.id}}
-                        />
+                        </LinkTo>
                       </ExpandableList>
                     {{else}}
                       <span class="ai-feature-card__label">
@@ -196,15 +198,13 @@ export default class AiFeaturesList extends Component {
                         @maxItemsToShow={{5}}
                         as |llm index isLastItem|
                       >
-                        <DButton
-                          class="btn-flat ai-feature-card__llm-button"
-                          @translatedLabel={{concat
-                            llm.name
-                            (unless (isLastItem index) ", ")
-                          }}
+                        <LinkTo
                           @route="adminPlugins.show.discourse-ai-llms.edit"
-                          @routeModels={{llm.id}}
-                        />
+                          @model={{llm.id}}
+                          class="ai-feature-card__llm-link"
+                        >
+                          {{concat llm.name (unless (isLastItem index) ", ")}}
+                        </LinkTo>
                       </ExpandableList>
                     {{else}}
                       <span class="ai-feature-card__label">

--- a/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
+++ b/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
@@ -55,17 +55,14 @@
     @include ellipsis;
   }
 
-  &__persona-button,
-  &__llm-button {
+  &__persona-link,
+  &__llm-link {
     padding: 0;
     margin-right: var(--space-1);
     overflow: hidden;
+    min-height: 1.5em;
 
-    .d-button-label {
-      min-height: 1.5em;
-
-      @include ellipsis;
-    }
+    @include ellipsis;
   }
 
   &__groups {


### PR DESCRIPTION
These aren't really styled like buttons at all, and styles from themes that are applied to buttons can cause issues... so I've converted them to links.


Before (note the button rounding obscuring text slightly):
<img width="628" height="520" alt="image" src="https://github.com/user-attachments/assets/2b6e4060-886a-411b-ac00-21eb2d06a067" />


After (mostly the same, but without button side-effects): 
<img width="618" height="538" alt="image" src="https://github.com/user-attachments/assets/9a1ae4d0-846d-4e67-82d5-bdac722f072d" />
