### PR TITLE
DEV: Remove logging for themable site settings

### DIFF
--- a/app/assets/javascripts/discourse/app/services/site-settings.js
+++ b/app/assets/javascripts/discourse/app/services/site-settings.js
@@ -11,10 +11,6 @@ export function createSiteSettingsFromPreloaded(
   if (themeSiteSettingOverrides) {
     for (const [key, value] of Object.entries(themeSiteSettingOverrides)) {
       settings[key] = value;
-      // eslint-disable-next-line no-console
-      console.info(
-        `[Discourse] Overriding site setting ${key} with theme site setting value: ${value}`
-      );
     }
     settings.themeSiteSettingOverrides = themeSiteSettingOverrides;
   }


### PR DESCRIPTION
Logging these on every page load is quite noisy. Best to keep the console as clear as possible, so that important messages are easier to identify.