### PR TITLE
UX: clarify color palette activation button

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6991,7 +6991,7 @@ en:
           dark_mode_warning: "You're currently using dark mode. When setting an active color palette the colors will be applied to the light mode of the theme. If you want to change the default dark mode colors, please edit the <a href='%{link}'>dark mode site setting</a>."
           title: "Colors"
           edit: "Edit"
-          set_default: "Set as active on default theme (%{theme})"
+          set_default: "Activate on default theme (%{theme})"
           set_default_success: "%{schemeName} set as active palette for %{themeName}"
           saved_refreshing: "Saved! Refreshing colors..."
           from_theme: "From theme: %{name}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6991,7 +6991,7 @@ en:
           dark_mode_warning: "You're currently using dark mode. When setting an active color palette the colors will be applied to the light mode of the theme. If you want to change the default dark mode colors, please edit the <a href='%{link}'>dark mode site setting</a>."
           title: "Colors"
           edit: "Edit"
-          set_default: "Set as active on %{theme}"
+          set_default: "Set as active on default theme (%{theme})"
           set_default_success: "%{schemeName} set as active palette for %{themeName}"
           saved_refreshing: "Saved! Refreshing colors..."
           from_theme: "From theme: %{name}"


### PR DESCRIPTION
Slightly longer, but clearer if you're new and don't know what the default theme's name is yet

Before:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/518e1548-a188-4dea-bdee-5f00d403945e" />


After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/36d98a55-a6fe-4f0a-b916-46517c2e1a10" />