### PR TITLE
DEV: apply common filter component to AI persona admin

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
@@ -227,33 +227,35 @@ export default class AdminConfigAreasComponents extends Component {
           @onResetFilters={{this.onResetFilters}}
           @loading={{this.loading}}
         >
-          <LoadMore @action={{this.loadMore}} @rootMargin="0px 0px 250px 0px">
-            <table class="d-table component-list">
-              <thead class="d-table__header">
-                <tr class="d-table__row">
-                  <th class="d-table__header-cell">{{i18n
-                      "admin.config_areas.themes_and_components.components.name"
-                    }}</th>
-                  <th class="d-table__header-cell">{{i18n
-                      "admin.config_areas.themes_and_components.components.used_on"
-                    }}</th>
-                  <th class="d-table__header-cell">{{i18n
-                      "admin.config_areas.themes_and_components.components.enabled"
-                    }}</th>
-                  <th class="d-table__header-cell"></th>
-                </tr>
-              </thead>
-              <tbody class="d-table__body">
-                {{#each this.components as |comp|}}
-                  <ComponentRow
-                    @component={{comp}}
-                    @deleteComponent={{this.deleteComponentById}}
-                  />
-                {{/each}}
-              </tbody>
-            </table>
-            <ConditionalLoadingSpinner @condition={{this.loadingMore}} />
-          </LoadMore>
+          <:content>
+            <LoadMore @action={{this.loadMore}} @rootMargin="0px 0px 250px 0px">
+              <table class="d-table component-list">
+                <thead class="d-table__header">
+                  <tr class="d-table__row">
+                    <th class="d-table__header-cell">{{i18n
+                        "admin.config_areas.themes_and_components.components.name"
+                      }}</th>
+                    <th class="d-table__header-cell">{{i18n
+                        "admin.config_areas.themes_and_components.components.used_on"
+                      }}</th>
+                    <th class="d-table__header-cell">{{i18n
+                        "admin.config_areas.themes_and_components.components.enabled"
+                      }}</th>
+                    <th class="d-table__header-cell"></th>
+                  </tr>
+                </thead>
+                <tbody class="d-table__body">
+                  {{#each this.components as |comp|}}
+                    <ComponentRow
+                      @component={{comp}}
+                      @deleteComponent={{this.deleteComponentById}}
+                    />
+                  {{/each}}
+                </tbody>
+              </table>
+              <ConditionalLoadingSpinner @condition={{this.loadingMore}} />
+            </LoadMore>
+          </:content>
         </AdminFilterControls>
       {{/if}}
       <ConditionalLoadingSpinner @condition={{this.loading}}>

--- a/app/assets/javascripts/admin/addon/components/admin-filter-controls.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-filter-controls.gjs
@@ -170,11 +170,13 @@ export default class AdminFilterControls extends Component {
             {{/each}}
           </DSelect>
         {{/if}}
+
+        {{yield to="actions"}}
       </div>
     {{/if}}
 
     {{#if this.filteredData.length}}
-      {{yield this.filteredData}}
+      {{yield this.filteredData to="content"}}
     {{else if this.showFilters}}
       {{#if (and this.hasActiveFilters (not @loading))}}
         <div class="admin-filter-controls__no-results">
@@ -190,7 +192,7 @@ export default class AdminFilterControls extends Component {
         </div>
       {{/if}}
     {{else}}
-      {{yield this.array}}
+      {{yield this.array to="content"}}
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/admin/addon/components/admin-reports.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-reports.gjs
@@ -38,18 +38,19 @@ export default class AdminReports extends Component {
           @searchableProps={{array "title" "description"}}
           @inputPlaceholder={{i18n "admin.filter_reports"}}
           @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
-          as |filteredReports|
         >
-          <AdminSectionLandingWrapper class="admin-reports-list">
-            {{#each filteredReports as |report|}}
-              <AdminSectionLandingItem
-                @titleLabelTranslated={{report.title}}
-                @descriptionLabelTranslated={{report.description}}
-                @titleRoute="adminReports.show"
-                @titleRouteModel={{report.type}}
-              />
-            {{/each}}
-          </AdminSectionLandingWrapper>
+          <:content as |filteredReports|>
+            <AdminSectionLandingWrapper class="admin-reports-list">
+              {{#each filteredReports as |report|}}
+                <AdminSectionLandingItem
+                  @titleLabelTranslated={{report.title}}
+                  @descriptionLabelTranslated={{report.description}}
+                  @titleRoute="adminReports.show"
+                  @titleRouteModel={{report.type}}
+                />
+              {{/each}}
+            </AdminSectionLandingWrapper>
+          </:content>
         </AdminFilterControls>
       </:content>
     </AsyncContent>

--- a/app/assets/javascripts/admin/addon/components/themes-grid.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid.gjs
@@ -76,19 +76,20 @@ export default class ThemesGrid extends Component {
       @dropdownOptions={{this.dropdownOptions}}
       @inputPlaceholder={{this.inputPlaceholder}}
       @noResultsMessage={{i18n "admin.customize.theme.no_themes_found"}}
-      as |themes|
     >
-      <div class="themes-cards-container">
-        {{#each themes as |theme|}}
-          <ThemesGridCard @theme={{theme}} @allThemes={{@themes}} />
-        {{/each}}
-        <PluginOutlet
-          @name="admin-themes-grid-additional-cards"
-          @outletArgs={{lazyHash
-            AdminConfigAreaCardComponent=AdminConfigAreaCard
-          }}
-        />
-      </div>
+      <:content as |themes|>
+        <div class="themes-cards-container">
+          {{#each themes as |theme|}}
+            <ThemesGridCard @theme={{theme}} @allThemes={{@themes}} />
+          {{/each}}
+          <PluginOutlet
+            @name="admin-themes-grid-additional-cards"
+            @outletArgs={{lazyHash
+              AdminConfigAreaCardComponent=AdminConfigAreaCard
+            }}
+          />
+        </div>
+      </:content>
     </AdminFilterControls>
   </template>
 }

--- a/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
@@ -65,21 +65,22 @@ export default RouteTemplate(
         "admin.customize.colors.filters.search_placeholder"
       }}
       @noResultsMessage={{i18n "admin.customize.colors.filters.no_results"}}
-      as |schemes|
     >
-      <ul class="color-palette__list">
-        {{#each schemes as |scheme|}}
-          <ColorPaletteListItem
-            @scheme={{scheme}}
-            @defaultTheme={{@controller.defaultTheme}}
-            @isDefaultThemeLightColorScheme={{@controller.isDefaultThemeLightColorScheme}}
-            @isDefaultThemeDarkColorScheme={{@controller.isDefaultThemeDarkColorScheme}}
-            @toggleUserSelectable={{@controller.toggleUserSelectable}}
-            @setAsDefaultThemePalette={{@controller.setAsDefaultThemePalette}}
-            @deleteColorScheme={{@controller.deleteColorScheme}}
-          />
-        {{/each}}
-      </ul>
+      <:content as |schemes|>
+        <ul class="color-palette__list">
+          {{#each schemes as |scheme|}}
+            <ColorPaletteListItem
+              @scheme={{scheme}}
+              @defaultTheme={{@controller.defaultTheme}}
+              @isDefaultThemeLightColorScheme={{@controller.isDefaultThemeLightColorScheme}}
+              @isDefaultThemeDarkColorScheme={{@controller.isDefaultThemeDarkColorScheme}}
+              @toggleUserSelectable={{@controller.toggleUserSelectable}}
+              @setAsDefaultThemePalette={{@controller.setAsDefaultThemePalette}}
+              @deleteColorScheme={{@controller.deleteColorScheme}}
+            />
+          {{/each}}
+        </ul>
+      </:content>
     </AdminFilterControls>
   </template>
 );

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.gjs
@@ -62,9 +62,10 @@ export default RouteTemplate(
           @dropdownOptions={{@controller.dropdownOptions}}
           @inputPlaceholder={{i18n "admin.plugins.filters.search_placeholder"}}
           @noResultsMessage={{i18n "admin.plugins.filters.no_results"}}
-          as |filteredPlugins|
         >
-          <AdminPluginsList @plugins={{filteredPlugins}} />
+          <:content as |filteredPlugins|>
+            <AdminPluginsList @plugins={{filteredPlugins}} />
+          </:content>
         </AdminFilterControls>
       {{else}}
         <p>{{i18n "admin.plugins.none_installed"}}</p>


### PR DESCRIPTION
This applies the common `AdminFilterControls` component here: 

<img width="2216" height="144" alt="image" src="https://github.com/user-attachments/assets/3e6ad0e9-9f14-4974-a80c-49e0d1b0b108" />

I also wanted to add the layout control button, so I added the ability to use an actions block in `AdminFilterControls` — this required creating two separate blocks `actions` and `content`, which required updating the other instances of `AdminFilterControls` ... but this should allow more flexibility going forward 