### PR TITLE
UX: Improve the color picker styling

### DIFF
--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -544,7 +544,6 @@
     }
 
     .color-picker input {
-      width: 80px;
       margin-bottom: 0;
     }
 

--- a/app/assets/stylesheets/common/components/color-input.scss
+++ b/app/assets/stylesheets/common/components/color-input.scss
@@ -1,25 +1,35 @@
 .color-picker {
   display: flex;
   align-items: stretch;
+  position: relative;
+  width: 12em;
 
   .add-on {
     @include form-item-sizing;
-    background-color: var(--primary-low);
-    border-color: var(--primary-low-mid);
-    border-right-color: transparent;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
+    position: absolute;
+    pointer-events: none;
   }
 
   .hex-input {
+    border-radius: 0;
+    border-bottom-left-radius: var(--d-input-border-radius);
+    border-top-left-radius: var(--d-input-border-radius);
     margin: 0;
+    width: 50%;
+  }
+
+  .add-on + .hex-input {
+    padding-left: 1.33em;
   }
 
   .picker {
     padding: 0;
     border-left: none;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
     cursor: pointer;
     margin-bottom: 0;
     height: unset;
+    width: 50%;
   }
 }


### PR DESCRIPTION
before/after

#### hex-only (`#` is just visual, not selectable)

<img width="548" height="201" alt="Screenshot 2025-08-14 at 15 36 40" src="https://github.com/user-attachments/assets/ff9b6ca7-d163-44e8-9498-48e86d2f0806" />
<img width="551" height="216" alt="Screenshot 2025-08-14 at 17 20 15" src="https://github.com/user-attachments/assets/9e3b06f3-f185-4a40-a395-0d748849384a" />

#### regular

<img width="615" height="188" alt="Screenshot 2025-08-14 at 17 11 28" src="https://github.com/user-attachments/assets/61a72417-d1ff-4466-88cc-ee44599bec28" />
<img width="612" height="184" alt="Screenshot 2025-08-14 at 17 19 50" src="https://github.com/user-attachments/assets/ce8e04f1-4d72-489d-b734-d9412d8ea7a8" />
