### PR TITLE
UX: [rte] properly put cursor at end when putCursorAtEnd is called

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -17,6 +17,7 @@ import * as ProsemirrorHistory from "prosemirror-history";
 import { history } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import * as ProsemirrorModel from "prosemirror-model";
+import { Fragment } from "prosemirror-model";
 import * as ProsemirrorState from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import * as ProsemirrorTransform from "prosemirror-transform";

--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -259,10 +259,13 @@ export default class ProsemirrorEditor extends Component {
     const doc = this.convertFromMarkdown(value);
 
     const tr = this.view.state.tr;
-    tr.replaceWith(0, this.view.state.doc.content.size, doc.content).setMeta(
-      "addToHistory",
-      false
-    );
+    tr.replaceWith(0, this.view.state.doc.content.size, doc.content);
+    tr.setMeta("addToHistory", false);
+
+    if (value.endsWith("\n\n")) {
+      tr.insert(tr.doc.content.size, this.schema.nodes.paragraph.create());
+    }
+
     this.view.updateState(this.view.state.apply(tr));
   }
 

--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -259,12 +259,21 @@ export default class ProsemirrorEditor extends Component {
     const doc = this.convertFromMarkdown(value);
 
     const tr = this.view.state.tr;
-    tr.replaceWith(0, this.view.state.doc.content.size, doc.content);
-    tr.setMeta("addToHistory", false);
 
     if (value.endsWith("\n\n")) {
-      tr.insert(tr.doc.content.size, this.schema.nodes.paragraph.create());
+      tr.replaceWith(
+        0,
+        this.view.state.doc.content.size,
+        Fragment.from([
+          ...doc.content.content,
+          this.schema.nodes.paragraph.create(),
+        ])
+      );
+    } else {
+      tr.replaceWith(0, this.view.state.doc.content.size, doc.content);
     }
+
+    tr.setMeta("addToHistory", false);
 
     this.view.updateState(this.view.state.apply(tr));
   }

--- a/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -17,7 +17,6 @@ import * as ProsemirrorHistory from "prosemirror-history";
 import { history } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import * as ProsemirrorModel from "prosemirror-model";
-import { Fragment } from "prosemirror-model";
 import * as ProsemirrorState from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import * as ProsemirrorTransform from "prosemirror-transform";
@@ -260,21 +259,10 @@ export default class ProsemirrorEditor extends Component {
     const doc = this.convertFromMarkdown(value);
 
     const tr = this.view.state.tr;
-
-    if (value.endsWith("\n\n")) {
-      tr.replaceWith(
-        0,
-        this.view.state.doc.content.size,
-        Fragment.from([
-          ...doc.content.content,
-          this.schema.nodes.paragraph.create(),
-        ])
-      );
-    } else {
-      tr.replaceWith(0, this.view.state.doc.content.size, doc.content);
-    }
-
-    tr.setMeta("addToHistory", false);
+    tr.replaceWith(0, this.view.state.doc.content.size, doc.content).setMeta(
+      "addToHistory",
+      false
+    );
 
     this.view.updateState(this.view.state.apply(tr));
   }

--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -82,7 +82,19 @@ export default class ProsemirrorTextManipulation {
 
   putCursorAtEnd() {
     this.focus();
-    next(() => (this.view.dom.scrollTop = this.view.dom.scrollHeight));
+
+    next(() => {
+      this.view.dispatch(
+        this.view.state.tr
+          .setSelection(
+            TextSelection.create(
+              this.view.state.doc,
+              this.view.state.doc.content.size
+            )
+          )
+          .scrollIntoView()
+      );
+    });
   }
 
   autocomplete(options) {


### PR DESCRIPTION
Our ProseMirror text-manipulation impl's `putCursorAtEnd` was not putting the cursor at the end of the document.

This change is important in particular for Quoting directly from a post selection, which was opening the composer but the cursor was not being correctly placed.