### PR TITLE
FIX: hide header search for certain routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -41,12 +41,17 @@ export default class Contents extends Component {
   }
 
   get showHeaderSearch() {
+    const hideForRoutes = [
+      "signup",
+      "login",
+      "invites.show",
+      "activate-account",
+    ];
+
     if (
       this.site.mobileView ||
       this.args.narrowDesktop ||
-      this.router.currentURL?.match(
-        /\/(signup|login|invites|activate-account)/
-      ) ||
+      hideForRoutes.some((name) => name === this.router.currentRouteName) ||
       this.search.welcomeBannerSearchInViewport
     ) {
       return false;

--- a/app/assets/javascripts/discourse/tests/integration/components/header-contents-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/header-contents-test.gjs
@@ -8,24 +8,78 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 module("Integration | Component | Header | Contents", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("showHeaderSearch", async function (assert) {
-    const site = getOwner(this).lookup("service:site");
-    const toggleNavigationMenu = () => {};
+  module("header search", function () {
+    test("is hidden in mobile view", async function (assert) {
+      const site = getOwner(this).lookup("service:site");
+      const toggleNavigationMenu = () => {};
 
-    sinon.stub(site, "mobileView").value(true);
+      sinon.stub(site, "mobileView").value(false);
 
-    await render(
-      <template>
-        <Contents
-          @sidebarEnabled={{true}}
-          @toggleNavigationMenu={{toggleNavigationMenu}}
-          @showSidebar={{true}}
-        >test</Contents>
-      </template>
-    );
+      await render(
+        <template>
+          <Contents
+            @sidebarEnabled={{true}}
+            @toggleNavigationMenu={{toggleNavigationMenu}}
+            @showSidebar={{true}}
+          >
+            test
+          </Contents>
+        </template>
+      );
 
-    assert
-      .dom(".floating-search-input-wrapper")
-      .doesNotExist("it does not display when the site is in mobile view");
+      assert
+        .dom(".floating-search-input-wrapper")
+        .doesNotExist("it does not display when the site is in mobile view");
+    });
+
+    ["signup", "login", "invites.show", "activate-account"].forEach((name) => {
+      test(`is hidden in route "${name}"`, async function (assert) {
+        const router = getOwner(this).lookup("service:router");
+        const toggleNavigationMenu = () => {};
+
+        sinon.stub(router, "currentRouteName").value(name);
+
+        await render(
+          <template>
+            <Contents
+              @sidebarEnabled={{true}}
+              @toggleNavigationMenu={{toggleNavigationMenu}}
+              @showSidebar={{true}}
+            >
+              {{router.currentRouteName}}
+            </Contents>
+          </template>
+        );
+
+        assert
+          .dom(".floating-search-input-wrapper")
+          .doesNotExist(`it does not display on "${name}" route`);
+      });
+    });
+
+    ["login-preferences", "badges.show"].forEach((name) => {
+      test(`is shown in route "${name}"`, async function (assert) {
+        const router = getOwner(this).lookup("service:router");
+        const toggleNavigationMenu = () => {};
+
+        sinon.stub(router, "currentRouteName").value(name);
+
+        await render(
+          <template>
+            <Contents
+              @sidebarEnabled={{true}}
+              @toggleNavigationMenu={{toggleNavigationMenu}}
+              @showSidebar={{true}}
+            >
+              {{router.currentRouteName}}
+            </Contents>
+          </template>
+        );
+
+        assert
+          .dom(".floating-search-input-wrapper")
+          .exists(`it is shown on "${name}" route`);
+      });
+    });
   });
 });


### PR DESCRIPTION
Switches check from URL to a route name.