### PR TITLE
UX: Adjust appearance of search icon

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -226,6 +226,21 @@ export default class GlimmerHeader extends Component {
           @narrowDesktop={{this.site.narrowDesktopView}}
         >
           <span class="header-buttons">
+            {{#if
+              (not
+                (and this.siteSettings.login_required (not this.currentUser))
+              )
+            }}
+              <Icons
+                @sidebarEnabled={{@sidebarEnabled}}
+                @toggleSearchMenu={{this.toggleSearchMenu}}
+                @toggleNavigationMenu={{this.toggleNavigationMenu}}
+                @toggleUserMenu={{this.toggleUserMenu}}
+                @topicInfoVisible={{@topicInfoVisible}}
+                @narrowDesktop={{this.site.narrowDesktopView}}
+                @searchButtonId={{SEARCH_BUTTON_ID}}
+              />
+            {{/if}}
             {{#each (headerButtons.resolve) as |entry|}}
               {{#if (and (eq entry.key "auth") (not this.currentUser))}}
                 <AuthButtons
@@ -239,20 +254,6 @@ export default class GlimmerHeader extends Component {
               {{/if}}
             {{/each}}
           </span>
-
-          {{#if
-            (not (and this.siteSettings.login_required (not this.currentUser)))
-          }}
-            <Icons
-              @sidebarEnabled={{@sidebarEnabled}}
-              @toggleSearchMenu={{this.toggleSearchMenu}}
-              @toggleNavigationMenu={{this.toggleNavigationMenu}}
-              @toggleUserMenu={{this.toggleUserMenu}}
-              @topicInfoVisible={{@topicInfoVisible}}
-              @narrowDesktop={{this.site.narrowDesktopView}}
-              @searchButtonId={{SEARCH_BUTTON_ID}}
-            />
-          {{/if}}
 
           {{#if this.search.visible}}
             <SearchMenuWrapper

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -134,6 +134,7 @@
     .auth-buttons {
       display: flex;
       gap: 0.5em;
+      margin-left: 0.5em;
     }
   }
 


### PR DESCRIPTION
For anon users visiting a forum with the search banner enabled, and the search experience being an icon in the header... when the icon appears in the header, it causes the auth buttons to jump to the left.

This PR fixes this by placing the icon to the left of the auth buttons.

|before|after|
|--|--|
|<img width="2824" height="1592" alt="CleanShot 2025-08-11 at 17 44 27@2x" src="https://github.com/user-attachments/assets/25c70a4e-bcbf-4e57-b068-01105c1accb0" />|<img width="2856" height="1582" alt="CleanShot 2025-08-11 at 17 43 51@2x" src="https://github.com/user-attachments/assets/0915a392-73ed-486d-9dbb-cdb8d88fd763" />|