### PR TITLE
FIX: add compontent to all themes button

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
@@ -39,7 +39,6 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
   @filterBy("allThemes", "component", false) availableParentThemes;
   @filterBy("availableParentThemes", "isActive") availableActiveParentThemes;
   @mapBy("availableParentThemes", "name") availableThemesNames;
-  @mapBy("availableActiveParentThemes", "name") availableActiveThemesNames;
   @filterBy("availableChildThemes", "hasParents") availableActiveChildThemes;
   @mapBy("availableChildThemes", "name") availableComponentsNames;
   @mapBy("availableActiveChildThemes", "name") availableActiveComponentsNames;
@@ -115,7 +114,7 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
       choices: this.availableThemesNames,
       default: this.parentThemesNames.join("|"),
       value: this.parentThemesNames.join("|"),
-      defaultValues: this.availableActiveThemesNames.join("|"),
+      defaultValues: this.availableThemesNames.join("|"),
       allThemes: this.allThemes,
       setDefaultValuesLabel: i18n("admin.customize.theme.add_all_themes"),
     });

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -223,6 +223,17 @@ describe "Admin Customize Themes", type: :system do
       visit("/admin/customize/themes/#{component.id}")
       expect(theme_page).to have_back_button_to_components_page
     end
+
+    it "allows to add component to all themes" do
+      visit("/admin/customize/themes/#{component.id}")
+      expect(page.find(".relative-theme-selector .formatted-selection").text).to eq(
+        I18n.t("js.select_kit.default_header_text"),
+      )
+      theme_page.click_add_all_themes_button
+      expect(page.find(".relative-theme-selector .formatted-selection").text).to eq(
+        "#{theme.name}, Foundation, Horizon",
+      )
+    end
   end
 
   describe "theme color palette editor" do

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -154,6 +154,11 @@ module PageObjects
         )
       end
 
+      def click_add_all_themes_button
+        find(".relative-theme-selector .setting-label .btn-link").click
+        find(".setting-controls .ok").click
+      end
+
       def has_no_page_header?
         has_no_css?(".d-page-header")
       end


### PR DESCRIPTION
Previously, the "add all themes" button was only adding user-selectable and active themes. Instead, it should include all installed themes.