### PR TITLE
FIX: correct open ai endpoint call

### DIFF
--- a/plugins/discourse-ai/lib/completions/endpoints/open_ai.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/open_ai.rb
@@ -14,7 +14,7 @@ module DiscourseAi
           # max_tokens is deprecated however we still need to support it
           # on older OpenAI models and older Azure models, so we will only normalize
           # if our model name starts with o (to denote all the reasoning models)
-          if llm_model.name.starts_with?("o") | llm_model.name.starts_with?("gpt-5")
+          if llm_model.name.starts_with?(/o|gpt-5/)
             max_tokens = model_params.delete(:max_tokens)
             model_params[:max_completion_tokens] = max_tokens if max_tokens
           end


### PR DESCRIPTION
Follow up to d410df351ddfc7542b71e30b8c5e72597ec94a3f which used '|' instead of '||' as or operator.

Decided to move the condition inside a regexp used by 'starts_with?'