### PR TITLE
DEV: Fix a flaky chat shortcut test

### DIFF
--- a/plugins/chat/spec/system/shortcuts/full_page_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/full_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Shortcuts | full page", type: :system do
   fab!(:current_user, :user)
 
   let(:chat) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
 
   before do
     chat_system_bootstrap
@@ -19,7 +20,7 @@ RSpec.describe "Shortcuts | full page", type: :system do
 
       page.send_keys("e")
 
-      expect(page).to have_field("channel-composer", with: "e")
+      expect(channel_page.composer).to have_value("e")
     end
   end
 end

--- a/plugins/chat/spec/system/shortcuts/full_page_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/full_page_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Shortcuts | full page", type: :system do
 
       page.send_keys("e")
 
-      expect(find(".chat-composer__input").value).to eq("e")
+      expect(page).to have_field("channel-composer", with: "e")
     end
   end
 end


### PR DESCRIPTION
## ✨ What's This?

Ref: t/159511

There's a race condition in this test that could cause the composer value to not have been updated before the test tries to read the value.

The composer page object makes use of the `has_field?()` test, which will wait until the value has been updated properly.
