### PR TITLE
UX: show navigate to post button on ignored quotes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/quoted-content.gjs
@@ -95,11 +95,7 @@ export default class PostQuotedContent extends Component {
   }
 
   get shouldDisplayNavigateToPostButton() {
-    return (
-      !this.args.quotedPostNotFound &&
-      this.quotedPostUrl &&
-      !this.isQuotedPostIgnored
-    );
+    return !this.args.quotedPostNotFound && this.quotedPostUrl;
   }
 
   get shouldDisplayQuoteControls() {


### PR DESCRIPTION
Currently we don't display quote controls if you're ignoring the quoted user: 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/05f6b0b9-6f2a-4377-9c0e-0c9de4a71329" />

Previously in the non-glimmer post stream, we would show the controls. The expand button was useless and showed no content, but the navigate to post button could still be useful for finding the ignored post. 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5de052ed-b68a-45ec-87dd-80fc1823ad54" />

This PR restores the jump to post button in the glimmer post stream, so someone can use it if they choose to:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1af7a92e-672b-4c50-b42e-101c41f9336b" />

