### PR TITLE
UX: Category header restyle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-logo.gjs
+++ b/app/assets/javascripts/discourse/app/components/category-logo.gjs
@@ -1,7 +1,7 @@
 import LightDarkImg from "discourse/components/light-dark-img";
 
 const CategoryLogo = <template>
-  <div class="category-logo aspect-image">
+  <div class="category-logo aspect-image" ...attributes>
     <LightDarkImg
       @lightImg={{@category.uploaded_logo}}
       @darkImg={{@category.uploaded_logo_dark}}

--- a/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
@@ -71,6 +71,13 @@ export default class DiscoveryNavigation extends Component {
     this.modal.show(ReorderCategories);
   }
 
+  get headingClasses() {
+    return concatClass(
+      "category-heading",
+      this.args.category?.uploaded_logo?.url ? "--has-logo" : null
+    );
+  }
+
   <template>
     <AddCategoryTagClasses
       @category={{@category}}
@@ -90,7 +97,7 @@ export default class DiscoveryNavigation extends Component {
         @outletArgs={{lazyHash category=@category tag=@tag}}
       />
 
-      <section class="category-heading">
+      <section class={{this.headingClasses}}>
         {{#if @category.uploaded_logo.url}}
           <CategoryLogo
             @category={{@category}}

--- a/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
@@ -91,9 +91,15 @@ export default class DiscoveryNavigation extends Component {
 
       <section class="category-heading">
         {{#if @category.uploaded_logo.url}}
-          <CategoryLogo @category={{@category}} />
+          <CategoryLogo
+            @category={{@category}}
+            class="category-heading__logo"
+          />
           {{#if @category.description}}
-            <p>{{dirSpan @category.description htmlSafe="true"}}</p>
+            <p class="category-heading__description">{{dirSpan
+                @category.description
+                htmlSafe="true"
+              }}</p>
           {{/if}}
         {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/navigation.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { array } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import AddCategoryTagClasses from "discourse/components/add-category-tag-classes";
 import CategoryLogo from "discourse/components/category-logo";
 import DNavigation from "discourse/components/d-navigation";
@@ -9,8 +10,8 @@ import AccessibleDiscoveryHeading from "discourse/components/discovery/accessibl
 import ReorderCategories from "discourse/components/modal/reorder-categories";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import bodyClass from "discourse/helpers/body-class";
+import categoryBadge from "discourse/helpers/category-badge";
 import concatClass from "discourse/helpers/concat-class";
-import dirSpan from "discourse/helpers/dir-span";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { calculateFilterMode } from "discourse/lib/filter-mode";
 import { TRACKED_QUERY_PARAM_VALUE } from "discourse/lib/topic-list-tracked-filter";
@@ -96,20 +97,21 @@ export default class DiscoveryNavigation extends Component {
             class="category-heading__logo"
           />
           {{#if @category.description}}
-            <p class="category-heading__description">{{dirSpan
-                @category.description
-                htmlSafe="true"
-              }}</p>
+            <div class="category-heading__content">
+              {{categoryBadge @category class="category-heading__badge"}}
+              <p class="category-heading__description">
+                {{htmlSafe @category.description}}
+              </p>
+            </div>
           {{/if}}
         {{/if}}
 
-        <span>
-          <PluginOutlet
-            @name="category-heading"
-            @connectorTagName="div"
-            @outletArgs={{lazyHash category=@category tag=@tag}}
-          />
-        </span>
+        <PluginOutlet
+          @name="category-heading"
+          @connectorTagName="div"
+          @outletArgs={{lazyHash category=@category tag=@tag}}
+        />
+
       </section>
     {{/if}}
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -46,18 +46,33 @@
 
 .category-heading {
   max-width: 100%;
-  font-size: var(--font-up-3);
   display: flex;
   gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  padding: var(--space-2);
+  border: 1px solid var(--content-border-color);
+  border-radius: var(--d-border-radius);
 
   &__logo.category-logo.aspect-image {
-    height: 2em;
-    width: 2em;
+    height: 6em;
+    width: 6em;
+    border-radius: var(--d-border-radius);
+    overflow: hidden;
   }
 
   &__description {
-    margin-top: 0;
+    margin: 0;
     line-height: var(--line-height-large);
+    font-size: var(--font-0);
+  }
+
+  &__content .badge-category__wrapper {
+    font-size: var(--font-up-3);
+  }
+
+  &__content .badge-category__name {
+    font-weight: bold;
+    color: var(--primary);
   }
 }
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -47,8 +47,15 @@
 .category-heading {
   max-width: 100%;
   font-size: var(--font-up-3);
+  display: flex;
+  gap: var(--space-4);
 
-  p {
+  &__logo.category-logo.aspect-image {
+    height: 2em;
+    width: 2em;
+  }
+
+  &__description {
     margin-top: 0;
     line-height: var(--line-height-large);
   }

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -46,12 +46,15 @@
 
 .category-heading {
   max-width: 100%;
-  display: flex;
-  gap: var(--space-4);
-  margin-bottom: var(--space-4);
-  padding: var(--space-2);
-  border: 1px solid var(--content-border-color);
-  border-radius: var(--d-border-radius);
+
+  &.--has-logo {
+    display: flex;
+    gap: var(--space-4);
+    margin-bottom: var(--space-4);
+    padding: var(--space-2);
+    border: 1px solid var(--content-border-color);
+    border-radius: var(--d-border-radius);
+  }
 
   &__logo.category-logo.aspect-image {
     height: 6em;
@@ -64,6 +67,12 @@
     margin: 0;
     line-height: var(--line-height-large);
     font-size: var(--font-0);
+    color: var(--category-boxes-description-text-color);
+  }
+
+  &__content {
+    // 100 container - width of logo - gap - padding
+    width: calc(100% - 6em - var(--space-4) - var(--space-2) * 2);
   }
 
   &__content .badge-category__wrapper {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -247,11 +247,6 @@
   }
 }
 
-.category-logo.aspect-image {
-  float: left;
-  margin: var(--space-1) var(--space-8) var(--space-8) 0;
-}
-
 /* Tablet (portrait) ----------- */
 
 // These styles kick in a little earlier when the sidebar appears


### PR DESCRIPTION
This PR applies better styling to the category title & description that appears when a category logo is uploaded.

|Before|After|
|-- | --|
|<img width="2868" height="1852" alt="CleanShot 2025-08-04 at 17 22 46@2x" src="https://github.com/user-attachments/assets/054a1757-118b-4a71-91be-533a7a805b9c" />|<img width="2844" height="1752" alt="CleanShot 2025-08-04 at 17 21 11@2x" src="https://github.com/user-attachments/assets/b4661c3e-874d-4496-b7db-756ad21c857d" />|
|<img width="2890" height="1838" alt="CleanShot 2025-08-04 at 17 23 40@2x" src="https://github.com/user-attachments/assets/a735fec9-d502-4956-8448-2201c96d022d" />|<img width="2886" height="1860" alt="CleanShot 2025-08-04 at 17 24 03@2x" src="https://github.com/user-attachments/assets/175feb8e-2604-4371-aefc-757ba3054636" />|