### PR TITLE
DEV: Tidy html/body classes in chat

### DIFF
--- a/app/assets/javascripts/discourse/app/services/element-classes.js
+++ b/app/assets/javascripts/discourse/app/services/element-classes.js
@@ -30,7 +30,7 @@ export default class ElementClassesService extends Service {
 
   removeUnusedClasses(element, classes) {
     const remainingClasses = new Set(
-      ...this.#helpers
+      this.#helpers
         .values()
         .filter(({ element: el }) => el === element)
         .flatMap(({ classes: cls }) => cls)

--- a/app/assets/javascripts/discourse/tests/integration/helpers/element-class-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/element-class-test.gjs
@@ -51,24 +51,29 @@ module("Integration | Helper | body-class and html-class", function (hooks) {
     await render(
       <template>
         {{#if state.condition}}
-          {{bodyClass "my-class"}}
+          {{bodyClass "my-class" "persistant-class"}}
           {{htmlClass "my-class"}}
+        {{else}}
+          {{bodyClass "persistant-class"}}
         {{/if}}
       </template>
     );
     assert.dom(document.body).doesNotHaveClass("my-class");
     assert.dom(document.documentElement).doesNotHaveClass("my-class");
+    assert.dom(document.body).hasClass("persistant-class");
 
     state.condition = true;
     await settled();
 
     assert.dom(document.body).hasClass("my-class");
     assert.dom(document.documentElement).hasClass("my-class");
+    assert.dom(document.body).hasClass("persistant-class");
 
     state.condition = false;
     await settled();
 
     assert.dom(document.body).doesNotHaveClass("my-class");
     assert.dom(document.documentElement).doesNotHaveClass("my-class");
+    assert.dom(document.body).hasClass("persistant-class");
   });
 });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.gjs
@@ -231,9 +231,8 @@ export default class ChatDrawer extends Component {
 
   <template>
     {{#if this.chatStateManager.isDrawerActive}}
-      {{bodyClass "chat-drawer-active"}}
       {{htmlClass "has-drawer-chat" "has-chat"}}
-      {{bodyClass "has-drawer-chat" "has-chat"}}
+      {{bodyClass "has-drawer-chat" "has-chat" "chat-drawer-active"}}
     {{/if}}
 
     {{#if this.chatStateManager.isDrawerExpanded}}

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -1,7 +1,5 @@
-import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { scrollTop } from "discourse/lib/scroll-top";
 import { defaultHomepage } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
@@ -71,12 +69,6 @@ export default class ChatRoute extends DiscourseRoute {
 
     this.chatStateManager.storeAppURL();
     this.chat.updatePresence();
-
-    schedule("afterRender", () => {
-      document.body.classList.add("has-full-page-chat", "has-chat");
-      document.documentElement.classList.add("has-full-page-chat", "has-chat");
-      scrollTop();
-    });
   }
 
   deactivate(transition) {
@@ -96,13 +88,5 @@ export default class ChatRoute extends DiscourseRoute {
 
     this.chat.activeChannel = null;
     this.chat.updatePresence();
-
-    schedule("afterRender", () => {
-      document.body.classList.remove("has-full-page-chat", "has-chat");
-      document.documentElement.classList.remove(
-        "has-full-page-chat",
-        "has-chat"
-      );
-    });
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/templates/chat.gjs
+++ b/plugins/chat/assets/javascripts/discourse/templates/chat.gjs
@@ -1,10 +1,15 @@
 import RouteTemplate from "ember-route-template";
+import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
+import htmlClass from "discourse/helpers/html-class";
 import ChannelsList from "discourse/plugins/chat/discourse/components/channels-list";
 import ChatFooter from "discourse/plugins/chat/discourse/components/chat-footer";
 
 export default RouteTemplate(
   <template>
+    {{bodyClass "has-chat" "has-full-page-chat"}}
+    {{htmlClass "has-chat" "has-full-page-chat"}}
+
     <div id="chat-progress-bar-container"></div>
 
     <div

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -12,6 +12,23 @@ RSpec.describe "Drawer", type: :system do
     chat_page.prefers_drawer
   end
 
+  it "handles transitions between drawer and full page and applies appropriate classes" do
+    visit("/")
+
+    chat_page.open_from_header
+    expect(page).to have_css(
+      "body.has-drawer-chat.has-chat.chat-drawer-active.chat-drawer-expanded",
+    )
+    expect(page).to have_css("html.has-drawer-chat.has-chat")
+    expect(page).to have_no_css("body.has-full-page-chat")
+
+    drawer_page.maximize
+    expect(page).to have_css("body.has-chat.has-full-page-chat")
+    expect(page).to have_css("html.has-chat.has-full-page-chat")
+    expect(page).to have_no_css("body.has-drawer-chat")
+    expect(page).to have_no_css("html.has-drawer-chat")
+  end
+
   context "when on channel" do
     fab!(:channel, :chat_channel)
     fab!(:membership) do


### PR DESCRIPTION
Also remove the `scrollTop()`, which is now handled by `services/route-scroll-manager`