### PR TITLE
UX: make rich-editor [quote] non-isolating

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
@@ -4,6 +4,7 @@ const extension = {
     quote: {
       content: "block+",
       group: "block",
+      defining: true,
       attrs: {
         username: { default: null },
         postNumber: { default: null },

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/quote.js
@@ -4,9 +4,6 @@ const extension = {
     quote: {
       content: "block+",
       group: "block",
-      inline: false,
-      selectable: true,
-      isolating: true,
       attrs: {
         username: { default: null },
         postNumber: { default: null },

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -1564,5 +1564,30 @@ describe "Composer - ProseMirror editor", type: :system do
 
       expect(composer).to have_value(markdown + "\n\nThis is a test")
     end
+
+    it "lifts the first paragraph out of the quote with Backspace" do
+      open_composer
+
+      composer.type_content("[quote]Text")
+      expect(rich).to have_css("aside.quote blockquote p", text: "Text")
+
+      composer.send_keys(:home)
+      composer.send_keys(:backspace)
+
+      expect(rich).to have_no_css("aside.quote")
+      expect(rich).to have_css("p", text: "Text")
+    end
+
+    it "breaks out of the quote with a double Enter" do
+      open_composer
+
+      composer.type_content("[quote]Inside")
+      composer.send_keys(:enter)
+      composer.send_keys(:enter)
+      composer.type_content("Outside")
+
+      expect(rich).to have_css("aside.quote blockquote p", text: "Inside")
+      expect(rich).to have_css("aside.quote + p", text: "Outside")
+    end
   end
 end


### PR DESCRIPTION
Changes the `[quote]` node making it `isolating: false` (the default), meaning it will be easier to backspace-delete it or break out of it via a double-enter (among other things).