### PR TITLE
UX: Use rotate icon for convert theme button

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
@@ -155,11 +155,6 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
   }
 
   @discourseComputed("model.component")
-  convertIcon(component) {
-    return component ? "cube" : "";
-  }
-
-  @discourseComputed("model.component")
   convertTooltip(component) {
     const type = component ? "component" : "theme";
     return `admin.customize.theme.convert_${type}_tooltip`;

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show-index.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show-index.gjs
@@ -451,7 +451,7 @@ export default RouteTemplate(
         <DButton
           @action={{@controller.switchType}}
           @label="admin.customize.theme.convert"
-          @icon={{@controller.convertIcon}}
+          @icon="rotate"
           @title={{@controller.convertTooltip}}
           class="btn-default btn-normal"
         />


### PR DESCRIPTION
Before this change, no icon is set for the button when the theme being
displayed is not a theme component. That made the UI inconsistent since
all the surrounding action buttons has an icon. Previously, a cube was
used for a theme component but we don't see how that makes sense
anymore.

Upon clicking the button, there is a confirmation dialog that indicates
to the user whether we are converting the curren theme to a component or
not.

### Screenshot

<img width="460" height="114" alt="Screenshot 2025-08-14 at 3 05 36 PM" src="https://github.com/user-attachments/assets/a31ad6ad-8ac5-4be5-a29d-e2c02aecb39a" />
