### PR TITLE
FEATURE: Allow re-localization twice a day if post version has changed

### DIFF
--- a/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
+++ b/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
@@ -41,21 +41,32 @@ module Jobs
 
       locales.each do |locale|
         next if LocaleNormalizer.is_same?(locale, detected_locale)
-        regionless_locale = locale.split("_").first
-        next if post.post_localizations.where("locale LIKE ?", "#{regionless_locale}%").exists?
 
-        begin
-          DiscourseAi::Translation::PostLocalizer.localize(post, locale)
-        rescue FinalDestination::SSRFDetector::LookupFailedError
-          # do nothing, there are too many sporadic lookup failures
-        rescue => e
-          DiscourseAi::Translation::VerboseLogger.log(
-            "Failed to translate post #{post.id} to #{locale}: #{e.message}\n\n#{e.backtrace[0..3].join("\n")}",
-          )
+        regionless_locale = locale.split("_").first
+        exists = post.post_localizations.where("locale LIKE ?", "#{regionless_locale}%").exists?
+
+        if exists && !DiscourseAi::Translation::PostLocalizer.has_relocalize_quota?(post, locale)
+          next
         end
+
+        localize(post, locale)
       end
 
       MessageBus.publish("/topic/#{post.topic_id}", type: :localized, id: post.id)
+    end
+
+    private
+
+    def localize(post, locale)
+      begin
+        DiscourseAi::Translation::PostLocalizer.localize(post, locale)
+      rescue FinalDestination::SSRFDetector::LookupFailedError
+        # do nothing, there are too many sporadic lookup failures
+      rescue => e
+        DiscourseAi::Translation::VerboseLogger.log(
+          "Failed to translate post #{post.id} to #{locale}: #{e.message}\n\n#{e.backtrace[0..3].join("\n")}",
+        )
+      end
     end
   end
 end

--- a/plugins/discourse-ai/lib/translation/post_localizer.rb
+++ b/plugins/discourse-ai/lib/translation/post_localizer.rb
@@ -4,8 +4,8 @@ module DiscourseAi
   module Translation
     class PostLocalizer
       def self.localize(post, target_locale = I18n.locale)
-        if post.blank? || target_locale.blank? || post.locale == target_locale.to_s ||
-             post.raw.blank?
+        if post.blank? || target_locale.blank? ||
+             LocaleNormalizer.is_same?(post.locale, target_locale) || post.raw.blank?
           return
         end
         return if post.raw.length > SiteSetting.ai_translation_max_post_length
@@ -22,6 +22,33 @@ module DiscourseAi
         localization.localizer_user_id = Discourse.system_user.id
         localization.save!
         localization
+      end
+
+      def self.has_relocalize_quota?(post, locale, skip_incr: false)
+        return false if get_relocalize_quota(post, locale).to_i >= 2
+
+        incr_relocalize_quota(post, locale) unless skip_incr
+        true
+      end
+
+      private
+
+      def self.relocalize_key(post, locale)
+        "post_relocalized_#{post.id}_#{locale}"
+      end
+
+      def self.get_relocalize_quota(post, locale)
+        Discourse.redis.get(relocalize_key(post, locale)) || 0
+      end
+
+      def self.incr_relocalize_quota(post, locale)
+        key = relocalize_key(post, locale)
+
+        if get_relocalize_quota(post, locale).blank?
+          Discourse.redis.set(key, 1, ex: 1.day.to_i)
+        else
+          Discourse.redis.incr(key)
+        end
       end
     end
   end

--- a/plugins/discourse-ai/spec/lib/translation/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/entry_point_spec.rb
@@ -51,7 +51,7 @@ describe DiscourseAi::Translation::EntryPoint do
     end
   end
 
-  describe "upon first post (topic) edited" do
+  describe "upon topic edited" do
     fab!(:post) { Fabricate(:post, post_number: 1) }
     fab!(:non_first_post) { Fabricate(:post, post_number: 2) }
 
@@ -60,18 +60,34 @@ describe DiscourseAi::Translation::EntryPoint do
       assign_fake_provider_to(:ai_default_llm_model)
     end
 
-    it "enqueues detect topic locale and translate topic job" do
+    it "enqueues in grace period detect translate topic job if title changed" do
+      freeze_time
+
+      SiteSetting.editing_grace_period = 10.minutes
       SiteSetting.ai_translation_enabled = true
       topic = post.topic
       revisor = PostRevisor.new(post, topic)
