### PR TITLE
UX: prevent footer reason from squishing buttons

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -79,6 +79,11 @@
       align-items: center;
       gap: 0.5rem;
       margin: 0;
+
+      details,
+      button {
+        flex: 1 0 auto;
+      }
     }
   }
 }


### PR DESCRIPTION
In some cases the reason text next to the button can cause the button text to wrap. Ideally we never want this to happen, we should make the reason wrap first. 

This prevents it from applying `flex-shrink: 0` to the button. 