### PR TITLE
UX: sidebar btn light dark support horizon

### DIFF
--- a/themes/horizon/scss/buttons.scss
+++ b/themes/horizon/scss/buttons.scss
@@ -19,7 +19,10 @@
 
     &:hover,
     &:focus-visible {
-      background: oklch(from var(--accent-color) 40% c h) !important;
+      background: light-dark(
+        oklch(from var(--accent-color) 40% c h),
+        oklch(from var(--accent-color) 50% c h)
+      ) !important;
       box-shadow: none;
     }
 

--- a/themes/horizon/scss/sidebar-new-topic-button.scss
+++ b/themes/horizon/scss/sidebar-new-topic-button.scss
@@ -26,7 +26,11 @@
       .sidebar-new-topic-button {
         border-radius: var(--d-button-border-radius) 0 0
           var(--d-button-border-radius);
-        border-right: 1px solid var(--primary-300);
+        border-right: 1px solid
+          light-dark(
+            oklch(from var(--primary-300) l c h),
+            oklch(from var(--primary-700) l c h)
+          ) !important;
       }
     }
 


### PR DESCRIPTION
Fixes some small inconsistencies between light and dark modes and small tidyups:

1) hover effect in dark mode is different for button and dropdown (matches correctly on light mode)
2) split button divider line disappears when hovering button but not dropdown arrow (we do remove border opacity for regular buttons for split buttons we should probably keep it)
3) divider line color could be better on dark mode

### Before

Example with forced hover state on both button and dropdown arrow (see point 1):
<img width="297" height="170" alt="Screenshot 2025-08-14 at 12 39 24 PM" src="https://github.com/user-attachments/assets/156ac36f-137c-4734-85eb-fbec36322e40" />

### After


https://github.com/user-attachments/assets/a70e78a9-25b2-4f6c-89e7-d25e58bb0feb


