### PR TITLE
DEV: Allow impersonation without session swapping

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -19,6 +19,7 @@ import {
 import { isDocumentRTL } from "discourse/lib/text-direction";
 import swipe from "discourse/modifiers/swipe";
 import Header from "./header";
+import ImpersonationNotice from "./impersonation-notice";
 
 let _menuPanelClassesToForceDropdown = [];
 const PANEL_WIDTH = 340;
@@ -45,6 +46,10 @@ export default class GlimmerSiteHeader extends Component {
 
     if (this.currentUser?.staff) {
       document.body.classList.add("staff");
+    }
+
+    if (this.currentUser?.is_impersonating) {
+      document.body.classList.add("impersonating");
     }
 
     schedule("afterRender", () => this.animateMenu());
@@ -84,6 +89,10 @@ export default class GlimmerSiteHeader extends Component {
     } else {
       return "hamburger-panel";
     }
+  }
+
+  get showImpersonationNotice() {
+    return this.currentUser?.is_impersonating;
   }
 
   @bind
@@ -438,6 +447,9 @@ export default class GlimmerSiteHeader extends Component {
         lockBody=false
       }}
     >
+      {{#if this.showImpersonationNotice}}
+        <ImpersonationNotice />
+      {{/if}}
       <Header
         @canSignUp={{@canSignUp}}
         @showSidebar={{@showSidebar}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-site-header.gjs
@@ -48,10 +48,6 @@ export default class GlimmerSiteHeader extends Component {
       document.body.classList.add("staff");
     }
 
-    if (this.currentUser?.is_impersonating) {
-      document.body.classList.add("impersonating");
-    }
-
     schedule("afterRender", () => this.animateMenu());
   }
 

--- a/app/assets/javascripts/discourse/app/components/impersonation-notice.gjs
+++ b/app/assets/javascripts/discourse/app/components/impersonation-notice.gjs
@@ -1,0 +1,48 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import DiscourseURL from "discourse/lib/url";
+import { i18n } from "discourse-i18n";
+
+export default class ImpersonationNotice extends Component {
+  @service currentUser;
+
+  @tracked stopping = false;
+
+  get impersonatedUserName() {
+    return this.currentUser.username;
+  }
+
+  @action
+  async stopImpersonating() {
+    try {
+      this.stopping = true;
+      await ajax("/admin/impersonate", {
+        type: "DELETE",
+      });
+      DiscourseURL.redirectTo("/");
+    } catch (err) {
+      popupAjaxError(err);
+      this.stopping = false;
+    }
+  }
+
+  <template>
+    <div class="impersonation-notice">
+      <div>{{i18n
+          "impersonation.notice"
+          username=this.impersonatedUserName
+        }}</div>
+      <DButton
+        @action={{this.stopImpersonating}}
+        @disabled={{this.stopping}}
+        @label="impersonation.stop"
+        class="btn-danger"
+      />
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/discourse/app/components/impersonation-notice.gjs
+++ b/app/assets/javascripts/discourse/app/components/impersonation-notice.gjs
@@ -39,7 +39,7 @@ export default class ImpersonationNotice extends Component {
         }}</div>
       <DButton
         @action={{this.stopImpersonating}}
-        @disabled={{this.stopping}}
+        @isLoading={{this.stopping}}
         @label="impersonation.stop"
         class="btn-danger"
       />

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -525,3 +525,16 @@ $mobile-avatar-height: 1.532em;
     }
   }
 }
