### PR TITLE
FIX: update fallback style for category-link helper

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -50,12 +50,12 @@ export function categoryBadgeHTML(category, opts) {
   }
 
   if (!opts.styleType) {
-    opts.styleType = category.styleType;
+    opts.styleType = category.style_type;
 
     if (opts.styleType === "icon") {
-      opts.icon = category.icon;
+      opts.icon = opts.icon || category.icon;
     } else if (opts.styleType === "emoji") {
-      opts.emoji = category.emoji;
+      opts.emoji = opts.emoji || category.emoji;
     }
   }
 

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -50,7 +50,7 @@ export function categoryBadgeHTML(category, opts) {
   }
 
   if (!opts.styleType) {
-    opts.styleType = category.style_type;
+    opts.styleType = category.style_type || "square";
 
     if (opts.styleType === "icon") {
       opts.icon = opts.icon || category.icon;

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -111,6 +111,15 @@ export function categoryLinkHTML(category, options) {
     if (options.ancestors) {
       categoryOptions.ancestors = options.ancestors;
     }
+    if (options.styleType) {
+      categoryOptions.styleType = options.styleType;
+    }
+    if (options.icon) {
+      categoryOptions.icon = options.icon;
+    }
+    if (options.emoji) {
+      categoryOptions.emoji = options.emoji;
+    }
   }
   return htmlSafe(categoryBadgeHTML(category, categoryOptions));
 }

--- a/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
@@ -26,11 +26,7 @@ module("Integration | Helper | category-link", function (hooks) {
   test("styleType option", async function (assert) {
     await render(
       <template>
-        {{categoryLink 
-          (hash name="test-cat")
-          styleType="icon" 
-          icon="user"
-        }}
+        {{categoryLink (hash name="test-cat") styleType="icon" icon="user"}}
       </template>
     );
 

--- a/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
@@ -26,9 +26,9 @@ module("Integration | Helper | category-link", function (hooks) {
   test("styleType option", async function (assert) {
     await render(
       <template>
-        {{categoryLink
-          (hash name="test-cat" style_type="square")
-          styleType="icon"
+        {{categoryLink 
+          (hash name="test-cat")
+          styleType="icon" 
           icon="user"
         }}
       </template>

--- a/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/category-link-test.gjs
@@ -22,4 +22,38 @@ module("Integration | Helper | category-link", function (hooks) {
 
     assert.dom(".badge-category").hasAttribute("title", "bar");
   });
+
+  test("styleType option", async function (assert) {
+    await render(
+      <template>
+        {{categoryLink
+          (hash name="test-cat" style_type="square")
+          styleType="icon"
+          icon="user"
+        }}
+      </template>
+    );
+
+    assert.dom(".badge-category").hasClass("--style-icon");
+    assert.dom(".d-icon-user").exists();
+  });
+
+  test("category.style_type auto-detection", async function (assert) {
+    await render(
+      <template>
+        {{categoryLink (hash name="icon-cat" style_type="icon" icon="user")}}
+      </template>
+    );
+
+    assert.dom(".badge-category").hasClass("--style-icon");
+    assert.dom(".d-icon-user").exists();
+  });
+
+  test("style falls back to square", async function (assert) {
+    await render(
+      <template>{{categoryLink (hash name="square-cat")}}</template>
+    );
+
+    assert.dom(".badge-category").hasClass("--style-square");
+  });
 });


### PR DESCRIPTION
The category-link helper isn't working in some cases, like the user summary: 

Before:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/5f89f71b-a298-4406-b21b-8b0742b24e02" />


After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/25871813-ca22-4c89-86c3-45baee7b95a1" />


It looks like we were using `category.styleType` instead of `category.style_type` — I've also added a fallback (to square) if for some reason `style_type` isn't defined and added some tests