### PR TITLE
FIX: Prioritize default light and dark palette in admin

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -132,28 +132,58 @@ export default class AdminCustomizeColorsController extends Controller {
     }
 
     const defaultThemeId = this.defaultTheme?.id;
+    const defaultLightId = this.defaultTheme?.color_scheme_id;
+    const defaultDarkId = this.defaultTheme?.dark_color_scheme_id;
 
     schemes.sort((a, b) => {
-      // 1. Sort by user selectable first
+      // 1. Display active light
+      if (
+        defaultLightId === null &&
+        (a.is_builtin_default || b.is_builtin_default)
+      ) {
+        return a.is_builtin_default ? -1 : 1;
+      }
+      if (
+        (defaultLightId === a.id && !a.is_builtin_default) ||
+        (defaultLightId === b.id && !b.is_builtin_default)
+      ) {
+        return defaultLightId === a.id ? -1 : 1;
+      }
+
+      // 2. Display active dark
+      if (
+        defaultDarkId === null &&
+        (a.is_builtin_default || b.is_builtin_default)
+      ) {
+        return a.is_builtin_default ? -1 : 1;
+      }
+      if (
+        (defaultDarkId === a.id && !a.is_builtin_default) ||
+        (defaultDarkId === b.id && !b.is_builtin_default)
+      ) {
+        return defaultDarkId === a.id ? -1 : 1;
+      }
+
+      // 3. Sort by user selectable first
       if (a.user_selectable !== b.user_selectable) {
         return a.user_selectable ? -1 : 1;
       }
 
-      // 2. Sort custom schemes (no theme) before themed schemes
+      // 4. Sort custom schemes (no theme) before themed schemes
       const aIsCustom = !a.theme_id && !a.is_builtin_default;
       const bIsCustom = !b.theme_id && !b.is_builtin_default;
       if (aIsCustom !== bIsCustom) {
         return aIsCustom ? -1 : 1;
       }
 
-      // 3. Prioritize schemes from the current default theme
+      // 5. Prioritize schemes from the current default theme
       const aIsFromDefaultTheme = a.theme_id === defaultThemeId;
       const bIsFromDefaultTheme = b.theme_id === defaultThemeId;
       if (aIsFromDefaultTheme !== bIsFromDefaultTheme) {
         return aIsFromDefaultTheme ? -1 : 1;
       }
 
-      // 4. Finally, sort alphabetically by name
+      // 6. Finally, sort alphabetically by name
       return (a.originals.name || "").localeCompare(b.originals.name || "");
     });
 

--- a/spec/system/admin_color_palettes_features_spec.rb
+++ b/spec/system/admin_color_palettes_features_spec.rb
@@ -65,6 +65,8 @@ describe "Admin Color Palettes Features", type: :system do
   let(:selectable_custom_scheme_b) do
     Fabricate(:color_scheme, name: "Selectable custom scheme b", user_selectable: true)
   end
+  let(:default_light_scheme) { Fabricate(:color_scheme, name: "Default light") }
+  let(:default_dark_scheme) { Fabricate(:color_scheme, name: "Default dark") }
 
   before { sign_in(admin) }
 
@@ -209,6 +211,12 @@ describe "Admin Color Palettes Features", type: :system do
       selectable_horizon_theme_scheme_b
       selectable_custom_scheme_a
       selectable_custom_scheme_b
+      default_light_scheme
+      default_dark_scheme
+      Theme.horizon_theme.update!(
+        color_scheme: default_light_scheme,
+        dark_color_scheme: default_dark_scheme,
+      )
     end
     it "sorts schemes in order: selectable, custom, current default theme, alphabetical for horizon theme" do
       SiteSetting.default_theme_id = Theme.horizon_theme.id
@@ -216,6 +224,8 @@ describe "Admin Color Palettes Features", type: :system do
       color_schemes = page.all(".color-palette__details h3").map(&:text)
       expect(color_schemes).to eq(
         [
+          "Default light",
+          "Default dark",
           "Selectable custom scheme a",
           "Selectable custom scheme b",
           "Selectable horizon scheme a",
@@ -239,6 +249,7 @@ describe "Admin Color Palettes Features", type: :system do
       color_schemes = page.all(".color-palette__details h3").map(&:text)
       expect(color_schemes).to eq(
         [
+          "Light (default)",
           "Selectable custom scheme a",
           "Selectable custom scheme b",
           "Selectable foundation scheme a",
@@ -247,9 +258,10 @@ describe "Admin Color Palettes Features", type: :system do
           "Selectable horizon scheme b",
           "Custom scheme a",
           "Custom scheme b",
+          "Default dark",
+          "Default light",
           "Foundation scheme a",
           "Foundation scheme b",
-          "Light (default)",
           "Horizon scheme a",
           "Horizon scheme b",
         ],


### PR DESCRIPTION
Update color palette sorting algorithm to display active light and dark palettes first