### PR TITLE
FIX: Border-radius should appear in the edit topic title input

### DIFF
--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -390,8 +390,6 @@
 #topic-title .edit-topic-title.showing-ai-suggestions {
   #edit-title {
     flex: 1 1 90%;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
   }
 
   .suggest-titles-button {


### PR DESCRIPTION
|Before|After|
|--|--|
|<img width="446" height="128" alt="CleanShot 2025-08-12 at 13 31 53@2x" src="https://github.com/user-attachments/assets/cdcf7c76-d045-4241-9070-d56ee81e9625" />|<img width="536" height="128" alt="CleanShot 2025-08-12 at 13 31 28@2x" src="https://github.com/user-attachments/assets/88af457c-579e-42e7-a506-0c02b5141e25" />|