### PR TITLE
DEV: Configure `skip_default_job_logging` for Sidekiq

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -10,6 +10,7 @@ Sidekiq.configure_client { |config| config.redis = Discourse.sidekiq_redis_confi
 
 Sidekiq.configure_server do |config|
   config.redis = Discourse.sidekiq_redis_config
+  config[:skip_default_job_logging] = false
 
   config.server_middleware do |chain|
     chain.add Sidekiq::Pausable


### PR DESCRIPTION
By default, Sidekiq logs the `start` and `done` messages at the `info` log level
when a sidekiq job executes. These log messages are not necessary in
production and is bloating our log files. Even in other environments, I
don't see how the messages are useful so we are going to just disable
this.

### Reviewer notes

See https://github.com/sidekiq/sidekiq/pull/6200