### PR TITLE
UX: on plugin index, unlink preinstall, simplify install banner

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-plugins-list-item.gjs
@@ -121,14 +121,9 @@ export default class AdminPluginsListItem extends Component {
           >
             {{@plugin.version}}<br />
             {{#if this.isPreinstalled}}
-              <a
-                href="https://meta.discourse.org/t/bundling-more-popular-plugins-with-discourse-core/373574"
-                rel="noopener noreferrer"
-                target="_blank"
-                class="admin-plugins-list__preinstalled-link"
-              >
+              <span class="admin-plugins-list__preinstalled">
                 {{i18n "admin.plugins.preinstalled"}}
-              </a>
+              </span>
             {{else}}
               <PluginCommitHash @plugin={{@plugin}} />
             {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -1,9 +1,10 @@
+import { concat } from "@ember/helper";
+import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DPageHeader from "discourse/components/d-page-header";
 import NavItem from "discourse/components/nav-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import icon from "discourse/helpers/d-icon";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 import AdminFilterControls from "admin/components/admin-filter-controls";
@@ -15,8 +16,14 @@ export default RouteTemplate(
 
       <DPageHeader
         @titleLabel={{i18n "admin.config.plugins.title"}}
-        @descriptionLabel={{i18n "admin.config.plugins.header_description"}}
-        @learnMoreUrl="https://www.discourse.org/plugins"
+        @descriptionLabel={{htmlSafe
+          (concat
+            (i18n "admin.config.plugins.header_description")
+            '<a class="admin-plugins-howto" href="https://meta.discourse.org/t/install-a-plugin/19157">'
+            (i18n "admin.plugins.howto")
+            "</a>"
+          )
+        }}
       >
         <:breadcrumbs>
           <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
@@ -47,13 +54,6 @@ export default RouteTemplate(
           {{/each}}
         </:tabs>
       </DPageHeader>
-
-      <div class="alert alert-info admin-plugins-howto">
-        <a href="https://meta.discourse.org/t/install-a-plugin/19157">
-          {{icon "circle-info"}}
-          {{i18n "admin.plugins.howto"}}
-        </a>
-      </div>
 
       {{#if @controller.model.length}}
         <AdminFilterControls

--- a/app/assets/stylesheets/admin/plugins.scss
+++ b/app/assets/stylesheets/admin/plugins.scss
@@ -63,6 +63,10 @@
       white-space: nowrap;
       display: block;
     }
+
+    &__preinstalled {
+      color: var(--primary-medium);
+    }
   }
 }
 
@@ -146,8 +150,5 @@
 }
 
 .admin-plugins-howto {
-  a {
-    display: inline-block;
-    width: 100%;
-  }
+  margin-left: 0.35em;
 }


### PR DESCRIPTION
The link we were using only applied to newly moved plugins, so wasn't the best fit for all of them. This unlinks it. 

I've also removed the plugin install banner and inlined it in the page description. The blue banner was kind of intense for a message that's always visible on the page. We need to retain the class there so it can be hidden for sites on our hosting. 

Before:
<img width="1802" height="988" alt="image" src="https://github.com/user-attachments/assets/d101e0e0-9476-4077-9815-3427e0db69f4" />


After:
<img width="1778" height="804" alt="image" src="https://github.com/user-attachments/assets/e04309e5-1d14-4f97-b43f-7f6ba7b8a483" />
