### PR TITLE
DEV: Fix a flaky AI bot upload test

### DIFF
--- a/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
@@ -153,6 +153,8 @@ RSpec.describe "AI Bot - Homepage", type: :system do
 
           ai_pm_homepage.input.fill_in(with: "Here are two image attachments")
 
+          expect(page).to have_no_css(".ai-bot-upload--in-progress")
+
           responses = ["hello user", "topic title"]
           DiscourseAi::Completions::Llm.with_prepared_responses(responses) do
             ai_pm_homepage.submit


### PR DESCRIPTION
## ✨ What's This?

This test is ensuring that uploads work correctly when starting a new conversation with a bot.

There's a race condition where the test can try to send a message before the uploads have finished process, this fix waits until the uploads have completed before continuing.