+
+.impersonation-notice {
+  background-color: var(--header_background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  text-align: center;
+
+  button {
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::ImpersonateController < Admin::AdminController
+  skip_before_action :ensure_admin, only: :destroy
+
   def create
     params.require(:username_or_email)
 
@@ -12,14 +14,22 @@ class Admin::ImpersonateController < Admin::AdminController
     # log impersonate
     StaffActionLogger.new(current_user).log_impersonate(user)
 
-    # Log on as the user
-    #log_on_user(user, impersonate: true)
-    start_impersonating_user(user)
+    if SiteSetting.experimental_impersonation
+      raise Discourse::InvalidAccess if current_user.is_impersonating
+
+      start_impersonating_user(user)
+    else
+      # Log on as the user
+      log_on_user(user, impersonate: true)
+    end
 
     render body: nil
   end
 
   def destroy
+    raise Discourse::NotFound if !SiteSetting.experimental_impersonation
+    raise Discourse::InvalidAccess if !current_user.is_impersonating
+
     stop_impersonating_user
 
     render body: nil

--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -13,7 +13,14 @@ class Admin::ImpersonateController < Admin::AdminController
     StaffActionLogger.new(current_user).log_impersonate(user)
 
     # Log on as the user
-    log_on_user(user, impersonate: true)
+    #log_on_user(user, impersonate: true)
+    start_impersonating_user(user)
+
+    render body: nil
+  end
+
+  def destroy
+    stop_impersonating_user
 
     render body: nil
   end

--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -30,7 +30,11 @@ class Admin::ImpersonateController < Admin::AdminController
     raise Discourse::NotFound if !SiteSetting.experimental_impersonation
     raise Discourse::InvalidAccess if !current_user.is_impersonating
 
+    puppet = current_user
+
     stop_impersonating_user
+
+    StaffActionLogger.new(current_user).log_stop_impersonation(puppet)
 
     render body: nil
   end

--- a/app/jobs/scheduled/clear_expired_impersonations.rb
+++ b/app/jobs/scheduled/clear_expired_impersonations.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ClearExpiredImpersonations < ::Jobs::Scheduled
+    every 30.minutes
+
+    def execute(args)
+      UserAuthToken.where("impersonation_expires_at < NOW()").update_all(
+        impersonated_user_id: nil,
+        impersonation_expires_at: nil,
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -264,6 +264,9 @@ class User < ActiveRecord::Base
   # Information if user was authenticated with OAuth
   attr_accessor :authenticated_with_oauth
 
+  # Flag used when admin is impersonating a user
+  attr_accessor :is_impersonating
+
   scope :with_email,
         ->(email) { joins(:user_emails).where("lower(user_emails.email) IN (?)", email) }
 

--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -34,7 +34,7 @@ class UserAuthToken < ActiveRecord::Base
     return if impersonated_user_id.blank?
     return if impersonation_expires_at.blank? || impersonation_expires_at.past?
 
-    User.find_by(id: impersonated_user_id)
+    User.find_by(id: impersonated_user_id).tap { |u| u.is_impersonating = true }
   end
 
   def self.log(info)
@@ -292,17 +292,19 @@ end
 # Table name: user_auth_tokens
 #
 #  id                       :integer          not null, primary key
-#  user_id                  :integer          not null
 #  auth_token               :string           not null
-#  prev_auth_token          :string           not null
-#  user_agent               :string
 #  auth_token_seen          :boolean          default(FALSE), not null
+#  authenticated_with_oauth :boolean          default(FALSE)
 #  client_ip                :inet
+#  impersonation_expires_at :datetime
+#  prev_auth_token          :string           not null
 #  rotated_at               :datetime         not null
+#  seen_at                  :datetime
+#  user_agent               :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  seen_at                  :datetime
-#  authenticated_with_oauth :boolean          default(FALSE)
+#  impersonated_user_id     :integer
+#  user_id                  :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -26,6 +26,17 @@ class UserAuthToken < ActiveRecord::Base
     )
   end
 
+  def user
+    impersonated_user || super
+  end
+
+  def impersonated_user
+    return if impersonated_user_id.blank?
+    return if impersonation_expires_at.blank? || impersonation_expires_at.past?
+
+    User.find_by(id: impersonated_user_id)
+  end
+
   def self.log(info)
     UserAuthTokenLog.create!(info)
   end

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -157,6 +157,7 @@ class UserHistory < ActiveRecord::Base
         tag_group_change: 118,
         delete_associated_accounts: 119,
         change_theme_site_setting: 120,
+        stop_impersonating: 121,
       )
   end
 
@@ -280,6 +281,7 @@ class UserHistory < ActiveRecord::Base
       update_flag
       create_flag
       change_theme_site_setting
+      stop_impersonating
     ]
   end
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -81,7 +81,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_localize_content?,
              :effective_locale,
              :use_reviewable_ui_refresh,
-             :can_see_ip
+             :can_see_ip,
+             :is_impersonating
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -99,6 +100,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def login_method
     @options[:login_method]
+  end
+
+  def is_impersonating
+    !!object.is_impersonating
   end
 
   def groups

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -566,6 +566,12 @@ class StaffActionLogger
     )
   end
 
