### PR TITLE
DEV: Clear serializers cache between tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -190,6 +190,7 @@ module TestSetup
     Middleware::AnonymousCache.disable_anon_cache
     BlockRequestsMiddleware.allow_requests!
     BlockRequestsMiddleware.current_example_location = nil
+    ApplicationSerializer.fragment_cache.clear
   end
 end
 


### PR DESCRIPTION
In our serializers, we have a method `cache_fragment` that we use for caching chunks of JSON that are expensive to generate. We currently don't clear this cache between tests, which causes tests to become flaky since a cached fragment from one test can leak to another test and make it fail.