### PR TITLE
FIX: Also show native names when editing category localizations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
@@ -8,9 +8,15 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
   "localizations"
 ) {
   @service siteSettings;
+  @service languageNameLookup;
 
   get availableLocales() {
-    return this.siteSettings.available_content_localization_locales;
+    return this.siteSettings.available_content_localization_locales.map(
+      ({ value }) => ({
+        name: this.languageNameLookup.getLanguageName(value),
+        value,
+      })
+    );
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/post-translation-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/post-translation-editor.gjs
@@ -13,6 +13,7 @@ import DropdownSelectBox from "select-kit/components/dropdown-select-box";
 export default class PostTranslationEditor extends Component {
   @service composer;
   @service siteSettings;
+  @service languageNameLookup;
 
   constructor() {
     super(...arguments);
@@ -55,14 +56,10 @@ export default class PostTranslationEditor extends Component {
 
     return this.siteSettings.available_content_localization_locales
       .filter(({ value }) => value !== originalPostLocale)
-      .map(({ native_name, name, value }) => {
-        name =
-          i18n(name) === native_name
-            ? native_name
-            : `${i18n(name)} (${native_name})`;
-
-        return { name, value };
-      });
+      .map(({ value }) => ({
+        name: this.languageNameLookup.getLanguageName(value),
+        value,
+      }));
   }
 
   @action

--- a/spec/system/edit_category_localizations_spec.rb
+++ b/spec/system/edit_category_localizations_spec.rb
@@ -82,11 +82,16 @@ describe "Edit Category Localizations", type: :system do
     end
 
     describe "when editing a category with localizations" do
-      fab!(:category_localization) { Fabricate(:category_localization, category: category) }
+      fab!(:category_localization) { Fabricate(:category_localization, category:, locale: "es") }
 
       it "allows you to delete localizations" do
         expect(CategoryLocalization.where(category_id: category.id).count).to eq(1)
         category_page.visit_edit_localizations(category)
+
+        expect(
+          category_page.find("#control-localizations-0-locale option.--selected"),
+        ).to have_content("Spanish (Español)")
+
         page.find(".edit-category-tab-localizations .remove-localization").click
         category_page.save_settings
         page.refresh


### PR DESCRIPTION
Editing category localizations was missed out in https://github.com/discourse/discourse/pull/33790.

<img width="498" height="572" alt="Screenshot 2025-07-29 at 6 10 13 PM" src="https://github.com/user-attachments/assets/2dfd40cd-9d4c-4763-ac63-0e4c9a06c249" />

This PR fixes the bug.