### PR TITLE
FEATURE: introduce max attendees for events

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -56,7 +56,7 @@ module DiscoursePostEvent
         invitee.update_attendance!(invitee_params[:status])
         render json: InviteeSerializer.new(invitee)
       rescue Discourse::InvalidParameters => e
-        if e.param == :max_attendees
+        if e.message == "max_attendees"
           render_json_error(
             I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
             422,
@@ -88,7 +88,7 @@ module DiscoursePostEvent
         invitee = Invitee.create_attendance!(user.id, params[:event_id], invitee_params[:status])
         render json: InviteeSerializer.new(invitee)
       rescue Discourse::InvalidParameters => e
-        if e.param == :max_attendees
+        if e.message == "max_attendees"
           render_json_error(
             I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
             422,

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -52,8 +52,19 @@ module DiscoursePostEvent
     def update
       invitee = Invitee.find_by(id: params[:invitee_id], post_id: params[:event_id])
       guardian.ensure_can_act_on_invitee!(invitee)
-      invitee.update_attendance!(invitee_params[:status])
-      render json: InviteeSerializer.new(invitee)
+      begin
+        invitee.update_attendance!(invitee_params[:status])
+        render json: InviteeSerializer.new(invitee)
+      rescue Discourse::InvalidParameters => e
+        if e.param == :max_attendees
+          render_json_error(
+            I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
+            422,
+          )
+        else
+          raise
+        end
+      end
     end
 
     def create
@@ -73,8 +84,19 @@ module DiscoursePostEvent
         raise Discourse::InvalidAccess if !guardian.can_act_on_discourse_post_event?(event)
       end
 
-      invitee = Invitee.create_attendance!(user.id, params[:event_id], invitee_params[:status])
-      render json: InviteeSerializer.new(invitee)
+      begin
+        invitee = Invitee.create_attendance!(user.id, params[:event_id], invitee_params[:status])
+        render json: InviteeSerializer.new(invitee)
+      rescue Discourse::InvalidParameters => e
+        if e.param == :max_attendees
+          render_json_error(
+            I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
+            422,
+          )
+        else
+          raise
+        end
+      end
     end
 
     def destroy

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -30,6 +30,7 @@ module DiscoursePostEvent
               },
               unless: ->(event) { event.name.blank? }
     validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
+    validates :max_attendees, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
 
     validate :raw_invitees_length
     validate :ends_before_start
@@ -242,6 +243,15 @@ module DiscoursePostEvent
       (self.starts_at..finishes_at).cover?(Time.now)
     end
 
+    def going_count
+      invitees.where(status: Invitee.statuses[:going]).count
+    end
+
+    def at_capacity?
+      return false if max_attendees.blank?
+      going_count >= max_attendees
+    end
+
     def self.statuses
       @statuses ||= Enum.new(standalone: 0, public: 1, private: 2)
     end
@@ -331,6 +341,7 @@ module DiscoursePostEvent
           minimal: event_params[:minimal],
           closed: event_params[:closed] || false,
           chat_enabled: event_params[:"chat-enabled"]&.downcase == "true",
+          max_attendees: event_params[:"max-attendees"]&.to_i,
         }
 
         params[:custom_fields] = {}
@@ -504,4 +515,5 @@ end
 #  chat_channel_id    :bigint
 #  recurrence_until   :datetime
 #  show_local_time    :boolean          default(FALSE), not null
+#  max_attendees      :integer
 #

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -29,6 +29,9 @@ module DiscoursePostEvent
     attributes :watching_invitee
     attributes :chat_enabled
     attributes :channel
+    attributes :rrule
+    attributes :max_attendees
+    attributes :at_capacity
 
     def channel
       ::Chat::ChannelSerializer.new(object.chat_channel, root: false, scope:)
@@ -36,6 +39,10 @@ module DiscoursePostEvent
 
     def include_channel?
       object.chat_enabled && defined?(::Chat::ChannelSerializer) && object.chat_channel.present?
