### PR TITLE
DEV: Remove now-redundant is_staff guardian check

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2542,7 +2542,8 @@ trust:
     type: group_list
     area: "group_permissions"
   edit_all_post_groups:
-    default: "14"
+    default: "1|2|14" # auto group admins, moderators, and TL4
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     area: "group_permissions"
 

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -159,7 +159,7 @@ module PostGuardian
     # Must be staff to edit a locked post
     return false if post.locked? && !is_staff?
 
-    if (is_staff? || is_in_edit_post_groups? || is_category_group_moderator?(post.topic&.category))
+    if is_in_edit_post_groups? || is_category_group_moderator?(post.topic&.category)
       return can_create_post?(post.topic)
     end
     return false if !can_see_post_topic?(post)
@@ -201,8 +201,7 @@ module PostGuardian
   end
 
   def is_in_edit_post_groups?
-    SiteSetting.edit_all_post_groups.present? &&
-      user.in_any_groups?(SiteSetting.edit_all_post_groups.to_s.split("|").map(&:to_i))
+    user.in_any_groups?(SiteSetting.edit_all_post_groups_map)
   end
 
   def can_edit_hidden_post?(post)

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -340,7 +340,7 @@ module DiscoursePostEvent
     end
 
     context "with a private event" do
-      let(:moderator) { Fabricate(:user, moderator: true) }
+      let(:moderator) { Fabricate(:moderator) }
       let(:topic) { Fabricate(:topic, user: moderator) }
       let(:first_post) { Fabricate(:post, user: moderator, topic: topic) }
       let(:private_event) { Fabricate(:event, post: first_post, status: Event.statuses[:private]) }

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -12,14 +12,15 @@ register_asset "stylesheets/presence.scss"
 
 after_initialize do
   register_presence_channel_prefix("discourse-presence") do |channel_name|
+    staff_groups = [::Group::AUTO_GROUPS[:admins], ::Group::AUTO_GROUPS[:moderators]]
+
     if topic_id = channel_name[%r{/discourse-presence/reply/(\d+)}, 1]
       topic = Topic.find(topic_id)
       config = PresenceChannel::Config.new
 
       if topic.private_message?
         config.allowed_user_ids = topic.allowed_users.pluck(:id)
-        config.allowed_group_ids =
-          topic.allowed_groups.pluck(:group_id) + [::Group::AUTO_GROUPS[:staff]]
+        config.allowed_group_ids = topic.allowed_groups.pluck(:group_id) + staff_groups
       elsif secure_group_ids = topic.secure_group_ids
         config.allowed_group_ids = secure_group_ids + [::Group::AUTO_GROUPS[:admins]]
       else
@@ -36,7 +37,7 @@ after_initialize do
       topic = Topic.find(post.topic_id)
 
       config = PresenceChannel::Config.new
-      config.allowed_group_ids = [::Group::AUTO_GROUPS[:staff]]
+      config.allowed_group_ids = staff_groups
 
       # Locked posts are staff only
       next config if post.locked?
@@ -67,6 +68,8 @@ after_initialize do
       if SiteSetting.enable_category_group_moderation? && topic.category
         config.allowed_group_ids.push(*topic.category.moderating_groups.pluck(:id))
       end
+
+      config.allowed_group_ids.uniq!
 
       config
     end

--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -70,13 +70,20 @@ RSpec.describe "discourse-presence" do
       p = Fabricate(:post, topic: private_topic, user: private_topic.user)
 
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
+      )
 
       SiteSetting.enable_category_group_moderation = true
       Fabricate(:category_moderation_group, category:, group:)
 
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}", use_cache: false)
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff], group.id)
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
+        group.id,
+      )
     end
 
     it "adds edit_all_post_groups to the presence channel" do
@@ -87,7 +94,8 @@ RSpec.describe "discourse-presence" do
 
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
       expect(c.config.allowed_group_ids).to contain_exactly(
-        Group::AUTO_GROUPS[:staff],
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
         Group::AUTO_GROUPS[:trust_level_1],
         g.id,
       )
@@ -109,7 +117,11 @@ RSpec.describe "discourse-presence" do
     it "handles permissions for private messages" do
       c = PresenceChannel.new("/discourse-presence/reply/#{private_message.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(group.id, Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        group.id,
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
+      )
       expect(c.config.allowed_user_ids).to contain_exactly(
         *private_message.topic_allowed_users.pluck(:user_id),
       )
@@ -129,7 +141,8 @@ RSpec.describe "discourse-presence" do
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
       expect(c.config.public).to eq(false)
       expect(c.config.allowed_group_ids).to contain_exactly(
-        Group::AUTO_GROUPS[:staff],
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
         *SiteSetting.whispers_allowed_groups_map,
       )
       expect(c.config.allowed_user_ids).to eq(nil)
@@ -139,7 +152,10 @@ RSpec.describe "discourse-presence" do
       p = Fabricate(:post, topic: public_topic, user: admin, locked_by_id: Discourse.system_user.id)
       c = PresenceChannel.new("/discourse-presence/edit/#{p.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
+      )
       expect(c.config.allowed_user_ids).to eq(nil)
     end
 
@@ -149,7 +165,8 @@ RSpec.describe "discourse-presence" do
       expect(c.config.public).to eq(false)
       expect(c.config.allowed_group_ids).to contain_exactly(
         Group::AUTO_GROUPS[:trust_level_4],
-        Group::AUTO_GROUPS[:staff],
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
       )
       expect(c.config.allowed_user_ids).to contain_exactly(user.id)
     end
@@ -169,7 +186,10 @@ RSpec.describe "discourse-presence" do
 
       c = PresenceChannel.new("/discourse-presence/edit/#{post.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:staff])
+      expect(c.config.allowed_group_ids).to contain_exactly(
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
+      )
       expect(c.config.allowed_user_ids).to contain_exactly(user.id)
     end
 
@@ -179,7 +199,8 @@ RSpec.describe "discourse-presence" do
       c = PresenceChannel.new("/discourse-presence/edit/#{post.id}")
       expect(c.config.public).to eq(false)
       expect(c.config.allowed_group_ids).to contain_exactly(
-        Group::AUTO_GROUPS[:staff],
+        Group::AUTO_GROUPS[:admins],
+        Group::AUTO_GROUPS[:moderators],
         *private_message.allowed_groups.pluck(:id),
       )
       expect(c.config.allowed_user_ids).to contain_exactly(


### PR DESCRIPTION
### What is this change?

The `edit_all_post_groups` used to have TL4 as the default setting. This update:

1. Adds in `admins` and `moderators` as well as makes those mandatory values.
2. Gets rid of now-redundant `is_staff?` check.
3. Makes use of the magic `#edit_all_post_groups_map` method.

Test coverage is here:

- https://github.com/discourse/discourse/blob/main/spec/lib/guardian/post_guardian_spec.rb#L507-L544
- https://github.com/discourse/discourse/blob/main/spec/lib/guardian/post_guardian_spec.rb#L624-L642