### PR TITLE
FIX: element-classes implementation on older browsers

### DIFF
--- a/app/assets/javascripts/discourse/app/services/element-classes.js
+++ b/app/assets/javascripts/discourse/app/services/element-classes.js
@@ -30,8 +30,7 @@ export default class ElementClassesService extends Service {
 
   removeUnusedClasses(element, classes) {
     const remainingClasses = new Set(
-      this.#helpers
-        .values()
+      [...this.#helpers.values()]
         .filter(({ element: el }) => el === element)
         .flatMap(({ classes: cls }) => cls)
     );


### PR DESCRIPTION
`Iterator.filter` only exists on Safari 18+. Need to convert to an array first