### PR TITLE
DEV: Fix a handful of flaky Prosemirror editor tests

### DIFF
--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -32,7 +32,9 @@ describe "Composer - ProseMirror editor", type: :system do
 
     expect(rich).to have_css(".composer-image-node img", count: 1)
     expect(rich).to have_no_css(".composer-image-node img[data-placeholder='true']")
-    rich.find(".composer-image-node img").click
+
+    rich.find(".composer-image-node").click
+
     expect(rich).to have_css(".composer-image-node composer-image-toolbar", count: 1)
   end
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -23,11 +23,14 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   def paste_and_click_image
+    # This helper can only be used reliably to paste a single image when no other images are present.
+    expect(rich).to have_no_css(".composer-image-node img")
+
     cdp.allow_clipboard
     cdp.copy_test_image
     cdp.paste
-    # account for the debounced resolution
-    sleep 0.2
+
+    expect(rich).to have_css(".composer-image-node img", count: 1)
     rich.find(".composer-image-node img").click
   end
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -33,9 +33,9 @@ describe "Composer - ProseMirror editor", type: :system do
     expect(rich).to have_css(".composer-image-node img", count: 1)
     expect(rich).to have_no_css(".composer-image-node img[data-placeholder='true']")
 
-    rich.find(".composer-image-node").click
+    rich.find(".composer-image-node img").click
 
-    expect(rich).to have_css(".composer-image-node composer-image-toolbar", count: 1)
+    expect(rich).to have_css(".composer-image-node .composer-image-toolbar", count: 1)
   end
 
   it "hides the Composer container's preview button" do

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -31,11 +31,12 @@ describe "Composer - ProseMirror editor", type: :system do
     cdp.paste
 
     expect(rich).to have_css(".composer-image-node img", count: 1)
+    expect(rich).to have_no_css(".composer-image-node img[src='/images/transparent.png']")
     expect(rich).to have_no_css(".composer-image-node img[data-placeholder='true']")
 
     rich.find(".composer-image-node img").click
 
-    expect(rich).to have_css(".composer-image-node .composer-image-toolbar", count: 1)
+    expect(rich).to have_css(".composer-image-node .fk-d-menu", count: 2)
   end
 
   it "hides the Composer container's preview button" do

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -31,7 +31,9 @@ describe "Composer - ProseMirror editor", type: :system do
     cdp.paste
 
     expect(rich).to have_css(".composer-image-node img", count: 1)
+    expect(rich).to have_no_css(".composer-image-node img[data-placeholder='true']")
     rich.find(".composer-image-node img").click
+    expect(rich).to have_css(".composer-image-node composer-image-toolbar", count: 1)
   end
 
   it "hides the Composer container's preview button" do


### PR DESCRIPTION
## ✨ What's This?

See #33381, #34035

There appears to be a race condition where the editor tests are pasting an image, but then not ensuring that the image has been added to the DOM before trying to click on it.

Switching from using `sleep` to `expect` tells Capybara to wait until the appropriate DOM element exists.