### PR TITLE
UX: Improve admin search padding

### DIFF
--- a/app/assets/stylesheets/admin/search.scss
+++ b/app/assets/stylesheets/admin/search.scss
@@ -1,8 +1,8 @@
-.admin-search-modal .d-modal__body {
+.d-modal.admin-search-modal .d-modal__body {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-4);
+  padding: 0 var(--space-2) var(--space-2) var(--space-2);
 }
 
 // Search field
@@ -106,7 +106,7 @@
 
   .admin-search__no-results,
   .admin-search__input-container {
-    padding-inline: var(--space-4);
+    padding-inline: var(--space-2);
   }
 
   .admin-search__no-results {
@@ -120,7 +120,7 @@
     z-index: z("modal", "content"); // above title icons
 
     &.--has-results {
-      padding-bottom: var(--space-4);
+      padding-bottom: var(--space-2);
     }
   }
 }


### PR DESCRIPTION
Fixes an issue where the admin search modal had bottom padding
that was very cut off, and other padding was quite big

**Before**

<img width="870" height="125" alt="image" src="https://github.com/user-attachments/assets/0a5700ad-bf29-43a0-9d7a-ef3509666db2" />

<img width="878" height="169" alt="image" src="https://github.com/user-attachments/assets/9e4331c9-3ee8-4350-a0b7-fba9454d713a" />


**After**

<img width="881" height="268" alt="image" src="https://github.com/user-attachments/assets/c8eec394-9a6b-43fb-94a9-9f7936f0afc0" />

<img width="872" height="197" alt="image" src="https://github.com/user-attachments/assets/78e416f0-daa9-4dc8-9019-e2857f37e358" />
