### PR TITLE
UX: Creating a new theme/component should redirect to theme edit route

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/components.gjs
@@ -55,6 +55,7 @@ const STATUS_FILTER_OPTIONS = [
 
 export default class AdminConfigAreasComponents extends Component {
   @service modal;
+  @service router;
   @service toasts;
 
   @tracked loading = true;
@@ -105,7 +106,12 @@ export default class AdminConfigAreasComponents extends Component {
       },
       duration: "short",
     });
-    this.load();
+
+    this.router.transitionTo(
+      "adminCustomizeThemes.show.index",
+      "components",
+      component.id
+    );
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/themes.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/themes.gjs
@@ -68,13 +68,12 @@ export default class AdminConfigAreasThemes extends Component {
       },
       duration: "short",
     });
+
     this.router.transitionTo(
-      `adminConfig.customize.${theme.component ? "components" : "themes"}`,
-      {
-        queryParams: { repoUrl: null, repoName: null },
-      }
+      "adminCustomizeThemes.show.index",
+      "themes",
+      theme.id
     );
-    this.router.refresh();
   }
 
   @action

--- a/app/assets/javascripts/admin/addon/components/install-theme-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/install-theme-item.gjs
@@ -1,23 +1,28 @@
+import Component from "@glimmer/component";
 import RadioButton from "discourse/components/radio-button";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-const InstallThemeItem = <template>
