### PR TITLE
FIX: Optimize shortcomings from topic truncation from a27e20c

### DIFF
--- a/plugins/discourse-ai/lib/embeddings/strategies/truncation.rb
+++ b/plugins/discourse-ai/lib/embeddings/strategies/truncation.rb
@@ -4,6 +4,8 @@ module DiscourseAi
   module Embeddings
     module Strategies
       class Truncation
+        TEXT_TO_HTML_TOKEN_RATIO = 3
+
         def id
           1
         end
@@ -69,7 +71,7 @@ module DiscourseAi
 
           if topic&.topic_embed&.embed_content_cache.present?
             text << Nokogiri::HTML5.fragment(topic.topic_embed.embed_content_cache).text
-            text << "\n\n"
+            text << " "
           end
 
           posts_text = +""
@@ -78,9 +80,11 @@ module DiscourseAi
           topic.posts.find_each do |post|
             posts_text_size += tokenizer.size(post.cooked)
             posts_text << post.cooked
-            break if posts_text_size >= max_length
+            posts_text << " "
 
-            text << "\n\n"
+            # Since we will strip all HTML tags before embedding, we can fit more text
+            # than the max_length as it will shrink after Nokogiri extracts the text
+            break if posts_text_size >= max_length * TEXT_TO_HTML_TOKEN_RATIO
           end
 
           text << Nokogiri::HTML5.fragment(posts_text).text

--- a/plugins/discourse-ai/spec/lib/modules/embeddings/strategies/truncation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/embeddings/strategies/truncation_spec.rb
@@ -63,8 +63,6 @@ RSpec.describe DiscourseAi::Embeddings::Strategies::Truncation do
 
         prepared_text = truncation.prepare_target_text(large_topic, open_ai_embedding_def)
 
-        pp prepared_text
-
         # Should still be within max_length after HTML stripping and tokenization
         expect(tokenizer.size(prepared_text)).to be <= max_length
 


### PR DESCRIPTION
On a27e20c we made an emergency perf fix to speedup generating text from
a topic for embeddings generation.

This introduced some issues, like missing separators between posts,
including to line breaks per included post all at the top of the
generated text, and resulted in using a lot less content per topics,
as we count the cooked size before stripping all the HTML tags.

This commit helps alleviate by:

  - removing the "\n\n" * quantity of posts at the top
  - adding a space between posts
  - generating text 3 times longer than the max allowed lenght, since
    it's getting shrinked after it's built by the Nokogiri.text call.
