### PR TITLE
DEV: Update concurrency for publish-assets to match tests

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -7,7 +7,7 @@ on:
       - stable
 
 concurrency:
-  group: publish-assets-${{ format('{0}-{1}', github.ref, github.job) }}
+  group: publish-assets-${{ format('{0}-{1}', github.run_number, github.job) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This job only runs on `main`, so we don't want to cancel existing runs when new commits land. This config now matches the behavior of `tests.yml` on `main`