### PR TITLE
FIX: rich editor html_inline parseDOM not setting the tag attr

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-inline.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/html-inline.js
@@ -32,7 +32,10 @@ const extension = {
       isolating: true,
       content: "inline*",
       attrs: { tag: {} },
-      parseDOM: ALLOWED_INLINE.map((tag) => ({ tag })),
+      parseDOM: ALLOWED_INLINE.map((tag) => ({
+        tag,
+        getAttrs: () => ({ tag }),
+      })),
       toDOM: (node) => [node.attrs.tag, 0],
     },
   },

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -760,7 +760,7 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(composer).to have_value("![image|244x66](upload://hGLky57lMjXvqCWRhcsH31ShzmO.png)")
     end
 
-    it "should correctly merge text with link marks created from parsing" do
+    it "merges text with link marks created from parsing" do
       cdp.allow_clipboard
       open_composer
 
@@ -772,6 +772,21 @@ describe "Composer - ProseMirror editor", type: :system do
       composer.type_content(:backspace)
 
       expect(rich).to have_css("a", text: "lin")
+    end
+
+    it "parses html inline tags from pasted HTML" do
+      cdp.allow_clipboard
+      open_composer
+
+      cdp.copy_paste("<mark>mark</mark> my <ins>words</ins> <kbd>ctrl</kbd>", html: true)
+
+      expect(rich).to have_css("mark", text: "mark")
+      expect(rich).to have_css("ins", text: "words")
+      expect(rich).to have_css("kbd", text: "ctrl")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("<mark>mark</mark> my <ins>words</ins> <kbd>ctrl</kbd>")
     end
   end
 


### PR DESCRIPTION
Fixes our `html_inline` node's `parseDOM` which was not correctly setting the `tag` attribute from the pasted HTML.