### PR TITLE
DEV: Get completion rates of each translatable type

### DIFF
--- a/plugins/discourse-ai/app/jobs/regular/localize_categories.rb
+++ b/plugins/discourse-ai/app/jobs/regular/localize_categories.rb
@@ -11,17 +11,17 @@ module Jobs
       limit = args[:limit]
       raise Discourse::InvalidParameters.new(:limit) if limit.nil?
       return if limit <= 0
-      locales = SiteSetting.content_localization_supported_locales.split("|")
 
-      categories = Category.where("locale IS NOT NULL")
-      if SiteSetting.ai_translation_backfill_limit_to_public_content
-        categories = categories.where(read_restricted: false)
-      end
-      categories = categories.order(:id).limit(limit)
+      categories =
+        DiscourseAi::Translation::CategoryCandidates
+          .get
+          .where("locale IS NOT NULL")
+          .order(:id)
+          .limit(limit)
       return if categories.empty?
 
       remaining_limit = limit
-
+      locales = SiteSetting.content_localization_supported_locales.split("|")
       categories.each do |category|
         break if remaining_limit <= 0
 

--- a/plugins/discourse-ai/app/jobs/regular/localize_posts.rb
+++ b/plugins/discourse-ai/app/jobs/regular/localize_posts.rb
@@ -14,41 +14,18 @@ module Jobs
       locales = SiteSetting.content_localization_supported_locales.split("|")
       locales.each do |locale|
         base_locale = locale.split("_").first
+
         posts =
-          Post
+          DiscourseAi::Translation::PostCandidates
+            .get
             .joins(
               "LEFT JOIN post_localizations pl ON pl.post_id = posts.id AND pl.locale LIKE '#{base_locale}%'",
             )
-            .where(
-              "posts.created_at > ?",
-              SiteSetting.ai_translation_backfill_max_age_days.days.ago,
-            )
-            .where(deleted_at: nil)
-            .where("posts.user_id > 0")
-            .where.not(raw: [nil, ""])
             .where.not(locale: nil)
             .where("posts.locale NOT LIKE '#{base_locale}%'")
             .where("pl.id IS NULL")
-
-        posts = posts.joins(:topic)
-
-        if SiteSetting.ai_translation_backfill_limit_to_public_content
-          # exclude all PMs
-          # and only include posts from public categories
-          posts =
-            posts
-              .where.not(topics: { archetype: Archetype.private_message })
-              .where(topics: { category_id: Category.where(read_restricted: false).select(:id) })
-        else
-          # all regular topics, and group PMs
-          posts =
-            posts.where(
-              "topics.archetype != ? OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
-              Archetype.private_message,
-            )
-        end
-
-        posts = posts.order(updated_at: :desc).limit(limit)
+            .order(updated_at: :desc)
+            .limit(limit)
 
         next if posts.empty?
 

--- a/plugins/discourse-ai/app/jobs/regular/localize_topics.rb
+++ b/plugins/discourse-ai/app/jobs/regular/localize_topics.rb
@@ -15,37 +15,16 @@ module Jobs
       locales.each do |locale|
         base_locale = locale.split("_").first
         topics =
-          Topic
+          DiscourseAi::Translation::TopicCandidates
+            .get
             .joins(
               "LEFT JOIN topic_localizations tl ON tl.topic_id = topics.id AND tl.locale LIKE '#{base_locale}%'",
             )
-            .where(
-              "topics.created_at > ?",
-              SiteSetting.ai_translation_backfill_max_age_days.days.ago,
-            )
-            .where(deleted_at: nil)
-            .where("topics.user_id > 0")
             .where.not(locale: nil)
             .where("topics.locale NOT LIKE '#{base_locale}%'")
             .where("tl.id IS NULL")
