### PR TITLE
DEV: Add arg to discovery-above PluginOutlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/layout.gjs
@@ -37,7 +37,11 @@ const Layout = <template>
   <PluginOutlet
     @name="discovery-above"
     @connectorTagName="div"
-    @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
+    @outletArgs={{lazyHash
+      category=@model.category
+      tag=@model.tag
+      model=@model
+    }}
   />
 
   <div class={{concatClass "container list-container" @listClass}}>


### PR DESCRIPTION
## Changes

This PR adds `model` arg to "discovery-above" PluginOutlet.