### PR TITLE
DEV: uses autoPlacement for filter-navigation-menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation-menu.gjs
@@ -19,6 +19,7 @@ import { bind } from "discourse/lib/decorators";
 import FilterSuggestions from "discourse/lib/filter-suggestions";
 import { resettableTracked } from "discourse/lib/tracked-tools";
 import { i18n } from "discourse-i18n";
+import { VISIBILITY_OPTIMIZERS } from "float-kit/lib/constants";
 
 const MAX_RESULTS = 20;
 
@@ -400,6 +401,7 @@ export default class FilterNavigationMenu extends Component {
       component: FilterNavigationMenuList,
       data: this.trackedMenuListData,
       maxWidth: 2000,
+      visibilityOptimizer: VISIBILITY_OPTIMIZERS.AUTO_PLACEMENT,
     });
 
     // HACK: We don't have a nice way for DMenu to be the same width as


### PR DESCRIPTION
This should prevent the content to be positioned above the input when there's only one result to show.