### PR TITLE
FIX: Simplify full name requirement logic during signup

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -278,10 +278,10 @@ class Site
   end
 
   def self.full_name_required_for_signup
-    SiteSetting.enable_names && SiteSetting.full_name_requirement == "required_at_signup"
+    SiteSetting.full_name_requirement == "required_at_signup"
   end
 
   def self.full_name_visible_in_signup
-    SiteSetting.enable_names && SiteSetting.full_name_requirement != "hidden_at_signup"
+    SiteSetting.full_name_requirement != "hidden_at_signup"
   end
 end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -433,15 +433,8 @@ RSpec.describe SiteSerializer do
       described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
     end
 
-    it "is false when enable_names setting is false" do
-      SiteSetting.full_name_requirement = "required_at_signup"
-      SiteSetting.enable_names = false
-      expect(site_json[:full_name_required_for_signup]).to eq(false)
-    end
-
     it "is false when full_name_requirement setting is optional_at_signup" do
       SiteSetting.full_name_requirement = "optional_at_signup"
-      SiteSetting.enable_names = true
       expect(site_json[:full_name_required_for_signup]).to eq(false)
     end
 
@@ -463,39 +456,23 @@ RSpec.describe SiteSerializer do
       described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
     end
 
-    it "is false when enable_names setting is false and full_name_requirement is hidden_at_signup" do
+    it "is false when full_name_requirement is hidden_at_signup" do
       SiteSetting.full_name_requirement = "hidden_at_signup"
-      SiteSetting.enable_names = false
-      expect(site_json[:full_name_visible_in_signup]).to eq(false)
-    end
-
-    it "is false when enable_names setting is false and full_name_requirement is required_at_signup" do
-      SiteSetting.full_name_requirement = "required_at_signup"
-      SiteSetting.enable_names = false
-      expect(site_json[:full_name_visible_in_signup]).to eq(false)
-    end
-
-    it "is false when enable_names setting is false and full_name_requirement is optional_at_signup" do
-      SiteSetting.full_name_requirement = "optional_at_signup"
-      SiteSetting.enable_names = false
       expect(site_json[:full_name_visible_in_signup]).to eq(false)
     end
 
     it "is true when enable_names setting is true and full_name_requirement is optional_at_signup" do
       SiteSetting.full_name_requirement = "optional_at_signup"
-      SiteSetting.enable_names = true
       expect(site_json[:full_name_visible_in_signup]).to eq(true)
     end
 
     it "is true when enable_names setting is true and full_name_requirement is required_at_signup" do
       SiteSetting.full_name_requirement = "required_at_signup"
-      SiteSetting.enable_names = true
       expect(site_json[:full_name_visible_in_signup]).to eq(true)
     end
 
     it "is false when enable_names setting is true and full_name_requirement is hidden_at_signup" do
       SiteSetting.full_name_requirement = "hidden_at_signup"
-      SiteSetting.enable_names = true
       expect(site_json[:full_name_visible_in_signup]).to eq(false)
     end
   end

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -343,7 +343,7 @@ shared_examples "signup scenarios" do
 
         it "hides the name field" do
           signup_page.open
-          expect(signup_page).to have_no_name_input
+          expect(signup_page).to have_name_input
         end
       end
     end
@@ -370,7 +370,7 @@ shared_examples "signup scenarios" do
 
         it "hides the name field" do
           signup_page.open
-          expect(signup_page).to have_no_name_input
+          expect(signup_page).to have_name_input
         end
       end
     end


### PR DESCRIPTION
Remove dependency on enable_names setting for controlling full name visibility and requirement during signup. This change ensures full name behavior is controlled exclusively by the full_name_requirement setting.