### PR TITLE
UX: set header tag color to header_primary-high

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -390,6 +390,7 @@
     gap: 0.5em;
 
     .discourse-tags {
+      --tag-text-color: var(--header_primary-high);
       display: inline;
 
       @include ellipsis;


### PR DESCRIPTION
This regressed at some point, tags should use a header color variable to match other header elements 


Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/8d35207e-3ff5-4435-8c9b-0fa994f18176" />


After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/4b1adc00-4130-4878-a3ff-ee42ff16798c" />
