### PR TITLE
DEV: Reduce unnecessary UI updates when posts change

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -843,8 +843,17 @@ export default class PostStream extends RestModel {
     return Promise.resolve();
   }
 
-  triggerChangedPost(postId, updatedAt, opts) {
-    opts = opts || {};
+  /**
+   * Updates a post in the stream when it has been changed on the server.
+   *
+   * @param {number} postId - The ID of the post to update
+   * @param {string} updatedAt - The timestamp when the post was last updated
+   * @param {Object} opts - Additional options for updating the post
+   * @param {boolean} [opts.preserveCooked] - Whether to preserve the cooked HTML content
+   * @returns {Promise} A promise that resolves when the post has been updated
+   */
+  async triggerChangedPost(postId, updatedAt, opts = {}) {
+    opts ||= {};
 
     const resolved = Promise.resolve();
     if (!postId) {
@@ -852,17 +861,26 @@ export default class PostStream extends RestModel {
     }
 
     const existing = this._identityMap[postId];
-    if (existing && existing.updated_at !== updatedAt) {
-      const url = "/posts/" + postId;
-      const store = this.store;
-      return ajax(url).then((p) => {
-        if (opts.preserveCooked) {
-          p.cooked = existing.get("cooked");
-        }
 
-        this.storePost(store.createRecord("post", p));
-      });
+    // Only fetch and update if the post exists and has a different updated timestamp
+    if (existing && existing.updated_at !== updatedAt) {
+      // Fetch the latest post data from the server
+      const updatedData = await ajax(`/posts/${postId}`);
+
+      // Preserve the existing cooked HTML content if requested
+      if (opts.preserveCooked) {
+        updatedData.cooked = existing.cooked;
+      }
+
+      // Create a new post record with updated data and store it in the identity map.
+      // Creating a new record will update the existing one in the map, which will then
+      // trigger re-rendering of UI components that use the tracked data that was updated.
+      const updatedPost = this.store.createRecord("post", updatedData);
+
+      // Update the post in the post stream's identity map
+      this.storePost(updatedPost);
     }
+
     return resolved;
   }
 
@@ -1098,7 +1116,9 @@ export default class PostStream extends RestModel {
         return existing;
       }
 
-      post.set("topic", this.topic);
+      if (post.topic !== this.topic) {
+        post.topic = this.topic;
+      }
       this._identityMap[post.get("id")] = post;
     }
     return post;

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -855,9 +855,8 @@ export default class PostStream extends RestModel {
   async triggerChangedPost(postId, updatedAt, opts = {}) {
     opts ||= {};
 
-    const resolved = Promise.resolve();
     if (!postId) {
-      return resolved;
+      return;
     }
 
     const existing = this._identityMap[postId];
@@ -880,8 +879,6 @@ export default class PostStream extends RestModel {
       // Update the post in the post stream's identity map
       this.storePost(updatedPost);
     }
-
-    return resolved;
   }
 
   triggerLikedPost(postId, likesCount, userID, eventType) {

--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -418,7 +418,15 @@ export default class StoreService extends Service {
         klass = RestModel;
       }
 
-      existing.setProperties(klass.munge(obj));
+      const updatedProperties = klass.munge(obj);
+      // update only the properties that the value changed to prevent unnecessary rerenders in Glimmer
+      updatedProperties &&
+        Object.keys(updatedProperties).forEach((key) => {
+          if (existing[key] !== updatedProperties[key]) {
+            existing.set(key, updatedProperties[key]);
+          }
+        });
+
       obj[adapter.primaryKey] = id;
       return existing;
     }


### PR DESCRIPTION
This PR refines how posts are updated in the post stream and store service to minimize unnecessary UI re-renders.

In the store service, only changed properties are set on existing records, preventing redundant updates and improving Glimmer performance.