### PR TITLE
DEV: simpler buildEngine used by prosemirror-editor

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/lib/markdown-it.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/lib/markdown-it.js
@@ -1,16 +1,9 @@
 import { buildEngine } from "discourse/static/markdown-it";
-import loadPluginFeatures from "discourse/static/markdown-it/features";
-import defaultFeatures from "discourse-markdown-it/features/index";
 
 let engine;
 
 function getEngine() {
-  engine ??= buildEngine({
-    featuresOverride: [...defaultFeatures, ...loadPluginFeatures()]
-      .map(({ id }) => id)
-      // Avoid oneboxing when parsing, we'll handle that separately
-      .filter((id) => id !== "onebox"),
-  });
+  engine ??= buildEngine();
 
   return engine;
 }


### PR DESCRIPTION
This avoid messing with the `featuresOverride`, which we only did before because of the attempt to filter the `onebox` feature out, which may not be necessary.

The previous `buildEngine` call could get in the way with customizations like discourse-calendar `[timezones]`, which relies on the presence of a feature and hence is not being interpreted during Markdown parsing as a token.