### PR TITLE
UX: direct to single tag page from tag intersection when one tag remains

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/tags-intersection-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/tags-intersection-chooser.js
@@ -31,11 +31,13 @@ export default class TagsIntersectionChooser extends MiniTagChooser {
           `/tags/intersection/${this.mainTag}/${remainingTags.join("/")}`
         );
       } else {
-        DiscourseURL.routeTo("/tags");
+        DiscourseURL.routeTo(`/tag/${this.mainTag}`);
       }
     } else {
       if (tags.length >= 2) {
         DiscourseURL.routeTo(`/tags/intersection/${tags.join("/")}`);
+      } else if (tags.length === 1) {
+        DiscourseURL.routeTo(`/tag/${tags[0]}`);
       } else {
         DiscourseURL.routeTo("/tags");
       }


### PR DESCRIPTION
When on a tag intersection like this: `/tags/intersection/foo/bar`

We have our tag selector:

<img width="946" height="136" alt="image" src="https://github.com/user-attachments/assets/6f64cec6-c8f0-456e-a139-769ae66584d1" />

When you remove all but one tag, we redirect to /tags, which isn't the best experience. This change will direct users to the single tag page `/tag/foo` instead. 