### PR TITLE
DEV: Group lint deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,3 +97,10 @@ updates:
       uppy:
         patterns:
           - "@uppy*"
+      lint:
+        patterns:
+          - "@discourse/lint-config"
+          - "eslint"
+          - "prettier"
+          - "ember-template-lint"
+          - "stylelint"


### PR DESCRIPTION
The hope is that this will allow dependabot to handle lint-config bump.