-
-        if SiteSetting.ai_translation_backfill_limit_to_public_content
-          # exclude all PMs
-          # and only include posts from public categories
-          topics =
-            topics
-              .where.not(archetype: Archetype.private_message)
-              .where(category_id: Category.where(read_restricted: false).select(:id))
-        else
-          # all regular topics, and group PMs
-          topics =
-            topics.where(
-              "topics.archetype != ? OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
-              Archetype.private_message,
-            )
-        end
-
-        topics = topics.order(updated_at: :desc).limit(limit)
+            .order(updated_at: :desc)
+            .limit(limit)
 
         next if topics.empty?
 

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Translation
+    class CategoryCandidates
+      def self.get
+        categories = Category.all
+        if SiteSetting.ai_translation_backfill_limit_to_public_content
+          categories = categories.where(read_restricted: false)
+        end
+        categories
+      end
+
+      def self.get_completion_per_locale(locale)
+        done = get.where(locale:).count
+        done += CategoryLocalization.where(locale:).count
+
+        total = get.count
+
+        done / total.to_f
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Translation
+    class PostCandidates
+      # Posts that are eligible for translation based on site settings
+      def self.get
+        posts =
+          Post
+            .where(
+              "posts.created_at > ?",
+              SiteSetting.ai_translation_backfill_max_age_days.days.ago,
+            )
+            .where(deleted_at: nil)
+            .where("posts.user_id > 0")
+            .where.not(raw: [nil, ""])
+
+        posts = posts.joins(:topic)
+        if SiteSetting.ai_translation_backfill_limit_to_public_content
+          # exclude all PMs
+          # and only include posts from public categories
+          posts =
+            posts
+              .where.not(topics: { archetype: Archetype.private_message })
+              .where(topics: { category_id: Category.where(read_restricted: false).select(:id) })
+        else
+          # all regular topics, and group PMs
+          posts =
+            posts.where(
+              "topics.archetype != ? OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
+              Archetype.private_message,
+            )
+        end
+      end
+
+      def self.get_completion_per_locale(locale)
+        done = get.where(locale:).count
+        done += PostLocalization.where(locale:).count
+
+        total = get.count
+
+        done / total.to_f
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Translation
+    class TopicCandidates
+      # Topics that are eligible for translation based on site settings
+      def self.get
+        topics =
+          Topic
+            .where(
+              "topics.created_at > ?",
+              SiteSetting.ai_translation_backfill_max_age_days.days.ago,
+            )
+            .where(deleted_at: nil)
+            .where("topics.user_id > 0")
+
+        if SiteSetting.ai_translation_backfill_limit_to_public_content
+          # exclude all PMs
+          # and only include posts from public categories
+          topics =
+            topics
+              .where.not(archetype: Archetype.private_message)
+              .where(category_id: Category.where(read_restricted: false).select(:id))
+        else
+          # all regular topics, and group PMs
+          topics =
+            topics.where(
+              "topics.archetype != ? OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
+              Archetype.private_message,
+            )
+        end
+      end
+
+      def self.get_completion_per_locale(locale)
+        done = get.where(locale:).count
+        done += TopicLocalization.where(locale:).count
+
+        total = get.count
+
+        done / total.to_f
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Translation::CategoryCandidates do
+  describe ".get" do
+    it "returns all categories" do
+      expect(DiscourseAi::Translation::CategoryCandidates.get.count).to eq(Category.count)
+    end
+
+    it "filters out read restricted categories if ai_translation_backfill_limit_to_public_content is enabled" do
+      SiteSetting.ai_translation_backfill_limit_to_public_content = true
+      restricted_category = Fabricate(:category, read_restricted: true)
+      public_category = Fabricate(:category, read_restricted: false)
+
+      categories = DiscourseAi::Translation::CategoryCandidates.get
+      expect(categories).not_to include(restricted_category)
+      expect(categories).to include(public_category)
+    end
+  end
+
+  describe ".get_completion_per_locale" do
+    context "when (scenario A) percentage determined by category's locale" do
+      it "returns 100% completion if all categories are in the locale" do
+        locale = "es"
+        Fabricate(:category, locale:)
+        Category.update_all(locale: locale)
+
+        completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some categories are in the locale" do
+        locale = "es"
+        Fabricate(:category, locale:)
+
+        completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Category.count.to_f)
+      end
+    end
+
+    context "when (scenario B) percentage determined by category localizations" do
+      it "returns 100% completion if all categories have a localization in the locale" do
+        locale = "es"
+        Fabricate(:category)
+        Category.all.each { |category| Fabricate(:category_localization, category:, locale:) }
+
+        completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some categories have a localization in the locale" do
+        locale = "es"
+        cat = Fabricate(:category)
+        Fabricate(:category_localization, category: cat, locale:)
+
+        completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Category.count.to_f)
+      end
+    end
+
+    it "returns the correct percentage based on (scenario A & B) `category.locale` and `CategoryLocalization` in the specified locale" do
+      locale = "es"
+      Fabricate(:category, locale:)
+      cat = Fabricate(:category)
+      Fabricate(:category_localization, category: cat, locale:)
+
+      completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+      expect(completion).to eq(2 / Category.count.to_f)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Translation::PostCandidates do
+  describe ".get" do
+    it "does not return bot posts" do
+      post = Fabricate(:post, user: Discourse.system_user)
+
+      expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post)
+    end
+
+    it "does not return posts older than ai_translation_backfill_max_age_days" do
+      post =
+        Fabricate(
+          :post,
+          created_at: SiteSetting.ai_translation_backfill_max_age_days.days.ago - 1.day,
+        )
+
+      expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post)
+    end
+
+    it "does not return deleted posts" do
+      post = Fabricate(:post, deleted_at: Time.now)
+
+      expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post)
+    end
+
+    describe "SiteSetting.ai_translation_backfill_limit_to_public_content" do
+      fab!(:pm_post) { Fabricate(:post, topic: Fabricate(:private_message_topic)) }
+      fab!(:group_pm_post) do
+        Fabricate(
+          :post,
+          topic: Fabricate(:private_message_topic, allowed_groups: [Fabricate(:group)]),
+        )
+      end
+      fab!(:public_post) do
+        Fabricate(
+          :post,
+          topic: Fabricate(:topic, category: Fabricate(:category, read_restricted: false)),
+        )
+      end
+
+      it "excludes PMs and only includes posts from public categories" do
+        SiteSetting.ai_translation_backfill_limit_to_public_content = true
+
+        posts = DiscourseAi::Translation::PostCandidates.get
+        expect(posts).not_to include(pm_post)
+        expect(posts).not_to include(group_pm_post)
+        expect(posts).to include(public_post)
+      end
+
+      it "includes all regular posts and group PMs but not personal PMs" do
+        SiteSetting.ai_translation_backfill_limit_to_public_content = false
+
+        posts = DiscourseAi::Translation::PostCandidates.get
+        expect(posts).not_to include(pm_post)
+        expect(posts).to include(group_pm_post)
+        expect(posts).to include(public_post)
+      end
+    end
+  end
+
+  describe ".get_completion_per_locale" do
+    context "when (scenario A) percentage determined by post's locale" do
+      it "returns 100% completion if all posts are in the locale" do
+        locale = "es"
+        Fabricate(:post, locale:)
+        Post.update_all(locale: locale)
+
+        completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some posts are in the locale" do
+        locale = "es"
+        Fabricate(:post, locale:)
+
+        completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Post.count.to_f)
+      end
+    end
+
+    context "when (scenario B) percentage determined by post localizations" do
+      it "returns 100% completion if all posts have a localization in the locale" do
+        locale = "es"
+        Fabricate(:post)
+        Post.all.each { |post| Fabricate(:post_localization, post:, locale:) }
+
+        completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some posts have a localization in the locale" do
+        locale = "es"
+        post = Fabricate(:post)
+        Fabricate(:post_localization, post:, locale:)
+
+        completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Post.count.to_f)
+      end
+    end
+
+    it "returns the correct percentage based on (scenario A & B) `post.locale` and `PostLocalization` in the specified locale" do
+      locale = "es"
+      Fabricate(:post, locale:)
+      post = Fabricate(:post)
+      Fabricate(:post_localization, post:, locale:)
+
+      completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+      expect(completion).to eq(2 / Post.count.to_f)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Translation::TopicCandidates do
+  describe ".get" do
+    it "does not return bot topics" do
+      topic = Fabricate(:topic, user: Discourse.system_user)
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).not_to include(topic)
+    end
+
+    it "does not return topics older than ai_translation_backfill_max_age_days" do
+      topic =
+        Fabricate(
+          :topic,
+          created_at: SiteSetting.ai_translation_backfill_max_age_days.days.ago - 1.day,
+        )
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).not_to include(topic)
+    end
+
+    it "does not return deleted topics" do
+      topic = Fabricate(:topic, deleted_at: Time.now)
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).not_to include(topic)
+    end
+
+    describe "SiteSetting.ai_translation_backfill_limit_to_public_content" do
+      fab!(:pm) { Fabricate(:private_message_topic) }
+      fab!(:group_pm) { Fabricate(:private_message_topic, allowed_groups: [Fabricate(:group)]) }
+      fab!(:public_topic) do
+        Fabricate(:topic, category: Fabricate(:category, read_restricted: false))
+      end
+
+      it "excludes PMs and only includes topics from public categories" do
+        SiteSetting.ai_translation_backfill_limit_to_public_content = true
+
+        topics = DiscourseAi::Translation::TopicCandidates.get
+        expect(topics).not_to include(pm)
+        expect(topics).not_to include(group_pm)
+        expect(topics).to include(public_topic)
+      end
+
+      it "includes all regular topics and group PMs but not personal PMs" do
+        SiteSetting.ai_translation_backfill_limit_to_public_content = false
+
+        topics = DiscourseAi::Translation::TopicCandidates.get
+        expect(topics).not_to include(pm)
+        expect(topics).to include(group_pm)
+        expect(topics).to include(public_topic)
+      end
+    end
+  end
+
+  describe ".get_completion_per_locale" do
+    context "when (scenario A) percentage determined by topic's locale" do
+      it "returns 100% completion if all topics are in the locale" do
+        locale = "es"
+        Fabricate(:topic, locale:)
+        Topic.update_all(locale: locale)
+
+        completion = DiscourseAi::Translation::TopicCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some topics are in the locale" do
+        locale = "es"
+        Fabricate(:topic, locale:)
+
+        completion = DiscourseAi::Translation::TopicCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Topic.count.to_f)
+      end
+    end
+
+    context "when (scenario B) percentage determined by topic localizations" do
+      it "returns 100% completion if all topics have a localization in the locale" do
+        locale = "es"
+        Fabricate(:topic)
+        Topic.all.each { |topic| Fabricate(:topic_localization, topic:, locale:) }
+
+        completion = DiscourseAi::Translation::TopicCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1.0)
+      end
+
+      it "returns X% completion if some topics have a localization in the locale" do
+        locale = "es"
+        topic = Fabricate(:topic)
+        Fabricate(:topic_localization, topic:, locale:)
+
+        completion = DiscourseAi::Translation::TopicCandidates.get_completion_per_locale(locale)
+        expect(completion).to eq(1 / Topic.count.to_f)
+      end
+    end
+
+    it "returns the correct percentage based on (scenario A & B) `topic.locale` and `TopicLocalization` in the specified locale" do
+      locale = "es"
+      Fabricate(:topic, locale:)
+      topic = Fabricate(:topic)
+      Fabricate(:topic_localization, topic:, locale:)
+
+      completion = DiscourseAi::Translation::TopicCandidates.get_completion_per_locale(locale)
+      expect(completion).to eq(2 / Topic.count.to_f)
+    end
+  end
+end


### PR DESCRIPTION
This PR helps set us up for set us up for <https://meta.discourse.org/t/content-localization-and-automatic-translations-for-your-community/370000#p-1792778-community-translation-progress-dashboard-7>, so that we make sure the Posts, Topics, and Categories to be backfilled have the same criteria as the ones shown on the translation progress dashboard.