### PR TITLE
FIX: Initialize mobileMode earlier

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
@@ -10,7 +10,6 @@ export default {
       return;
     }
 
-    Mobile.init();
     setResolverOption("mobileView", Mobile.mobileView);
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/mobile.js
+++ b/app/assets/javascripts/discourse/app/lib/mobile.js
@@ -1,4 +1,3 @@
-import $ from "jquery";
 import { isTesting } from "discourse/lib/environment";
 
 let mobileForced = false;
@@ -9,9 +8,10 @@ const Mobile = {
   mobileView: false,
 
   init() {
-    const $html = $("html");
-    this.isMobileDevice = mobileForced || $html.hasClass("mobile-device");
-    this.mobileView = mobileForced || $html.hasClass("mobile-view");
+    const documentClassList = document.documentElement.classList;
+    this.isMobileDevice =
+      mobileForced || documentClassList.contains("mobile-device");
+    this.mobileView = mobileForced || documentClassList.contains("mobile-view");
 
     if (isTesting() || mobileForced) {
       return;
@@ -66,5 +66,7 @@ export function resetMobile() {
   mobileForced = false;
   Mobile.init();
 }
+
+Mobile.init();
 
 export default Mobile;

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -67,7 +67,9 @@ class ChatSetupInit {
           class: "chat-emoji-btn",
           icon: "face-smile",
           position: "dropdown",
-          displayed: owner.lookup("service:site").mobileView,
+          get displayed() {
+            return owner.lookup("service:site").mobileView;
+          },
           action(context) {
             const didSelectEmoji = (emoji) => {
               const composer = owner.lookup(`service:chat-${context}-composer`);


### PR DESCRIPTION
Early initializers (e.g. chat-setup) were checking mobile mode before the lib was initialized. This moves the init into the root of the module, so it's definitely ready before anything accesses it.

Also updates the chat-emoji-button `displayed` property to be a getter, so that it updates dynamically in 'viewport based mobile mode'.