### PR TITLE
UX: remove btn-default class from light-dark toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/interface-color-selector.gjs
+++ b/app/assets/javascripts/discourse/app/components/interface-color-selector.gjs
@@ -51,7 +51,7 @@ export default class InterfaceColorSelector extends Component {
         <DropdownMenu as |dropdown|>
           <dropdown.item>
             <DButton
-              class="btn-default interface-color-selector__light-option"
+              class="interface-color-selector__light-option"
               @icon="sun"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.light"
@@ -61,7 +61,7 @@ export default class InterfaceColorSelector extends Component {
           </dropdown.item>
           <dropdown.item>
             <DButton
-              class="btn-default interface-color-selector__dark-option"
+              class="interface-color-selector__dark-option"
               @icon="moon"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.dark"
@@ -71,7 +71,7 @@ export default class InterfaceColorSelector extends Component {
           </dropdown.item>
           <dropdown.item>
             <DButton
-              class="btn-default interface-color-selector__auto-option"
+              class="interface-color-selector__auto-option"
               @icon="circle-half-stroke"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.auto"


### PR DESCRIPTION
The dropdown has `btn-default` classes applied, while they aren't button defaults and thus it's causing styling issues.

Example mint theme:
* missing icons
* awkward border 

| Before | After |
|--------|--------|
| <img width="253" height="210" alt="CleanShot 2025-08-04 at 17 54 28" src="https://github.com/user-attachments/assets/073b459a-e6f1-41ae-8065-77c81e6c70df" /> | <img width="253" height="210" alt="CleanShot 2025-08-04 at 17 55 06" src="https://github.com/user-attachments/assets/c36931a8-39e9-49c4-86aa-726a463be78c" />  | 