### PR TITLE
FEATURE: Disable user tips + narrative bot welcome post for all sites

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -489,7 +489,7 @@ basic:
     area: "analytics"
   enable_user_tips:
     client: true
-    default: true
+    default: false
     refresh: true
     area: "users"
   page_loading_indicator:

--- a/plugins/discourse-narrative-bot/config/settings.yml
+++ b/plugins/discourse-narrative-bot/config/settings.yml
@@ -3,7 +3,7 @@ plugins:
     default: true
     client: true
   disable_discourse_narrative_bot_welcome_post:
-    default: false
+    default: true
   discourse_narrative_bot_welcome_post_type:
     default: 'new_user_track'
     enum: 'DiscourseNarrativeBot::WelcomePostTypeSiteSetting'

--- a/plugins/discourse-narrative-bot/spec/requests/discobot_welcome_post_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/requests/discobot_welcome_post_spec.rb
@@ -3,7 +3,10 @@
 RSpec.describe "Discobot welcome post" do
   let(:user) { Fabricate(:user) }
 
-  before { SiteSetting.discourse_narrative_bot_enabled = true }
+  before do
+    SiteSetting.discourse_narrative_bot_enabled = true
+    SiteSetting.disable_discourse_narrative_bot_welcome_post = false
+  end
 
   context "when discourse_narrative_bot_welcome_post_delay is 0" do
     it "should not delay the welcome post" do

--- a/plugins/discourse-narrative-bot/spec/system/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/system/user_spec.rb
@@ -2,7 +2,7 @@
 
 describe "Narrative Bot PM", type: :system do
   fab!(:admin)
-  fab!(:user)
+  fab!(:current_user, :user)
   fab!(:topics) { Fabricate.times(2, :post).map(&:topic) }
   fab!(:posts) { Fabricate.times(3, :post, topic: topics[0]) }
 
@@ -11,24 +11,28 @@ describe "Narrative Bot PM", type: :system do
       Jobs.run_immediately!
       SiteSetting.enable_user_tips = true
       SiteSetting.discourse_narrative_bot_enabled = true
+      SiteSetting.disable_discourse_narrative_bot_welcome_post = false
     end
 
     it "does not delete the narrative bot PM when skipping all tips" do
-      sign_in user
+      sign_in(current_user)
 
       # shortcut to generate welcome post since we're not going through user creation or first login
-      user.enqueue_bot_welcome_post
+      current_user.enqueue_bot_welcome_post
 
-      visit "/"
+      visit("/")
 
       tooltip = PageObjects::Components::Tooltips.new("user-tip")
-      tooltip.find(".btn", text: "Skip tips").click
+      tooltip.find(".btn", text: I18n.t("js.user_tips.skip")).click
 
       expect(tooltip).to be_not_present
       expect(page).to have_css(".badge-notification.new-pms")
 
       find("#toggle-current-user").click
-      expect(page).to have_css(".notification.unread.private-message", text: "Greetings!")
+      expect(page).to have_css(
+        ".notification.unread.private-message",
+        text: I18n.t("discourse_narrative_bot.new_user_narrative.hello.title"),
+      )
     end
   end
 end

--- a/plugins/discourse-narrative-bot/spec/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/user_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe User do
     stub_image_size
     Jobs.run_immediately!
     SiteSetting.discourse_narrative_bot_enabled = true
+    SiteSetting.disable_discourse_narrative_bot_welcome_post = false
   end
 
   describe "when a user is created" do


### PR DESCRIPTION
We want to temporarily disable user tips and the Discobot welcome PM
on all sites by default until we have time to improve their functionality, because
right now they create a lot of noise for new members and admins without
providing obvious benefits.
