### PR TITLE
DEV: Add `...attributes` in edits indicator

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/edits-indicator.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/edits-indicator.gjs
@@ -49,6 +49,7 @@ export default class PostMetaDataEditsIndicator extends Component {
   <template>
     <div class="post-info edits">
       <DButton
+        ...attributes
         class={{concatClass
           "btn-flat"
           (historyHeat this.siteSettings this.updatedAt)


### PR DESCRIPTION
While updating the usage of [widget:post-edits-indicator](https://github.com/discourse/discourse/blob/c671cfff84fdd54468b03b29907feb7f11af6645/app/assets/javascripts/discourse/app/widgets/post-edits-indicator.js#L7), in a plugin, I got the need to pass down `...attributes` to the `DButton`.

This allows for more flexible and dynamic usage of the component in different contexts.