### PR TITLE
DEV: Fix a flaky system test

### DIFF
--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -133,7 +133,8 @@ describe "Admin About Config Area Page", type: :system do
 
         config_area.general_settings_section.submit
         expect(config_area.general_settings_section).to have_saved_successfully
-        expect(SiteSetting.about_banner_image).to eq(nil)
+
+        try_until_success { expect(SiteSetting.about_banner_image).to eq(nil) }
       end
 
       it "can upload an image using keyboard nav" do


### PR DESCRIPTION
Asserting for the state of the database needs to be wrapped in a
`try_until_success` block as we may need to retry the assertion multiple
times in order to ensure that all inflight requests by the server have
been processed.