+    end
+
+    def at_capacity
+      object.at_capacity?
     end
 
     def can_act_on_discourse_post_event

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_stats_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_stats_serializer.rb
@@ -6,6 +6,7 @@ module DiscoursePostEvent
     attributes :interested
     attributes :not_going
     attributes :invited
+    attributes :capacity
 
     def invited
       unanswered = counts[nil] || 0
@@ -31,6 +32,10 @@ module DiscoursePostEvent
 
     def counts
       @counts ||= object.invitees.group(:status).count
+    end
+
+    def capacity
+      object.max_attendees
     end
   end
 end

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { eq, and, not } from "truth-helpers";
+import { and, eq, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { and, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
@@ -81,6 +82,7 @@ export default class DiscoursePostEventStatus extends Component {
         postId: this.args.event.id,
       });
     } catch (e) {
+      // in case of 422 full, backend returns error string, let popup handle
       popupAjaxError(e);
     }
   }
@@ -132,8 +134,16 @@ export default class DiscoursePostEventStatus extends Component {
             >
               <DButton
                 class="going-button"
+                @disabled={{and
+                  @event.atCapacity
+                  (not this.watchingInviteeStatus)
+                }}
                 @icon="check"
-                @label="discourse_post_event.models.invitee.status.going"
+                @label={{if
+                  @event.atCapacity
+                  "discourse_post_event.models.event.full"
+                  "discourse_post_event.models.invitee.status.going"
+                }}
                 @action={{fn this.changeWatchingInviteeStatus "going"}}
               />
             </PluginOutlet>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { and, not } from "truth-helpers";
+import { eq, and, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
@@ -136,7 +136,7 @@ export default class DiscoursePostEventStatus extends Component {
                 class="going-button"
                 @disabled={{and
                   @event.atCapacity
-                  (not this.watchingInviteeStatus)
+                  (not (eq this.watchingInviteeStatus "going"))
                 }}
                 @icon="check"
                 @label={{if

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -55,6 +55,10 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
     params.chatEnabled = "true";
   }
 
+  if (event.maxAttendees) {
+    params.maxAttendees = `${event.maxAttendees}`;
+  }
+
   if (endsAt) {
     params.end = moment(endsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
   }

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -168,7 +168,6 @@ export default class DiscoursePostEventEvent {
     this.minimal = event.minimal;
     this.chatEnabled = event.chatEnabled;
     this.rrule = event.rrule;
-    // keep capacity fields in sync when server pushes updates
     this.maxAttendees = event.maxAttendees;
     this.atCapacity = event.atCapacity;
     this.recurrence = event.recurrence;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -168,6 +168,9 @@ export default class DiscoursePostEventEvent {
     this.minimal = event.minimal;
     this.chatEnabled = event.chatEnabled;
     this.rrule = event.rrule;
+    // keep capacity fields in sync when server pushes updates
+    this.maxAttendees = event.maxAttendees;
+    this.atCapacity = event.atCapacity;
     this.recurrence = event.recurrence;
     this.recurrenceUntil = event.recurrenceUntil;
     this.canUpdateAttendance = event.canUpdateAttendance;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -46,6 +46,8 @@ export default class DiscoursePostEventEvent {
   @tracked isClosed;
   @tracked isExpired;
   @tracked isStandalone;
+  @tracked maxAttendees;
+  @tracked atCapacity;
   @tracked recurrenceUntil;
   @tracked recurrence;
   @tracked customFields;
@@ -80,6 +82,8 @@ export default class DiscoursePostEventEvent {
     this.isStandalone = args.is_standalone;
     this.minimal = args.minimal;
     this.chatEnabled = args.chat_enabled;
+    this.maxAttendees = args.max_attendees;
+    this.atCapacity = args.at_capacity;
     this.recurrence = args.recurrence;
     this.recurrenceUntil = args.recurrence_until;
     this.canUpdateAttendance = args.can_update_attendance;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
@@ -63,6 +63,12 @@ export default class DiscoursePostEventApi extends Service {
     event.shouldDisplayInvitees =
       result.invitee.meta.event_should_display_invitees;
 
+    // keep capacity state in sync immediately without waiting for MessageBus
+    const capacity1 = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity1) && capacity1 > 0) {
+      event.atCapacity = Number(event.stats.going) >= capacity1;
+    }
+
     return event;
   }
 
@@ -75,6 +81,15 @@ export default class DiscoursePostEventApi extends Service {
 
     if (event.watchingInvitee?.id === invitee.id) {
       event.watchingInvitee = null;
+    }
+
+    // optimistically update stats and capacity when leaving
+    if (invitee?.status === "going" && Number(event.stats?.going) > 0) {
+      event.stats.going = Number(event.stats.going) - 1;
+    }
+    const capacity2 = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity2) && capacity2 > 0) {
+      event.atCapacity = Number(event.stats?.going) >= capacity2;
     }
   }
 
@@ -90,9 +105,20 @@ export default class DiscoursePostEventApi extends Service {
       event.sampleInvitees.push(event.watchingInvitee);
     }
 
+    // If joining as going, increment going count immediately for responsiveness
+    if (invitee?.status === "going") {
+      event.stats.going = Number(event.stats.going || 0) + 1;
+    }
+
     event.stats = result.invitee.meta.event_stats;
     event.shouldDisplayInvitees =
       result.invitee.meta.event_should_display_invitees;
+
+    // keep capacity state in sync immediately without waiting for MessageBus
+    const capacity3 = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity3) && capacity3 > 0) {
+      event.atCapacity = Number(event.stats.going) >= capacity3;
+    }
 
     return invitee;
   }

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
@@ -63,10 +63,9 @@ export default class DiscoursePostEventApi extends Service {
     event.shouldDisplayInvitees =
       result.invitee.meta.event_should_display_invitees;
 
-    // keep capacity state in sync immediately without waiting for MessageBus
-    const capacity1 = Number(event.maxAttendees);
-    if (!Number.isNaN(capacity1) && capacity1 > 0) {
-      event.atCapacity = Number(event.stats.going) >= capacity1;
+    const capacity = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity) && capacity > 0) {
+      event.atCapacity = Number(event.stats.going) >= capacity;
     }
 
     return event;
@@ -83,13 +82,13 @@ export default class DiscoursePostEventApi extends Service {
       event.watchingInvitee = null;
     }
 
-    // optimistically update stats and capacity when leaving
     if (invitee?.status === "going" && Number(event.stats?.going) > 0) {
       event.stats.going = Number(event.stats.going) - 1;
     }
-    const capacity2 = Number(event.maxAttendees);
-    if (!Number.isNaN(capacity2) && capacity2 > 0) {
-      event.atCapacity = Number(event.stats?.going) >= capacity2;
+
+    const capacity = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity) && capacity > 0) {
+      event.atCapacity = Number(event.stats?.going) >= capacity;
     }
   }
 
