### PR TITLE
UX: make tables in blockquotes fixed to prevent overflow

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1130,6 +1130,10 @@ blockquote .post__contents-cooked-quote {
   > *:last-child {
     margin-bottom: 0 !important;
   }
+
+  table {
+    table-layout: fixed; // prevents table from expanding past the post body width
+  }
 }
 
 .gap {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1133,6 +1133,7 @@ blockquote .post__contents-cooked-quote {
 
   table {
     table-layout: fixed; // prevents table from expanding past the post body width
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Fix for meta report
https://meta.discourse.org/t/a-table-renders-outside-the-boundaries-of-the-post-comment/375689

Broken overflow gets replaced by horizontal scrolling within the table cells. Not ideal either, but better than before and not much alternatives afaik.

| Normal (before) | With fixed layout (after) |
|--------|--------|
| <img width="754" height="769" alt="CleanShot 2025-08-04 at 11 49 29" src="https://github.com/user-attachments/assets/68d040d6-2e0c-45a8-90da-0879d142f1ba" /> | <img width="789" height="751" alt="CleanShot 2025-08-04 at 11 56 09" src="https://github.com/user-attachments/assets/d1e2439b-0a5c-46ce-a282-e205e687f5a1" /> | 