### PR TITLE
FIX: Deleted topic causes an issue when replacing attributes

### DIFF
--- a/lib/localization_attributes_replacer.rb
+++ b/lib/localization_attributes_replacer.rb
@@ -20,7 +20,7 @@ module LocalizationAttributesReplacer
       topic.excerpt = loc.excerpt if loc.excerpt.present?
     end
 
-    replace_category_attributes(topic.category, crawl_locale)
+    replace_category_attributes(topic.category, crawl_locale) if topic&.category.present?
   end
 
   def self.replace_post_attributes(post, crawl_locale)
@@ -32,7 +32,7 @@ module LocalizationAttributesReplacer
   private
 
   def self.get_localization(model, crawl_locale)
-    model.locale.present? && !LocaleNormalizer.is_same?(model.locale, crawl_locale) &&
-      model.get_localization(crawl_locale)
+    model.present? && model.locale.present? &&
+      !LocaleNormalizer.is_same?(model.locale, crawl_locale) && model.get_localization(crawl_locale)
   end
 end

--- a/spec/lib/localization_attributes_replacer_spec.rb
+++ b/spec/lib/localization_attributes_replacer_spec.rb
@@ -57,6 +57,12 @@ describe LocalizationAttributesReplacer do
       expect(topic.title).to eq(topic.title)
       expect(topic.excerpt).to eq(topic.excerpt)
     end
+
+    it "does not error out if topic does not exist" do
+      expect {
+        LocalizationAttributesReplacer.replace_topic_attributes(nil, "ja")
+      }.not_to raise_error
+    end
   end
 
   describe ".replace_post_attributes" do


### PR DESCRIPTION
Follow up https://github.com/discourse/discourse/pull/34253 - There's a bug now where deleted topics will fail attribute replacement.