### PR TITLE
UX: expose shift buttons for lists on touch-devices

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1074,7 +1074,9 @@ table#user-badges {
 
     .shift-up-value-btn,
     .shift-down-value-btn {
-      display: none;
+      .discourse-no-touch & {
+        display: none;
+      }
       margin-inline: 0.25em;
     }
 


### PR DESCRIPTION
Meta request.

Makes sense to expose the buttons on touch-devices, otherwise it gets very tricky to use.

| Before | After |
|--------|--------|
| <img width="1126" height="798" alt="CleanShot 2025-08-05 at 18 56 24@2x" src="https://github.com/user-attachments/assets/f81f9213-1e5a-4b6e-bb85-0922faa1016f" /> | <img width="1126" height="798" alt="CleanShot 2025-08-05 at 18 55 55@2x" src="https://github.com/user-attachments/assets/da167903-dbc6-41ea-8d56-208949d9227c" /> | 