### PR TITLE
DEV: Update smoke test for new composer

### DIFF
--- a/test/smoke-test.mjs
+++ b/test/smoke-test.mjs
@@ -228,9 +228,9 @@ import puppeteer from "puppeteer-core";
       return promise;
     });
 
-    await exec("updates preview", () => {
-      return page.waitForSelector(".d-editor-preview p", { visible: true });
-    });
+    // await exec("updates preview", () => {
+    //   return page.waitForSelector(".d-editor-preview p", { visible: true });
+    // });
 
     await exec("submit the topic", () => {
       return page.click(".submit-panel .create");
@@ -255,14 +255,14 @@ import puppeteer from "puppeteer-core";
       return page.type("#reply-control .d-editor-input", post);
     });
 
-    await exec("waiting for the preview", async () => {
-      await page.waitForSelector("div.d-editor-preview", {
-        visible: true,
-      });
-      return page.waitForFunction(
-        "document.querySelector('div.d-editor-preview').innerText.includes('I can even write a reply')"
-      );
-    });
+    // await exec("waiting for the preview", async () => {
+    //   await page.waitForSelector("div.d-editor-preview", {
+    //     visible: true,
+    //   });
+    //   return page.waitForFunction(
+    //     "document.querySelector('div.d-editor-preview').innerText.includes('I can even write a reply')"
+    //   );
+    // });
 
     await exec("wait a little bit", () => {
       return new Promise((resolve) => setTimeout(resolve, 5000));


### PR DESCRIPTION
Remove preview checks since now rich composer is the
default. We may want to change the smoke test to test
both paths (rich and markdown), but for now let's just
get it working.
