### PR TITLE
UX: Horizon > messages page – change box-shadow to inset

### DIFF
--- a/themes/horizon/scss/topic-cards.scss
+++ b/themes/horizon/scss/topic-cards.scss
@@ -154,6 +154,10 @@
     box-shadow:
       0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
+
+    .user-messages-page & {
+      box-shadow: inset 0 0 0 2px var(--accent-color);
+    }
   }
 
   &.excerpt-expanded {


### PR DESCRIPTION
The topic-cards on the messages page are laid out differently than on the main topiclist page and lack spacing. This causes the box-shadow on selected-highlight to be cutoff:

<img width="690" height="374" alt="image" src="https://github.com/user-attachments/assets/4318acf8-1ec0-4f8f-8a00-15d8fb5c9d23" />

This commit uses an inset box-shadow to avoid that, on this page specifically:
<img width="2178" height="1146" alt="CleanShot 2025-07-30 at 13 33 27@2x" src="https://github.com/user-attachments/assets/7af241fe-9d85-48e1-b2aa-2b465a4ba991" />
