### PR TITLE
DEV: Run tests workflow for all commits on `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,6 @@ on:
       - main
       - beta
       - stable
-    paths-ignore:
-      - ".github/workflows/migration-tests.yml"
-      - ".github/dependabot.yml"
-      - ".github/labeler.yml"
-      - "migrations/**"
 
 concurrency:
   group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}


### PR DESCRIPTION
This github workflow is now part of the pipeline to tests-passed, so we need to run it on every commit that lands. We can continue skipping tests for PRs that only touch certain paths