### PR TITLE
UX: remove one-off style for notification buttons

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -238,20 +238,6 @@
     .notifications-dismiss {
       margin-left: 0.5em;
     }
-
-    .btn {
-      background-color: var(--primary-very-low);
-
-      --d-button-default-icon-color: var(--primary-high);
-
-      &:hover,
-      &:focus-visible {
-        background-color: var(--primary-low);
-
-        --d-button-default-icon-color--hover: var(--primary);
-        --d-button-default-text-color--hover: var(--primary);
-      }
-    }
   }
 
   .badge-notification {

--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -91,13 +91,6 @@ html {
     }
   }
 
-  .menu-panel .panel-body-bottom .btn:hover,
-  .menu-panel .panel-body-bottom .btn:focus {
-    .d-icon {
-      color: var(--primary);
-    }
-  }
-
   .d-header-icons .d-icon,
   .header-sidebar-toggle button .d-icon {
     color: var(--primary-low-mid);


### PR DESCRIPTION
The lighter style here probably isn't worth making these buttons a special case... we apply the btn-default style, so we should use it like all the other buttons do. 

The default style is darker, but this makes theming and other button changes easier because we don't have a special case. 

Before:

<img width="850" height="414" alt="image" src="https://github.com/user-attachments/assets/cf6825d2-ae67-4f04-a870-cfaa2b3bb32a" />


After:

<img width="780" height="470" alt="image" src="https://github.com/user-attachments/assets/71874a44-4567-47ca-97cd-6241fca163fc" />