@@ -105,7 +104,6 @@ export default class DiscoursePostEventApi extends Service {
       event.sampleInvitees.push(event.watchingInvitee);
     }
 
-    // If joining as going, increment going count immediately for responsiveness
     if (invitee?.status === "going") {
       event.stats.going = Number(event.stats.going || 0) + 1;
     }
@@ -114,10 +112,9 @@ export default class DiscoursePostEventApi extends Service {
     event.shouldDisplayInvitees =
       result.invitee.meta.event_should_display_invitees;
 
-    // keep capacity state in sync immediately without waiting for MessageBus
-    const capacity3 = Number(event.maxAttendees);
-    if (!Number.isNaN(capacity3) && capacity3 > 0) {
-      event.atCapacity = Number(event.stats.going) >= capacity3;
+    const capacity = Number(event.maxAttendees);
+    if (!Number.isNaN(capacity) && capacity > 0) {
+      event.atCapacity = Number(event.stats.going) >= capacity;
     }
 
     return invitee;

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -407,6 +407,7 @@ en:
         event:
           expired: "Expired"
           closed: "Closed"
+          full: "Full"
           status:
             standalone:
               title: "Standalone"
@@ -464,6 +465,9 @@ en:
         minimal:
           label: "Minimal event"
           checkbox_label: "Hide Going/Not going buttons and invitees status"
+        max_attendees:
+          label: "Maximum attendees"
+          placeholder: "No limit"
         allow_chat:
           label: "Chat integration"
           checkbox_label: "Create and manage event specific chat channel"

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -83,6 +83,7 @@ en:
           raw_invitees:
             only_group: "An event accepts only group names."
           ends_at_before_starts_at: "An event can't end before it starts."
+          max_attendees_reached: "This event is full."
           start_must_be_present_and_a_valid_date: "An event requires a valid start date."
           end_must_be_a_valid_date: "End date must be a valid date."
           invalid_recurrence: "Recurrence must be one of: every_month, every_week, every_two_weeks, every_four_weeks, every_day, every_weekday."

--- a/plugins/discourse-calendar/db/migrate/20250811120000_add_max_attendees_to_events.rb
+++ b/plugins/discourse-calendar/db/migrate/20250811120000_add_max_attendees_to_events.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddMaxAttendeesToEvents < ActiveRecord::Migration[7.0]
+  def up
+    add_column :discourse_post_event_events, :max_attendees, :integer
+  end
+
+  def down
+    remove_column :discourse_post_event_events, :max_attendees
+  end
+end

--- a/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
+++ b/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
@@ -71,7 +71,15 @@ module Jobs
       end
 
       users.each do |user_id|
-        create_attendance(user_id, @event.post.id, invitee["attendance"] || "going")
+        # Respect capacity: skip creating new going when full
+        attendance = invitee["attendance"] || "going"
+        if attendance == "going" && @event.at_capacity?
+          save_log "Skipping '#{invitee["identifier"]}' due to max attendees reached"
+          @failed += 1
+          next
+        end
+
+        create_attendance(user_id, @event.post.id, attendance)
       end
 
       @processed += 1

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
@@ -18,6 +18,7 @@ module DiscoursePostEvent
       :minimal,
       :closed,
       :"chat-enabled",
+      :"max-attendees",
     ]
 
     def self.extract_events(post)

--- a/plugins/discourse-calendar/spec/fabricators/invitee_fabricator.rb
+++ b/plugins/discourse-calendar/spec/fabricators/invitee_fabricator.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Fabricator(:invitee, from: "DiscoursePostEvent::Invitee") {}

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -731,3 +731,22 @@ describe DiscoursePostEvent::Event do
     end
   end
 end
+
+describe DiscoursePostEvent::Event, "#capacity" do
+  before do
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  it "detects capacity when max_attendees set" do
+    creator = Fabricate(:user)
+    topic = Fabricate(:topic, user: creator)
+    post = Fabricate(:post, user: creator, topic: topic)
+    event = Fabricate(:event, post: post, max_attendees: 1)
+    event.create_invitees(
+      [{ user_id: creator.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+    )
+    expect(event.at_capacity?).to eq(true)
+  end
+end

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -413,7 +413,6 @@ module DiscoursePostEvent
 
   describe "bulk invite respects capacity" do
     before do
-      Jobs.run_immediately!
       SiteSetting.calendar_enabled = true
       SiteSetting.discourse_post_event_enabled = true
     end

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -410,4 +410,47 @@ module DiscoursePostEvent
       end
     end
   end
+
+  describe "bulk invite respects capacity" do
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    let(:user) { Fabricate(:user, admin: true) }
+    let(:topic) { Fabricate(:topic, user: user) }
+    let(:post1) { Fabricate(:post, user: user, topic: topic) }
+    let!(:event) { Fabricate(:event, post: post1, max_attendees: 1) }
+
+    it "skips creating going when full" do
+      sign_in(user)
+      user1 = Fabricate(:user)
+      user2 = Fabricate(:user)
+
+      expect_enqueued_with(
+        job: :discourse_post_event_bulk_invite,
+        args: {
+          "event_id" => event.id,
+          "invitees" => [
+            { "identifier" => user1.username, "attendance" => "going" },
+            { "identifier" => user2.username, "attendance" => "going" },
+          ],
+          "current_user_id" => user.id,
+        },
+      ) do
+        post "/discourse-post-event/events/#{event.id}/bulk-invite.json",
+             params: {
+               invitees: [
+                 { "identifier" => user1.username, "attendance" => "going" },
+                 { "identifier" => user2.username, "attendance" => "going" },
+               ],
+             }
+      end
+
+      Jobs.run_immediately!
+      event.reload
+      expect(event.invitees.with_status(:going).count).to be <= 1
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -337,6 +337,19 @@ module DiscoursePostEvent
 
             expect(response.status).to eq(200)
           end
+
+          it "allows not_going when full" do
+            sign_in(user_b)
+
+            post "/discourse-post-event/events/#{post_event_full.id}/invitees.json",
+                 params: {
+                   invitee: {
+                     status: "not_going",
+                   },
+                 }
+
+            expect(response.status).to eq(200)
+          end
         end
       end
     end

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -302,10 +302,11 @@ module DiscoursePostEvent
         end
 
         context "when event has max attendees and is full" do
+          let(:post_2) { create_post(user: Fabricate(:admin), category: Fabricate(:category)) }
           let(:user_a) { Fabricate(:user) }
           let(:user_b) { Fabricate(:user) }
           let(:post_event_full) do
-            pe = Fabricate(:event, post: post_1, max_attendees: 1)
+            pe = Fabricate(:event, post: post_2, max_attendees: 1)
             pe.create_invitees([{ user_id: user_a.id, status: Invitee.statuses[:going] }])
             pe
           end

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -35,7 +35,13 @@ describe DiscoursePostEvent::EventSerializer do
 
       it "returns the correct stats" do
         json = DiscoursePostEvent::EventSerializer.new(private_event, scope: Guardian.new).as_json
-        expect(json[:event][:stats]).to eq(going: 1, interested: 0, invited: 2, not_going: 0)
+        expect(json[:event][:stats]).to eq(
+          going: 1,
+          interested: 0,
+          invited: 2,
+          not_going: 0,
+          capacity: nil,
+        )
       end
     end
   end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -80,6 +80,37 @@ describe "Post event", type: :system do
     end
   end
 
+  context "with max attendees" do
+    it "updates the going button label from Full after toggling" do
+      post =
+        PostCreator.create(
+          admin,
+          title: "Max attendees event",
+          raw: "[event status='public' start='2222-02-22 14:22' max-attendees='1']\n[/event]",
+        )
+
+      visit(post.topic.url)
+
+      # First click: join the event; since max is 1, it reaches capacity and shows Full
+      post_event_page.going
+      expect(page).to have_css(
+        ".going-button",
+        text: I18n.t("js.discourse_post_event.models.event.full"),
+      )
+
+      # Second click: leave the event; label should no longer be Full
+      post_event_page.going
+      expect(page).to have_no_css(
+        ".going-button",
+        text: I18n.t("js.discourse_post_event.models.event.full"),
+      )
+      expect(page).to have_css(
+        ".going-button",
+        text: I18n.t("js.discourse_post_event.models.invitee.status.going"),
+      )
+    end
+  end
+
   context "when showing local time", timezone: "Australia/Brisbane" do
     it "correctly shows month/day" do
       page.driver.with_playwright_page do |pw_page|


### PR DESCRIPTION
Allows to set the max attendees of an event. When an event is full you can only mark yourself as interested or not going. The going button will be disabled.

Maximum attendees can be defined in the post builder:
<img width="569" height="106" alt="Screenshot 2025-09-01 at 20 57 16" src="https://github.com/user-attachments/assets/bf61cd57-d35e-44a7-8d05-263ee9cd7df0" />
