### PR TITLE
UX: subcategory image tweaks

### DIFF
--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -129,12 +129,11 @@ export default class CategoriesBoxes extends Component {
                   <div class="subcategories">
                     {{#each c.subcategories as |sc|}}
                       <a class="subcategory" href={{sc.url}}>
-                        <span class="subcategory-image-placeholder">
-                          {{#if sc.uploaded_logo.url}}
+                        {{#if sc.uploaded_logo.url}}
+                          <span class="subcategory-image-placeholder">
                             <CategoryLogo @category={{sc}} />
-                          {{/if}}
-                        </span>
-
+                          </span>
+                        {{/if}}
                         {{categoryLink sc hideParent="true"}}
                       </a>
                     {{/each}}

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -129,11 +129,11 @@ export default class CategoriesBoxes extends Component {
                   <div class="subcategories">
                     {{#each c.subcategories as |sc|}}
                       <a class="subcategory" href={{sc.url}}>
-                        <span class="subcategory-image-placeholder">
-                          {{#if sc.uploaded_logo.url}}
+                        {{#if sc.uploaded_logo.url}}
+                          <span class="subcategory-image-placeholder">
                             <CategoryLogo @category={{sc}} />
-                          {{/if}}
-                        </span>
+                          </span>
+                        {{/if}}
                         {{categoryLink sc hideParent="true"}}
                       </a>
                     {{/each}}

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.gjs
@@ -129,11 +129,11 @@ export default class CategoriesBoxes extends Component {
                   <div class="subcategories">
                     {{#each c.subcategories as |sc|}}
                       <a class="subcategory" href={{sc.url}}>
-                        {{#if sc.uploaded_logo.url}}
-                          <span class="subcategory-image-placeholder">
+                        <span class="subcategory-image-placeholder">
+                          {{#if sc.uploaded_logo.url}}
                             <CategoryLogo @category={{sc}} />
-                          </span>
-                        {{/if}}
+                          {{/if}}
+                        </span>
                         {{categoryLink sc hideParent="true"}}
                       </a>
                     {{/each}}

--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -256,13 +256,13 @@
   .subcategories {
     display: flex;
     flex-flow: wrap;
+    gap: var(--space-2);
 
     .subcategory {
       display: flex;
       align-items: center;
 
       @include ellipsis;
-      margin-bottom: 0.6em;
 
       .badge-category__wrapper {
         overflow: hidden;
@@ -270,8 +270,12 @@
 
       .subcategory-image-placeholder {
         display: inline-block;
-        margin-right: 0.6em;
         flex: 1 0 auto;
+
+        .category-logo.aspect-image {
+          margin-top: 0;
+          margin-right: var(--space-1);
+        }
       }
 
       .subcategory-link {


### PR DESCRIPTION
This PR adjusts the way we render subcategory image logos. It will only render its container if present. Right now, the container is rendered regardless and causes spacing issues.

|Before|After|
|-- | --|
|<img width="1950" height="1352" alt="CleanShot 2025-08-04 at 18 30 37@2x" src="https://github.com/user-attachments/assets/3d976a75-f12f-4dbb-9168-b18f016868ce" />|<img width="1940" height="1352" alt="CleanShot 2025-08-04 at 18 29 59@2x" src="https://github.com/user-attachments/assets/23c1b943-4a97-40f2-99be-b67d958b6267" />|