### PR TITLE
FIX: Mention with a status should open the user card

### DIFF
--- a/app/assets/javascripts/discourse/app/components/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/components/card-contents-base.js
@@ -145,7 +145,7 @@ export default class CardContentsBase extends Component {
 
     // Mention click
     this._showCardOnClick(event, this.mentionSelector, (el) =>
-      el.innerText.replace(/^@/, "")
+      el.innerText.trim().replace(/^@/, "")
     );
   }
 

--- a/spec/system/page_objects/components/post.rb
+++ b/spec/system/page_objects/components/post.rb
@@ -69,6 +69,10 @@ module PageObjects
         post.find(".post-info.edits").click
       end
 
+      def mentions_of(user)
+        post.all("a.mention[href='/u/#{user.username}']")
+      end
+
       private
 
       def post_id

--- a/spec/system/page_objects/components/user_card.rb
+++ b/spec/system/page_objects/components/user_card.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class UserCard < PageObjects::Components::Base
+      def visible?
+        has_css?("#user-card")
+      end
+
+      def showing_user?(username)
+        has_css?("#user-card.user-card-#{username}")
+      end
+    end
+  end
+end

--- a/spec/system/user_card_spec.rb
+++ b/spec/system/user_card_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "User Card", type: :system do
+  fab!(:current_user, :admin)
+  fab!(:topic) { Fabricate(:post).topic }
+  fab!(:user)
+  let(:mention) { "@#{user.username}" }
+  let!(:post_with_mention) do
+    PostCreator.create!(current_user, topic_id: topic.id, raw: "Hello #{mention}")
+  end
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:user_card) { PageObjects::Components::UserCard.new }
+  let(:mention_post) { PageObjects::Components::Post.new(post_with_mention.post_number) }
+
+  before { sign_in(current_user) }
+
+  context "when the mentioned user has set a status" do
+    fab!(:user_status) { Fabricate(:user_status, user: user) }
+
+    before { SiteSetting.enable_user_status = true }
+
+    it "is still possible to view the user card via a mention even there's a status next to the mention" do
+      topic_page.visit_topic(topic)
+
+      mention_anchors = mention_post.mentions_of(user)
+      expect(mention_anchors.size).to eq(1)
+
+      mention_anchors.first.click
+
+      expect(user_card).to be_visible
+      expect(user_card).to be_showing_user(user.username)
+    end
+  end
+end


### PR DESCRIPTION
Currently, clicking on a mention of user who has set a custom status causes the user card to fail to load. This happens because when the username is extracted from the mention `<a>` element, the space between the username and the status emoji is captured with the username and is sent to the server which fails to lookup the user due to the erroneously appended space.

To fix this, we should cleanup the captured username and remove surrounding spaces using `trim()`.