-  <div class="install-theme-item">
-    <RadioButton
-      @name="install-items"
-      @id={{@value}}
-      @value={{@value}}
-      @selection={{@selection}}
-    />
-    <label class="radio" for={{@value}}>
-      {{#if @showIcon}}
-        {{icon "plus"}}
-      {{/if}}
-      {{i18n @label}}
-    </label>
-    {{icon "caret-right"}}
-  </div>
-</template>;
+export default class InstallThemeItem extends Component {
+  get classes() {
+    return `install-theme-item install-theme-item__${this.args.value}`;
+  }
 
-export default InstallThemeItem;
+  <template>
+    <div class={{this.classes}}>
+      <RadioButton
+        @name="install-items"
+        @id={{@value}}
+        @value={{@value}}
+        @selection={{@selection}}
+      />
+      <label class="radio" for={{@value}}>
+        {{#if @showIcon}}
+          {{icon "plus"}}
+        {{/if}}
+        {{i18n @label}}
+      </label>
+      {{icon "caret-right"}}
+    </div>
+  </template>
+}

--- a/app/assets/javascripts/admin/addon/components/modal/install-theme.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/install-theme.gjs
@@ -443,6 +443,7 @@ export default class InstallThemeModal extends Component {
                     "admin.customize.theme.create_name"
                   }}</div>
                 <input
+                  class="install-theme-content__theme-name"
                   type="text"
                   {{on "input" (withEventValue (fn (mut this.name)))}}
                   value={{this.name}}

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.gjs
@@ -15,7 +15,7 @@ import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
   <template>
-    <div class="show-current-style">
+    <div class="show-current-style admin-customize-themes-show">
       <div class="back-to-themes-and-components">
         <LinkTo
           @route={{if
@@ -43,7 +43,7 @@ export default RouteTemplate(
         />
       </span>
 
-      <div class="title">
+      <div class="title admin-customize-themes-show__title">
         {{#if @controller.editingName}}
           <div class="container-edit-title">
             <TextField @value={{@controller.model.name}} @autofocus="true" />

--- a/spec/system/admin_customize_components_config_area_spec.rb
+++ b/spec/system/admin_customize_components_config_area_spec.rb
@@ -341,14 +341,25 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     end
   end
 
-  context "when there are no components installed" do
-    it "doesn't display filters when there are no components installed" do
-      config_area.visit
+  it "doesn't display filters when there are no components installed" do
+    config_area.visit
 
-      expect(config_area).to have_no_components_installed_text
-      expect(config_area).to have_no_components
-      expect(config_area).to have_no_status_selector
-      expect(config_area).to have_no_name_filter_input
-    end
+    expect(config_area).to have_no_components_installed_text
+    expect(config_area).to have_no_components
+    expect(config_area).to have_no_status_selector
+    expect(config_area).to have_no_name_filter_input
+  end
+
+  it "allows a user to create a new component" do
+    config_area.visit.click_install_button.create_new_theme(
+      name: "some new component",
+      component: true,
+    )
+
+    expect(PageObjects::Components::Toasts.new).to have_success(
+      I18n.t("admin_js.admin.customize.theme.install_success", theme: "some new component"),
+    )
+
+    expect(page).to have_current_path(%r{/admin/customize/components/\d+})
   end
 end

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -19,8 +19,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
   it "has an install button in the subheader" do
     config_area.visit
 
-    config_area.subheader.find(".btn-primary").click
-    expect(install_modal).to be_open
+    install_modal = config_area.click_install_button
     expect(install_modal.popular_options.first).to have_text("Air")
   end
 
@@ -53,6 +52,16 @@ describe "Admin Customize Themes Config Area Page", type: :system do
     expect(config_area).to have_badge(theme, "--selectable")
     config_area.toggle_selectable(theme)
     expect(config_area).to have_no_badge(theme, "--selectable")
+  end
+
+  it "allows a theme to be created" do
+    config_area.visit.click_install_button.create_new_theme(name: "some new theme")
+
+    expect(PageObjects::Components::Toasts.new).to have_success(
+      I18n.t("admin_js.admin.customize.theme.install_success", theme: "some new theme"),
+    )
+
+    expect(page).to have_current_path(%r{/admin/customize/themes/\d+})
   end
 
   it "allows to edit and delete theme" do

--- a/spec/system/page_objects/components/admin_customize_theme_install_button.rb
+++ b/spec/system/page_objects/components/admin_customize_theme_install_button.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AdminCustomizeThemeInstallButton < PageObjects::Components::Base
+      def click
+        find(".d-page-subheader .btn-primary").click
+        modal = PageObjects::Modals::InstallTheme.new
+        expect(modal).to be_open
+        modal
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/install_theme.rb
+++ b/spec/system/page_objects/modals/install_theme.rb
@@ -3,12 +3,26 @@
 module PageObjects
   module Modals
     class InstallTheme < PageObjects::Modals::Base
+      MODAL_CLASS = ".admin-install-theme-modal"
+
       def modal
-        find(".admin-install-theme-modal")
+        find(MODAL_CLASS)
       end
 
       def popular_options
         all(".popular-theme-item")
+      end
+
+      def create_new_theme(name:, component: false)
+        within(MODAL_CLASS) do
+          find(".install-theme-item__create").click
+          find(".install-theme-content__theme-name").fill_in(with: name)
+
+          type_dropdown = PageObjects::Components::SelectKit.new(".single-select")
+          expect(type_dropdown.value).to eq(component ? "components" : "themes")
+
+          click_button(I18n.t("admin_js.admin.customize.theme.create"))
+        end
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_customize_components_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_components_config_area.rb
@@ -117,6 +117,7 @@ module PageObjects
 
       def visit
         page.visit("/admin/config/customize/components")
+        self
       end
 
       def component(id)
@@ -185,6 +186,10 @@ module PageObjects
             "admin_js.admin.config_areas.themes_and_components.components.no_components_found",
           ),
         )
+      end
+
+      def click_install_button
+        PageObjects::Components::AdminCustomizeThemeInstallButton.new.click
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -5,6 +5,7 @@ module PageObjects
     class AdminCustomizeThemesConfigArea < PageObjects::Pages::Base
       def visit(query_params = {})
         page.visit("/admin/config/customize?#{query_params.to_query}")
+        self
       end
 
       def find_theme_card(theme)
@@ -47,6 +48,10 @@ module PageObjects
 
       def click_edit(theme)
         find_theme_card(theme).find(".edit").click
+      end
+
+      def click_install_button
+        PageObjects::Components::AdminCustomizeThemeInstallButton.new.click
       end
     end
   end


### PR DESCRIPTION
Prior to this change, creating a new theme or theme component was causing the user to stay on the index route. 