### PR TITLE
DEV: Consistently use Guardian helper methods

### DIFF
--- a/lib/guardian/bookmark_guardian.rb
+++ b/lib/guardian/bookmark_guardian.rb
@@ -2,11 +2,11 @@
 
 module BookmarkGuardian
   def can_delete_bookmark?(bookmark)
-    @user == bookmark.user
+    is_my_own?(bookmark)
   end
 
   def can_edit_bookmark?(bookmark)
-    @user == bookmark.user
+    is_my_own?(bookmark)
   end
 
   def can_see_bookmarkable?(bookmark)

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -315,9 +315,7 @@ module PostGuardian
     return false if post.blank?
     return true if is_admin?
     return false unless can_see_post_topic?(post)
-    unless post.user == @user || Topic.visible_post_types(@user).include?(post.post_type)
-      return false
-    end
+    return false unless is_my_own?(post) || Topic.visible_post_types(@user).include?(post.post_type)
     return true if is_moderator? || is_category_group_moderator?(post.topic.category)
     if (!post.trashed? || can_see_deleted_post?(post)) &&
          (!post.hidden? || can_see_hidden_post?(post))
@@ -339,7 +337,9 @@ module PostGuardian
     end
     return false if anonymous?
     return true if is_staff?
-    post.user_id == @user.id || @user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
+    return true if is_my_own?(post)
+
+    @user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
   end
 
   def can_view_edit_history?(post)
@@ -349,7 +349,10 @@ module PostGuardian
       return true if post.wiki || SiteSetting.edit_history_visible_to_public
     end
 
-    authenticated? && (is_staff? || @user.id == post.user_id) && can_see_post?(post)
+    return false if !authenticated?
+    return false if !can_see_post?(post)
+
+    is_staff? || is_my_own?(post)
   end
 
   def can_change_post_owner?

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -21,7 +21,7 @@ module TagGuardian
   def can_tag_pms?
     return false if !SiteSetting.tagging_enabled
     return false if !authenticated?
-    return true if @user == Discourse.system_user
+    return true if @user.is_system_user?
 
     group_ids = SiteSetting.pm_tags_allowed_for_groups_map
     group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -3,11 +3,8 @@
 #mixin for all guardian methods dealing with topic permissions
 module TopicGuardian
   def can_remove_allowed_users?(topic, target_user = nil)
-    is_staff? || (topic.user == @user && @user.has_trust_level?(TrustLevel[2])) ||
-      (
-        topic.allowed_users.count > 1 && topic.user != target_user &&
-          !!(target_user && user == target_user)
-      )
+    is_staff? || (is_my_own?(topic) && @user.has_trust_level?(TrustLevel[2])) ||
+      (topic.allowed_users.count > 1 && topic.user != target_user && !!(is_me?(target_user)))
   end
 
   def can_review_topic?(topic)
@@ -281,7 +278,7 @@ module TopicGuardian
     can_see_category?(category) &&
       (
         !category.read_restricted || !is_staged? || secure_category_ids.include?(category.id) ||
-          topic.user == user
+          is_my_own?(topic)
       )
   end
 

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -12,7 +12,7 @@ module UserGuardian
     # can always pick blank avatar
     return true if !upload
     return true if user_avatar.contains_upload?(upload.id)
-    return true if upload.user_id == user_avatar.user_id || upload.user_id == user.id
+    return true if upload.user_id == user_avatar.user_id || is_my_own?(upload)
 
     UserUpload.exists?(upload_id: upload.id, user_id: user.id)
   end
@@ -112,12 +112,12 @@ module UserGuardian
 
   def can_see_suspension_reason?(user)
     return true unless SiteSetting.hide_suspension_reasons?
-    user == @user || is_staff?
+    is_me?(user) || is_staff?
   end
 
   def can_see_silencing_reason?(user)
     return true unless SiteSetting.hide_silencing_reasons?
-    user == @user || is_staff?
+    is_me?(user) || is_staff?
   end
 
   def can_disable_second_factor?(user)
@@ -156,7 +156,7 @@ module UserGuardian
   end
 
   def can_see_user_actions?(user, action_types)
-    return true if !@user.anonymous? && (@user.id == user.id || is_admin?)
+    return true if !@user.anonymous? && (is_me?(user) || is_admin?)
     return false if SiteSetting.hide_user_activity_tab?
     (action_types & UserAction.private_types).empty?
   end

--- a/spec/lib/guardian/bookmark_guardian_spec.rb
+++ b/spec/lib/guardian/bookmark_guardian_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe BookmarkGuardian do
+  fab!(:user)
+  fab!(:moderator)
+  fab!(:bookmark) { Fabricate(:bookmark, user:) }
+
+  describe "#can_delete_bookmark?" do
+    it "returns true when user owns the bookmark" do
+      expect(Guardian.new(user).can_delete_bookmark?(bookmark)).to eq(true)
+    end
+
+    it "returns false when user doesn't own the bookmark" do
+      expect(Guardian.new(moderator).can_delete_bookmark?(bookmark)).to eq(false)
+    end
+  end
+
+  describe "#can_edit_bookmark?" do
+    it "returns true when user owns the bookmark" do
+      expect(Guardian.new(user).can_delete_bookmark?(bookmark)).to eq(true)
+    end
+
+    it "returns false when user doesn't own the bookmark" do
+      expect(Guardian.new(moderator).can_delete_bookmark?(bookmark)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
### What is this change?

1. Make consistent use of `is_me?`, `is_my_own?`, etc. since these are more robust and don't use the `user` accessor method (soon to be deprecated) directly.
2. Add missing test coverage for `BookmarkGuardian` methods.