### PR TITLE
DEV: Add admin widget notices

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -32,6 +32,8 @@ export const CRITICAL_DEPRECATIONS = [
   "component-template-resolving",
   "discourse.script-tag-hbs",
   "discourse.script-tag-discourse-plugin",
+  "discourse.post-stream-widget-overrides",
+  "discourse.widgets-end-of-life",
 ];
 
 const REPLACEMENT_URLS = {


### PR DESCRIPTION
Expanded the `CRITICAL_DEPRECATIONS` list to include `discourse.post-stream-widget-overrides` and `discourse.widgets-end-of-life` enabling admin notices.