### PR TITLE
DRAFT: Feature/assuming IAM role when using s3

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2097,6 +2097,9 @@ files:
   s3_secret_access_key:
     default: ""
     secret: true
+  s3_role_arn:
+    default: ""
+    secret: true
   s3_region:
     default: "us-east-1"
     enum: "S3RegionSiteSetting"


### PR DESCRIPTION
This change introduces: 
  - a SiteSetting for S3_ROLE_ARN
  - logic to assume a special role when uploading to s3 if above SiteSetting is present. 
    If not, it will fall back to the previous behavior.

Opening as a draft to see if tests will run as I can't get them to run locally.