### PR TITLE
UX: avoid prosemirror nodes w/ content and draggable:true

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-block.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-block.js
@@ -10,7 +10,6 @@ const extension = {
       marks: "",
       isolating: true,
       selectable: true,
-      draggable: true,
       parseDOM: [{ tag: "pre.html-block", preserveWhitespace: "full" }],
       toDOM() {
         return ["pre", { class: "html-block" }, ["code", 0]];

--- a/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/poll/assets/javascripts/lib/rich-editor-extension.js
@@ -15,7 +15,6 @@ const extension = {
       },
       content: "heading? bullet_list poll_info?",
       group: "block",
-      draggable: true,
       selectable: true,
       isolating: true,
       defining: true,


### PR DESCRIPTION
A `draggable: true` ProseMirror node ["can be dragged without being selected"](https://prosemirror.net/docs/ref/#model.NodeSpec.draggable), so it doesn't make sense for nodes that allow inner `content`, as it would break the drag-text selection.

We had `html_block` and `poll` in this situation.