### PR TITLE
FIX: Completion rate double-count and normalize

### DIFF
--- a/plugins/discourse-ai/lib/translation/base_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/base_candidates.rb
@@ -3,6 +3,8 @@
 module DiscourseAi
   module Translation
     class BaseCandidates
+      COMPLETION_CACHE_TTL = 1.hour
+
       # ModelType that are eligible for translation based on site settings
       # @return [ActiveRecord::Relation] the ActiveRecord relation of the candidates
       def self.get
@@ -15,11 +17,15 @@ module DiscourseAi
       def self.get_completion_per_locale(locale)
         Discourse
           .cache
-          .fetch(get_completion_cache_key(locale), expires_in: 1.hour) do
+          .fetch(get_completion_cache_key(locale), expires_in: COMPLETION_CACHE_TTL) do
             done, total = calculate_completion_per_locale(locale)
             return 1.0 if total.zero?
             done / total.to_f
           end
+      end
+
+      def self.clear_completion_cache(locale)
+        Discourse.cache.delete(get_completion_cache_key(locale))
       end
 
       private

--- a/plugins/discourse-ai/lib/translation/base_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/base_candidates.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Translation
+    class BaseCandidates
+      # ModelType that are eligible for translation based on site settings
+      # @return [ActiveRecord::Relation] the ActiveRecord relation of the candidates
+      def self.get
+        raise NotImplementedError
+      end
+
+      # The completion in float percentage for the given locale
+      # @param locale [String] the locale for which to calculate the completion percentage
+      # @return [Float] the completion percentage for the given locale e.g. 0.75 for 75%
+      def self.get_completion_per_locale(locale)
+        Discourse
+          .cache
+          .fetch(get_completion_cache_key(locale), expires_in: 1.hour) do
+            done, total = calculate_completion_per_locale(locale)
+            return 1.0 if total.zero?
+            done / total.to_f
+          end
+      end
+
+      private
+
+      # This method should return [completed_translations, total_needed_translations]
+      #
+      # This allows flexibility for the implementation to determine how the completion percentage is calculated.
+      # # @param locale [String] the locale for which to calculate the completion percentage
+      # @return [integer, integer]
+      def self.calculate_completion_per_locale(locale)
+        raise NotImplementedError
+      end
+
+      def self.completion_cache_key_for_type
+        raise NotImplementedError
+      end
+
+      def self.get_completion_cache_key(locale)
+        "#{completion_cache_key_for_type}_#{locale}"
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -12,11 +12,21 @@ module DiscourseAi
       end
 
       def self.get_completion_per_locale(locale)
-        done = get.where(locale:).count
-        done += CategoryLocalization.where(locale:).count
-
         total = get.count
+        return 1.0 if total.zero?
 
+        base_locale = "#{locale.split("_").first}%"
+        sql = <<~SQL
+          WITH eligible_categories AS (
+            #{get.to_sql}
+          )
+          SELECT COUNT(DISTINCT c.id)
+          FROM eligible_categories c
+          LEFT JOIN category_localizations cl ON c.id = cl.category_id AND cl.locale LIKE :base_locale
+          WHERE c.locale LIKE :base_locale OR cl.category_id IS NOT NULL
+        SQL
+
+        done = DB.query_single(sql, base_locale:).first.to_i || 0
         done / total.to_f
       end
     end

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -2,7 +2,7 @@
 
 module DiscourseAi
   module Translation
-    class PostCandidates
+    class PostCandidates < BaseCandidates
       # Posts that are eligible for translation based on site settings
       def self.get
         posts =
@@ -33,23 +33,33 @@ module DiscourseAi
         end
       end
 
-      def self.get_completion_per_locale(locale)
-        total = get.count
-        return 1.0 if total.zero?
+      private
 
+      def self.calculate_completion_per_locale(locale)
         base_locale = "#{locale.split("_").first}%"
+
         sql = <<~SQL
           WITH eligible_posts AS (
             #{get.to_sql}
+          ),
+          total_count AS (
+            SELECT COUNT(*) AS count FROM eligible_posts
+          ),
+          done_count AS (
+            SELECT COUNT(DISTINCT p.id)
+            FROM eligible_posts p
+            LEFT JOIN post_localizations pl ON p.id = pl.post_id AND pl.locale LIKE :base_locale
+            WHERE p.locale LIKE :base_locale OR pl.post_id IS NOT NULL
           )
-          SELECT COUNT(DISTINCT p.id)
-          FROM eligible_posts p
-          LEFT JOIN post_localizations pl ON p.id = pl.post_id AND pl.locale LIKE :base_locale
-          WHERE p.locale LIKE :base_locale OR pl.post_id IS NOT NULL
+          SELECT d.count AS done, t.count AS total
+          FROM total_count t, done_count d
         SQL
 
-        done = DB.query_single(sql, base_locale:).first.to_i || 0
-        done / total.to_f
+        DB.query_single(sql, base_locale: "#{base_locale}%")
+      end
+
+      def self.completion_cache_key_for_type
+        "discourse_ai::translation::post_candidates"
       end
     end
   end

--- a/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
@@ -20,17 +20,19 @@ describe DiscourseAi::Translation::CategoryCandidates do
   describe ".get_completion_per_locale" do
     context "when (scenario A) percentage determined by category's locale" do
       it "returns 100% completion if all categories are in the locale" do
-        locale = "es"
+        locale = "pt_BR"
         Fabricate(:category, locale:)
         Category.update_all(locale: locale)
+        Fabricate(:category, locale: "pt")
 
         completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1.0)
       end
 
       it "returns X% completion if some categories are in the locale" do
-        locale = "es"
+        locale = "pt_BR"
         Fabricate(:category, locale:)
+        Fabricate(:category, locale: "not_pt")
 
         completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1 / Category.count.to_f)
@@ -39,9 +41,10 @@ describe DiscourseAi::Translation::CategoryCandidates do
 
     context "when (scenario B) percentage determined by category localizations" do
       it "returns 100% completion if all categories have a localization in the locale" do
-        locale = "es"
+        locale = "pt_BR"
         Fabricate(:category)
         Category.all.each { |category| Fabricate(:category_localization, category:, locale:) }
+        Fabricate(:category_localization, locale: "pt")
 
         completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1.0)
@@ -49,8 +52,8 @@ describe DiscourseAi::Translation::CategoryCandidates do
 
       it "returns X% completion if some categories have a localization in the locale" do
         locale = "es"
-        cat = Fabricate(:category)
-        Fabricate(:category_localization, category: cat, locale:)
+        Fabricate(:category_localization, locale:)
+        Fabricate(:category_localization, locale: "pt")
 
         completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1 / Category.count.to_f)
@@ -58,13 +61,44 @@ describe DiscourseAi::Translation::CategoryCandidates do
     end
 
     it "returns the correct percentage based on (scenario A & B) `category.locale` and `CategoryLocalization` in the specified locale" do
-      locale = "es"
+      locale = "pt_BR"
+
+      # translated candidates
       Fabricate(:category, locale:)
-      cat = Fabricate(:category)
-      Fabricate(:category_localization, category: cat, locale:)
+      category2 = Fabricate(:category)
+      Fabricate(:category_localization, category: category2, locale:)
+
+      # untranslated candidate
+      category3 = Fabricate(:category)
+      Fabricate(:category_localization, category: category3, locale: "zh_CN")
+
+      # not a candidate as it is read restricted
+      SiteSetting.ai_translation_backfill_limit_to_public_content = true
+      category4 = Fabricate(:category, read_restricted: true)
+      Fabricate(:category_localization, category: category4, locale:)
 
       completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
-      expect(completion).to eq(2 / Category.count.to_f)
+      translated_candidates = 2 # category1 + category2
+      total_candidates = Category.count - 1 # excluding the read restricted category
+      expect(completion).to eq(translated_candidates / total_candidates.to_f)
+    end
+
+    it "does not exceed 100% completion when category.locale and category_localization both exist" do
+      locale = "pt_BR"
+      Category.update_all(locale:)
+      category = Fabricate(:category, locale:)
+      Fabricate(:category_localization, category:, locale:)
+
+      completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale(locale)
+      expect(completion).to be(1.0)
+    end
+
+    it "returns 100% completion when there are no categories" do
+      SiteSetting.ai_translation_backfill_limit_to_public_content = false
+      Category.destroy_all
+
+      completion = DiscourseAi::Translation::CategoryCandidates.get_completion_per_locale("pt")
+      expect(completion).to eq(1.0)
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -62,9 +62,10 @@ describe DiscourseAi::Translation::PostCandidates do
   describe ".get_completion_per_locale" do
     context "when (scenario A) percentage determined by post's locale" do
       it "returns 100% completion if all posts are in the locale" do
