### PR TITLE
DEV: remove experimental_sidebar_messages_count_enabled_groups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-dropdown.gjs
@@ -16,10 +16,7 @@ export default class MessagesDropdown extends Component {
   }
 
   get showUnreadIcon() {
-    return (
-      this.currentUser?.use_experimental_sidebar_messages_count &&
-      !this.currentUser?.sidebarShowCountOfNewItems
-    );
+    return !this.currentUser?.sidebarShowCountOfNewItems;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-dropdown.gjs
@@ -16,7 +16,7 @@ export default class MessagesDropdown extends Component {
   }
 
   get showUnreadIcon() {
-    return !this.currentUser?.sidebarShowCountOfNewItems;
+    return !this.currentUser.sidebarShowCountOfNewItems;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -67,12 +67,8 @@ export default class extends Controller {
     return value;
   }
 
-  get showUnread() {
-    return this.currentUser?.use_experimental_sidebar_messages_count;
-  }
-
   get showCount() {
-    return this.showUnread && this.currentUser?.sidebarShowCountOfNewItems;
+    return this.currentUser.sidebarShowCountOfNewItems;
   }
 
   @cached
@@ -80,18 +76,16 @@ export default class extends Controller {
     const usernameLower = this.model.username_lower;
     let inboxName = i18n("user.messages.inbox");
     let userMsgsCount = 0;
-    if (this.showUnread) {
-      userMsgsCount = ["new", "unread"].reduce((count, type) => {
-        return (
-          count +
-          this.pmTopicTrackingState.lookupCount(type, {
-            inboxFilter: "user",
-          })
-        );
-      }, userMsgsCount);
-      if (userMsgsCount && this.showCount) {
-        inboxName = htmlSafe(`${inboxName}&nbsp;(${userMsgsCount})`);
-      }
+    userMsgsCount = ["new", "unread"].reduce((count, type) => {
+      return (
+        count +
+        this.pmTopicTrackingState.lookupCount(type, {
+          inboxFilter: "user",
+        })
+      );
+    }, userMsgsCount);
+    if (userMsgsCount && this.showCount) {
+      inboxName = htmlSafe(`${inboxName}&nbsp;(${userMsgsCount})`);
     }
     const content = [
       {
@@ -104,19 +98,17 @@ export default class extends Controller {
     this.model.groupsWithMessages.forEach(({ name }) => {
       let groupName = name;
       let groupMsgsCount = 0;
-      if (this.showUnread) {
-        groupMsgsCount = ["new", "unread"].reduce((count, type) => {
-          return (
-            count +
-            this.pmTopicTrackingState.lookupCount(type, {
-              inboxFilter: "group",
-              groupName: name,
-            })
-          );
-        }, groupMsgsCount);
-        if (groupMsgsCount && this.showCount) {
-          groupName = htmlSafe(`${name}&nbsp;(${groupMsgsCount})`);
-        }
+      groupMsgsCount = ["new", "unread"].reduce((count, type) => {
+        return (
+          count +
+          this.pmTopicTrackingState.lookupCount(type, {
+            inboxFilter: "group",
+            groupName: name,
+          })
+        );
+      }, groupMsgsCount);
+      if (groupMsgsCount && this.showCount) {
+        groupName = htmlSafe(`${name}&nbsp;(${groupMsgsCount})`);
       }
       content.push({
         id: this.router.urlFor(

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
@@ -66,7 +66,7 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get showCount() {
-    return this.currentUser?.sidebarShowCountOfNewItems;
+    return this.currentUser.sidebarShowCountOfNewItems;
   }
 
   get badgeText() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-messages-section-link.js
@@ -31,10 +31,6 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get totalCount() {
-    if (!this.currentUser?.use_experimental_sidebar_messages_count) {
-      return 0;
-    }
-
     const newUserMsgs = this._lookupCount({ type: "new", inboxFilter: "user" });
     const unreadUserMsgs = this._lookupCount({
       type: "unread",
@@ -70,10 +66,7 @@ export default class MyMessagesSectionLink extends BaseSectionLink {
   }
 
   get showCount() {
-    return (
-      this.currentUser?.use_experimental_sidebar_messages_count &&
-      this.currentUser?.sidebarShowCountOfNewItems
-    );
+    return this.currentUser?.sidebarShowCountOfNewItems;
   }
 
   get badgeText() {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -81,7 +81,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_localize_content?,
              :effective_locale,
              :use_reviewable_ui_refresh,
-             :use_experimental_sidebar_messages_count,
              :can_see_ip
 
   delegate :user_stat, to: :object, private: true
@@ -353,10 +352,6 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def use_reviewable_ui_refresh
     scope.can_see_reviewable_ui_refresh?
-  end
-
-  def use_experimental_sidebar_messages_count
-    scope.user.in_any_groups?(SiteSetting.experimental_sidebar_messages_count_enabled_groups_map)
   end
 
   def include_use_reviewable_ui_refresh?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2734,7 +2734,6 @@ en:
     show_preview_for_form_templates: "Enable the preview for form templates feature"
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."
     experimental_auto_grid_images: "Automatically wraps images in [grid] tags when 3 or more images are uploaded in the composer."
-    experimental_sidebar_messages_count_enabled_groups: "Show an unread indicator or count next to the 'My messages' sidebar link, depending on the user's Navigation preferences"
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     about_page_hidden_groups: "Do not show members of specific groups on the /about page."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4134,10 +4134,3 @@ experimental:
     client: true
     type: group_list
     default: ""
-  experimental_sidebar_messages_count_enabled_groups:
-    client: true
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true

--- a/db/migrate/20250808064354_remove_experimental_sidebar_messages_count_enabled_groups_site_setting.rb
+++ b/db/migrate/20250808064354_remove_experimental_sidebar_messages_count_enabled_groups_site_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveExperimentalSidebarMessagesCountEnabledGroupsSiteSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'experimental_sidebar_messages_count_enabled_groups'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -203,11 +203,6 @@ describe "Viewing sidebar", type: :system do
         end
         let(:user_private_messages_page) { PageObjects::Pages::UserPrivateMessages.new }
 
-        before do
-          SiteSetting.experimental_sidebar_messages_count_enabled_groups =
-            Group::AUTO_GROUPS[:trust_level_0]
-        end
-
         it "should show new messages indicator" do
           sign_in(admin)
           visit("/")
@@ -227,16 +222,6 @@ describe "Viewing sidebar", type: :system do
           user_private_messages_page.click_unseen_private_mesage(private_message.id)
           expect(sidebar).to have_my_messages_link_with_unread_icon
           try_until_success { expect(sidebar).to have_my_messages_link_without_unread_icon }
-        end
-
-        context "when user does not belong to experimental_sidebar_messages_count_enabled_groups" do
-          before { SiteSetting.experimental_sidebar_messages_count_enabled_groups = "" }
-
-          it "does not show new messages indicator" do
-            sign_in(admin)
-            visit("/")
-            expect(sidebar).to have_my_messages_link_without_unread_icon
-          end
         end
       end
     end

--- a/spec/system/viewing_user_private_messages_spec.rb
+++ b/spec/system/viewing_user_private_messages_spec.rb
@@ -30,8 +30,6 @@ describe "Viewing user private messages", type: :system do
     context "when user has unread messages" do
       fab!(:pm_topic) { Fabricate(:private_message_topic, user: user2, recipient: user) }
 
-      before { SiteSetting.experimental_sidebar_messages_count_enabled_groups = "trust_level_0" }
-
       it "shows unread icon in inbox dropdown trigger and dropdown" do
         user_private_messages_page.visit(user)
 


### PR DESCRIPTION
Removes the temporary `experimental_sidebar_messages_count_enabled_groups` site setting.

Reverts #33774.