### PR TITLE
UX: Make AI streaming more efficient under glimmer post stream

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-streamer/progress-handlers.js
@@ -111,7 +111,7 @@ export async function applyProgress(status, updater) {
 
   if (status.done) {
     if (status.cooked) {
-      await updater.setCooked(status.cooked);
+      await updater.setCooked(status.cooked, true);
     }
     updater.streaming = false;
   }


### PR DESCRIPTION
In the glimmer post stream, mutating `post.cooked` will cause ember to re-render the HTML. That conflicts with d-ai's own morphlex-based diff streaming.

To avoid this, we can wait until all streaming has finished before setting the cooked property of the model.

Co-authored-by: Sérgio Saquetim <saquetim@discourse.org>