### PR TITLE
DEV: use floatkit autocomplete for chat composer

### DIFF
--- a/app/assets/javascripts/discourse/app/modifiers/d-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/modifiers/d-autocomplete.js
@@ -27,6 +27,7 @@ export const CANCELLED_STATUS = "__CANCELLED";
  * @param {boolean} [autoSelectFirstSuggestion=true] - Auto-select first result
  * @param {Function} [triggerRule] - Function to determine if autocomplete should trigger: (element, opts) => Promise<boolean>
  * @param {Function} [onKeyUp] - Function to extract search patterns from text on keyup: (text, caretPosition) => Array<string>
+ * @param {boolean} [fixedTextareaPosition=false] - If true, positions autocomplete relative to textarea bounds instead of cursor position
  */
 export default class DAutocompleteModifier extends Modifier {
   /**
@@ -386,8 +387,10 @@ export default class DAutocompleteModifier extends Modifier {
   async openAutocomplete() {
     this.selectedIndex = this.autoSelectFirstSuggestion ? 0 : -1;
     try {
-      // Create virtual element positioned at the caret location
-      const virtualElement = this.createVirtualElementAtCaret();
+      // Create virtual element with appropriate positioning
+      const virtualElement = this.options.fixedTextareaPosition
+        ? this.createVirtualElementAtTextarea()
+        : this.createVirtualElementAtCaret();
 
       const menuOptions = {
         identifier: "d-autocomplete",
@@ -616,6 +619,18 @@ export default class DAutocompleteModifier extends Modifier {
         top: caretCoords.y + this.VERTICAL_RELATIVE_OFFSET,
         width: 1,
         height: 10,
+      }),
+    };
+  }
+
+  createVirtualElementAtTextarea() {
+    const textareaRect = this.targetElement.getBoundingClientRect();
+    return {
+      getBoundingClientRect: () => ({
+        left: textareaRect.left,
+        top: textareaRect.top,
+        width: textareaRect.width,
+        height: 2,
       }),
     };
   }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2727,6 +2727,7 @@ en:
     glimmer_post_stream_mode_auto_groups: "Enable the new 'glimmer' post stream implementation in 'auto' mode for the specified user groups. This implementation is under active development, and is not intended for production use. Do not develop themes/plugins against it until the implementation is finalized and announced."
     deactivate_widgets_rendering: "Disable the legacy widgets rendering engine. This will disable all widgets that have not been updated to Glimmer components, it will also force the Glimmer Post Stream to be enabled unconditionally regardless of the value of the `glimmer_post_stream_mode` setting. This setting is not recommended for production sites, as it may break existing themes and plugins."
     floatkit_autocomplete_composer: "Enable the Floatkit-based autocomplete menu in composer. This is an UI enhancement that will replace the current JQuery-based autocomplete menu."
+    floatkit_autocomplete_chat_composer: "Enable the Floatkit-based autocomplete menu in chat composer. This is a UI enhancement that will replace the current jQuery-based autocomplete menu."
     experimental_form_templates: "Enable the form templates feature. Manage the templates at <a href='%{base_path}/admin/customize/form-templates'>Customize / Templates</a>."
     show_preview_for_form_templates: "Enable the preview for form templates feature"
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -568,6 +568,10 @@ basic:
     client: true
     default: true
     area: "interface"
+  floatkit_autocomplete_chat_composer:
+    client: true
+    default: true
+    area: "interface"
 
 login:
   invite_only:

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -27,11 +27,12 @@ import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import renderEmojiAutocomplete from "discourse/lib/autocomplete/emoji";
 import userAutocomplete from "discourse/lib/autocomplete/user";
-import { setupHashtagAutocomplete } from "discourse/lib/hashtag-autocomplete";
+import { hashtagAutocompleteOptions } from "discourse/lib/hashtag-autocomplete";
 import loadEmojiSearchAliases from "discourse/lib/load-emoji-search-aliases";
 import { cloneJSON } from "discourse/lib/object";
 import optionalService from "discourse/lib/optional-service";
 import { emojiUrlFor } from "discourse/lib/text";
+import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipulation";
 import userSearch from "discourse/lib/user-search";
 import {
   destroyUserStatuses,
@@ -40,7 +41,9 @@ import {
 } from "discourse/lib/user-status-on-autocomplete";
 import virtualElementFromTextRange from "discourse/lib/virtual-element-from-text-range";
 import { waitForClosedKeyboard } from "discourse/lib/wait-for-keyboard";
-import { SKIP } from "discourse/modifiers/d-autocomplete";
+import DAutocompleteModifier, {
+  SKIP,
+} from "discourse/modifiers/d-autocomplete";
 import { i18n } from "discourse-i18n";
 import Button from "discourse/plugins/chat/discourse/components/chat/composer/button";
 import ChatComposerDropdown from "discourse/plugins/chat/discourse/components/chat-composer-dropdown";
@@ -105,10 +108,9 @@ export default class ChatComposer extends Component {
 
   @action
   setupAutocomplete(textarea) {
-    const $textarea = $(textarea);
-    this.#applyUserAutocomplete($textarea);
-    this.#applyEmojiAutocomplete($textarea);
-    this.#applyCategoryHashtagAutocomplete($textarea);
+    this.#applyUserAutocomplete(textarea);
+    this.#applyEmojiAutocomplete(textarea);
+    this.#applyCategoryHashtagAutocomplete(textarea);
   }
 
   @action
@@ -118,6 +120,21 @@ export default class ChatComposer extends Component {
     if (this.site.desktopView && this.args.autofocus) {
       this.composer.focus({ ensureAtEnd: true, refreshHeight: true });
     }
+  }
+
+  applyAutocomplete(textarea, options) {
+    if (!this.siteSettings.floatkit_autocomplete_composer) {
+      const $textarea = $(textarea);
+      return $textarea.autocomplete(options);
+    }
+
+    const autocompleteHandler = new TextareaAutocompleteHandler(textarea);
+    return DAutocompleteModifier.setupAutocomplete(
+      getOwner(this),
+      textarea,
+      autocompleteHandler,
+      options
+    );
   }
 
   @action
@@ -451,16 +468,17 @@ export default class ChatComposer extends Component {
     this.draft.mentionedUsers.set(user.id, user);
   }
 
-  #applyUserAutocomplete($textarea) {
+  #applyUserAutocomplete(textarea) {
     if (!this.siteSettings.enable_mentions) {
       return;
     }
 
-    $textarea.autocomplete({
+    this.applyAutocomplete(textarea, {
       template: userAutocomplete,
       key: "@",
       width: "100%",
       treatAsTextarea: true,
+      fixedTextareaPosition: true,
       autoSelectFirstSuggestion: true,
       transformComplete: (obj) => {
         if (obj.isUser) {
@@ -498,28 +516,31 @@ export default class ChatComposer extends Component {
     });
   }
 
-  #applyCategoryHashtagAutocomplete($textarea) {
-    setupHashtagAutocomplete(
-      this.site.hashtag_configurations["chat-composer"],
-      $textarea,
-      this.siteSettings,
-      {
-        treatAsTextarea: true,
-        afterComplete: (text, event) => {
-          event.preventDefault();
-          this.composer.textarea.value = text;
-          this.composer.focus();
-        },
-      }
+  #applyCategoryHashtagAutocomplete(textarea) {
+    this.applyAutocomplete(
+      textarea,
+      hashtagAutocompleteOptions(
+        this.site.hashtag_configurations["chat-composer"],
+        this.siteSettings,
+        {
+          fixedTextareaPosition: true,
+          treatAsTextarea: true,
+          afterComplete: (text, event) => {
+            event.preventDefault();
+            this.composer.textarea.value = text;
+            this.composer.focus();
+          },
+        }
+      )
     );
   }
 
-  #applyEmojiAutocomplete($textarea) {
+  #applyEmojiAutocomplete(textarea) {
     if (!this.siteSettings.enable_emoji) {
       return;
     }
 
-    $textarea.autocomplete({
+    this.applyAutocomplete(textarea, {
       template: renderEmojiAutocomplete,
       key: ":",
       afterComplete: (text, event) => {
@@ -528,6 +549,7 @@ export default class ChatComposer extends Component {
         this.composer.focus();
       },
       treatAsTextarea: true,
+      fixedTextareaPosition: true,
       onKeyUp: (text, cp) => {
         const matches =
           /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()+])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
@@ -542,7 +564,10 @@ export default class ChatComposer extends Component {
         if (v.code) {
           return `${v.code}:`;
         } else {
-          $textarea.autocomplete({ cancel: true });
+          if (!this.siteSettings.floatkit_autocomplete_chat_composer) {
+            const $textarea = $(textarea);
+            $textarea.autocomplete({ cancel: true });
+          }
 
           const menuOptions = {
             identifier: "emoji-picker",

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Chat composer", type: :system do
   let(:open_thread) { PageObjects::Pages::ChatThread.new }
 
   before do
+    SiteSetting.floatkit_autocomplete_composer = true
     chat_system_bootstrap
     channel_1.add(current_user)
     sign_in(current_user)
@@ -316,6 +317,31 @@ RSpec.describe "Chat composer", type: :system do
         open_thread.send_message("+👍")
 
         expect(open_thread).to have_reaction(thread_message, "+1")
+      end
+    end
+  end
+
+  context "with floatkit autocomplete disabled" do
+    before { SiteSetting.floatkit_autocomplete_composer = false }
+
+    context "when adding an emoji through the autocomplete" do
+      it "adds the emoji to the composer" do
+        chat_page.visit_channel(channel_1)
+        find(".chat-composer__input").send_keys(":gri")
+        find(".emoji-shortname", text: "grimacing").click
+
+        expect(channel_page.composer).to have_value(":grimacing: ")
+      end
+
+      it "doesn't suggest denied emojis and aliases" do
+        SiteSetting.emoji_deny_list = "peach|poop"
+        chat_page.visit_channel(channel_1)
+
+        find(".chat-composer__input").fill_in(with: ":peac")
+        expect(page).to have_no_selector(".emoji-shortname", text: "peach")
+
+        find(".chat-composer__input").fill_in(with: ":hank") # alias
+        expect(page).to have_no_selector(".emoji-shortname", text: "poop")
       end
     end
   end

--- a/plugins/chat/spec/system/hashtag_autocomplete_spec.rb
+++ b/plugins/chat/spec/system/hashtag_autocomplete_spec.rb
@@ -15,6 +15,7 @@ describe "Using #hashtag autocompletion to search for and lookup channels", type
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
   before do
+    SiteSetting.floatkit_autocomplete_composer = true
     chat_system_bootstrap(user, [channel1, channel2])
     sign_in(user)
   end
@@ -168,6 +169,37 @@ describe "Using #hashtag autocompletion to search for and lookup channels", type
       expect(page).to have_css(".hashtag-cooked")
       css_class = ".hashtag-color--channel-#{management_channel.id}"
       expect(find("#hashtag-css-generator", visible: false).text(:all)).not_to include(css_class)
+    end
+
+    context "with floatkit autocomplete disabled" do
+      before { SiteSetting.floatkit_autocomplete_composer = false }
+
+      it "searches for channels, categories, and tags with # and prioritises channels in the results" do
+        chat_page.visit_channel(channel1)
+        chat_channel_page.composer.send_keys("this is #ra")
+        expect(page).to have_css(
+          ".hashtag-autocomplete .hashtag-autocomplete__option .hashtag-autocomplete__link",
+          count: 3,
+        )
+        hashtag_results = page.all(".hashtag-autocomplete__link", count: 3)
+        expect(hashtag_results.map(&:text).map { |r| r.gsub("\n", " ") }).to eq(
+          ["Random", "Raspberry", "razed (x0)"],
+        )
+      end
+
+      it "searches for channels as well with # in a topic composer and deprioritises them" do
+        topic_page.visit_topic_and_open_composer(topic)
+        expect(topic_page).to have_expanded_composer
+        topic_page.type_in_composer("something #ra")
+        expect(page).to have_css(
+          ".hashtag-autocomplete .hashtag-autocomplete__option .hashtag-autocomplete__link",
+          count: 3,
+        )
+        hashtag_results = page.all(".hashtag-autocomplete__link", count: 3)
+        expect(hashtag_results.map(&:text).map { |r| r.gsub("\n", " ") }).to eq(
+          ["Raspberry", "razed (x0)", "Random"],
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This PR ports the floatkit-based autocomplete system to chat composer under a site setting, providing consistent UX across both regular and chat composers.

### Key Changes

* Adds floatkit_autocomplete_chat_composer setting (defaults to true)
* Adds `fixedTextareaPosition` option and `createVirtualElementAtTextarea` to DAutocompleteModifier to allow for positioning of the autocomplete menu relative to the whole textarea bounds instead of following the cursor - this is better for chat UI & aligns with current behaviour