### PR TITLE
UX: fix width on hidden-upload-field on the admin backup btn

### DIFF
--- a/app/assets/stylesheets/admin/backups.scss
+++ b/app/assets/stylesheets/admin/backups.scss
@@ -40,4 +40,5 @@
 
 label.admin-backups-upload {
   font-weight: 400;
+  position: relative;
 }

--- a/app/assets/stylesheets/common/base/upload.scss
+++ b/app/assets/stylesheets/common/base/upload.scss
@@ -140,4 +140,8 @@
 .hidden-upload-field {
   visibility: hidden;
   position: absolute;
+
+  .admin-backups-upload & {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
The hidden-upload-field input exceeds the parent width, which causes horizontal scrollbars in certain situations

<img width="1848" height="1542" alt="image" src="https://github.com/user-attachments/assets/d142760e-4a86-4480-83a5-b0964068d3e5" />

This commit makes sure it does not exceed the width of the button.

Alas, it's not a generalised solution for all instances, as there is no way to select the variety of parent elements that would need to get `position:relative`
