### PR TITLE
FIX: Add `pen` icon to core icons list

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -207,6 +207,7 @@ module SvgSprite
         palette
         paper-plane
         pause
+        pen
         pencil
         play
         plug


### PR DESCRIPTION
This icon is used in the rich editor. Normally it works fine because it's the default icon for the "Editor" badge. But if that icon was changed, or the badge was disabled, then the icon was unavailable.