### PR TITLE
DEV: Simplify post decorators by removing `afterAdopt` handling

### DIFF
--- a/app/assets/javascripts/discourse/app/components/decorated-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/decorated-html.gjs
@@ -47,21 +47,6 @@ export default class DecoratedHtml extends Component {
 
     document.adoptNode(cookedDiv);
 
-    try {
-      const afterAdoptDecorateFn = this.args.decorateAfterAdopt;
-      untrack(() => afterAdoptDecorateFn?.(cookedDiv, helper, decorateArgs));
-    } catch (e) {
-      if (isRailsTesting() || isTesting()) {
-        throw e;
-      } else {
-        // in case one of the decorators throws an error we want to surface it to the console but prevent
-        // the application from crashing
-
-        // eslint-disable-next-line no-console
-        console.error(e);
-      }
-    }
-
     return cookedDiv;
   });
 

--- a/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/cooked-html.gjs
@@ -48,7 +48,7 @@ export default class PostCookedHtml extends Component {
   }
 
   @bind
-  decorateBeforeAdopt(element, helper, args) {
+  decorate(element, helper, args) {
     this.#cleanupDecorations();
 
     const decorators = [...POST_COOKED_DECORATORS, ...this.extraDecorators];
@@ -133,21 +133,8 @@ export default class PostCookedHtml extends Component {
 
     this.appEvents.trigger(
       this.isStreamElement
-        ? "decorate-post-cooked-element:before-adopt"
+        ? "decorate-post-cooked-element"
         : "decorate-non-stream-cooked-element",
-      element,
-      helper
-    );
-  }
-
-  @bind
-  decorateAfterAdopt(element, helper) {
-    if (!this.isStreamElement) {
-      return;
-    }
-
-    this.appEvents.trigger(
-      "decorate-post-cooked-element:after-adopt",
       element,
       helper
     );
@@ -196,8 +183,7 @@ export default class PostCookedHtml extends Component {
   <template>
     <DecoratedHtml
       @className={{this.className}}
-      @decorate={{this.decorateBeforeAdopt}}
-      @decorateAfterAdopt={{this.decorateAfterAdopt}}
+      @decorate={{this.decorate}}
       @decorateArgs={{lazyHash
         highlightTerm=this.highlightTerm
         isIgnored=this.isIgnored

--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -13,41 +13,36 @@ export function nativeLazyLoading(api) {
     }
   });
 
-  api.decorateCookedElement(
-    (post) => {
-      const siteSettings = api.container.lookup("service:site-settings");
+  api.decorateCookedElement((post) => {
+    const siteSettings = api.container.lookup("service:site-settings");
 
-      post.querySelectorAll("img").forEach((img) => {
-        // Support for smallUpload should be maintained until Post::BAKED_VERSION is bumped higher than 2
-        const { smallUpload, dominantColor } = img.dataset;
+    post.querySelectorAll("img").forEach((img) => {
+      // Support for smallUpload should be maintained until Post::BAKED_VERSION is bumped higher than 2
+      const { smallUpload, dominantColor } = img.dataset;
 
-        if (siteSettings.secure_uploads && smallUpload) {
-          // Secure uploads requests go through the app. In topics with many images,
-          // this makes it very easy to hit rate limiters. Skipping the low-res
-          // placeholders reduces the chance of this problem occuring.
-          return;
+      if (siteSettings.secure_uploads && smallUpload) {
+        // Secure uploads requests go through the app. In topics with many images,
+        // this makes it very easy to hit rate limiters. Skipping the low-res
+        // placeholders reduces the chance of this problem occuring.
+        return;
+      }
+
+      if ((smallUpload || dominantColor) && !isLoaded(img)) {
+        if (!img.onload) {
+          img.onload = () => {
+            img.style.removeProperty("background-image");
+            img.style.removeProperty("background-size");
+            img.style.removeProperty("background-color");
+          };
         }
 
-        if ((smallUpload || dominantColor) && !isLoaded(img)) {
-          if (!img.onload) {
-            img.onload = () => {
-              img.style.removeProperty("background-image");
-              img.style.removeProperty("background-size");
-              img.style.removeProperty("background-color");
-            };
-          }
-
-          if (smallUpload) {
-            img.style.setProperty("background-image", `url(${smallUpload})`);
-            img.style.setProperty("background-size", "cover");
-          } else {
-            img.style.setProperty("background-color", `#${dominantColor}`);
-          }
+        if (smallUpload) {
+          img.style.setProperty("background-image", `url(${smallUpload})`);
+          img.style.setProperty("background-size", "cover");
+        } else {
+          img.style.setProperty("background-color", `#${dominantColor}`);
         }
-      });
-    },
-    {
-      afterAdopt: true,
-    }
-  );
+      }
+    });
+  });
 }

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -606,9 +606,6 @@ class PluginApi {
    * Use `options.onlyStream` if you only want to decorate posts within a topic,
    * and not in other places like the user stream.
    *
-   * Decoration normally happens in a detached DOM. Use `options.afterAdopt`
-   * to decorate html content after it is adopted by the main `document`.
-   *
    * For example, to add a yellow background to all posts you could do this:
    *
    * ```
@@ -622,16 +619,9 @@ class PluginApi {
 
     callback = wrapWithErrorHandler(callback, "broken_decorator_alert");
 
-    addDecorator(callback, { afterAdopt: !!opts.afterAdopt });
+    addDecorator(callback);
 
-    this.onAppEvent(
-      opts.afterAdopt
-        ? "decorate-post-cooked-element:after-adopt"
-        : "decorate-post-cooked-element:before-adopt",
-      callback
-    );
-
-    // TODO (glimmer-post-stream) should we also handle afterAdopt for non-stream renderings?
+    this.onAppEvent("decorate-post-cooked-element", callback);
     if (!opts.onlyStream) {
       this.onAppEvent("decorate-non-stream-cooked-element", callback);
     }

--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -15,21 +15,15 @@ import {
 } from "discourse/lib/update-user-status-on-mention";
 import { i18n } from "discourse-i18n";
 
-let _beforeAdoptDecorators = [];
-let _afterAdoptDecorators = [];
+let _decorators = [];
 
 // Don't call this directly: use `plugin-api/decorateCookedElement`
-export function addDecorator(callback, { afterAdopt = false } = {}) {
-  if (afterAdopt) {
-    _afterAdoptDecorators.push(callback);
-  } else {
-    _beforeAdoptDecorators.push(callback);
-  }
+export function addDecorator(callback) {
+  _decorators.push(callback);
 }
 
 export function resetDecorators() {
-  _beforeAdoptDecorators = [];
-  _afterAdoptDecorators = [];
+  _decorators = [];
 }
 
 let detachedDocument = document.implementation.createHTMLDocument("detached");
@@ -83,11 +77,8 @@ export default class PostCooked {
   }
 
   _decorateAndAdopt(cooked) {
-    _beforeAdoptDecorators.forEach((d) => d(cooked, this.decoratorHelper));
-
+    _decorators.forEach((d) => d(cooked, this.decoratorHelper));
     document.adoptNode(cooked);
-
-    _afterAdoptDecorators.forEach((d) => d(cooked, this.decoratorHelper));
   }
 
   _applySearchHighlight(html) {


### PR DESCRIPTION
Consolidated all decorator logic into a single `decorate` method, eliminating the complexity of separate `beforeAdopt` and `afterAdopt` options. Streamlined related API and component logic for consistency and maintainability.