### PR TITLE
UX: switch to overflow:auto on post-controls

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -35,7 +35,7 @@ nav.post-controls {
   --control-space-large: calc(var(--control-space) * 1.3);
 
   // on small devices with many buttons this can overflow
-  overflow-x: scroll;
+  overflow-x: auto;
 
   .actions {
     // using an auto margin on first-child instead of justify-content on the parent


### PR DESCRIPTION
Since we're showing some more narrow screen CSS on desktop devices when applicable, we should change this to `auto` so the empty track doesn't show in cases where it's not needed. This wasn't needed on mobile devices because scrollbars generally don't appear. 


Before:
<img width="806" height="252" alt="image" src="https://github.com/user-attachments/assets/7fdc98bb-68a2-4332-89d7-18909da89e2d" />


After:
<img width="796" height="210" alt="image" src="https://github.com/user-attachments/assets/c03cc2d8-e2e9-4846-830b-413a55e00836" />
