### PR TITLE
FIX: JS error when silencing and unsilencing the user

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -259,7 +259,13 @@ export default class AdminUser extends User {
     return ajax(`/admin/users/${this.id}/unsilence`, {
       type: "PUT",
     })
-      .then((result) => this.setProperties(result.unsilence))
+      .then((result) => {
+        this.setProperties({
+          silence_reason: result.unsilence.silence_reason,
+          silenced_at: result.unsilence.silence_at,
+          silenced_till: result.unsilence.silence_till,
+        });
+      })
       .finally(() => this.set("silencingUser", false));
   }
 
@@ -270,7 +276,14 @@ export default class AdminUser extends User {
       type: "PUT",
       data,
     })
-      .then((result) => this.setProperties(result.silence))
+      .then((result) => {
+        this.setProperties({
+          silence_reason: result.silence.silence_reason,
+          silenced_at: result.silence.silenced_at,
+          silenced_by: result.silence.silenced_by,
+          silenced_till: result.silence.silenced_till,
+        });
+      })
       .finally(() => this.set("silencingUser", false));
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -90,7 +90,12 @@ async function pressEnter(selector, modifier) {
         });
         server.put("/admin/users/5/silence", () => {
           return helper.response({
-            silenced: true,
+            silence: {
+              silence_reason: "spamming",
+              silenced_at: "",
+              silenced_till: "",
+              silenced_by: "",
+            },
           });
         });
         server.post("/post_actions", () => {

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -70,17 +70,22 @@ describe "Admin User Page", type: :system do
         )
       end
 
-      it "suspends the user" do
+      it "suspends and unsuspends the user" do
         admin_user_page.click_suspend_button
-        suspend_user_modal.fill_in_reason("spamming")
+        suspend_user_modal.fill_in_suspend_reason("spamming")
         suspend_user_modal.set_future_date("tomorrow")
         suspend_user_modal.perform
         expect(suspend_user_modal).to be_closed
+
+        expect(page).to have_css(".suspension-info")
+
+        admin_user_page.click_unsuspend_button
+        expect(page).not_to have_css(".suspension-info")
       end
 
       it "displays error when used is already suspended" do
         admin_user_page.click_suspend_button
-        suspend_user_modal.fill_in_reason("spamming")
+        suspend_user_modal.fill_in_suspend_reason("spamming")
         suspend_user_modal.set_future_date("tomorrow")
 
         user.update!(suspended_till: 1.day.from_now)
@@ -103,6 +108,20 @@ describe "Admin User Page", type: :system do
         expect(admin_user_page.similar_users_warning).to include(
           I18n.t("admin_js.admin.user.other_matches", count: 1, username: user.username),
         )
+      end
+
+      it "silence and unsilence the user" do
+        admin_user_page.click_silence_button
+
+        silence_user_modal.fill_in_silence_reason("spamming")
+        silence_user_modal.set_future_date("tomorrow")
+        silence_user_modal.perform
+
+        expect(silence_user_modal).to be_closed
+        expect(page).to have_css(".silence-info")
+
+        admin_user_page.click_unsilence_button
+        expect(page).not_to have_css(".silence-info")
       end
     end
   end

--- a/spec/system/page_objects/modals/penalize_user.rb
+++ b/spec/system/page_objects/modals/penalize_user.rb
@@ -15,8 +15,12 @@ module PageObjects
         find(".d-modal.#{@penalty_type}-user-modal")
       end
 
-      def fill_in_reason(reason)
+      def fill_in_suspend_reason(reason)
         find("input.suspend-reason").fill_in with: reason
+      end
+
+      def fill_in_silence_reason(reason)
+        find("input.silence-reason").fill_in with: reason
       end
 
       def set_future_date(date)

--- a/spec/system/page_objects/pages/admin_user.rb
+++ b/spec/system/page_objects/pages/admin_user.rb
@@ -27,8 +27,16 @@ module PageObjects
         find(".btn-danger.suspend-user").click
       end
 
+      def click_unsuspend_button
+        find(".btn-danger.unsuspend-user").click
+      end
+
       def click_silence_button
         find(".btn-danger.silence-user").click
+      end
+
+      def click_unsilence_button
+        find(".btn-danger.unsilence-user").click
       end
 
       def similar_users_warning


### PR DESCRIPTION
In this PR `silenced` became a computed property - https://github.com/discourse/discourse/pull/33537

When we silence the user, one of the serialised attributes is `silenced`. When we tried to assign it with `setProperties`, Ember was throwing an error. This was fixed by explicitly defining the arguments.


https://github.com/user-attachments/assets/e8126484-2980-4fd8-90a7-35594076e9d8

