### PR TITLE
UX: Introduce shadow variables

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer/toolbar-buttons.gjs
@@ -72,6 +72,7 @@ export default class ComposerToolbarButtons extends Component {
                 "toolbar__button"
                 button.className
                 (if (this.isButtonActive button) "--active")
+                "btn-transparent"
               }}
               rel={{if button.href "noopener noreferrer"}}
               target={{if button.href "_blank"}}

--- a/app/assets/javascripts/discourse/app/components/interface-color-selector.gjs
+++ b/app/assets/javascripts/discourse/app/components/interface-color-selector.gjs
@@ -51,7 +51,7 @@ export default class InterfaceColorSelector extends Component {
         <DropdownMenu as |dropdown|>
           <dropdown.item>
             <DButton
-              class="interface-color-selector__light-option"
+              class="interface-color-selector__light-option btn-flat"
               @icon="sun"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.light"
@@ -61,7 +61,7 @@ export default class InterfaceColorSelector extends Component {
           </dropdown.item>
           <dropdown.item>
             <DButton
-              class="interface-color-selector__dark-option"
+              class="interface-color-selector__dark-option btn-flat"
               @icon="moon"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.dark"
@@ -71,7 +71,7 @@ export default class InterfaceColorSelector extends Component {
           </dropdown.item>
           <dropdown.item>
             <DButton
-              class="interface-color-selector__auto-option"
+              class="interface-color-selector__auto-option btn-flat"
               @icon="circle-half-stroke"
               @translatedLabel={{i18n
                 "sidebar.footer.interface_color_selector.auto"

--- a/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
@@ -137,8 +137,7 @@ export default class ToolbarPopupmenuOptions extends Component {
       @onKeydown={{@onKeydown}}
       tabindex="-1"
       @triggerClass={{concatClass "toolbar__button" @class}}
-      @class="toolbar-popup-menu-options"
-      title={{@title}}
+      @class="toolbar-popup-menu-options btn-transparent"
     >
       <:trigger>
         {{icon (this.getIcon this.args)}}

--- a/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
@@ -152,7 +152,10 @@ export default class ToolbarPopupmenuOptions extends Component {
                 @icon={{this.getIcon option}}
                 @action={{fn this.onSelect option}}
                 data-name={{option.name}}
-                class={{concatClass (if (this.getActive option) "--active")}}
+                class={{concatClass
+                  (if (this.getActive option) "--active")
+                  "btn-transparent"
+                }}
               />
             </dropdown.item>
           {{/each}}

--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -107,6 +107,7 @@ export default class TopicAdminMenu extends Component {
                   @label="topic.actions.multi_select"
                   @action={{fn this.onButtonAction "toggleMultiSelect"}}
                   @icon="list-check"
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -123,7 +124,7 @@ export default class TopicAdminMenu extends Component {
                     @label="topic.actions.delete"
                     @action={{fn this.onButtonAction "deleteTopic"}}
                     @icon="trash-can"
-                    class="popup-menu-btn-danger btn-danger"
+                    class="popup-menu-btn-danger btn-danger btn-transparent"
                   />
                 </dropdown.item>
               {{else if this.canRecover}}
@@ -132,6 +133,7 @@ export default class TopicAdminMenu extends Component {
                     @label="topic.actions.recover"
                     @action={{fn this.onButtonAction "recoverTopic"}}
                     @icon="arrow-rotate-left"
+                    class="btn-transparent"
                   />
                 </dropdown.item>
               {{/if}}
@@ -153,6 +155,7 @@ export default class TopicAdminMenu extends Component {
                   }}
                   @action={{fn this.onButtonAction "toggleClosed"}}
                   @icon={{if @topic.closed "topic.opened" "topic.closed"}}
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -173,6 +176,7 @@ export default class TopicAdminMenu extends Component {
                   }}
                   @action={{fn this.onButtonAction "showFeatureTopic"}}
                   @icon="thumbtack"
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -189,6 +193,7 @@ export default class TopicAdminMenu extends Component {
                   }}
                   @action={{fn this.onButtonAction "toggleArchived"}}
                   @icon="folder"
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -203,6 +208,7 @@ export default class TopicAdminMenu extends Component {
                   }}
                   @action={{fn this.onButtonAction "toggleVisibility"}}
                   @icon={{if this.visible "far-eye-slash" "far-eye"}}
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -215,6 +221,7 @@ export default class TopicAdminMenu extends Component {
                     "topic.actions.make_public"
                     "topic.actions.make_private"
                   }}
+                  class="btn-transparent"
                   @action={{fn
                     this.onButtonAction
                     (if
@@ -236,6 +243,7 @@ export default class TopicAdminMenu extends Component {
                   @label="topic.actions.timed_update"
                   @action={{fn this.onButtonAction "showTopicTimerModal"}}
                   @icon="far-clock"
+                  class="btn-transparent"
                 />
               </dropdown.item>
 
@@ -245,6 +253,7 @@ export default class TopicAdminMenu extends Component {
                     @label="topic.change_timestamp.title"
                     @action={{fn this.onButtonAction "showChangeTimestamp"}}
                     @icon="calendar-days"
+                    class="btn-transparent"
                   />
                 </dropdown.item>
               {{/if}}
@@ -254,6 +263,7 @@ export default class TopicAdminMenu extends Component {
                   @label="topic.actions.reset_bump_date"
                   @action={{fn this.onButtonAction "resetBumpDate"}}
                   @icon="anchor"
+                  class="btn-transparent"
                 />
               </dropdown.item>
 
@@ -262,6 +272,7 @@ export default class TopicAdminMenu extends Component {
                   @label="topic.actions.slow_mode"
                   @action={{fn this.onButtonAction "showTopicSlowModeUpdate"}}
                   @icon="hourglass-start"
+                  class="btn-transparent"
                 />
               </dropdown.item>
             {{/if}}
@@ -275,6 +286,7 @@ export default class TopicAdminMenu extends Component {
                     @label="review.moderation_history"
                     @href={{this.topicModerationHistoryUrl}}
                     @icon="list"
+                    class="btn-transparent"
                   />
                 </dropdown.item>
               {{/if}}

--- a/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -247,6 +247,7 @@ export default class TopicMapSummary extends Component {
         @arrow={{true}}
         @identifier="topic-map__views"
         @interactive={{true}}
+        @triggerClass="btn-flat"
         @triggers="click"
         @modalForMobile={{true}}
         @placement="right"

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -118,7 +118,7 @@ export default class WelcomeBanner extends Component {
                 @icon="magnifying-glass"
                 @title="search.open_advanced"
                 @href="/search?expanded=true"
-                class="search-icon"
+                class="search-icon btn-transparent"
               />
               <SearchMenu
                 @location="welcome-banner"

--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -41,6 +41,7 @@
     outline: none !important;
     background: none !important;
     width: 100% !important;
+    box-shadow: none !important;
   }
 }
 

--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -128,6 +128,7 @@
   --d-link-color: var(--tertiary);
   --title-color--read: var(--primary-medium);
   --content-border-color: var(--primary-low);
+  --d-popover-border-color: var(--content-border-color);
   --input-border-color: var(--primary-400);
   --table-border-color: var(--content-border-color);
   --metadata-color: var(--primary-medium);

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -321,6 +321,7 @@ input {
     border: var(--d-input-border);
     border-radius: var(--d-input-border-radius);
     color-scheme: var(--scheme-type);
+    box-shadow: var(--d-box-shadow);
 
     &:focus {
       @include default-focus;

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -14,6 +14,7 @@
   --d-input-border--disabled: 1px solid var(--primary-low);
   --d-nav-color: var(--primary);
   --d-nav-bg-color: transparent;
+  --d-nav-border: none;
   --d-nav-color--hover: var(--tertiary);
   --d-nav-bg-color--hover: transparent;
   --d-nav-color--active: var(--tertiary);
@@ -70,6 +71,14 @@
   --topic-list-item-background-color--visited: var(--secondary);
   --list-container-padding-x: 0em;
   --d-topic-list-header-font-size: initial;
+  --x-shadow-offset: 0px;
+  --y-shadow-offset: 0px;
+  --blur-shadow: 0px;
+  --spread-shadow: 0px;
+  --d-shadow-color: rgb(0, 0, 0, 0.1);
+  --d-box-shadow: var(--x-shadow-offset) var(--y-shadow-offset)
+    var(--blur-shadow) var(--spread-shadow) var(--d-shadow-color);
+  --d-popover-box-shadow: var(--shadow-dropdown);
 }
 
 // Animation Keyframes

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -75,7 +75,7 @@
   --y-shadow-offset: 0px;
   --blur-shadow: 0px;
   --spread-shadow: 0px;
-  --d-shadow-color: rgb(0, 0, 0, 0.1);
+  --d-shadow-color: transparent;
   --d-box-shadow: var(--x-shadow-offset) var(--y-shadow-offset)
     var(--blur-shadow) var(--spread-shadow) var(--d-shadow-color);
   --d-popover-box-shadow: var(--shadow-dropdown);

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -256,11 +256,6 @@
 .fk-d-menu.interface-color-selector-content.-expanded {
   margin-top: -0.75em;
   z-index: z("header");
-  box-shadow: var(--shadow-dropdown);
-
-  .fk-d-menu__inner-content {
-    border-color: transparent;
-  }
 }
 
 .header-sidebar-toggle {

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -45,6 +45,10 @@
       border: none;
     }
 
+    .nav-pills li a {
+      box-shadow: none;
+    }
+
     @include viewport.until(md) {
       width: 100%;
       margin-top: 0.5em;

--- a/app/assets/stylesheets/common/base/list-controls.scss
+++ b/app/assets/stylesheets/common/base/list-controls.scss
@@ -18,6 +18,7 @@
     border: 1px solid var(--input-border-color);
     font-size: var(--font-0);
     height: 100%;
+    box-shadow: var(--d-box-shadow);
 
     &:focus {
       border-color: var(--tertiary);

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -54,9 +54,8 @@
 }
 
 .menu-panel {
-  --shadow-dropdown: 0 4px 6px -1px #0000001a, 0 2px 4px -2px #0000001a;
   --list-item-padding: 0.5em 1rem;
-  border: 1px solid var(--content-border-color);
+  border: 1px solid var(--d-popover-border-color);
   box-shadow: var(--shadow-dropdown);
   background-color: var(--secondary);
   z-index: z("header");

--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -61,6 +61,7 @@
 
 .new-user-wrapper {
   .user-navigation {
+    --d-box-shadow: none;
     --user-navigation__border-width: 4px;
     border-bottom: 1px solid var(--content-border-color);
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -54,6 +54,7 @@
     border: var(--d-input-border);
     border-radius: var(--d-input-border-radius);
     padding: var(--space-1) 0;
+    box-shadow: var(--d-box-shadow);
 
     input.search-term__input {
       background: none;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -456,6 +456,7 @@
     width: 100%;
     height: var(--d-sidebar-row-height);
     cursor: pointer;
+    box-shadow: none;
 
     &:focus {
       outline: none;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -449,14 +449,6 @@ nav.post-controls {
     }
 
     button {
-      flex: 0 1 auto;
-      font-size: var(--font-up-1);
-      padding: 8px 10px;
-      vertical-align: top;
-      background: transparent;
-      border: none;
-      border-radius: var(--d-post-control-border-radius);
-
       .discourse-no-touch & {
         &:hover,
         &:focus-visible,
@@ -491,7 +483,6 @@ nav.post-controls {
       }
 
       &.create {
-        margin-right: 0;
         color: var(--d-post-control-create-text-color);
 
         .d-icon {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -86,6 +86,7 @@
 
   @include form-item-sizing;
   border: var(--d-button-border);
+  box-shadow: var(--d-box-shadow);
 
   &:visited {
     /* covers cases where we add button classes to links */
@@ -345,6 +346,7 @@
   border: 0;
   line-height: var(--line-height-small);
   transition: var(--d-button-transition);
+  box-shadow: none;
 
   .d-icon {
     color: var(--d-button-flat-icon-color);
@@ -490,6 +492,7 @@
     background: transparent;
     border: 0;
     color: var(--d-button-transparent-text-color);
+    box-shadow: none;
 
     .d-icon {
       color: var(--d-button-transparent-icon-color);

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -40,6 +40,8 @@
       align-items: center;
       background-color: var(--d-nav-bg-color);
       transition: var(--d-button-transition);
+      box-shadow: var(--d-box-shadow);
+      border: var(--d-nav-border);
 
       .d-icon {
         margin-right: 5px;
@@ -55,6 +57,16 @@
     a.active,
     button.active {
       @include nav-active;
+    }
+  }
+}
+
+.admin-content,
+.user-navigation {
+  .nav-pills > li {
+    a,
+    button {
+      box-shadow: none;
     }
   }
 }

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -56,6 +56,7 @@
       .search-term__input {
         min-width: 0;
         flex: 1 1;
+        box-shadow: none;
       }
     }
 

--- a/app/assets/stylesheets/common/float-kit/d-menu.scss
+++ b/app/assets/stylesheets/common/float-kit/d-menu.scss
@@ -42,7 +42,7 @@
     display: flex;
     border-radius: var(--d-border-radius);
     background-color: var(--secondary);
-    border: 1px solid var(--content-border-color);
+    border: 1px solid var(--d-popover-border-color);
     box-shadow: var(--shadow-dropdown);
     overscroll-behavior: contain;
     overflow: auto;

--- a/app/assets/stylesheets/common/select-kit/combo-box.scss
+++ b/app/assets/stylesheets/common/select-kit/combo-box.scss
@@ -27,7 +27,8 @@
 
     .select-kit-header {
       background: var(--secondary);
-      border-color: var(--primary-400);
+      border-color: var(--input-border-color);
+      box-shadow: var(--d-box-shadow);
 
       &.is-focused {
         @include default-focus;

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -38,8 +38,8 @@
       align-items: center;
       justify-content: center;
       border-radius: var(--d-border-radius);
-      border: 1px solid var(--content-border-color);
-      box-shadow: var(--shadow-dropdown);
+      border: 1px solid var(--d-popover-border-color);
+      box-shadow: var(--d-popover-box-shadow);
       background: var(--secondary);
       max-width: 600px;
     }

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -78,28 +78,8 @@ section.post-menu-area {
 }
 
 nav.post-controls {
-  // for consistency, try to control spacing by editing these variables
-  --control-margin: 0.33em;
-  --control-icon-space: 0.33em;
-
   .actions {
-    button {
-      margin-left: var(--control-margin);
-
-      &.btn-icon-text,
-      &.create {
-        margin-left: calc(var(--control-margin) * 1.52);
-
-        .d-icon {
-          margin-right: var(--control-icon-space);
-        }
-      }
-    }
-
-    // Some buttons can be doubled up, like likes or flags
-    .double-button {
-      margin-left: var(--control-margin);
-    }
+    gap: var(--space-2);
   }
 
   .show-replies {
@@ -111,11 +91,6 @@ nav.post-controls {
 
     .topic-post & {
       margin-right: var(--space-2);
-    }
-
-    .d-icon {
-      margin-inline: var(--control-icon-space);
-      margin-left: 0;
     }
 
     &[aria-expanded="true"] {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -80,7 +80,6 @@ section.post-menu-area {
 nav.post-controls {
   .actions {
     gap: var(--space-1);
-    font-size: var(--font-up-1);
   }
 
   .show-replies {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -79,7 +79,8 @@ section.post-menu-area {
 
 nav.post-controls {
   .actions {
-    gap: var(--space-2);
+    gap: var(--space-1);
+    font-size: var(--font-up-1);
   }
 
   .show-replies {

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import { and } from "truth-helpers";
+import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
 import closeOnClickOutside from "discourse/modifiers/close-on-click-outside";
@@ -203,12 +204,12 @@ export default class DiscourseReactionsCounter extends Component {
 
         {{#if (and @post.yours this.onlyOneMainReaction)}}
           <div class="discourse-reactions-reaction-button my-likes">
-            <button
+            <DButton
               type="button"
-              class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+              class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
             >
               {{icon this.siteSettings.discourse_reactions_like_icon}}
-            </button>
+            </DButton>
           </div>
         {{/if}}
       {{/if}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
@@ -134,6 +134,7 @@ export default class DiscourseReactionsPicker extends Component {
           {{#each this.reactionInfo as |reaction|}}
             <DButton
               class={{concatClass
+                "btn-flat"
                 "pickable-reaction"
                 reaction.id
                 (if reaction.canUndo "can-undo")

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
@@ -126,7 +126,7 @@ export default class ReactionsReactionButton extends Component {
       {{else if @post.current_user_reaction}}
         <DButton
           type="button"
-          class="btn-icon btn no-text btn-flat reaction-button"
+          class="btn-icon no-text btn-flat reaction-button"
           title={{this.title}}
         >
           <img
@@ -138,7 +138,7 @@ export default class ReactionsReactionButton extends Component {
       {{else}}
         <DButton
           type="button"
-          class="btn-toggle-reaction-like btn btn-flat btn-icon no-text reaction-button"
+          class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
           title={{this.title}}
         >
           {{icon

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { isBlank } from "@ember/utils";
+import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { emojiUrlFor } from "discourse/lib/text";
 import { i18n } from "discourse-i18n";
@@ -115,17 +116,17 @@ export default class ReactionsReactionButton extends Component {
       title={{this.title}}
     >
       {{#if @post.current_user_used_main_reaction}}
-        <button
+        <DButton
           type="button"
-          class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+          class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
           title={{this.title}}
         >
           {{icon this.siteSettings.discourse_reactions_like_icon}}
-        </button>
+        </DButton>
       {{else if @post.current_user_reaction}}
-        <button
+        <DButton
           type="button"
-          class="btn-icon no-text reaction-button"
+          class="btn-icon btn no-text btn-flat reaction-button"
           title={{this.title}}
         >
           <img
@@ -133,17 +134,17 @@ export default class ReactionsReactionButton extends Component {
             src={{emojiUrlFor @post.current_user_reaction.id}}
             alt={{concat ":" @post.current_user_reaction.id}}
           />
-        </button>
+        </DButton>
       {{else}}
-        <button
+        <DButton
           type="button"
-          class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+          class="btn-toggle-reaction-like btn btn-flat btn-icon no-text reaction-button"
           title={{this.title}}
         >
           {{icon
             (concat "far-" this.siteSettings.discourse_reactions_like_icon)
           }}
-        </button>
+        </DButton>
       {{/if}}
     </div>
   </template>


### PR DESCRIPTION
This pr applies box-shadow variables in order to allow theming users to easily & quickly add drop shadow to multiple areas.

|area|example|
|--|--|
|drop-down, pop-up|<img width="200" height="1030" alt="CleanShot 2025-08-07 at 16 35 09@2x" src="https://github.com/user-attachments/assets/539ce748-adaa-4338-b590-683040304173" />| 
|default buttons w/ text|<img width="344" height="180" alt="CleanShot 2025-08-07 at 16 33 09@2x" src="https://github.com/user-attachments/assets/b4af32a1-3666-4fc5-b45b-5b5abb1f343e" />|
|default button w/ icon|<img width="164" height="140" alt="CleanShot 2025-08-07 at 16 33 35@2x" src="https://github.com/user-attachments/assets/93abe505-0e14-48a1-9f42-4ce50800b90e" />|
|select kit header|<img width="436" height="178" alt="CleanShot 2025-08-07 at 16 32 58@2x" src="https://github.com/user-attachments/assets/d0bbb55b-6ec9-4576-acf4-52a9d1948227" />|
|nav pills|<img width="632" height="166" alt="CleanShot 2025-08-07 at 16 32 36@2x" src="https://github.com/user-attachments/assets/8bef2a52-68bc-4eb0-99e1-6a99d42d27bf" />|
|inputs|<img width="1344" height="278" alt="CleanShot 2025-08-07 at 16 32 26@2x" src="https://github.com/user-attachments/assets/2adbd720-fe53-4520-a544-b7d5f5c5b571" />|