### PR TITLE
UX: improve header alignment in mobile modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -112,6 +112,10 @@ export default class DModal extends Component {
     return this.args.autofocus ?? true;
   }
 
+  get mobileDismissable() {
+    return this.site.mobileView && this.dismissable;
+  }
+
   shouldTriggerClickOnEnter(event) {
     if (this.args.submitOnEnter === false) {
       return false;
@@ -340,7 +344,14 @@ export default class DModal extends Component {
             )
           }}
             <div
-              class={{concatClass "d-modal__header" @headerClass}}
+              class={{concatClass
+                "d-modal__header"
+                (if
+                  (and this.mobileDismissable (has-block "headerPrimaryAction"))
+                  "--has-primary-action"
+                )
+                @headerClass
+              }}
               {{swipe
                 onDidSwipe=this.handleSwipe
                 onDidEndSwipe=this.handleSwipeEnded
@@ -350,11 +361,7 @@ export default class DModal extends Component {
               {{yield to="headerAboveTitle"}}
 
               {{#if
-                (and
-                  this.site.mobileView
-                  this.dismissable
-                  (has-block "headerPrimaryAction")
-                )
+                (and this.mobileDismissable (has-block "headerPrimaryAction"))
               }}
                 <div class="d-modal__dismiss-action">
                   <DButton

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -89,8 +89,12 @@ html:not(.keyboard-visible.mobile-view) {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5rem 0.5rem 0.5rem 1.5rem; // offset for close button padding
+    padding: 0.5rem;
     border-bottom: 1px solid var(--content-border-color);
+
+    &:not(.--has-primary-action) {
+      padding: 0.5rem 0.5rem 0.5rem 1.5rem; // offset for close button padding
+    }
 
     .modal-close {
       margin-left: auto;


### PR DESCRIPTION
This improves modal header padding in the case of mobile modals having a primary action

Before:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/441579cc-0de8-4f1b-9819-0e04105f9e03" />

After:
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/e081560e-c6de-4505-815e-5fc0dceac3da" />

Modals without primary actions look like (unchanged):

<img width="500" alt="image" src="https://github.com/user-attachments/assets/47549411-3061-47d7-b939-4675cafc6373" />

