### PR TITLE
DEV: remove redundant translations for disabled new topic btn

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3566,8 +3566,6 @@ en:
         one: "%{count} post in topic"
         other: "%{count} posts in topic"
       create: "New Topic"
-      create_disabled_category: "You're not allowed to create topics in this category"
-      create_disabled_tag: "You're not allowed to create topics with this tag"
       create_long: "Create a new Topic"
       open_draft: "Open Draft"
       private_message: "Start a message"


### PR DESCRIPTION
Small cleanup from #33495 to remove translations that are no longer used.