### PR TITLE
FIX: CSV bulk invites broken when S3 uploads enabled

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/csv-uploader.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/csv-uploader.gjs
@@ -15,6 +15,7 @@ export default class CsvUploader extends Component {
     id: "discourse-post-event-csv-uploader",
     autoStartUploads: false,
     uploadUrl: this.args.uploadUrl,
+    preventDirectS3Uploads: true,
     uppyReady: () => {
       this.uppyUpload.uppyWrapper.uppyInstance.on("file-added", () => {
         this.dialog.confirm({


### PR DESCRIPTION
CSV bulk invites need to be uploaded direct to the controller, otherwise
uploadUrl is not respected and upload never heads to the correct place

