### PR TITLE
FIX: Extend cache key due to user locale

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2270,7 +2270,7 @@ class UsersController < ApplicationController
   end
 
   def summary_cache_key(user)
-    "user_summary:#{user.id}:#{current_user ? current_user.id : 0}"
+    "user_summary:#{user.id}:#{current_user ? current_user.id : 0}:#{I18n.locale}"
   end
 
   def render_invite_error(message)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4605,6 +4605,31 @@ RSpec.describe UsersController do
         PostActionCreator.like(liker, post)
       end
     end
+
+    context "when content localization enabled" do
+      fab!(:topic) { Fabricate(:topic, user:, locale: "en") }
+      fab!(:es_localization) { Fabricate(:topic_localization, topic:, locale: "es") }
+      fab!(:de_localization) { Fabricate(:topic_localization, topic:, locale: "de") }
+
+      before do
+        SiteSetting.content_localization_enabled = true
+        SiteSetting.content_localization_supported_locales = "es|de"
+      end
+
+      it "returns localized topic titles in summary" do
+        I18n.stubs(:locale).returns(:es)
+        get "/u/#{user.username_lower}/summary.json"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["topics"][0]["fancy_title"]).to eq(es_localization.fancy_title)
+
+        I18n.stubs(:locale).returns(:de)
+        get "/u/#{user.username_lower}/summary.json"
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["topics"][0]["fancy_title"]).to eq(de_localization.fancy_title)
+      end
+    end
   end
 
   describe "#confirm_admin" do


### PR DESCRIPTION
If an anon Japanese user views Jane's summary page, then subsequently an anon German user views Jane's summary page, the German user will see topic titles in Japanese.

This PR prevents cache poisoning on the user summary page when content localization is enabled. 