### PR TITLE
DEV: Unify reviewable action definition.

### DIFF
--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ReviewableActionBuilder
+  extend ActiveSupport::Concern
+
+  # Build a single reviewable action and add it to the provided actions list.
+  # This is the canonical API used by both the legacy and refreshed UI code paths.
+  #
+  # Parameters
+  # - actions: Reviewable::Actions instance to add to
+  # - id: Symbol for the action, used to derive I18n keys
+  # - icon: Ignored in the refreshed UI; accepted for compatibility
+  # - button_class: Optional CSS class for buttons in clients that render it
+  # - bundle: Optional bundle object returned by add_bundle to group actions
+  # - client_action: Optional client-side action identifier (e.g. "edit")
+  # - confirm: When true, uses "reviewables.actions.<id>.confirm" for confirm_message
+  # - confirm_message: Optional explicit confirm message key to override the default
+  # - label: Optional explicit label key to override the default
+  # - description: Optional explicit description key to override the default
+  # - require_reject_reason: When true, requires a rejection reason for the action
+  def build_action(
+    actions,
+    id,
+    icon: nil,
+    button_class: nil,
+    bundle: nil,
+    client_action: nil,
+    confirm: false,
+    confirm_message: nil,
+    label: nil,
+    description: nil,
+    require_reject_reason: false
+  )
+    actions.add(id, bundle: bundle) do |action|
+      prefix = "reviewables.actions.#{id}"
+      action.icon = icon if icon
+      action.button_class = button_class if button_class
+      action.label = label || "#{prefix}.title"
+      action.description = description || "#{prefix}.description"
+      action.client_action = client_action if client_action
+      action.confirm_message = confirm_message if confirm_message
+      action.confirm_message = "#{prefix}.confirm" if confirm && confirm_message.nil?
+      action.require_reject_reason = require_reject_reason
+    end
+  end
+end

--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -8,14 +8,11 @@ module ReviewableActionBuilder
   #
   # @param {Reviewable::Actions} actions - actions instance to add to.
   # @param {Symbol} id - Symbol for the action, used to derive I18n keys.
-  # @param {String} icon - Name of the icon to display with the action. Ignored in the refreshed UI.
+  # @param {String} icon - Optional name of the icon to display with the action. Ignored in the refreshed UI.
   # @param {String} button_class - Optional CSS class for buttons in clients that render it.
   # @param {Reviewable::Actions::Bundle} bundle - Optional bundle object returned by add_bundle to group actions.
   # @param {String} client_action - Optional client-side action identifier (e.g. "edit").
   # @param {Boolean} confirm - When true, uses "reviewables.actions.<id>.confirm" for confirm_message.
-  # @param {String} confirm_message - Optional explicit confirm message key to override the default.
-  # @param {String} label - Optional explicit label key to override the default.
-  # @param {String} description - Optional explicit description key to override the default.
   # @param {Boolean} require_reject_reason - When true, requires a rejection reason for the action.
   def build_action(
     actions,
@@ -25,20 +22,17 @@ module ReviewableActionBuilder
     bundle: nil,
     client_action: nil,
     confirm: false,
-    confirm_message: nil,
-    label: nil,
-    description: nil,
     require_reject_reason: false
   )
     actions.add(id, bundle: bundle) do |action|
       prefix = "reviewables.actions.#{id}"
       action.icon = icon if icon
       action.button_class = button_class if button_class
-      action.label = label || "#{prefix}.title"
-      action.description = description || "#{prefix}.description"
+      action.label = "#{prefix}.title"
+      action.description = "#{prefix}.description"
       action.client_action = client_action if client_action
-      action.confirm_message = confirm_message if confirm_message
-      action.confirm_message = "#{prefix}.confirm" if confirm && confirm_message.nil?
+      action.confirm_message = "#{prefix}.confirm" if confirm
+      action.completed_message = "#{prefix}.complete"
       action.require_reject_reason = require_reject_reason
     end
   end

--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -6,18 +6,17 @@ module ReviewableActionBuilder
   # Build a single reviewable action and add it to the provided actions list.
   # This is the canonical API used by both the legacy and refreshed UI code paths.
   #
