### PR TITLE
FEATURE: theme default option in user interface

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -1,7 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Controller, { inject as controller } from "@ember/controller";
 import { action, computed } from "@ember/object";
-import { not, reads } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { reload } from "discourse/helpers/page-reloader";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -51,12 +50,6 @@ export default class InterfaceController extends Controller {
   @propertyEqual("model.id", "currentUser.id") canPreviewColorScheme;
   @propertyEqual("model.id", "currentUser.id") isViewingOwnProfile;
   subpageTitle = i18n("user.preferences_nav.interface");
-
-  @reads("userSelectableColorSchemes.length") showColorSchemeSelector;
-
-  @not("currentSchemeCanBeSelected") showColorSchemeNoneItem;
-
-  selectedColorSchemeNoneLabel = i18n("user.color_schemes.default_description");
 
   init() {
     super.init(...arguments);
@@ -250,13 +243,14 @@ export default class InterfaceController extends Controller {
     });
   }
 
+  @discourseComputed("userSelectableColorSchemes")
+  showColorSchemeSelector(lightSchemes) {
+    return lightSchemes && lightSchemes.length > 1;
+  }
+
   @discourseComputed("userSelectableDarkColorSchemes")
   showDarkColorSchemeSelector(darkSchemes) {
-    // when a default dark scheme is set
-    // dropdown has two items (disable / use site default)
-    // but we show a checkbox in that case
-    const minToShow = this.defaultDarkSchemeId > 0 ? 2 : 1;
-    return darkSchemes && darkSchemes.length > minToShow;
+    return darkSchemes && darkSchemes.length > 1;
   }
 
   get interfaceColorModes() {

--- a/app/assets/javascripts/discourse/app/initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/initializers/discourse-bootstrap.js
@@ -77,9 +77,8 @@ export default {
 
     session.highlightJsPath = setupData.highlightJsPath;
     session.svgSpritePath = setupData.svgSpritePath;
-    session.userColorSchemeId =
-      parseInt(setupData.userColorSchemeId, 10) || null;
-    session.userDarkSchemeId = parseInt(setupData.userDarkSchemeId, 10) || -1;
+    session.userColorSchemeId = parseInt(setupData.userColorSchemeId, 10);
+    session.userDarkSchemeId = parseInt(setupData.userDarkSchemeId, 10);
 
     let iconList = setupData.svgIconList;
     if (isDevelopment() && iconList) {

--- a/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
+++ b/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
@@ -35,8 +35,8 @@ export function listColorSchemes(site, options = {}) {
     id: -1,
     name: `${i18n("user.color_schemes.default_description")}`,
     colors: options.darkOnly
-      ? defaultDarkColorScheme?.colors
-      : defaultLightColorScheme?.colors,
+      ? defaultDarkColorScheme?.colors || []
+      : defaultLightColorScheme?.colors || [],
   });
 
   return results.length === 0 ? null : results;

--- a/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
+++ b/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
@@ -29,36 +29,15 @@ export function listColorSchemes(site, options = {}) {
   });
 
   const defaultLightColorScheme = site.get("default_light_color_scheme");
-  if (defaultLightColorScheme && !options.darkOnly) {
-    const existing = schemes.findBy("id", defaultLightColorScheme.id);
-    if (!existing) {
-      results.unshift({
-        id: defaultLightColorScheme.id,
-        name: `${i18n("user.color_schemes.default_description")}`,
-        theme_id: defaultLightColorScheme.theme_id,
-        colors: defaultLightColorScheme.colors,
-      });
-    }
-  }
-  if (options.darkOnly) {
-    const defaultDarkColorScheme = site.get("default_dark_color_scheme");
-    if (defaultDarkColorScheme) {
-      const existing = schemes.findBy("id", defaultDarkColorScheme.id);
-      if (!existing) {
-        results.unshift({
-          id: defaultDarkColorScheme.id,
-          name: `${i18n("user.color_schemes.default_description")}`,
-          theme_id: defaultDarkColorScheme.theme_id,
-          colors: defaultDarkColorScheme.colors,
-        });
-      }
-    } else {
-      results.unshift({
-        id: -1,
-        name: `${i18n("user.color_schemes.default_description")}`,
-      });
-    }
-  }
+  const defaultDarkColorScheme = site.get("default_dark_color_scheme");
+
+  results.unshift({
+    id: -1,
+    name: `${i18n("user.color_schemes.default_description")}`,
+    colors: options.darkOnly
+      ? defaultDarkColorScheme?.colors
+      : defaultLightColorScheme?.colors,
+  });
 
   return results.length === 0 ? null : results;
 }

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
@@ -62,10 +62,6 @@ export default RouteTemplate(
                 @content={{@controller.userSelectableColorSchemes}}
                 @value={{@controller.selectedColorSchemeId}}
                 @onChange={{@controller.loadColorScheme}}
-                @options={{hash
-                  translatedNone=@controller.selectedColorSchemeNoneLabel
-                  autoInsertNoneItem=@controller.showColorSchemeNoneItem
-                }}
               />
             </div>
           </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -65,27 +65,6 @@ acceptance("User Preferences - Interface", function (needs) {
     removeCookie("text_size");
   });
 
-  test("shows light color scheme default option when theme's color scheme is not user selectable", async function (assert) {
-    let site = Site.current();
-    site.set("user_themes", [
-      { theme_id: 1, name: "Cool Theme", color_scheme_id: null },
-    ]);
-
-    site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
-
-    await visit("/u/eviltrout/preferences/interface");
-    assert.dom(".light-color-scheme").exists("has regular dropdown");
-
-    assert.strictEqual(
-      selectKit(".light-color-scheme .select-kit").header().value(),
-      null
-    );
-    assert.strictEqual(
-      selectKit(".light-color-scheme .select-kit").header().label(),
-      i18n("user.color_schemes.default_description")
-    );
-  });
-
   skip("shows no default option for light scheme when theme's color scheme is user selectable", async function (assert) {
     let meta = document.createElement("meta");
     meta.name = "discourse_theme_id";
@@ -202,11 +181,14 @@ acceptance(
         );
     });
 
-    test("display 'Theme default' when default color scheme is not marked as selectable", async function (assert) {
+    test("always display 'Theme default'", async function (assert) {
       let meta = document.createElement("meta");
       meta.name = "discourse_theme_id";
       meta.content = "1";
       document.getElementsByTagName("head")[0].appendChild(meta);
+
+      let session = Session.current();
+      session.userColorSchemeId = -1;
 
       let site = Site.current();
       site.set("user_themes", [
@@ -219,14 +201,14 @@ acceptance(
 
       assert.dom(".light-color-scheme").exists("has regular dropdown");
       const dropdownObject = selectKit(".light-color-scheme .select-kit");
-      assert.strictEqual(dropdownObject.header().value(), null);
+      assert.strictEqual(dropdownObject.header().value(), "-1");
       assert.strictEqual(
         dropdownObject.header().label(),
         i18n("user.color_schemes.default_description")
       );
 
       await dropdownObject.expand();
-      assert.strictEqual(dropdownObject.rows().length, 1);
+      assert.strictEqual(dropdownObject.rows().length, 2);
 
       document.querySelector("meta[name='discourse_theme_id']").remove();
     });
@@ -302,8 +284,8 @@ acceptance(
       // dark scheme
       await selectKit(".dark-color-scheme .combobox").expand();
       assert.true(
-        selectKit(".dark-color-scheme .combobox").rowByValue(1).exists(),
-        "default dark scheme is included"
+        selectKit(".dark-color-scheme .combobox").rowByValue(3).exists(),
+        "user selectable dark scheme is included"
       );
 
       await click("button.undo-preview");

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -868,7 +868,7 @@ RSpec.describe ApplicationHelper do
 
     context "with dark scheme with user option and/or cookies" do
       before do
-        user.user_option.dark_scheme_id = -1
+        user.user_option.interface_color_mode = UserOption::LIGHT_MODE
         user.user_option.save!
         helper.request.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY] = user
         @new_cs = Fabricate(:color_scheme, name: "Custom Color Scheme")
@@ -884,7 +884,10 @@ RSpec.describe ApplicationHelper do
       end
 
       it "returns user-selected dark color scheme stylesheet" do
-        user.user_option.update!(dark_scheme_id: @new_cs.id)
+        user.user_option.update!(
+          dark_scheme_id: @new_cs.id,
+          interface_color_mode: UserOption::AUTO_MODE,
+        )
 
         color_stylesheets = helper.discourse_color_scheme_stylesheets
         expect(color_stylesheets).to include("(prefers-color-scheme: dark)")
@@ -892,6 +895,7 @@ RSpec.describe ApplicationHelper do
       end
 
       it "respects cookie value over user option for dark color scheme" do
+        user.user_option.update!(interface_color_mode: UserOption::AUTO_MODE)
         helper.request.cookies["dark_scheme_id"] = @new_cs.id
 
         color_stylesheets = helper.discourse_color_scheme_stylesheets

--- a/spec/system/interface_color_selector_spec.rb
+++ b/spec/system/interface_color_selector_spec.rb
@@ -62,7 +62,7 @@ describe "Interface color selector", type: :system do
   end
 
   it "is not available if the user uses the same scheme for dark mode as the light mode" do
-    user.user_option.update!(color_scheme_id: light_scheme.id, dark_scheme_id: -1)
+    user.user_option.update!(color_scheme_id: light_scheme.id, dark_scheme_id: light_scheme.id)
     sign_in(user)
 
     visit("/")

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -24,6 +24,28 @@ module PageObjects
         page.find('.dark-mode input[type="checkbox"]')
       end
 
+      def light_scheme_dropdown
+        PageObjects::Components::SelectKit.new(".light-color-scheme .select-kit")
+      end
+
+      def dark_scheme_dropdown
+        PageObjects::Components::SelectKit.new(".dark-color-scheme .select-kit")
+      end
+
+      def has_light_scheme_css?(color_scheme)
+        expect(page).to have_css(
+          "link.light-scheme[data-scheme-id=\"#{color_scheme.id}\"]",
+          visible: false,
+        )
+      end
+
+      def has_dark_scheme_css?(color_scheme)
+        expect(page).to have_css(
+          "link.dark-scheme[data-scheme-id=\"#{color_scheme.id}\"]",
+          visible: false,
+        )
+      end
+
       def color_mode_dropdown
         PageObjects::Components::SelectKit.new(".interface-color-mode .select-kit")
       end

--- a/spec/system/user_page/user_preferences_interface_spec.rb
+++ b/spec/system/user_page/user_preferences_interface_spec.rb
@@ -96,6 +96,74 @@ describe "User preferences | Interface", type: :system do
     before { SiteSetting.interface_color_selector = "sidebar_footer" }
 
     context "when changing own preferences" do
+      fab!(:color_scheme_light_1) { Fabricate(:color_scheme, base_scheme_id: "Light") }
+      fab!(:color_scheme_dark_1) { Fabricate(:color_scheme, base_scheme_id: "Dark") }
+      fab!(:color_scheme_light_2) { Fabricate(:color_scheme, base_scheme_id: "Light") }
+      fab!(:color_scheme_dark_2) { Fabricate(:color_scheme, base_scheme_id: "Dark") }
+      fab!(:color_scheme_light_3) do
+        Fabricate(:color_scheme, base_scheme_id: "Light", user_selectable: true)
+      end
+      fab!(:color_scheme_dark_3) do
+        Fabricate(:color_scheme, base_scheme_id: "Dark", user_selectable: true)
+      end
+
+      it "has and can change default color scheme for light and dark" do
+        Theme.find_default.update!(
+          color_scheme: color_scheme_light_1,
+          dark_color_scheme: color_scheme_dark_1,
+        )
+        user_preferences_interface_page.visit(user)
+
+        expect(user_preferences_interface_page.light_scheme_dropdown).to have_selected_name(
+          I18n.t("js.user.color_schemes.default_description"),
+        )
+        expect(user_preferences_interface_page.light_scheme_dropdown).to have_selected_value(-1)
+        expect(user_preferences_interface_page.dark_scheme_dropdown).to have_selected_name(
+          I18n.t("js.user.color_schemes.default_description"),
+        )
+        expect(user_preferences_interface_page.dark_scheme_dropdown).to have_selected_value(-1)
+        expect(user_preferences_interface_page).to have_light_scheme_css(color_scheme_light_1)
+        expect(user_preferences_interface_page).to have_dark_scheme_css(color_scheme_dark_1)
+
+        Theme.find_default.update!(
+          color_scheme: color_scheme_light_2,
+          dark_color_scheme: color_scheme_dark_2,
+        )
+        user_preferences_interface_page.visit(user)
+
+        expect(user_preferences_interface_page.light_scheme_dropdown).to have_selected_name(
+          I18n.t("js.user.color_schemes.default_description"),
+        )
+        expect(user_preferences_interface_page.light_scheme_dropdown).to have_selected_value(-1)
+        expect(user_preferences_interface_page.dark_scheme_dropdown).to have_selected_name(
+          I18n.t("js.user.color_schemes.default_description"),
+        )
+        expect(user_preferences_interface_page.dark_scheme_dropdown).to have_selected_value(-1)
+        expect(user_preferences_interface_page).to have_light_scheme_css(color_scheme_light_2)
+        expect(user_preferences_interface_page).to have_dark_scheme_css(color_scheme_dark_2)
+
+        user_preferences_interface_page.light_scheme_dropdown.expand
+        user_preferences_interface_page.light_scheme_dropdown.select_row_by_value(
+          color_scheme_light_3.id,
+        )
+        user_preferences_interface_page.dark_scheme_dropdown.expand
+        user_preferences_interface_page.dark_scheme_dropdown.select_row_by_value(
+          color_scheme_dark_3.id,
+        )
+        user_preferences_interface_page.save_changes
+
+        user_preferences_interface_page.visit(user)
+
+        expect(user_preferences_interface_page.light_scheme_dropdown).to have_selected_name(
+          color_scheme_light_3.name,
+        )
+        expect(user_preferences_interface_page.dark_scheme_dropdown).to have_selected_name(
+          color_scheme_dark_3.name,
+        )
+        expect(user_preferences_interface_page).to have_light_scheme_css(color_scheme_light_3)
+        expect(user_preferences_interface_page).to have_dark_scheme_css(color_scheme_dark_3)
+      end
+
       it "can change the color mode for the current device only" do
         user_preferences_interface_page.visit(user)
 

--- a/spec/system/user_page/user_preferences_interface_spec.rb
+++ b/spec/system/user_page/user_preferences_interface_spec.rb
@@ -67,6 +67,7 @@ describe "User preferences | Interface", type: :system do
       before do
         dark = ColorScheme.find_by(base_scheme_id: "Dark")
         ColorScheme.where.not(id: dark.id).destroy_all
+        dark.update!(user_selectable: false)
         user.user_option.update!(dark_scheme_id: dark.id, theme_ids: [SiteSetting.default_theme_id])
       end
 

--- a/themes/horizon/javascripts/discourse/components/user-color-palette-selector.gjs
+++ b/themes/horizon/javascripts/discourse/components/user-color-palette-selector.gjs
@@ -39,16 +39,20 @@ export default class UserColorPaletteSelector extends Component {
   get userColorPalettes() {
     const availablePalettes = listColorSchemes(this.site)
       ?.map((userPalette) => {
+        const hex = userPalette.colors.find(
+          (color) => color.name === "tertiary"
+        )?.hex;
         return {
           ...userPalette,
-          accent: `#${
-            userPalette.colors.find((color) => color.name === "tertiary").hex
-          }`,
+          accent: hex && `#${hex}`,
         };
       })
       .filter((userPalette) => {
         return HORIZON_PALETTES.some((palette) => {
-          return userPalette.name.toLowerCase().includes(palette.toLowerCase());
+          return (
+            userPalette.name.toLowerCase().includes(palette.toLowerCase()) &&
+            userPalette.accent
+          );
         });
       })
       .sort();

--- a/themes/horizon/spec/system/horizon_high_level_spec.rb
+++ b/themes/horizon/spec/system/horizon_high_level_spec.rb
@@ -20,6 +20,9 @@ describe "Horizon theme | High level", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
   let(:palette_selector) { PageObjects::Components::UserColorPaletteSelector.new }
+  fab!(:incorrect_scheme) do
+    Fabricate(:color_scheme, name: "Incorrect Scheme", user_selectable: true)
+  end
 
   def run_all_high_level_tests
     expect(page).to have_css(".experimental-screen")

--- a/themes/horizon/spec/system/user_color_palette_selector_spec.rb
+++ b/themes/horizon/spec/system/user_color_palette_selector_spec.rb
@@ -19,7 +19,14 @@ describe "Horizon theme | User color palette selector", type: :system do
   let(:marigold_palette) { theme.color_schemes.find_by(name: "Marigold") }
   let(:marigold_palette_dark) { theme.color_schemes.find_by(name: "Marigold Dark") }
 
-  before { SiteSetting.interface_color_selector = "sidebar_footer" }
+  before do
+    SiteSetting.interface_color_selector = "sidebar_footer"
+    SiteSetting.default_theme_id = theme.id
+    theme.update!(
+      color_scheme_id: marigold_palette.id,
+      dark_color_scheme_id: marigold_palette_dark.id,
+    )
+  end
 
   it "does not show the sidebar button if there are no user-selectable color palettes" do
     ColorScheme.update_all(user_selectable: false)


### PR DESCRIPTION
Before the "theme default" option appeared conditionally, which caused confusion. For example, it was shown when the theme was using a color scheme that was not user-selectable. If the scheme was selectable, then a specific scheme like "Merigold" was preselected. If the theme changed default schemes, that change was not reflected on the user interface.

Therefore, it would be better to always have the "Theme default" option, which would have `-1` id. It means that the user's color scheme will always follow theme defaults.

<img width="400" height="221" alt="Screenshot 2025-08-06 at 10 07 40 am" src="https://github.com/user-attachments/assets/e3d3588d-1d4a-4e95-9c10-925e48c4a58b" />
