### PR TITLE
FEATURE: Reset bump date when unhiding a post

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -706,6 +706,8 @@ class Post < ActiveRecord::Base
         should_update_user_stat = false
       end
 
+      self.topic.reset_bumped_at(self) if is_last_reply? && !whisper?
+
       # We need to do this because TopicStatusUpdater also does the increment
       # and we don't want to double count for the OP.
       UserStatCountUpdater.increment!(self) if should_update_user_stat

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1922,7 +1922,7 @@ class Topic < ActiveRecord::Base
     @is_category_topic ||= Category.exists?(topic_id: self.id.to_i)
   end
 
-  def reset_bumped_at( = nil)
+  def reset_bumped_at(post_or_post_id = nil)
     post =
       if post_or_post_id.is_a?(Post)
         post_or_post_id

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1924,7 +1924,9 @@ class Topic < ActiveRecord::Base
 
   def reset_bumped_at(post_id = nil)
     post =
-      (
+      if post_id.is_a?(Post)
+        post_id
+      else
         if post_id
           Post.find_by(id: post_id)
         else
@@ -1934,7 +1936,7 @@ class Topic < ActiveRecord::Base
             post_type: Post.types[:regular],
           ).last || first_post
         end
-      )
+      end
 
     return if !post
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1922,9 +1922,9 @@ class Topic < ActiveRecord::Base
     @is_category_topic ||= Category.exists?(topic_id: self.id.to_i)
   end
 
-  def reset_bumped_at(post_id = nil)
+  def reset_bumped_at(post_or_post_id = nil)
     post =
-      if post_id.is_a?(Post)
+      if post_or_post_id.is_a?(Post)
         post_id
       else
         if post_id

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1922,13 +1922,13 @@ class Topic < ActiveRecord::Base
     @is_category_topic ||= Category.exists?(topic_id: self.id.to_i)
   end
 
-  def reset_bumped_at(post_or_post_id = nil)
+  def reset_bumped_at( = nil)
     post =
       if post_or_post_id.is_a?(Post)
-        post_id
+        post_or_post_id
       else
-        if post_id
-          Post.find_by(id: post_id)
+        if post_or_post_id
+          Post.find_by(id: post_or_post_id)
         else
           ordered_posts.where(
             user_deleted: false,

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1655,6 +1655,42 @@ RSpec.describe Post do
         1,
       )
     end
+
+    context "in a topic with multiple replies" do
+      let!(:second_last_reply) do
+        freeze_time 1.day.from_now
+        create_post(topic:, user: coding_horror, hidden: true)
+      end
+      fab!(:user)
+      let!(:last_reply) do
+        freeze_time 2.days.from_now
+        create_post(topic:, user:, hidden: true)
+      end
+      let!(:whisper_post) do
+        freeze_time 3.days.from_now
+        create_post(topic:, user: user, post_type: Post.types[:whisper], hidden: true)
+      end
+
+      before { topic.update_columns(bumped_at: 1.day.from_now) }
+
+      it "does not reset the topic's bumped_at when unhiding a whisper" do
+        whisper_post.unhide!
+
+        expect(topic.reload.bumped_at).to eq_time(1.day.from_now)
+      end
+
+      it "resets the topic's bumped_at when unhiding the last visible reply" do
+        last_reply.unhide!
+
+        expect(topic.reload.bumped_at).to eq_time(last_reply.created_at)
+      end
+
+      it "does not reset the topic's bumped_at when unhiding a reply that is not the last" do
+        second_last_reply.unhide!
+
+        expect(topic.reload.bumped_at).to eq_time(1.day.from_now)
+      end
+    end
   end
 
   it "will unhide the post but will keep the topic invisible/unlisted" do


### PR DESCRIPTION
This is a continuation of #33895, implements automatic resetting of topic bump date when a last reply is unhidden, so the topic will back to the correct place it belongs on /latest based on its last public post.