### PR TITLE
DEV: Fix up TopicGuardian#can_delete_topic?

### DIFF
--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -173,6 +173,72 @@ RSpec.describe TopicGuardian do
     end
   end
 
+  describe "#can_delete_topic?" do
+    it "returns false for an unauthenticated user" do
+      expect(Guardian.new.can_delete_topic?(topic)).to be_falsey
+    end
+
+    it "returns false for a regular user" do
+      expect(Guardian.new(Fabricate(:user)).can_delete_topic?(topic)).to be_falsey
+    end
+
+    it "returns true for a moderator" do
+      expect(Guardian.new(moderator).can_delete_topic?(topic)).to be_truthy
+    end
+
+    it "returns true for an admin" do
+      expect(Guardian.new(admin).can_delete_topic?(topic)).to be_truthy
+    end
+
+    it "returns false for static doc topics" do
+      tos_topic = Fabricate(:topic, user: Discourse.system_user)
+      SiteSetting.tos_topic_id = tos_topic.id
+      expect(Guardian.new(admin).can_delete_topic?(tos_topic)).to be_falsey
+    end
+
+    it "returns true for own topics with no replies" do
+      topic.update_attribute(:posts_count, 1)
+      topic.update_attribute(:created_at, Time.zone.now)
+      expect(Guardian.new(topic.user).can_delete_topic?(topic)).to be_truthy
+    end
+
+    it "returns false for own topic with replies" do
+      topic.update!(posts_count: 2, created_at: Time.zone.now)
+      expect(Guardian.new(topic.user).can_delete_topic?(topic)).to be_falsey
+    end
+
+    it "returns false for own topic within cooldown period" do
+      topic.update!(posts_count: 1, created_at: 48.hours.ago)
+      expect(Guardian.new(topic.user).can_delete_topic?(topic)).to be_falsey
+    end
+
+    it "returns true for user in allowed groups" do
+      SiteSetting.delete_all_posts_and_topics_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
+      expect(Guardian.new(tl4_user).can_delete_topic?(topic)).to be_truthy
+    end
+
+    it "returns false for user not in allowed groups" do
+      SiteSetting.delete_all_posts_and_topics_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
+      expect(Guardian.new(tl3_user).can_delete_topic?(topic)).to be_falsey
+    end
+
+    context "when category group moderation is enabled" do
+      fab!(:group_user)
+
+      before { SiteSetting.enable_category_group_moderation = true }
+
+      it "returns false if user is not a member of the appropriate group" do
+        expect(Guardian.new(group_user.user).can_delete_topic?(topic)).to be_falsey
+      end
+
+      it "returns true if user is a member of the appropriate group" do
+        Fabricate(:category_moderation_group, category: topic.category, group: group_user.group)
+
+        expect(Guardian.new(group_user.user).can_delete_topic?(topic)).to be_truthy
+      end
+    end
+  end
+
   describe "#is_in_edit_topic_groups?" do
     it "returns true if the user is in edit_all_topic_groups" do
       group.add(user)

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe TopicGuardian do
       expect(Guardian.new(admin).can_delete_topic?(topic)).to be_falsey
     end
 
-    it "returns true for own topics with no replies" do
+    it "returns true for own topic with no replies" do
       topic.update_attribute(:posts_count, 1)
       topic.update_attribute(:created_at, Time.zone.now)
       expect(Guardian.new(topic.user).can_delete_topic?(topic)).to be_truthy

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -196,6 +196,16 @@ RSpec.describe TopicGuardian do
       expect(Guardian.new(admin).can_delete_topic?(tos_topic)).to be_falsey
     end
 
+    it "returns false when topic is trashed" do
+      topic.stubs(:trashed?).returns(true)
+      expect(Guardian.new(admin).can_delete_topic?(topic)).to be_falsey
+    end
+
+    it "returns false when topic is category topic" do
+      topic.stubs(:is_category_topic?).returns(true)
+      expect(Guardian.new(admin).can_delete_topic?(topic)).to be_falsey
+    end
+
     it "returns true for own topics with no replies" do
       topic.update_attribute(:posts_count, 1)
       topic.update_attribute(:created_at, Time.zone.now)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1509,68 +1509,6 @@ RSpec.describe Guardian do
       expect(Guardian.new(user).can_delete?(nil)).to be_falsey
     end
 
-    context "with a Topic" do
-      it "returns false when not logged in" do
-        expect(Guardian.new.can_delete?(topic)).to be_falsey
-      end
-
-      it "returns false when not a moderator" do
-        expect(Guardian.new(Fabricate(:user)).can_delete?(topic)).to be_falsey
-      end
-
-      it "returns true when a moderator" do
-        expect(Guardian.new(moderator).can_delete?(topic)).to be_truthy
-      end
-
-      it "returns true when an admin" do
-        expect(Guardian.new(admin).can_delete?(topic)).to be_truthy
-      end
-
-      it "returns false for static doc topics" do
-        tos_topic = Fabricate(:topic, user: Discourse.system_user)
-        SiteSetting.tos_topic_id = tos_topic.id
-        expect(Guardian.new(admin).can_delete?(tos_topic)).to be_falsey
-      end
-
-      it "returns true for own topics" do
-        topic.update_attribute(:posts_count, 1)
-        topic.update_attribute(:created_at, Time.zone.now)
-        expect(Guardian.new(topic.user).can_delete?(topic)).to be_truthy
-      end
-
-      it "returns false if topic has replies" do
-        topic.update!(posts_count: 2, created_at: Time.zone.now)
-        expect(Guardian.new(topic.user).can_delete?(topic)).to be_falsey
-      end
-
-      it "returns true when tl4 can delete posts and topics" do
-        expect(Guardian.new(trust_level_4).can_delete?(topic)).to be_falsey
-        SiteSetting.delete_all_posts_and_topics_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
-        expect(Guardian.new(trust_level_4).can_delete?(topic)).to be_truthy
-      end
-
-      it "returns false if topic was created > 24h ago" do
-        topic.update!(posts_count: 1, created_at: 48.hours.ago)
-        expect(Guardian.new(topic.user).can_delete?(topic)).to be_falsey
-      end
-
-      context "when category group moderation is enabled" do
-        fab!(:group_user)
-
-        before { SiteSetting.enable_category_group_moderation = true }
-
-        it "returns false if user is not a member of the appropriate group" do
-          expect(Guardian.new(group_user.user).can_delete?(topic)).to be_falsey
-        end
-
-        it "returns true if user is a member of the appropriate group" do
-          Fabricate(:category_moderation_group, category: topic.category, group: group_user.group)
-
-          expect(Guardian.new(group_user.user).can_delete?(topic)).to be_truthy
-        end
-      end
-    end
-
     context "with a Post" do
       before { post.post_number = 2 }
 


### PR DESCRIPTION
### What is this change?

In a previous PR I had to work with `TopicGuardian#can_delete_topic?` and I had to whip out pen and paper to untangle the single conditional that governs it. Now that that task is done, I'm going back to it to clear it up.

Commit by commit:

1. Move the tests to `topic_guardian_spec.rb`.
2. Add missing test cases for trashed- and category topics.
3. Break the conditional into individual code paths using guard clauses.