### PR TITLE
DEV: Fix a handful of flaky AI bot persona tests

### DIFF
--- a/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe "AI Bot - Homepage", type: :system do
           ai_pm_homepage.visit
           ai_pm_homepage.persona_selector.expand
           expect(ai_pm_homepage.persona_selector).to have_no_option_name(persona.name)
+          persona.update!(allow_personal_messages: true)
         end
 
         it "includes persona in selector when allow_personal_messages is enabled" do


### PR DESCRIPTION
## ✨ What's This?

Introduced in #33853.

When testing that an AI persona can't be PMed when it has PMs disabled, we need to re-enable PMs at the end, so other tests function correctly.

## 👑 Testing

I was able to consistently reproduce the issue locally with this test run: `bin/rspec --order random:57636 plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb`