### PR TITLE
FEATURE: Localize topic titles in notifications and bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
@@ -32,7 +32,7 @@ export default class UserMenuBookmarkItem extends UserMenuBaseItem {
   }
 
   get description() {
-    return this.bookmark.title;
+    return this.bookmark.fancy_title;
   }
 
   get topicId() {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -357,8 +357,8 @@ acceptance("User menu", function (needs) {
     withPluginApi((api) => {
       api.registerModelTransformer("bookmark", (bookmarks) => {
         bookmarks.forEach((bookmark) => {
-          if (bookmark.title) {
-            bookmark.title = `pluginBookmarkTransformer ${bookmark.title}`;
+          if (bookmark.fancy_title) {
+            bookmark.fancy_title = `pluginBookmarkTransformer ${bookmark.fancy_title}`;
           }
         });
       });

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-item-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-item-test.gjs
@@ -536,7 +536,7 @@ module(
 
     test("item description is the bookmark title", async function (assert) {
       const item = getBookmark(
-        { title: "Custom bookmark title" },
+        { fancy_title: "Custom bookmark title" },
         this.siteSettings,
         this.site
       );

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2141,7 +2141,7 @@ class Topic < ActiveRecord::Base
   end
 
   def in_user_locale?
-    locale == I18n.locale.to_s
+    LocaleNormalizer.is_same?(locale, I18n.locale)
   end
 
   def get_localization(locale = I18n.locale)

--- a/app/serializers/basic_topic_serializer.rb
+++ b/app/serializers/basic_topic_serializer.rb
@@ -2,15 +2,7 @@
 
 # The most basic attributes of a topic that we need to create a link for it.
 class BasicTopicSerializer < ApplicationSerializer
+  include LocalizedFancyTopicTitleMixin
+
   attributes :id, :title, :fancy_title, :slug, :posts_count
-
-  def fancy_title
-    f = object.fancy_title
-
-    if (ContentLocalization.show_translated_topic?(object, scope))
-      object.get_localization&.fancy_title.presence || f
-    else
-      f
-    end
-  end
 end

--- a/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
+++ b/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
@@ -22,8 +22,8 @@ module LocalizedFancyTopicTitleMixin
   private
 
   def _topic
-    return topic if defined?(topic) && topic.class == Topic
     return object if object.class == Topic
+    return topic if defined?(topic) && topic.class == Topic
     object.topic if defined?(object.topic) && object.topic.class == Topic
   end
 end

--- a/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
+++ b/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module LocalizedFancyTopicTitleMixin
+  def self.included(klass)
+    klass.attributes :fancy_title
+  end
+
+  def fancy_title
+    f = _topic.fancy_title
+
+    if (ContentLocalization.show_translated_topic?(_topic, scope))
+      _topic.get_localization&.fancy_title.presence || f
+    else
+      f
+    end
+  end
+
+  def include_fancy_title?
+    _topic.present? && _topic&.fancy_title.present?
+  end
+
+  private
+
+  def _topic
+    return topic if defined?(topic) && topic.class == Topic
+    return object if object.class == Topic
+    object.topic if object.topic.class == Topic
+  end
+end

--- a/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
+++ b/app/serializers/concerns/localized_fancy_topic_title_mixin.rb
@@ -24,6 +24,6 @@ module LocalizedFancyTopicTitleMixin
   def _topic
     return topic if defined?(topic) && topic.class == Topic
     return object if object.class == Topic
-    object.topic if object.topic.class == Topic
+    object.topic if defined?(object.topic) && object.topic.class == Topic
   end
 end

--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class NotificationSerializer < ApplicationSerializer
+  include LocalizedFancyTopicTitleMixin
+
   attributes :id,
              :user_id,
              :external_id,
@@ -23,14 +25,6 @@ class NotificationSerializer < ApplicationSerializer
 
   def is_warning
     object.topic.present? && object.topic.subtype == TopicSubtype.moderator_warning
-  end
-
-  def include_fancy_title?
-    object.topic&.fancy_title
-  end
-
-  def fancy_title
-    object.topic.fancy_title
   end
 
   def include_is_warning?

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -5,6 +5,7 @@ class TopicViewSerializer < ApplicationSerializer
   include SuggestedTopicsMixin
   include TopicTagsMixin
   include ApplicationHelper
+  include LocalizedFancyTopicTitleMixin
 
   def self.attributes_from_topic(*list)
     [list].flatten.each do |attribute|
@@ -18,7 +19,6 @@ class TopicViewSerializer < ApplicationSerializer
   attributes_from_topic(
     :id,
     :title,
-    :fancy_title,
     :posts_count,
     :created_at,
     :views,
@@ -317,16 +317,6 @@ class TopicViewSerializer < ApplicationSerializer
 
   def include_visibility_reason_id?
     object.topic.visibility_reason_id.present?
-  end
-
-  def fancy_title
-    f = object.topic.fancy_title
-
-    if ContentLocalization.show_translated_topic?(object.topic, scope)
-      object.topic.get_localization&.fancy_title.presence || f
-    else
-      f
-    end
   end
 
   def has_localized_content

--- a/app/serializers/user_post_topic_bookmark_base_serializer.rb
+++ b/app/serializers/user_post_topic_bookmark_base_serializer.rb
@@ -5,6 +5,7 @@ require_relative "post_item_excerpt"
 class UserPostTopicBookmarkBaseSerializer < UserBookmarkBaseSerializer
   include TopicTagsMixin
   include PostItemExcerpt
+  include LocalizedFancyTopicTitleMixin
 
   attributes :topic_id,
              :linked_post_number,
@@ -24,10 +25,6 @@ class UserPostTopicBookmarkBaseSerializer < UserBookmarkBaseSerializer
 
   def title
     topic.title
-  end
-
-  def fancy_title
-    topic.fancy_title
   end
 
   def category_id

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3673,6 +3673,9 @@ describe Topic do
 
       expect(topic.in_user_locale?).to eq(true)
 
+      topic.update!(locale: "ja_JP")
+      expect(topic.in_user_locale?).to eq(true)
+
       topic.update!(locale: "es")
       expect(topic.in_user_locale?).to eq(false)
     end

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -441,6 +441,49 @@ RSpec.describe NotificationsController do
             end
           end
         end
+
+        context "when a notification topic has localizations" do
+          fab!(:jap_user) { Fabricate(:user, locale: "ja") }
+          fab!(:topic) { Fabricate(:topic, locale: "en") }
+          fab!(:topic_localization_es) do
+            Fabricate(:topic_localization, topic:, locale: "es", fancy_title: "Hola Mundo")
+          end
+          fab!(:topic_localization_ja) do
+            Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "こんにちは世界")
+          end
+          fab!(:notification) do
+            Fabricate(
+              :notification,
+              topic:,
+              user: jap_user,
+              notification_type: Notification.types[:liked],
+            )
+          end
+
+          it "displays the localized fancy title in the user's locale when content_localization_enabled enabled" do
+            SiteSetting.content_localization_enabled = true
+            SiteSetting.allow_user_locale = true
+            sign_in(jap_user)
+
+            get "/notifications.json"
+
+            expect(response.status).to eq(200)
+            notifications = response.parsed_body["notifications"]
+            expect(notifications.first["fancy_title"]).to eq(topic_localization_ja.fancy_title)
+          end
+
+          it "does not display the localized fancy title in the user's locale when content_localization_enabled disabled" do
+            SiteSetting.content_localization_enabled = false
+            SiteSetting.allow_user_locale = true
+            sign_in(jap_user)
+
+            get "/notifications.json"
+
+            expect(response.status).to eq(200)
+            notifications = response.parsed_body["notifications"]
+            expect(notifications.first["fancy_title"]).to eq(topic.fancy_title)
+          end
+        end
       end
 
       it "should succeed" do

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -443,19 +443,28 @@ RSpec.describe NotificationsController do
         end
 
         context "when a notification topic has localizations" do
-          fab!(:jap_user) { Fabricate(:user, locale: "ja") }
-          fab!(:topic) { Fabricate(:topic, locale: "en") }
+          fab!(:english_topic) { Fabricate(:topic, locale: "en") }
           fab!(:topic_localization_es) do
-            Fabricate(:topic_localization, topic:, locale: "es", fancy_title: "Hola Mundo")
+            Fabricate(
+              :topic_localization,
+              topic: english_topic,
+              locale: "es",
+              fancy_title: "Hola Mundo",
+            )
           end
           fab!(:topic_localization_ja) do
-            Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "こんにちは世界")
+            Fabricate(
+              :topic_localization,
+              topic: english_topic,
+              locale: "ja",
+              fancy_title: "こんにちは世界",
+            )
           end
           fab!(:notification) do
             Fabricate(
               :notification,
-              topic:,
-              user: jap_user,
+              topic: english_topic,
+              user:,
               notification_type: Notification.types[:liked],
             )
           end
@@ -463,7 +472,7 @@ RSpec.describe NotificationsController do
           it "displays the localized fancy title in the user's locale when content_localization_enabled enabled" do
             SiteSetting.content_localization_enabled = true
             SiteSetting.allow_user_locale = true
-            sign_in(jap_user)
+            user.update!(locale: "ja")
 
             get "/notifications.json"
 
@@ -475,13 +484,13 @@ RSpec.describe NotificationsController do
           it "does not display the localized fancy title in the user's locale when content_localization_enabled disabled" do
             SiteSetting.content_localization_enabled = false
             SiteSetting.allow_user_locale = true
-            sign_in(jap_user)
+            user.update!(locale: "ja")
 
             get "/notifications.json"
 
             expect(response.status).to eq(200)
             notifications = response.parsed_body["notifications"]
-            expect(notifications.first["fancy_title"]).to eq(topic.fancy_title)
+            expect(notifications.first["fancy_title"]).to eq(english_topic.fancy_title)
           end
         end
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7212,8 +7212,10 @@ RSpec.describe UsersController do
 
     after { DiscoursePluginRegistry.reset! }
 
-    let(:bookmark1) { Fabricate(:bookmark, user: user1, bookmarkable: Fabricate(:post)) }
-    let(:bookmark2) { Fabricate(:bookmark, user: user1, bookmarkable: Fabricate(:topic)) }
+    fab!(:topic)
+    fab!(:post)
+    let(:bookmark1) { Fabricate(:bookmark, user: user1, bookmarkable: post) }
+    let(:bookmark2) { Fabricate(:bookmark, user: user1, bookmarkable: topic) }
     let(:bookmark3) { Fabricate(:bookmark, user: user1, bookmarkable: Fabricate(:user)) }
     let(:bookmark4) { Fabricate(:bookmark) }
 
@@ -7313,6 +7315,45 @@ RSpec.describe UsersController do
       include_examples "invalid limit params",
                        "/u/someusername/bookmarks.json",
                        described_class::BOOKMARKS_LIMIT
+    end
+
+    describe "when a notification topic has localizations" do
+      fab!(:jap_user) { Fabricate(:user, locale: "ja") }
+      fab!(:topic_localization_es) do
+        Fabricate(:topic_localization, topic:, locale: "es", fancy_title: "Hola Mundo")
+      end
+      fab!(:topic_localization_ja) do
+        Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "こんにちは世界")
+      end
+
+      before do
+        topic.update(locale: "en")
+        user1.update(locale: "ja")
+      end
+
+      it "displays the localized fancy title in the user's locale when content_localization_enabled enabled" do
+        SiteSetting.content_localization_enabled = true
+        SiteSetting.allow_user_locale = true
+        sign_in(user1)
+
+        get "/u/#{user1.username}/bookmarks.json"
+        expect(response.status).to eq(200)
+        response_bookmarks = response.parsed_body["user_bookmark_list"]["bookmarks"]
+        expect(response_bookmarks.map { |b| b["fancy_title"] }).to include(
+          topic_localization_ja.fancy_title,
+        )
+      end
+
+      it "does not display the localized fancy title in the user's locale when content_localization_enabled disabled" do
+        SiteSetting.content_localization_enabled = false
+        SiteSetting.allow_user_locale = true
+        sign_in(user1)
+
+        get "/u/#{user1.username}/bookmarks.json"
+        expect(response.status).to eq(200)
+        response_bookmarks = response.parsed_body["user_bookmark_list"]["bookmarks"]
+        expect(response_bookmarks.map { |b| b["fancy_title"] }).to include(topic.fancy_title)
+      end
     end
   end
 


### PR DESCRIPTION
Localizes topic titles in these areas
- user notification
- bookmarks

This PR also updates the user notification bookmark list to use fancy title instead of title, similar to the other user notification tabs.

<img width="507" height="197" alt="Screenshot 2025-08-04 at 5 26 42 PM" src="https://github.com/user-attachments/assets/9f272014-15ff-47e6-b764-76b021a5abf4" />
<img width="390" height="294" alt="Screenshot 2025-08-04 at 5 39 06 PM" src="https://github.com/user-attachments/assets/8155d8c3-7af6-41e8-bf7e-c95997cfae18" />
<img width="842" height="505" alt="Screenshot 2025-08-04 at 5 40 20 PM" src="https://github.com/user-attachments/assets/6c79f2e0-fb3f-49e3-abb9-6f7ab393de14" />
