### PR TITLE
DEV: Simple refactor of button markup

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import { and } from "truth-helpers";
+import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
 import closeOnClickOutside from "discourse/modifiers/close-on-click-outside";
@@ -203,12 +204,12 @@ export default class DiscourseReactionsCounter extends Component {
 
         {{#if (and @post.yours this.onlyOneMainReaction)}}
           <div class="discourse-reactions-reaction-button my-likes">
-            <button
+            <DButton
               type="button"
-              class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+              class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
             >
               {{icon this.siteSettings.discourse_reactions_like_icon}}
-            </button>
+            </DButton>
           </div>
         {{/if}}
       {{/if}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
@@ -134,6 +134,7 @@ export default class DiscourseReactionsPicker extends Component {
           {{#each this.reactionInfo as |reaction|}}
             <DButton
               class={{concatClass
+                "btn-flat"
                 "pickable-reaction"
                 reaction.id
                 (if reaction.canUndo "can-undo")

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-reaction-button.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { isBlank } from "@ember/utils";
+import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { emojiUrlFor } from "discourse/lib/text";
 import { i18n } from "discourse-i18n";
@@ -115,17 +116,17 @@ export default class ReactionsReactionButton extends Component {
       title={{this.title}}
     >
       {{#if @post.current_user_used_main_reaction}}
-        <button
+        <DButton
           type="button"
-          class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+          class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
           title={{this.title}}
         >
           {{icon this.siteSettings.discourse_reactions_like_icon}}
-        </button>
+        </DButton>
       {{else if @post.current_user_reaction}}
-        <button
+        <DButton
           type="button"
-          class="btn-icon no-text reaction-button"
+          class="btn-icon no-text btn-flat reaction-button"
           title={{this.title}}
         >
           <img
@@ -133,17 +134,17 @@ export default class ReactionsReactionButton extends Component {
             src={{emojiUrlFor @post.current_user_reaction.id}}
             alt={{concat ":" @post.current_user_reaction.id}}
           />
-        </button>
+        </DButton>
       {{else}}
-        <button
+        <DButton
           type="button"
-          class="btn-toggle-reaction-like btn-icon no-text reaction-button"
+          class="btn-toggle-reaction-like btn-flat btn-icon no-text reaction-button"
           title={{this.title}}
         >
           {{icon
             (concat "far-" this.siteSettings.discourse_reactions_like_icon)
           }}
-        </button>
+        </DButton>
       {{/if}}
     </div>
   </template>


### PR DESCRIPTION
This PR moves reactions to use DButton component in order to better inherit styles. It also adds `btn-flat` class for the same purpose.