### PR TITLE
UX: add background image setting for welcome banner

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -110,15 +110,15 @@ export default class WelcomeBanner extends Component {
   }
 
   get bgImgClass() {
-    if (this.siteSettings.welcome_banner_bg_img) {
+    if (this.siteSettings.welcome_banner_image) {
       return `--with-bg-img`;
     }
   }
 
   get bgImgStyle() {
-    if (this.siteSettings.welcome_banner_bg_img) {
+    if (this.siteSettings.welcome_banner_image) {
       return htmlSafe(
-        `background-image: url(${escapeExpression(this.siteSettings.welcome_banner_bg_img)})`
+        `background-image: url(${escapeExpression(this.siteSettings.welcome_banner_image)})`
       );
     }
   }

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -9,7 +9,7 @@ import SearchMenu from "discourse/components/search-menu";
 import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
 import { prioritizeNameFallback } from "discourse/lib/settings";
-import { defaultHomepage } from "discourse/lib/utilities";
+import { defaultHomepage, escapeExpression } from "discourse/lib/utilities";
 import I18n, { i18n } from "discourse-i18n";
 
 export default class WelcomeBanner extends Component {
@@ -109,11 +109,30 @@ export default class WelcomeBanner extends Component {
     return `--location-${dasherize(this.siteSettings.welcome_banner_location)}`;
   }
 
+  get bgImgClass() {
+    if (this.siteSettings.welcome_banner_bg_img) {
+      return `--with-bg-img`;
+    }
+  }
+
+  get bgImgStyle() {
+    if (this.siteSettings.welcome_banner_bg_img) {
+      return htmlSafe(
+        `background-image: url(${escapeExpression(this.siteSettings.welcome_banner_bg_img)})`
+      );
+    }
+  }
+
   <template>
     {{bodyClass this.bodyClasses}}
     {{#if this.shouldDisplay}}
       <div
-        class={{concatClass "welcome-banner" this.locationClass}}
+        style={{if this.bgImgStyle this.bgImgStyle}}
+        class={{concatClass
+          "welcome-banner"
+          this.locationClass
+          this.bgImgClass
+        }}
         {{this.checkViewport}}
         {{this.handleKeyboardShortcut}}
       >

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -143,6 +143,12 @@
     // hacky but best guestimate we can do: full height of the viewport minus the header, minus the welcome banner spacing,  minus font-size:6 title
     max-height: calc(100vh - var(--header-offset) - -3em - 4em);
   }
+
+  &.--with-bg-img {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
 }
 
 .welcome-banner__title {

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -148,7 +148,7 @@
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    margin-bottom: 10px;
+    margin-bottom: 0.625rem;
   }
 }
 

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -148,7 +148,7 @@
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
-    margin-bottom: 0.625rem;
+    margin-bottom: var(--space-2);
   }
 }
 

--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -148,6 +148,7 @@
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
+    margin-bottom: 10px;
   }
 }
 

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -123,6 +123,7 @@
     }
 
     .controls {
+      align-self: center;
       max-width: 13.5em;
       margin-left: 0.5em;
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2716,6 +2716,7 @@ en:
     show_bottom_topic_map: "Shows the topic map at the bottom of the topic when it has 10 replies or more."
     show_topic_map_in_topics_without_replies: "Shows the topic map even if the topic has no replies."
     enable_welcome_banner: "Display a banner on your main topic list pages to welcome members and allow them to search site content"
+    welcome_banner_bg_img: "Set an image to display in the background of the welcome banner."
     welcome_banner_location: "Determines where on the page the welcome banner will appear."
     welcome_banner_page_visibility: "Determines on which pages the welcome banner will appear."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2716,7 +2716,7 @@ en:
     show_bottom_topic_map: "Shows the topic map at the bottom of the topic when it has 10 replies or more."
     show_topic_map_in_topics_without_replies: "Shows the topic map even if the topic has no replies."
     enable_welcome_banner: "Display a banner on your main topic list pages to welcome members and allow them to search site content"
-    welcome_banner_bg_img: "Set an image to display in the background of the welcome banner."
+    welcome_banner_image: "Set an image to display in the background of the welcome banner."
     welcome_banner_location: "Determines where on the page the welcome banner will appear."
     welcome_banner_page_visibility: "Determines on which pages the welcome banner will appear."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3670,6 +3670,12 @@ uncategorized:
     themeable: true
     area: "interface"
 
+  welcome_banner_bg_img:
+    client: true
+    default: ""
+    type: upload
+    area: "interface"
+
   welcome_banner_location:
     client: true
     enum: "WelcomeBannerLocation"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3670,7 +3670,7 @@ uncategorized:
     themeable: true
     area: "interface"
 
-  welcome_banner_bg_img:
+  welcome_banner_image:
     client: true
     default: ""
     type: upload

--- a/spec/system/page_objects/components/welcome_banner.rb
+++ b/spec/system/page_objects/components/welcome_banner.rb
@@ -48,6 +48,18 @@ module PageObjects
         )
       end
 
