### PR TITLE
DEV: Enable local-storage for smoke test

### DIFF
--- a/test/smoke-test.mjs
+++ b/test/smoke-test.mjs
@@ -20,9 +20,15 @@ import puppeteer from "puppeteer-core";
     executablePath: Launcher.getInstallations()[0],
     // when debugging locally setting the SHOW_BROWSER env variable can be very helpful
     headless: process.env.SHOW_BROWSER === undefined,
-    args: ["--disable-local-storage", "--no-sandbox"],
+    args: ["--no-sandbox"],
   });
   const page = await browser.newPage();
+  page.on("console", (msg) => {
+    if (["error", "warning"].includes(msg.type())) {
+      console.log(`PAGE ${msg.type().toUpperCase()}: ${msg.text()}`);
+    }
+  });
+  page.on("pageerror", (err) => console.log(`PAGE ERROR: ${err.message}`));
 
   await page.setViewport({
     width: 1366,


### PR DESCRIPTION
The localStorage API has been a web standard for a very long time. It's safe to assume it'll be available in all users browsers, so it makes sense for the smoke test to match.

Also adds console logs to the smoke-test output, to make debugging failures easier.