### PR TITLE
UX: minor search spacing improvements

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -40,7 +40,7 @@
 
     .search-menu-panel & {
       @include viewport.from(sm) {
-        padding: var(--space-3) var(--space-4) 0;
+        padding: var(--space-3) var(--space-4);
       }
     }
   }
@@ -68,7 +68,6 @@
     }
 
     .btn.search-context {
-      margin: 2px;
       margin-right: 0;
       white-space: nowrap;
       background-color: var(--primary-200);
@@ -116,7 +115,7 @@
     background-color: var(--primary-200);
 
     @include viewport.from(sm) {
-      margin-left: var(--space-4);
+      margin-left: var(--space-1);
       margin-right: 0;
     }
 
@@ -136,7 +135,6 @@
     display: flex;
     flex-direction: column;
     border-radius: var(--d-border-radius);
-    padding-top: var(--space-3);
 
     .heading {
       padding: var(--space-2) 0 0 var(--space-4);

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -114,10 +114,6 @@
   width: 1.15em;
 }
 
-.ai-discobot-discoveries {
-  padding-top: 0.5em;
-}
-
 @include viewport.from(lg) {
   .search-menu .menu-panel:has(.ai-search-discoveries__discoveries-title) {
     width: 80vw;
@@ -153,6 +149,7 @@
     .ai-search-discoveries {
       font-size: var(--font-0);
       color: var(--primary-high);
+      padding-top: 0.5em;
       padding-right: 0.5em;
     }
 


### PR DESCRIPTION
The context button and the bottom of the input don't have enough space

Before:
<img width="1054" height="274" alt="image" src="https://github.com/user-attachments/assets/3998f7ac-2b0e-4ecb-887c-081d92af1c81" />

After:
<img width="1072" height="280" alt="image" src="https://github.com/user-attachments/assets/800046ec-45ba-4b8e-85e9-8f1047c308a8" />

