### PR TITLE
FIX: Incorrect site setting link for plugins in admin search

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -48,7 +48,16 @@ function fabricateVisiblePlugins() {
     {
       name: "discourse-calendar",
       humanized_name: "Calendar",
-      enabled: false,
+      enabled: true,
+      admin_route: {
+        auto_generated: false,
+        // Dummy value so the router works, usually this is `adminPlugins.calendar`
+        full_location: "adminPlugins.show",
+        label: "admin.calendar",
+        // Dummy value so the router works, usually this is `calendar`
+        location: "index",
+        use_new_show_route: false,
+      },
       description:
         "Adds the ability to create a dynamic calendar with events in a topic.",
     },
@@ -321,7 +330,14 @@ module(
 
     hooks.beforeEach(function () {
       this.router = getOwner(this).lookup("service:router");
-      this.plugins = { chat: fabricateVisiblePlugins()[0] };
+
+      const visiblePlugins = fabricateVisiblePlugins();
+
+      this.plugins = {
+        chat: visiblePlugins[0],
+        "discourse-new-features-feeds": visiblePlugins[1],
+        "discourse-calendar": visiblePlugins[2],
+      };
     });
 
     test("label is correct for a setting that comes from a plugin", async function (assert) {
@@ -403,6 +419,24 @@ module(
         formatter.format().url,
         "/admin/plugins/chat/settings?filter=enable_chat",
         "url uses the plugin admin route location and setting"
+      );
+    });
+
+    test("url is correct for a setting that belongs to a plugin not using the new show page", async function (assert) {
+      let setting = {
+        plugin: "discourse-calendar",
+        setting: "calendar_enabled",
+      };
+      let formatter = new SettingLinkFormatter(
+        this.router,
+        setting,
+        this.plugins,
+        {}
+      );
+      assert.deepEqual(
+        formatter.format().url,
+        "/admin/site_settings/category/discourse_calendar?filter=calendar_enabled",
+        "url uses the admin site settings category and setting"
       );
     });
 

--- a/lib/site_settings/label_formatter.rb
+++ b/lib/site_settings/label_formatter.rb
@@ -10,6 +10,7 @@ module SiteSettings
       cdn
       cors
       cta
+      cx
       dm
       eu
       faq
@@ -27,6 +28,7 @@ module SiteSettings
       jpg
       json
       kb
+      llm
       mb
       oidc
       pm
@@ -35,6 +37,7 @@ module SiteSettings
       s3
       smtp
       svg
+      tei
       tl
       tl0
       tl1
@@ -66,6 +69,7 @@ module SiteSettings
       %w[japanese Japanese],
       %w[linkedin LinkedIn],
       %w[oauth2 OAuth2],
+      %w[openai OpenAI],
       %w[opengraph OpenGraph],
       ["powered by discourse", "Powered by Discourse"],
       %w[tiktok TikTok],


### PR DESCRIPTION
In the admin search, links to site settings for plugins that
are not using the new show page for plugins were pointing to
the admin route for the plugin. This is not useful, because most
plugins do not show their site settings here.

Instead, we should link to the plugin category on the /admin/site_settings
route.

This was first noticed with this setting:

<img width="958" height="226" alt="image" src="https://github.com/user-attachments/assets/f2a22919-03ba-43f2-82b3-6304c12fae04" />

