### PR TITLE
FIX: Showing errors during social auth in some edge cases

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
@@ -54,6 +54,7 @@ export default {
               };
 
               router.transitionTo("login").then(({ controller }) => {
+                controller ??= owner.lookup("controller:login");
                 controller.setProperties(props);
               });
 

--- a/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/auth-complete.js
@@ -53,8 +53,8 @@ export default {
                 ...properties,
               };
 
-              router.transitionTo("login").then(({ controller }) => {
-                controller ??= owner.lookup("controller:login");
+              router.transitionTo("login").then(() => {
+                const controller = owner.lookup("controller:login");
                 controller.setProperties(props);
               });
 
@@ -104,8 +104,8 @@ export default {
                 skipConfirmation: siteSettings.auth_skip_create_confirm,
               };
 
-              router.transitionTo("signup").then(({ controller }) => {
-                controller ??= owner.lookup("controller:signup");
+              router.transitionTo("signup").then(() => {
+                const controller = owner.lookup("controller:signup");
                 controller.setProperties(props);
                 controller.handleSkipConfirmation();
               });

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -176,14 +176,16 @@ export default class ApplicationRoute extends DiscourseRoute {
   showLogin(props = {}) {
     const t = this.router.transitionTo("login");
     t.wantsTo = true;
-    return t.then(({ controller }) => controller.setProperties({ ...props }));
+    const controller = getOwnerWithFallback(this).lookup("controller:login");
+    return t.then(() => controller.setProperties({ ...props }));
   }
 
   @action
   showCreateAccount(props = {}) {
     const t = this.router.transitionTo("signup");
     t.wantsTo = true;
-    return t.then(({ controller }) => controller.setProperties({ ...props }));
+    const controller = getOwnerWithFallback(this).lookup("controller:signup");
+    return t.then(() => controller.setProperties({ ...props }));
   }
 
   @action


### PR DESCRIPTION
Unable to repro this using tests, but can confirm with a local repro, when the site is `login required`, the controller isn't present in the router's promise. In those cases, we should look it up.

We do the same for signups later in this file.