### PR TITLE
FIX: Catch possible PG exception from `Chat::AutoJoinChannels`

### DIFF
--- a/plugins/chat/app/services/chat/auto_join_channels.rb
+++ b/plugins/chat/app/services/chat/auto_join_channels.rb
@@ -17,7 +17,9 @@ module Chat
       attribute :category_id, :integer
     end
 
-    step :create_memberships
+    lock(:user_id, :channel_id, :category_id) do
+      try(PG::UniqueViolation) { step :create_memberships }
+    end
 
     private
 

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -339,8 +339,14 @@ after_initialize do
     Chat::AutoJoinChannels.call(params: { user_id: user.id }) if user.active?
   end
 
-  on(:user_added_to_group) do |user, _group|
-    Chat::AutoJoinChannels.call(params: { user_id: user.id })
+  on(:user_added_to_group) do |user, group|
+    Chat::AutoJoinChannels.call(params: { user_id: user.id }) do |result|
+      on_exceptions do |exception|
+        Rails.logger.warn(
+          "[chat] Error auto-joining user #{user.id} to channels after being added to group #{group.id}: #{exception.message}\n\n#{result.inspect_steps}",
+        )
+      end
+    end
   end
 
   on(:user_removed_from_group) do |user, _group|

--- a/plugins/chat/spec/services/chat/auto_join_channels_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_join_channels_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe Chat::AutoJoinChannels do
       it { is_expected.to fail_a_policy(:chat_enabled?) }
     end
 
+    context "when a duplicate key error occurs" do
+      before { allow(DB).to receive(:query_array).and_raise(PG::UniqueViolation) }
+
+      it { is_expected.to fail_with_exception(PG::UniqueViolation) }
+    end
+
     context "when chat is enabled" do
       let(:trust_level) { 1 } # SiteSetting.chat_allowed_groups defaults to admins, moderators, and TL1 users
       let(:last_seen_at) { 5.minutes.ago } # Users must have been seen "recently" to be auto-joined to a channel


### PR DESCRIPTION
Currently, it can happen that the `Chat::AutoJoinChannels` service raises a `PG::UniqueViolation` error. This is probably due to a race condition. That exception is not rescued, leading to 500s.

This PR wraps the main step inside a `try` block and also inside a `lock` block.