### PR TITLE
UX: don't highlight admin content on hover if it isn't clickable

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
@@ -13,6 +13,11 @@ import element from "discourse/helpers/element";
 import { i18n } from "discourse-i18n";
 
 export default class AdminSectionLandingItem extends Component {
+  wrapperElement = (hasButtons) => {
+    const makeClickable = this.args.titleRoute && !hasButtons;
+    return makeClickable ? LinkTo : element("div");
+  };
+
   get title() {
     if (this.args.titleLabelTranslated) {
       return this.args.titleLabelTranslated;
@@ -35,11 +40,6 @@ export default class AdminSectionLandingItem extends Component {
     } else if (this.args.taglineLabel) {
       return i18n(this.args.taglineLabel);
     }
-  }
-
-  wrapperElement(hasButtons) {
-    const makeClickable = this.args.titleRoute && !hasButtons;
-    return makeClickable ? LinkTo : element("div");
   }
 
   <template>

--- a/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-section-landing-item.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
+import { and } from "truth-helpers";
 import {
   DangerButton,
   DefaultButton,
@@ -8,6 +9,7 @@ import {
 } from "discourse/components/d-page-action-button";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import element from "discourse/helpers/element";
 import { i18n } from "discourse-i18n";
 
 export default class AdminSectionLandingItem extends Component {
@@ -35,50 +37,69 @@ export default class AdminSectionLandingItem extends Component {
     }
   }
 
+  wrapperElement(hasButtons) {
+    const makeClickable = this.args.titleRoute && !hasButtons;
+    return makeClickable ? LinkTo : element("div");
+  }
+
   <template>
-    <div
-      class={{concatClass "admin-section-landing-item" (if @icon "-has-icon")}}
-      ...attributes
-    >
-      {{#if @imageUrl}}
-        <img class="admin-section-landing-item__image" src={{@imageUrl}} />
-      {{/if}}
-      {{#if @icon}}
-        <div class="admin-section-landing-item__icon">
-          {{icon @icon}}
-        </div>
-      {{/if}}
-      <div class="admin-section-landing-item__content">
-        {{#if this.tagline}}
-          <h4 class="admin-section-landing-item__tagline">{{this.tagline}}</h4>
-        {{/if}}
-
-        {{#if @titleRoute}}
-          {{#if @titleRouteModel}}
-            <LinkTo @route={{@titleRoute}} @model={{@titleRouteModel}}><h3
-                class="admin-section-landing-item__title"
-              >{{this.title}}</h3></LinkTo>
-          {{else}}
-            <LinkTo @route={{@titleRoute}}><h3
-                class="admin-section-landing-item__title"
-              >{{this.title}}</h3></LinkTo>
+    {{#let (has-block "buttons") as |hasButtons|}}
+      {{! When there are no nested buttons, the entire component is a link }}
+      {{#let (this.wrapperElement hasButtons) as |WrapperComponent|}}
+        <WrapperComponent
+          @route={{@titleRoute}}
+          @model={{@titleRouteModel}}
+          class={{concatClass
+            "admin-section-landing-item"
+            (if @icon "--has-icon")
+          }}
+          ...attributes
+        >
+          {{#if @imageUrl}}
+            <img class="admin-section-landing-item__image" src={{@imageUrl}} />
           {{/if}}
+          {{#if @icon}}
+            <div class="admin-section-landing-item__icon">
+              {{icon @icon}}
+            </div>
+          {{/if}}
+          <div class="admin-section-landing-item__content">
+            {{#if this.tagline}}
+              <h4
+                class="admin-section-landing-item__tagline"
+              >{{this.tagline}}</h4>
+            {{/if}}
 
-        {{else}}
-          <h3 class="admin-section-landing-item__title">{{this.title}}</h3>
-        {{/if}}
+            {{#if (and @titleRoute hasButtons)}}
+              {{! Individual title is a link when buttons exist}}
+              <LinkTo @route={{@titleRoute}} @model={{@titleRouteModel}}>
+                <h3
+                  class="admin-section-landing-item__title"
+                >{{this.title}}</h3>
+              </LinkTo>
+            {{else}}
+              <h3 class="admin-section-landing-item__title">{{this.title}}</h3>
+            {{/if}}
 
-        <p
-          class="admin-section-landing-item__description"
-        >{{this.description}}</p>
-      </div>
+            <p class="admin-section-landing-item__description">
+              {{this.description}}
+            </p>
+          </div>
 
-      <div class="admin-section-landing-item__buttons">
-        {{yield
-          (hash Primary=PrimaryButton Default=DefaultButton Danger=DangerButton)
-          to="buttons"
-        }}
-      </div>
-    </div>
+          {{#if hasButtons}}
+            <div class="admin-section-landing-item__buttons">
+              {{yield
+                (hash
+                  Primary=PrimaryButton
+                  Default=DefaultButton
+                  Danger=DangerButton
+                )
+                to="buttons"
+              }}
+            </div>
+          {{/if}}
+        </WrapperComponent>
+      {{/let}}
+    {{/let}}
   </template>
 }

--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -124,10 +124,6 @@ $mobile-breakpoint: 700px;
     padding: 8px;
   }
 
-  tr:hover {
-    background-color: var(--primary-very-low);
-  }
-
   tr.selected {
     background-color: var(--primary-low);
   }

--- a/app/assets/stylesheets/admin/admin_report.scss
+++ b/app/assets/stylesheets/admin/admin_report.scss
@@ -241,7 +241,6 @@
     padding-top: 0;
 
     .admin-section-landing-item {
-      padding: var(--space-4);
       border-radius: var(--d-border-radius);
       border: 1px solid var(--content-border-color);
       margin-bottom: 0;

--- a/app/assets/stylesheets/admin/admin_section_landing_page.scss
+++ b/app/assets/stylesheets/admin/admin_section_landing_page.scss
@@ -14,13 +14,16 @@
     grid-row: span 2;
     gap: 0;
     margin-bottom: 2em;
+    padding: var(--space-4);
+    color: var(--primary);
 
     @include viewport.from(sm) {
       margin-bottom: 2em;
     }
 
-    &.-has-icon {
+    &.--has-icon {
       grid-template-columns: 1fr 8fr;
+      gap: 0 var(--space-4);
 
       .admin-section-landing-item__buttons {
         grid-column: 2;

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -246,10 +246,6 @@
   display: flex;
   flex-direction: column;
 
-  &:hover {
-    border-color: var(--tertiary-medium);
-  }
-
   .admin-config-area-card__content {
     margin: 0;
     padding-right: 0;

--- a/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
+++ b/plugins/discourse-ai/assets/stylesheets/common/ai-features.scss
@@ -25,7 +25,6 @@
   background: var(--secondary);
   border: 1px solid var(--primary-low);
   border-radius: var(--d-border-radius);
-  padding: var(--space-3) var(--space-4) var(--space-2);
   display: flex;
   flex-direction: column;
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-persona.scss
@@ -185,10 +185,6 @@
     }
 
     &__row {
-      &:hover {
-        background: transparent;
-      }
-
       &__overview {
         padding-left: var(--space-2);
       }

--- a/plugins/discourse-ai/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/llms/common/ai-llms-editor.scss
@@ -50,10 +50,6 @@
 .ai-persona-list-editor__current,
 .ai-llms-list-editor__configured {
   .d-admin-table {
-    tr:hover {
-      background: inherit;
-    }
-
     @include viewport.from(md) {
       th,
       td {


### PR DESCRIPTION
This resolves a number of cases where we were highlighting content on hover that isn't clickable. 


Common table example

Before:
<img width="1726" height="548" alt="image" src="https://github.com/user-attachments/assets/24635052-0efd-4c02-b75b-dc3901acd799" />


After:
<img width="1744" height="550" alt="image" src="https://github.com/user-attachments/assets/73837bff-532b-48ec-99de-2e579221eccb" />




Reports are a case where the box *should* be clickable, so I kept the hover effect and made the box clickable via changes to `admin-section-landing-item`... 

Before: 
<img width="1710" height="838" alt="image" src="https://github.com/user-attachments/assets/a8bc8f67-5f1f-44c1-8de7-e64c1a60fd49" />


After (removed the blue because the headings aren't actually links anymore, the whole box is): 
<img width="1732" height="922" alt="image" src="https://github.com/user-attachments/assets/2fb5b63a-1cdc-4fc9-906a-c343c26cd025" />

In cases where these boxes have buttons, the inner title (if linked) and buttons are clickable, not the box... 

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/3bf04522-179b-49e6-ae0a-f5d3714b94ec" />



