### PR TITLE
FIX: rich editor ENTER after non-text node

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/core/keymap.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/core/keymap.js
@@ -75,7 +75,7 @@ export function buildKeymap(
       return false;
     }
 
-    if ($from.nodeBefore?.text.endsWith("  ")) {
+    if ($from.nodeBefore?.isText && $from.nodeBefore.text.endsWith("  ")) {
       if (dispatch) {
         const tr = state.tr.replaceRangeWith(
           $from.pos - 2,

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -663,6 +663,16 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(composer).to have_value(nil)
       expect(rich).to have_css("blockquote", text: "This is a test")
     end
+
+    it "adds a new paragraph when ENTER is pressed after an image" do
+      open_composer
+      composer.type_content("![image](https://example.com/image.png)")
+      composer.send_keys(:right, :enter)
+      composer.type_content("This is a test")
+
+      composer.toggle_rich_editor
+      expect(composer).to have_value("\n![image](https://example.com/image.png)\n\nThis is a test")
+    end
   end
 
   describe "pasting content" do


### PR DESCRIPTION
https://github.com/discourse/discourse/commit/909d19ddb8bd7cc68baf07529152d60cab5c47e5 introduced a bug (`Uncaught TypeError: can't access property "endsWith", n.nodeBefore.text is undefined`) when hitting ENTER after non-text nodes.

This should fix it.