### PR TITLE
UX: Fix tabs in new notification panel

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -278,10 +278,8 @@
   .menu-tabs-container {
     display: flex;
     flex-direction: column;
-    padding: var(--space-half);
     overflow-y: auto;
     overscroll-behavior: contain;
-    margin-inline: calc(var(--user-menu-border-width) * -1);
   }
 
   .tabs-list {
@@ -292,20 +290,22 @@
       display: flex;
       position: relative;
       border-radius: 0;
-      padding: 0.8125em;
+      padding: 0.375em; // 6px
 
       @include viewport.until(sm) {
-        padding: 1.2em 1.4em;
+        padding: 0.75em 0.875em; // 12px 14px
       }
 
       @media screen and (height <= 400px) {
         // helps with 400% zoom level
         font-size: var(--font-down-1);
-        padding: 0.5em 0.875em;
+        padding: 0.125em 0.375em; // 2px 6px
       }
 
       .d-icon {
+        border-radius: var(--d-border-radius);
         color: var(--primary-medium);
+        padding: 0.5em; // 8px
       }
 
       .badge-notification {
@@ -317,29 +317,24 @@
 
         @media screen and (height <= 400px) {
           // helps with 400% zoom level
-          right: 0;
+          right: 3px;
           top: 0;
         }
       }
 
       &.active {
         .d-icon {
-          box-shadow: var(--active-shadow);
           color: var(--d-sidebar-active-color);
           background-color: var(--d-sidebar-active-background);
-          border-radius: calc(var(--d-border-radius) * 0.25);
         }
       }
 
       &:not(.active):hover,
       &:not(.active):focus-visible {
         background: none;
-        padding-left: calc(0.875em - var(--user-menu-border-width));
 
         .d-icon {
-          box-shadow: var(--hover-shadow);
           background-color: var(--d-sidebar-highlight-background);
-          border-radius: calc(var(--d-border-radius) * 0.25);
         }
       }
     }


### PR DESCRIPTION
A followup to #33795

1. the hover effect was broken in Safari (because it was trying to emulate a background by setting a box-shadow of a small child element)
   <img width="45" height="47" alt="image" src="https://github.com/user-attachments/assets/53deaa3c-d4f5-4b02-ad74-ec464cd12d38" />
2. in <= 400px height viewports elements were overlapping eachother and icons moved on hover
   <img width="40" height="64" alt="Screenshot 2025-07-26 at 12 17 21" src="https://github.com/user-attachments/assets/950ef5f0-6d80-418f-b522-78a58730174f" />
3. changing `--user-menu-border-width` had issues: at 0px and at >= 3px icons would move on hover, and increasing the value would make tabs overlap with the border
   <img width="49" height="93" alt="image" src="https://github.com/user-attachments/assets/4e514f02-437c-4bfd-8d98-f0dffdfccac5" />
