### PR TITLE
A11Y: composer toolbar dropdown title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
@@ -43,6 +43,7 @@ export default class ComposerToolbarButtons extends Component {
             <div class="toolbar-separator"></div>
           {{else if button.popupMenu}}
             <ToolbarPopupMenuOptions
+              @title={{button.title}}
               @context={{@data.context}}
               @content={{(button.popupMenu.options)}}
               @onChange={{button.popupMenu.action}}

--- a/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
@@ -138,6 +138,7 @@ export default class ToolbarPopupmenuOptions extends Component {
       tabindex="-1"
       @triggerClass={{concatClass "toolbar__button" @class}}
       @class="toolbar-popup-menu-options"
+      title={{@title}}
     >
       <:trigger>
         {{icon (this.getIcon this.args)}}

--- a/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
@@ -193,7 +193,6 @@ export default class Toolbar extends ToolbarBase {
       active: ({ state }) => state.inItalic,
     });
 
-
     this.addButton({
       id: "heading",
       group: "fontStyles",

--- a/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
+++ b/app/assets/javascripts/discourse/app/lib/composer/toolbar.js
@@ -193,8 +193,7 @@ export default class Toolbar extends ToolbarBase {
       active: ({ state }) => state.inItalic,
     });
 
-    const headingLabel = getButtonLabel("composer.heading_label", "H");
-    const unformattedHeadingIcon = headingLabel ? null : "discourse-text";
+
     this.addButton({
       id: "heading",
       group: "fontStyles",
@@ -211,16 +210,16 @@ export default class Toolbar extends ToolbarBase {
       },
       icon: ({ state }) => {
         if (!state || !state.inHeading) {
-          return unformattedHeadingIcon;
+          return "discourse-text";
         }
 
         if (state.inHeadingLevel > 4) {
-          return unformattedHeadingIcon;
+          return "discourse-text";
         }
 
         return `discourse-h${state.inHeadingLevel}`;
       },
-      label: headingLabel,
+      title: "composer.heading_title",
       popupMenu: {
         options: () => {
           const headingOptions = [];

--- a/config/locales/client.cs.yml
+++ b/config/locales/client.cs.yml
@@ -2956,7 +2956,6 @@ cs:
       italic_label: "I"
       italic_title: "Kurzíva"
       italic_text: "text kurzívou"
-      heading_label: "H"
       heading_title: "Nadpisy"
       heading_level_n: "Nadpis %{levelNumber}"
       heading_level_n_title: "Nadpis %{levelNumber}"

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -2667,7 +2667,6 @@ de:
       italic_label: "K"
       italic_title: "Betonung"
       italic_text: "betonter Text"
-      heading_label: "H"
       heading_title: "Überschriften"
       heading_level_n: "Überschrift %{levelNumber}"
       heading_level_n_title: "Überschrift %{levelNumber}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2978,7 +2978,6 @@ en:
       italic_label: "I"
       italic_title: "Emphasis"
       italic_text: "emphasized text"
-      heading_label: "H"
       heading_title: "Headings"
       heading_level_n: "Heading %{levelNumber}"
       heading_level_n_title: "Heading %{levelNumber}"

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -2948,7 +2948,6 @@ he:
       italic_label: "I"
       italic_title: "נטוי"
       italic_text: "טקסט נטוי"
-      heading_label: "כ"
       heading_title: "כותרות"
       heading_level_n: "כותרת %{levelNumber}"
       heading_level_n_title: "כותרת %{levelNumber}"

--- a/config/locales/client.pl_PL.yml
+++ b/config/locales/client.pl_PL.yml
@@ -2948,7 +2948,6 @@ pl_PL:
       italic_label: "I"
       italic_title: "Wyróżnienie"
       italic_text: "wyróżniony tekst"
-      heading_label: "N"
       heading_title: "Nagłówki"
       heading_level_n: "Nagłówek %{levelNumber}"
       heading_level_n_title: "Nagłówek %{levelNumber}"

--- a/config/locales/client.ro.yml
+++ b/config/locales/client.ro.yml
@@ -2116,7 +2116,6 @@ ro:
       italic_label: "I"
       italic_title: "Italic"
       italic_text: "text italic"
-      heading_label: "T"
       heading_title: "Titluri"
       heading_level_n: "Titlu %{levelNumber}"
       heading_level_n_title: "Titlu %{levelNumber}"

--- a/config/locales/client.sk.yml
+++ b/config/locales/client.sk.yml
@@ -2961,7 +2961,6 @@ sk:
       italic_label: "I"
       italic_title: "Zdôraznene"
       italic_text: "zdôraznený text"
-      heading_label: "H"
       heading_title: "Nadpisy"
       heading_level_n: "Nadpis %{levelNumber}"
       heading_level_n_title: "Nadpis %{levelNumber}"

--- a/config/locales/client.uk.yml
+++ b/config/locales/client.uk.yml
@@ -2950,7 +2950,6 @@ uk:
       italic_label: "К"
       italic_title: "Курсив"
       italic_text: "виділення тексту курсивом"
-      heading_label: "Н"
       heading_title: "Заголовки"
       heading_level_n: "Заголовок %{levelNumber}"
       heading_level_n_title: "Заголовок %{levelNumber}"

--- a/config/locales/client.ur.yml
+++ b/config/locales/client.ur.yml
@@ -2668,7 +2668,6 @@ ur:
       italic_label: "I"
       italic_title: "آئیٹیلک"
       italic_text: "زور دیا گیا ٹَیکسٹ"
-      heading_label: "H"
       heading_title: "سرخیاں"
       heading_level_n: "سرخی %{levelNumber}"
       heading_level_n_title: "سرخی %{levelNumber}"

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -2501,7 +2501,6 @@ zh_CN:
       italic_label: "I"
       italic_title: "强调"
       italic_text: "强调文本"
-      heading_label: "H"
       heading_title: "标题"
       heading_level_n: "标题 %{levelNumber}"
       heading_level_n_title: "标题 %{levelNumber}"


### PR DESCRIPTION
Adds a `title` attribute to the composer toolbar items that are used to trigger a dropdown menu.