### PR TITLE
FIX: Automatically clean up user_auth_token_logs

### DIFF
--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -205,8 +205,9 @@ class UserAuthToken < ActiveRecord::Base
 
   def self.cleanup!
     UserAuthTokenLog.where(
-      "created_at < :time",
+      "created_at < :time AND action NOT IN (:preserved_actions)",
       time: SiteSetting.maximum_session_age.hours.ago - ROTATE_TIME,
+      preserved_actions: %w[suspicious generate],
     ).delete_all
 
     where(

--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -204,12 +204,10 @@ class UserAuthToken < ActiveRecord::Base
   end
 
   def self.cleanup!
-    if SiteSetting.verbose_auth_token_logging
-      UserAuthTokenLog.where(
-        "created_at < :time",
-        time: SiteSetting.maximum_session_age.hours.ago - ROTATE_TIME,
-      ).delete_all
-    end
+    UserAuthTokenLog.where(
+      "created_at < :time",
+      time: SiteSetting.maximum_session_age.hours.ago - ROTATE_TIME,
+    ).delete_all
 
     where(
       "rotated_at < :time",

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UserAuthToken do
       expect(UserAuthToken.where(id: token.id).count).to eq(0)
     end
 
-    it "deletes old logs excluding certain types" do
+    it "deletes old logs excluding the `suspicious` and `generate` types" do
       SiteSetting.maximum_session_age = 1
       UserAuthTokenLog.delete_all
 

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -5,33 +5,54 @@ require "discourse_ip_info"
 RSpec.describe UserAuthToken do
   fab!(:user)
 
-  it "can remove old expired tokens" do
-    SiteSetting.verbose_auth_token_logging = true
+  describe ".cleanup!" do
+    it "can remove old expired tokens" do
+      freeze_time Time.zone.now
+      SiteSetting.maximum_session_age = 1
 
-    freeze_time Time.zone.now
-    SiteSetting.maximum_session_age = 1
+      token =
+        UserAuthToken.generate!(
+          user_id: user.id,
+          user_agent: "some user agent 2",
+          client_ip: "1.1.2.3",
+        )
 
-    token =
-      UserAuthToken.generate!(
-        user_id: user.id,
-        user_agent: "some user agent 2",
-        client_ip: "1.1.2.3",
-      )
+      freeze_time 1.hour.from_now
+      UserAuthToken.cleanup!
 
-    freeze_time 1.hour.from_now
-    UserAuthToken.cleanup!
+      expect(UserAuthToken.where(id: token.id).count).to eq(1)
 
-    expect(UserAuthToken.where(id: token.id).count).to eq(1)
+      freeze_time 1.second.from_now
+      UserAuthToken.cleanup!
 
-    freeze_time 1.second.from_now
-    UserAuthToken.cleanup!
+      expect(UserAuthToken.where(id: token.id).count).to eq(1)
 
-    expect(UserAuthToken.where(id: token.id).count).to eq(1)
+      freeze_time UserAuthToken::ROTATE_TIME.from_now
+      UserAuthToken.cleanup!
 
-    freeze_time UserAuthToken::ROTATE_TIME.from_now
-    UserAuthToken.cleanup!
+      expect(UserAuthToken.where(id: token.id).count).to eq(0)
+    end
 
-    expect(UserAuthToken.where(id: token.id).count).to eq(0)
+    it "deletes old logs excluding certain types" do
+      SiteSetting.maximum_session_age = 1
+      UserAuthTokenLog.delete_all
+
+      preserved = []
+
+      preserved << UserAuthTokenLog.create!(action: "suspicious").id
+      preserved << UserAuthTokenLog.create!(action: "suspicious", created_at: 10.days.ago).id
+
+      preserved << UserAuthTokenLog.create!(action: "generate").id
+      preserved << UserAuthTokenLog.create!(action: "generate", created_at: 10.years.ago).id
+
+      preserved << UserAuthTokenLog.create!(action: "random but fresh").id
+
+      UserAuthTokenLog.create!(action: "random but not very fresh", created_at: 2.hours.ago)
+
+      expect do UserAuthToken.cleanup! end.to change { UserAuthTokenLog.count }.by(-1)
+
+      expect(UserAuthTokenLog.pluck(:id)).to contain_exactly(*preserved)
+    end
   end
 
   it "can lookup hashed" do


### PR DESCRIPTION
Fixes: https://meta.discourse.org/t/clean-up-user-auth-token-logs/326397?u=jonaharagon1

Currently (since 2021 when this logging was [made unconditional](https://github.com/discourse/discourse/commit/8fb823c30f7fd3086f4370c2dc6e4e3737ae6acf)) all user IP addresses and user agent strings for all forum users are continuously logged and never cleared. Keeping unnecessary PII is a massive liability for us, so I hope this can be merged ASAP.

I observe (in my user archive download) this indefinite logging does not happen on Meta, presumably because you have _verbose_ logging enabled, but it does happen on virtually all Discourse-hosted and self-hosted sites, which indicates to me this is unintended behavior. I should not have to enable verbose logging to _decrease_ the amount of logging here, but that is what I had to do as a temporary solution.

This change will keep the logs for a few months by default. I can find no reason the logs should be kept longer, _especially_ as they only seem to be used for a feature (suspicious login reporting) which currently only applies to staff accounts and not regular users.

cc: @OsamaSayegh