### PR TITLE
FIX: set category text color on field blur

### DIFF
--- a/app/assets/javascripts/admin/addon/components/color-input.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-input.gjs
@@ -61,9 +61,7 @@ export default class ColorInput extends Component {
 
   @action
   handleBlur() {
-    if (this.onBlur) {
-      this.onBlur(this.normalize(this.hexValue));
-    }
+    this.onBlur?.(this.normalize(this.hexValue));
   }
 
   @observes("hexValue", "brightnessValue", "valid")

--- a/app/assets/javascripts/admin/addon/components/color-input.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-input.gjs
@@ -34,9 +34,14 @@ export default class ColorInput extends Component {
       if (!color.startsWith("#")) {
         color = "#" + color;
       }
-      // auto fill common hex codes like #F8F -> #F8F8F8 and #DDD -> #DDDDDD
-      if (color.length === 4 && color[1] === color[3]) {
-        color = "#" + color.slice(1).slice(0, 2).repeat(3);
+      if (color.length === 4) {
+        color =
+          "#" +
+          color
+            .slice(1)
+            .split("")
+            .map((hex) => hex + hex)
+            .join("");
       }
     }
     return color;
@@ -52,6 +57,13 @@ export default class ColorInput extends Component {
   @action
   onPickerInput(event) {
     this.set("hexValue", event.target.value.replace("#", ""));
+  }
+
+  @action
+  handleBlur() {
+    if (this.onBlur) {
+      this.onBlur(this.normalize(this.hexValue));
+    }
   }
 
   @observes("hexValue", "brightnessValue", "valid")
@@ -78,6 +90,7 @@ export default class ColorInput extends Component {
       @input={{this.onHexInput}}
       class="hex-input"
       aria-labelledby={{this.ariaLabelledby}}
+      {{on "blur" this.handleBlur}}
     />
     <input
       class="picker"

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -352,7 +352,7 @@ export default class EditCategoryGeneral extends Component {
                 <ColorInput
                   @hexValue={{readonly field.value}}
                   @ariaLabelledby="foreground-color-label"
-                  @onChangeColor={{fn this.updateColor field}}
+                  @onBlur={{fn this.updateColor field}}
                 />
                 <ColorPicker
                   @colors={{CATEGORY_TEXT_COLORS}}

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -65,6 +65,10 @@ export default class EditCategoryTabsController extends Controller {
       return false;
     }
 
+    if (transientData.text_color.length < 6) {
+      return false;
+    }
+
     if (this.saving || this.deleting) {
       return true;
     }

--- a/app/assets/javascripts/discourse/tests/integration/components/color-input-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/color-input-test.gjs
@@ -1,4 +1,4 @@
-import { fillIn, render } from "@ember/test-helpers";
+import { fillIn, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ColorInput from "admin/components/color-input";
@@ -10,20 +10,22 @@ module("Integration | Component | ColorInput", function (hooks) {
     let result;
     const expandHex = (color) => (result = color.replace("#", ""));
 
-    await render(
-      <template><ColorInput @onChangeColor={{expandHex}} /></template>
-    );
+    await render(<template><ColorInput @onBlur={{expandHex}} /></template>);
 
     await fillIn(".hex-input", "000");
+    await triggerEvent(".hex-input", "blur");
     assert.strictEqual(result, "000000", "with black text");
 
     await fillIn(".hex-input", "fff");
+    await triggerEvent(".hex-input", "blur");
     assert.strictEqual(result, "ffffff", "with white text");
 
     await fillIn(".hex-input", "f2f");
+    await triggerEvent(".hex-input", "blur");
     assert.strictEqual(result, "ff22ff", "with 3 digit hex");
 
     await fillIn(".hex-input", "052e3d");
+    await triggerEvent(".hex-input", "blur");
     assert.strictEqual(result, "052e3d", "with 6 digit hex");
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/color-input-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/color-input-test.gjs
@@ -6,23 +6,24 @@ import ColorInput from "admin/components/color-input";
 module("Integration | Component | ColorInput", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("autocompletes hex codes", async function (assert) {
+  test("updates hex codes on blur", async function (assert) {
     let result;
-    const autocompleteHex = (color) => (result = color.replace("#", ""));
+    const expandHex = (color) => (result = color.replace("#", ""));
 
     await render(
-      <template><ColorInput @onChangeColor={{autocompleteHex}} /></template>
+      <template><ColorInput @onChangeColor={{expandHex}} /></template>
     );
 
     await fillIn(".hex-input", "000");
-    assert.strictEqual(result, "000000", "black text");
+    assert.strictEqual(result, "000000", "with black text");
+
     await fillIn(".hex-input", "fff");
-    assert.strictEqual(result, "ffffff", "white text");
+    assert.strictEqual(result, "ffffff", "with white text");
+
     await fillIn(".hex-input", "f2f");
-    assert.strictEqual(result, "f2f2f2", "2 digit sequence");
-    await fillIn(".hex-input", "DDD");
-    assert.strictEqual(result, "DDDDDD", "3 digit sequence");
-    await fillIn(".hex-input", "0f8");
-    assert.strictEqual(result, "0f8", "with no sequence");
+    assert.strictEqual(result, "ff22ff", "with 3 digit hex");
+
+    await fillIn(".hex-input", "052e3d");
+    assert.strictEqual(result, "052e3d", "with 6 digit hex");
   });
 });


### PR DESCRIPTION
This change allows users to update category text color without autocompleting the input value. Instead we are using `onBlur` to allow the normalized hex value to be updated when the using submits or tabs/clicks out of the field.

We are also restoring the normalized hex back to the correct value - for example`f8f` becomes `ff88ff` if using only 3 digits. This was mistakenly changed in #34218 to improve auto complete in the edit category page but it affects the color pickers in other parts of the app too.