### PR TITLE
UX: Fix padding/spacing issues at smaller widths

### DIFF
--- a/themes/horizon/scss/main.scss
+++ b/themes/horizon/scss/main.scss
@@ -87,12 +87,10 @@ body:not(.has-full-page-chat, .wizard) {
       }
 
       > *:not(.experimental-screen, .activate-account) {
-        @include viewport.from(lg) {
-          box-sizing: border-box;
-          max-width: 1000px;
-          margin-inline: auto;
-          padding-inline: var(--spacing-inline-l);
-        }
+        box-sizing: border-box;
+        max-width: 1000px;
+        margin-inline: auto;
+        padding-inline: var(--spacing-inline-l);
       }
     }
   }

--- a/themes/horizon/scss/topic-cards.scss
+++ b/themes/horizon/scss/topic-cards.scss
@@ -61,7 +61,6 @@
 
   @include viewport.until(lg) {
     gap: 0.5em;
-    padding: 0 0.5em;
   }
 
   @include viewport.until(sm) {


### PR DESCRIPTION
This PR adjusts some of the padding targets at smaller widths.

|Before|After|
|--|--|
|<img width="1502" height="1594" alt="CleanShot 2025-08-08 at 11 25 12@2x" src="https://github.com/user-attachments/assets/6f2e1f5d-31b4-46f6-ba18-766ba28dac98" />|<img width="1488" height="1594" alt="CleanShot 2025-08-08 at 11 23 55@2x" src="https://github.com/user-attachments/assets/54955d1c-cb0d-4503-90e9-1d0e08eb95d3" />|
|<img width="1012" height="1596" alt="CleanShot 2025-08-08 at 11 24 55@2x" src="https://github.com/user-attachments/assets/f96fc134-cae5-4c2f-82cb-e3365b2570eb" />|<img width="1004" height="1592" alt="CleanShot 2025-08-08 at 11 24 36@2x" src="https://github.com/user-attachments/assets/e93dc07c-b73c-4cec-af55-06537c82dbf0" />|