### PR TITLE
DEV: Unify `ListChannelMessages`/`ListChannelThreadMessages` behaviors

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 class Chat::Api::ChannelMessagesController < Chat::ApiController
+  MAX_PAGE_SIZE = 50 # Previous limit to avoid abuses
+
   def index
-    ::Chat::ListChannelMessages.call(service_params) do |result|
+    ::Chat::ListChannelMessages.call(
+      options: {
+        max_page_size: MAX_PAGE_SIZE,
+      },
+      **service_params,
+    ) do |result|
       on_success { render_serialized(result, ::Chat::MessagesSerializer, root: false) }
       on_failure { render(json: failed_json, status: 422) }
       on_failed_policy(:can_view_channel) { raise Discourse::InvalidAccess }

--- a/plugins/chat/app/services/chat/list_channel_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_messages.rb
@@ -16,6 +16,8 @@ module Chat
     #   @option params [Integer] :channel_id
     #   @return [Service::Base::Context]
 
+    options { attribute :max_page_size, :integer, default: Chat::MessagesQuery::MAX_PAGE_SIZE }
+
     params do
       attribute :channel_id, :integer
       attribute :page_size, :integer
@@ -30,7 +32,6 @@ module Chat
       validates :channel_id, presence: true
       validates :page_size,
                 numericality: {
-                  less_than_or_equal_to: Chat::MessagesQuery::MAX_PAGE_SIZE,
                   greater_than_or_equal_to: 1,
                   only_integer: true,
                   only_numeric: true,
@@ -42,7 +43,10 @@ module Chat
                 },
                 allow_nil: true
 
-      after_validation { self.page_size ||= Chat::MessagesQuery::MAX_PAGE_SIZE }
+      after_validation do
+        self.page_size ||= options.max_page_size
+        self.page_size = options.max_page_size if page_size > options.max_page_size
+      end
     end
 
     model :channel

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Chat::Api::ChannelMessagesController do
 
     context "when params are invalid" do
       it "returns a 400" do
-        get "/chat/api/channels/#{channel.id}/messages?page_size=9999"
+        get "/chat/api/channels/#{channel.id}/messages?page_size=0"
 
         expect(response.status).to eq(400)
       end
@@ -70,6 +70,19 @@ RSpec.describe Chat::Api::ChannelMessagesController do
         get "/chat/api/channels/#{channel.id}/messages"
 
         expect(response.status).to eq(403)
+      end
+    end
+
+    context "when page_size is above limit" do
+      fab!(:messages) { Fabricate.times(5, :chat_message, chat_channel: channel) }
+
+      it "clamps it to the max" do
+        stub_const(Chat::Api::ChannelMessagesController, "MAX_PAGE_SIZE", 1) do
+          get "/chat/api/channels/#{channel.id}/messages?page_size=9999"
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["messages"].size).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
We recently updated `Chat::ListChannelThreadMessages` to take an option so its `max_page_size` could be configured.

This behavior should be consistent between `Chat::ListChannelThreadMessages` and `Chat::ListChannelMessages` since they’re basically doing the same thing.

This PR updates the behavior of the `Chat::ListChannelMessages` service.