### PR TITLE
DEV: Replace <Input /> text usage in plugins

### DIFF
--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/components/create-coupon-form.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/components/create-coupon-form.gjs
@@ -1,8 +1,10 @@
 /* eslint-disable ember/no-classic-components */
 import Component, { Input } from "@ember/component";
 import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
+import withEventValue from "discourse/helpers/with-event-value";
 import discourseComputed from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -45,7 +47,12 @@ export default class CreateCouponForm extends Component {
           <label for="promo_code">
             {{i18n "discourse_subscriptions.admin.coupons.promo_code"}}
           </label>
-          <Input @type="text" name="promo_code" @value={{this.promoCode}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.promoCode)))}}
+            type="text"
+            name="promo_code"
+            value={{this.promoCode}}
+          />
         </p>
 
         <p>
@@ -57,11 +64,12 @@ export default class CreateCouponForm extends Component {
             @value={{this.discountType}}
             @onChange={{fn (mut this.discountType)}}
           />
-          <Input
+          <input
+            {{on "input" (withEventValue (fn (mut this.discount)))}}
             class="discount-amount"
-            @type="text"
+            type="text"
             name="amount"
-            @value={{this.discount}}
+            value={{this.discount}}
           />
         </p>
 

--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show-plans-show.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show-plans-show.gjs
@@ -3,6 +3,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";
+import withEventValue from "discourse/helpers/with-event-value";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
 
@@ -16,10 +17,14 @@ export default RouteTemplate(
           {{i18n "discourse_subscriptions.admin.products.product.name"}}
         </label>
 
-        <Input
-          @type="text"
+        <input
+          {{on
+            "input"
+            (withEventValue (fn (mut @controller.model.product.name)))
+          }}
+          type="text"
           name="product_name"
-          @value={{@controller.model.product.name}}
+          value={{@controller.model.product.name}}
           disabled={{true}}
         />
       </p>
@@ -29,10 +34,14 @@ export default RouteTemplate(
           {{i18n "discourse_subscriptions.admin.plans.plan.nickname"}}
         </label>
 
-        <Input
-          @type="text"
+        <input
+          {{on
+            "input"
+            (withEventValue (fn (mut @controller.model.plan.nickname)))
+          }}
+          type="text"
           name="name"
-          @value={{@controller.model.plan.nickname}}
+          value={{@controller.model.plan.nickname}}
         />
 
         <div class="control-instructions">
@@ -63,10 +72,11 @@ export default RouteTemplate(
         </label>
 
         {{#if @controller.planFieldDisabled}}
-          <Input
+          <input
             class="plan-amount plan-currency"
             disabled={{true}}
-            @value={{@controller.model.plan.currency}}
+            type="text"
+            value={{@controller.model.plan.currency}}
           />
         {{else}}
           <ComboBox
@@ -77,11 +87,15 @@ export default RouteTemplate(
           />
         {{/if}}
 
-        <Input
+        <input
+          {{on
+            "input"
+            (withEventValue (fn (mut @controller.model.plan.amountDollars)))
+          }}
           class="plan-amount"
-          @type="text"
+          type="text"
           name="name"
-          @value={{@controller.model.plan.amountDollars}}
+          value={{@controller.model.plan.amountDollars}}
           disabled={{@controller.planFieldDisabled}}
         />
       </p>
@@ -115,7 +129,11 @@ export default RouteTemplate(
           </label>
 
           {{#if @controller.planFieldDisabled}}
-            <Input disabled={{true}} @value={{@controller.selectedInterval}} />
+            <input
+              disabled={{true}}
+              type="text"
+              value={{@controller.selectedInterval}}
+            />
           {{else}}
             <ComboBox
               @valueProperty="name"
@@ -132,10 +150,16 @@ export default RouteTemplate(
             ({{i18n "discourse_subscriptions.optional"}})
           </label>
 
-          <Input
-            @type="text"
+          <input
+            {{on
+              "input"
+              (withEventValue
+                (fn (mut @controller.model.plan.trial_period_days))
+              )
+            }}
+            type="text"
             name="trial"
-            @value={{@controller.model.plan.trial_period_days}}
+            value={{@controller.model.plan.trial_period_days}}
           />
 
           <div class="control-instructions">

--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.gjs
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-classic-components */
-import Component, { Input, Textarea } from "@ember/component";
+import Component, { Textarea } from "@ember/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import EmberObject, { action } from "@ember/object";
@@ -15,6 +15,7 @@ import InputTip from "discourse/components/input-tip";
 import RadioButton from "discourse/components/radio-button";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import withEventValue from "discourse/helpers/with-event-value";
 import discourseComputed from "discourse/lib/decorators";
 import autoFocus from "discourse/modifiers/auto-focus";
 import { i18n } from "discourse-i18n";
@@ -476,7 +477,11 @@ export default class PollUiBuilderModal extends Component {
             <label class="input-group-label">{{i18n
                 "poll.ui_builder.poll_title.label"
               }}</label>
-            <Input @value={{this.pollTitle}} />
+            <input
+              {{on "input" (withEventValue (fn (mut this.pollTitle)))}}
+              type="text"
+              value={{this.pollTitle}}
+            />
           </div>
         {{/if}}
 
@@ -540,9 +545,10 @@ export default class PollUiBuilderModal extends Component {
               <label class="input-group-label">{{i18n
                   "poll.ui_builder.poll_config.min"
                 }}</label>
-              <Input
-                @type="number"
-                @value={{this.pollMin}}
+              <input
+                {{on "input" (withEventValue (fn (mut this.pollMin)))}}
+                type="number"
+                value={{this.pollMin}}
                 class="poll-options-min"
                 min="1"
               />
@@ -552,9 +558,10 @@ export default class PollUiBuilderModal extends Component {
               <label class="input-group-label">{{i18n
                   "poll.ui_builder.poll_config.max"
                 }}</label>
-              <Input
-                @type="number"
-                @value={{this.pollMax}}
+              <input
+                {{on "input" (withEventValue (fn (mut this.pollMax)))}}
+                type="number"
+                value={{this.pollMax}}
                 class="poll-options-max"
                 min="1"
               />
@@ -565,9 +572,10 @@ export default class PollUiBuilderModal extends Component {
                 <label class="input-group-label">{{i18n
                     "poll.ui_builder.poll_config.step"
                   }}</label>
-                <Input
-                  @type="number"
-                  @value={{this.pollStep}}
+                <input
+                  {{on "input" (withEventValue (fn (mut this.pollStep)))}}
+                  type="number"
+                  value={{this.pollStep}}
                   min="1"
                   class="poll-options-step"
                 />

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/menus.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/menus.gjs
@@ -1,12 +1,13 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
+import withEventValue from "discourse/helpers/with-event-value";
 import DMenu from "float-kit/components/d-menu";
 import { MENU } from "float-kit/lib/constants";
 import DummyComponent from "discourse/plugins/styleguide/discourse/components/dummy-component";
@@ -189,25 +190,53 @@ export default class Menus extends Component {
 
       <Controls>
         <Row @name="Example label">
-          <Input @value={{this.label}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.label)))}}
+            type="text"
+            value={{this.label}}
+          />
         </Row>
         <Row @name="[@content]">
-          <Input @value={{this.content}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.content)))}}
+            type="text"
+            value={{this.content}}
+          />
         </Row>
         <Row @name="[@identifier]">
-          <Input @value={{this.identifier}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.identifier)))}}
+            type="text"
+            value={{this.identifier}}
+          />
         </Row>
         <Row @name="[@offset]">
-          <Input @value={{this.offset}} @type="number" />
+          <input
+            {{on "input" (withEventValue (fn (mut this.offset)))}}
+            type="number"
+            value={{this.offset}}
+          />
         </Row>
         <Row @name="[@triggers]">
-          <Input @value={{this.triggers}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.triggers)))}}
+            type="text"
+            value={{this.triggers}}
+          />
         </Row>
         <Row @name="[@untriggers]">
