### PR TITLE
FIX: Incorrect component closing in ai tool options

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-persona-tool-options.gjs
@@ -101,8 +101,8 @@ export default class AiPersonaToolOptions extends Component {
               {{/let}}
             </div>
           {{/each}}
-        </@form.Object>
-      </@form.Container>
+        </form.Object>
+      </form.Container>
     {{/if}}
   </template>
 }


### PR DESCRIPTION
Form was closed with `</@form.Object>` instead of `</form.Object>`