### PR TITLE
FEATURE: Reset bump date when hiding a post

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -629,6 +629,7 @@ class Post < ActiveRecord::Base
       )
 
     hiding_again = hidden_at.present?
+    should_reset_bumped_at = is_last_reply? && !whisper?
 
     Post.transaction do
       self.skip_validation = true
@@ -679,6 +680,8 @@ class Post < ActiveRecord::Base
         message_options: options,
       )
     end
+
+    topic.reset_bumped_at if should_reset_bumped_at
   end
 
   def unhide!

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1589,7 +1589,7 @@ RSpec.describe Post do
         expect(topic.reload.bumped_at).to eq_time(second_last_reply.created_at)
       end
 
-      it "hiding other reply will not reset the topic's bumped_at" do
+      it "does not reset the topic's bumped_at when hiding a reply that is not the last" do
         second_last_reply.hide!(PostActionType.types[:off_topic])
 
         expect(topic.reload.bumped_at).to eq_time(1.day.from_now)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1577,7 +1577,7 @@ RSpec.describe Post do
 
       before { topic.update_columns(bumped_at: 1.day.from_now) }
 
-      it "hiding whisper will not reset the topic's bumped_at" do
+      it "does not reset the topic's bumped_at when hiding a whisper" do
         whisper_post.hide!(PostActionType.types[:off_topic])
 
         expect(topic.reload.bumped_at).to eq_time(1.day.from_now)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1583,7 +1583,7 @@ RSpec.describe Post do
         expect(topic.reload.bumped_at).to eq_time(1.day.from_now)
       end
 
-      it "hiding last visible reply will reset the topic's bumped_at" do
+      it "resets the topic's bumped_at when hiding the last visible reply" do
         last_reply.hide!(PostActionType.types[:off_topic])
 
         expect(topic.reload.bumped_at).to eq_time(second_last_reply.created_at)


### PR DESCRIPTION
This is a continuation of #33747, implements automatic resetting of topic bump date when a last reply is hidden, so the topic will go to the correct place  it belongs on /latest based on its last public post.