### PR TITLE
DEV: Add support for converting and importing `user_badges`

### DIFF
--- a/migrations/config/intermediate_db.yml
+++ b/migrations/config/intermediate_db.yml
@@ -89,6 +89,13 @@ schema:
       columns:
         exclude:
           - "id"
+    user_badges:
+      columns:
+        exclude:
+          - "id"
+          - "notification_id"
+          - "featured_rank"
+          - "seq"
     user_emails:
       columns:
         include:
@@ -389,7 +396,6 @@ schema:
         - "user_auth_token_logs"
         - "user_auth_tokens"
         - "user_avatars"
-        - "user_badges"
         - "user_chat_channel_memberships"
         - "user_chat_thread_memberships"
         - "user_custom_fields"

--- a/migrations/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/db/intermediate_db_schema/100-base-schema.sql
@@ -139,6 +139,17 @@ CREATE TABLE muted_users
     user_id       NUMERIC  NOT NULL
 );
 
+CREATE TABLE user_badges
+(
+    badge_id      NUMERIC  NOT NULL,
+    created_at    DATETIME,
+    granted_at    DATETIME NOT NULL,
+    granted_by_id NUMERIC  NOT NULL,
+    is_favorite   BOOLEAN,
+    post_id       NUMERIC,
+    user_id       NUMERIC  NOT NULL
+);
+
 CREATE TABLE user_emails
 (
     email      TEXT     NOT NULL,

--- a/migrations/lib/converters/discourse/steps/user_badges.rb
+++ b/migrations/lib/converters/discourse/steps/user_badges.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Migrations::Converters::Discourse
+  class UserBadges < ::Migrations::Converters::Base::ProgressStep
+    attr_accessor :source_db
+
+    def max_progress
+      @source_db.count <<~SQL
+        SELECT COUNT(*) FROM user_badges
+      SQL
+    end
+
+    def items
+      @source_db.query <<~SQL
+        SELECT *
+        FROM user_badges
+        WHERE user_id >= 0
+        ORDER BY user_id, badge_id, granted_at
+      SQL
+    end
+
+    def process_item(item)
+      IntermediateDB::UserBadge.create(
+        badge_id: item[:badge_id],
+        created_at: item[:created_at],
+        granted_at: item[:granted_at],
+        granted_by_id: item[:granted_by_id],
+        is_favorite: item[:is_favorite],
+        post_id: item[:post_id],
+        user_id: item[:user_id],
+      )
+    end
+  end
+end

--- a/migrations/lib/database/intermediate_db/user_badge.rb
+++ b/migrations/lib/database/intermediate_db/user_badge.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the "config/intermediate_db.yml" configuration file and then run
+# `bin/cli schema generate` to regenerate this file.
+
+module Migrations::Database::IntermediateDB
+  module UserBadge
+    SQL = <<~SQL
+      INSERT INTO user_badges (
+        badge_id,
+        created_at,
+        granted_at,
+        granted_by_id,
+        is_favorite,
+        post_id,
+        user_id
+      )
+      VALUES (
+        ?, ?, ?, ?, ?, ?, ?
+      )
+    SQL
+
+    def self.create(
+      badge_id:,
+      created_at: nil,
+      granted_at:,
+      granted_by_id:,
+      is_favorite: nil,
+      post_id: nil,
+      user_id:
+    )
+      ::Migrations::Database::IntermediateDB.insert(
+        SQL,
+        badge_id,
+        ::Migrations::Database.format_datetime(created_at),
+        ::Migrations::Database.format_datetime(granted_at),
+        granted_by_id,
+        ::Migrations::Database.format_boolean(is_favorite),
+        post_id,
+        user_id,
+      )
+    end
+  end
+end

--- a/migrations/lib/importer/steps/anniversary_user_badges.rb
+++ b/migrations/lib/importer/steps/anniversary_user_badges.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps
+  class AnniversaryUserBadges < ::Migrations::Importer::Step
+    depends_on :user_badges
+
+    def execute
+      super
+
+      return unless SiteSetting.enable_badges?
+
+      # TODO:(selase): Explore scoping the update to only imported users
+      DB.exec(<<~SQL)
+        WITH
+          eligible_users AS (
+                              SELECT u.id, u.created_at
+                              FROM users u
+                              WHERE u.active
+                                AND NOT u.staged
+                                AND u.id > 0
+                                AND (u.silenced_till IS NULL OR u.silenced_till < CURRENT_TIMESTAMP)
+                                AND (u.suspended_till IS NULL OR u.suspended_till < CURRENT_TIMESTAMP)
+                                AND NOT EXISTS (SELECT 1 FROM anonymous_users AS au WHERE au.user_id = u.id)
+                            ),
+          anniversary_dates AS ( -- Series of anniversary dates starting from the user's created_at + 1 year up to the current year
+                                 SELECT
+                                   eu.id AS user_id,
+                                   (
+                                     eu.created_at +
+                                     ((year_num - EXTRACT(YEAR FROM eu.created_at)) || ' years')::interval
+                                   )::timestamp AS anniversary_date
+                                 FROM eligible_users eu,
+                                      generate_series(
+                                        EXTRACT(YEAR FROM eu.created_at)::int + 1,
+                                        EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::int
+                                      ) AS year_num
+                                  WHERE
+                                    (
+                                      eu.created_at +
+                                      ((year_num - EXTRACT(YEAR FROM eu.created_at)) || ' years')::interval
+                                    ) < CURRENT_TIMESTAMP
+                               )
+        INSERT INTO user_badges (granted_at, created_at, granted_by_id, user_id, badge_id, seq)
+        SELECT a.anniversary_date,
+              CURRENT_TIMESTAMP,
+              #{Discourse::SYSTEM_USER_ID},
+              a.user_id,
+               #{Badge::Anniversary},
+              (ROW_NUMBER() OVER (PARTITION BY a.user_id ORDER BY a.anniversary_date) - 1) AS seq
+        FROM anniversary_dates a
+            JOIN eligible_users u ON a.user_id = u.id
+            JOIN posts  AS p ON p.user_id = u.id
+            JOIN topics AS t ON p.topic_id = t.id
+        WHERE p.deleted_at IS NULL
+          AND NOT p.hidden
+          AND p.created_at BETWEEN a.anniversary_date - '1 year'::interval AND a.anniversary_date
+          AND t.visible
+          AND t.archetype <> 'private_message'
+          AND t.deleted_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM user_badges AS ub
+              WHERE ub.user_id = u.id
+              AND ub.badge_id =  #{Badge::Anniversary}
+              AND ub.granted_at BETWEEN a.anniversary_date - '1 year'::interval AND a.anniversary_date
+          )
+        GROUP BY a.user_id, a.anniversary_date
+      SQL
+
+      UserBadge.update_featured_ranks!
+    end
+  end
+end