-          <Input @value={{this.untriggers}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.untriggers)))}}
+            type="text"
+            value={{this.untriggers}}
+          />
         </Row>
         <Row @name="[@maxWidth]">
-          <Input @value={{this.maxWidth}} @type="number" />
+          <input
+            {{on "input" (withEventValue (fn (mut this.maxWidth)))}}
+            type="number"
+            value={{this.maxWidth}}
+          />
         </Row>
         <Row @name="[@interactive]">
           <DToggleSwitch

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/toasts.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/toasts.gjs
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
+import withEventValue from "discourse/helpers/with-event-value";
 import IconPicker from "select-kit/components/icon-picker";
 import { TOAST } from "float-kit/lib/constants";
 import DummyComponent from "discourse/plugins/styleguide/discourse/components/dummy-component";
@@ -157,20 +157,36 @@ export default class Toasts extends Component {
         </Row>
         {{#if this.autoClose}}
           <Row @name="[@options.duration] ms">
-            <Input @value={{this.duration}} @type="number" />
+            <input
+              {{on "input" (withEventValue (fn (mut this.duration)))}}
+              type="number"
+              value={{this.duration}}
+            />
           </Row>
         {{/if}}
         <Row @name="[@options.class]">
-          <Input @value={{this.class}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.class)))}}
+            type="text"
+            value={{this.class}}
+          />
         </Row>
         <Row>
           <b>Model props for default:</b>
         </Row>
         <Row @name="[@options.data.title]">
