### PR TITLE
UX: better handling of admin email log overflow

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/email-logs-bounced.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-bounced.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import LoadMore from "discourse/components/load-more";
 import TextField from "discourse/components/text-field";
 import avatar from "discourse/helpers/avatar";
@@ -13,87 +14,95 @@ import { i18n } from "discourse-i18n";
 export default RouteTemplate(
   <template>
     <LoadMore @action={{@controller.loadMore}}>
-      <table class="table email-list">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.email.time"}}</th>
-            <th>{{i18n "admin.email.user"}}</th>
-            <th>{{i18n "admin.email.to_address"}}</th>
-            <th colspan="2">{{i18n "admin.email.email_type"}}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="filters">
-            <td>{{i18n "admin.email.logs.filters.title"}}</td>
-            <td>
-              <TextField
-                @value={{@controller.filter.user}}
-                @placeholderKey="admin.email.logs.filters.user_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.address}}
-                @placeholderKey="admin.email.logs.filters.address_placeholder"
-              /></td>
-            <td colspan="2">
-              <TextField
-                @value={{@controller.filter.type}}
-                @placeholderKey="admin.email.logs.filters.type_placeholder"
-              /></td>
-          </tr>
-
-          {{#each @controller.model as |l|}}
+      <HorizontalScrollSyncWrapper>
+        <table class="table email-list">
+          <thead>
             <tr>
-              <td>{{formatDate l.created_at}}</td>
-              <td>
-                {{#if l.user}}
-                  <LinkTo @route="adminUser" @model={{l.user}}>{{avatar
-                      l.user
-                      imageSize="tiny"
-                    }}</LinkTo>
-                  <LinkTo
-                    @route="adminUser"
-                    @model={{l.user}}
-                  >{{l.user.username}}</LinkTo>
-                {{else}}
-                  &mdash;
-                {{/if}}
-              </td>
-              <td class="email-address"><a
-                  href="mailto:{{l.to_address}}"
-                >{{l.to_address}}</a></td>
-              <td>
-                {{#if l.has_bounce_key}}
-                  <a
-                    href
-                    {{on "click" (fn @controller.handleShowIncomingEmail l.id)}}
-                  >
-                    {{l.email_type}}
-                  </a>
-                {{else}}
-                  {{l.email_type}}
-                {{/if}}
-              </td>
-              <td class="email-details">
-                {{#if l.has_bounce_key}}
-                  <a
-                    href
-                    {{on "click" (fn @controller.handleShowIncomingEmail l.id)}}
-                    title={{i18n "admin.email.details_title"}}
-                  >
-                    {{icon "circle-info"}}
-                  </a>
-                {{/if}}
-              </td>
+              <th>{{i18n "admin.email.time"}}</th>
+              <th>{{i18n "admin.email.user"}}</th>
+              <th>{{i18n "admin.email.to_address"}}</th>
+              <th colspan="2">{{i18n "admin.email.email_type"}}</th>
             </tr>
-          {{else}}
-            {{#unless @controller.loading}}
+          </thead>
+          <tbody>
+            <tr class="filters">
+              <td>{{i18n "admin.email.logs.filters.title"}}</td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.user}}
+                  @placeholderKey="admin.email.logs.filters.user_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.address}}
+                  @placeholderKey="admin.email.logs.filters.address_placeholder"
+                /></td>
+              <td colspan="2">
+                <TextField
+                  @value={{@controller.filter.type}}
+                  @placeholderKey="admin.email.logs.filters.type_placeholder"
+                /></td>
+            </tr>
+
+            {{#each @controller.model as |l|}}
               <tr>
-                <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
-            {{/unless}}
-          {{/each}}
-        </tbody>
-      </table>
+                <td>{{formatDate l.created_at}}</td>
+                <td>
+                  {{#if l.user}}
+                    <LinkTo @route="adminUser" @model={{l.user}}>{{avatar
+                        l.user
+                        imageSize="tiny"
+                      }}</LinkTo>
+                    <LinkTo
+                      @route="adminUser"
+                      @model={{l.user}}
+                    >{{l.user.username}}</LinkTo>
+                  {{else}}
+                    &mdash;
+                  {{/if}}
+                </td>
+                <td class="email-address"><a
+                    href="mailto:{{l.to_address}}"
+                  >{{l.to_address}}</a></td>
+                <td>
+                  {{#if l.has_bounce_key}}
+                    <a
+                      href
+                      {{on
+                        "click"
+                        (fn @controller.handleShowIncomingEmail l.id)
+                      }}
+                    >
+                      {{l.email_type}}
+                    </a>
+                  {{else}}
+                    {{l.email_type}}
+                  {{/if}}
+                </td>
+                <td class="email-details">
+                  {{#if l.has_bounce_key}}
+                    <a
+                      href
+                      {{on
+                        "click"
+                        (fn @controller.handleShowIncomingEmail l.id)
+                      }}
+                      title={{i18n "admin.email.details_title"}}
+                    >
+                      {{icon "circle-info"}}
+                    </a>
+                  {{/if}}
+                </td>
+              </tr>
+            {{else}}
+              {{#unless @controller.loading}}
+                <tr>
+                  <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
+              {{/unless}}
+            {{/each}}
+          </tbody>
+        </table>
+      </HorizontalScrollSyncWrapper>
     </LoadMore>
 
     <ConditionalLoadingSpinner @condition={{@controller.loading}} />

--- a/app/assets/javascripts/admin/addon/templates/email-logs-received.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-received.gjs
@@ -1,6 +1,7 @@
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import LoadMore from "discourse/components/load-more";
 import TextField from "discourse/components/text-field";
 import avatar from "discourse/helpers/avatar";
@@ -10,76 +11,78 @@ import { i18n } from "discourse-i18n";
 export default RouteTemplate(
   <template>
     <LoadMore @action={{@controller.loadMore}}>
-      <table class="table email-list">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.email.time"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.from_address"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.to_addresses"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.subject"}}</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr class="filters">
-            <td>{{i18n "admin.email.logs.filters.title"}}</td>
-            <td>
-              <TextField
-                @value={{@controller.filter.from}}
-                @placeholderKey="admin.email.incoming_emails.filters.from_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.to}}
-                @placeholderKey="admin.email.incoming_emails.filters.to_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.subject}}
-                @placeholderKey="admin.email.incoming_emails.filters.subject_placeholder"
-              /></td>
-          </tr>
-
-          {{#each @controller.model as |email|}}
+      <HorizontalScrollSyncWrapper>
+        <table class="table email-list">
+          <thead>
             <tr>
-              <td class="time">{{formatDate email.created_at}}</td>
-              <td class="username">
-                <div>
-                  {{#if email.user}}
-                    <LinkTo @route="adminUser" @model={{email.user}}>
-                      {{avatar email.user imageSize="tiny"}}
-                      {{email.from_address}}
-                    </LinkTo>
-                  {{else}}
-                    &mdash;
-                  {{/if}}
-                </div>
-              </td>
-              <td class="addresses">
-                {{#each email.to_addresses as |to|}}
-                  <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
-                {{/each}}
-                {{#each email.cc_addresses as |cc|}}
-                  <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
-                {{/each}}
-              </td>
+              <th>{{i18n "admin.email.time"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.from_address"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.to_addresses"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.subject"}}</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr class="filters">
+              <td>{{i18n "admin.email.logs.filters.title"}}</td>
               <td>
-                {{#if email.post_url}}
-                  <a href={{email.post_url}}>{{email.subject}}</a>
-                {{else}}
-                  {{email.subject}}
-                {{/if}}
-              </td>
+                <TextField
+                  @value={{@controller.filter.from}}
+                  @placeholderKey="admin.email.incoming_emails.filters.from_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.to}}
+                  @placeholderKey="admin.email.incoming_emails.filters.to_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.subject}}
+                  @placeholderKey="admin.email.incoming_emails.filters.subject_placeholder"
+                /></td>
             </tr>
-          {{else}}
-            <tr>
-              <td colspan="4">
-                {{i18n "admin.email.incoming_emails.none"}}
-              </td>
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
+
+            {{#each @controller.model as |email|}}
+              <tr>
+                <td class="time">{{formatDate email.created_at}}</td>
+                <td class="username">
+                  <div>
+                    {{#if email.user}}
+                      <LinkTo @route="adminUser" @model={{email.user}}>
+                        {{avatar email.user imageSize="tiny"}}
+                        {{email.from_address}}
+                      </LinkTo>
+                    {{else}}
+                      &mdash;
+                    {{/if}}
+                  </div>
+                </td>
+                <td class="addresses">
+                  {{#each email.to_addresses as |to|}}
+                    <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
+                  {{/each}}
+                  {{#each email.cc_addresses as |cc|}}
+                    <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
+                  {{/each}}
+                </td>
+                <td>
+                  {{#if email.post_url}}
+                    <a href={{email.post_url}}>{{email.subject}}</a>
+                  {{else}}
+                    {{email.subject}}
+                  {{/if}}
+                </td>
+              </tr>
+            {{else}}
+              <tr>
+                <td colspan="4">
+                  {{i18n "admin.email.incoming_emails.none"}}
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </HorizontalScrollSyncWrapper>
     </LoadMore>
 
     <ConditionalLoadingSpinner @condition={{@controller.loading}} />

--- a/app/assets/javascripts/admin/addon/templates/email-logs-rejected.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-rejected.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import LoadMore from "discourse/components/load-more";
 import TextField from "discourse/components/text-field";
 import avatar from "discourse/helpers/avatar";
@@ -13,102 +14,104 @@ import { i18n } from "discourse-i18n";
 export default RouteTemplate(
   <template>
     <LoadMore @action={{@controller.loadMore}}>
-      <table class="table email-list">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.email.time"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.from_address"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.to_addresses"}}</th>
-            <th>{{i18n "admin.email.incoming_emails.subject"}}</th>
-            <th colspan="2">{{i18n "admin.email.incoming_emails.error"}}</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr class="filters">
-            <td>{{i18n "admin.email.logs.filters.title"}}</td>
-            <td>
-              <TextField
-                @value={{@controller.filter.from}}
-                @placeholderKey="admin.email.incoming_emails.filters.from_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.to}}
-                @placeholderKey="admin.email.incoming_emails.filters.to_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.subject}}
-                @placeholderKey="admin.email.incoming_emails.filters.subject_placeholder"
-              /></td>
-            <td colspan="2">
-              <TextField
-                @value={{@controller.filter.error}}
-                @placeholderKey="admin.email.incoming_emails.filters.error_placeholder"
-              /></td>
-          </tr>
-
-          {{#each @controller.model as |email|}}
+      <HorizontalScrollSyncWrapper>
+        <table class="table email-list">
+          <thead>
             <tr>
-              <td class="time">{{formatDate email.created_at}}</td>
-              <td class="username">
-                <div>
-                  {{#if email.user}}
-                    <LinkTo @route="adminUser" @model={{email.user}}>
-                      {{avatar email.user imageSize="tiny"}}
-                      {{email.from_address}}
-                    </LinkTo>
-                  {{else}}
-                    {{#if email.from_address}}
-                      <a
-                        href="mailto:{{email.from_address}}"
-                      >{{email.from_address}}</a>
-                    {{else}}
-                      &mdash;
-                    {{/if}}
-                  {{/if}}
-                </div>
-              </td>
-              <td class="addresses">
-                {{#each email.to_addresses as |to|}}
-                  <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
-                {{/each}}
-                {{#each email.cc_addresses as |cc|}}
-                  <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
-                {{/each}}
-              </td>
-              <td>{{email.subject}}</td>
-              <td class="error">
-                <a
-                  href
-                  {{on
-                    "click"
-                    (fn @controller.handleShowIncomingEmail email.id)
-                  }}
-                >{{email.error}}</a>
-              </td>
-              <td class="email-details">
-                <a
-                  href
-                  {{on
-                    "click"
-                    (fn @controller.handleShowIncomingEmail email.id)
-                  }}
-                  title={{i18n "admin.email.details_title"}}
-                >
-                  {{icon "circle-info"}}
-                </a>
-              </td>
+              <th>{{i18n "admin.email.time"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.from_address"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.to_addresses"}}</th>
+              <th>{{i18n "admin.email.incoming_emails.subject"}}</th>
+              <th colspan="2">{{i18n "admin.email.incoming_emails.error"}}</th>
             </tr>
-          {{else}}
-            <tr>
-              <td colspan="6">{{i18n
-                  "admin.email.incoming_emails.none"
-                }}</td></tr>
-          {{/each}}
-        </tbody>
-      </table>
+          </thead>
+
+          <tbody>
+            <tr class="filters">
+              <td>{{i18n "admin.email.logs.filters.title"}}</td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.from}}
+                  @placeholderKey="admin.email.incoming_emails.filters.from_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.to}}
+                  @placeholderKey="admin.email.incoming_emails.filters.to_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.subject}}
+                  @placeholderKey="admin.email.incoming_emails.filters.subject_placeholder"
+                /></td>
+              <td colspan="2">
+                <TextField
+                  @value={{@controller.filter.error}}
+                  @placeholderKey="admin.email.incoming_emails.filters.error_placeholder"
+                /></td>
+            </tr>
+
+            {{#each @controller.model as |email|}}
+              <tr>
+                <td class="time">{{formatDate email.created_at}}</td>
+                <td class="username">
+                  <div>
+                    {{#if email.user}}
+                      <LinkTo @route="adminUser" @model={{email.user}}>
+                        {{avatar email.user imageSize="tiny"}}
+                        {{email.from_address}}
+                      </LinkTo>
+                    {{else}}
+                      {{#if email.from_address}}
+                        <a
+                          href="mailto:{{email.from_address}}"
+                        >{{email.from_address}}</a>
+                      {{else}}
+                        &mdash;
+                      {{/if}}
+                    {{/if}}
+                  </div>
+                </td>
+                <td class="addresses">
+                  {{#each email.to_addresses as |to|}}
+                    <p><a href="mailto:{{to}}" title="TO">{{to}}</a></p>
+                  {{/each}}
+                  {{#each email.cc_addresses as |cc|}}
+                    <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
+                  {{/each}}
+                </td>
+                <td>{{email.subject}}</td>
+                <td class="error">
+                  <a
+                    href
+                    {{on
+                      "click"
+                      (fn @controller.handleShowIncomingEmail email.id)
+                    }}
+                  >{{email.error}}</a>
+                </td>
+                <td class="email-details">
+                  <a
+                    href
+                    {{on
+                      "click"
+                      (fn @controller.handleShowIncomingEmail email.id)
+                    }}
+                    title={{i18n "admin.email.details_title"}}
+                  >
+                    {{icon "circle-info"}}
+                  </a>
+                </td>
+              </tr>
+            {{else}}
+              <tr>
+                <td colspan="6">{{i18n
+                    "admin.email.incoming_emails.none"
+                  }}</td></tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </HorizontalScrollSyncWrapper>
     </LoadMore>
 
     <ConditionalLoadingSpinner @condition={{@controller.loading}} />

--- a/app/assets/javascripts/admin/addon/templates/email-logs-sent.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-sent.gjs
@@ -3,6 +3,7 @@ import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import { gt } from "truth-helpers";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import LoadMore from "discourse/components/load-more";
 import TextField from "discourse/components/text-field";
 import avatar from "discourse/helpers/avatar";
@@ -15,149 +16,148 @@ import DTooltip from "float-kit/components/d-tooltip";
 export default RouteTemplate(
   <template>
     <LoadMore @action={{@controller.loadMore}}>
-      <table class="table email-list">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.email.sent_at"}}</th>
-            <th>{{i18n "admin.email.user"}}</th>
-            <th>{{i18n "admin.email.to_address"}}</th>
-            <th>{{i18n "admin.email.email_type"}}</th>
-            <th>{{i18n "admin.email.reply_key"}}</th>
-            <th>{{i18n "admin.email.post_link_with_smtp"}}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="filters">
-            <td>{{i18n "admin.email.logs.filters.title"}}</td>
-            <td>
-              <TextField
-                @value={{@controller.filter.user}}
-                @placeholderKey="admin.email.logs.filters.user_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.address}}
-                @placeholderKey="admin.email.logs.filters.address_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.type}}
-                @placeholderKey="admin.email.logs.filters.type_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.reply_key}}
-                @placeholderKey="admin.email.logs.filters.reply_key_placeholder"
-              /></td>
-            <td></td>
-          </tr>
-
-          {{#each @controller.model as |l|}}
-            <tr class="sent-email-item">
-              <td class="sent-email-date">{{formatDate l.created_at}}</td>
-              <td class="sent-email-username">
-                {{#if l.user}}
-                  <LinkTo @route="adminUser" @model={{l.user}}>{{avatar
-                      l.user
-                      imageSize="tiny"
-                    }}</LinkTo>
-                  <LinkTo
-                    @route="adminUser"
-                    @model={{l.user}}
-                  >{{l.user.username}}</LinkTo>
-                {{else}}
-                  &mdash;
-                {{/if}}
-              </td>
-              <td class="sent-email-address">
-                {{#if l.bounced}}{{icon
-                    "arrow-rotate-right"
-                    title="admin.email.bounced"
-                  }}{{/if}}
-                <p><a
-                    href="mailto:{{l.to_address}}"
-                    title="TO"
-                  >{{l.to_address}}</a></p>
-                {{#if l.cc_addresses}}
-                  {{#if
-                    (gt
-                      l.cc_addresses.length
-                      @controller.ccAddressDisplayThreshold
-                    )
-                  }}
-                    {{#each
-                      (slice
-                        0
-                        @controller.ccAddressDisplayThreshold
-                        (fn @controller.sortWithAddressFilter l.cc_addresses)
-                      )
-                      as |cc|
-                    }}
-                      <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
-                    {{/each}}
-                    <DTooltip
-                      @placement="right-start"
-                      @arrow={{true}}
-                      @identifier="email-log-cc-addresses"
-                      @interactive={{true}}
-                    >
-                      <:trigger>
-                        {{i18n "admin.email.logs.email_addresses.see_more"}}
-                      </:trigger>
-                      <:content>
-                        <ul>
-                          {{#each
-                            (slice
-                              @controller.ccAddressDisplayThreshold
-                              l.cc_addresses
-                            )
-                            as |cc|
-                          }}
-                            <li>
-                              <span>
-                                <a href="mailto:{{cc}}" title="CC">{{cc}}</a>
-                              </span>
-                            </li>
-                          {{/each}}
-                        </ul>
-                      </:content>
-                    </DTooltip>
-
-                  {{else}}
-                    {{#each l.cc_addresses as |cc|}}
-                      <p><a href="mailto:{{cc}}" title="CC">{{cc}}</a></p>
-                    {{/each}}
-                  {{/if}}
-                {{/if}}
-              </td>
-              <td class="sent-email-type">{{l.email_type}}</td>
-              <td class="sent-email-reply-key">
-                <span
-                  title={{l.reply_key}}
-                  class="reply-key"
-                >{{l.reply_key}}</span>
-              </td>
-              <td class="sent-email-post-link-with-smtp-response">
-                {{#if l.post_url}}
-                  <a href={{l.post_url}}>
-                    {{l.post_description}}
-                  </a>
-                  {{i18n "admin.email.logs.post_id" post_id=l.post_id}}
-                  <br />
-                  /{{/if}}
-                <code
-                  title={{l.smtp_transaction_response}}
-                >{{l.smtp_transaction_response}}</code>
-              </td>
+      <HorizontalScrollSyncWrapper>
+        <table class="table email-list">
+          <thead>
+            <tr>
+              <th>{{i18n "admin.email.sent_at"}}</th>
+              <th>{{i18n "admin.email.user"}}</th>
+              <th>{{i18n "admin.email.to_address"}}</th>
+              <th>{{i18n "admin.email.email_type"}}</th>
+              <th>{{i18n "admin.email.reply_key"}}</th>
+              <th>{{i18n "admin.email.post_link_with_smtp"}}</th>
             </tr>
-          {{else}}
-            {{#unless @controller.loading}}
-              <tr>
-                <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
-            {{/unless}}
-          {{/each}}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <tr class="filters">
+              <td>{{i18n "admin.email.logs.filters.title"}}</td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.user}}
+                  @placeholderKey="admin.email.logs.filters.user_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.address}}
+                  @placeholderKey="admin.email.logs.filters.address_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.type}}
+                  @placeholderKey="admin.email.logs.filters.type_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.reply_key}}
+                  @placeholderKey="admin.email.logs.filters.reply_key_placeholder"
+                /></td>
+              <td></td>
+            </tr>
+
+            {{#each @controller.model as |l|}}
+              <tr class="sent-email-item">
+                <td class="sent-email-date">{{formatDate l.created_at}}</td>
+                <td class="sent-email-username">
+                  {{#if l.user}}
+                    <LinkTo @route="adminUser" @model={{l.user}}>{{avatar
+                        l.user
+                        imageSize="tiny"
+                      }}</LinkTo>
+                    <LinkTo
+                      @route="adminUser"
+                      @model={{l.user}}
+                    >{{l.user.username}}</LinkTo>
+                  {{else}}
+                    &mdash;
+                  {{/if}}
+                </td>
+                <td class="sent-email-address">
+                  {{#if l.bounced}}
+                    {{icon "arrow-rotate-right" title="admin.email.bounced"}}
+                  {{/if}}
+                  <a href="mailto:{{l.to_address}}" title="TO">
+                    {{l.to_address}}
+                  </a>
+                  {{#if l.cc_addresses}}
+                    {{#if
+                      (gt
+                        l.cc_addresses.length
+                        @controller.ccAddressDisplayThreshold
+                      )
+                    }}
+                      {{#each
+                        (slice
+                          0
+                          @controller.ccAddressDisplayThreshold
+                          (fn @controller.sortWithAddressFilter l.cc_addresses)
+                        )
+                        as |cc|
+                      }}
+                        <a href="mailto:{{cc}}" title="CC">{{cc}}</a>
+                      {{/each}}
+                      <DTooltip
+                        @placement="right-start"
+                        @arrow={{true}}
+                        @identifier="email-log-cc-addresses"
+                        @interactive={{true}}
+                      >
+                        <:trigger>
+                          {{i18n "admin.email.logs.email_addresses.see_more"}}
+                        </:trigger>
+                        <:content>
+                          <ul>
+                            {{#each
+                              (slice
+                                @controller.ccAddressDisplayThreshold
+                                l.cc_addresses
+                              )
+                              as |cc|
+                            }}
+                              <li>
+                                <span>
+                                  <a href="mailto:{{cc}}" title="CC">{{cc}}</a>
+                                </span>
+                              </li>
+                            {{/each}}
+                          </ul>
+                        </:content>
+                      </DTooltip>
+                    {{else}}
+                      {{#each l.cc_addresses as |cc|}}
+                        <a href="mailto:{{cc}}" title="CC">{{cc}}</a>
+                      {{/each}}
+                    {{/if}}
+                  {{/if}}
+                </td>
+                <td class="sent-email-type">{{l.email_type}}</td>
+                <td class="sent-email-reply-key">
+                  <span
+                    title={{l.reply_key}}
+                    class="reply-key"
+                  >{{l.reply_key}}</span>
+                </td>
+                <td class="sent-email-post-link-with-smtp-response">
+                  {{#if l.post_url}}
+                    <a href={{l.post_url}}>
+                      {{l.post_description}}
+                    </a>
+                    {{i18n "admin.email.logs.post_id" post_id=l.post_id}}
+                    <br />
+                    /{{/if}}
+                  <code
+                    title={{l.smtp_transaction_response}}
+                  >{{l.smtp_transaction_response}}</code>
+                </td>
+              </tr>
+            {{else}}
+              {{#unless @controller.loading}}
+                <tr>
+                  <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
+              {{/unless}}
+            {{/each}}
+          </tbody>
+        </table>
+      </HorizontalScrollSyncWrapper>
     </LoadMore>
 
     <ConditionalLoadingSpinner @condition={{@controller.loading}} />

--- a/app/assets/javascripts/admin/addon/templates/email-logs-skipped.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-skipped.gjs
@@ -1,6 +1,7 @@
 import { LinkTo } from "@ember/routing";
 import RouteTemplate from "ember-route-template";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import LoadMore from "discourse/components/load-more";
 import TextField from "discourse/components/text-field";
 import avatar from "discourse/helpers/avatar";
@@ -10,74 +11,76 @@ import { i18n } from "discourse-i18n";
 export default RouteTemplate(
   <template>
     <LoadMore @action={{@controller.loadMore}}>
-      <table class="table email-list">
-        <thead>
-          <tr>
-            <th>{{i18n "admin.email.time"}}</th>
-            <th>{{i18n "admin.email.user"}}</th>
-            <th>{{i18n "admin.email.to_address"}}</th>
-            <th>{{i18n "admin.email.email_type"}}</th>
-            <th>{{i18n "admin.email.skipped_reason"}}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="filters">
-            <td>{{i18n "admin.email.logs.filters.title"}}</td>
-            <td>
-              <TextField
-                @value={{@controller.filter.user}}
-                @placeholderKey="admin.email.logs.filters.user_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.address}}
-                @placeholderKey="admin.email.logs.filters.address_placeholder"
-              /></td>
-            <td>
-              <TextField
-                @value={{@controller.filter.type}}
-                @placeholderKey="admin.email.logs.filters.type_placeholder"
-              /></td>
-            <td></td>
-          </tr>
-
-          {{#each @controller.model as |l|}}
+      <HorizontalScrollSyncWrapper>
+        <table class="table email-list">
+          <thead>
             <tr>
-              <td>{{formatDate l.created_at}}</td>
-              <td>
-                {{#if l.user}}
-                  <LinkTo @route="adminUser" @model={{l.user}}>{{avatar
-                      l.user
-                      imageSize="tiny"
-                    }}</LinkTo>
-                  <LinkTo
-                    @route="adminUser"
-                    @model={{l.user}}
-                  >{{l.user.username}}</LinkTo>
-                {{else}}
-                  &mdash;
-                {{/if}}
-              </td>
-              <td class="email-address"><a
-                  href="mailto:{{l.to_address}}"
-                >{{l.to_address}}</a></td>
-              <td>{{l.email_type}}</td>
-              <td>
-                {{#if l.post_url}}
-                  <a href={{l.post_url}}>{{l.skipped_reason}}</a>
-                {{else}}
-                  {{l.skipped_reason}}
-                {{/if}}
-              </td>
+              <th>{{i18n "admin.email.time"}}</th>
+              <th>{{i18n "admin.email.user"}}</th>
+              <th>{{i18n "admin.email.to_address"}}</th>
+              <th>{{i18n "admin.email.email_type"}}</th>
+              <th>{{i18n "admin.email.skipped_reason"}}</th>
             </tr>
-          {{else}}
-            {{#unless @controller.loading}}
+          </thead>
+          <tbody>
+            <tr class="filters">
+              <td>{{i18n "admin.email.logs.filters.title"}}</td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.user}}
+                  @placeholderKey="admin.email.logs.filters.user_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.address}}
+                  @placeholderKey="admin.email.logs.filters.address_placeholder"
+                /></td>
+              <td>
+                <TextField
+                  @value={{@controller.filter.type}}
+                  @placeholderKey="admin.email.logs.filters.type_placeholder"
+                /></td>
+              <td></td>
+            </tr>
+
+            {{#each @controller.model as |l|}}
               <tr>
-                <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
-            {{/unless}}
-          {{/each}}
-        </tbody>
-      </table>
+                <td>{{formatDate l.created_at}}</td>
+                <td>
+                  {{#if l.user}}
+                    <span class="email-logs-user">
+                      <LinkTo @route="adminUser" @model={{l.user}}>
+                        {{avatar l.user imageSize="tiny"}}
+                      </LinkTo>
+                      <LinkTo @route="adminUser" @model={{l.user}}>
+                        {{l.user.username}}
+                      </LinkTo>
+                    </span>
+                  {{else}}
+                    &mdash;
+                  {{/if}}
+                </td>
+                <td class="email-address"><a
+                    href="mailto:{{l.to_address}}"
+                  >{{l.to_address}}</a></td>
+                <td>{{l.email_type}}</td>
+                <td>
+                  {{#if l.post_url}}
+                    <a href={{l.post_url}}>{{l.skipped_reason}}</a>
+                  {{else}}
+                    {{l.skipped_reason}}
+                  {{/if}}
+                </td>
+              </tr>
+            {{else}}
+              {{#unless @controller.loading}}
+                <tr>
+                  <td colspan="5">{{i18n "admin.email.logs.none"}}</td></tr>
+              {{/unless}}
+            {{/each}}
+          </tbody>
+        </table>
+      </HorizontalScrollSyncWrapper>
     </LoadMore>
 
     <ConditionalLoadingSpinner @condition={{@controller.loading}} />

--- a/app/assets/javascripts/discourse/app/components/horizontal-scroll-sync-wrapper.gjs
+++ b/app/assets/javascripts/discourse/app/components/horizontal-scroll-sync-wrapper.gjs
@@ -1,0 +1,137 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { modifier } from "ember-modifier";
+import { bind } from "discourse/lib/decorators";
+import onResize from "discourse/modifiers/on-resize";
+
+export default class HorizontalScrollSyncWrapper extends Component {
+  scrollableElement;
+  topHorizontalScrollBar;
+  fakeScrollContent;
+  intersectionObserver;
+  lastScrollLeft = 0;
+
+  setup = modifier((containerElement) => {
+    // Always use the content wrapper as the scrollable element
+    this.scrollableElement = containerElement.querySelector(
+      ".horizontal-scroll-sync__content"
+    );
+
+    this.topHorizontalScrollBar = containerElement.querySelector(
+      ".horizontal-scroll-sync__top-scroll"
+    );
+    this.fakeScrollContent = containerElement.querySelector(
+      ".horizontal-scroll-sync__fake-content"
+    );
+
+    if (this.scrollableElement) {
+      this.scrollableElement.addEventListener(
+        "scroll",
+        this.handleScrollableElementScroll,
+        { passive: true }
+      );
+    }
+
+    this.setupObserver();
+    this.syncScrollWidth();
+
+    return () => {
+      if (this.scrollableElement) {
+        this.scrollableElement.removeEventListener(
+          "scroll",
+          this.handleScrollableElementScroll
+        );
+      }
+      this.cleanup();
+    };
+  });
+
+  @bind
+  syncScrollPosition(source, target) {
+    const newScrollLeft = source.scrollLeft;
+
+    // need to check if content position has actually changed
+    // to avoid getting stuck in a loop on position sync
+    if (Math.abs(newScrollLeft - this.lastScrollLeft) > 1) {
+      this.lastScrollLeft = newScrollLeft;
+      requestAnimationFrame(() => {
+        target.scrollLeft = newScrollLeft;
+      });
+    }
+  }
+
+  @bind
+  handleScrollableElementScroll() {
+    this.syncScrollPosition(
+      this.scrollableElement,
+      this.topHorizontalScrollBar
+    );
+  }
+
+  @bind
+  handleTopScrollBarScroll() {
+    this.syncScrollPosition(
+      this.topHorizontalScrollBar,
+      this.scrollableElement
+    );
+  }
+
+  @bind
+  setupObserver() {
+    if (!this.scrollableElement || !this.fakeScrollContent) {
+      return;
+    }
+
+    this.intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.boundingClientRect.bottom < entry.rootBounds.height) {
+          // bottom is visible, hide the top scrollbar
+          this.fakeScrollContent.style.height = "0";
+        } else {
+          this.syncScrollWidth();
+        }
+      },
+      {
+        root: null, // viewport
+        threshold: 0,
+      }
+    );
+
+    this.intersectionObserver.observe(this.scrollableElement);
+  }
+
+  @bind
+  syncScrollWidth() {
+    if (this.scrollableElement && this.fakeScrollContent) {
+      this.fakeScrollContent.style.width = `${this.scrollableElement.scrollWidth}px`;
+      this.fakeScrollContent.style.height = "12px"; // needs height to show the scrollbar
+    }
+  }
+
+  @bind
+  cleanup() {
+    if (this.intersectionObserver) {
+      this.intersectionObserver.disconnect();
+      this.intersectionObserver = null;
+    }
+  }
+
+  <template>
+    <div {{this.setup}} class="horizontal-scroll-sync__container" ...attributes>
+      <div
+        {{on "scroll" this.handleTopScrollBarScroll passive=true}}
+        class="horizontal-scroll-sync__top-scroll"
+      >
+        <div class="horizontal-scroll-sync__fake-content"></div>
+      </div>
+
+      <div
+        {{onResize this.syncScrollWidth}}
+        class="horizontal-scroll-sync__content"
+      >
+        {{yield}}
+      </div>
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/responsive-table.gjs
+++ b/app/assets/javascripts/discourse/app/components/responsive-table.gjs
@@ -1,88 +1,23 @@
-import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
-import { on } from "@ember/modifier";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
-import { modifier } from "ember-modifier";
+import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import concatClass from "discourse/helpers/concat-class";
-import { bind } from "discourse/lib/decorators";
-import onResize from "discourse/modifiers/on-resize";
 
-export default class ResponsiveTable extends Component {
-  lastScrollPosition = 0;
-  ticking = false;
-  table;
-  topHorizontalScrollBar;
-  fakeScrollContent;
-
-  setup = modifier((element) => {
-    this.table = element.querySelector(".directory-table");
-    this.topHorizontalScrollBar = element.querySelector(
-      ".directory-table-top-scroll"
-    );
-    this.fakeScrollContent = element.querySelector(
-      ".directory-table-top-scroll-fake-content"
-    );
-
-    this.checkScroll();
-  });
-
-  @bind
-  checkScroll() {
-    if (this.table.getBoundingClientRect().bottom < window.innerHeight) {
-      // Bottom of the table is visible. Hide the scrollbar
-      this.fakeScrollContent.style.height = 0;
-    } else {
-      this.fakeScrollContent.style.width = `${this.table.scrollWidth}px`;
-      this.fakeScrollContent.style.height = "1px";
-    }
-  }
-
-  @bind
-  replicateScroll(from, to) {
-    this.lastScrollPosition = from?.scrollLeft;
-
-    if (!this.ticking) {
-      window.requestAnimationFrame(() => {
-        to.scrollLeft = this.lastScrollPosition;
-        this.ticking = false;
-      });
-
-      this.ticking = true;
-    }
-  }
-
-  <template>
-    <div {{this.setup}} class="directory-table-container" ...attributes>
-      <div
-        {{on
-          "scroll"
-          (fn this.replicateScroll this.topHorizontalScrollBar this.table)
-        }}
-        class="directory-table-top-scroll"
-      >
-        <div class="directory-table-top-scroll-fake-content"></div>
+const ResponsiveTable = <template>
+  <HorizontalScrollSyncWrapper class="directory-table-container" ...attributes>
+    <div
+      role="table"
+      aria-label={{@ariaLabel}}
+      style={{@style}}
+      class={{concatClass "directory-table" @className}}
+    >
+      <div class="directory-table__header">
+        {{yield to="header"}}
       </div>
 
-      <div
-        {{didUpdate this.checkScroll}}
-        {{onResize this.checkScroll}}
-        {{on
-          "scroll"
-          (fn this.replicateScroll this.table this.topHorizontalScrollBar)
-        }}
-        role="table"
-        aria-label={{@ariaLabel}}
-        style={{@style}}
-        class={{concatClass "directory-table" @className}}
-      >
-        <div class="directory-table__header">
-          {{yield to="header"}}
-        </div>
-
-        <div class="directory-table__body">
-          {{yield to="body"}}
-        </div>
+      <div class="directory-table__body">
+        {{yield to="body"}}
       </div>
     </div>
-  </template>
-}
+  </HorizontalScrollSyncWrapper>
+</template>;
+
+export default ResponsiveTable;

--- a/app/assets/stylesheets/admin/emails.scss
+++ b/app/assets/stylesheets/admin/emails.scss
@@ -1,7 +1,23 @@
 // Styles for admin/emails
 
 // Emails
+.admin-email-logs {
+  .admin-container {
+    margin-top: 0;
+  }
+}
+
 .email-list {
+  th {
+    white-space: nowrap;
+    min-width: 6rem;
+  }
+
+  .email-logs-user {
+    display: flex;
+    gap: var(--space-2);
+  }
+
   .filters input {
     width: 100%;
   }
@@ -18,28 +34,22 @@
 
   .username div {
     max-width: 180px;
-
-    @include ellipsis;
   }
 
   .addresses p {
     margin: 2px 0;
     max-width: 200px;
-
-    @include ellipsis;
   }
 
-  .sent-email-address a {
-    // prevent long email addresses from breaking the layout
+  a {
+    // prevent long links from breaking the layout
     display: inline-block;
     max-width: 300px;
     overflow-wrap: break-word;
   }
 
-  .email-address {
-    max-width: 250px;
-
-    @include ellipsis;
+  code {
+    white-space: pre-wrap;
   }
 
   .email-details {

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -1,8 +1,23 @@
 @use "lib/viewport";
 
-.directory-table-top-scroll {
-  width: 100%;
-  overflow-x: auto;
+.horizontal-scroll-sync {
+  &__container {
+    overflow-x: auto;
+    width: 100%;
+  }
+
+  &__top-scroll {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  &__fake-content {
+    pointer-events: auto;
+  }
+
+  &__content {
+    overflow-x: auto;
+  }
 }
 
 .directory {
@@ -140,7 +155,6 @@
   gap: 0;
   width: 100%;
   margin-top: var(--space-1);
-  overflow-x: auto;
 
   .me {
     .directory-table__cell {


### PR DESCRIPTION
This improves the admin email log overflow by: 

* allowing tables to horizontally scroll if needed
* ensuring `code` has pre-wrap to avoid very long lines
* making all links have overflow-wrap to avoid very long email address and link issues 

I've also removed some truncation CSS, because this is data we ideally need to see all of, even if it has to wrap. 

The horizontal scrolling is implemented by horizontal-scroll-sync-wrapper.gjs, this is a new component I pulled out of the existing responsive-table.gjs and updated. The component adds a top scrollbar to horiztonally overflowing areas and syncs it up with the bottom scrollbar to make scrolling a little easier. 

These templates are quite old and can use some more general improvements, but this gets them to a place where they aren't breaking the layout. 


Before (whole page scrolls, note the header and missing nav):
<img width="2302" height="1626" alt="image" src="https://github.com/user-attachments/assets/551973cb-e4cc-4881-a0d9-33bb1237403b" />


After (only table scrolls): 
<img width="2350" height="1354" alt="image" src="https://github.com/user-attachments/assets/739b1f37-ae39-424e-8603-715bbc872e31" />