-      revisor.revise!(
-        post.user,
-        { title: "A whole new hole" },
-        { validate_post: false, bypass_bump: false },
-      )
+      revisor.revise!(post.user, { title: "A whole new hole" }, { skip_validations: true })
       revisor.post_process_post
 
-      expect_job_enqueued(job: :detect_translate_topic, args: { topic_id: topic.id })
+      expect_job_enqueued(
+        job: :detect_translate_topic,
+        args: {
+          topic_id: topic.id,
+        },
+        at: 10.minutes.from_now,
+      )
+      expect(job_enqueued?(job: :detect_translate_post)).to eq false
+    end
+
+    it "does not enqueue detect translate topic job if title did not change" do
+      new_category = Fabricate(:category)
+      SiteSetting.ai_translation_enabled = true
+      topic = post.topic
+      post.revise(post.user, category_id: new_category.id)
+
+      expect(job_enqueued?(job: :detect_translate_topic, args: { topic_id: topic.id })).to eq false
+      expect(job_enqueued?(job: :detect_translate_post)).to eq false
     end
 
     it "does not enqueue if setting disabled" do
@@ -80,6 +96,36 @@ describe DiscourseAi::Translation::EntryPoint do
       expect(
         job_enqueued?(job: :detect_translate_topic, args: { topic_id: post.topic_id }),
       ).to eq false
+      expect(job_enqueued?(job: :detect_translate_post)).to eq false
+    end
+  end
+
+  describe "upon post edited" do
+    it "enqueues detect translate post job in grace period" do
+      freeze_time
+
+      SiteSetting.editing_grace_period = 10.minutes
+      SiteSetting.ai_translation_enabled = true
+      post = Fabricate(:post, post_number: 1)
+      post.revise(post.user, { raw: "new raw" }, { force_new_version: true })
+
+      expect_job_enqueued(
+        job: :detect_translate_post,
+        args: {
+          post_id: post.id,
+        },
+        at: 10.minutes.from_now,
+      )
+      expect(job_enqueued?(job: :detect_translate_topic)).to eq false
+    end
+
+    it "does not enqueue detect translate post job if no new version of post" do
+      SiteSetting.ai_translation_enabled = true
+      post = Fabricate(:post, post_number: 1)
+      post.revise(post.user, { raw: post.raw + "A" })
+
+      expect(job_enqueued?(job: :detect_translate_post)).to eq false
+      expect(job_enqueued?(job: :detect_translate_topic)).to eq false
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
@@ -88,4 +88,35 @@ describe DiscourseAi::Translation::PostLocalizer do
       }.to_not change { PostLocalization.count }
     end
   end
+
+  describe ".has_relocalize_quota?" do
+    fab!(:post)
+
+    it "returns false if quota is already 2 or more" do
+      Discourse.redis.set(described_class.relocalize_key(post, "en"), 2)
+      expect(described_class.has_relocalize_quota?(post, "en")).to eq(false)
+
+      Discourse.redis.set(described_class.relocalize_key(post, "en"), 3)
+      expect(described_class.has_relocalize_quota?(post, "en")).to eq(false)
+    end
+
+    it "returns true if quota is less than 2 and increments quota" do
+      Discourse.redis.set(described_class.relocalize_key(post, "en"), 1)
+
+      expect(described_class.has_relocalize_quota?(post, "en")).to eq(true)
+    end
+
+    it "does not increment quota if skip_incr is true" do
+      Discourse.redis.set(described_class.relocalize_key(post, "en"), 1)
+
+      described_class.has_relocalize_quota?(post, "en", skip_incr: true)
+      expect(Discourse.redis.get(described_class.relocalize_key(post, "en"))).to eq("1")
+    end
+
+    it "increments quota if it was not set before" do
+      described_class.has_relocalize_quota?(post, "en")
+
+      expect(Discourse.redis.get(described_class.relocalize_key(post, "en"))).to eq("1")
+    end
+  end
 end


### PR DESCRIPTION
This PR is a continuation of https://github.com/discourse/discourse-ai/pull/1422.

Previously, we entirely skipped / disallowed localization. With this PR, 
- For topics, we will only enqueue the translate title job if the post revisor indicates there is a title change
- For posts, we will only enqueue the translate post job if there is a post version change

Both jobs will be enqueued with a delay of `SiteSetting.editing_grace_period` or `5 minutes`, whichever is larger. Each topic or post may be retranslated to a locale at a maximum of twice a day.