### PR TITLE
UX: minor hashtag alignment adjustments

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -58,6 +58,14 @@ a.hashtag {
   .hashtag-category-emoji {
     display: inline-block;
   }
+
+  &[data-type="channel"] {
+    align-items: baseline;
+
+    .d-icon {
+      align-self: center;
+    }
+  }
 }
 
 .hashtag-autocomplete {
@@ -110,13 +118,15 @@ a.hashtag {
       height: 0.93em;
       margin-right: 5px;
       display: inline-block;
+      line-height: 1;
     }
 
     .hashtag-category-icon .svg-icon,
     .hashtag-category-emoji .emoji {
+      vertical-align: unset;
       width: 0.93em;
       height: 0.93em;
-      vertical-align: middle;
+      line-height: 1;
     }
   }
 


### PR DESCRIPTION
🔎 spot the difference

Before:
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/2d765fd4-f713-4c09-9eff-b01a19af9f53" />


After:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/eccc70b6-60df-4470-b977-30b803ffe23d" />


Before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/967c4a5e-1d0f-44dd-9a59-ee956de2a6d6" />


After:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/14ec5b09-941b-4313-8d99-b73a7a911631" />
