### PR TITLE
DEV: Fix a flaky deprecated settings test

### DIFF
--- a/spec/lib/site_settings/deprecated_settings_spec.rb
+++ b/spec/lib/site_settings/deprecated_settings_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe SiteSettings::DeprecatedSettings do
           expect(SiteSetting.new_one?).to eq(false)
         end
       end
-
-      after { SiteSetting.remove_instance_variable(:@shadowed_settings) }
     end
 
     describe "when overriding deprecated settings" do
@@ -88,8 +86,12 @@ RSpec.describe SiteSettings::DeprecatedSettings do
           expect(SiteSetting.new_one?).to eq(true)
         end
       end
+    end
 
-      after { SiteSetting.remove_instance_variable(:@shadowed_settings) }
+    after do
+      global_setting(:old_one, false)
+      SiteSetting.refresh!
+      SiteSetting.remove_instance_variable(:@shadowed_settings)
     end
   end
 end


### PR DESCRIPTION
## ✨ What's This?

See: t/158747

Some of the deprecated settings tests set our site settings to be global settings. When the settings are reloaded between tests (see `stub_deprecated_settings!()`), the setting loader (`SiteSettingExtension.setting()`) will check to see if there's a global setting that would override the site setting, and use that value from previous tests.

To fix this, we need to un-global the site setting after the test finishes.

## 👑 Testing

`bin/rspec --order random:37535 spec/lib/site_settings/deprecated_settings_spec.rb`