### PR TITLE
UX: fix category badges on 404 page and oneboxes

### DIFF
--- a/lib/category_badge.rb
+++ b/lib/category_badge.rb
@@ -41,7 +41,16 @@ module CategoryBadge
   def self.style_for_browser(category, opts)
     data = shared_data(category, opts)
 
-    class_names = "badge-category #{data[:parent_category] ? "--has-parent" : ""}"
+    style_class =
+      case category.respond_to?(:style_type) && category.style_type
+      when "icon"
+        "--style-icon"
+      when "emoji"
+        "--style-emoji"
+      else
+        "--style-square"
+      end
+    class_names = "badge-category #{style_class} #{data[:parent_category] ? "--has-parent" : ""}"
     description = category.description_text ? "title='#{category.description_text}'" : ""
 
     badge_styles = {
@@ -57,6 +66,13 @@ module CategoryBadge
     result << " style='#{map_styles_to_string(badge_styles)}'"
     result << " data-parent-category-id='#{data[:parent_category].id}'" if data[:parent_category]
     result << " data-drop-close='true' class='#{class_names}' #{description}>"
+
+    if category.style_type == "icon" && category.icon.present?
+      result << SvgSprite.raw_svg(category.icon)
+    elsif category.style_type == "emoji" && category.emoji.present?
+      result << Emoji.codes_to_img(":#{category.emoji}:")
+    end
+
     result << "<span class='badge-category__name'>"
     result << ERB::Util.html_escape(category.name)
     result << "</span></span>"

--- a/lib/category_badge.rb
+++ b/lib/category_badge.rb
@@ -42,14 +42,14 @@ module CategoryBadge
     data = shared_data(category, opts)
 
     style_class =
-      case category.respond_to?(:style_type) && category.style_type
-      when "icon"
-        "--style-icon"
-      when "emoji"
-        "--style-emoji"
-      else
-        "--style-square"
-      end
+      if category.respond_to?(:style_type) && category.style_type.present?
+        case category.style_type
+        when "icon"
+          "--style-icon"
+        when "emoji"
+          "--style-emoji"
+        end
+      end || "--style-square"
     class_names = "badge-category #{style_class} #{data[:parent_category] ? "--has-parent" : ""}"
     description = category.description_text ? "title='#{category.description_text}'" : ""
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -459,12 +459,10 @@ RSpec.describe ApplicationController do
         it "should render category badges with correct style classes on 404 page" do
           Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
 
-          # Create categories with different style types
           square_cat = Fabricate(:category, style_type: :square)
           icon_cat = Fabricate(:category, style_type: :icon, icon: "user")
           emoji_cat = Fabricate(:category, style_type: :emoji, emoji: "smile")
 
-          # Create topics in each category
           Fabricate(:topic, title: "Square Category Topic", category: square_cat)
           Fabricate(:topic, title: "Icon Category Topic", category: icon_cat)
           Fabricate(:topic, title: "Emoji Category Topic", category: emoji_cat)
@@ -472,14 +470,12 @@ RSpec.describe ApplicationController do
           get "/t/nope-nope/99999999"
           expect(response.status).to eq(404)
 
-          # Check that category badges have the correct style classes
           expect(response.body).to include("badge-category --style-square")
           expect(response.body).to include("badge-category --style-icon")
           expect(response.body).to include("badge-category --style-emoji")
 
-          # Check that icon and emoji content are rendered
-          expect(response.body).to include('<svg id="user"') # SVG icon
-          expect(response.body).to include('class="emoji"') # Emoji image
+          expect(response.body).to include('<svg id="user"')
+          expect(response.body).to include('class="emoji"')
         end
       end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -455,6 +455,32 @@ RSpec.describe ApplicationController do
           expect(fake_logger.errors.length).to eq(0)
           expect(fake_logger.warnings.length).to eq(0)
         end
+
+        it "should render category badges with correct style classes on 404 page" do
+          Discourse.cache.delete("page_not_found_topics:#{I18n.locale}")
+
+          # Create categories with different style types
+          square_cat = Fabricate(:category, style_type: :square)
+          icon_cat = Fabricate(:category, style_type: :icon, icon: "user")
+          emoji_cat = Fabricate(:category, style_type: :emoji, emoji: "smile")
+
+          # Create topics in each category
+          Fabricate(:topic, title: "Square Category Topic", category: square_cat)
+          Fabricate(:topic, title: "Icon Category Topic", category: icon_cat)
+          Fabricate(:topic, title: "Emoji Category Topic", category: emoji_cat)
+
+          get "/t/nope-nope/99999999"
+          expect(response.status).to eq(404)
+
+          # Check that category badges have the correct style classes
+          expect(response.body).to include("badge-category --style-square")
+          expect(response.body).to include("badge-category --style-icon")
+          expect(response.body).to include("badge-category --style-emoji")
+
+          # Check that icon and emoji content are rendered
+          expect(response.body).to include('<svg id="user"') # SVG icon
+          expect(response.body).to include('class="emoji"') # Emoji image
+        end
       end
 
       it "should cache results" do


### PR DESCRIPTION
Looks like the new styles weren't implemented here, this does it


Before:
<img width="1526" height="504" alt="image" src="https://github.com/user-attachments/assets/bd00570b-c64c-4a96-a156-f2d64793e4ee" />



After: 
<img width="1416" height="526" alt="image" src="https://github.com/user-attachments/assets/31d75336-c704-40bd-a422-6a553ece62f8" />

<img width="1490" height="754" alt="image" src="https://github.com/user-attachments/assets/22848386-c359-445d-b581-3417f29bde96" />

<img width="1446" height="532" alt="image" src="https://github.com/user-attachments/assets/132b904a-1ef8-4357-be98-5ded856a8edf" />
