### PR TITLE
FIX: Allow admins to delete invites created by others

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
@@ -77,9 +77,13 @@ export default class UserInvitedShowController extends Controller {
   }
 
   @action
-  destroyInvite(invite) {
-    invite.destroy();
-    this.model.invites.removeObject(invite);
+  async destroyInvite(invite) {
+    try {
+      await invite.destroy();
+      this.model.invites.removeObject(invite);
+    } catch (error) {
+      popupAjaxError(error);
+    }
   }
 
   @action

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -319,8 +319,10 @@ class InvitesController < ApplicationController
   def destroy
     params.require(:id)
 
-    invite = Invite.find_by(invited_by_id: current_user.id, id: params[:id])
+    invite = Invite.find_by(id: params[:id])
     raise Discourse::InvalidParameters.new(:id) if invite.blank?
+
+    guardian.ensure_can_destroy_invite!(invite)
 
     invite.trash!(current_user)
 

--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -33,7 +33,7 @@ class InviteSerializer < ApplicationSerializer
   end
 
   def can_delete_invite
-    scope.is_admin? || object.invited_by_id == scope.current_user.id
+    scope.can_destroy_invite?(object)
   end
 
   def include_custom_message?

--- a/lib/guardian/invite_guardian.rb
+++ b/lib/guardian/invite_guardian.rb
@@ -57,4 +57,8 @@ module InviteGuardian
   def can_destroy_all_invites?
     is_staff?
   end
+
+  def can_destroy_invite?(invite)
+    invite && (is_admin? || is_me?(invite.invited_by))
+  end
 end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -913,7 +913,22 @@ RSpec.describe InvitesController do
         another_invite = Fabricate(:invite, email: "test2@example.com")
 
         delete "/invites.json", params: { id: another_invite.id }
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(403)
+        expect(invite.reload.trashed?).to be_falsey
+        expect(another_invite.reload.trashed?).to be_falsey
+      end
+
+      it "allows an admin to delete any invite" do
+        user.update!(admin: true)
+        another_invite = Fabricate(:invite, email: "test2@example.com")
+
+        delete "/invites.json", params: { id: another_invite.id }
+        expect(response.status).to eq(200)
+        expect(another_invite.reload.trashed?).to be_truthy
+
+        delete "/invites.json", params: { id: invite.id }
+        expect(response.status).to eq(200)
+        expect(invite.reload.trashed?).to be_truthy
       end
 
       it "destroys the invite" do


### PR DESCRIPTION
Admins can view the list of invites created by other users and they can see the delete button, but it currently doesn't actually delete anything due to a bug in the `invites#destroy` controller action where it looks up the invite record by the given id and expects it to be created by the current user, but when an invite is being deleted by an admin, this logic fails because the invite isn't created by the admin.

This PR fixes the issue by removing this check for current user and adding a proper guardian check that validates the action is performed by either the user who created the invite or an admin.

Internal topic: t/158288.