### PR TITLE
FIX: filter route views- error, "views" is ambiguous

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -381,7 +381,7 @@ class TopicsFilter
   end
 
   def filter_by_number_of_views(min: nil, max: nil)
-    filter_by_topic_range(column_name: "views", min:, max:)
+    filter_by_topic_range(column_name: "topics.views", min:, max:)
   end
 
   def filter_categories(values:)


### PR DESCRIPTION
When using the `/filter` route a filter like... `created_by:foo views-min:2` causes an error  `column reference "views" is ambiguous` 

<img width="1280" height="674" alt="image" src="https://github.com/user-attachments/assets/cd578481-24c5-48e8-b1c2-114038b2f4e8" />



This fixes it. 

<img width="1872" height="398" alt="image" src="https://github.com/user-attachments/assets/a37f6fe7-ca8b-47b0-bcba-eea0a557c1cb" />
