### PR TITLE
DEV: Clean up a couple of flaky theme customization specs.

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -83,6 +83,7 @@ describe "Admin Customize Themes", type: :system do
   it "cannot edit js, upload files or delete system themes" do
     theme.update_columns(id: -10)
     visit("/admin/customize/themes/#{theme.id}")
+    expect(page).to have_css(".system-theme-info")
     expect(page).to have_css(".title button")
     expect(page).to have_no_css(".title button svg")
     expect(page).to have_no_css(".edit-code")
@@ -109,13 +110,19 @@ describe "Admin Customize Themes", type: :system do
     expect(page).to have_css(".export")
     expect(page).to have_css(".extra-files")
     expect(page).to have_css(".theme-settings")
+    expect(page).to have_no_css(".system-theme-info")
 
-    allow(theme).to receive(:system?).and_return(true)
+    # Since we're only testing the one theme, we can stub the system? method
+    # for every theme to return true.
+    # This avoids needing to update the theme field data to point to a different theme id.
+    allow_any_instance_of(Theme).to receive(:system?).and_return(true)
+
     visit("/admin/customize/themes/#{theme.id}")
+    expect(page).to have_css(".system-theme-info")
     expect(page).to have_no_css(".created-by")
     expect(page).to have_no_css(".export")
     expect(page).to have_no_css(".extra-files")
-    expect(page).to have_no_css(".theme-settings")
+    expect(page).to have_css(".theme-settings")
   end
 
   describe "when editing theme translations" do

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -83,7 +83,8 @@ describe "Admin Customize Themes", type: :system do
   it "cannot edit js, upload files or delete system themes" do
     theme.update_columns(id: -10)
     visit("/admin/customize/themes/#{theme.id}")
-    expect(page).to have_no_css(".title button")
+    expect(page).to have_css(".title button")
+    expect(page).to have_no_css(".title button svg")
     expect(page).to have_no_css(".edit-code")
     expect(page).to have_no_css("button.upload")
     expect(page).to have_no_css(".delete")
@@ -109,7 +110,7 @@ describe "Admin Customize Themes", type: :system do
     expect(page).to have_css(".extra-files")
     expect(page).to have_css(".theme-settings")
 
-    theme.stubs(:system?).returns(true)
+    allow(theme).to receive(:system?).and_return(true)
     visit("/admin/customize/themes/#{theme.id}")
     expect(page).to have_no_css(".created-by")
     expect(page).to have_no_css(".export")
@@ -245,7 +246,6 @@ describe "Admin Customize Themes", type: :system do
 
       expect(theme_page).to have_current_path("/admin/customize/themes/#{theme.id}/colors")
 
-      original_hex = theme_page.color_palette_editor.get_color_value("primary")
       theme_page.color_palette_editor.change_color("primary", "#ff000e")
 
       expect(theme_page.changes_banner).to be_visible
@@ -280,7 +280,6 @@ describe "Admin Customize Themes", type: :system do
 
       theme_page.color_palette_editor.switch_to_dark_tab
 
-      original_dark_hex = theme_page.color_palette_editor.get_color_value("primary")
       theme_page.color_palette_editor.change_color("primary", "#000fff")
 
       theme_page.changes_banner.click_save


### PR DESCRIPTION
## ✨ What's This?

Previously: #33997
See t/157993

The `hides unecessary sections and buttons for system themes` spec is still be flaky after the previous fix. It seems like the `system?` method was not being properly stubbed on the theme object we have in the spec, so now it stubs all Theme objects, so that the corresponding theme object created in the Playwright thread will also be stubbed.

I've also tweaked the `cannot edit js, upload files or delete system themes`, the test was wrong, I suspect it was only passing when the checks managed to all run before the page loaded. 