### PR TITLE
FIX: use group name in unreachable mention warning

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -153,7 +153,7 @@ en:
     mention_warning:
       dismiss: "dismiss"
       cannot_see: "%{first_identifier} can't access this channel and was not notified."
-      cannot_see_group: "Members of %{group_name} can't access this channel and were not notified."
+      cannot_see_group: "Some members of %{group_name} can't access this channel and were not notified."
       cannot_see_multiple:
         one: "%{first_identifier} and %{count} other user cannot access this channel and were not notified."
         other: "%{first_identifier} and %{count} other users cannot access this channel and were not notified."

--- a/plugins/chat/spec/system/channel_notice_spec.rb
+++ b/plugins/chat/spec/system/channel_notice_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe "Channel notice", type: :system do
       )
     end
 
+    it "does not show group notice if unreachable member is not part of member visibility restricted group" do
+      secret_group.add(user_2)
+
+      chat_page.visit_channel(private_channel)
+      channel_page.send_message("hello @#{group_2.name} and @#{group_3.name}")
+
+      expect(page).to have_no_selector(
+        ".chat-notices__notice",
+        text: I18n.t("chat.mention_warning.cannot_see_group", group_name: group_3.name),
+      )
+    end
+
     context "when navigating away and back to the channel" do
       it "dismisses the notice" do
         chat_page.visit_channel(private_channel)


### PR DESCRIPTION
In cases where there are mentioned users that are unreachable (ie. they cannot join the channel), then we normally notify the sender of those users in the chat notice. However, with groups have a `members_visible_level` setting which determines who can view members. This change takes into account this setting when showing the chat notice to the sender.

If there is a mentioned group that the sender does not have permission to view members then we will show the group name instead of the users.

Internal ref: /t/-/145343