### PR TITLE
UX: Fix github repo oneboxes in chat (drawer)

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -623,6 +623,12 @@ pre.onebox code ol.lines li.selected {
   }
 }
 
+.onebox.githubrepo {
+  .github-row {
+    display: contents;
+  }
+}
+
 .onebox.githubactions {
   h4 {
     margin-top: 5px;


### PR DESCRIPTION
no more 2000px tall oneboxes