### PR TITLE
DEV: Add `isElementInDocument` method to validate target elements

### DIFF
--- a/app/assets/javascripts/discourse/app/components/decorated-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/decorated-html.gjs
@@ -4,7 +4,11 @@ import { htmlSafe, isHTMLSafe } from "@ember/template";
 import { TrackedArray } from "@ember-compat/tracked-built-ins";
 import helperFn from "discourse/helpers/helper-fn";
 import deprecated from "discourse/lib/deprecated";
-import { isRailsTesting, isTesting } from "discourse/lib/environment";
+import {
+  isProduction,
+  isRailsTesting,
+  isTesting,
+} from "discourse/lib/environment";
 import { POST_STREAM_DEPRECATION_OPTIONS } from "discourse/widgets/widget";
 
 const detachedDocument = document.implementation.createHTMLDocument("detached");
@@ -83,19 +87,46 @@ export default class DecoratedHtml extends Component {
     return cookedDiv;
   }
 
+  /**
+   * Checks if a given HTML element belongs to the current document.
+   * In development mode, it warns if the element is not in the document.
+   *
+   * This is used to ensure components added using `renderGlimmer` are only rendered in the same document, preventing
+   * rendering errors that otherwise would crash the application.
+   *
+   * @param {Object} info - Object containing element information
+   * @param {Element} info.element - The DOM element to check
+   * @returns {boolean} True if element belongs to current document, false otherwise
+   */
+  isElementInDocument(info) {
+    const result = info.element.ownerDocument === document;
+
+    if (!isProduction() && !result) {
+      console.warn(
+        "The `renderGlimmer` definition below was unable to render the decorated HTML because the target element is not in the " +
+          "current document. This likely occurred because the element was removed by another decorator.\n",
+        info
+      );
+    }
+
+    return result;
+  }
+
   <template>
     {{~this.decoratedContent decorateArgs=@decorateArgs~}}
 
     {{~#each this.renderGlimmerInfos as |info|~}}
-      {{~#if info.append}}
-        {{~#in-element info.element insertBefore=null~}}
-          <info.component @data={{info.data}} />
-        {{~/in-element~}}
-      {{~else}}
-        {{~#in-element info.element~}}
-          <info.component @data={{info.data}} />
-        {{~/in-element~}}
-      {{~/if}}
+      {{~#if (this.isElementInDocument info)~}}
+        {{~#if info.append}}
+          {{~#in-element info.element insertBefore=null~}}
+            <info.component @data={{info.data}} />
+          {{~/in-element~}}
+        {{~else}}
+          {{~#in-element info.element~}}
+            <info.component @data={{info.data}} />
+          {{~/in-element~}}
+        {{~/if}}
+      {{~/if~}}
     {{~/each~}}
   </template>
 }


### PR DESCRIPTION
Introduced `isElementInDocument` to ensure components are rendered only in valid DOM elements. Prevents application crashes caused by rendering into detached or removed elements.