### PR TITLE
UX: fix category dropdown size in title editor

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -276,6 +276,10 @@
 
     .select-kit.combo-box.category-chooser {
       width: 100%;
+
+      .badge-category__wrapper {
+        font-size: var(--font-0);
+      }
     }
   }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -276,10 +276,7 @@
 
     .select-kit.combo-box.category-chooser {
       width: 100%;
-
-      .badge-category__wrapper {
-        font-size: var(--font-0);
-      }
+      height: 100%;
     }
   }
 


### PR DESCRIPTION
This category dropdown can become a little too short at different font scales, this fixes it. 

Before: 
<img width="1584" height="262" alt="image" src="https://github.com/user-attachments/assets/16bcef3a-3231-4433-8ec2-bbf9aa51676b" />


After:
<img width="1600" height="272" alt="image" src="https://github.com/user-attachments/assets/41caa8cf-ef54-4ce4-893c-436d4d91abd1" />
