### PR TITLE
DEV: Fix flakey spec with media convert

### DIFF
--- a/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
+++ b/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
   end
 
   describe "#convert" do
-    let(:output_path) { "/uploads/default/test_0/original/1X/#{new_sha1}" }
+    let(:output_path) do
+      "/uploads/default/test_#{ENV["TEST_ENV_NUMBER"].presence || "0"}/original/1X/#{new_sha1}"
+    end
     let(:job_id) { "job-123" }
 
     before { allow(Jobs).to receive(:enqueue_in) }


### PR DESCRIPTION
Looks like we need to use the TEST_ENV_NUMBER in the spec which appears to be a
common pattern in other specs.
