### PR TITLE
FIX: system themesite serializer specs

### DIFF
--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -979,7 +979,7 @@ RSpec.describe Stylesheet::Manager do
 
       # Ensure we force compile each theme only once
       expect(output.scan(/#{child_theme_with_css.name}/).length).to eq(2) # ltr/rtl
-      expect(StylesheetCache.count).to eq(42) # (1 theme with rtl/ltr) + 32 color schemes (2 themes * 8 color schemes (7 defaults + 1 theme scheme) * 2 (light and dark mode per scheme)) + 8 Horizon
+      expect(StylesheetCache.count).to eq(34) # (1 theme with rtl/ltr) + 32 color schemes (2 themes * 8 color schemes (7 defaults + 1 theme scheme) * 2 (light and dark mode per scheme))
     end
 
     it "generates precompiled CSS - core and themes" do
@@ -987,7 +987,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(52) # 10 core targets + 2 theme (ltr/rtl) + 32 color schemes (light and dark mode per scheme) + 8 Horizon
+      expect(results.size).to eq(44) # 10 core targets + 2 theme (ltr/rtl) + 32 color schemes (light and dark mode per scheme)
 
       expect(results.count { |target| target =~ /^common_theme_/ }).to eq(2) # ltr/rtl
     end
@@ -999,7 +999,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(70) # 10 core targets + theme rtl/ltr + 32 color schemes (light and dark mode per scheme) + 14 Foundation + 12 Horizon
+      expect(results.size).to eq(58) # 10 core targets + theme rtl/ltr + 32 color schemes (light and dark mode per scheme) + 14 Foundation
 
       expect(results).to include("color_definitions_#{scheme1.name}_#{scheme1.id}_#{user_theme.id}")
       expect(results).to include(

--- a/spec/lib/system_themes_manager_spec.rb
+++ b/spec/lib/system_themes_manager_spec.rb
@@ -5,12 +5,11 @@ RSpec.describe SystemThemesManager do
     Theme.delete_all
     expect { SystemThemesManager.sync! }.to change { Theme.system.count }.by(2)
     expect { SystemThemesManager.sync! }.not_to change { Theme.count }
-    expect(Theme.horizon_theme.color_scheme.user_selectable).to be true
+    expect(Theme.horizon_theme.color_scheme.user_selectable).to be false
     expect(
       Theme.horizon_theme.color_schemes.where(name: "Horizon Dark").first.user_selectable,
-    ).to be true
-    expect(Theme.horizon_theme.color_schemes.where(user_selectable: true).count).to eq(2)
-    expect(Theme.horizon_theme.color_schemes.where(user_selectable: false).count).to eq(10)
+    ).to be false
+    expect(Theme.horizon_theme.color_schemes.where(user_selectable: false).count).to eq(12)
   end
 
   it "renables themes" do

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe SiteSerializer do
   it "includes user-selectable color schemes" do
     # it includes seeded color schemes
     serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    expect(serialized[:user_color_schemes].count).to eq(8)
+    expect(serialized[:user_color_schemes].count).to eq(6)
 
     scheme_names = serialized[:user_color_schemes].map { |x| x[:name] }
     expect(scheme_names).to include(I18n.t("color_schemes.dark"))
@@ -99,15 +99,13 @@ RSpec.describe SiteSerializer do
     expect(scheme_names).to include(I18n.t("color_schemes.solarized_light"))
     expect(scheme_names).to include(I18n.t("color_schemes.solarized_dark"))
     expect(scheme_names).to include(I18n.t("color_schemes.dracula"))
-    expect(scheme_names).to include("Horizon")
-    expect(scheme_names).to include("Horizon Dark")
 
     dark_scheme = ColorScheme.create_from_base(name: "AnotherDarkScheme", base_scheme_id: "Dark")
     dark_scheme.user_selectable = true
     dark_scheme.save!
 
     serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    expect(serialized[:user_color_schemes].count).to eq(9)
+    expect(serialized[:user_color_schemes].count).to eq(7)
     expect(serialized[:user_color_schemes][0][:is_dark]).to eq(true)
   end
 


### PR DESCRIPTION
After changes in this PR - https://github.com/discourse/discourse/pull/34062 - all color schemes are not selectable by default.

CI did not pick up those broken specs because of DB caching.