### PR TITLE
UX: Horizon > chat-drawer z-index adjustments for popup content

### DIFF
--- a/themes/horizon/scss/chat.scss
+++ b/themes/horizon/scss/chat.scss
@@ -45,6 +45,19 @@ body.has-full-page-chat {
   }
 }
 
+// the below are elements whose z-index needs to be adjusted due to the above change
+.chat-message-actions-container {
+  .chat-drawer.is-expanded & {
+    z-index: calc(z("composer", "dropdown") + 1);
+  }
+}
+
+.fk-d-menu[data-identifier="usercard"] {
+  .has-drawer-chat & {
+    z-index: z("modal", "dialog");
+  }
+}
+
 .chat-drawer {
   .peek-mode-active & {
     max-width: 90vw;


### PR DESCRIPTION
Because Horizon has a different drawer-composer interaction as default (#33677) this means that certain floating elements such as the `fk-d-menu[data-identifier="usercard"]` and the `chat-message-actions-container` need an adjusted z-index to remain visible.

Scoped to chat-drawer for safety.