### PR TITLE
UX: Horizon theme, fix d-toc class on smaller screens

### DIFF
--- a/themes/horizon/scss/topic.scss
+++ b/themes/horizon/scss/topic.scss
@@ -54,14 +54,14 @@
 body:not(.d-toc-installed) {
   .container.posts {
     grid-template-columns: auto 8em;
+
+    @media screen and (width <= 924px) {
+      grid-template-columns: auto auto;
+    }
   }
 }
 
 .container.posts {
-  @media screen and (width <= 924px) {
-    grid-template-columns: auto auto;
-  }
-
   .post-notice {
     padding: var(--spacing-block-sm);
     border-radius: var(--d-border-radius);


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/7404e3f526fee93471a39a7f62cbb87bc76214ab, The new `grid-template-columns: auto 8em;` style is too specific and was overriding this on mobile, moving the query fixes it

Before: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7ea096f5-d9f7-4cce-b254-54e365060a33" />


After: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/519e8689-abb3-4fe9-b196-4da85507766b" />
