### PR TITLE
UX: Mention browser console in theme error banner

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -229,7 +229,7 @@ en:
 
     themes:
       default_description: "Default"
-      broken_theme_alert: "Your site may not work because a theme / component has errors."
+      broken_theme_alert: "Your site may not work because a theme / component has errors. Check the browser console for more information."
       error_caused_by: "Caused by '%{name}'. <a target='blank' href='%{path}'>Click here</a> to update, reconfigure or disable."
       only_admins: "(this message is only shown to site administrators)"
 


### PR DESCRIPTION
<img width="861" height="82" alt="SCR-20250728-jfqt" src="https://github.com/user-attachments/assets/503d7237-6ec1-49a3-ae0a-466cbc1ca71c" />
