### PR TITLE
UX: Update copy from Active -> Default for themes + palettes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/color-palette-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-palette-list-item.gjs
@@ -59,24 +59,24 @@ export default class ColorPaletteListItem extends Component {
     );
   }
 
-  get activeBadgeTitle() {
+  get defaultBadgeTitle() {
     if (this.isDefaultLight && this.isDefaultDark) {
-      return i18n("admin.customize.colors.active_both_badge.title");
+      return i18n("admin.customize.colors.default_both_badge.title");
     }
     if (this.isDefaultLight) {
-      return i18n("admin.customize.colors.active_light_badge.title");
+      return i18n("admin.customize.colors.default_light_badge.title");
     }
-    return i18n("admin.customize.colors.active_dark_badge.title");
+    return i18n("admin.customize.colors.default_dark_badge.title");
   }
 
-  get activeBadgeText() {
+  get defaultBadgeText() {
     if (this.isDefaultLight && this.isDefaultDark) {
-      return i18n("admin.customize.colors.active_both_badge.text");
+      return i18n("admin.customize.colors.default_both_badge.text");
     }
     if (this.isDefaultLight) {
-      return i18n("admin.customize.colors.active_light_badge.text");
+      return i18n("admin.customize.colors.default_light_badge.text");
     }
-    return i18n("admin.customize.colors.active_dark_badge.text");
+    return i18n("admin.customize.colors.default_dark_badge.text");
   }
 
   @bind
@@ -143,10 +143,10 @@ export default class ColorPaletteListItem extends Component {
 
           {{#if (or this.isDefaultLight this.isDefaultDark)}}
             <span
-              title={{this.activeBadgeTitle}}
-              class="theme-card__badge --active"
+              title={{this.defaultBadgeTitle}}
+              class="theme-card__badge --default"
             >
-              {{this.activeBadgeText}}
+              {{this.defaultBadgeText}}
             </span>
           {{/if}}
         </div>

--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -27,7 +27,7 @@ export default class ThemeCard extends Component {
   get themeCardClasses() {
     return [
       "theme-card",
-      this.args.theme.get("default") ? "-active" : "",
+      this.args.theme.get("default") ? "--default" : "",
       this.isUpdating ? "--updating" : "",
       dasherize(this.args.theme.name),
     ].join(" ");
@@ -137,7 +137,7 @@ export default class ThemeCard extends Component {
       <:content>
         {{#if @theme.default}}
           <span
-            class="theme-card__badge --active"
+            class="theme-card__badge --default"
             title={{i18n "admin.customize.theme.default_theme"}}
           >
             {{i18n "admin.customize.theme.default"}}
@@ -208,7 +208,7 @@ export default class ThemeCard extends Component {
                         @action={{this.setDefault}}
                         @preventFocus={{true}}
                         @icon={{if @theme.default "star" "far-star"}}
-                        class="theme-card__button set-active"
+                        class="theme-card__button set-default"
                         @translatedLabel={{i18n
                           (if
                             @theme.default

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -80,7 +80,7 @@
     flex-grow: 1;
   }
 
-  &.-active {
+  &.--default {
     @include theme-card-border(tertiary);
   }
 
@@ -203,7 +203,7 @@
       color: var(--primary-high);
     }
 
-    &.--active {
+    &.--default {
       background-color: var(--tertiary);
       color: var(--secondary);
       position: absolute;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6905,7 +6905,7 @@ en:
           extra_files_upload: "Export theme to view these files."
           extra_files_remote: "Export theme or check the git repository to view these files."
           preview: "Preview"
-          default: "Active"
+          default: "Default"
           settings_editor: "Settings Editor"
           show_advanced: "Show advanced"
           is_default: "Theme is enabled by default"
@@ -6933,8 +6933,8 @@ en:
           convert_theme_alert_generic: "Are you sure you want to convert this theme to component?"
           convert_theme_tooltip: "Convert this theme to component"
           inactive_themes: "Inactive themes:"
-          set_default_theme: "Set as active"
-          default_theme: "Active theme"
+          set_default_theme: "Set as default"
+          default_theme: "Default theme"
           set_default_success: "Default theme set to %{theme}"
           setting_was_saved: "Theme setting was saved"
           install_success: "%{theme} installed successfully!"
@@ -7123,7 +7123,7 @@ en:
           edit: "Edit"
           set_default_light: "Set as light palette on default theme (%{theme})"
           set_default_dark: "Set as dark palette on default theme (%{theme})"
-          set_default_success: "%{schemeName} set as active palette for %{themeName}"
+          set_default_success: "%{schemeName} set as default palette for %{themeName}"
           saved_refreshing: "Saved! Refreshing colors..."
           from_theme: "From theme: %{name}"
           filters:
@@ -7132,16 +7132,16 @@ en:
             user_selectable: "User selectable"
             from_theme: "From theme"
             no_results: "No color palettes found"
-          active_light_badge:
-            text: "Active light"
-            title: "Active light color palette"
+          default_light_badge:
+            text: "Default light"
+            title: "Default light color palette"
             reset: "Reset filters"
-          active_dark_badge:
-            text: "Active dark"
-            title: "Active light color palette"
-          active_both_badge:
-            text: "Active light and dark"
-            title: "Active light and dark color palette"
+          default_dark_badge:
+            text: "Default dark"
+            title: "Default light color palette"
+          default_both_badge:
+            text: "Default light and dark"
+            title: "Default light and dark color palette"
           system_palette: "This is a built-in color palette, it cannot be edited or deleted."
           back_to_colors: "Back to color palettes"
           long_title: "Color palettes"

--- a/spec/system/admin_color_palettes_features_spec.rb
+++ b/spec/system/admin_color_palettes_features_spec.rb
@@ -157,8 +157,8 @@ describe "Admin Color Palettes Features", type: :system do
 
       within("[data-palette-id='#{regular_palette.id}']") do
         expect(page).to have_css(
-          ".theme-card__badge.--active",
-          text: I18n.t("admin_js.admin.customize.colors.active_light_badge.text").upcase,
+          ".theme-card__badge.--default",
+          text: I18n.t("admin_js.admin.customize.colors.default_light_badge.text").upcase,
         )
       end
 
@@ -175,8 +175,8 @@ describe "Admin Color Palettes Features", type: :system do
 
       within("[data-palette-id='#{regular_palette.id}']") do
         expect(page).to have_css(
-          ".theme-card__badge.--active",
-          text: I18n.t("admin_js.admin.customize.colors.active_both_badge.text").upcase,
+          ".theme-card__badge.--default",
+          text: I18n.t("admin_js.admin.customize.colors.default_both_badge.text").upcase,
         )
       end
     end

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -37,13 +37,13 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     expect(page).to have_current_path("/admin/config/customize/themes")
   end
 
-  it "allows to mark theme as active" do
+  it "allows to mark theme as default" do
     config_area.visit
-    expect(config_area).to have_badge(foundation_theme, "--active")
-    expect(config_area).to have_no_badge(theme_2, "--active")
-    config_area.mark_as_active(theme_2)
-    expect(config_area).to have_badge(theme_2, "--active")
-    expect(config_area).to have_no_badge(foundation_theme, "--active")
+    expect(config_area).to have_badge(foundation_theme, "--default")
+    expect(config_area).to have_no_badge(theme_2, "--default")
+    config_area.mark_as_default(theme_2)
+    expect(config_area).to have_badge(theme_2, "--default")
+    expect(config_area).to have_no_badge(foundation_theme, "--default")
   end
 
   it "allows to make theme selectable by users" do

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -19,9 +19,9 @@ module PageObjects
         find_theme_card(theme).find(".theme-card__footer-menu-trigger").click
       end
 
-      def mark_as_active(theme)
+      def mark_as_default(theme)
         open_theme_menu(theme)
-        find(".set-active").click
+        find(".set-default").click
       end
 
       def has_badge?(theme, badge)


### PR DESCRIPTION
Active is a confusing term to use for the default theme
and color palette in the admin UI.

This commit updates the copy for consistency
to use Default instead of Active to reflect the code
and the way people think about how this works generally.

**Before**

<img width="414" height="604" alt="image" src="https://github.com/user-attachments/assets/80059093-1c3d-44e5-82f6-9b608e991afa" />
<img width="409" height="209" alt="image" src="https://github.com/user-attachments/assets/7695a256-1cf9-42c0-bae8-d69cc0b67914" />
<img width="914" height="709" alt="image" src="https://github.com/user-attachments/assets/ed7d5a69-f736-42d9-9c60-b328d3922534" />


**After**

<img width="432" height="500" alt="image" src="https://github.com/user-attachments/assets/2f65b7a5-8c85-4328-926a-07dbf05ddc19" />
<img width="381" height="245" alt="image" src="https://github.com/user-attachments/assets/a7420484-ed57-4e0e-a5e0-c2fe067a15ef" />
<img width="834" height="610" alt="image" src="https://github.com/user-attachments/assets/1567544f-203e-4e9e-9e74-e828de08ad0b" />

