### PR TITLE
FIX: Update logic for displaying admin palette warning

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -72,12 +72,14 @@ export default class AdminCustomizeColorsController extends Controller {
       this._captureInitialState();
     }
 
-    const changedColors =
-      this._initialUserColorSchemeId !==
-      this._initialDefaultThemeLightColorSchemeId;
+    const usingDefaultColors = this.isUsingDarkMode
+      ? this._initialUserDarkSchemeId !==
+        this._initialDefaultThemeDarkColorSchemeId
+      : this._initialUserLightSchemeId !==
+        this._initialDefaultThemeLightColorSchemeId;
     const changedTheme = this.defaultTheme?.id !== currentThemeId(this.site);
 
-    return changedColors || changedTheme;
+    return !usingDefaultColors || changedTheme;
   }
 
   get isUsingDarkMode() {

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -64,22 +64,9 @@ export default class AdminCustomizeColorsController extends Controller {
   }
 
   get changedThemePreferences() {
-    // can't check against null, because the default scheme ID is null
-    if (
-      this._initialUserLightColorSchemeId === undefined &&
-      this.defaultTheme
-    ) {
-      this._captureInitialState();
-    }
-
-    const usingDefaultColors = this.isUsingDarkMode
-      ? this._initialUserDarkSchemeId !==
-        this._initialDefaultThemeDarkColorSchemeId
-      : this._initialUserLightSchemeId !==
-        this._initialDefaultThemeLightColorSchemeId;
     const changedTheme = this.defaultTheme?.id !== currentThemeId(this.site);
 
-    return !usingDefaultColors || changedTheme;
+    return changedTheme;
   }
 
   get isUsingDarkMode() {


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/7a9cf9356e486cf3eb6a2c2bf6cd6927a6ef59e4, `_initialUserColorSchemeId` no longer exists — we can simplify to only showing this warning if the admin isn't using the default theme

<img width="700" alt="image" src="https://github.com/user-attachments/assets/b32617e6-be1c-4238-847b-0e03f04204d9" />
