### PR TITLE
FEATURE: Localize topic view in crawler view

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1382,6 +1382,8 @@ class TopicsController < ApplicationController
     respond_to do |format|
       format.html do
         @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
+
+        helpers.localize_topic_view_content(@topic_view) if SiteSetting.content_localization_enabled
         @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
         @description_meta =
           @topic_view.topic.excerpt.present? ? @topic_view.topic.excerpt : @topic_view.summary

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -20,4 +20,13 @@ module TopicsHelper
 
     Plugin::Filter.apply(:topic_categories_breadcrumb, topic, breadcrumb)
   end
+
+  def localize_topic_view_content(topic_view)
+    crawl_locale = params[Discourse::LOCALE_PARAM].presence || SiteSetting.default_locale
+
+    LocalizationAttributesReplacer.replace_topic_attributes(topic_view.topic, crawl_locale)
+    topic_view.posts.each do |post|
+      LocalizationAttributesReplacer.replace_post_attributes(post, crawl_locale)
+    end
+  end
 end

--- a/lib/localization_attributes_replacer.rb
+++ b/lib/localization_attributes_replacer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module LocalizationAttributesReplacer
+  def self.replace_category_attributes(category, crawl_locale)
+    if loc = get_localization(category, crawl_locale)
+      category.name = loc.name if loc.name.present?
+      category.description = loc.description if loc.description.present?
+    end
+
+    while category = category.parent_category
+      replace_category_attributes(category, crawl_locale)
+    end
+  end
+
+  def self.replace_topic_attributes(topic, crawl_locale)
+    if loc = get_localization(topic, crawl_locale)
+      # assigning directly to title would commit the change to the database
+      # due to the setter method defined in the Topic model
+      topic.send(:write_attribute, :title, loc.title) if loc.title.present?
+      topic.excerpt = loc.excerpt if loc.excerpt.present?
+    end
+
+    replace_category_attributes(topic.category, crawl_locale)
+  end
+
+  def self.replace_post_attributes(post, crawl_locale)
+    if loc = get_localization(post, crawl_locale)
+      post.cooked = loc.cooked if loc.cooked.present?
+    end
+  end
+
+  private
+
+  def self.get_localization(model, crawl_locale)
+    model.locale.present? && !LocaleNormalizer.is_same?(model.locale, crawl_locale) &&
+      model.get_localization(crawl_locale)
+  end
+end

--- a/lib/topic_list_responder.rb
+++ b/lib/topic_list_responder.rb
@@ -25,26 +25,8 @@ module TopicListResponder
     return if list.topics.blank? || !SiteSetting.content_localization_enabled
     crawl_locale = params[Discourse::LOCALE_PARAM].presence || SiteSetting.default_locale
 
-    list.topics.each { |topic| replace_topic_attributes(crawl_locale, topic) }
-  end
-
-  def replace_topic_attributes(crawl_locale, topic)
-    if topic.locale.present? && !LocaleNormalizer.is_same?(topic.locale, crawl_locale) &&
-         (loc = topic.get_localization(crawl_locale))
-      # assigning directly to title would commit the change to the database
-      # due to the setter method defined in the Topic model
-      topic.send(:write_attribute, :title, loc.title) if loc.title.present?
-      topic.excerpt = loc.excerpt if loc.excerpt.present?
-
-      category = topic.category
-      replace_category_name(category, crawl_locale)
-    end
-  end
-
-  def replace_category_name(category, crawl_locale)
-    if category.locale.present? && !LocaleNormalizer.is_same?(category.locale, crawl_locale) &&
-         (category_loc = category.get_localization(crawl_locale))
-      category.name = category_loc.name if category_loc.name.present?
+    list.topics.each do |topic|
+      LocalizationAttributesReplacer.replace_topic_attributes(topic, crawl_locale)
     end
   end
 end

