### PR TITLE
DEV: Fix a flaky system test for customising themes

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -16,16 +16,16 @@ describe "Admin Customize Themes", type: :system do
 
       color_scheme_settings = find(".theme-settings__color-scheme")
 
-      expect(color_scheme_settings).not_to have_css(".submit-edit")
-      expect(color_scheme_settings).not_to have_css(".cancel-edit")
+      expect(color_scheme_settings).to have_no_css(".submit-edit")
+      expect(color_scheme_settings).to have_no_css(".cancel-edit")
 
       color_scheme_settings.find(".color-palettes").click
       color_scheme_settings.find(".color-palettes-row[data-value='#{color_scheme.id}']").click
       color_scheme_settings.find(".submit-edit").click
 
       expect(color_scheme_settings.find(".setting-value")).to have_content(color_scheme.name)
-      expect(color_scheme_settings).not_to have_css(".submit-edit")
-      expect(color_scheme_settings).not_to have_css(".cancel-edit")
+      expect(color_scheme_settings).to have_no_css(".submit-edit")
+      expect(color_scheme_settings).to have_no_css(".cancel-edit")
     end
   end
 
@@ -66,10 +66,10 @@ describe "Admin Customize Themes", type: :system do
   it "cannot edit js, upload files or delete system themes" do
     theme.update_columns(id: -10)
     visit("/admin/customize/themes/#{theme.id}")
-    expect(page).not_to have_css(".title button")
-    expect(page).not_to have_css(".edit-code")
-    expect(page).not_to have_css("button.upload")
-    expect(page).not_to have_css(".delete")
+    expect(page).to have_no_css(".title button")
+    expect(page).to have_no_css(".edit-code")
+    expect(page).to have_no_css("button.upload")
+    expect(page).to have_no_css(".delete")
   end
 
   it "hides unecessary sections and buttons for system themes" do
@@ -94,10 +94,10 @@ describe "Admin Customize Themes", type: :system do
 
     theme.stubs(:system?).returns(true)
     visit("/admin/customize/themes/#{theme.id}")
-    expect(page).not_to have_css(".created-by")
-    expect(page).not_to have_css(".export")
-    expect(page).not_to have_css(".extra-files")
-    expect(page).not_to have_css(".theme-settings")
+    expect(page).to have_no_css(".created-by")
+    expect(page).to have_no_css(".export")
+    expect(page).to have_no_css(".extra-files")
+    expect(page).to have_no_css(".theme-settings")
   end
 
   describe "when editing theme translations" do


### PR DESCRIPTION
## ✨ What's This?

See t/157993, introduced in #33406.

These tests have a race condition when updating their models, they're using a `expect(page).to_not have_css(...)` check that may look at the DOM before the model update has been reflected in the DOM.

Switching to using `expect(page).to have_no_css(...)` lets Capybara wait until the DOM has finished updating.