+      def has_no_bg_img?
+        has_no_css?(".welcome-banner.--with-bg-img")
+      end
+
+      def has_bg_img?(url)
+        has_css?(
+          ".welcome-banner.--with-bg-img",
+          style: "background-image: url(#{url})",
+          visible: :visible,
+        )
+      end
+
       def above_topic_content?
         has_css?("#main-outlet > .--location-above-topic-content", visible: :visible)
       end

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -147,21 +147,26 @@ describe "Welcome banner", type: :system do
     end
 
     context "with background image setting" do
-      fab!(:image_upload)
+      fab!(:bg_img) { Fabricate(:image_upload, color: "cyan") }
 
       before do
         current_user.update!(admin: true)
         SiteSetting.welcome_banner_page_visibility = "all_pages"
       end
 
-      it "sets a background image with uploaded image" do
+      it "shows banner without background image" do
         sign_in(current_user)
         visit "/admin/config/interface"
         expect(banner).to be_visible
         expect(banner).to have_no_bg_img
+      end
 
-        SiteSetting.welcome_banner_image = image_upload.url
-        expect(banner).to have_bg_img(image_upload.url)
+      it "sets a background image with uploaded image" do
+        SiteSetting.welcome_banner_image = bg_img
+
+        sign_in(current_user)
+        visit "/admin/config/interface"
+        expect(banner).to have_bg_img(bg_img.url)
       end
     end
 

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -147,12 +147,10 @@ describe "Welcome banner", type: :system do
     end
 
     context "with background image setting" do
+      fab!(:current_user, :admin)
       fab!(:bg_img) { Fabricate(:image_upload, color: "cyan") }
 
-      before do
-        current_user.update!(admin: true)
-        SiteSetting.welcome_banner_page_visibility = "all_pages"
-      end
+      before { SiteSetting.welcome_banner_page_visibility = "all_pages" }
 
       it "shows banner without background image" do
         sign_in(current_user)

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -146,6 +146,25 @@ describe "Welcome banner", type: :system do
       end
     end
 
+    context "with background image setting" do
+      fab!(:image_upload)
+
+      before do
+        current_user.update!(admin: true)
+        SiteSetting.welcome_banner_page_visibility = "all_pages"
+      end
+
+      it "sets a background image with uploaded image" do
+        sign_in(current_user)
+        visit "/admin/config/interface"
+        expect(banner).to be_visible
+        expect(banner).to have_no_bg_img
+
+        SiteSetting.welcome_banner_image = image_upload.url
+        expect(banner).to have_bg_img(image_upload.url)
+      end
+    end
+
     context "with interface location setting" do
       it "shows above topic content" do
         SiteSetting.welcome_banner_location = "above_topic_content"


### PR DESCRIPTION
Add a background image setting for a core welcome banner to the *Interface & layout* admin page.

Replaces [advanced search banner](https://meta.discourse.org/t/advanced-search-banner/122939).