### PR TITLE
FEATURE: AI header icon should remember last URL, create service for it

### DIFF
--- a/app/assets/javascripts/discourse/app/services/last-forum-url.js
+++ b/app/assets/javascripts/discourse/app/services/last-forum-url.js
@@ -1,0 +1,49 @@
+import { tracked } from "@glimmer/tracking";
+import Service, { service } from "@ember/service";
+import { defaultHomepage } from "discourse/lib/utilities";
+
+/**
+ * Service for managing the "last forum URL" across different modes
+ * (chat & AI conversations). Ensures that when users click "back to forum"
+ * they go to actual forum content and don't loop between modes.
+ */
+export default class LastForumUrl extends Service {
+  @service router;
+
+  @tracked _lastForumURL = null;
+
+  /**
+   * Store the current URL as the last forum URL if it's not a different mode
+   * @param {string|null} url - Optional URL to store, defaults to current URL
+   */
+  storeUrl(url = null) {
+    const urlToStore = url || this.router.currentURL;
+
+    if (urlToStore && !this._isSpecialMode(urlToStore)) {
+      this._lastForumURL = urlToStore;
+    }
+  }
+
+  /**
+   * Get the last known forum URL
+   * @returns {string} The last forum URL
+   */
+  get url() {
+    if (this._lastForumURL && this._lastForumURL !== "/") {
+      return this._lastForumURL;
+    }
+
+    return this.router.urlFor(`discovery.${defaultHomepage()}`);
+  }
+
+  /**
+   * Check if a URL belongs to a mode that shouldn't be stored as forum URL
+   * @param {string} url - The URL to check
+   * @returns {boolean} True if the URL is from a specific mode
+   * @private
+   */
+  _isSpecialMode(url) {
+    const modePrefixes = ["/chat", "/discourse-ai/ai-bot"];
+    return modePrefixes.some((prefix) => url.startsWith(prefix));
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -3,7 +3,6 @@ import Service, { service } from "@ember/service";
 import KeyValueStore from "discourse/lib/key-value-store";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
-import { defaultHomepage } from "discourse/lib/utilities";
 import { getUserChatSeparateSidebarMode } from "discourse/plugins/chat/discourse/lib/get-user-chat-separate-sidebar-mode";
 import { CHAT_PANEL } from "discourse/plugins/chat/discourse/lib/init-sidebar-state";
 
@@ -28,6 +27,7 @@ export default class ChatStateManager extends Service {
   @service router;
   @service site;
   @service chatDrawerRouter;
+  @service lastForumUrl;
 
   @tracked isSidePanelExpanded = false;
   @tracked isDrawerExpanded = false;
@@ -35,14 +35,12 @@ export default class ChatStateManager extends Service {
   @tracked hasPreloadedChannels = false;
 
   @tracked _chatURL = null;
-  @tracked _appURL = null;
 
   _store = new KeyValueStore(PREFERRED_MODE_STORE_NAMESPACE);
 
   reset() {
     this._store.remove(PREFERRED_MODE_KEY);
     this._chatURL = null;
-    this._appURL = null;
   }
 
   prefersFullPage() {
@@ -166,13 +164,7 @@ export default class ChatStateManager extends Service {
   }
 
   storeAppURL(url = null) {
-    if (url) {
-      this._appURL = url;
-    } else if (this.router.currentURL?.startsWith("/chat")) {
-      this._appURL = "/";
-    } else {
-      this._appURL = this.router.currentURL;
-    }
+    this.lastForumUrl.storeUrl(url);
   }
 
   storeChatURL(url) {
@@ -180,13 +172,7 @@ export default class ChatStateManager extends Service {
   }
 
   get lastKnownAppURL() {
-    const url = this._appURL;
-
-    if (url && url !== "/") {
-      return url;
-    }
-
-    return this.router.urlFor(`discovery.${defaultHomepage()}`);
+    return this.lastForumUrl.url;
   }
 
   get lastKnownChatURL() {

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
@@ -4,7 +4,7 @@ import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
-import { defaultHomepage } from "discourse/lib/utilities";
+import getURL from "discourse/lib/get-url";
 import { i18n } from "discourse-i18n";
 import { composeAiBotMessage } from "../lib/ai-bot-helper";
 import { AI_CONVERSATIONS_PANEL } from "../services/ai-conversations-sidebar-manager";
@@ -17,6 +17,7 @@ export default class AiBotHeaderIcon extends Component {
   @service router;
   @service sidebarState;
   @service siteSettings;
+  @service aiConversationsSidebarManager;
 
   get bots() {
     const availableBots = this.currentUser.ai_enabled_chat_bots
@@ -28,6 +29,14 @@ export default class AiBotHeaderIcon extends Component {
 
   get showHeaderButton() {
     return this.bots.length > 0 && this.siteSettings.ai_bot_add_to_header;
+  }
+
+  get title() {
+    if (this.clickShouldRouteOutOfConversations) {
+      return i18n("sidebar.panels.forum.label");
+    }
+
+    return i18n("discourse_ai.ai_bot.shortcut_title");
   }
 
   get icon() {
@@ -45,18 +54,30 @@ export default class AiBotHeaderIcon extends Component {
     );
   }
 
-  @action
-  onClick() {
+  get href() {
     if (this.clickShouldRouteOutOfConversations) {
-      return this.router.transitionTo(`discovery.${defaultHomepage()}`);
+      return getURL(this.aiConversationsSidebarManager.lastKnownAppURL || "/");
     }
 
     if (this.siteSettings.ai_bot_enable_dedicated_ux) {
-      this.appEvents.trigger("discourse-ai:bot-header-icon-clicked");
-      return this.router.transitionTo("discourse-ai-bot-conversations");
+      return getURL("/discourse-ai/ai-bot/conversations");
     }
 
-    composeAiBotMessage(this.bots[0], this.composer);
+    return null;
+  }
+
+  @action
+  onClick() {
+    if (!this.siteSettings.ai_bot_enable_dedicated_ux) {
+      composeAiBotMessage(this.bots[0], this.composer);
+    }
+
+    if (
+      this.siteSettings.ai_bot_enable_dedicated_ux &&
+      !this.clickShouldRouteOutOfConversations
+    ) {
+      this.appEvents.trigger("discourse-ai:bot-header-icon-clicked");
+    }
   }
 
   <template>
@@ -67,9 +88,10 @@ export default class AiBotHeaderIcon extends Component {
           @outletArgs={{lazyHash onClick=this.onClick icon=this.icon}}
         >
           <DButton
-            @action={{this.onClick}}
+            @href={{this.href}}
+            @action={{unless this.href this.onClick}}
             @icon={{this.icon}}
-            title={{i18n "discourse_ai.ai_bot.shortcut_title"}}
+            title={{this.title}}
             class="ai-bot-button icon btn-flat"
           />
         </PluginOutlet>

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-conversations-sidebar.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-conversations-sidebar.js
@@ -56,9 +56,15 @@ export default {
         aiConversationsSidebarManager.stopForcingCustomSidebar();
       };
 
-      api.container
-        .lookup("service:router")
-        .on("routeDidChange", setSidebarPanel);
+      const router = api.container.lookup("service:router");
+
+      router.on("routeWillChange", (transition) => {
+        if (transition?.to?.name === "discourse-ai-bot-conversations") {
+          aiConversationsSidebarManager.storeAppURL(router.currentURL);
+        }
+      });
+
+      router.on("routeDidChange", setSidebarPanel);
     });
   },
 };

--- a/plugins/discourse-ai/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/services/ai-conversations-sidebar-manager.js
@@ -18,6 +18,7 @@ export default class AiConversationsSidebarManager extends Service {
   @service appEvents;
   @service sidebarState;
   @service messageBus;
+  @service lastForumUrl;
 
   @tracked topics = [];
   @tracked sections = new TrackedArray();
@@ -159,6 +160,14 @@ export default class AiConversationsSidebarManager extends Service {
     }
 
     this._removeScrollListener();
+  }
+
+  storeAppURL(url = null) {
+    this.lastForumUrl.storeUrl(url);
+  }
+
+  get lastKnownAppURL() {
+    return this.lastForumUrl.url;
   }
 
   async fetchMessages() {


### PR DESCRIPTION
This change concerns these header icons

<img width="220" height="116" alt="image" src="https://github.com/user-attachments/assets/eb7883cf-4766-4499-8d1a-116a542a2cdd" />


Currently the chat icon in the header switches to chat "mode" when possible, and remembers your last forum location. The AI header icon does not remember your last forum location, and just redirects you to the homepage when you toggle it off. 

In this PR I've created a `LastForumUrl` service in core, which we can use for both of these special modes. The service checks the prefix of chat or AI conversations so you don't get stuck in a loop if you navigate between the two. 

So if you go from:
Chat -> AI (or AI -> Chat) instead of toggling from Chat <-> AI over and over again, we pass along the last known forum URL. So now you're always going from Chat -> Forum or AI -> Forum when toggling the header icons. 

I've also updated the AI header icon to be a link when `ai_bot_enable_dedicated_ux` is enabled, this way it can be opened in a new tab and do all the typical link behavior. It is still a button when `ai_bot_enable_dedicated_ux`, which is appropriate for opening the composer. 