### PR TITLE
FIX: composer link modal ENTER event

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
@@ -109,8 +109,6 @@ export default class UpsertHyperlink extends Component {
             ".internal-link-results .search-link"
           )[this.selectedRow];
           this.selectLink(selected);
-          event.preventDefault();
-          event.stopPropagation();
         }
 
         // this would ideally be handled by nesting a submit button within the form tag
@@ -118,6 +116,9 @@ export default class UpsertHyperlink extends Component {
         if (event.target.tagName === "INPUT") {
           this.formApi.submit();
         }
+
+        event.preventDefault();
+        event.stopPropagation();
 
         break;
       case "Escape":
@@ -151,16 +152,8 @@ export default class UpsertHyperlink extends Component {
       return;
     }
 
-    const linkText = data.linkText || "";
-
-    if (linkText.length) {
-      this.args.model.toolbarEvent.addText(`[${linkText}](${linkUrl})`);
-    } else if (sel.value) {
-      this.args.model.toolbarEvent.addText(`[${sel.value}](${linkUrl})`);
-    } else {
-      this.args.model.toolbarEvent.addText(`[${origLink}](${linkUrl})`);
-      this.args.model.toolbarEvent.selectText(sel.start + 1, origLink.length);
-    }
+    const linkText = data.linkText || sel.value || origLink || "";
+    this.args.model.toolbarEvent.addText(`[${linkText.trim()}](${linkUrl})`);
 
     this.args.closeModal();
   }

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -1055,7 +1055,7 @@ describe "Composer - ProseMirror editor", type: :system do
 
       upsert_hyperlink_modal.fill_in_link_text("Updated Example")
       upsert_hyperlink_modal.fill_in_link_url("https://updated-example.com")
-      upsert_hyperlink_modal.click_primary_button
+      upsert_hyperlink_modal.send_enter_link_text
 
       expect(rich).to have_css("a[href='https://updated-example.com']", text: "Updated Example")
 

--- a/spec/system/page_objects/modals/upsert_hyperlink.rb
+++ b/spec/system/page_objects/modals/upsert_hyperlink.rb
@@ -11,6 +11,10 @@ module PageObjects
         find(LINK_TEXT_SELECTOR).fill_in(with: text)
       end
 
+      def send_enter_link_text
+        find(LINK_TEXT_SELECTOR).send_keys(:enter)
+      end
+
       def fill_in_link_url(url)
         find(LINK_URL_SELECTOR).fill_in(with: url)
       end


### PR DESCRIPTION
Using ENTER on the composer link modal was having unwanted consequences because of a misplaced preventDefault.

