### PR TITLE
FIX: Make theme live-reload safer

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
@@ -1,3 +1,4 @@
+import { isProduction } from "discourse/lib/environment";
 import { setOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
@@ -88,10 +89,14 @@ class LiveDevelopmentInit {
   }
 
   refreshCSS(node, newHref) {
-    const reloaded = node.cloneNode(true);
-    reloaded.href = newHref;
-    node.insertAdjacentElement("afterend", reloaded);
-    discourseLater(() => node?.parentNode?.removeChild(node), 500);
+    if (isProduction()) {
+      this.session.requiresRefresh = true;
+    } else {
+      const reloaded = node.cloneNode(true);
+      reloaded.href = newHref;
+      node.insertAdjacentElement("afterend", reloaded);
+      discourseLater(() => node?.parentNode?.removeChild(node), 500);
+    }
   }
 }
 

--- a/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/live-development.js
@@ -1,7 +1,7 @@
-import { isProduction } from "discourse/lib/environment";
 import { setOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
+import { isProduction } from "discourse/lib/environment";
 import discourseLater from "discourse/lib/later";
 
 // Use the message bus for live reloading of components for faster development.

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -496,7 +496,7 @@ class Theme < ActiveRecord::Base
     targets = %i[common_theme mobile_theme desktop_theme]
 
     if with_scheme
-      targets.prepend(:desktop, :mobile, :admin)
+      targets.prepend(:common, :desktop, :mobile, :admin)
       targets.append(*Discourse.find_plugin_css_assets(mobile_view: true, desktop_view: true))
       Stylesheet::Manager.cache.clear if clear_manager_cache
     end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -595,6 +595,7 @@ HTML
         .filter { |m| m.channel == "/file-change" }
     expect(messages.count).to eq(1)
     expect(messages.first.data.map { |d| d[:target] }).to contain_exactly(
+      :common,
       :admin,
       :desktop,
       :mobile,


### PR DESCRIPTION
In production, reloading CSS files before loading new JS is risky, and can lead to surprising UI flickering/breakage. This commit updates theme CSS 'file-change' notifications to trigger a reload on next navigation, just like regular core updates.

In development mode, CSS will still be refreshed 'live'.

Also adds the 'common' target to the list of refreshed CSS bundles, which will improve the experience in development mode.