### PR TITLE
FIX: Process templates before previewing

### DIFF
--- a/app/assets/javascripts/admin/addon/components/form-template/form.gjs
+++ b/app/assets/javascripts/admin/addon/components/form-template/form.gjs
@@ -20,6 +20,7 @@ export default class FormTemplateForm extends Component {
 
   @tracked formSubmitted = false;
   @tracked templateContent = this.args.model?.template || "";
+  @tracked processedTemplateContent = "";
   @tracked templateName = this.args.model?.name || "";
   @tracked showFormTemplateFormPreview;
 
@@ -139,7 +140,8 @@ export default class FormTemplateForm extends Component {
     }
 
     FormTemplate.validateTemplate(data)
-      .then(() => {
+      .then(({ form_template }) => {
+        this.processedTemplateContent = form_template.template;
         this.showFormTemplateFormPreview = true;
       })
       .catch(popupAjaxError);
@@ -224,7 +226,7 @@ export default class FormTemplateForm extends Component {
     {{#if this.showFormTemplateFormPreview}}
       <FormTemplateFormPreview
         @closeModal={{fn (mut this.showFormTemplateFormPreview) false}}
-        @content={{this.templateContent}}
+        @content={{this.processedTemplateContent}}
       />
     {{/if}}
   </template>

--- a/app/controllers/admin/form_templates_controller.rb
+++ b/app/controllers/admin/form_templates_controller.rb
@@ -24,7 +24,8 @@ class Admin::FormTemplatesController < Admin::StaffController
 
     begin
       template.validate!
-      render json: success_json
+      template.process!(guardian)
+      render_serialized(template, FormTemplateSerializer, root: "form_template")
     rescue FormTemplate::NotAllowed => err
       render_json_error(err.message)
     end

--- a/app/controllers/form_templates_controller.rb
+++ b/app/controllers/form_templates_controller.rb
@@ -16,7 +16,7 @@ class FormTemplatesController < ApplicationController
 
     raise Discourse::NotFound if template.nil?
 
-    template.template = process_template(template.template)
+    template.process!(guardian)
 
     render_serialized(template, FormTemplateSerializer, root: "form_template")
   end
@@ -25,48 +25,5 @@ class FormTemplatesController < ApplicationController
 
   def ensure_form_templates_enabled
     raise Discourse::InvalidAccess.new unless SiteSetting.experimental_form_templates
-  end
-
-  def process_template(template_content)
-    parsed_template = YAML.safe_load(template_content)
-
-    tag_group_names = parsed_template.map { |f| f["tag_group"] }.compact.map(&:downcase).uniq
-
-    tag_groups =
-      TagGroup
-        .includes(:tags)
-        .visible(guardian)
-        .where("lower(name) IN (?)", tag_group_names)
-        .index_by { |tg| tg.name }
-
-    parsed_template.map! do |form_field|
-      next form_field unless form_field["tag_group"]
-
-      tag_group_name = form_field["tag_group"]
-      tags = tag_groups[tag_group_name].tags.reject { |tag| tag.target_tag_id.present? }
-      ordered_field = {}
-
-      tags =
-        tags.sort_by do |t|
-          # Transform the name to the displayed value before ordering
-          display = t.description.presence || t.name.tr("-", " ").upcase
-          display
-        end
-
-      form_field.each do |key, value|
-        ordered_field[key] = value
-
-        ordered_field["choices"] = tags.map(&:name) if key == "id"
-        if key == "attributes"
-          ordered_field["attributes"]["tag_group"] = tag_group_name
-          translated_tags = tags.select { |t| t.description }.to_h { |t| [t.name, t.description] }
-          ordered_field["attributes"]["tag_choices"] = translated_tags
-        end
-      end
-
-      ordered_field
-    end
-
-    YAML.dump(parsed_template)
   end
 end

--- a/app/models/form_template.rb
+++ b/app/models/form_template.rb
@@ -19,6 +19,50 @@ class FormTemplate < ActiveRecord::Base
 
   class NotAllowed < StandardError
   end
+
+  def process!(guardian)
+    parsed_template = YAML.safe_load(template)
+
+    tag_group_names = parsed_template.map { |f| f["tag_group"] }.compact.map(&:downcase).uniq
+
+    tag_groups =
+      TagGroup
+        .includes(:tags)
+        .visible(guardian)
+        .where("lower(name) IN (?)", tag_group_names)
+        .index_by { |tg| tg.name }
+
+    parsed_template.map! do |form_field|
+      next form_field unless form_field["tag_group"]
+
+      tag_group_name = form_field["tag_group"]
+      tags = tag_groups[tag_group_name].tags.reject { |tag| tag.target_tag_id.present? }
+      ordered_field = {}
+
+      tags =
+        tags.sort_by do |t|
+          # Transform the name to the displayed value before ordering
+          display = t.description.presence || t.name.tr("-", " ").upcase
+          display
+        end
+
+      form_field.each do |key, value|
+        ordered_field[key] = value
+
+        ordered_field["choices"] = tags.map(&:name) if key == "id"
+        if key == "attributes"
+          ordered_field["attributes"]["tag_group"] = tag_group_name
+          translated_tags = tags.select { |t| t.description }.to_h { |t| [t.name, t.description] }
+          ordered_field["attributes"]["tag_choices"] = translated_tags
+        end
+      end
+
+      ordered_field
+    end
+
+    self.template = YAML.dump(parsed_template)
+    self
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
The bare template yaml file provided by the user cannot be directly used for form templates preview, because components such as `TagChooserField` actually rely on a backend process step. This step exists when users actually use the template, but is missing when the admin writes and previews the template.

This commit supplements the missing process step, thus fixing the problem that tag-chooser may break ember during admin preview