### PR TITLE
FEATURE: remove dark mode checkbox 

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -231,9 +231,9 @@ export default class InterfaceController extends Controller {
     return result;
   }
 
-  @discourseComputed
-  showDarkModeToggle() {
-    return this.defaultDarkSchemeId > 0 && !this.showDarkColorSchemeSelector;
+  @discourseComputed("selectedDarkColorSchemeId")
+  showInterfaceColorModeSelector(selectedDarkColorSchemeId) {
+    return this.defaultDarkSchemeId > 0 || selectedDarkColorSchemeId > 0;
   }
 
   @discourseComputed
@@ -243,8 +243,20 @@ export default class InterfaceController extends Controller {
     });
   }
 
+  @discourseComputed(
+    "userSelectableColorSchemes",
+    "userSelectableDarkColorSchemes"
+  )
+  showColorSchemeSelector() {
+    return (
+      this.showLightColorSchemeSelector ||
+      this.showDarkColorSchemeSelector ||
+      this.showInterfaceColorModeSelector
+    );
+  }
+
   @discourseComputed("userSelectableColorSchemes")
-  showColorSchemeSelector(lightSchemes) {
+  showLightColorSchemeSelector(lightSchemes) {
     return lightSchemes && lightSchemes.length > 1;
   }
 
@@ -325,26 +337,19 @@ export default class InterfaceController extends Controller {
 
     if (!this.showColorSchemeSelector) {
       this.set("model.user_option.color_scheme_id", null);
+      this.set("model.user_option.dark_scheme_id", null);
     } else if (this.makeColorSchemeDefault) {
       this.set("model.user_option.color_scheme_id", this.selectedColorSchemeId);
+      this.set(
+        "model.user_option.dark_scheme_id",
+        this.selectedDarkColorSchemeId
+      );
       if (this.selectedInterfaceColorModeId) {
         this.set(
           "model.user_option.interface_color_mode",
           this.selectedInterfaceColorModeId
         );
       }
-    }
-
-    if (this.showDarkModeToggle) {
-      this.set(
-        "model.user_option.dark_scheme_id",
-        this.enableDarkMode ? null : -1
-      );
-    } else {
-      this.set(
-        "model.user_option.dark_scheme_id",
-        this.selectedDarkColorSchemeId
-      );
     }
 
     return this.model

--- a/app/assets/javascripts/discourse/app/routes/preferences-interface.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-interface.js
@@ -12,7 +12,6 @@ export default class PreferencesInterface extends RestrictedUserRoute {
         currentThemeId() === user.get("user_option.theme_ids")[0],
       makeTextSizeDefault:
         user.get("currentTextSize") === user.get("user_option.text_size"),
-      enableDarkMode: user.get("user_option.dark_scheme_id") !== -1,
     });
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.gjs
@@ -52,20 +52,20 @@ export default RouteTemplate(
       >
         <legend class="control-label">{{i18n "user.color_scheme"}}</legend>
         <div class="controls">
-          <div class="control-subgroup light-color-scheme">
-            {{#if @controller.showDarkColorSchemeSelector}}
+          {{#if @controller.showLightColorSchemeSelector}}
+            <div class="control-subgroup light-color-scheme">
               <div class="instructions">{{i18n
                   "user.color_schemes.regular"
                 }}</div>
-            {{/if}}
-            <div class="controls">
-              <ColorPalettePicker
-                @content={{@controller.userSelectableColorSchemes}}
-                @value={{@controller.selectedColorSchemeId}}
-                @onChange={{@controller.loadColorScheme}}
-              />
+              <div class="controls">
+                <ColorPalettePicker
+                  @content={{@controller.userSelectableColorSchemes}}
+                  @value={{@controller.selectedColorSchemeId}}
+                  @onChange={{@controller.loadColorScheme}}
+                />
+              </div>
             </div>
-          </div>
+          {{/if}}
           {{#if @controller.showDarkColorSchemeSelector}}
             <div class="control-subgroup dark-color-scheme">
               <div class="instructions">{{i18n "user.color_schemes.dark"}}</div>
@@ -77,6 +77,8 @@ export default RouteTemplate(
                 />
               </div>
             </div>
+          {{/if}}
+          {{#if @controller.showInterfaceColorModeSelector}}
             <div class="control-subgroup interface-color-mode">
               <div class="instructions">{{i18n
                   "user.color_schemes.interface_mode"
@@ -113,18 +115,6 @@ export default RouteTemplate(
           </div>
         {{/if}}
       </fieldset>
-    {{/if}}
-
-    {{#if @controller.showDarkModeToggle}}
-      <div class="control-group dark-mode" data-setting-name="user-dark-mode">
-        <label class="control-label">{{i18n "user.dark_mode"}}</label>
-        <div class="controls">
-          <PreferenceCheckbox
-            @labelKey="user.dark_mode_enable"
-            @checked={{@controller.enableDarkMode}}
-          />
-        </div>
-      </div>
     {{/if}}
 
     <div class="control-group text-size" data-setting-name="user-text-size">

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -241,9 +241,6 @@ acceptance(
           session.userDarkSchemeId.toString(),
           "sets site default as selected dark scheme"
         );
-      assert
-        .dom(".control-group.dark-mode")
-        .doesNotExist("does not show disable dark mode checkbox");
 
       removeCookie("color_scheme_id");
       removeCookie("dark_scheme_id");

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -773,18 +773,6 @@
     }
   }
 
-  @media (prefers-color-scheme: dark) {
-    .light-color-scheme {
-      @include inactiveMode;
-    }
-  }
-
-  @media (prefers-color-scheme: light) {
-    .dark-color-scheme {
-      @include inactiveMode;
-    }
-  }
-
   .undo-preview {
     margin: 1em 0;
   }

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -163,7 +163,8 @@ class Theme < ActiveRecord::Base
 
     theme_fields.select(&:basic_html_field?).each(&:invalidate_baked!) if saved_change_to_name?
 
-    if saved_change_to_color_scheme_id? || saved_change_to_user_selectable? || saved_change_to_name?
+    if saved_change_to_color_scheme_id? || saved_change_to_dark_color_scheme_id? ||
+         saved_change_to_user_selectable? || saved_change_to_name?
       Theme.expire_site_cache!
     end
     notify_with_scheme = saved_change_to_color_scheme_id?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1560,7 +1560,6 @@ en:
         picker:
           active: "Active"
       dark_mode: "Dark Mode"
-      dark_mode_enable: "Enable automatic dark mode color palette"
       text_size_default_on_all_devices: "Make this the default text size on all my devices"
       allow_private_messages: "Allow other users to send me personal messages"
       external_links_in_new_tab: "Open all external links in a new tab"

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -20,10 +20,6 @@ module PageObjects
         self
       end
 
-      def dark_mode_checkbox
-        page.find('.dark-mode input[type="checkbox"]')
-      end
-
       def light_scheme_dropdown
         PageObjects::Components::SelectKit.new(".light-color-scheme .select-kit")
       end

--- a/spec/system/user_page/user_preferences_interface_spec.rb
+++ b/spec/system/user_page/user_preferences_interface_spec.rb
@@ -71,19 +71,12 @@ describe "User preferences | Interface", type: :system do
         user.user_option.update!(dark_scheme_id: dark.id, theme_ids: [SiteSetting.default_theme_id])
       end
 
-      it "displays a checkbox for activating/deactivating the dark palette" do
+      it "always display a mode selector when schemes selectors are available" do
         user_preferences_interface_page.visit(user)
-
-        expect(user_preferences_interface_page.dark_mode_checkbox.checked?).to eq(true)
-
-        user_preferences_interface_page.dark_mode_checkbox.click
-        user_preferences_interface_page.save_changes
-
-        expect(user_preferences_interface_page.dark_mode_checkbox.checked?).to eq(false)
-
-        page.refresh
-
-        expect(user_preferences_interface_page.dark_mode_checkbox.checked?).to eq(false)
+        expect(user_preferences_interface_page.color_mode_dropdown).to have_selected_value(
+          UserOption::AUTO_MODE,
+        ),
+        "the default value should be auto mode"
       end
     end
   end


### PR DESCRIPTION
  Improves the user interface preferences by:
  - Removing the separate dark mode toggle in favor of a unified color mode selector
  - Ensuring proper theme cache invalidation when dark color scheme changes
  - Remove dim out dark/light mode based on system settings
<img width="1358" height="445" alt="Screenshot 2025-08-08 at 12 30 50 pm" src="https://github.com/user-attachments/assets/6716d02c-ed45-40af-acff-672ae37bfe26" />
