### PR TITLE
UX: fix theme toggle component positioning in Horizon

### DIFF
--- a/themes/horizon/scss/sidebar.scss
+++ b/themes/horizon/scss/sidebar.scss
@@ -93,3 +93,15 @@
     }
   }
 }
+
+.sidebar-theme-toggle__wrapper {
+  order: -1;
+
+  .d-icon-paintbrush {
+    display: none;
+  }
+}
+
+.sidebar-theme-toggle-dropdown.select-kit.combo-box .select-kit-header {
+  padding-left: 1em;
+}


### PR DESCRIPTION
I believe updating the way the component is connected in https://github.com/discourse/discourse-sidebar-theme-toggle/commit/9f2217410c97b87c9f82d2114a6da60a1b195505 caused ordering to become inconsistent here... so I've got to do it manually 

This PR puts the theme selector first, and removes the redundant icon (in Horizon the paintbrush icon is used to swap the color palette) 

Before:
<img width="530" height="90" alt="image" src="https://github.com/user-attachments/assets/506483fb-ea65-4200-9aed-48d6f78c531a" />


After:
<img width="538" height="130" alt="image" src="https://github.com/user-attachments/assets/8afdfeb3-54c6-4541-873c-9a9e9cf5c25a" />
