### PR TITLE
FEATURE: Make staff action logs export respect the filter

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-logs-staff-action-logs.js
@@ -156,6 +156,7 @@ export default class AdminLogsStaffActionLogsController extends Controller {
   @action
   exportStaffActionLogs() {
     exportEntity("staff_action", {
+      ...this.filters,
       start_date: this.startDate?.toISOString(),
       end_date: this.endDate?.toISOString(),
     }).then(outputExportResult);

--- a/app/controllers/export_csv_controller.rb
+++ b/app/controllers/export_csv_controller.rb
@@ -67,7 +67,7 @@ class ExportCsvController < ApplicationController
     @_export_params ||=
       begin
         params.require(:entity)
-        params.permit(:entity, args: Report::FILTERS).to_h
+        params.permit(:entity, args: [*Report::FILTERS, *UserHistory.staff_filters]).to_h
       end
   end
 end

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -148,23 +148,9 @@ module Jobs
     end
 
     def staff_action_export
-      start_date = @extra[:start_date]&.to_time if @extra
-      end_date = @extra[:end_date]&.to_time if @extra
-
-      query = UserHistory
-      query = query.where("created_at >= ?", start_date) if start_date.present?
-      query = query.where("created_at <= ?", end_date) if end_date.present?
-
-      staff_action_data =
-        if @current_user.admin?
-          query.only_staff_actions
-        else
-          query.where(admin_only: false).only_staff_actions
-        end
-
-      staff_action_data.find_each(order: :desc) do |staff_action|
-        yield get_staff_action_fields(staff_action)
-      end
+      UserHistory
+        .staff_action_records(@current_user, @extra)
+        .find_each { |staff_action| yield get_staff_action_fields(staff_action) }
     end
 
     def screened_email_export


### PR DESCRIPTION
On the Admin > Logs & Screening page, the Export button never applied the current page's filters. For older websites, viewing large exported logs may cause lag.

This commit makes the Export button respect the current page's filters, reducing the size of exported staff action logs and improving consistency.