### PR TITLE
DEV: Schema only dump for databases cache in `tests` workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Create and migrate database
         if: steps.app-cache.outputs.cache-hit != 'true'
         env:
-          LOAD_PLUGINS: ${{ (matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
+          DB_MIGRATE_SKIP_SEED_FU: true
         run: |
           bin/rake db:create
           script/silence_successful_output bin/rake db:migrate
@@ -193,7 +193,7 @@ jobs:
           env.USES_PARALLEL_DATABASES == 'true' &&
           steps.app-cache.outputs.cache-hit != 'true'
         env:
-          LOAD_PLUGINS: ${{ (matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
+          DB_MIGRATE_SKIP_SEED_FU: true
         run: |
           bin/rake parallel:create
           script/silence_successful_output bin/rake parallel:migrate
@@ -201,6 +201,13 @@ jobs:
       - name: Dump database for cache
         if: steps.app-cache.outputs.cache-hit != 'true'
         run: mkdir -p tmp/app-cache && pg_dumpall > tmp/app-cache/cache.sql
+
+      - name: Seed database
+        run: bin/rake db:migrate
+
+      - name: Seed parallel databases
+        if: env.USES_PARALLEL_DATABASES == 'true'
+        run: bin/rake parallel:migrate
 
       - name: Dump uploads for cache
         if: steps.app-cache.outputs.cache-hit != 'true'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -131,12 +131,7 @@ if ENV["LOAD_PLUGINS"] == "1"
   Dir[Rails.root.join("plugins/*/spec/system/page_objects/**/*.rb")].each { |f| require f }
 end
 
-# let's not run seed_fu every test
-SeedFu.quiet = true if SeedFu.respond_to? :quiet
-
 SiteSetting.automatically_download_gravatars = false
-
-SeedFu.seed
 
 # we need this env var to ensure that we can impersonate in test
 # this enable integration_helpers sign_in helper


### PR DESCRIPTION
The output from `pg_dumpall` is reused across tests workflow runs based
on the cache key of the `app-cache` actions cache. However, the dump
file contains database rows that have been inserted by our seed process.
The problem here is that our seed files may reference code in other
files but those files are not included as part of the cache key for
`app-cache`. It is also impractical for us to be able to identify all
possible files that alter the outcome of the seeding process.

As such, this commit updates the `tests` github actions workflow to only
dump the schema of the databases and will seed the databases from
scratch.
