### PR TITLE
FIX: remove unneeded overflow in horizontal-scroll-sync

### DIFF
--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -2,7 +2,6 @@
 
 .horizontal-scroll-sync {
   &__container {
-    overflow-x: auto;
     width: 100%;
   }
 


### PR DESCRIPTION
Follow-up to 459a58f

Had an extra overflow style causing an issue with dropdowns, it's unnecessary because we have overflow handled on a descendant 


Before:
<img width="1106" height="602" alt="image" src="https://github.com/user-attachments/assets/3f156f68-53c1-4bf0-8f28-04e1e07e56af" />


After:
<img width="1652" height="810" alt="image" src="https://github.com/user-attachments/assets/a2e5163b-c183-4a0c-a25b-99039974c1fb" />
