### PR TITLE
UX: add trailing paragraph when pasting a [quote] at the end of a text block

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
@@ -102,9 +102,27 @@ const extension = {
       state.write("[/quote]\n\n");
     },
   },
-  plugins({ pmState: { Plugin, NodeSelection } }) {
+  plugins({
+    pmState: { Plugin, NodeSelection },
+    pmModel: { Slice, Fragment },
+  }) {
     return new Plugin({
       props: {
+        transformPasted(slice, view) {
+          if (
+            view.endOfTextblock("forward") &&
+            slice.content.childCount === 1 &&
+            slice.content.firstChild.type.name === "quote"
+          ) {
+            const quote = slice.content.firstChild;
+            const paragraph = view.state.schema.nodes.paragraph.create();
+
+            return Slice.maxOpen(Fragment.from([quote, paragraph]), false);
+          }
+
+          return slice;
+        },
+
         handleClickOn(view, pos, node, nodePos, event) {
           if (
             node.type.name === "quote" &&

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -1497,4 +1497,18 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("h2", text: "This is a test")
     end
   end
+
+  describe "quote node" do
+    it "keeps the cursor outside quote when pasted" do
+      open_composer
+
+      markdown = "[quote]\nThis is a quote\n\n[/quote]"
+      cdp.copy_paste(markdown)
+      composer.type_content("This is a test")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value(markdown + "\n\nThis is a test")
+    end
+  end
 end


### PR DESCRIPTION
Adds a `transformPasted` phase that enforces a trailing paragraph if (at the end of a text block AND single child AND child is a `[quote]`) so the cursor can be outside the pasted quote.

internal /t/149983