### PR TITLE
FIX: Ensure imported category slug is deduplicate

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -264,12 +264,16 @@ class BulkImport::Base
     @last_category_id = last_id(Category)
     @last_category_group_id = last_id(CategoryGroup)
     @highest_category_position = Category.unscoped.maximum(:position) || 0
-    @category_names =
-      Category
-        .unscoped
-        .pluck(:parent_category_id, :name)
-        .map { |pci, name| "#{pci}-#{name.downcase}" }
-        .to_set
+
+    @category_names = Set.new
+    @category_slugs = Set.new
+    Category
+      .unscoped
+      .pluck(:parent_category_id, :name, :slug)
+      .each do |pci, name, slug|
+        @category_names << "#{pci}-#{name.downcase}"
+        @category_slugs << slug.downcase
+      end
 
     puts "Loading topics indexes..."
     @last_topic_id = last_id(Topic)
@@ -1460,20 +1464,27 @@ class BulkImport::Base
     category[:id] ||= @last_category_id += 1
     @categories[category[:imported_id].to_i] ||= category[:id]
 
-    next_number = 1
+    name_next_number = 1
     original_name = name = category[:name][0...50].scrub.strip
 
-    while @category_names.include?("#{category[:parent_category_id]}-#{name.downcase}")
-      name = "#{original_name[0...50 - next_number.to_s.length]}#{next_number}"
-      next_number += 1
+    while !@category_names.add?("#{category[:parent_category_id]}-#{name.downcase}")
+      name = "#{original_name[0...50 - name_next_number.to_s.length]}#{name_next_number}"
+      name_next_number += 1
     end
 
-    @category_names << "#{category[:parent_category_id]}-#{name.downcase}"
     name_lower = name.downcase
-
     category[:name] = name
     category[:name_lower] = name_lower
-    category[:slug] ||= Slug.for(name_lower, "") # TODO Ensure that slug doesn't exist yet
+
+    slug_next_number = 1
+    original_slug = slug = (category[:slug] || Slug.for(name_lower, ""))
+
+    while !@category_slugs.add?(slug.downcase)
+      slug = "#{original_slug}-#{slug_next_number}"
+      slug_next_number += 1
+    end
+
+    category[:slug] = slug
     category[:description] = (category[:description] || "").scrub.strip.presence
     category[:user_id] ||= Discourse::SYSTEM_USER_ID
     category[:created_at] ||= NOW


### PR DESCRIPTION
This change ensures the incoming category slug doesn't already exist