### PR TITLE
FIX: `applySurround` should detect both sides when deleting surrounde…

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/lib/textarea-text-manipulation.js
@@ -285,8 +285,8 @@ export default class TextareaTextManipulation {
 
         if (
           operation !== OP.ADDED &&
-          ((l.slice(0, hlen) === hval && tlen === 0) ||
-            (tail.length && l.slice(-tlen) === tail))
+          l.slice(0, hlen) === hval &&
+          (tlen === 0 || l.slice(-tlen) === tail)
         ) {
           operation = OP.REMOVED;
           if (tlen === 0) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-area-manipulaton-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-area-manipulaton-test.js
@@ -1,0 +1,54 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import TextareaTextManipulation from "discourse/lib/textarea-text-manipulation";
+
+module("Unit | Utility | text-area-manipulation", function (hooks) {
+  setupTest(hooks);
+
+  test("applySurround - add", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = "Hello World";
+    textarea.select();
+    manipulation.applySurroundSelection("**", "**", "example");
+
+    assert.strictEqual(textarea.value, "**Hello World**");
+  });
+
+  test("applySurround - remove", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = "**Hello World**";
+    textarea.select();
+    manipulation.applySurroundSelection("**", "**", "example");
+
+    assert.strictEqual(textarea.value, "Hello World");
+  });
+
+  test("applySurround - one side", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = "Hello World**";
+    textarea.select();
+    manipulation.applySurroundSelection("**", "**", "example");
+    assert.strictEqual(textarea.value, "**Hello World****");
+
+    textarea.value = "**Hello World";
+    textarea.select();
+    manipulation.applySurroundSelection("**", "**", "example");
+    assert.strictEqual(textarea.value, "****Hello World**");
+  });
+});


### PR DESCRIPTION
…d text

In the current Textarea Editor `applySurround`, only the right side is checked. That means if you write `something**`, pressing `Ctrl + B` will unexpectedly turn it into `mething`, since the `TextareaTextManipulation` detected the double asterisk `**` on the right and thought `something**` was the bold syntax, so it removed it.

This commit fixes the bug here.

Related meta topic: https://meta.discourse.org/t/-/358800