### PR TITLE
DEV: Wait for editor in smoke test

### DIFF
--- a/test/smoke-test.mjs
+++ b/test/smoke-test.mjs
@@ -214,6 +214,12 @@ import puppeteer from "puppeteer-core";
       document.getElementById("reply-title").value = "";
     });
 
+    await exec("composer is open", () => {
+      return page.waitForSelector("#reply-control .d-editor-input", {
+        visible: true,
+      });
+    });
+
     await exec("compose new topic", () => {
       const date = `(${+new Date()})`;
       const title = `This is a new topic ${date}`;


### PR DESCRIPTION
Followup c6287038e4ae4143228e25ff13e93184fdfb0909

We should ensure the element for the editor is present
before trying to type into it, I think this was failing
in some cases because the rich editor takes a little extra
time to load vs the markdown editor.
