### PR TITLE
UX: user status emoji alignment in sidebar and chat mention

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -113,9 +113,13 @@
     .sidebar-section-link-content-text {
       @include ellipsis;
 
+      .user-status-message {
+        vertical-align: -0.125em;
+      }
+
       .emoji {
-        width: 15px;
-        height: 15px;
+        width: 1em;
+        height: 1em;
         vertical-align: baseline;
       }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -81,6 +81,14 @@
       &.highlighted {
         background: var(--tertiary-low);
       }
+
+      .user-status-message {
+        margin-left: var(--space-1);
+
+        .emoji {
+          vertical-align: middle;
+        }
+      }
     }
 
     // unlinked, invalid mention


### PR DESCRIPTION
Follow up of https://github.com/discourse/discourse/pull/33902

Fixes:
* User status in chat mentions needed a spacing
<img width="404" height="70" alt="CleanShot 2025-08-14 at 11 00 21" src="https://github.com/user-attachments/assets/3c3f3e8b-5a0a-4516-a152-c2e8a5e361e4" />

* Sidebar user status was misaligned
<img width="181" height="65" alt="CleanShot 2025-08-14 at 11 00 58" src="https://github.com/user-attachments/assets/ef86b103-1cbd-4a2d-8169-1c3ae125b8fc" />
