### PR TITLE
FIX: Don't force user-selectable on Horizon's default color palettes

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -113,6 +113,7 @@ class RemoteTheme < ActiveRecord::Base
         )
       existing = false
     end
+    theme.has_just_been_created = !existing
 
     theme.component = theme_info["component"].to_s == "true"
     theme.child_components = child_components = theme_info["components"].presence || []

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -30,6 +30,7 @@ class Theme < ActiveRecord::Base
 
   attr_accessor :child_components
   attr_accessor :skip_child_components_update
+  attr_accessor :has_just_been_created
 
   def self.cache
     @cache ||= DistributedCache.new("theme:compiler:#{BASE_COMPILER_VERSION}")

--- a/lib/system_themes_manager.rb
+++ b/lib/system_themes_manager.rb
@@ -12,20 +12,22 @@ class SystemThemesManager
     theme_dir = "#{Rails.root}/themes/#{theme_name}"
 
     remote_theme = RemoteTheme.import_theme_from_directory(theme_dir, theme_id: theme_id)
-    if remote_theme.color_scheme
-      remote_theme.color_scheme.update!(user_selectable: true)
-      alternative_theme_name =
-        if remote_theme.color_scheme.name =~ / Dark$/
-          remote_theme.color_scheme.name.sub(" Dark", "")
-        else
-          "#{remote_theme.color_scheme.name} Dark"
-        end
+    if remote_theme.has_just_been_created
+      if remote_theme.color_scheme
+        remote_theme.color_scheme.update!(user_selectable: true)
+        alternative_scheme_name =
+          if remote_theme.color_scheme.name =~ / Dark$/
+            remote_theme.color_scheme.name.sub(" Dark", "")
+          else
+            "#{remote_theme.color_scheme.name} Dark"
+          end
 
-      alternative_color_scheme =
-        remote_theme.color_schemes.where(name: alternative_theme_name).first
-      alternative_color_scheme&.update!(user_selectable: true)
-      if remote_theme.dark_color_scheme.blank? && alternative_color_scheme
-        remote_theme.update!(dark_color_scheme: alternative_color_scheme)
+        alternative_color_scheme =
+          remote_theme.color_schemes.where(name: alternative_scheme_name).first
+        alternative_color_scheme&.update!(user_selectable: true)
+        if remote_theme.dark_color_scheme.blank? && alternative_color_scheme
+          remote_theme.update!(dark_color_scheme: alternative_color_scheme)
+        end
       end
     end
     remote_theme.update_column(:enabled, true)

--- a/spec/lib/system_themes_manager_spec.rb
+++ b/spec/lib/system_themes_manager_spec.rb
@@ -19,4 +19,21 @@ RSpec.describe SystemThemesManager do
     SystemThemesManager.sync!
     expect(Theme.horizon_theme.reload.enabled).to be true
   end
+
+  it "marks Horizon's default color palettes as user selectable only the first time the theme is installed" do
+    Theme.delete_all
+
+    expect { SystemThemesManager.sync! }.to change { Theme.system.count }.by(2)
+
+    expect(Theme.horizon_theme.color_scheme.user_selectable).to eq(true)
+    expect(Theme.horizon_theme.dark_color_scheme.user_selectable).to eq(true)
+
+    Theme.horizon_theme.color_scheme.update!(user_selectable: false)
+    Theme.horizon_theme.dark_color_scheme.update!(user_selectable: false)
+
+    expect { SystemThemesManager.sync! }.not_to change { Theme.system.count }
+
+    expect(Theme.horizon_theme.color_scheme.reload.user_selectable).to eq(false)
+    expect(Theme.horizon_theme.dark_color_scheme.reload.user_selectable).to eq(false)
+  end
 end


### PR DESCRIPTION
We currently have logic that ensures Horizon's default palettes are marked as user-selectable each time the server boots up (i.e. on deploy), even if an admin has previously chosen to remove the user-selectable status on those palettes. We should respect the admin's choice, so this PR amends that logic so it only marks the palettes user-selectable when Horizon is first installed.

Internal topic: t/160291.