-        locale = "es"
+        locale = "pt_BR"
         Fabricate(:post, locale:)
         Post.update_all(locale: locale)
+        Fabricate(:post, locale: "pt")
 
         completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1.0)
@@ -73,6 +74,7 @@ describe DiscourseAi::Translation::PostCandidates do
       it "returns X% completion if some posts are in the locale" do
         locale = "es"
         Fabricate(:post, locale:)
+        Fabricate(:post, locale: "not_es")
 
         completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1 / Post.count.to_f)
@@ -81,9 +83,10 @@ describe DiscourseAi::Translation::PostCandidates do
 
     context "when (scenario B) percentage determined by post localizations" do
       it "returns 100% completion if all posts have a localization in the locale" do
-        locale = "es"
+        locale = "pt_BR"
         Fabricate(:post)
         Post.all.each { |post| Fabricate(:post_localization, post:, locale:) }
+        Fabricate(:post_localization, locale: "pt")
 
         completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1.0)
@@ -91,8 +94,8 @@ describe DiscourseAi::Translation::PostCandidates do
 
       it "returns X% completion if some posts have a localization in the locale" do
         locale = "es"
-        post = Fabricate(:post)
-        Fabricate(:post_localization, post:, locale:)
+        Fabricate(:post_localization, locale:)
+        Fabricate(:post_localization, locale: "not_es")
 
         completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
         expect(completion).to eq(1 / Post.count.to_f)
@@ -101,12 +104,40 @@ describe DiscourseAi::Translation::PostCandidates do
 
     it "returns the correct percentage based on (scenario A & B) `post.locale` and `PostLocalization` in the specified locale" do
       locale = "es"
+
+      # translated candidates
       Fabricate(:post, locale:)
-      post = Fabricate(:post)
+      post2 = Fabricate(:post)
+      Fabricate(:post_localization, post: post2, locale:)
+
+      # untranslated candidate
+      post4 = Fabricate(:post)
+      Fabricate(:post_localization, post: post4, locale: "zh_CN")
+
+      # not a candidate as it is a bot post
+      post3 = Fabricate(:post, user: Discourse.system_user)
+      Fabricate(:post_localization, post: post3, locale:)
+
+      completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
+      translated_candidates = 2 # post1 + post2
+      total_candidates = Post.count - 1 # excluding the bot post
+      expect(completion).to eq(translated_candidates / total_candidates.to_f)
+    end
+
+    it "does not exceed 100% completion when post.locale and post_localization both exist" do
+      locale = "es"
+      post = Fabricate(:post, locale:)
       Fabricate(:post_localization, post:, locale:)
 
       completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale(locale)
-      expect(completion).to eq(2 / Post.count.to_f)
+      expect(completion).to be(1.0)
+    end
+
+    it "returns 100% completion when no posts are present" do
+      SiteSetting.ai_translation_backfill_max_age_days = 0
+
+      completion = DiscourseAi::Translation::PostCandidates.get_completion_per_locale("es")
+      expect(completion).to eq(1.0)
     end
   end
 end


### PR DESCRIPTION
This PR fixes 2 things. 

1. If a `post` was written in `ja` (Japanese) and for some reason also had a `post_localization` that is `ja`, it becomes 200%
2. When getting completion progress for "English (US)", if there exists a "English (UK)" localization, we want to include that
3. Previously the completion count was also getting `post_localization` from posts that are not candidates. If the user switches `ai_translation_backfill_limit_to_public_content` from false to true, it would include previously localized PMs when it should not.

Follow up: https://github.com/discourse/discourse/pull/33927