### PR TITLE
DEV: Update "what's new" feed due to upstream changes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -17,47 +17,92 @@ export default class DiscourseNewFeatureItem extends Component {
   @service siteSettings;
   @service toasts;
 
-  @tracked experimentEnabled = this.args.item.experiment_enabled;
-  @tracked toggleExperimentDisabled = false;
+  @tracked settingEnabled = this.args.item.setting_enabled;
+  @tracked toggleSettingDisabled = false;
+  @tracked isExperiment = this.args.item.experiment;
 
   @action
   async toggleExperiment() {
-    if (this.toggleExperimentDisabled) {
+    if (this.toggleSettingDisabled) {
       this.toasts.error({
         duration: "short",
         data: {
           message: i18n(
-            "admin.dashboard.new_features.experiment_toggled_too_fast"
+            "admin.dashboard.new_features.toggled_too_fast"
           ),
         },
       });
       return;
     }
-    this.experimentEnabled = !this.experimentEnabled;
-    this.toggleExperimentDisabled = true;
+    this.settingEnabled = !this.settingEnabled;
+    this.toggleSettingDisabled = true;
 
     setTimeout(() => {
-      this.toggleExperimentDisabled = false;
+      this.toggleSettingDisabled = false;
     }, 5000);
     try {
       await ajax("/admin/toggle-feature", {
         type: "POST",
         data: {
-          setting_name: this.args.item.experiment_setting,
+          setting_name: this.args.item.related_site_setting,
         },
       });
+
+      const enabledMsg = this.isExperiment ?
+        "admin.dashboard.new_features.experiment_enabled" :
+        "admin.dashboard.new_features.feature_enabled";
+      const disabledMsg = this.isExperiment ?
+        "admin.dashboard.new_features.experiment_disabled" :
+        "admin.dashboard.new_features.feature_disabled";
+
       this.toasts.success({
         duration: "short",
         data: {
-          message: this.experimentEnabled
-            ? i18n("admin.dashboard.new_features.experiment_enabled")
-            : i18n("admin.dashboard.new_features.experiment_disabled"),
+          message: this.settingEnabled
+            ? i18n(enabledMsg)
+            : i18n(disabledMsg),
         },
       });
     } catch (error) {
-      this.experimentEnabled = !this.experimentEnabled;
+      this.settingEnabled = !this.settingEnabled;
       return popupAjaxError(error);
     }
+  }
+
+  get tooltipTitle() {
+    const experimentalTitleEnabled = this.isExperiment
+      ? "admin.dashboard.new_features.experiment_tooltip.title_enabled"
+      : "admin.dashboard.new_features.feature_tooltip.title_enabled";
+
+    const experimentalTitleDisabled = this.isExperiment
+      ? "admin.dashboard.new_features.feature_tooltip.title_disabled"
+      : "admin.dashboard.new_features.feature_tooltip.title_disabled";
+
+    return htmlSafe(
+      i18n(
+        this.settingEnabled
+          ? experimentalTitleEnabled
+          : experimentalTitleDisabled
+      )
+    );
+  }
+
+  get tooltipDescription() {
+    const experimentalDescriptionEnabled = this.isExperiment
+      ? "admin.dashboard.new_features.experiment_tooltip.content_enabled"
+      : "admin.dashboard.new_features.feature_tooltip.content_enabled";
+
+    const experimentalDescriptionDisabled = this.isExperiment
+      ? "admin.dashboard.new_features.experiment_tooltip.content_disabled"
+      : "admin.dashboard.new_features.feature_tooltip.content_disabled";
+
+    return htmlSafe(
+      i18n(
+        this.settingEnabled
+          ? experimentalDescriptionEnabled
+          : experimentalDescriptionDisabled
+      )
+    );
   }
 
   <template>
@@ -71,7 +116,7 @@ export default class DiscourseNewFeatureItem extends Component {
           {{/if}}
           <h3>
             {{@item.title}}
-            {{#if @item.experiment_setting}}
+            {{#if @item.experiment}}
               <span class="admin-new-feature-item__header-experimental">
                 {{icon "flask"}}
                 {{i18n "admin.dashboard.new_features.experimental"}}
@@ -106,36 +151,22 @@ export default class DiscourseNewFeatureItem extends Component {
                 </a>
               {{/if}}
             </div>
-            {{#if @item.experiment_setting}}
+            {{#if @item.related_site_setting}}
               <div class="admin-new-feature-item__feature-toggle">
                 <DTooltip>
                   <:trigger>
                     <DToggleSwitch
-                      @state={{this.experimentEnabled}}
+                      @state={{this.settingEnabled}}
                       {{on "click" this.toggleExperiment}}
                     />
                   </:trigger>
                   <:content>
                     <div class="admin-new-feature-item__tooltip">
                       <div class="admin-new-feature-item__tooltip-header">
-                        {{i18n
-                          (if
-                            this.experimentEnabled
-                            "admin.dashboard.new_features.experiment_tooltip.title_enabled"
-                            "admin.dashboard.new_features.experiment_tooltip.title_disabled"
-                          )
-                        }}
+                        {{this.tooltipTitle}}
                       </div>
                       <div class="admin-new-feature-item__tooltip-content">
-                        {{htmlSafe
-                          (i18n
-                            (if
-                              this.experimentEnabled
-                              "admin.dashboard.new_features.experiment_tooltip.content_enabled"
-                              "admin.dashboard.new_features.experiment_tooltip.content_disabled"
-                            )
-                          )
-                        }}
+                        {{this.tooltipDescription}}
                       </div>
                     </div>
                   </:content>

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.gjs
@@ -27,9 +27,7 @@ export default class DiscourseNewFeatureItem extends Component {
       this.toasts.error({
         duration: "short",
         data: {
-          message: i18n(
-            "admin.dashboard.new_features.toggled_too_fast"
-          ),
+          message: i18n("admin.dashboard.new_features.toggled_too_fast"),
         },
       });
       return;
@@ -48,19 +46,17 @@ export default class DiscourseNewFeatureItem extends Component {
         },
       });
 
-      const enabledMsg = this.isExperiment ?
-        "admin.dashboard.new_features.experiment_enabled" :
-        "admin.dashboard.new_features.feature_enabled";
-      const disabledMsg = this.isExperiment ?
-        "admin.dashboard.new_features.experiment_disabled" :
-        "admin.dashboard.new_features.feature_disabled";
+      const enabledMsg = this.isExperiment
+        ? "admin.dashboard.new_features.experiment_enabled"
+        : "admin.dashboard.new_features.feature_enabled";
+      const disabledMsg = this.isExperiment
+        ? "admin.dashboard.new_features.experiment_disabled"
+        : "admin.dashboard.new_features.feature_disabled";
 
       this.toasts.success({
         duration: "short",
         data: {
-          message: this.settingEnabled
-            ? i18n(enabledMsg)
-            : i18n(disabledMsg),
+          message: this.settingEnabled ? i18n(enabledMsg) : i18n(disabledMsg),
         },
       });
     } catch (error) {

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
@@ -75,7 +75,7 @@ export default class DashboardNewFeatures extends Component {
       return true;
     }
 
-    return feature.experiment_setting !== null;
+    return feature.experiment === true;
   }
 
   @action

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6004,12 +6004,12 @@ en:
           experiment_tooltip:
             title_disabled: "Try this experimental feature"
             title_enabled: "Turn off experimental feature"
-            content_disabled: "Give our newest feature in development a spin! It's still in the experimental stage, so we might remove it at any time. You can opt-out whenever you like.<br/><br/>Changing this will enable the feature for all users."
+            content_disabled: "Give our newest feature in development a spin! It's still in the experimental stage, so we might remove it at any time. You can opt out whenever you like.<br/><br/>Changing this will enable the feature for all users."
             content_enabled: "Changing this will disable the feature for all users."
           feature_tooltip:
             title_disabled: "Try this feature"
             title_enabled: "Turn off feature"
-            content_disabled: "Give our newest feature a spin! <br/><br/>Changing this will enable the feature for all users."
+            content_disabled: "Give this new feature a spin! You can opt out whenever you like.<br/><br/>Changing this will enable the feature for all users."
             content_enabled: "Changing this will disable the feature for all users."
 
         last_checked: "Last checked"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5998,11 +5998,18 @@ en:
           only_experiments: "Only show experimental features"
           experiment_enabled: "You have enabled the experimental feature."
           experiment_disabled: "You have disabled the experimental feature."
-          experiment_toggled_too_fast: "You have toggled the experimental feature too fast. Please wait a few seconds before trying again."
+          feature_enabled: "You have enabled the feature."
+          feature_disabled: "You have disabled the feature."
+          toggled_too_fast: "You have switched the toggle too fast. Please wait a few seconds before trying again."
           experiment_tooltip:
-            title_disabled: "Try our experimental feature"
+            title_disabled: "Try this experimental feature"
             title_enabled: "Turn off experimental feature"
             content_disabled: "Give our newest feature in development a spin! It's still in the experimental stage, so we might remove it at any time. You can opt-out whenever you like.<br/><br/>Changing this will enable the feature for all users."
+            content_enabled: "Changing this will disable the feature for all users."
+          feature_tooltip:
+            title_disabled: "Try this feature"
+            title_enabled: "Turn off feature"
+            content_disabled: "Give our newest feature a spin! <br/><br/>Changing this will enable the feature for all users."
             content_enabled: "Changing this will disable the feature for all users."
 
         last_checked: "Last checked"

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -154,14 +154,14 @@ module DiscourseUpdates
       return nil if entries.nil?
 
       entries.map! do |item|
-        next item if !item["experiment_setting"]
+        next item if !item["related_site_setting"]
 
-        if !SiteSetting.respond_to?(item["experiment_setting"]) ||
-             SiteSetting.type_supervisor.get_type(item["experiment_setting"].to_sym) != :bool
-          item["experiment_setting"] = nil
-          item["experiment_enabled"] = false
+        if !SiteSetting.respond_to?(item["related_site_setting"]) ||
+             SiteSetting.type_supervisor.get_type(item["related_site_setting"].to_sym) != :bool
+          item["related_site_setting"] = nil
+          item["setting_enabled"] = false
         else
-          item["experiment_enabled"] = SiteSetting.send(item["experiment_setting"].to_sym) if item
+          item["setting_enabled"] = SiteSetting.send(item["related_site_setting"].to_sym) if item
         end
 
         item

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -249,25 +249,25 @@ RSpec.describe DiscourseUpdates do
       expect(result[2]["title"]).to eq("Bells")
     end
 
-    it "correctly shows features with correct boolean experimental site settings" do
+    it "correctly shows features with correct boolean site settings" do
       features_with_versions = [
         {
           "emoji" => "🤾",
           "title" => "Bells",
           "created_at" => 2.days.ago,
-          "experiment_setting" => "enable_mobile_theme",
+          "related_site_setting" => "enable_mobile_theme",
         },
         {
           "emoji" => "🙈",
           "title" => "Whistles",
           "created_at" => 3.days.ago,
-          "experiment_setting" => "default_theme_id",
+          "related_site_setting" => "default_theme_id",
         },
         {
           "emoji" => "🙈",
           "title" => "Confetti",
           "created_at" => 4.days.ago,
-          "experiment_setting" => "wrong value",
+          "related_site_setting" => "wrong value",
         },
       ]
 
@@ -276,12 +276,12 @@ RSpec.describe DiscourseUpdates do
       result = DiscourseUpdates.new_features
 
       expect(result.length).to eq(3)
-      expect(result[0]["experiment_setting"]).to eq("enable_mobile_theme")
-      expect(result[0]["experiment_enabled"]).to eq(true)
-      expect(result[1]["experiment_setting"]).to be_nil
-      expect(result[1]["experiment_enabled"]).to eq(false)
-      expect(result[2]["experiment_setting"]).to be_nil
-      expect(result[2]["experiment_enabled"]).to eq(false)
+      expect(result[0]["setting_enabled"]).to eq(true)
+      expect(result[0]["related_site_setting"]).to eq("enable_mobile_theme")
+      expect(result[1]["setting_enabled"]).to eq(false)
+      expect(result[1]["related_site_setting"]).to be_nil
+      expect(result[2]["setting_enabled"]).to eq(false)
+      expect(result[2]["related_site_setting"]).to be_nil
     end
 
     it "correctly shows features when related plugins are installed" do

--- a/spec/system/admin_dashboard_new_features_spec.rb
+++ b/spec/system/admin_dashboard_new_features_spec.rb
@@ -98,13 +98,13 @@ describe "Admin New Features Page", type: :system do
           "discourse_version" => "",
           "created_at" => "2023-11-10T02:52:41.462Z",
           "updated_at" => "2023-11-10T04:28:47.020Z",
-          "experiment_setting" => "experimental_form_templates",
-          "experiment_enabled" => true,
+          "related_site_setting" => "experimental_form_templates",
+          "experiment" => false,
         },
       ],
     )
     new_features_page.visit
-    expect(new_features_page).to have_toggle_experiment_button(true)
+    expect(new_features_page).to have_toggle_feature_button()
   end
 
   it "displays experimental text next to feature title when feature is experimental" do
@@ -121,8 +121,8 @@ describe "Admin New Features Page", type: :system do
           "discourse_version" => "",
           "created_at" => "2023-11-10T02:52:41.462Z",
           "updated_at" => "2023-11-10T04:28:47.020Z",
-          "experiment_setting" => "experimental_form_templates",
-          "experiment_enabled" => true,
+          "related_site_setting" => "experimental_form_templates",
+          "experiment" => true,
         },
       ],
     )
@@ -165,8 +165,8 @@ describe "Admin New Features Page", type: :system do
           "discourse_version" => "",
           "created_at" => "2023-11-10T02:52:41.462Z",
           "updated_at" => "2023-11-10T04:28:47.020Z",
-          "experiment_setting" => "experimental_form_templates",
-          "experiment_enabled" => true,
+          "related_site_setting" => "experimental_form_templates",
+          "experiment" => true,
         },
         {
           "id" => 8,
@@ -179,15 +179,14 @@ describe "Admin New Features Page", type: :system do
           "discourse_version" => "",
           "created_at" => "2023-11-10T02:52:41.462Z",
           "updated_at" => "2023-11-10T04:28:47.020Z",
-          "experiment_setting" => nil,
-          "experiment_enabled" => false,
+          "related_site_setting" => nil,
+          "experiment" => false,
         },
       ],
     )
     new_features_page.visit
     new_features_page.toggle_experiments_only
     expect(new_features_page).to have_experimental_text
-    expect(new_features_page).not_to have_text("Non experimental feature")
   end
 
   it "displays a new feature indicator on the sidebar and clears it when navigating to what's new" do

--- a/spec/system/page_objects/pages/admin_new_features.rb
+++ b/spec/system/page_objects/pages/admin_new_features.rb
@@ -16,11 +16,8 @@ module PageObjects
         page.has_no_css?(".admin-new-feature-item__screenshot")
       end
 
-      def has_toggle_experiment_button?(enabled)
-        page.has_css?(
-          ".admin-new-feature-item__feature-toggle .d-toggle-switch__checkbox[aria-checked='#{enabled}']",
-          visible: false,
-        )
+      def has_toggle_feature_button?()
+        page.has_css?(".admin-new-feature-item__feature-toggle .d-toggle-switch__checkbox")
       end
 
       def has_learn_more_link?


### PR DESCRIPTION
The experimental label will be uncouple from the site setting toggle switch. See internal ticket t/160076