-  # Parameters
-  # - actions: Reviewable::Actions instance to add to
-  # - id: Symbol for the action, used to derive I18n keys
-  # - icon: Ignored in the refreshed UI; accepted for compatibility
-  # - button_class: Optional CSS class for buttons in clients that render it
-  # - bundle: Optional bundle object returned by add_bundle to group actions
-  # - client_action: Optional client-side action identifier (e.g. "edit")
-  # - confirm: When true, uses "reviewables.actions.<id>.confirm" for confirm_message
-  # - confirm_message: Optional explicit confirm message key to override the default
-  # - label: Optional explicit label key to override the default
-  # - description: Optional explicit description key to override the default
-  # - require_reject_reason: When true, requires a rejection reason for the action
+  # @param {Reviewable::Actions} actions - actions instance to add to.
+  # @param {Symbol} id - Symbol for the action, used to derive I18n keys.
+  # @param {String} icon - Name of the icon to display with the action. Ignored in the refreshed UI.
+  # @param {String} button_class - Optional CSS class for buttons in clients that render it.
+  # @param {Reviewable::Actions::Bundle} bundle - Optional bundle object returned by add_bundle to group actions.
+  # @param {String} client_action - Optional client-side action identifier (e.g. "edit").
+  # @param {Boolean} confirm - When true, uses "reviewables.actions.<id>.confirm" for confirm_message.
+  # @param {String} confirm_message - Optional explicit confirm message key to override the default.
+  # @param {String} label - Optional explicit label key to override the default.
+  # @param {String} description - Optional explicit description key to override the default.
+  # @param {Boolean} require_reject_reason - When true, requires a rejection reason for the action.
   def build_action(
     actions,
     id,

--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -6,14 +6,16 @@ module ReviewableActionBuilder
   # Build a single reviewable action and add it to the provided actions list.
   # This is the canonical API used by both the legacy and refreshed UI code paths.
   #
-  # @param {Reviewable::Actions} actions - actions instance to add to.
-  # @param {Symbol} id - Symbol for the action, used to derive I18n keys.
-  # @param {String} icon - Optional name of the icon to display with the action. Ignored in the refreshed UI.
-  # @param {String} button_class - Optional CSS class for buttons in clients that render it.
-  # @param {Reviewable::Actions::Bundle} bundle - Optional bundle object returned by add_bundle to group actions.
-  # @param {String} client_action - Optional client-side action identifier (e.g. "edit").
-  # @param {Boolean} confirm - When true, uses "reviewables.actions.<id>.confirm" for confirm_message.
-  # @param {Boolean} require_reject_reason - When true, requires a rejection reason for the action.
+  # @param actions [Reviewable::Actions] Actions instance to add to.
+  # @param id [Symbol] Symbol for the action, used to derive I18n keys.
+  # @param icon [String] Optional name of the icon to display with the action. Ignored in the refreshed UI.
+  # @param button_class [String] Optional CSS class for buttons in clients that render it.
+  # @param bundle [Reviewable::Actions::Bundle] Optional bundle object returned by add_bundle to group actions.
+  # @param client_action [String] Optional client-side action identifier (e.g. "edit").
+  # @param confirm [Boolean] When true, uses "reviewables.actions.<id>.confirm" for confirm_message.
+  # @param require_reject_reason [Boolean] When true, requires a rejection reason for the action.
+  #
+  # @return [Reviewable::Actions] The updated actions instance.
   def build_action(
     actions,
     id,

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Reviewable < ActiveRecord::Base
-  include ReviewableActionBuilder
-
   TYPE_TO_BASIC_SERIALIZER = {
     ReviewableFlaggedPost: BasicReviewableFlaggedPostSerializer,
     ReviewableQueuedPost: BasicReviewableQueuedPostSerializer,
@@ -750,24 +748,18 @@ class Reviewable < ActiveRecord::Base
         label: "reviewables.actions.reject_user.title",
       )
 
-    build_action(
-      actions,
-      :delete_user,
-      icon: "user-xmark",
-      bundle: bundle,
-      label: "reviewables.actions.reject_user.delete.title",
-      require_reject_reason: require_reject_reason,
-    )
+    actions.add(:delete_user, bundle: bundle) do |a|
+      a.icon = "user-xmark"
+      a.label = "reviewables.actions.reject_user.delete.title"
+      a.require_reject_reason = require_reject_reason
+    end
 
-    build_action(
-      actions,
-      :delete_user_block,
-      icon: "ban",
-      bundle: bundle,
-      label: "reviewables.actions.reject_user.block.title",
-      description: "reviewables.actions.reject_user.block.description",
-      require_reject_reason: require_reject_reason,
-    )
+    actions.add(:delete_user_block, bundle: bundle) do |a|
+      a.icon = "ban"
+      a.label = "reviewables.actions.reject_user.block.title"
+      a.description = "reviewables.actions.reject_user.block.description"
+      a.require_reject_reason = require_reject_reason
+    end
   end
 
   protected

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -757,8 +757,8 @@ class Reviewable < ActiveRecord::Base
     actions.add(:delete_user_block, bundle: bundle) do |a|
       a.icon = "ban"
       a.label = "reviewables.actions.reject_user.block.title"
-      a.description = "reviewables.actions.reject_user.block.description"
       a.require_reject_reason = require_reject_reason
+      a.description = "reviewables.actions.reject_user.block.description"
     end
   end
 

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Reviewable < ActiveRecord::Base
+  include ReviewableActionBuilder
+
   TYPE_TO_BASIC_SERIALIZER = {
     ReviewableFlaggedPost: BasicReviewableFlaggedPostSerializer,
     ReviewableQueuedPost: BasicReviewableQueuedPostSerializer,
@@ -748,18 +750,24 @@ class Reviewable < ActiveRecord::Base
         label: "reviewables.actions.reject_user.title",
       )
 
-    actions.add(:delete_user, bundle: bundle) do |a|
-      a.icon = "user-xmark"
-      a.label = "reviewables.actions.reject_user.delete.title"
-      a.require_reject_reason = require_reject_reason
-    end
+    build_action(
+      actions,
+      :delete_user,
+      icon: "user-xmark",
+      bundle: bundle,
+      label: "reviewables.actions.reject_user.delete.title",
+      require_reject_reason: require_reject_reason,
+    )
 
-    actions.add(:delete_user_block, bundle: bundle) do |a|
-      a.icon = "ban"
-      a.label = "reviewables.actions.reject_user.block.title"
-      a.require_reject_reason = require_reject_reason
-      a.description = "reviewables.actions.reject_user.block.description"
-    end
+    build_action(
+      actions,
+      :delete_user_block,
+      icon: "ban",
+      bundle: bundle,
+      label: "reviewables.actions.reject_user.block.title",
+      description: "reviewables.actions.reject_user.block.description",
+      require_reject_reason: require_reject_reason,
+    )
   end
 
   protected

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReviewableFlaggedPost < Reviewable
+  include ReviewableActionBuilder
+
   scope :pending_and_default_visible, -> { pending.default_visible }
 
   # Penalties are handled by the modal after the action is performed
@@ -308,27 +310,6 @@ class ReviewableFlaggedPost < Reviewable
     create_result(:success, :approved) do |result|
       result.update_flag_stats = { status: :agreed, user_ids: actions.map(&:user_id) }
       result.recalculate_score = true
-    end
-  end
-
-  def build_action(
-    actions,
-    id,
-    icon:,
-    button_class: nil,
-    bundle: nil,
-    client_action: nil,
-    confirm: false
-  )
-    actions.add(id, bundle: bundle) do |action|
-      prefix = "reviewables.actions.#{id}"
-      action.icon = icon
-      action.button_class = button_class
-      action.label = "#{prefix}.title"
-      action.description = "#{prefix}.description"
-      action.client_action = client_action
-      action.confirm_message = "#{prefix}.confirm" if confirm
-      action.completed_message = "#{prefix}.complete"
     end
   end
 

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReviewablePost < Reviewable
+  include ReviewableActionBuilder
+
   def self.action_aliases
     { reject_and_silence: :reject_and_suspend }
   end
@@ -106,27 +108,6 @@ class ReviewablePost < Reviewable
 
   def post
     @post ||= (target || Post.with_deleted.find_by(id: target_id))
-  end
-
-  def build_action(
-    actions,
-    id,
-    icon:,
-    button_class: nil,
-    bundle: nil,
-    client_action: nil,
-    confirm: false
-  )
-    actions.add(id, bundle: bundle) do |action|
-      prefix = "reviewables.actions.#{id}"
-      action.icon = icon
-      action.button_class = button_class
-      action.label = "#{prefix}.title"
-      action.description = "#{prefix}.description"
-      action.client_action = client_action
-      action.confirm_message = "#{prefix}.confirm" if confirm
-      action.completed_message = "#{prefix}.complete"
-    end
   end
 
   def successful_transition(to_state, recalculate_score: true)

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -67,7 +67,7 @@ class ReviewableQueuedPost < Reviewable
       build_action(actions, :revise_and_reject_post)
     end
 
-    build_action(actions, :delete) if guardian.can_delete_post_or_topic?(post)
+    build_action(actions, :delete) if guardian.can_delete?(self)
   end
 
   def build_editable_fields(fields, guardian, args)

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReviewableUser < Reviewable
+  include ReviewableActionBuilder
+
   def self.create_for(user)
     create(created_by_id: Discourse.system_user.id, target: user)
   end
@@ -12,12 +14,7 @@ class ReviewableUser < Reviewable
   def build_actions(actions, guardian, args)
     return unless pending?
 
-    if guardian.can_approve?(target)
-      actions.add(:approve_user) do |a|
-        a.icon = "user-plus"
-        a.label = "reviewables.actions.approve_user.title"
-      end
-    end
+    build_action(actions, :approve_user, icon: "user-plus") if guardian.can_approve?(target)
 
     delete_user_actions(actions, require_reject_reason: !is_a_suspect_user?)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5780,7 +5780,7 @@ en:
         complete: "Post approved."
       approve_post_closed:
         title: "Approve Post"
-        confirm_closed: "This topic is closed. Would you like to create the post anyway?"
+        confirm: "This topic is closed. Would you like to create the post anyway?"
         complete: "Post approved."
       reject_post:
         title: "Reject Post"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5731,11 +5731,9 @@ en:
         title: "Agree and Edit Post"
         description: "Agree with flag and open a composer window to edit the post."
         complete: "Flag acknowledged, you can now edit the post."
-      delete_single:
+      delete:
         title: "Delete"
         complete: "Post deleted."
-      delete:
-        title: "Delete…"
       delete_and_ignore:
         title: "Ignore flag and delete post"
         description: "Ignore the flag by removing it from the queue and delete the post; if the first post, delete the topic as well. "
@@ -5778,6 +5776,9 @@ en:
         title: "Approve"
         complete: "Post approved."
       approve_post:
+        title: "Approve Post"
+        complete: "Post approved."
+      approve_post_closed:
         title: "Approve Post"
         confirm_closed: "This topic is closed. Would you like to create the post anyway?"
         complete: "Post approved."

--- a/lib/reviewable/actions.rb
+++ b/lib/reviewable/actions.rb
@@ -17,7 +17,7 @@ class Reviewable < ActiveRecord::Base
       {
         approve: Action.new(:approve, "thumbs-up", "reviewables.actions.approve.title"),
         reject: Action.new(:reject, "thumbs-down", "reviewables.actions.reject.title"),
-        delete: Action.new(:delete, "trash-can", "reviewables.actions.delete_single.title"),
+        delete: Action.new(:delete, "trash-can", "reviewables.actions.delete.title"),
       }
     end
 

--- a/spec/models/concerns/reviewable_action_builder_spec.rb
+++ b/spec/models/concerns/reviewable_action_builder_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewableActionBuilder do
+  let(:admin) { Fabricate(:admin) }
+  let(:guardian) { Guardian.new(admin) }
+  let(:user) { Fabricate(:user) }
+  let(:reviewable) { ReviewableUser.create_for(user) }
+  let(:actions) { Reviewable::Actions.new(reviewable, guardian) }
+
+  describe "#build_action" do
+    it "adds an action with i18n-derived defaults" do
+      reviewable.build_action(actions, :approve_user)
+
+      action = actions.to_a.first
+      expect(action).to be_present
+      expect(action.label).to eq("reviewables.actions.approve_user.title")
+      expect(action.description).to eq("reviewables.actions.approve_user.description")
+      expect(action.completed_message).to eq("reviewables.actions.approve_user.complete")
+      expect(action.confirm_message).to be_nil
+      expect(action.icon).to be_nil
+      expect(action.button_class).to be_nil
+      expect(action.client_action).to be_nil
+      expect(action.require_reject_reason).to be(false)
+
+      # It should attach to a bundle automatically matching the full action id
+      bundle_ids = actions.bundles.map(&:id)
+      expect(bundle_ids).to include(action.id)
+    end
+
+    it "sets optional fields when provided" do
+      reviewable.build_action(
+        actions,
+        :approve_user,
+        icon: "user-plus",
+        button_class: "btn-primary",
+        client_action: "go",
+        confirm: true,
+        require_reject_reason: true,
+      )
+
+      action = actions.to_a.first
+      expect(action.icon).to eq("user-plus")
+      expect(action.button_class).to eq("btn-primary")
+      expect(action.client_action).to eq("go")
+      expect(action.confirm_message).to eq("reviewables.actions.approve_user.confirm")
+      expect(action.require_reject_reason).to be(true)
+    end
+
+    it "adds the action to the provided bundle" do
+      bundle = actions.add_bundle("custom-bundle", icon: "x", label: "Custom")
+      reviewable.build_action(actions, :approve_user, bundle: bundle)
+
+      action = actions.to_a.first
+      expect(actions.bundles).to include(bundle)
+      expect(bundle.actions).to include(action)
+    end
+  end
+end

--- a/spec/models/concerns/reviewable_action_builder_spec.rb
+++ b/spec/models/concerns/reviewable_action_builder_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe ReviewableActionBuilder do
   fab!(:admin)
   fab!(:guardian) { Guardian.new(admin) }


### PR DESCRIPTION
## ✨ What's This?

This is a step towards unifying how reviewable types are defined.

In this PR, we add a new `ReviewableActionBuilder` concern, which can be included by the various reviewable types to give them a standard helper for adding actions that can be performed on the reviewable.

The first feature for this concern takes the `build_action()` helper that some reviewables used, and makes it available to all reviewables. This is done in a backward compatible fashion, so it will work even whilst we transition to the new reviewable UI.

