### PR TITLE
FIX: paste mention from post to rich editor

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/mention.js
@@ -24,11 +24,12 @@ const extension = {
       selectable: false,
       parseDOM: [
         {
+          priority: 60,
           tag: "a.mention",
           preserveWhitespace: "full",
           getAttrs: (dom) => {
             return {
-              name: dom.getAttribute("data-name"),
+              name: dom.getAttribute("data-name") ?? dom.textContent.slice(1),
             };
           },
         },

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -656,6 +656,21 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   describe "pasting content" do
+    it "creates a mention when pasting an HTML anchor with class mention" do
+      cdp.allow_clipboard
+      open_composer
+
+      html = %(<a href="/u/#{current_user.username}" class="mention">@#{current_user.username}</a>)
+      cdp.copy_paste(html, html: true)
+
+      expect(rich).to have_css("a.mention", text: current_user.username)
+      expect(rich).to have_css("a.mention[data-name='#{current_user.username}']")
+      expect(rich).to have_no_css("a.mention[href]")
+
+      composer.toggle_rich_editor
+      expect(composer).to have_value("@#{current_user.username}")
+    end
+
     it "does not freeze the editor when pasting markdown code blocks without a language" do
       with_logs do |logger|
         open_composer


### PR DESCRIPTION
Prioritizes the mention `parseDOM` handler so it happens before the link mark parser, and makes sure to get the username from `textContent` when `data-name` isn't available.