### PR TITLE
Fix: cleanup UserAuthTokenLog unconditionally

### DIFF
--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -204,12 +204,10 @@ class UserAuthToken < ActiveRecord::Base
   end
 
   def self.cleanup!
-    if SiteSetting.verbose_auth_token_logging
-      UserAuthTokenLog.where(
-        "created_at < :time",
-        time: SiteSetting.maximum_session_age.hours.ago - ROTATE_TIME,
-      ).delete_all
-    end
+    UserAuthTokenLog.where(
+      "created_at < :time",
+      time: SiteSetting.maximum_session_age.hours.ago - ROTATE_TIME,
+    ).delete_all
 
     where(
       "rotated_at < :time",


### PR DESCRIPTION
Cleanup of `UserAuthTokenLog` only runs when `verbose_auth_token_logging` is true, but since `8fb823c` non-verbose logging always happens regardless of that setting. This results in up to 100 GB wasted database storage per instance.

See https://meta.discourse.org/t/clean-up-user-auth-token-logs/326397/13