### PR TITLE
FIX: Infinite reload in viewport-based-mobile-mode

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/mobile.js
@@ -11,5 +11,6 @@ export default {
     }
 
     setResolverOption("mobileView", Mobile.mobileView);
+    Mobile.maybeReload();
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/mobile.js
+++ b/app/assets/javascripts/discourse/app/lib/mobile.js
@@ -27,15 +27,18 @@ const Mobile = {
       if (window.location.search.match(/mobile_view=auto/)) {
         localStorage.removeItem("mobileView");
       }
-      if (localStorage.mobileView) {
-        let savedValue = localStorage.mobileView === "true";
-        if (savedValue !== this.mobileView) {
-          this.reloadPage(savedValue);
-        }
-      }
     } catch {
       // localStorage may be disabled, just skip this
       // you get security errors if it is disabled
+    }
+  },
+
+  maybeReload() {
+    if (localStorage.mobileView) {
+      let savedValue = localStorage.mobileView === "true";
+      if (savedValue !== this.mobileView) {
+        this.reloadPage(savedValue);
+      }
     }
   },
 


### PR DESCRIPTION
We only want to run this logic in the legacy mobile-mode. Setting the query params in the new viewport-based mobile mode won't do anything.

Followup to 36a42c5ea71d1a899da514c0130850b0cd804165