### PR TITLE
FIX: correctly update last message bus id for threads and channels

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-notice.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-notice.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import MentionWithoutMembership from "discourse/plugins/chat/discourse/components/chat/notices/mention_without_membership";
@@ -13,6 +14,7 @@ export default class ChatNotices extends Component {
 
   @action
   clearNotice() {
+    console.log("clearNotice", this.args.notice);
     this.noticesManager.clearNotice(this.args.notice);
   }
 
@@ -21,8 +23,7 @@ export default class ChatNotices extends Component {
   }
 
   <template>
-    <div class="chat-notices__notice">
-
+    <div class="chat-notices__notice" {{willDestroy this.clearNotice}}>
       {{#if @notice.textContent}}
         <p class="chat-notices__notice__content">
           {{@notice.textContent}}

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
@@ -39,7 +39,7 @@ export default class ChatChannelSubscriptionManager {
   }
 
   @bind
-  onMessage(busData) {
+  onMessage(busData, _, lastMessageBusId) {
     switch (busData.type) {
       case "sent":
         this.handleSentMessage(busData);
@@ -81,6 +81,8 @@ export default class ChatChannelSubscriptionManager {
         this.handleNotice(busData);
         break;
     }
+
+    this.channel.channelMessageBusLastId = lastMessageBusId;
   }
 
   handleSentMessage(data) {

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-channel-thread-subscription-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-channel-thread-subscription-manager.js
@@ -37,7 +37,7 @@ export default class ChatChannelThreadSubscriptionManager {
   }
 
   @bind
-  onMessage(busData, _, __, lastMessageBusId) {
+  onMessage(busData, _, lastMessageBusId) {
     switch (busData.type) {
       case "sent":
         this.handleSentMessage(busData);

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-notices-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-notices-manager.js
@@ -7,10 +7,12 @@ export default class ChatChannelNoticesManager extends Service {
   @tracked notices = new TrackedArray();
 
   handleNotice(data) {
-    this.notices.pushObject(ChatNotice.create(data));
+    this.notices.push(ChatNotice.create(data));
   }
 
   clearNotice(notice) {
-    this.notices.removeObject(notice);
+    this.notices = new TrackedArray(
+      this.notices.filter((n) => n.id !== notice.id)
+    );
   }
 }

--- a/plugins/chat/spec/system/channel_notice_spec.rb
+++ b/plugins/chat/spec/system/channel_notice_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "Channel notice", type: :system do
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+  let(:drawer_page) { PageObjects::Pages::ChatDrawer.new }
+
+  fab!(:current_user, :user)
+
+  before do
+    chat_system_bootstrap
+    sign_in(current_user)
+  end
+
+  context "when mentioned user can't see the channel" do
+    fab!(:secret_group, :group)
+    fab!(:private_category) { Fabricate(:private_category, group: secret_group) }
+    fab!(:private_channel) { Fabricate(:chat_channel, chatable: private_category) }
+    fab!(:mentioned_user, :user)
+
+    before do
+      secret_group.add(current_user)
+      private_channel.add(current_user)
+    end
+
+    it "shows the notice" do
+      chat_page.visit_channel(private_channel)
+      channel_page.send_message("@#{mentioned_user.username} hello")
+
+      expect(page).to have_selector(
+        ".chat-notices__notice",
+        text: I18n.t("chat.mention_warning.cannot_see", first_identifier: mentioned_user.username),
+      )
+    end
+
+    context "when navigating away and back to the channel" do
+      it "dismisses the notice" do
+        chat_page.visit_channel(private_channel)
+        channel_page.send_message("@#{mentioned_user.username} hello")
+        expect(page).to have_css(".chat-notices__notice")
+        find("#site-logo").click
+        expect(page).to have_no_css("body.has-chat")
+        find(".sidebar-row.channel-#{private_channel.id}").click
+        expect(drawer_page).to have_open_channel(private_channel)
+
+        wait_for_timeout(1000) # we are waiting for message bus to update the notice
+
+        expect(page).to have_no_css(".chat-notices__notice", wait: 0)
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -119,7 +119,7 @@ module PageObjects
 
       def has_open_channel?(channel)
         has_css?("html.has-drawer-chat")
-        has_css?("#{VISIBLE_DRAWER} .chat-channel[data-id='#{channel.id}']")
+        has_css?("#{VISIBLE_DRAWER} .chat-channel.--loaded[data-id='#{channel.id}']")
       end
 
       def has_channel_settings?


### PR DESCRIPTION
Given we cache the channels and threads we also store the last message bus id returned by the serializer initially. We need to ensure we update this id when we receive a message otherwise if you leave a channel and come back to it we will load the state from the id stored in the cache initially.

threads were doing it but we were not using the correct parameter.

This commit will fix multiple bugs, as for example notices that would replay each time you visit channel. We also took this opportunity to clear a notice once you leave a channel even if you didn't click dismiss.