--- a/migrations/lib/importer/steps/badge_grant_counts.rb
+++ b/migrations/lib/importer/steps/badge_grant_counts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps
+  class BadgeGrantCounts < ::Migrations::Importer::Step
+    depends_on :user_badges, :anniversary_user_badges
+
+    def execute
+      super
+
+      DB.exec(<<~SQL)
+        WITH
+            grants AS (
+                        SELECT badge_id, COUNT(*) AS grant_count FROM user_badges GROUP BY badge_id
+                      )
+        UPDATE badges
+          SET grant_count = grants.grant_count
+          FROM grants
+         WHERE badges.id = grants.badge_id
+           AND badges.grant_count <> grants.grant_count
+      SQL
+    end
+  end
+end

--- a/migrations/lib/importer/steps/user_badges.rb
+++ b/migrations/lib/importer/steps/user_badges.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps
+  class UserBadges < ::Migrations::Importer::CopyStep
+    # TODO:(selase): Add posts dependency once we have posts
+    depends_on :users, :badges
+
+    requires_set :existing_user_badges, "SELECT user_id, badge_id, seq FROM user_badges"
+
+    column_names %i[badge_id created_at granted_at granted_by_id is_favorite post_id seq user_id]
+
+    total_rows_query <<~SQL, MappingType::USERS, MappingType::BADGES
+      SELECT COUNT(*)
+      FROM user_badges
+           JOIN mapped.ids mapped_user
+             ON user_badges.user_id = mapped_user.original_id AND mapped_user.type = ?1
+           JOIN mapped.ids mapped_badge
+             ON user_badges.badge_id = mapped_badge.original_id AND mapped_badge.type = ?2
+    SQL
+
+    rows_query <<~SQL, MappingType::USERS, MappingType::BADGES, MappingType::POSTS
+      SELECT user_badges.*,
+             ROW_NUMBER() OVER (PARTITION BY user_badges.user_id, user_badges.badge_id
+                                ORDER BY user_badges.granted_at) - 1 AS seq,
+             mapped_user.discourse_id                                AS discourse_user_id,
+             mapped_badge.discourse_id                               AS discourse_badge_id,
+             mapped_granted_by.discourse_id                          AS discourse_granted_by_id,
+             mapped_post.discourse_id                                AS discourse_post_id
+      FROM user_badges
+           JOIN mapped.ids mapped_user
+             ON user_badges.user_id = mapped_user.original_id AND mapped_user.type = ?1
+           JOIN mapped.ids mapped_badge
+             ON user_badges.badge_id = mapped_badge.original_id AND mapped_badge.type = ?2
+           LEFT JOIN mapped.ids mapped_granted_by
+             ON user_badges.granted_by_id = mapped_granted_by.original_id AND mapped_granted_by.type = ?1
+           LEFT JOIN mapped.ids mapped_post
+             ON user_badges.post_id = mapped_post.original_id AND mapped_post.type = ?3
+      ORDER BY discourse_user_id,
+               discourse_badge_id,
+               COALESCE(user_badges.granted_at, user_badges.created_at)
+    SQL
+
+    private
+
+    def transform_row(row)
+      badge_id = row[:discourse_badge_id]
+      user_id = row[:discourse_user_id]
+
+      # TODO:(selase): Is there a scenario where we might offset the seq based off
+      #                the existing user badges?
+      return nil unless @existing_user_badges.add?(user_id, badge_id, row[:seq])
+
+      row[:is_favorite] ||= false
+      row[:badge_id] = badge_id
+      row[:user_id] = user_id
+      row[:post_id] = row[:discourse_post_id]
+      row[:granted_by_id] = row[:discourse_granted_by_id] || Discourse::SYSTEM_USER_ID
+
+      super
+    end
+  end
+end

--- a/migrations/spec/lib/database/intermediate_db/user_badge_spec.rb
+++ b/migrations/spec/lib/database/intermediate_db/user_badge_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe ::Migrations::Database::IntermediateDB::UserBadge do
+  it_behaves_like "a database entity"
+end


### PR DESCRIPTION
This adds converter(Discourse-only, for now) and importer steps for `user_badges`. It also adds an import step to recalculate `badges.grant_counts` after the badge grants import