### PR TITLE
UX: use success colour for solved icon in topic list

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -968,12 +968,6 @@ form {
       height: 0.74em;
       width: 0.74em;
     }
-
-    &.solved {
-      .d-icon {
-        color: var(--success);
-      }
-    }
   }
 
   .topic-status-warning .d-icon-envelope {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -968,6 +968,12 @@ form {
       height: 0.74em;
       width: 0.74em;
     }
+
+    &.solved {
+      .d-icon {
+        color: var(--success);
+      }
+    }
   }
 
   .topic-status-warning .d-icon-envelope {

--- a/plugins/discourse-solved/assets/stylesheets/solutions.scss
+++ b/plugins/discourse-solved/assets/stylesheets/solutions.scss
@@ -108,3 +108,9 @@ aside.quote.accepted-answer {
   .fk-d-tooltip__inner-content {
   display: block;
 }
+
+.topic-statuses .topic-status.solved {
+  .d-icon {
+    color: $solved-color;
+  }
+}


### PR DESCRIPTION
For increased clarity when scanning the topic list

| Before | After |
|--------|--------|
| <img width="678" height="243" alt="CleanShot 2025-08-05 at 09 57 01" src="https://github.com/user-attachments/assets/72e25e99-40a2-4b3b-94c8-6cdedb006fef" /> | <img width="678" height="243" alt="CleanShot 2025-08-05 at 09 56 41" src="https://github.com/user-attachments/assets/b31c1b87-8620-4db2-9c4e-b1f1be038f73" /> | 