### PR TITLE
DEV: raise error on missing name properties for user autocomplete results

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-editor.gjs
@@ -38,7 +38,7 @@ import loadEmojiSearchAliases from "discourse/lib/load-emoji-search-aliases";
 import loadRichEditor from "discourse/lib/load-rich-editor";
 import { rovingButtonBar } from "discourse/lib/roving-button-bar";
 import { emojiUrlFor, generateCookFunction } from "discourse/lib/text";
-import userSearch from "discourse/lib/user-search";
+import userSearch, { validateSearchResult } from "discourse/lib/user-search";
 import {
   destroyUserStatuses,
   initUserStatusHtml,
@@ -463,7 +463,10 @@ export default class DEditor extends Component {
       },
       onRender: (options) => renderUserStatusHtml(options),
       key: "@",
-      transformComplete: (v) => v.username || v.name,
+      transformComplete: (v) => {
+        validateSearchResult(v);
+        return v.username || v.name;
+      },
       afterComplete: () => {
         schedule(
           "afterRender",

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -7,7 +7,7 @@ import getURL from "discourse/lib/get-url";
 import { deepMerge } from "discourse/lib/object";
 import { emojiUnescape } from "discourse/lib/text";
 import { userPath } from "discourse/lib/url";
-import userSearch from "discourse/lib/user-search";
+import userSearch, { validateSearchResult } from "discourse/lib/user-search";
 import { escapeExpression } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import Post from "discourse/models/post";
@@ -26,6 +26,7 @@ const logSearchLinkClickedCallbacks = [];
 export function addLogSearchLinkClickedCallbacks(fn) {
   logSearchLinkClickedCallbacks.push(fn);
 }
+
 export function resetLogSearchLinkClickedCallbacks() {
   logSearchLinkClickedCallbacks.clear();
 }
@@ -244,7 +245,10 @@ export function applySearchAutocomplete($input, siteSettings) {
         width: "100%",
         treatAsTextarea: true,
         autoSelectFirstSuggestion: false,
-        transformComplete: (v) => v.username || v.name,
+        transformComplete: (v) => {
+          validateSearchResult(v);
+          return v.username || v.name;
+        },
         dataSource: (term) => userSearch({ term, includeGroups: true }),
       })
     );

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -9,6 +9,7 @@ import { cloneJSON } from "discourse/lib/object";
 import { userPath } from "discourse/lib/url";
 import { emailValid } from "discourse/lib/utilities";
 import { CANCELLED_STATUS } from "discourse/modifiers/d-autocomplete";
+import { i18n } from "discourse-i18n";
 
 let cache = {},
   cacheKey,
@@ -376,16 +377,23 @@ export default function userSearch(options) {
 
 export function validateSearchResult(obj) {
   const expectedPropertiesMap = {
-    isUser: "username",
-    isEmail: "username",
-    isGroup: "name",
+    isUser: {
+      nameProperty: "username",
+      translateKey: "composer.autocomplete.username_missing",
+    },
+    isEmail: {
+      nameProperty: "username",
+      translateKey: "composer.autocomplete.username_missing",
+    },
+    isGroup: {
+      nameProperty: "name",
+      translateKey: "composer.autocomplete.name_missing",
+    },
   };
 
-  for (const [isEntity, nameProperty] of Object.entries(
-    expectedPropertiesMap
-  )) {
-    if (obj[isEntity] && !obj[nameProperty]) {
-      throw new Error(`Invalid autocomplete result: missing ${nameProperty}`);
+  for (const [isEntity, props] of Object.entries(expectedPropertiesMap)) {
+    if (obj[isEntity] && !obj[props.nameProperty]) {
+      throw new Error(i18n(props.translateKey));
     }
   }
   return true;

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -373,3 +373,20 @@ export default function userSearch(options) {
     );
   });
 }
+
+export function validateSearchResult(obj) {
+  const expectedPropertiesMap = {
+    isUser: "username",
+    isEmail: "username",
+    isGroup: "name",
+  };
+
+  for (const [isEntity, nameProperty] of Object.entries(
+    expectedPropertiesMap
+  )) {
+    if (obj[isEntity] && !obj[nameProperty]) {
+      throw new Error(`Invalid autocomplete result: missing ${nameProperty}`);
+    }
+  }
+  return true;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2880,6 +2880,10 @@ en:
       publishing: "Publishing Topic…"
 
     composer:
+      autocomplete:
+        username_missing: "Selected autocomplete result is missing username."
+        name_missing: "Selected autocomplete result is missing name."
+
       emoji: "Emoji :)"
       more_emoji: "more…"
       options: "Options"

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -33,7 +33,7 @@ import { cloneJSON } from "discourse/lib/object";
 import optionalService from "discourse/lib/optional-service";
 import { emojiUrlFor } from "discourse/lib/text";
 import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipulation";
-import userSearch from "discourse/lib/user-search";
+import userSearch, { validateSearchResult } from "discourse/lib/user-search";
 import {
   destroyUserStatuses,
   initUserStatusHtml,
@@ -482,7 +482,7 @@ export default class ChatComposer extends Component {
         if (obj.isUser) {
           this.#addMentionedUser(cloneJSON(obj));
         }
-
+        validateSearchResult(obj);
         return obj.username || obj.name;
       },
       dataSource: (term) => {

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -19,7 +19,7 @@ import userAutocomplete from "discourse/lib/autocomplete/user";
 import { setupHashtagAutocomplete } from "discourse/lib/hashtag-autocomplete";
 import UppyUpload from "discourse/lib/uppy/uppy-upload";
 import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
-import userSearch from "discourse/lib/user-search";
+import userSearch, { validateSearchResult } from "discourse/lib/user-search";
 import {
   destroyUserStatuses,
   initUserStatusHtml,
@@ -204,7 +204,10 @@ export default class AiBotConversations extends Component {
       width: "100%",
       treatAsTextarea: true,
       autoSelectFirstSuggestion: true,
-      transformComplete: (obj) => obj.username || obj.name,
+      transformComplete: (obj) => {
+        validateSearchResult(obj);
+        return obj.username || obj.name;
+      },
       afterComplete: (text) => {
         this.textarea.value = text;
         this.focusTextarea();


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/pull/34208.

Previously, missing name properties for a selected user search result would fail silently which made it difficult to tell if something had gone wrong with the user autocomplete. 

This PR adds some error handling to make it more obvious that an error has occurred. I've opted for using `toasts` here since it's less intrusive compared to the `dialog` modal. ~~Also left out translation as it's not actually actionable by the user other than reporting it to us.~~ added it anyway ✨ 

https://github.com/user-attachments/assets/92f585d8-95bf-4c5b-a08a-698c1a527b79
