### PR TITLE
DEV: Add value transformer for post edits indicator labels

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/meta-data/edits-indicator.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/meta-data/edits-indicator.gjs
@@ -4,6 +4,7 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
 import { longDate } from "discourse/lib/formatter";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 
 export default class PostMetaDataEditsIndicator extends Component {
@@ -14,9 +15,11 @@ export default class PostMetaDataEditsIndicator extends Component {
   }
 
   get label() {
-    if (this.args.post.version > 1) {
-      return this.args.post.version - 1;
-    }
+    return applyValueTransformer(
+      "post-meta-data-edits-indicator-label",
+      this.args.post.version > 1 ? this.args.post.version - 1 : null,
+      { post: this.args.post }
+    );
   }
 
   get title() {

--- a/app/assets/javascripts/discourse/app/lib/transformer/registry.js
+++ b/app/assets/javascripts/discourse/app/lib/transformer/registry.js
@@ -53,6 +53,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "post-flag-title",
   "post-menu-buttons",
   "post-menu-collapsed",
+  "post-meta-data-edits-indicator-label",
   "post-meta-data-infos",
   "post-meta-data-poster-name-suppress-similar-name",
   "post-notice-component",

--- a/app/assets/javascripts/discourse/tests/integration/components/post/meta-data/edits-indicator-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/meta-data/edits-indicator-test.gjs
@@ -1,0 +1,73 @@
+import { getOwner } from "@ember/owner";
+import { render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import PostMetaDataEditsIndicator from "discourse/components/post/meta-data/edits-indicator";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+function renderComponent(post) {
+  return render(
+    <template><PostMetaDataEditsIndicator @post={{post}} /></template>
+  );
+}
+
+module(
+  "Integration | Component | Post | PostMetaDataEditsIndicator",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.glimmer_post_stream_mode = "enabled";
+
+      this.store = getOwner(this).lookup("service:store");
+      const topic = this.store.createRecord("topic", { id: 1 });
+      const post = this.store.createRecord("post", {
+        id: 123,
+        post_number: 1,
+        topic,
+        like_count: 3,
+        actions_summary: [{ id: 2, count: 1, hidden: false, can_act: true }],
+      });
+
+      this.post = post;
+    });
+
+    test("basic rendering", async function (assert) {
+      this.post.username = "eviltrout";
+      this.post.name = "Robin Ward";
+      this.post.user_title = "Trout Master";
+
+      await renderComponent(this.post);
+
+      assert.dom(".post-info.edits button").exists().hasText(/\s+/);
+
+      this.post.version = 2;
+      await settled();
+
+      assert.dom(".post-info.edits button").exists().hasText("1");
+    });
+
+    test("customize labels using the post-meta-data-edits-indicator-label transformer", async function (assert) {
+      withPluginApi((api) => {
+        api.registerValueTransformer(
+          "post-meta-data-edits-indicator-label",
+          ({ value }) => {
+            if (value) {
+              return "(edited)";
+            } else {
+              return "(original)";
+            }
+          }
+        );
+      });
+
+      await renderComponent(this.post);
+      assert.dom(".post-info.edits button").hasText("(original)");
+
+      this.post.version = 2;
+      await settled();
+
+      assert.dom(".post-info.edits button").hasText("(edited)");
+    });
+  }
+);


### PR DESCRIPTION
Introduced the `post-meta-data-edits-indicator-label` transformer to enable customization of post edits indicator labels. Added integration tests to validate customization and default behavior.