### PR TITLE
FIX: Use correct subcategory subfolder path in crawler

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -8,7 +8,7 @@
       <div class="topic-category" itemscope itemtype="http://schema.org/BreadcrumbList">
         <% @breadcrumbs.each_with_index do |c, i| %>
           <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="<%= @topic_view.topic.category.url %>" class="badge-wrapper bullet" itemprop="item">
+            <a href="<%= c[:url] %>" class="badge-wrapper bullet" itemprop="item">
               <span class='badge-category-bg' style='background-color: #<%= c[:color] %>'></span>
               <span class='badge-category clear-badge'>
                 <span class='category-name' itemprop='name'><%= c[:name] %></span>

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5639,6 +5639,27 @@ RSpec.describe TopicsController do
         get "#{topic.relative_url}/2"
       end
 
+      it "adds breadcrumbs to the correct subcategory and category url in subfolder" do
+        set_subfolder "/subpath"
+
+        subcategory = Fabricate(:category, parent_category_id: category.id)
+        topic.update!(category: subcategory)
+
+        get "/t/#{topic.slug}/#{topic.id}",
+            env: {
+              "HTTP_USER_AGENT" => "Mozilla/5.0 ...",
+              "HTTP_VIA" => "HTTP/1.0 web.archive.org",
+            }
+        expect(response.body).to have_tag(
+          "a",
+          with: {
+            href: subcategory.url,
+          },
+          text: subcategory.name,
+        )
+        expect(response.body).to have_tag("a", with: { href: category.url }, text: category.name)
+      end
+
       context "with canonical_url" do
         fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
         let!(:user_agent) do


### PR DESCRIPTION
Many moons ago there was a [fix](https://github.com/discourse/discourse/pull/24595) to category urls in crawler view for a topic, due to subfolder. 

The old fix solved subfolders, but fumbled subcategories. This fix caters for both, such that subcategory links won't use its parent's URL.

<img width="673" height="605" alt="image" src="https://github.com/user-attachments/assets/c093e369-8309-4326-9368-5da4d4a55232" />
