### PR TITLE
UX: add spacing to discourse tag box-style

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -127,6 +127,10 @@
   display: inline-flex;
   flex-wrap: wrap;
 
+  &:has(.box) {
+    gap: var(--space-1);
+  }
+
   &__tag-separator {
     margin-right: 0.25em;
     color: var(--tag-text-color);


### PR DESCRIPTION
Meta report https://meta.discourse.org/t/very-minor-tag-issue/375029

| Before | After |
|--------|--------|
| <img width="938" height="248" alt="CleanShot 2025-08-04 at 13 28 06@2x" src="https://github.com/user-attachments/assets/db816c75-dc49-4a73-b161-7475a8ccca6c" /> | <img width="938" height="248" alt="CleanShot 2025-08-04 at 13 27 50@2x" src="https://github.com/user-attachments/assets/78468f6c-fa04-4d0f-a60f-a9d332e0a7f5" /> | 