### PR TITLE
FIX: Do not exit early from login route in webviews

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/login.js
+++ b/app/assets/javascripts/discourse/app/routes/login.js
@@ -45,7 +45,6 @@ export default class extends DiscourseRoute {
     // When inside a webview, it handles the login flow itself
     if (isAppWebview) {
       postRNWebviewMessage("showLogin", true);
-      return;
     }
 
     // When Discourse Connect is enabled, redirect to the SSO endpoint

--- a/app/assets/javascripts/discourse/app/routes/signup.js
+++ b/app/assets/javascripts/discourse/app/routes/signup.js
@@ -58,7 +58,6 @@ export default class extends DiscourseRoute {
     // When inside a webview, it handles the login flow itself
     if (isAppWebview) {
       postRNWebviewMessage("showLogin", true);
-      return;
     }
 
     // When Discourse Connect is enabled, redirect to the SSO endpoint


### PR DESCRIPTION
This ensure auth works on webviews that aren't DiscourseHub.