### PR TITLE
FIX: display alert when casting last remaining vote

### DIFF
--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-box.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-box.gjs
@@ -37,9 +37,7 @@ export default class VoteBox extends Component {
         topic.user_voted = true;
         this.currentUser.votes_exceeded = !result.can_vote;
         this.currentUser.votes_left = result.votes_left;
-        if (result.alert) {
-          this.votesAlert = result.votes_left;
-        }
+        this.votesAlert = result.alert;
         this.allowClick = true;
         this.showOptions = false;
       })
@@ -114,7 +112,7 @@ export default class VoteBox extends Component {
           {{htmlSafe
             (i18n
               "topic_voting.votes_left"
-              count=this.votesAlert
+              count=this.currentUser.votes_left
               path="/my/activity/votes"
             )
           }}

--- a/plugins/discourse-topic-voting/spec/system/page_objects/pages/topic.rb
+++ b/plugins/discourse-topic-voting/spec/system/page_objects/pages/topic.rb
@@ -7,6 +7,17 @@ module TopicVotingTopic
     find(".voting .vote-count")
   end
 
+  def has_votes_left_popup?(count)
+    expected_html =
+      I18n
+        .t("js.topic_voting.votes_left", count:, path: "/my/activity/votes")
+        .gsub(/'([^']*)'/) { "\"#{$1}\"" }
+    selector = ".voting-popup-menu"
+    has_css?(selector)
+    actual_html = find(selector)[:innerHTML].strip
+    actual_html.include?(expected_html)
+  end
+
   def vote_popup
     find(".voting-popup-menu")
   end

--- a/plugins/discourse-topic-voting/spec/system/voting_spec.rb
+++ b/plugins/discourse-topic-voting/spec/system/voting_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe "Topic voting", type: :system, js: true do
   fab!(:topic3) { Fabricate(:topic, category: category2) }
   fab!(:post1) { Fabricate(:post, topic: topic1) }
   fab!(:post2) { Fabricate(:post, topic: topic2) }
-  fab!(:category_page) { PageObjects::Pages::Category.new }
-  fab!(:topic_page) { PageObjects::Pages::Topic.new }
-  fab!(:user_page) { PageObjects::Pages::User.new }
-  fab!(:admin_page) { PageObjects::Pages::AdminSiteSettings.new }
+
+  let(:category_page) { PageObjects::Pages::Category.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:user_page) { PageObjects::Pages::User.new }
+  let(:admin_page) { PageObjects::Pages::AdminSiteSettings.new }
 
   before do
     SiteSetting.topic_voting_enabled = true
@@ -53,5 +54,19 @@ RSpec.describe "Topic voting", type: :system, js: true do
     # unvoting
     topic_page.remove_vote
     expect(topic_page.vote_count).to have_text("0")
+  end
+
+  context "when no votes are left" do
+    before do
+      DiscourseTopicVoting::CategorySetting.create!(category: category1)
+      SiteSetting.topic_voting_tl4_vote_limit = 1
+    end
+
+    it "alerts the user" do
+      category_page.visit(category1).select_topic(topic1)
+      topic_page.vote
+
+      expect(topic_page).to have_votes_left_popup(0)
+    end
   end
 end


### PR DESCRIPTION
This corrects a slight logic bug that was preventing the alert when the number of remaining votes was zero.