### PR TITLE
UX: remove margin on user badge

### DIFF
--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -11,7 +11,6 @@
   display: inline-flex;
   align-items: center;
   background-color: var(--secondary);
-  margin: 4px 0 0;
 
   img {
     height: 16px;


### PR DESCRIPTION
Reported on meta
https://meta.discourse.org/t/xxx-more-box-in-user-card-not-aligned/378031?mobile_view=1

This commit removes margin on `user-badge` class to avoid misalignment on the usercard.

Only other instance I think uses this element is the admin badge page:
<img width="1015" height="581" alt="CleanShot 2025-08-11 at 11 32 05" src="https://github.com/user-attachments/assets/a55581f5-063d-476d-aea4-2ffee5d653c6" />
Which also does not need that margin.
