### PR TITLE
DEV: Remove redundant newlines in generated indexes

### DIFF
--- a/migrations/lib/database/schema/table_writer.rb
+++ b/migrations/lib/database/schema/table_writer.rb
@@ -88,12 +88,12 @@ module Migrations::Database::Schema
     def output_indexes(table)
       return unless table.indexes
 
+      @output.puts ""
       table.indexes.each do |index|
         index_name = escape_identifier(index.name)
         table_name = escape_identifier(table.name)
         column_names = index.column_names.map { |name| escape_identifier(name) }
 
-        @output.puts ""
         @output.print "CREATE "
         @output.print "UNIQUE " if index.unique
         @output.print "INDEX #{index_name} ON #{table_name} (#{column_names.join(", ")})"


### PR DESCRIPTION
Before:
```sql
CREATE TABLE muted_users
(
    created_at    DATETIME,
    muted_user_id NUMERIC  NOT NULL,
    user_id       NUMERIC  NOT NULL
);

CREATE TABLE user_custom_fields
(
    created_at           DATETIME,
    field_id             NUMERIC,
    is_multiselect_field BOOLEAN,
    name                 TEXT     NOT NULL,
    user_id              NUMERIC  NOT NULL,
    value                TEXT
);

CREATE UNIQUE INDEX ucf_multiselect_by_field_id_index ON user_custom_fields (user_id, field_id, value) WHERE is_multiselect_field = TRUE AND field_id IS NOT NULL;

CREATE UNIQUE INDEX ucf_not_multiselect_by_field_id_index ON user_custom_fields (user_id, field_id) WHERE is_multiselect_field = FALSE AND field_id IS NOT NULL;

CREATE UNIQUE INDEX ucf_multiselect_by_name_index ON user_custom_fields (user_id, name, value) WHERE is_multiselect_field = TRUE;

CREATE UNIQUE INDEX ucf_not_multiselect_by_name_index ON user_custom_fields (user_id, name) WHERE is_multiselect_field = FALSE;

CREATE TABLE user_emails
(
    email      TEXT     NOT NULL,
    user_id    NUMERIC  NOT NULL,
    created_at DATETIME,
    "primary"  BOOLEAN,
    PRIMARY KEY (user_id, email)
);
```

After:
```sql
CREATE TABLE muted_users
(
    created_at    DATETIME,
    muted_user_id NUMERIC  NOT NULL,
    user_id       NUMERIC  NOT NULL
);

CREATE TABLE user_custom_fields
(
    created_at           DATETIME,
    field_id             NUMERIC,
    is_multiselect_field BOOLEAN,
    name                 TEXT     NOT NULL,
    user_id              NUMERIC  NOT NULL,
    value                TEXT
);

CREATE UNIQUE INDEX ucf_multiselect_by_field_id_index ON user_custom_fields (user_id, field_id, value) WHERE is_multiselect_field = TRUE AND field_id IS NOT NULL; 
CREATE UNIQUE INDEX ucf_not_multiselect_by_field_id_index ON user_custom_fields (user_id, field_id) WHERE is_multiselect_field = FALSE AND field_id IS NOT NULL; 
CREATE UNIQUE INDEX ucf_multiselect_by_name_index ON user_custom_fields (user_id, name, value) WHERE is_multiselect_field = TRUE; 
CREATE UNIQUE INDEX ucf_not_multiselect_by_name_index ON user_custom_fields (user_id, name) WHERE is_multiselect_field = FALSE;

CREATE TABLE user_emails
(
    email      TEXT     NOT NULL,
    user_id    NUMERIC  NOT NULL,
    created_at DATETIME,
    "primary"  BOOLEAN,
    PRIMARY KEY (user_id, email)
);
```