### PR TITLE
DEV: Enable goldiloader in tests environment

### DIFF
--- a/config/initializers/000-goldiloader.rb
+++ b/config/initializers/000-goldiloader.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "goldiloader" if GlobalSetting.try(:load_goldiloader)
+require "goldiloader" if (Rails.env.test? || GlobalSetting.try(:load_goldiloader))


### PR DESCRIPTION
Early results of testing out goldiloader is promising so we want to
start enabling it by default in the test environment to help catch
potential problems early.
