### PR TITLE
FIX: Remove redundant allowedGroups parameter

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -63,10 +63,6 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
     params.allowedGroups = (event.rawInvitees || []).join(",");
   }
 
-  if (event.status === "public") {
-    params.allowedGroups = "trust_level_0";
-  }
-
   if (event.reminders && event.reminders.length) {
     params.reminders = event.reminders
       .map((r) => {

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -66,7 +66,7 @@ describe "Post event", type: :system do
       time = Time.now.strftime("%Y-%m-%d %H:%M")
 
       EXPECTED_BBCODE = <<~EVENT
-        [event start="#{time}" status="public" timezone="Europe/Paris" allowedGroups="trust_level_0"]
+        [event start="#{time}" status="public" timezone="Europe/Paris"]
         foo
         bar
         [/event]

--- a/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
@@ -61,7 +61,7 @@ acceptance("Post event - composer", function (needs) {
     assert
       .dom(".d-editor-input")
       .hasValue(
-        `[event start="2022-07-01 12:00" status="public" timezone="Europe/Paris" end="2022-07-01 13:00" allowedGroups="trust_level_0"]\n[/event]`,
+        `[event start="2022-07-01 12:00" status="public" timezone="Europe/Paris" end="2022-07-01 13:00"]\n[/event]`,
         "bbcode is correct"
       );
   });

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -8,16 +8,16 @@ module("Integration | Component | rich-editor-extension", function (hooks) {
   const testCases = {
     "event alone": [
       [
-        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" allowedGroups="trust_level_0"]\n[/event]\n`,
-        `<div class="discourse-post-event discourse-post-event-preview ProseMirror-selectednode" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" data-allowed-groups="trust_level_0" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div>`,
-        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" allowedGroups="trust_level_0"]\n[/event]\n`,
+        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\n`,
+        `<div class="discourse-post-event discourse-post-event-preview ProseMirror-selectednode" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div>`,
+        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\n`,
       ],
     ],
     "event with content around": [
       [
-        `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" allowedGroups="trust_level_0"]\n[/event]\nGoodbye world`,
-        `<p>Hello world</p><div class="discourse-post-event discourse-post-event-preview" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" data-allowed-groups="trust_level_0" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div><p>Goodbye world</p>`,
-        `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" allowedGroups="trust_level_0"]\n[/event]\nGoodbye world`,
+        `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\nGoodbye world`,
+        `<p>Hello world</p><div class="discourse-post-event discourse-post-event-preview" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div><p>Goodbye world</p>`,
+        `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\nGoodbye world`,
       ],
     ],
   };


### PR DESCRIPTION
Remove frontend code that automatically adds allowedGroups="trust_level_0" to public events.