### PR TITLE
UX: add hard break with double space+enter on rich editor

### DIFF
--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -554,6 +554,16 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("hr")
     end
 
+    it "creates hard break when pressing Enter after double space at end of line" do
+      open_composer
+      composer.type_content("Line with double space  ")
+      composer.send_keys(:enter)
+      composer.type_content("Next line")
+
+      composer.toggle_rich_editor
+      expect(composer).to have_value("Line with double space\nNext line")
+    end
+
     it "supports Backspace to reset a heading" do
       open_composer
       composer.type_content("# With text")


### PR DESCRIPTION
Supports an ENTER key mapping to add a hard break when triggered at the end of a line ending in two spaces.