### PR TITLE
FIX: Allow themes index to resort when adding new themes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-grid.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid.gjs
@@ -1,7 +1,5 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
-import { action } from "@ember/object";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { cached } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -10,26 +8,27 @@ import AdminConfigAreaCard from "admin/components/admin-config-area-card";
 import AdminFilterControls from "admin/components/admin-filter-controls";
 import ThemesGridCard from "./themes-grid-card";
 
-// NOTE (martin): Much of the JS code in this component is placeholder code. Much
-// of the existing theme logic in /admin/customize/themes has old patterns
-// and technical debt, so anything copied from there to here is subject
-// to change as we improve this incrementally.
-
 const FILTER_MINIMUM = 8;
 
 export default class ThemesGrid extends Component {
   @service modal;
   @service router;
 
-  @tracked _cachedSortedThemes = null;
-  _sortPerformed = false;
-
+  @cached
   get sortedThemes() {
-    if (!this._sortPerformed) {
-      this.resortThemes();
-    }
-
-    return [...this._cachedSortedThemes];
+    return this.args.themes.sort((a, b) => {
+      if (a.get("default")) {
+        return -1;
+      } else if (b.get("default")) {
+        return 1;
+      }
+      if (a.id < 0) {
+        return a.id;
+      }
+      if (b.id < 0) {
+        return -b.id;
+      }
+    });
   }
 
   get searchableProps() {
@@ -55,36 +54,7 @@ export default class ThemesGrid extends Component {
     ];
   }
 
-  @action
-  resortThemes() {
-    // Show default theme at the top of the list, we do the sort
-    // manually and cache it to make sure we don't reorder the list
-    // if the default theme changes.
-    this._cachedSortedThemes = this.args.themes.sort((a, b) => {
-      if (a.get("default")) {
-        return -1;
-      } else if (b.get("default")) {
-        return 1;
-      }
-      if (a.id < 0) {
-        return a.id;
-      }
-      if (b.id < 0) {
-        return -b.id;
-      }
-    });
-    this._sortPerformed = true;
-  }
-
-  @action
-  resetSortedThemes() {
-    this._cachedSortedThemes = null;
-    this._sortPerformed = null;
-  }
-
   <template>
-    <span {{didUpdate this.resetSortedThemes @themes}}></span>
-
     <AdminFilterControls
       @array={{this.sortedThemes}}
       @minItemsForFilter={{FILTER_MINIMUM}}

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -32,7 +32,7 @@ export default class AdminCustomizeColorsController extends Controller {
   _initialUserDarkColorSchemeId = undefined;
   _initialDefaultThemeLightColorSchemeId = null;
   _initialDefaultThemeDarkColorSchemeId = null;
-  _sortedOnce = false;
+  _sortPerformed = false;
 
   canPreviewColorScheme(mode) {
     const usingDefaultTheme = currentThemeId() === this.defaultTheme?.id;
@@ -80,7 +80,7 @@ export default class AdminCustomizeColorsController extends Controller {
 
   get sortedColorSchemes() {
     // only sort initially, this avoids position jumps when state changes on interaction
-    if (!this._sortedOnce && this.model?.length > 0) {
+    if (!this._sortPerformed && this.model?.length > 0) {
       this._doInitialSort();
     }
 
@@ -158,11 +158,11 @@ export default class AdminCustomizeColorsController extends Controller {
     });
 
     this._initialSortedSchemes = schemes;
-    this._sortedOnce = true;
+    this._sortPerformed = true;
   }
 
   _resetSortedSchemes() {
-    this._sortedOnce = false;
+    this._sortPerformed = false;
     this._initialSortedSchemes = [];
   }
 


### PR DESCRIPTION
Follows the same pattern as the color palette index, where we
sort the themes once, and then resort only when the themes array
from the model changes. This fixes the issue where if you installed
a new theme, it would not show up on the grid until you refreshed.
