### PR TITLE
UX: Show bulk select on filter page when set to show in nav controls

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
@@ -1,11 +1,11 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
-import { and } from "truth-helpers";
 import BulkSelectToggle from "discourse/components/bulk-select-toggle";
 import FilterNavigationMenu from "discourse/components/discovery/filter-navigation-menu";
 import bodyClass from "discourse/helpers/body-class";
 import { bind } from "discourse/lib/decorators";
 import { resettableTracked } from "discourse/lib/tracked-tools";
+import { applyValueTransformer } from "discourse/lib/transformer";
 
 export default class DiscoveryFilterNavigation extends Component {
   @service site;
@@ -22,12 +22,22 @@ export default class DiscoveryFilterNavigation extends Component {
     }
   }
 
+  get showBulkSelectInNavControls() {
+    const enableOnDesktop = applyValueTransformer(
+      "bulk-select-in-nav-controls",
+      false,
+      { site: this.site }
+    );
+
+    return this.site.mobileView || (enableOnDesktop && this.args.canBulkSelect);
+  }
+
   <template>
     {{bodyClass "navigation-filter"}}
 
     <section class="navigation-container">
       <div class="topic-query-filter">
-        {{#if (and this.site.mobileView @canBulkSelect)}}
+        {{#if this.showBulkSelectInNavControls}}
           <div class="topic-query-filter__bulk-action-btn">
             <BulkSelectToggle @bulkSelectHelper={{@bulkSelectHelper}} />
           </div>


### PR DESCRIPTION
The toggle bulk select was not showing on horizon on the filter route.

This is happened for two reasons:

We use a value transformer to render bulk select in the nav controls instead of the table header in horizon. In the filter markup, the bulk select toggle was set to only show on mobile, due to typically it rendering in the table header.

|Before|After|
|--|--|
|<img width="2396" height="1580" alt="CleanShot 2025-08-11 at 18 00 18@2x" src="https://github.com/user-attachments/assets/c4269b79-cd7a-4266-b0af-02251a2e065a" />|<img width="2400" height="1584" alt="CleanShot 2025-08-11 at 18 00 04@2x" src="https://github.com/user-attachments/assets/98381ecc-7f7a-439e-a283-35a736f05c4d" />|
