### PR TITLE
UX: add [^n] rich editor footnote input rule

### DIFF
--- a/plugins/footnote/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/footnote/assets/javascripts/lib/rich-editor-extension.js
@@ -20,6 +20,10 @@ function createFootnoteNodeView({
       if (!this.innerView) {
         this.open();
       }
+
+      if (this.innerView) {
+        this.innerView.dom.focus();
+      }
     }
 
     deselectNode() {
@@ -231,18 +235,31 @@ const extension = {
       }
     },
   },
-  inputRules: [
-    {
-      match: /\^\[(.*?)]$/,
-      handler: (state, match, start, end) => {
-        const content = state.doc.slice(start + 2, end).content;
-        const paragraph = state.schema.nodes.paragraph.create(null, content);
-        const footnote = state.schema.nodes.footnote.create(null, paragraph);
+  inputRules({ pmState: { NodeSelection } }) {
+    return [
+      {
+        match: /\^\[(.*?)]$/,
+        handler: (state, match, start, end) => {
+          const content = state.doc.slice(start + 2, end).content;
+          const paragraph = state.schema.nodes.paragraph.create(null, content);
+          const footnote = state.schema.nodes.footnote.create(null, paragraph);
 
-        return state.tr.replaceWith(start, end, footnote);
+          return state.tr.replaceWith(start, end, footnote);
+        },
       },
-    },
-  ],
+      {
+        match: /\[\^\d+]$/,
+        handler: (state, match, start, end) => {
+          const paragraph = state.schema.nodes.paragraph.create();
+          const footnote = state.schema.nodes.footnote.create(null, paragraph);
+
+          const tr = state.tr.replaceWith(start, end, footnote);
+          tr.setSelection(NodeSelection.create(tr.doc, start));
+          return tr;
+        },
+      },
+    ];
+  },
 };
 
 export default extension;

--- a/plugins/footnote/spec/system/rich_editor_extension_spec.rb
+++ b/plugins/footnote/spec/system/rich_editor_extension_spec.rb
@@ -69,4 +69,19 @@ describe "Composer - ProseMirror editor - Footnote extension", type: :system do
       expect(composer).to have_value("What is this? ^[multiple inline] ^[footnotes]")
     end
   end
+
+  describe "typing reference" do
+    it "creates an inline footnote from [^n] and focuses inside" do
+      open_composer_and_toggle_rich_editor
+      rich.click
+
+      rich.send_keys("[^1]Hello")
+
+      expect(rich).to have_css("div.footnote", count: 1)
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("^[Hello]")
+    end
+  end
 end


### PR DESCRIPTION
Adds a `[^n]` input rule to trigger a footnote creation on rich editor.