### PR TITLE
DEV: Pin Rack to < 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,8 @@ gem "mini_racer"
 
 gem "highline", require: false
 
-gem "rack"
+# When unicorn is not used anymore, we can use Rack 3
+gem "rack", "< 3"
 
 gem "rack-protection" # security
 gem "cbor", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -822,7 +822,7 @@ DEPENDENCIES
   pry-rails
   pry-stack_explorer
   puma
-  rack
+  rack (< 3)
   rack-mini-profiler
   rack-protection
   rails-dom-testing


### PR DESCRIPTION
Upgrading Rack to version 3 will break Unicorn. When we don’t use Unicorn anymore, we’ll be able to upgrade to Rack 3.