### PR TITLE
FEATURE: Add new edit_tags_allowed_groups setting

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -310,7 +310,7 @@ export default class DNavigation extends Component {
       {{#if this.tag}}
         {{#if this.showToggleInfo}}
           <DButton
-            @icon={{if this.currentUser.staff "wrench" "circle-info"}}
+            @icon={{if this.currentUser.canEditTags "wrench" "circle-info"}}
             @ariaLabel="tagging.info"
             @action={{this.toggleInfo}}
             id="show-tag-info"

--- a/app/assets/javascripts/discourse/app/components/tag-info.gjs
+++ b/app/assets/javascripts/discourse/app/components/tag-info.gjs
@@ -36,8 +36,9 @@ export default class TagInfo extends Component {
   newTagName = null;
   newTagDescription = null;
 
+  @reads("currentUser.canEditTags") canEditTags;
   @reads("currentUser.staff") canAdminTag;
-  @and("canAdminTag", "showEditControls") editSynonymsMode;
+  @and("canEditTags", "showEditControls") editSynonymsMode;
 
   @discourseComputed("tagInfo.tag_group_names")
   tagGroupsInfo(tagGroupNames) {
@@ -281,7 +282,7 @@ export default class TagInfo extends Component {
           {{else}}
             <div class="tag-name-wrapper">
               {{discourseTag this.tagInfo.name tagName="div"}}
-              {{#if this.canAdminTag}}
+              {{#if this.canEditTags}}
                 <a
                   href
                   {{on "click" this.edit}}
@@ -339,13 +340,15 @@ export default class TagInfo extends Component {
                     >
                       {{icon "link-slash" title="tagging.remove_synonym"}}
                     </a>
-                    <a
-                      href
-                      {{on "click" (fn this.deleteSynonym tag)}}
-                      class="delete-synonym"
-                    >
-                      {{icon "trash-can" title="tagging.delete_tag"}}
-                    </a>
+                    {{#if this.canAdminTag}}
+                      <a
+                        href
+                        {{on "click" (fn this.deleteSynonym tag)}}
+                        class="delete-synonym"
+                      >
+                        {{icon "trash-can" title="tagging.delete_tag"}}
+                      </a>
+                    {{/if}}
                   {{/if}}
                 </div>
               {{/each}}
@@ -379,7 +382,7 @@ export default class TagInfo extends Component {
             </div>
           </section>
         {{/if}}
-        {{#if this.canAdminTag}}
+        {{#if this.canEditTags}}
           <PluginOutlet
             @name="tag-custom-settings"
             @outletArgs={{lazyHash tag=this.tagInfo}}

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -252,6 +252,7 @@ export default class User extends RestModel.extend(Evented) {
   @mapBy("sidebarTags", "name") sidebarTagNames;
   @filterBy("groups", "has_messages", true) groupsWithMessages;
   @alias("can_pick_theme_with_custom_homepage") canPickThemeWithCustomHomepage;
+  @alias("can_edit_tags") canEditTags;
 
   numGroupsToDisplay = 2;
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -443,7 +443,7 @@ acceptance("Tag info", function (needs) {
   });
 
   test("tag info hides only current tag in synonyms dropdown", async function (assert) {
-    updateCurrentUser({ moderator: false, admin: true });
+    updateCurrentUser({ moderator: false, admin: true, can_edit_tags: true });
 
     await visit("/tag/happy-monkey");
     assert.dom("#show-tag-info").exists();
@@ -465,7 +465,7 @@ acceptance("Tag info", function (needs) {
   });
 
   test("edit tag is showing input for name and description", async function (assert) {
-    updateCurrentUser({ moderator: false, admin: true });
+    updateCurrentUser({ moderator: false, admin: true, can_edit_tags: true });
 
     await visit("/tag/happy-monkey");
     assert.dom("#show-tag-info").exists();
@@ -577,7 +577,7 @@ acceptance("Tag info", function (needs) {
   });
 
   test("admin can manage tags", async function (assert) {
-    updateCurrentUser({ moderator: false, admin: true });
+    updateCurrentUser({ moderator: false, admin: true, can_edit_tags: true });
 
     await visit("/tag/planters");
     assert.dom("#show-tag-info").exists();

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -200,10 +200,10 @@ class TagsController < ::ApplicationController
   end
 
   def update
-    guardian.ensure_can_admin_tags!
-
     tag = Tag.find_by_name(params[:tag_id])
     raise Discourse::NotFound if tag.nil?
+
+    guardian.ensure_can_edit_tag!(tag)
 
     if (params[:tag][:id].present?)
       new_tag_name = DiscourseTagging.clean_tag(params[:tag][:id])
@@ -402,7 +402,7 @@ class TagsController < ::ApplicationController
   end
 
   def create_synonyms
-    guardian.ensure_can_admin_tags!
+    guardian.ensure_can_edit_tag!
     value = DiscourseTagging.add_or_create_synonyms_by_name(@tag, params[:synonyms])
     if value.is_a?(Array)
       render json:

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -419,9 +419,11 @@ class TagsController < ::ApplicationController
   end
 
   def destroy_synonym
-    guardian.ensure_can_admin_tags!
     synonym = Tag.where_name(params[:synonym_id]).first
     raise Discourse::NotFound unless synonym
+
+    guardian.ensure_can_edit_tag!(synonym)
+
     if synonym.target_tag == @tag
       synonym.update!(target_tag: nil)
       render json: success_json

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -28,6 +28,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_delete_account,
              :can_post_anonymously,
              :can_ignore_users,
+             :can_edit_tags,
              :can_delete_all_posts_and_topics,
              :custom_fields,
              :muted_category_ids,
@@ -164,6 +165,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def can_edit
     true
+  end
+
+  def can_edit_tags
+    scope.can_edit_tag?
   end
 
   def can_invite_to_forum

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2651,6 +2651,7 @@ en:
     tagging_enabled: "Enable tags on topics? See the <a href='https://meta.discourse.org/t/admin-guide-to-tags-in-discourse/121041'>Admin guide to tags on Meta</a> for more information."
     min_trust_to_create_tag: "The minimum trust level required to create a tag."
     create_tag_allowed_groups: "Groups that are allowed to create tags. Admins and moderators can always create tags."
+    edit_tags_allowed_groups: "Groups that are allowed to edit tags, tag descriptions, and tag synonyms."
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
     enable_max_tags_per_email_subject: "Use max_tags_per_email_subject when generating the subject of an email"
     max_tags_per_email_subject: "The maximum tags that can be in the subject of an email"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3937,6 +3937,13 @@ tags:
     allow_any: false
     refresh: true
     area: "group_permissions"
+  edit_tags_allowed_groups:
+    default: "1|2" # auto group admins, moderators
+    mandatory_values: "1|2" # auto group admins, moderators
+    type: group_list
+    allow_any: false
+    refresh: true
+    area: "group_permissions"
   min_trust_level_to_tag_topics:
     default: "0"
     enum: "TrustLevelAndStaffSetting"

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -10,6 +10,10 @@ module TagGuardian
     SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map)
   end
 
+  def can_edit_tag?(_tag)
+    SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.edit_tags_allowed_groups_map)
+  end
+
   def can_tag_topics?
     SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.tag_topic_allowed_groups_map)
   end

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -10,7 +10,7 @@ module TagGuardian
     SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.create_tag_allowed_groups_map)
   end
 
-  def can_edit_tag?(_tag)
+  def can_edit_tag?(_tag = nil)
     SiteSetting.tagging_enabled && @user.in_any_groups?(SiteSetting.edit_tags_allowed_groups_map)
   end
 

--- a/spec/lib/guardian/tag_guardian_spec.rb
+++ b/spec/lib/guardian/tag_guardian_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe TagGuardian do
   fab!(:user)
   fab!(:admin)
+  fab!(:tag)
   fab!(:trust_level_0)
   fab!(:trust_level_1)
   fab!(:trust_level_2)
@@ -31,6 +32,24 @@ RSpec.describe TagGuardian do
 
     it "returns true when user is in an allowed group" do
       expect(Guardian.new(trust_level_3).can_create_tag?).to be_truthy
+    end
+  end
+
+  ###### EDITING ######
+
+  describe "#can_edit_tag?" do
+    it "returns false when tagging is disabled" do
+      SiteSetting.tagging_enabled = false
+
+      expect(Guardian.new(admin).can_edit_tag?(tag)).to be_falsey
+    end
+
+    it "returns false when user is not in an allowed group" do
+      expect(Guardian.new(trust_level_2).can_edit_tag?(tag)).to be_falsey
+    end
+
+    it "returns true when user is in an allowed group" do
+      expect(Guardian.new(trust_level_3).can_edit_tag?(tag)).to be_truthy
     end
   end
 

--- a/spec/lib/guardian/tag_guardian_spec.rb
+++ b/spec/lib/guardian/tag_guardian_spec.rb
@@ -45,10 +45,12 @@ RSpec.describe TagGuardian do
     end
 
     it "returns false when user is not in an allowed group" do
+      SiteSetting.edit_tags_allowed_groups = "1|2|13"
       expect(Guardian.new(trust_level_2).can_edit_tag?(tag)).to be_falsey
     end
 
     it "returns true when user is in an allowed group" do
+      SiteSetting.edit_tags_allowed_groups = "1|2|13"
       expect(Guardian.new(trust_level_3).can_edit_tag?(tag)).to be_truthy
     end
   end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1348,6 +1348,7 @@ RSpec.describe TagsController do
     end
 
     it "succeeds when user in allowed group" do
+      SiteSetting.edit_tags_allowed_groups = "1|2|13"
       sign_in(regular_user)
       post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ["synonym1"] }
       expect(response.status).to eq(200)

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1341,10 +1341,16 @@ RSpec.describe TagsController do
       expect(response.status).to eq(403)
     end
 
-    it "fails if not staff user" do
+    it "fails if user not in allowed group" do
       sign_in(user)
       post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ["synonym1"] }
       expect(response.status).to eq(403)
+    end
+
+    it "succeeds when user in allowed group" do
+      sign_in(regular_user)
+      post "/tag/#{tag.name}/synonyms.json", params: { synonyms: ["synonym1"] }
+      expect(response.status).to eq(200)
     end
 
     context "when signed in as admin" do

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -44,6 +44,14 @@ module PageObjects
         find(".edit-controls .cancel-edit").click
       end
 
+      def delete_tag
+        find(".delete-tag").click
+      end
+
+      def has_no_tag?(name)
+        has_no_css?(".tag-box", text: name)
+      end
+
       def add_synonyms_dropdown
         PageObjects::Components::SelectKit.new("#add-synonyms")
       end

--- a/spec/system/tag_edit_spec.rb
+++ b/spec/system/tag_edit_spec.rb
@@ -2,32 +2,83 @@
 
 describe "Tag Edit", type: :system do
   let(:tags_page) { PageObjects::Pages::Tag.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
   fab!(:tag_1) { Fabricate(:tag, name: "design") }
-  fab!(:current_user, :admin)
+  fab!(:user)
+  fab!(:admin)
+  fab!(:trust_level_4)
 
-  before { sign_in(current_user) }
+  before { SiteSetting.edit_tags_allowed_groups = "1|2|14" }
 
-  it "allows the admin to edit a tag name and description" do
-    tags_page.visit_tag(tag_1)
-    tags_page.tag_info_btn.click
-    tags_page.open_edit_tag
-    tags_page.fill_tag_name("ux")
-    tags_page.fill_tag_description("new description")
-    tags_page.save_edit
-    expect(tags_page.tag_info).to have_content("ux")
-    expect(tags_page.tag_info).to have_content("new description")
+  context "when signed in as admin" do
+    before { sign_in(admin) }
+
+    it "allows the admin to edit a tag name and description" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      tags_page.open_edit_tag
+      tags_page.fill_tag_name("ux")
+      tags_page.fill_tag_description("new description")
+      tags_page.save_edit
+      expect(tags_page.tag_info).to have_content("ux")
+      expect(tags_page.tag_info).to have_content("new description")
+    end
+
+    it "allows the admin to delete the tag" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      tags_page.delete_tag
+
+      expect(dialog).to be_open
+
+      dialog.click_danger
+
+      expect(tags_page).to have_no_tag("design")
+    end
+
+    it "does not error when editing a tag name to something then reverting back to the original name" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      tags_page.open_edit_tag
+      tags_page.fill_tag_name("ux")
+      tags_page.save_edit
+      expect(tags_page.tag_info).to have_content("ux")
+      tags_page.open_edit_tag
+      tags_page.fill_tag_name("design")
+      tags_page.save_edit
+      expect(tags_page.tag_info).to have_content("design")
+    end
   end
 
-  it "does not error when editing a tag name to something then reverting back to the original name" do
-    tags_page.visit_tag(tag_1)
-    tags_page.tag_info_btn.click
-    tags_page.open_edit_tag
-    tags_page.fill_tag_name("ux")
-    tags_page.save_edit
-    expect(tags_page.tag_info).to have_content("ux")
-    tags_page.open_edit_tag
-    tags_page.fill_tag_name("design")
-    tags_page.save_edit
-    expect(tags_page.tag_info).to have_content("design")
+  context "when signed in as a user allowed to edit tags" do
+    before { sign_in(trust_level_4) }
+
+    it "allows the user to edit a tag name and description" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      tags_page.open_edit_tag
+      tags_page.fill_tag_name("ux")
+      tags_page.fill_tag_description("new description")
+      tags_page.save_edit
+      expect(tags_page.tag_info).to have_content("ux")
+      expect(tags_page.tag_info).to have_content("new description")
+    end
+
+    it "does not allow the user to delete the tag" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      expect(tags_page.tag_info).to have_no_css(".delete-tag")
+    end
+  end
+
+  context "when signed in as a regular user" do
+    before { sign_in(user) }
+
+    it "does not allow the user to edit or delete the tag" do
+      tags_page.visit_tag(tag_1)
+      tags_page.tag_info_btn.click
+      expect(tags_page.tag_info).to have_no_css(".edit-tag")
+      expect(tags_page.tag_info).to have_no_css(".delete-tag")
+    end
   end
 end


### PR DESCRIPTION
### What is this change?

Break down tag admin into more fine grained permissions using a new setting listing groups that can edit (but not create or delete) tags.

### Screenshots

**Admin:**

<img width="600" height="350" alt="Screenshot 2025-07-31 at 4 42 37 PM" src="https://github.com/user-attachments/assets/9f755a6f-ddbd-4404-b0ce-083d92e779e4" />

**User in access group:**

<img width="350" height="318" alt="Screenshot 2025-07-31 at 4 44 01 PM" src="https://github.com/user-attachments/assets/b0866cdf-03b9-4910-998c-e556c913f260" />

**Regular user:**

<img width="350" height="224" alt="Screenshot 2025-07-31 at 4 44 22 PM" src="https://github.com/user-attachments/assets/244ec18a-cb42-41fa-9641-02406a803a14" />