### PR TITLE
FIX: Link to correct staff action logs for theme site setting

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -339,6 +339,7 @@ export default class SiteSettingComponent extends Component {
             <LinkTo
               @route="adminLogs.staffActionLogs"
               @query={{hash filters=this.staffLogFilter force_refresh=true}}
+              class="staff-action-log-link"
               title={{i18n "admin.settings.history"}}
             >
               <span class="history-icon">

--- a/app/assets/javascripts/admin/addon/components/theme-site-setting-editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/theme-site-setting-editor.gjs
@@ -5,6 +5,13 @@ import SiteSettingComponent from "./site-setting";
 export default class ThemeSiteSettingEditor extends SiteSettingComponent {
   @service toasts;
 
+  get staffLogFilter() {
+    return {
+      subject: `${this.args.model.name}: ${this.setting.setting}`,
+      action_name: "change_theme_site_setting",
+    };
+  }
+
   _save() {
     return this.setting
       .updateSetting(this.args.model.id, this.buffered.get("value"))

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.gjs
@@ -1,4 +1,10 @@
-import { click, fillIn, render, typeIn } from "@ember/test-helpers";
+import {
+  click,
+  fillIn,
+  render,
+  triggerEvent,
+  typeIn,
+} from "@ember/test-helpers";
 import { module, skip, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
@@ -7,7 +13,7 @@ import { i18n } from "discourse-i18n";
 import SiteSettingComponent from "admin/components/site-setting";
 import SiteSetting from "admin/models/site-setting";
 
-module("Integration | Component | site-setting", function (hooks) {
+module("Integration | Component | SiteSetting", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displays host-list setting value", async function (assert) {
@@ -29,7 +35,7 @@ module("Integration | Component | site-setting", function (hooks) {
     assert.dom(".formatted-selection").hasText("a.com, b.com");
   });
 
-  test("Error response with html_message is rendered as HTML", async function (assert) {
+  test("error response with html_message is rendered as HTML", async function (assert) {
     const self = this;
 
     this.set(
@@ -56,7 +62,7 @@ module("Integration | Component | site-setting", function (hooks) {
     assert.dom(".validation-error").includesHtml(message);
   });
 
-  test("Error response without html_message is not rendered as HTML", async function (assert) {
+  test("error response without html_message is not rendered as HTML", async function (assert) {
     const self = this;
 
     this.set(
@@ -180,10 +186,38 @@ module("Integration | Component | site-setting", function (hooks) {
     assert.dom(".input-setting-string").hasAttribute("type", "password");
     assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
   });
+
+  test("shows link to the staff action logs for the setting on hover", async function (assert) {
+    const self = this;
+
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "enable_badges",
+        value: "false",
+        default: "true",
+        type: "bool",
+      })
+    );
+
+    await render(
+      <template><SiteSettingComponent @setting={{self.setting}} /></template>
+    );
+
+    await triggerEvent("[data-setting='enable_badges']", "mouseenter");
+
+    assert
+      .dom("[data-setting='enable_badges'] .staff-action-log-link")
+      .exists()
+      .hasAttribute(
+        "href",
+        `/admin/logs/staff_action_logs?filters=${encodeURIComponent(JSON.stringify({ subject: "enable_badges", action_name: "change_site_setting" }))}&force_refresh=true`
+      );
+  });
 });
 
 module(
-  "Integration | Component | site-setting | file_size_restriction type",
+  "Integration | Component | SiteSetting | file_size_restriction type",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -434,7 +468,7 @@ module(
 );
 
 module(
-  "Integration | Component | site-setting | font-list type",
+  "Integration | Component | SiteSetting | font-list type",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/theme-site-setting-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/theme-site-setting-editor-test.gjs
@@ -1,0 +1,45 @@
+import { render, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ThemeSiteSettingEditor from "admin/components/theme-site-setting-editor";
+import SiteSetting from "admin/models/site-setting";
+import Theme from "admin/models/theme";
+
+module("Integration | Component | ThemeSiteSettingEditor", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("shows link to the staff action logs for the setting on hover", async function (assert) {
+    const self = this;
+
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "enable_welcome_banner",
+        value: "false",
+        default: "true",
+        type: "bool",
+      })
+    );
+
+    this.set("model", Theme.create({ name: "Test Theme" }));
+
+    await render(
+      <template>
+        <ThemeSiteSettingEditor
+          @setting={{self.setting}}
+          @model={{self.model}}
+        />
+      </template>
+    );
+
+    await triggerEvent("[data-setting='enable_welcome_banner']", "mouseenter");
+
+    assert
+      .dom("[data-setting='enable_welcome_banner'] .staff-action-log-link")
+      .exists()
+      .hasAttribute(
+        "href",
+        `/admin/logs/staff_action_logs?filters=${encodeURIComponent(JSON.stringify({ subject: "Test Theme: enable_welcome_banner", action_name: "change_theme_site_setting" }))}&force_refresh=true`
+      );
+  });
+});


### PR DESCRIPTION
Fixes an issue where the history link on hover for a theme site setting
would point to the staff action logs for regular site settings, not  the
theme site setting ones which include the theme name in the subject
and also have a different `change_theme_site_setting` action.

c.f. https://meta.discourse.org/t/link-to-change-history-on-themeable-site-settings/377394

**This icon**

<img width="942" height="457" alt="image" src="https://github.com/user-attachments/assets/7b2f2e44-1026-4ed8-a97a-0a499ccf971f" />


**Linking here**

<img width="1318" height="602" alt="image" src="https://github.com/user-attachments/assets/0f6cd205-c078-465a-b5d7-845756e2c334" />