--- a/spec/lib/localization_attributes_replacer_spec.rb
+++ b/spec/lib/localization_attributes_replacer_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+describe LocalizationAttributesReplacer do
+  describe ".replace_category_attributes" do
+    fab!(:category) { Fabricate(:category, locale: "en") }
+    fab!(:subcategory) { Fabricate(:category, parent_category: category, locale: "en") }
+    fab!(:ja_subcategory) do
+      Fabricate(:category_localization, category: subcategory, locale: "ja", name: "猫犬")
+    end
+    fab!(:ja_category) { Fabricate(:category_localization, category:, locale: "ja", name: "猫犬") }
+
+    it "replaces category and subcategory attributes with localized value" do
+      LocalizationAttributesReplacer.replace_category_attributes(subcategory, "ja")
+
+      expect(subcategory.name).to eq(ja_subcategory.name)
+      expect(subcategory.description).to eq(ja_subcategory.description)
+      expect(subcategory.parent_category.name).to eq(ja_category.name)
+      expect(subcategory.parent_category.description).to eq(ja_category.description)
+    end
+
+    it "does not change the name if the locale is the same" do
+      LocalizationAttributesReplacer.replace_category_attributes(category, "en")
+
+      expect(category.name).to eq(category.name)
+    end
+
+    it "does not change attributes if no localization exists for the given locale" do
+      LocalizationAttributesReplacer.replace_category_attributes(category, "fr")
+
+      expect(category.name).to eq(category.name)
+    end
+  end
+
+  describe ".replace_topic_attributes" do
+    fab!(:topic) { Fabricate(:topic, locale: "en") }
+    fab!(:ja_localization) do
+      Fabricate(:topic_localization, topic:, locale: "ja", title: "猫犬", excerpt: "柴犬は猫のような犬です。")
+    end
+
+    it "replaces the title and excerpt with localized values" do
+      LocalizationAttributesReplacer.replace_topic_attributes(topic, "ja")
+
+      expect(topic.title).to eq(ja_localization.title)
+      expect(topic.excerpt).to eq(ja_localization.excerpt)
+    end
+
+    it "does not change the title or excerpt if the locale is the same" do
+      LocalizationAttributesReplacer.replace_topic_attributes(topic, "en")
+
+      expect(topic.title).to eq(topic.title)
+      expect(topic.excerpt).to eq(topic.excerpt)
+    end
+
+    it "does not change attributes if no localization exists for the given locale" do
+      LocalizationAttributesReplacer.replace_topic_attributes(topic, "fr")
+
+      expect(topic.title).to eq(topic.title)
+      expect(topic.excerpt).to eq(topic.excerpt)
+    end
+  end
+
+  describe ".replace_post_attributes" do
+    fab!(:post) { Fabricate(:post, locale: "en") }
+    fab!(:ja_localization) do
+      Fabricate(:post_localization, post:, locale: "ja", cooked: "猫犬は柴犬のような猫です。")
+    end
+
+    it "replaces the cooked content with localized values" do
+      LocalizationAttributesReplacer.replace_post_attributes(post, "ja")
+
+      expect(post.cooked).to eq(ja_localization.cooked)
+    end
+
+    it "does not change the cooked content if the locale is the same" do
+      LocalizationAttributesReplacer.replace_post_attributes(post, "en")
+
+      expect(post.cooked).to eq(post.cooked)
+    end
+
+    it "does not change attributes if no localization exists for the given locale" do
+      LocalizationAttributesReplacer.replace_post_attributes(post, "fr")
+
+      expect(post.cooked).to eq(post.cooked)
+    end
+  end
+end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5566,10 +5566,12 @@ RSpec.describe TopicsController do
         )
       end
 
-      it "renders with the crawler layout, and handles proper pagination" do
-        user_agent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+      let!(:bot_user_agent) do
+        "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+      end
 
-        get topic.relative_url, env: { "HTTP_USER_AGENT" => user_agent }
+      it "renders with the crawler layout, and handles proper pagination" do
+        get topic.relative_url, env: { "HTTP_USER_AGENT" => bot_user_agent }
 
         body = response.body
 
@@ -5582,7 +5584,7 @@ RSpec.describe TopicsController do
 
         expect(response.headers["Last-Modified"]).to eq(page1_time.httpdate)
 
-        get topic.relative_url + "?page=2", env: { "HTTP_USER_AGENT" => user_agent }
+        get topic.relative_url + "?page=2", env: { "HTTP_USER_AGENT" => bot_user_agent }
         body = response.body
 
         expect(response.headers["Last-Modified"]).to eq(page2_time.httpdate)
@@ -5593,7 +5595,7 @@ RSpec.describe TopicsController do
         expect(body).to include('<link rel="prev" href="' + topic.relative_url)
         expect(body).to include('<link rel="next" href="' + topic.relative_url + "?page=3")
 
-        get topic.relative_url + "?page=3", env: { "HTTP_USER_AGENT" => user_agent }
+        get topic.relative_url + "?page=3", env: { "HTTP_USER_AGENT" => bot_user_agent }
         body = response.body
 
         expect(response.headers["Last-Modified"]).to eq(page3_time.httpdate)
@@ -5662,18 +5664,15 @@ RSpec.describe TopicsController do
 
       context "with canonical_url" do
         fab!(:topic_embed) { Fabricate(:topic_embed, embed_url: "https://markvanlan.com") }
-        let!(:user_agent) do
-          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
-        end
 
         it "set to topic.url when embed_set_canonical_url is false" do
-          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => user_agent }
+          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => bot_user_agent }
           expect(response.body).to include('<link rel="canonical" href="' + topic_embed.topic.url)
         end
 
         it "set to topic_embed.embed_url when embed_set_canonical_url is true" do
           SiteSetting.embed_set_canonical_url = true
-          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => user_agent }
+          get topic_embed.topic.url, env: { "HTTP_USER_AGENT" => bot_user_agent }
           expect(response.body).to include('<link rel="canonical" href="' + topic_embed.embed_url)
         end
       end