+  def log_stop_impersonation(user, opts = {})
+    UserHistory.create!(
+      params(opts).merge(action: UserHistory.actions[:stop_impersonating], target_user_id: user.id),
+    )
+  end
+
   def log_roll_up(subnet, ips, opts = {})
     UserHistory.create!(
       params(opts).merge(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -326,6 +326,10 @@ en:
         anonymous_members: ""
       search: "Search"
 
+    impersonation:
+      notice: "You are impersonating %{username}"
+      stop: "Stop impersonating"
+
     themes:
       default_description: "Default"
       broken_theme_alert: "Your site may not work because a theme / component has errors. Check the browser console for more information."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2734,6 +2734,8 @@ en:
     show_preview_for_form_templates: "Enable the preview for form templates feature"
     lazy_load_categories_groups: "Lazy load category information only for users of these groups. This improves performance on sites with many categories."
     experimental_auto_grid_images: "Automatically wraps images in [grid] tags when 3 or more images are uploaded in the composer."
+    experimental_impersonation: "Impersonate a user without having to log out of your admin account."
+    experimental_impersonation_time_limit_minutes: "How long before an impersonation session is automatically ended."
     page_loading_indicator: "Configure the loading indicator which appears during page navigations within Discourse. 'Spinner' is a full page indicator. 'Slider' shows a narrow bar at the top of the screen."
     show_user_menu_avatars: "Show user avatars in the user menu"
     about_page_hidden_groups: "Do not show members of specific groups on the /about page."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,9 @@ Discourse::Application.routes.draw do
     get "wizard/steps/:id" => "wizard#index"
     put "wizard/steps/:id" => "steps#update"
 
+    delete "admin/impersonate" => "admin/impersonate#destroy",
+           :constraints => ImpersonatorConstraint.new
+
     namespace :admin, constraints: StaffConstraint.new do
       get "" => "admin#index"
       get "search" => "search#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4084,6 +4084,9 @@ experimental:
   experimental_form_templates:
     client: true
     default: false
+  experimental_impersonation:
+    default: false
+    hidden: true
   show_preview_for_form_templates:
     client: true
     default: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4087,6 +4087,9 @@ experimental:
   experimental_impersonation:
     default: false
     hidden: true
+  experimental_impersonation_time_limit_minutes:
+    default: 15
+    hidden: true
   show_preview_for_form_templates:
     client: true
     default: true

--- a/db/migrate/20250811070948_add_impersonated_user_fields_to_user_auth_token.rb
+++ b/db/migrate/20250811070948_add_impersonated_user_fields_to_user_auth_token.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddImpersonatedUserFieldsToUserAuthToken < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_auth_tokens, :impersonated_user_id, :integer
+    add_column :user_auth_tokens, :impersonation_expires_at, :datetime
+  end
+end

--- a/db/migrate/20250811070948_add_impersonated_user_fields_to_user_auth_token.rb
+++ b/db/migrate/20250811070948_add_impersonated_user_fields_to_user_auth_token.rb
@@ -3,5 +3,9 @@ class AddImpersonatedUserFieldsToUserAuthToken < ActiveRecord::Migration[8.0]
   def change
     add_column :user_auth_tokens, :impersonated_user_id, :integer
     add_column :user_auth_tokens, :impersonation_expires_at, :datetime
+
+    add_index :user_auth_tokens,
+              %i[impersonation_expires_at],
+              where: "impersonation_expires_at IS NOT NULL"
   end
 end

--- a/lib/auth/current_user_provider.rb
+++ b/lib/auth/current_user_provider.rb
@@ -23,6 +23,14 @@ class Auth::CurrentUserProvider
   def refresh_session(user, session, cookie_jar)
   end
 
+  # Optional interface for implementing impersonation.
+  def start_impersonating_user(user)
+  end
+
+  # Optional interface for implementing impersonation.
+  def stop_impersonating_user
+  end
+
   # api has special rights return true if api was detected
   def is_api?
     raise NotImplementedError

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -281,6 +281,17 @@ class Auth::DefaultCurrentUserProvider
     @env[CURRENT_USER_KEY] = user
   end
 
+  def start_impersonating_user(user)
+    @user_token.update!(
+      impersonated_user_id: user.id,
+      impersonation_expires_at: 15.minutes.from_now,
+    )
+  end
+
+  def stop_impersonating_user
+    @user_token.update!(impersonated_user_id: nil, impersonation_expires_at: nil)
+  end
+
   def set_auth_cookie!(unhashed_auth_token, user, cookie_jar)
     data = {
       token: unhashed_auth_token,

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -284,12 +284,16 @@ class Auth::DefaultCurrentUserProvider
   def start_impersonating_user(user)
     @user_token.update!(
       impersonated_user_id: user.id,
-      impersonation_expires_at: 15.minutes.from_now,
+      impersonation_expires_at:
+        SiteSetting.experimental_impersonation_time_limit_minutes.minutes.from_now,
     )
   end
 
   def stop_impersonating_user
     @user_token.update!(impersonated_user_id: nil, impersonation_expires_at: nil)
+    # Clear memoization of `current_user` so we can get the acting user back in
+    # the context of the same request.
+    @env.delete(CURRENT_USER_KEY)
   end
 
   def set_auth_cookie!(unhashed_auth_token, user, cookie_jar)

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -23,6 +23,14 @@ module CurrentUser
     current_user_provider.log_off_user(session, cookies)
   end
 
+  def start_impersonating_user(user)
+    current_user_provider.start_impersonating_user(user)
+  end
+
+  def stop_impersonating_user
+    current_user_provider.stop_impersonating_user
+  end
+
   def is_api?
     current_user_provider.is_api?
   end

--- a/lib/impersonator_constraint.rb
+++ b/lib/impersonator_constraint.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ImpersonatorConstraint
+  def matches?(request)
+    current_user = CurrentUser.lookup_from_env(request.env)
+    !!current_user&.is_impersonating
+  rescue Discourse::InvalidAccess, Discourse::ReadOnly
+    false
+  end
+end

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -4,6 +4,53 @@ require "discourse_ip_info"
 
 RSpec.describe UserAuthToken do
   fab!(:user)
+  fab!(:admin)
+
+  describe "#user" do
+    context "when no impersonation is happening" do
+      it "returns the user associated with the session" do
+        token =
+          UserAuthToken.generate!(
+            user_id: user.id,
+            user_agent: "some user agent 2",
+            client_ip: "1.1.2.3",
+          )
+
+        expect(token.user).to eq(user)
+        expect(token.user.is_impersonating).to be_falsey
+      end
+    end
+
+    context "when impersonating another user" do
+      it "returns the user being impersonated if not expired" do
+        token =
+          UserAuthToken.generate!(
+            user_id: admin.id,
+            user_agent: "some user agent 2",
+            client_ip: "1.1.2.3",
+          )
+
+        token.update!(impersonated_user_id: user.id, impersonation_expires_at: 15.minutes.from_now)
+
+        expect(token.user).to eq(user)
+        expect(token.user.is_impersonating).to eq(true)
+      end
+
+      it "returns the user associated with the session if expired" do
+        token =
+          UserAuthToken.generate!(
+            user_id: admin.id,
+            user_agent: "some user agent 2",
+            client_ip: "1.1.2.3",
+          )
+
+        token.update!(impersonated_user_id: user.id, impersonation_expires_at: 15.minutes.ago)
+
+        expect(token.user).to eq(admin)
+        expect(token.user.is_impersonating).to be_falsey
+      end
+    end
+  end
 
   it "can remove old expired tokens" do
     SiteSetting.verbose_auth_token_logging = true

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -46,10 +46,6 @@ RSpec.describe UserAuthToken do
 
         token.update!(impersonated_user_id: user.id, impersonation_expires_at: 1.hour.ago)
 
-        expect { token.user }.to change {
-          [token.impersonated_user_id, token.impersonation_expires_at]
-        }.to([nil, nil])
-
         expect(token.user).to eq(admin)
         expect(token.user.is_impersonating).to be_falsey
       end

--- a/spec/system/impersonation_spec.rb
+++ b/spec/system/impersonation_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe "Impersonation", type: :system do
+  fab!(:admin)
+  fab!(:user)
+
+  before do
+    SiteSetting.experimental_impersonation = true
+
+    sign_in(admin)
+  end
+
+  it "allows you to start and stop impersonating with the click of a button" do
+    visit("/admin/users/#{user.id}/#{user.username}")
+
+    page.find(".btn-impersonate").click
+
+    expect(page).to have_current_path("/")
+    expect(page).to have_css(
+      ".impersonation-notice",
+      text: I18n.t("js.impersonation.notice", username: user.username),
+    )
+
+    visit("/latest")
+
+    page.find(".impersonation-notice .btn-danger").click
+
+    expect(page).to have_current_path("/")
+    expect(page).to have_no_css(".impersonation-notice")
+  end
+end


### PR DESCRIPTION
### What is this feature?

The current impersonation feature works by signing you in as the user you are impersonating. This has the side effect of invalidating your own session and forcing you to log out and in again.

In this experimental implementation you keep your existing session, but `DefaultCurrentUserProvider` returns the user being impersonated, allowing you to see the site from their perspective.

![impersonation](https://github.com/user-attachments/assets/61826378-62d2-427f-8967-63f8bb42d3b4)

### Security

There are two immediate questions to ask here:

**What if the application code path is compromised?**

The new implementation uses the same code path as the old one (with `ImpersonateController#create` as an entry point), and (critically) is behind the same guardian check.

**What if the database is compromised?**

As an implementation detail, this has a new field `impersonated_user_id` on the `UserAuthToken`. This table already has a `user_id` associated with the session, so if the table is compromised, it is already a pre-existing one.

So this implementation should have the exact same surface area and risk profile as the existing one.