### PR TITLE
UX: fix Horizon disabled new topic button

### DIFF
--- a/themes/horizon/scss/buttons.scss
+++ b/themes/horizon/scss/buttons.scss
@@ -6,17 +6,26 @@
   transition: none;
 }
 
-.sidebar-new-topic-button__wrapper .topic-drafts-menu-trigger.btn.no-text {
-  background: var(--accent-color);
-
-  &:hover,
-  &:focus-visible {
-    background: oklch(from var(--accent-color) 40% c h) !important;
-    box-shadow: none;
+.sidebar-new-topic-button__wrapper {
+  &:has(.fk-d-tooltip__trigger) {
+    #create-topic.btn {
+      border-radius: var(--d-button-border-radius) 0 0
+        var(--d-button-border-radius);
+    }
   }
 
-  .d-icon {
-    color: var(--accent-text-color);
+  .topic-drafts-menu-trigger.btn.no-text {
+    background: var(--accent-color);
+
+    &:hover,
+    &:focus-visible {
+      background: oklch(from var(--accent-color) 40% c h) !important;
+      box-shadow: none;
+    }
+
+    .d-icon {
+      color: var(--accent-text-color);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes a minor styling regression with the disabled new topic button in the sidebar

Before:
<img width="426" height="212" alt="image" src="https://github.com/user-attachments/assets/df89a6e5-1390-4fc7-9a67-b991b9645da8" />

After:
<img width="454" height="438" alt="image" src="https://github.com/user-attachments/assets/e741e139-75f6-4bcd-9823-33f2e80af1b4" />