@@ -5690,6 +5689,119 @@ RSpec.describe TopicsController do
 
           expect(body).to have_tag(:body, with: { class: "crawler" })
           expect(body).to_not have_tag(:meta, with: { name: "fragment" })
+        end
+      end
+
+      context "when content localization is enabled" do
+        fab!(:category) { Fabricate(:category, locale: "en") }
+        fab!(:subcategory) { Fabricate(:category, parent_category: category, locale: "en") }
+        fab!(:tag)
+
+        before do
+          SiteSetting.content_localization_enabled = true
+
+          topic.update!(category: subcategory, tags: [tag], locale: "en")
+          topic.first_post.update(locale: "en")
+          # randomly create localizations for an untested locale
+          topic
+            .posts
+            .sample(3)
+            .each do |post|
+              post.update!(locale: "en")
+              Fabricate(:post_localization, post:, locale: "de")
+            end
+        end
+
+        describe "when tl param is absent" do
+          fab!(:pt_topic) { Fabricate(:topic_localization, topic:, locale: "pt") }
+          fab!(:pt_category) { Fabricate(:category_localization, category:, locale: "pt") }
+          fab!(:pt_subcategory) do
+            Fabricate(:category_localization, category: subcategory, locale: "pt")
+          end
+          fab!(:pt_first_post) do
+            Fabricate(:post_localization, post: topic.first_post, locale: "pt_BR")
+          end
+
+          it "localizes (english) topic for crawler to (portuguese) default locale when localization exists" do
+            SiteSetting.default_locale = "pt"
+
+            get topic.relative_url, env: { "HTTP_USER_AGENT" => bot_user_agent }
+
+            expect(response.body).to include(pt_topic.title)
+            expect(response.body).to include(pt_category.name)
+            expect(response.body).to include(pt_subcategory.name)
+            expect(response.body).to include(pt_first_post.cooked)
+          end
+
+          it "leaves topic as-is if no localization" do
+            SiteSetting.default_locale = "es"
+
+            get topic.relative_url, env: { "HTTP_USER_AGENT" => bot_user_agent }
+
+            expect(response.body).to include(topic.title)
+            expect(response.body).to include(category.name)
+            expect(response.body).to include(subcategory.name)
+            expect(response.body).to include(topic.first_post.cooked)
+          end
+        end
+
+        describe "when tl param is present ?tl=ja" do
+          fab!(:ja_topic) { Fabricate(:topic_localization, topic:, locale: "ja") }
+          fab!(:ja_category) { Fabricate(:category_localization, category:, locale: "ja") }
+          fab!(:ja_subcategory) do
+            Fabricate(:category_localization, category: subcategory, locale: "ja")
+          end
+
+          it "localizes topic for crawler" do
+            get topic.relative_url,
+                env: {
+                  "HTTP_USER_AGENT" => bot_user_agent,
+                },
+                params: {
+                  tl: "ja",
+                }
+
+            expect(response.body).to include(ja_topic.title)
+            # breadcrumbs
+            expect(response.body).to include(ja_category.name)
+            expect(response.body).to include(ja_subcategory.name)
+          end
+        end
+
+        it "does not have N+1s when loading localizations" do
+          Fabricate(:topic_localization, topic:, locale: "ja")
+          topic
+            .posts
+            .where("post_number < 4")
+            .each { |post| Fabricate(:post_localization, post:, locale: "ja") }
+
+          initial_sql_queries =
+            track_sql_queries do
+              get topic.relative_url,
+                  env: {
+                    "HTTP_USER_AGENT" => bot_user_agent,
+                  },
+                  params: {
+                    tl: "ja",
+                  }
+              expect(response.status).to eq(200)
+            end.select { |q| q.include?("_localizations") }.count
+
+          Fabricate(:post_localization, post: topic.posts.find_by_post_number(4), locale: "ja")
+
+          new_sql_queries =
+            track_sql_queries do
+              get topic.relative_url,
+                  env: {
+                    "HTTP_USER_AGENT" => bot_user_agent,
+                  },
+                  params: {
+                    tl: "ja",
+                  }
+              expect(response.status).to eq(200)
+            end.select { |q| q.include?("_localizations") }.count
+
+          expect(new_sql_queries).to eq(initial_sql_queries)
         end
       end
     end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/34212

This PR affects the crawler view for topic view, e.g. \<site>/t/:slug/:id, and updates the title, subcategory (+parent category breadcrumb), post, if any of them are not in the site default locale, and have an equivalent localization.


| before | after |
|---|---|
| <img width="1264" height="831" alt="Screenshot 2025-08-12 at 7 09 50 PM" src="https://github.com/user-attachments/assets/677d4595-4d4a-482e-b948-c0043576348e" /> mixed mode | <img width="1264" height="831" alt="Screenshot 2025-08-12 at 7 11 35 PM" src="https://github.com/user-attachments/assets/552f16ca-ebf2-4bdd-a052-a3abb8174a29" /> site default locale |