### PR TITLE
UX: add [quote] rich editor input rule

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
@@ -8,7 +8,7 @@ const extension = {
       selectable: true,
       isolating: true,
       attrs: {
-        username: {},
+        username: { default: null },
         postNumber: { default: null },
         topicId: { default: null },
         full: { default: null },
@@ -102,6 +102,16 @@ const extension = {
       state.write("[/quote]\n\n");
     },
   },
+  inputRules: ({ utils: { convertFromMarkdown } }) => ({
+    match: /^\[quote([^\]]*)\]$/,
+    handler: (state, match, start, end) => {
+      const markdown = match[0] + "\n[/quote]";
+
+      return state.tr
+        .replaceWith(start - 1, end, convertFromMarkdown(markdown))
+        .scrollIntoView();
+    },
+  }),
   plugins({
     pmState: { Plugin, NodeSelection },
     pmModel: { Slice, Fragment },

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -309,7 +309,10 @@ describe "Composer - ProseMirror editor", type: :system do
       open_composer
       composer.type_content("[quote=\"johndoe, post:1, topic:123\"]")
 
-      expect(rich).to have_css("aside.quote[data-username='johndoe'][data-post='1'][data-topic='123'] .title", text: "johndoe:")
+      expect(rich).to have_css(
+        "aside.quote[data-username='johndoe'][data-post='1'][data-topic='123'] .title",
+        text: "johndoe:",
+      )
       expect(rich).to have_css("aside.quote blockquote")
 
       composer.toggle_rich_editor

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -281,6 +281,49 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(composer).to have_value("<http://example.com>")
     end
+
+    it "supports [quote] to create a quote block" do
+      open_composer
+      composer.type_content("[quote]")
+
+      expect(rich).to have_css("aside.quote blockquote")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("[quote]\n\n[/quote]\n\n")
+    end
+
+    it "supports [quote=\"username\"] to create a quote block with attribution" do
+      open_composer
+      composer.type_content("[quote=\"johndoe\"]")
+
+      expect(rich).to have_css("aside.quote[data-username='johndoe'] .title", text: "johndoe:")
+      expect(rich).to have_css("aside.quote blockquote")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("[quote=\"johndoe\"]\n\n[/quote]\n\n")
+    end
+
+    it "supports [quote=\"username, post:1, topic:123\"] to create a quote block with full attribution" do
+      open_composer
+      composer.type_content("[quote=\"johndoe, post:1, topic:123\"]")
+
+      expect(rich).to have_css("aside.quote[data-username='johndoe'][data-post='1'][data-topic='123'] .title", text: "johndoe:")
+      expect(rich).to have_css("aside.quote blockquote")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("[quote=\"johndoe, post:1, topic:123\"]\n\n[/quote]\n\n")
+    end
+
+    it "doesn't trigger quote input rule in the middle of text" do
+      open_composer
+      composer.type_content("This [quote] should not trigger")
+
+      expect(rich).to have_no_css("aside.quote")
+      expect(rich).to have_content("This [quote] should not trigger")
+    end
   end
 
   context "with oneboxing" do


### PR DESCRIPTION
Adds a `[quote*]` input rule – when matched, leverages the markdown parser to convert it to ProseMirror.