### PR TITLE
DEV: Remove now-redundant is_staff? guardian check

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2527,7 +2527,8 @@ trust:
     hidden: true
     area: "trust_levels"
   delete_all_posts_and_topics_allowed_groups:
-    default: ""
+    default: "1|2" # auto group admins, moderators
+    mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
     allow_any: false
     refresh: true

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -225,7 +225,7 @@ module PostGuardian
     # Can't delete the first post
     return false if post.is_first_post?
 
-    return true if is_staff? || is_category_group_moderator?(post.topic&.category)
+    return true if is_category_group_moderator?(post.topic&.category)
 
     return true if user.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
 
@@ -388,7 +388,7 @@ module PostGuardian
   end
 
   def can_see_deleted_posts?(category = nil)
-    is_staff? || is_category_group_moderator?(category) ||
+    is_category_group_moderator?(category) ||
       @user.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
   end
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -145,22 +145,23 @@ module TopicGuardian
   end
 
   def can_recover_topic?(topic)
-    if is_staff? || (topic&.category && is_category_group_moderator?(topic.category)) ||
+    return false if topic.blank?
+
+    if is_category_group_moderator?(topic.category) ||
          user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
-      !!(topic && topic.deleted_at)
+      topic.deleted_at?
     else
-      topic && can_recover_post?(topic.ordered_posts.first)
+      can_recover_post?(topic.ordered_posts.first)
     end
   end
 
   def can_delete_topic?(topic)
     !topic.trashed? &&
       (
-        is_staff? ||
-          (
-            is_my_own?(topic) && topic.posts_count <= 1 && topic.created_at &&
-              topic.created_at > 24.hours.ago
-          ) || is_category_group_moderator?(topic.category) ||
+        (
+          is_my_own?(topic) && topic.posts_count <= 1 && topic.created_at &&
+            topic.created_at > 24.hours.ago
+        ) || is_category_group_moderator?(topic.category) ||
           user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
       ) && !topic.is_category_topic? && !Discourse.static_doc_topic_ids.include?(topic.id)
   end
@@ -216,7 +217,7 @@ module TopicGuardian
   end
 
   def can_see_deleted_topics?(category)
-    is_staff? || is_category_group_moderator?(category) ||
+    is_category_group_moderator?(category) ||
       user&.in_any_groups?(SiteSetting.delete_all_posts_and_topics_allowed_groups_map)
   end
 

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -647,13 +647,8 @@ RSpec.describe TopicView do
     end
 
     describe "filter_posts_near" do
-      def topic_view_near(post, show_deleted = false)
-        TopicView.new(
-          topic.id,
-          evil_trout,
-          post_number: post.post_number,
-          show_deleted: show_deleted,
-        )
+      def topic_view_near(post, user = evil_trout, show_deleted: false)
+        TopicView.new(topic.id, user, post_number: post.post_number, show_deleted: show_deleted)
       end
 
       it "snaps to the lower boundary" do
@@ -688,8 +683,7 @@ RSpec.describe TopicView do
       end
 
       it "gaps deleted posts to an admin" do
-        evil_trout.admin = true
-        near_view = topic_view_near(p3)
+        near_view = topic_view_near(p3, admin)
         expect(near_view.desired_post).to eq(p3)
         expect(near_view.posts).to eq([p2, p3, p5])
         expect(near_view.gaps.before).to eq(p5.id => [p4.id])
@@ -697,16 +691,14 @@ RSpec.describe TopicView do
       end
 
       it "returns deleted posts to an admin with show_deleted" do
-        evil_trout.admin = true
-        near_view = topic_view_near(p3, true)
+        near_view = topic_view_near(p3, admin, show_deleted: true)
         expect(near_view.desired_post).to eq(p3)
         expect(near_view.posts).to eq([p2, p3, p4])
         expect(near_view.contains_gaps?).to eq(false)
       end
 
       it "gaps deleted posts by nuked users to an admin" do
-        evil_trout.admin = true
-        near_view = topic_view_near(p5)
+        near_view = topic_view_near(p5, admin)
         expect(near_view.desired_post).to eq(p5)
         # note: both p4 and p6 get skipped
         expect(near_view.posts).to eq([p2, p3, p5])
@@ -715,8 +707,7 @@ RSpec.describe TopicView do
       end
 
       it "returns deleted posts by nuked users to an admin with show_deleted" do
-        evil_trout.admin = true
-        near_view = topic_view_near(p5, true)
+        near_view = topic_view_near(p5, admin, show_deleted: true)
         expect(near_view.desired_post).to eq(p5)
         expect(near_view.posts).to eq([p4, p5, p6])
         expect(near_view.contains_gaps?).to eq(false)
@@ -732,16 +723,14 @@ RSpec.describe TopicView do
         end
 
         it "gaps deleted posts to admins" do
-          evil_trout.admin = true
-          near_view = topic_view_near(p5)
+          near_view = topic_view_near(p5, admin)
           expect(near_view.posts).to eq([p1, p2, p3, p5])
           expect(near_view.gaps.before).to eq(p5.id => [p4.id])
           expect(near_view.gaps.after).to eq(p5.id => [p6.id, p7.id])
         end
 
         it "returns deleted posts to admins" do
-          evil_trout.admin = true
-          near_view = topic_view_near(p5, true)
+          near_view = topic_view_near(p5, admin, show_deleted: true)
           expect(near_view.posts).to eq([p1, p2, p3, p4, p5, p6, p7])
           expect(near_view.contains_gaps?).to eq(false)
         end


### PR DESCRIPTION
### What is this change?

Instead of doing both an `is_staff?` and a group access check, just add `admins` and `moderators` as mandatory values to the group access setting.