-          <Input @value={{this.title}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.title)))}}
+            type="text"
+            value={{this.title}}
+          />
         </Row>
         <Row @name="[@options.data.message]">
-          <Input @value={{this.message}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.message)))}}
+            type="text"
+            value={{this.message}}
+          />
         </Row>
         <Row @name="[@options.data.icon]">
           <IconPicker

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/tooltips.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/molecules/tooltips.gjs
@@ -1,12 +1,13 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input } from "@ember/component";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
+import withEventValue from "discourse/helpers/with-event-value";
 import DTooltip from "float-kit/components/d-tooltip";
 import { TOOLTIP } from "float-kit/lib/constants";
 import DummyComponent from "discourse/plugins/styleguide/discourse/components/dummy-component";
@@ -188,25 +189,53 @@ export default class Tooltips extends Component {
 
       <Controls>
         <Row @name="Example label">
-          <Input @value={{this.label}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.label)))}}
+            type="text"
+            value={{this.label}}
+          />
         </Row>
         <Row @name="[@content]">
-          <Input @value={{this.content}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.content)))}}
+            type="text"
+            value={{this.content}}
+          />
         </Row>
         <Row @name="[@identifier]">
-          <Input @value={{this.identifier}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.identifier)))}}
+            type="text"
+            value={{this.identifier}}
+          />
         </Row>
         <Row @name="[@offset]">
-          <Input @value={{this.offset}} @type="number" />
+          <input
+            {{on "input" (withEventValue (fn (mut this.offset)))}}
+            type="number"
+            value={{this.offset}}
+          />
         </Row>
         <Row @name="[@triggers]">
-          <Input @value={{this.triggers}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.triggers)))}}
+            type="text"
+            value={{this.triggers}}
+          />
         </Row>
         <Row @name="[@untriggers]">
-          <Input @value={{this.untriggers}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.untriggers)))}}
+            type="text"
+            value={{this.untriggers}}
+          />
         </Row>
         <Row @name="[@maxWidth]">
-          <Input @value={{this.maxWidth}} @type="number" />
+          <input
+            {{on "input" (withEventValue (fn (mut this.maxWidth)))}}
+            type="number"
+            value={{this.maxWidth}}
+          />
         </Row>
         <Row @name="[@interactive]">
           <DToggleSwitch

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/modal.gjs
@@ -1,11 +1,12 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Input, Textarea } from "@ember/component";
+import { Textarea } from "@ember/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DModal from "discourse/components/d-modal";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
+import withEventValue from "discourse/helpers/with-event-value";
 import { getLoadedFaker } from "discourse/lib/load-faker";
 import { i18n } from "discourse-i18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -111,16 +112,28 @@ export default class extends Component {
           />
         </Row>
         <Row @name="@title">
-          <Input @value={{this.title}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.title)))}}
+            type="text"
+            value={{this.title}}
+          />
         </Row>
         <Row @name="@subtitle">
-          <Input @value={{this.subtitle}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.subtitle)))}}
+            type="text"
+            value={{this.subtitle}}
+          />
         </Row>
         <Row @name="<:body>">
           <Textarea @value={{this.body}} />
         </Row>
         <Row @name="@flash">
-          <Input @value={{this.flash}} />
+          <input
+            {{on "input" (withEventValue (fn (mut this.flash)))}}
+            type="text"
+            value={{this.flash}}
+          />
         </Row>
         <Row @name="@flashType">
           <ComboBox


### PR DESCRIPTION
Replaces usage of the Ember `<Input />` component with
native `<input>` elements in core plugins for text and
number inputs.

Generated with claude.
