### PR TITLE
DEV: Allow avatars contained within DMenu to trigger user-card open

### DIFF
--- a/app/assets/javascripts/discourse/app/components/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/components/card-contents-base.js
@@ -10,18 +10,18 @@ import { headerOffset } from "discourse/lib/offset-calculator";
 import DiscourseURL from "discourse/lib/url";
 import { escapeExpression } from "discourse/lib/utilities";
 
-const DEFAULT_SELECTOR = "#main-outlet";
+const DEFAULT_SELECTORS = ["#main-outlet", "#d-menu-portals"];
 const AVATAR_OVERFLOW_SIZE = 44;
 const MOBILE_SCROLL_EVENT = "scroll.mobile-card-cloak";
 
-let _cardClickListenerSelectors = [DEFAULT_SELECTOR];
+let _cardClickListenerSelectors = [...DEFAULT_SELECTORS];
 
 export function addCardClickListenerSelector(selector) {
   _cardClickListenerSelectors.push(selector);
 }
 
 export function resetCardClickListenerSelector() {
-  _cardClickListenerSelectors = [DEFAULT_SELECTOR];
+  _cardClickListenerSelectors = [...DEFAULT_SELECTORS];
 }
 
 export default class CardContentsBase extends Component {


### PR DESCRIPTION
Currently, avatars located within a `DMenu` when clicked bring you to the user's activity page.

This PR adds `#d-menu-portals` to the selectors list. It will allow user-avatars within `DMenu` to trigger user-card appearance on click.

Thanks @CvX for the how-to.

## Before
https://github.com/user-attachments/assets/e07edb5a-f479-4382-8568-3df12f09a675

## After
https://github.com/user-attachments/assets/3d9de236-8978-4b62-92d8-8d9708fb0488