### PR TITLE
DEV: Fix flaky test when editing category logo image

### DIFF
--- a/spec/system/edit_category_images_spec.rb
+++ b/spec/system/edit_category_images_spec.rb
@@ -26,7 +26,7 @@ describe "Edit Category Images", type: :system do
         )
 
         expect(page).to have_content("uploaded successfully").or have_css(
-               ".uploaded-image-preview.input-xxlarge",
+               ".has-image .uploaded-image-preview.input-xxlarge",
              )
 
         upload = Upload.last


### PR DESCRIPTION
## ✨ What's This?

See t/158096, introduced in #33423.

This test was flaky due to the page having multiple uploaders on the same page, so the `have_css(".uploaded-image-preview.input-xxlarge")` check will always be true for the entire page. It would sometimes work correctly depending on if the uploader managed to finish quickly enough.

## 👑 Testing

The test fails consistently for me with this command:

`bin/rspec --fail-fast --tag ~type:multisite --order random:29076 spec/system/admin_customize_themes_spec.rb spec/system/admin_embeddable_hosts_spec.rb spec/system/admin_fonts_spec.rb spec/system/admin_notices_spec.rb spec/system/admin_reports_spec.rb spec/system/admin_site_setting_bulk_action_spec.rb spec/system/admin_site_setting_label_formatting_spec.rb spec/system/admin_site_setting_search_spec.rb spec/system/admin_users_list_spec.rb spec/system/bookmarks_spec.rb spec/system/composer/discard_draft_spec.rb spec/system/composer/post_validation_spec.rb spec/system/composer/review_media_unless_trust_level_spec.rb spec/system/content_localization_spec.rb spec/system/discovery_breadcrumb_navigation_spec.rb spec/system/discovery_list_spec.rb spec/system/edit_category_images_spec.rb spec/system/editing_sidebar_tags_navigation_spec.rb spec/system/ember_deprecation_spec.rb spec/system/emojis/emoji_deny_list_spec.rb spec/system/filtering_topics_spec.rb spec/system/grant_badge_spec.rb spec/system/header_search_spec.rb spec/system/homepage_spec.rb spec/system/interface_color_selector_spec.rb spec/system/keyboard_shortcuts_spec.rb spec/system/network_disconnected_spec.rb spec/system/post_replies_spec.rb spec/system/post_selection_fast_edit_spec.rb spec/system/powered_by_discourse_spec.rb spec/system/request_tracker_spec.rb spec/system/s3_secure_uploads_spec.rb spec/system/social_authentication_spec.rb spec/system/user_activation_spec.rb spec/system/user_activity_posts_spec.rb spec/system/user_page/user_invites_spec.rb spec/system/user_page/user_page_search_spec.rb spec/system/user_page/user_preferences_profile_spec.rb spec/system/viewing_group_members_spec.rb spec/system/viewing_user_private_messages_spec.rb spec/system/welcome_banner_spec.r`

It no longer fails after this fix.