### PR TITLE
FIX: Event notification translation for predefined attendance

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -223,6 +223,7 @@ module DiscoursePostEvent
           topic_title: self.name || post.topic.title,
           display_username: post.user.username,
           message: message,
+          event_name: self.name,
         }.to_json,
       }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/initializers/discourse-calendar.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/initializers/discourse-calendar.js
@@ -289,6 +289,9 @@ function initializeDiscourseCalendar(api) {
             ) {
               return i18n(this.notification.data.message, {
                 username: this.username,
+                eventName:
+                  this.notification.data.event_name ||
+                  i18n("discourse_post_event.notifications.an_event"),
               });
             }
             return super.label;

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -317,14 +317,9 @@ en:
         before_event_reminder: "An event is about to start"
         after_event_reminder: "An event has ended"
         ongoing_event_reminder: "An event is ongoing"
-        # TODO: delete the following keys (until ongoing_event_reminder_html)
-        # when event-invitation and event-reminder notification item widgets
-        # are removed
         invite_user_notification: "%{username} %{description}"
-        invite_user_predefined_attendance_notification_html: "%{username} has automatically set your attendance and invited you to %{description}"
-        before_event_reminder_html: "An event is about to start %{description}"
-        after_event_reminder_html: "An event has ended %{description}"
-        ongoing_event_reminder_html: "An event is ongoing  %{description}"
+        invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to %{eventName}"
+        an_event: "an event"
       edit_reason: "Event updated"
       edit_reason_closed: "Event closed"
       edit_reason_opened: "Event opened"

--- a/plugins/discourse-calendar/test/javascripts/acceptance/notifications-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/notifications-test.js
@@ -99,6 +99,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
               display_username: "apacer",
               message:
                 "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
+              event_name: "APAC call",
             },
           },
         ],
@@ -179,7 +180,7 @@ acceptance("Discourse Calendar - Notifications", function (needs) {
       notifications[4].textContent.replaceAll(/\s+/g, " ").trim(),
       `${i18n(
         "discourse_post_event.notifications.invite_user_predefined_attendance_notification",
-        { username: "apacer" }
+        { username: "apacer", eventName: "APAC call" }
       )} Asia Pacific team call`,
       "event invitation with predefined attendance notification has the right content"
     );


### PR DESCRIPTION
When users were sent a notification when they were signed up to
an event with predefined attendance, the translation key was misssing,
since we originally needed to append `_html` to the key, but don't
anymore.

Handled this broken translation and used the eventName instead
of description in the notification, since the latter is not always
set and was not passed to I18n anyway.

<img width="1108" height="100" alt="image" src="https://github.com/user-attachments/assets/d1d1ed16-237a-451b-b376-0c9f4acb9cd4" />

<img width="484" height="148" alt="image" src="https://github.com/user-attachments/assets/bb793249-9c5e-4ef1-b045-abcef8706c97" />
