### PR TITLE
UX: show 0% instead of em dash in percent-type report columns

### DIFF
--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -622,7 +622,7 @@ export default class Report extends EmberObject {
   _percentLabel(value) {
     return {
       value: toNumber(value),
-      formattedValue: value ? `${value}%` : "—",
+      formattedValue: value === null || value === undefined ? "—" : `${value}%`,
     };
   }
 


### PR DESCRIPTION
When the y-axis value is 0 and the column type is percent, display 0% instead of replacing it with an em dash. Only show an em dash when the value is null or undefined.