### PR TITLE
DEV: Fix flaky test for formtemplate

### DIFF
--- a/spec/models/form_template_spec.rb
+++ b/spec/models/form_template_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe FormTemplate, type: :model do
 
       g1, g2 = YAML.safe_load(form_template.template)
 
-      expect(g1["choices"]).to eq([tag1.name, tag2.name, tag3.name])
+      expect(g1["choices"]).to match_array([tag1.name, tag2.name, tag3.name])
       expect(g2["attributes"]["tag_group"]).to eq(tag_group2.name)
       expect(g2["attributes"]["multiple"]).to eq(true)
     end


### PR DESCRIPTION
The order of the `g1["choices"]` array is not important, match_array should be used