### PR TITLE
UX: fix quote control position in non-glimmer post stream

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -706,6 +706,7 @@ aside.quote {
   display: flex;
   align-items: center;
   margin-left: auto;
+  order: 2; // for non-glimmer post stream
 
   a {
     margin-left: 0.3em;


### PR DESCRIPTION
The element ordering is different in the non-glimmer post stream, so this will fix it (and won't change anything in the glimmer version)

Before:
<img width="1150" height="330" alt="image" src="https://github.com/user-attachments/assets/926826fe-7671-45da-b985-176cfe5c2cf5" />


After: 
<img width="1164" height="302" alt="image" src="https://github.com/user-attachments/assets/4fa966f4-9a34-4dc4-8b54-d370273a6064" />
