### PR TITLE
FEATURE: enable topic creation button for read only categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.gjs
@@ -254,6 +254,7 @@ export default class ComposerContainer extends Component {
                               disabled=this.composer.disableCategoryChooser
                               scopedCategoryId=this.composer.scopedCategoryId
                               prioritizedCategoryId=this.composer.prioritizedCategoryId
+                              readOnlyCategoryId=this.composer.readOnlyCategoryId
                             }}
                           />
                           <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -3,45 +3,21 @@ import Component from "@ember/component";
 import { tagName } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
 import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
-import { i18n } from "discourse-i18n";
-import DButtonTooltip from "float-kit/components/d-button-tooltip";
-import DTooltip from "float-kit/components/d-tooltip";
 
 @tagName("")
 export default class CreateTopicButton extends Component {
   label = "topic.create";
   btnClass = "btn-default";
 
-  get disallowedReason() {
-    if (this.canCreateTopicOnTag === false) {
-      return "topic.create_disabled_tag";
-    } else if (this.disabled) {
-      return "topic.create_disabled_category";
-    }
-  }
-
   <template>
     {{#if this.canCreateTopic}}
-      <DButtonTooltip>
-        <:button>
-          <DButton
-            @action={{this.action}}
-            @icon="far-pen-to-square"
-            @disabled={{this.disabled}}
-            @label={{this.label}}
-            id="create-topic"
-            class={{this.btnClass}}
-          />
-        </:button>
-        <:tooltip>
-          {{#if @disabled}}
-            <DTooltip
-              @icon="circle-info"
-              @content={{i18n this.disallowedReason}}
-            />
-          {{/if}}
-        </:tooltip>
-      </DButtonTooltip>
+      <DButton
+        @action={{this.action}}
+        @icon="far-pen-to-square"
+        @label={{this.label}}
+        id="create-topic"
+        class={{this.btnClass}}
+      />
 
       {{#if @showDrafts}}
         <TopicDraftsDropdown @disabled={{false}} />

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -5,7 +5,6 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
 import { and, gt } from "truth-helpers";
 import BreadCrumbs from "discourse/components/bread-crumbs";
@@ -118,35 +117,6 @@ export default class DNavigation extends Component {
     }
   }
 
-  @discourseComputed(
-    "createTopicDisabled",
-    "categoryReadOnlyBanner",
-    "canCreateTopicOnTag",
-    "tag.id"
-  )
-  createTopicButtonDisabled(
-    createTopicDisabled,
-    categoryReadOnlyBanner,
-    canCreateTopicOnTag,
-    tagId
-  ) {
-    if (tagId && !canCreateTopicOnTag) {
-      return true;
-    } else if (categoryReadOnlyBanner) {
-      return false;
-    }
-    return createTopicDisabled;
-  }
-
-  @discourseComputed("categoryReadOnlyBanner")
-  createTopicClass(categoryReadOnlyBanner) {
-    let classNames = ["btn-default"];
-    if (categoryReadOnlyBanner) {
-      classNames.push("disabled");
-    }
-    return classNames.join(" ");
-  }
-
   @discourseComputed("category.can_edit")
   showCategoryEdit(canEdit) {
     return canEdit;
@@ -226,11 +196,7 @@ export default class DNavigation extends Component {
 
   @action
   clickCreateTopicButton() {
-    if (this.categoryReadOnlyBanner) {
-      this.dialog.alert({ message: htmlSafe(this.categoryReadOnlyBanner) });
-    } else {
-      this.createTopic();
-    }
+    this.createTopic();
   }
 
   <template>
@@ -334,10 +300,7 @@ export default class DNavigation extends Component {
       <CreateTopicButton
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
-        @disabled={{this.createTopicButtonDisabled}}
         @label={{this.createTopicLabel}}
-        @btnClass={{this.createTopicClass}}
-        @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
         @showDrafts={{if (gt this.draftCount 0) true false}}
       />
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -164,8 +164,13 @@ export default class DiscoveryListController extends Controller {
 
   @action
   createTopic() {
+    const readOnlyCategoryId = this.createTopicDisabled
+      ? this.model.category.id
+      : null;
+
     this.composer.openNewTopic({
       category: this.createTopicTargetCategory,
+      readOnlyCategoryId,
       tags: [this.model.tag?.id, ...(this.model.additionalTags ?? [])]
         .filter(Boolean)
         .reject((t) => ["none", "all"].includes(t))

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -231,6 +231,11 @@ export function defaultCategoryLinkRenderer(category, opts) {
     )}</span>`;
   }
 
+  if (opts.readOnly) {
+    const desc = i18n("category_row.read_only");
+    html += `<span class="read-only" aria-label="${desc}">${i18n(desc)}</span>`;
+  }
+
   if (href) {
     href = ` href="${href}" `;
   }

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -233,7 +233,7 @@ export function defaultCategoryLinkRenderer(category, opts) {
 
   if (opts.readOnly) {
     const desc = i18n("category_row.read_only");
-    html += `<span class="read-only" aria-label="${desc}">${i18n(desc)}</span>`;
+    html += `<span class="read-only" aria-label="${desc}">${desc}</span>`;
   }
 
   if (href) {

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -948,10 +948,12 @@ export default class Composer extends RestModel {
     });
 
     // We set the category id separately for topic templates on opening of composer
-    this.set(
-      "categoryId",
-      opts.topicCategoryId || opts.categoryId || this.get("topic.category.id")
-    );
+    if (!opts.readOnlyCategoryId) {
+      this.set(
+        "categoryId",
+        opts.topicCategoryId || opts.categoryId || this.get("topic.category.id")
+      );
+    }
 
     if (!this.categoryId && this.creatingTopic) {
       const categories = this.site.categories;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -118,6 +118,7 @@ export default class ComposerService extends Service {
   editReason = null;
   scopedCategoryId = null;
   prioritizedCategoryId = null;
+  readOnlyCategoryId = null;
   lastValidatedAt = null;
   isUploading = false;
   isProcessingUpload = false;
@@ -1335,6 +1336,7 @@ export default class ComposerService extends Service {
    @param {Boolean} [opts.disableScopedCategory]
    @param {Number} [opts.categoryId] Sets `scopedCategoryId` and `categoryId` on the Composer model
    @param {Number} [opts.prioritizedCategoryId]
+   @param {Number} [opts.readOnlyCategory] Shows category as read-only in category chooser, with a read-only badge
    @param {Number} [opts.formTemplateId]
    @param {String} [opts.draftSequence]
    @param {Boolean} [opts.skipJumpOnSave] Option to skip navigating to the post when saved in this composer session
@@ -1362,6 +1364,7 @@ export default class ComposerService extends Service {
       editReason: null,
       scopedCategoryId: null,
       prioritizedCategoryId: null,
+      readOnlyCategoryId: null,
       skipAutoSave: true,
     });
 
@@ -1391,6 +1394,10 @@ export default class ComposerService extends Service {
       if (category) {
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
       }
+    }
+
+    if (opts.readOnlyCategoryId) {
+      this.set("readOnlyCategoryId", opts.readOnlyCategoryId);
     }
 
     // If we want a different draft than the current composer, close it and clear our model.
@@ -1451,7 +1458,14 @@ export default class ComposerService extends Service {
   }
 
   @action
-  async openNewTopic({ title, body, category, tags, formTemplate } = {}) {
+  async openNewTopic({
+    title,
+    body,
+    category,
+    readOnlyCategoryId,
+    tags,
+    formTemplate,
+  } = {}) {
     return this.open({
       prioritizedCategoryId: category?.id,
       topicCategoryId: category?.id,
@@ -1463,6 +1477,7 @@ export default class ComposerService extends Service {
       draftKey: this.topicDraftKey,
       draftSequence: 0,
       locale: null,
+      readOnlyCategoryId,
     });
   }
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1336,7 +1336,7 @@ export default class ComposerService extends Service {
    @param {Boolean} [opts.disableScopedCategory]
    @param {Number} [opts.categoryId] Sets `scopedCategoryId` and `categoryId` on the Composer model
    @param {Number} [opts.prioritizedCategoryId]
-   @param {Number} [opts.readOnlyCategory] Shows category as read-only in category chooser, with a read-only badge
+   @param {Number} [opts.readOnlyCategoryId] Shows category as read-only in category chooser, with a read-only badge
    @param {Number} [opts.formTemplateId]
    @param {String} [opts.draftSequence]
    @param {Boolean} [opts.skipJumpOnSave] Option to skip navigating to the post when saved in this composer session

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -50,10 +50,12 @@ acceptance("Category Banners", function (needs) {
     await visit("/c/test-read-only-with-banner");
 
     await click("#create-topic");
-    assert.dom(".dialog-body").exists("pops up a modal");
+    assert.dom(".d-editor").exists("opens composer");
 
-    await click(".dialog-footer .btn-primary");
-    assert.dom(".dialog-body").doesNotExist("closes the modal");
+    assert
+      .dom(".d-editor .selected-name[data-name='test-read-only-with-banner']")
+      .doesNotExist("does not show read-only category in composer");
+
     assert.dom(".category-read-only-banner").exists("shows a banner");
     assert
       .dom(".category-read-only-banner .inner")

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -228,14 +228,14 @@ acceptance("Tags listed by group", function (needs) {
       );
   });
 
-  test("new topic button is not available for staff-only tags", async function (assert) {
+  test("new topic button works when viewing staff-only tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/regular-tag");
     assert.dom("#create-topic").isEnabled();
 
     await visit("/tag/staff-only-tag");
-    assert.dom("#create-topic").isDisabled();
+    assert.dom("#create-topic").isEnabled();
 
     updateCurrentUser({ moderator: true });
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -56,12 +56,15 @@ export default class CategoryChooser extends ComboBoxComponent {
         null,
         htmlSafe(i18n(isString ? this.selectKit.options.none : "category.none"))
       );
+    } else if (this.selectKit.options.readOnlyCategoryId) {
+      return this.defaultItem(null, htmlSafe(i18n("category.choose")));
     } else if (this.selectKit.options.allowUncategorized) {
       return Category.findUncategorized();
     } else {
-      const defaultCategoryId = !this.selectKit.options.readOnlyCategoryId
-        ? parseInt(this.siteSettings.default_composer_category, 10)
-        : null;
+      const defaultCategoryId = parseInt(
+        this.siteSettings.default_composer_category,
+        10
+      );
       if (!defaultCategoryId || defaultCategoryId < 0) {
         return this.defaultItem(null, htmlSafe(i18n("category.choose")));
       }

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -59,10 +59,9 @@ export default class CategoryChooser extends ComboBoxComponent {
     } else if (this.selectKit.options.allowUncategorized) {
       return Category.findUncategorized();
     } else {
-      const defaultCategoryId = parseInt(
-        this.siteSettings.default_composer_category,
-        10
-      );
+      const defaultCategoryId = !this.selectKit.options.readOnlyCategoryId
+        ? parseInt(this.siteSettings.default_composer_category, 10)
+        : null;
       if (!defaultCategoryId || defaultCategoryId < 0) {
         return this.defaultItem(null, htmlSafe(i18n("category.choose")));
       }

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -21,6 +21,7 @@ import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
   excludeCategoryId: null,
   scopedCategoryId: null,
   prioritizedCategoryId: null,
+  readOnlyCategoryId: null,
 })
 @pluginApiIdentifiers(["category-chooser"])
 export default class CategoryChooser extends ComboBoxComponent {
@@ -96,6 +97,7 @@ export default class CategoryChooser extends ComboBoxComponent {
         rejectCategoryIds: [this.selectKit.options.excludeCategoryId],
         scopedCategoryId: this.selectKit.options.scopedCategoryId,
         prioritizedCategoryId: this.selectKit.options.prioritizedCategoryId,
+        readOnlyCategoryId: this.selectKit.options.readOnlyCategoryId,
       });
     }
 
@@ -123,11 +125,13 @@ export default class CategoryChooser extends ComboBoxComponent {
   @computed(
     "selectKit.filter",
     "selectKit.options.scopedCategoryId",
-    "selectKit.options.prioritizedCategoryId"
+    "selectKit.options.prioritizedCategoryId",
+    "selectKit.options.readOnlyCategoryId"
   )
   get content() {
     if (!this.selectKit.filter) {
-      let { scopedCategoryId, prioritizedCategoryId } = this.selectKit.options;
+      let { scopedCategoryId, prioritizedCategoryId, readOnlyCategoryId } =
+        this.selectKit.options;
 
       if (scopedCategoryId) {
         return this.categoriesByScope({ scopedCategoryId });
@@ -135,6 +139,10 @@ export default class CategoryChooser extends ComboBoxComponent {
 
       if (prioritizedCategoryId) {
         return this.categoriesByScope({ prioritizedCategoryId });
+      }
+
+      if (readOnlyCategoryId) {
+        return this.categoriesByScope({ readOnlyCategoryId });
       }
     }
 
@@ -144,6 +152,7 @@ export default class CategoryChooser extends ComboBoxComponent {
   categoriesByScope({
     scopedCategoryId = null,
     prioritizedCategoryId = null,
+    readOnlyCategoryId = null,
   } = {}) {
     const categories = this.fixedCategoryPositionsOnCreate
       ? Category.list()
@@ -163,6 +172,10 @@ export default class CategoryChooser extends ComboBoxComponent {
 
     let scopedCategories = categories.filter((category) => {
       const categoryId = this.getValue(category);
+
+      if (readOnlyCategoryId === categoryId) {
+        return true;
+      }
 
       if (
         scopedCategoryId &&

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -31,6 +31,14 @@ export default class CategoryRow extends Component {
     return this.rowValue === this.args.value;
   }
 
+  get isReadOnly() {
+    return this.rowValue === this.readOnlyCategoryId;
+  }
+
+  get readOnlyCategoryId() {
+    return this.args.selectKit.options.readOnlyCategoryId;
+  }
+
   get hideParentCategory() {
     return this.args.selectKit.options.hideParentCategory;
   }
@@ -114,6 +122,7 @@ export default class CategoryRow extends Component {
         subcategoryCount: this.args.item?.category
           ? this.category.subcategory_count
           : 0,
+        readOnly: this.isReadOnly,
       })
     );
   }
@@ -187,6 +196,11 @@ export default class CategoryRow extends Component {
   handleClick(event) {
     event.preventDefault();
     event.stopPropagation();
+
+    if (this.isReadOnly) {
+      return false;
+    }
+
     this.args.selectKit.select(this.rowValue, this.args.item);
     return false;
   }
@@ -225,11 +239,16 @@ export default class CategoryRow extends Component {
         event.preventDefault();
       } else if (event.key === "Enter") {
         event.stopImmediatePropagation();
+        event.preventDefault();
+
+        if (this.isReadOnly) {
+          return false;
+        }
+
         this.args.selectKit.select(
           this.args.selectKit.highlighted.id,
           this.args.selectKit.highlighted
         );
-        event.preventDefault();
       } else if (event.key === "Escape") {
         this.args.selectKit.close(event);
         this.args.selectKit.headerElement().focus();

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -32,6 +32,10 @@ export default class CategoryRow extends Component {
   }
 
   get isReadOnly() {
+    if (!this.readOnlyCategoryId) {
+      return false;
+    }
+
     return this.rowValue === this.readOnlyCategoryId;
   }
 

--- a/app/assets/stylesheets/common/select-kit/category-row.scss
+++ b/app/assets/stylesheets/common/select-kit/category-row.scss
@@ -24,5 +24,14 @@
     .topic-count {
       white-space: nowrap;
     }
+
+    .read-only {
+      padding: 0.2em 0.5em;
+      margin: 0 0 0.25em 0.5em;
+      border-radius: 8px;
+      color: var(--secondary);
+      font-size: var(--font-down-1);
+      background: var(--primary-low-mid);
+    }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2812,6 +2812,7 @@ en:
       topic_count:
         one: "%{count} topic in this category"
         other: "%{count} topics in this category"
+      read_only: "read-only"
 
     timezone_input:
       ambiguous_ist: "IST is ambiguous, please select a specific timezone (eg: Asia/Kolkata)"
@@ -3577,8 +3578,6 @@ en:
         one: "%{count} post in topic"
         other: "%{count} posts in topic"
       create: "New Topic"
-      create_disabled_category: "You're not allowed to create topics in this category"
-      create_disabled_tag: "You're not allowed to create topics with this tag"
       create_long: "Create a new Topic"
       open_draft: "Open Draft"
       private_message: "Start a message"

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -50,8 +50,6 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
                 PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
 
               expect(select_kit).to have_selected_name("category&hellip;")
-              # expect(select_kit).to be_blank
-              # or alternatively like
             end
           end
         end

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -41,9 +41,17 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
             end
           end
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "should have the 'New Topic' button enabled and no category set in the composer" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+
+              category_page.new_topic_button.click
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+
+              expect(select_kit).to have_selected_name("category&hellip;")
+              # expect(select_kit).to be_blank
+              # or alternatively like
             end
           end
         end
@@ -66,9 +74,14 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
         end
         describe "Can't post on parent category" do
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "opens composer with no category selected" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+
+              category_page.new_topic_button.click
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+              expect(select_kit).to have_selected_name("category&hellip;")
             end
           end
         end
@@ -87,10 +100,18 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
     end
 
     describe "Setting disabled and can't post on parent category" do
-      before { SiteSetting.default_subcategory_on_read_only_category = false }
-      it "should have 'New Topic' button disabled" do
+      before do
+        SiteSetting.default_subcategory_on_read_only_category = false
+        SiteSetting.default_composer_category = default_latest_category.id
+      end
+
+      it "opens composer with no category selected" do
         category_page.visit(category)
-        expect(category_page).to have_button("New Topic", disabled: true)
+        expect(category_page).to have_button("New Topic", disabled: false)
+
+        page.find("#create-topic").click
+        select_kit = PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+        expect(select_kit).to have_selected_name("category&hellip;")
       end
     end
   end

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Drafts dropdown", type: :system do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:category)
   let(:composer) { PageObjects::Components::Composer.new }
   let(:drafts_dropdown) { PageObjects::Components::DraftsMenu.new }
   let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
@@ -110,10 +111,10 @@ describe "Drafts dropdown", type: :system do
       )
     end
 
-    it "disables the drafts dropdown menu when new topic button is disabled" do
+    it "is still enabled" do
       category_page.visit(category)
 
-      expect(category_page).to have_button("New Topic", disabled: true)
+      expect(category_page).to have_button("New Topic", disabled: false)
       expect(drafts_dropdown).to be_enabled
     end
   end

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -5,7 +5,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import { gt, not } from "truth-helpers";
+import { gt } from "truth-helpers";
 import CreateTopicButton from "discourse/components/create-topic-button";
 
 export default class SidebarNewTopicButton extends Component {
@@ -39,30 +39,6 @@ export default class SidebarNewTopicButton extends Component {
     if (this.siteSettings.default_subcategory_on_read_only_category) {
       return this.category?.subcategoryWithCreateTopicPermission;
     }
-  }
-
-  get tagRestricted() {
-    return this.tag?.staff;
-  }
-
-  get createTopicDisabled() {
-    return (
-      (this.category && !this.createTopicTargetCategory) ||
-      (this.tagRestricted && !this.currentUser.staff)
-    );
-  }
-
-  get categoryReadOnlyBanner() {
-    if (this.category && this.currentUser && this.createTopicDisabled) {
-      return this.category.read_only_banner;
-    }
-  }
-
-  get createTopicClass() {
-    const baseClasses = "btn-default sidebar-new-topic-button";
-    return this.categoryReadOnlyBanner
-      ? `${baseClasses} disabled`
-      : baseClasses;
   }
 
   @action
@@ -104,10 +80,8 @@ export default class SidebarNewTopicButton extends Component {
         <CreateTopicButton
           @canCreateTopic={{this.canCreateTopic}}
           @action={{this.createNewTopic}}
-          @disabled={{this.createTopicDisabled}}
           @label="topic.create"
-          @btnClass={{this.createTopicClass}}
-          @canCreateTopicOnTag={{not this.tagRestricted}}
+          @btnClass="btn-default sidebar-new-topic-button"
           @showDrafts={{gt this.draftCount 0}}
         />
       </div>

--- a/themes/horizon/spec/system/sidebar_topic_button_spec.rb
+++ b/themes/horizon/spec/system/sidebar_topic_button_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "Sidebar New Topic Button", system: true do
       expect(page).to have_css(".sidebar-new-topic-button__wrapper .topic-drafts-menu-trigger")
     end
 
-    it "disables button when visiting read-only category" do
+    it "does not disable button when visiting read-only category" do
       visit("/c/#{private_category.slug}/#{private_category.id}")
 
-      expect(page).to have_css(".sidebar-new-topic-button[disabled]")
+      expect(page).to have_no_css(".sidebar-new-topic-button[disabled]")
 
       visit("/c/#{category.slug}/#{category.id}")
 


### PR DESCRIPTION
Most of this feature was already approved in #33495 but it was reverted temporarily due to users accidentally posting in the wrong category (due to the default composer category site setting).

This PR removes the default category from composer when the user doesn't have permission to post in the category (preventing accidental posts in the wrong category), and also inserts the read-only category into the category chooser with a read only badge, this way providing some information to the user when they find it in the dropdown.

The read only category in the drop down can't be selected via clicking or keyboard selection.

<img width="1336" height="854" alt="Screenshot 2025-08-12 at 6 33 34 PM" src="https://github.com/user-attachments/assets/a1640f5d-2c73-4c37-8f6a-e284982a8c12" />
