### PR TITLE
UX: set emoji size to 1em

### DIFF
--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -115,8 +115,8 @@ article.post {
 }
 
 img.emoji {
-  width: 20px;
-  height: 20px;
+  width: 1em;
+  height: 1em;
 }
 
 .in-reply-to {


### PR DESCRIPTION
The default use is an emoji that matches the surrounding font-size so it makes sense to set this globally to 1em and adjust in the instances it needs to be different (which is often already in place)