### PR TITLE
PERF: limit the number of upcoming dates generated

### DIFF
--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_summary_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_summary_serializer.rb
@@ -57,6 +57,7 @@ module DiscoursePostEvent
           recurrence_until: object.recurrence_until,
         )
         .map { |date| { starts_at: date, ends_at: date + difference.seconds } }
+        .take(31)
     end
   end
 end

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -29,6 +29,18 @@ module DiscoursePostEvent
         # TODO: There is still N+1 query problem here so uncomment this line when it is fixed
         # expect(new_queries.count).to eq(original_queries.count)
       end
+
+      context "when an event is recurring" do
+        before { event_1.update!(recurrence: "every_day") }
+
+        it "limits upcoming dates count to 31" do
+          get "/discourse-post-event/events.json"
+
+          expect(response.status).to eq(200)
+          events = response.parsed_body["events"]
+          expect(events[0]["upcoming_dates"].length).to eq(31)
+        end
+      end
     end
 
     context "with an existing post" do

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -29,18 +29,6 @@ module DiscoursePostEvent
         # TODO: There is still N+1 query problem here so uncomment this line when it is fixed
         # expect(new_queries.count).to eq(original_queries.count)
       end
-
-      context "when an event is recurring" do
-        before { event_1.update!(recurrence: "every_day") }
-
-        it "limits upcoming dates count to 31" do
-          get "/discourse-post-event/events.json"
-
-          expect(response.status).to eq(200)
-          events = response.parsed_body["events"]
-          expect(events[0]["upcoming_dates"].length).to eq(31)
-        end
-      end
     end
 
     context "with an existing post" do

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
@@ -94,7 +94,7 @@ describe DiscoursePostEvent::EventSummarySerializer do
 
     it "returns next dates for the every week event" do
       json = described_class.new(every_week_event, scope: Guardian.new).as_json
-      expect(json[:event_summary][:upcoming_dates].length).to eq(52)
+      expect(json[:event_summary][:upcoming_dates].length).to eq(31)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
           starts_at: "2023-12-24 15:00:00.000000000 +0000", # Sunday
@@ -127,7 +127,7 @@ describe DiscoursePostEvent::EventSummarySerializer do
 
     it "returns next dates for the every weekday event" do
       json = described_class.new(every_weekday_event, scope: Guardian.new).as_json
-      expect(json[:event_summary][:upcoming_dates].length).to eq(260)
+      expect(json[:event_summary][:upcoming_dates].length).to eq(31)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
           starts_at: "2023-12-29 15:00:00.000000000 +0000", # Friday

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_summary_serializer_spec.rb
@@ -83,11 +83,11 @@ describe DiscoursePostEvent::EventSummarySerializer do
 
     it "returns next dates for the every day event" do
       json = described_class.new(every_day_event, scope: Guardian.new).as_json
-      expect(json[:event_summary][:upcoming_dates].length).to eq(365)
+      expect(json[:event_summary][:upcoming_dates].length).to eq(31)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-31 15:00:00.000000000 +0000",
-          ends_at: "2023-12-31 16:00:00.000000000 +0000",
+          starts_at: "2023-01-31 15:00:00.000000000 +0000",
+          ends_at: "2023-01-31 16:00:00.000000000 +0000",
         },
       )
     end
@@ -97,8 +97,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(31)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-24 15:00:00.000000000 +0000", # Sunday
-          ends_at: "2023-12-24 16:00:00.000000000 +0000",
+          starts_at: "2023-07-30 15:00:00.000000000 +0000", # Sunday
+          ends_at: "2023-07-30 16:00:00.000000000 +0000",
         },
       )
     end
@@ -130,8 +130,8 @@ describe DiscoursePostEvent::EventSummarySerializer do
       expect(json[:event_summary][:upcoming_dates].length).to eq(31)
       expect(json[:event_summary][:upcoming_dates].last).to eq(
         {
-          starts_at: "2023-12-29 15:00:00.000000000 +0000", # Friday
-          ends_at: "2023-12-29 16:00:00.000000000 +0000",
+          starts_at: "2023-02-13 15:00:00.000000000 +0000", # Friday
+          ends_at: "2023-02-13 16:00:00.000000000 +0000",
         },
       )
     end


### PR DESCRIPTION
If you have a lot of recurring events, and particularly when recurring every day we would generate data for each of these days for a year, which means ~365 entries, multiplied by your number of events, you would quickly end up with a very large json payload.

This commit ensures we never return more than 31 upcoming dates (31 to ensure we can show a full month of events in the month view).

This was a known issue and this fix is not a definitive solution as it comes with a massive limitation: when clicking next we won't be showing you future events. This is mostly an issue for daily events, as monthly event will still allow you to see about 3 years of events which should be enough for most cases.

The ideal solution is to load only the events (and dates) we show on the screen instead of trying to load the future state from the start. For various reasons this might be a complicated change and Im writing this commit to fix pathological cases which could prevent the page to load.