### PR TITLE
UX: Render emojis consistently on 404 page

### DIFF
--- a/app/views/exceptions/_not_found_topics.html.erb
+++ b/app/views/exceptions/_not_found_topics.html.erb
@@ -15,7 +15,7 @@
       <h2 class="recent-topics-title"><%= t 'page_not_found.recent_topics' %></h2>
       <% @recent.each do |t| %>
         <div class='not-found-topic'>
-          <%= link_to t.title, t.relative_url %><%= category_badge(t.category) %>
+          <%= link_to emoji_codes_to_img(t.fancy_title), t.relative_url %><%= category_badge(t.category) %>
         </div>
       <% end %>
       <a href="<%= path "/latest" %>" class="btn btn-default"><%= t 'page_not_found.see_more' %>&hellip;</a>


### PR DESCRIPTION
We were transforming emoji codes for 'popular' topics, but not 'recent' topics