### PR TITLE
UX: remove flex from admin email appearance form layout

### DIFF
--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -961,12 +961,6 @@
 }
 
 .mobile-view .admin-customize {
-  .admin-container {
-    display: flex;
-    flex-wrap: wrap;
-    padding: 0;
-  }
-
   .color-scheme {
     h1,
     h1 input {


### PR DESCRIPTION
On mobile, the email appearance form isn't very useable

<img width="230" height="500" alt="image" src="https://github.com/user-attachments/assets/b5f9f844-5a6e-4589-9976-3737494c5a8f" />

Due to a seemingly unnecessary flex being applied. I can't find another instance of `.admin-customise .admin-container`, so I think it's safe to remove it and it won't impact other places?