### PR TITLE
DEV: Markup refactor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
@@ -31,7 +31,7 @@ const FilterNavigationMenuList = <template>
             "filter-navigation__tip-item"
             (if (eq index @data.selectedIndex) "--selected")
           }}
-          onClick={{fn @data.selectItem item}}
+         {{on "click" (fn @data.selectItem item)}}
         >
           {{#if item.category}}
             {{categoryBadge item.category allowUncategorized=true}}

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
@@ -31,7 +31,7 @@ const FilterNavigationMenuList = <template>
             "filter-navigation__tip-item"
             (if (eq index @data.selectedIndex) "--selected")
           }}
-         {{on "click" (fn @data.selectItem item)}}
+          {{on "click" (fn @data.selectItem item)}}
         >
           {{#if item.category}}
             {{categoryBadge item.category allowUncategorized=true}}

--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
@@ -26,27 +26,25 @@ const FilterNavigationMenuList = <template>
   {{#if @data.filteredTips.length}}
     <DropdownMenu as |dropdown|>
       {{#each @data.filteredTips as |item index|}}
-        <dropdown.item>
-          <DButton
-            class={{concatClass
-              "filter-navigation__tip-button"
-              (if (eq index @data.selectedIndex) "--selected")
-            }}
-            @action={{fn @data.selectItem item}}
-          >
-            {{#if item.category}}
-              {{categoryBadge item.category allowUncategorized=true}}
-            {{else}}
-              <span class="filter-navigation__tip-name">
-                {{item.name}}
-              </span>
+        <dropdown.item
+          class={{concatClass
+            "filter-navigation__tip-item"
+            (if (eq index @data.selectedIndex) "--selected")
+          }}
+          onClick={{fn @data.selectItem item}}
+        >
+          {{#if item.category}}
+            {{categoryBadge item.category allowUncategorized=true}}
+          {{else}}
+            <span class="filter-navigation__tip-name">
+              {{item.name}}
+            </span>
 
-              {{#if item.description}}
-                <span class="filter-navigation__tip-description">—
-                  {{item.description}}</span>
-              {{/if}}
+            {{#if item.description}}
+              <span class="filter-navigation__tip-description">—
+                {{item.description}}</span>
             {{/if}}
-          </DButton>
+          {{/if}}
         </dropdown.item>
       {{/each}}
     </DropdownMenu>

--- a/app/assets/javascripts/discourse/tests/integration/components/discovery/filter-navigation-menu-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/discovery/filter-navigation-menu-test.gjs
@@ -68,7 +68,7 @@ module(
 
       await triggerEvent("#topic-query-filter-input", "focus");
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .exists({ count: 3 }, "tips appear");
 
       await triggerKeyEvent(
@@ -78,7 +78,7 @@ module(
       );
       assert
         .dom(
-          ".filter-navigation__tip-button.--selected .filter-navigation__tip-name"
+          ".filter-navigation__tip-item.--selected .filter-navigation__tip-name"
         )
         .hasText("category:");
 
@@ -89,14 +89,14 @@ module(
       );
       assert
         .dom(
-          ".filter-navigation__tip-button.--selected .filter-navigation__tip-name"
+          ".filter-navigation__tip-item.--selected .filter-navigation__tip-name"
         )
         .hasText("tag:");
 
       await triggerKeyEvent("#topic-query-filter-input", "keydown", "ArrowUp");
       assert
         .dom(
-          ".filter-navigation__tip-button.--selected .filter-navigation__tip-name"
+          ".filter-navigation__tip-item.--selected .filter-navigation__tip-name"
         )
         .hasText("category:");
     });
@@ -155,7 +155,7 @@ module(
       await triggerEvent("#topic-query-filter-input", "focus");
 
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .exists("tag search results shown");
 
       await triggerKeyEvent(
@@ -183,13 +183,13 @@ module(
 
       await triggerEvent("#topic-query-filter-input", "focus");
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .exists({ count: 3 }, "tips visible after focus");
 
       await triggerKeyEvent("#topic-query-filter-input", "keydown", "Escape");
       await triggerKeyEvent("#topic-query-filter-input", "keydown", "Escape");
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .doesNotExist("tips hidden after escape");
     });
 
@@ -223,11 +223,11 @@ module(
       await fillIn("#topic-query-filter-input", "cat");
 
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .exists("category search results shown");
 
       assert
-        .dom(".filter-navigation__tip-button")
+        .dom(".filter-navigation__tip-item")
         .exists(".badge-category__wrapper", "category badge HTML shown");
 
       await triggerKeyEvent(

--- a/app/assets/stylesheets/common/components/filter-navigation.scss
+++ b/app/assets/stylesheets/common/components/filter-navigation.scss
@@ -1,42 +1,35 @@
 .fk-d-menu[data-identifier="filter-navigation-menu-list"] {
   max-height: 300px;
 
-  .fk-d-menu__inner-content {
+  .fk-d-menu__inner-content,
+  .dropdown-menu {
     width: 100%;
+  }
+}
 
-    .dropdown-menu {
-      width: 100%;
+.filter-navigation {
+  &__tip-item {
+    padding: var(--space-2) var(--space-4);
+    cursor: pointer;
+    color: var(--primary);
+    transition: background-color 0.15s;
+
+    &:hover,
+    &.--selected {
+      background-color: var(--d-hover);
     }
+  }
 
-    .dropdown-menu-item {
-      width: 100%;
-    }
+  &__tip-name {
+    font-weight: 600;
+    color: var(--primary);
+  }
 
-    .filter-navigation__tip-button {
-      display: block;
-      width: 100%;
-      text-align: left;
-      padding: 0.5em 1em;
-      border: none;
-      background: transparent;
-      cursor: pointer;
-      font-size: var(--font-down-1);
-      color: var(--primary);
-      transition: background-color 0.15s;
+  &__tip-description {
+    color: var(--primary-high);
+  }
 
-      &:hover,
-      &.--selected {
-        background-color: var(--d-hover);
-      }
-
-      .filter-navigation__tip-name {
-        font-weight: 600;
-        color: var(--primary);
-      }
-
-      .filter-navigation__tip-description {
-        color: var(--primary-high);
-      }
-    }
+  &__tip-item .badge-category__wrapper {
+    font-size: var(--font-0);
   }
 }


### PR DESCRIPTION
This PR:

- removes DButton from being needed in the filter-tip list
- simplifies some of the CSS as well.
- normalized the font sizes in the tip list

|before|after|
|--|--|
|<img width="1956" height="796" alt="CleanShot 2025-08-05 at 09 17 51@2x" src="https://github.com/user-attachments/assets/c4fca721-3c23-4535-93e2-9da5cf80b763" />|<img width="1976" height="924" alt="CleanShot 2025-08-05 at 09 17 17@2x" src="https://github.com/user-attachments/assets/03dcf528-bd75-42b4-a651-b5fa122eff43" />|