### PR TITLE
FIX: don't grow topic footer button

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -82,7 +82,7 @@
 
       details,
       button {
-        flex: 1 0 auto;
+        flex-shrink: 0;
       }
     }
   }


### PR DESCRIPTION
Follow-up to e61f2e1b89a6bf02c7b555d5f3cdb88ff9d9f3c0, unintentionally added `flex-grow: 1` when using the shorthand, should only apply `flex-shrink: 0`

Before:

<img width="1648" height="226" alt="image" src="https://github.com/user-attachments/assets/fa50835b-ae7b-4025-94c4-443b73976b56" />

After:

<img width="1390" height="236" alt="image" src="https://github.com/user-attachments/assets/a6fdcc4b-a236-4a87-b182-9df28b0163fd" />
