### PR TITLE
DEV: Stabilize `ColorSchemeSerializer#colors` spec

### DIFF
--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -9,7 +9,7 @@ class ColorSchemeSerializer < ApplicationSerializer
   end
 
   def colors
-    db_colors = object.colors.index_by(&:name)
+    db_colors = object.colors.order(name: :asc).index_by(&:name)
     resolved = ColorScheme.sort_colors(object.resolved_colors)
     resolved.map do |name, default|
       db_colors[name] || ColorSchemeColor.new(name: name, hex: default, color_scheme: object)

--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -9,7 +9,7 @@ class ColorSchemeSerializer < ApplicationSerializer
   end
 
   def colors
-    db_colors = object.colors.order(name: :asc).index_by(&:name)
+    db_colors = object.colors.sort_by(&:name).index_by(&:name)
     resolved = ColorScheme.sort_colors(object.resolved_colors)
     resolved.map do |name, default|
       db_colors[name] || ColorSchemeColor.new(name: name, hex: default, color_scheme: object)

--- a/spec/serializers/color_scheme_serializer_spec.rb
+++ b/spec/serializers/color_scheme_serializer_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe ColorSchemeSerializer do
           highlight-high
           highlight-medium
           highlight-low
-          color_0
-          color_1
-        ],
+        ] + color_scheme.colors.map(&:name).sort,
       )
     end
   end


### PR DESCRIPTION
The color scheme fabricator doesn't always user `color_0` and `color_1` for the names, which can make this spec fail.