### PR TITLE
UX: improve admin width restriction, fix theme setting width

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -4,6 +4,10 @@
 
 $mobile-breakpoint: 700px;
 
+:root {
+  --admin-content-max-width: min(700px, 100%);
+}
+
 // Common admin styles
 .admin-main-nav {
   display: inline-flex;

--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -74,14 +74,11 @@
   }
 
   &__primary-content {
-    flex: 0 1 70%;
+    flex: 0 1 100%;
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
-
-    @media (max-width: $mobile-breakpoint) {
-      flex: 0 1 auto;
-    }
+    max-width: var(--admin-content-max-width);
   }
 
   &__aside {

--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -144,6 +144,7 @@
   .show-current-style {
     display: inline-block;
     vertical-align: top;
+    max-width: var(--admin-content-max-width);
 
     .title {
       font-family: var(--heading-font-family);


### PR DESCRIPTION
This fixes a width blowout in theme settings (caused by https://github.com/discourse/discourse/commit/8fea4eaaa5aa6c473dfed800b6c51c752ee68120), and improves width restriction so it doesn't apply on narrower screens where it may not be needed. This behavior is unified behind a reusable `--admin-content-max-width` variable. 


Before: 
<img width="2262" height="1586" alt="image" src="https://github.com/user-attachments/assets/a69a435c-1880-4b02-adf8-ff3e6cc98a69" />


After: 
<img width="2248" height="1582" alt="image" src="https://github.com/user-attachments/assets/8a666bdc-797a-40f0-8ae8-b857e48c554a" />


Before: 
<img width="1654" height="1714" alt="image" src="https://github.com/user-attachments/assets/12e45ae5-2e93-40d1-8eac-56f5d9735a10" />


After:
<img width="1920" height="1684" alt="image" src="https://github.com/user-attachments/assets/aae98eb2-3967-4c20-87aa-110696c8852d" />

