### PR TITLE
UX: remove wizard-specific styling and add core classes

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/wizard-step.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/wizard-step.gjs
@@ -263,7 +263,7 @@ export default class WizardStepComponent extends Component {
                 {{on "click" this.backStep}}
                 disabled={{this.saving}}
                 type="button"
-                class="wizard-container__button back"
+                class="wizard-container__button back btn-transparent"
               >
                 {{i18n "wizard.back"}}
               </button>
@@ -276,7 +276,7 @@ export default class WizardStepComponent extends Component {
                 {{on "click" this.finish}}
                 disabled={{this.saving}}
                 type="button"
-                class="wizard-container__button finish"
+                class="wizard-container__button finish btn-primary"
               >
                 {{i18n "wizard.finish"}}
               </button>
@@ -287,7 +287,7 @@ export default class WizardStepComponent extends Component {
                 {{on "click" this.jumpIn}}
                 disabled={{this.saving}}
                 type="button"
-                class="wizard-container__button primary jump-in"
+                class="wizard-container__button jump-in btn-primary"
               >
                 {{i18n "wizard.jump_in"}}
               </button>
@@ -296,7 +296,7 @@ export default class WizardStepComponent extends Component {
                 {{on "click" this.nextStep}}
                 disabled={{this.saving}}
                 type="button"
-                class="wizard-container__button primary next"
+                class="wizard-container__button next btn-primary"
               >
                 {{i18n "wizard.next"}}
               </button>

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -17,6 +17,13 @@ $blob-mobile-bg: absolute-image-url("/branded-background-mobile.svg");
   }
 }
 
+// horizon specific style
+.experimental-screen {
+  .wizard & {
+    display: none;
+  }
+}
+
 body.wizard {
   background-color: var(--secondary);
   background-image: $blob-bg;
@@ -24,7 +31,6 @@ body.wizard {
   background-repeat: no-repeat;
   background-position: bottom;
   color: var(--primary-very-high);
-  font-family: system-ui, Arial, sans-serif;
 
   .wrap {
     max-width: 100%;
@@ -272,14 +278,6 @@ body.wizard {
   }
 
   &__button {
-    border-radius: 2px;
-    border: 0;
-    padding: 0.5em;
-    transition: var(--d-button-transition);
-    text-decoration: none;
-    background-color: var(--secondary);
-    color: var(--primary-very-high);
-    cursor: pointer;
     font-size: var(--font-up-1);
   }
 
@@ -312,41 +310,10 @@ body.wizard {
     }
   }
 
-  &__button.primary:hover,
-  &__button.primary:focus {
-    background-color: var(--tertiary-hover);
-  }
-
-  &__button.primary:active {
-    background-color: var(--tertiary-high);
-  }
-
-  &__button.primary:disabled {
-    background-color: var(--tertiary-low);
-  }
-
-  &__button.jump-in {
-    &:hover {
-      background-color: var(--primary-300);
-    }
-  }
-
   &__button.finish {
-    color: var(--tertiary);
-
     @include viewport.until(sm) {
       order: 2;
     }
-  }
-
-  &__button.finish:hover {
-    color: var(--tertiary-hover);
-    background-color: transparent;
-  }
-
-  &__button.finish:active,
-  &__button.finish:disabled {
-    background-color: transparent;
   }
 
   &__button.next {


### PR DESCRIPTION
* Changed the wizard template to use standard classes for buttons.
* Removed obsolete wizard overrules for basic components
* Hid Horizon experimental layout on wizard screens

<img width="1220" height="1666" alt="image" src="https://github.com/user-attachments/assets/d090c79d-94ad-48b0-b786-16ec96ec5ecb" />
<img width="1220" height="1666" alt="image" src="https://github.com/user-attachments/assets/d027d977-6924-4123-b76d-9cc222aa6165" />
<img width="1220" height="1666" alt="image" src="https://github.com/user-attachments/assets/64262353-0e68-4fa9-b162-544fe62f2ef8" />
