### PR TITLE
DEV: add text area option to custom user fields

### DIFF
--- a/app/assets/javascripts/admin/addon/models/user-field.js
+++ b/app/assets/javascripts/admin/addon/models/user-field.js
@@ -8,6 +8,7 @@ export default class UserField extends RestModel {
     if (!this._fieldTypes) {
       this._fieldTypes = [
         UserFieldType.create({ id: "text" }),
+        UserFieldType.create({ id: "textarea" }),
         UserFieldType.create({ id: "confirm" }),
         UserFieldType.create({ id: "dropdown", hasOptions: true }),
         UserFieldType.create({ id: "multiselect", hasOptions: true }),

--- a/app/assets/javascripts/discourse/app/components/user-field.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-field.gjs
@@ -5,6 +5,7 @@ import UserFieldConfirm from "./user-fields/confirm";
 import UserFieldDropdown from "./user-fields/dropdown";
 import UserFieldMultiselect from "./user-fields/multiselect";
 import UserFieldText from "./user-fields/text";
+import UserFieldTextArea from "./user-fields/textarea";
 
 export default class UserField extends Component {
   get components() {
@@ -13,6 +14,7 @@ export default class UserField extends Component {
       dropdown: UserFieldDropdown,
       multiselect: UserFieldMultiselect,
       text: UserFieldText,
+      textarea: UserFieldTextArea,
     });
   }
 

--- a/app/assets/javascripts/discourse/app/components/user-fields/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/textarea.gjs
@@ -8,6 +8,12 @@ import UserFieldBase from "./base";
 export default class UserFieldTextArea extends UserFieldBase {
   <template>
     <div class="controls">
+      <Textarea
+        id={{concat "user-" this.elementId}}
+        @value={{this.value}}
+        class="form-template-field__textarea"
+        maxlength={{this.site.user_field_max_length}}
+      />
       <label
         class="control-label alt-placeholder"
         for={{concat "user-" this.elementId}}
@@ -16,12 +22,6 @@ export default class UserFieldTextArea extends UserFieldBase {
         {{~#unless this.field.required}}
           {{i18n "user_fields.optional"}}{{/unless~}}
       </label>
-      <Textarea
-        id={{concat "user-" this.elementId}}
-        @value={{this.value}}
-        class="form-template-field__textarea"
-        maxlength={{this.site.user_field_max_length}}
-      />
       {{#if this.validation.failed}}
         <InputTip @validation={{this.validation}} />
       {{else}}

--- a/app/assets/javascripts/discourse/app/components/user-fields/textarea.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-fields/textarea.gjs
@@ -1,0 +1,32 @@
+import { Textarea } from "@ember/component";
+import { concat } from "@ember/helper";
+import { htmlSafe } from "@ember/template";
+import InputTip from "discourse/components/input-tip";
+import { i18n } from "discourse-i18n";
+import UserFieldBase from "./base";
+
+export default class UserFieldTextArea extends UserFieldBase {
+  <template>
+    <div class="controls">
+      <label
+        class="control-label alt-placeholder"
+        for={{concat "user-" this.elementId}}
+      >
+        {{this.field.name}}
+        {{~#unless this.field.required}}
+          {{i18n "user_fields.optional"}}{{/unless~}}
+      </label>
+      <Textarea
+        id={{concat "user-" this.elementId}}
+        @value={{this.value}}
+        class="form-template-field__textarea"
+        maxlength={{this.site.user_field_max_length}}
+      />
+      {{#if this.validation.failed}}
+        <InputTip @validation={{this.validation}} />
+      {{else}}
+        <div class="instructions">{{htmlSafe this.field.description}}</div>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -112,11 +112,17 @@ body.signup-page {
     margin-bottom: 1em;
 
     input,
-    .select-kit-header {
+    .select-kit-header,
+    textarea {
       padding: 0.75em 0.77em;
       min-width: 250px;
       margin-bottom: 0.25em;
       width: 100%;
+    }
+
+    textarea {
+      border: var(--d-input-border);
+      border-radius: var(--d-input-border-radius);
     }
 
     input:not(.filter-input):focus {
@@ -340,9 +346,11 @@ body.signup-page {
 
   .user-fields .input-group {
     .user-field {
-      &.text {
+      &.text,
+      &.textarea {
         &.value-entered label.alt-placeholder.control-label,
-        input:focus + label.alt-placeholder.control-label {
+        input:focus + label.alt-placeholder.control-label,
+        textarea:focus + label.alt-placeholder.control-label {
           top: -8px;
           left: calc(1em - 0.25em);
           background-color: var(--secondary);

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -1182,25 +1182,29 @@
 }
 
 // Due to special login animations, the order here needs to be changed
-.control-group[data-setting-name="user-user-fields"]
-  .user-field.text
-  .controls {
-  display: flex;
-  flex-direction: column;
+.control-group[data-setting-name="user-user-fields"] {
+  .user-field.text,
+  .user-field.textarea {
+    .controls {
+      display: flex;
+      flex-direction: column;
 
-  .control-label.alt-placeholder {
-    order: 1;
-  }
+      .control-label.alt-placeholder {
+        order: 1;
+      }
 
-  .ember-text-field {
-    order: 2;
-  }
+      .ember-text-field,
+      .ember-text-area {
+        order: 2;
+      }
 
-  .tip {
-    order: 3;
-  }
+      .tip {
+        order: 3;
+      }
 
-  .instructions {
-    order: 4;
+      .instructions {
+        order: 4;
+      }
+    }
   }
 }

--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -25,7 +25,7 @@ class UserField < ActiveRecord::Base
   scope :required, -> { not_optional }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
-  enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3 }.freeze
+  enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3, textarea: 4 }.freeze
   alias_attribute :field_type, :field_type_enum
 
   def self.max_length

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8044,6 +8044,7 @@ en:
 
         field_types:
           text: "Text"
+          textarea: "Textarea"
           confirm: "Confirmation"
           dropdown: "Dropdown"
           multiselect: "Multiselect"

--- a/spec/requests/admin/user_fields_controller_spec.rb
+++ b/spec/requests/admin/user_fields_controller_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Admin::UserFieldsController do
         }.to change(UserField, :count).by(1)
       end
 
+      it "creates a user text field" do
+        expect {
+          post "/admin/config/user_fields.json",
+               params: {
+                 user_field: {
+                   name: "hello",
+                   description: "hello desc",
+                   field_type: "textarea",
+                   requirement: "on_signup",
+                 },
+               }
+
+          expect(response.status).to eq(200)
+        }.to change(UserField, :count).by(1)
+      end
+
       it "creates a user field with options" do
         expect do
           post "/admin/config/user_fields.json",


### PR DESCRIPTION
Meta feature request https://meta.discourse.org/t/is-it-possible-to-have-a-multi-line-longer-text-field-in-the-signup-form/257642/7

This commit adds the option to use a textarea as a custom field:
<img width="1430" height="1520" alt="CleanShot 2025-08-04 at 19 06 45@2x" src="https://github.com/user-attachments/assets/f827a473-1493-479a-903f-cc2b719e5e87" />

### Shown on profile:
<img width="690" height="433" alt="image" src="https://github.com/user-attachments/assets/c9f386a3-0ca9-4402-9f4e-c3564f347a1c" />

### Shown on usercard (not particularly recommended):
<img width="1300" height="670" alt="CleanShot 2025-08-04 at 19 07 22@2x" src="https://github.com/user-attachments/assets/a9b981cb-afd2-4402-a350-553604b5d070" />

### Shown on signup screen
<img width="976" height="1404" alt="CleanShot 2025-08-04 at 19 41 17@2x" src="https://github.com/user-attachments/assets/548b0bd5-fc6f-4300-94a5-ff1d945a1f43" />


