### PR TITLE
UX: Improve wording of non-user-selectable option for colour palettes

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6901,7 +6901,7 @@ en:
           user_selectable: "Theme can be selected by users"
           user_selectable_badge_label: "User selectable"
           user_selectable_button_label: "Allow users to select"
-          user_selectable_unavailable_button_label: "Make unavailable to users"
+          user_selectable_unavailable_button_label: "Do not allow users to select"
           broken_badge_label: "Broken theme"
           color_scheme_user_selectable: "Color palette can be selected by users"
           auto_update: "Auto update when Discourse is updated"


### PR DESCRIPTION
Updating wording of `user_selectable_unavailable_button_label` to be more clear and accurate.