### PR TITLE
FIX: Show category localization selector for non-supported locales when localization exists

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-localizations.gjs
@@ -10,13 +10,18 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
   @service siteSettings;
   @service languageNameLookup;
 
-  get availableLocales() {
-    return this.siteSettings.available_content_localization_locales.map(
-      ({ value }) => ({
-        name: this.languageNameLookup.getLanguageName(value),
-        value,
-      })
-    );
+  get selectableLocales() {
+    const supported =
+      this.siteSettings.available_content_localization_locales.map(
+        (obj) => obj.value
+      );
+    const committed = this.transientData.localizations.map((obj) => obj.locale);
+    const allLocales = [...supported, ...committed].uniq();
+
+    return allLocales.map((value) => ({
+      name: this.languageNameLookup.getLanguageName(value),
+      value,
+    }));
   }
 
   <template>
@@ -47,7 +52,7 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
             as |field|
           >
             <field.Select as |select|>
-              {{#each this.availableLocales as |locale|}}
+              {{#each this.selectableLocales as |locale|}}
                 <select.Option
                   @value={{locale.value}}
                 >{{locale.name}}</select.Option>

--- a/spec/system/edit_category_localizations_spec.rb
+++ b/spec/system/edit_category_localizations_spec.rb
@@ -83,21 +83,31 @@ describe "Edit Category Localizations", type: :system do
 
     describe "when editing a category with localizations" do
       fab!(:category_localization) { Fabricate(:category_localization, category:, locale: "es") }
+      fab!(:category_localization) { Fabricate(:category_localization, category:, locale: "ja") }
 
       it "allows you to delete localizations" do
-        expect(CategoryLocalization.where(category_id: category.id).count).to eq(1)
+        expect(CategoryLocalization.where(category_id: category.id).count).to eq(2)
         category_page.visit_edit_localizations(category)
 
+        expect(category_page).to have_selector(
+          ".edit-category-tab-localizations .form-kit__collection .form-kit__row",
+          count: 2,
+        )
         expect(
           category_page.find("#control-localizations-0-locale option.--selected"),
         ).to have_content("Spanish (Español)")
+        expect(
+          category_page.find("#control-localizations-1-locale option.--selected"),
+        ).to have_content("Japanese (日本語)")
 
-        page.find(".edit-category-tab-localizations .remove-localization").click
+        page.find(".edit-category-tab-localizations .remove-localization", match: :first).click
         category_page.save_settings
         page.refresh
-        try_until_success do
-          expect(CategoryLocalization.where(category_id: category.id).count).to eq(0)
-        end
+
+        expect(category_page).to_not have_css("#control-localizations-0-locale option.--selected")
+        expect(
+          category_page.find("#control-localizations-0-locale option.--selected"),
+        ).to have_content("Japanese (日本語)")
       end
     end
   end


### PR DESCRIPTION
There's a bug now where if a category localization exists for an unsupported locale, its locale would show up defaulting to the first item in the dropdown. By right, the dropdown only shows locales set in `SiteSetting.content_localization_supported_locales`.

<img width="864" height="427" alt="Screenshot 2025-08-01 at 5 07 07 PM" src="https://github.com/user-attachments/assets/7ddda3e5-00a0-480a-bba5-266b8fb6c42a" />

This PR makes sure that localization's locale is added to the dropdown.