### PR TITLE
DEV: Fix a flaky AI composer helper test

### DIFF
--- a/plugins/discourse-ai/spec/system/ai_helper/ai_composer_helper_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_helper/ai_composer_helper_spec.rb
@@ -326,9 +326,8 @@ RSpec.describe "AI Composer helper", type: :system do
 
       suggestion = ai_suggestion_dropdown.suggestion_name(0)
       ai_suggestion_dropdown.select_suggestion_by_value(0)
-      tag_selector = page.find(".mini-tag-chooser summary")
 
-      expect(tag_selector["data-name"]).to eq(suggestion)
+      expect(page).to have_css(".mini-tag-chooser summary[data-name='#{suggestion}']")
     end
 
     it "does not suggest tags that already exist" do


### PR DESCRIPTION
## ✨ What's This?

There was a race condition in this test, where the mini tag chooser may not have had time to update after a tag was selected.

## 👑 Testing

`bin/rspec --order random:49018 plugins/discourse-ai/spec/system/ai_helper/ai_composer_helper_spec.rb`