### PR TITLE
UX: Display toast message when deleting a theme

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show-index.js
@@ -27,6 +27,7 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
   @service router;
   @service siteSettings;
   @service modal;
+  @service toasts;
 
   editRouteName = "adminCustomizeThemes.edit";
 
@@ -408,6 +409,16 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
         model.setProperties({ recentlyInstalled: false });
         model.destroyRecord().then(() => {
           this.allThemes.removeObject(model);
+
+          this.toasts.success({
+            data: {
+              message: i18n("admin.customize.theme.delete_success", {
+                theme: model.name,
+              }),
+            },
+            duration: "short",
+          });
+
           this.router.transitionTo("adminConfig.customize.themes");
         });
       },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6938,6 +6938,7 @@ en:
           set_default_success: "Default theme set to %{theme}"
           setting_was_saved: "Theme setting was saved"
           install_success: "%{theme} installed successfully!"
+          delete_success: "%{theme} deleted successfully!"
           inactive_components: "Unused components:"
           selected:
             one: "%{count} selected"

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -6,6 +6,7 @@ describe "Admin Customize Themes", type: :system do
   fab!(:admin) { Fabricate(:admin, locale: "en") }
 
   let(:theme_page) { PageObjects::Pages::AdminCustomizeThemes.new }
+  let(:themes_page) { PageObjects::Pages::AdminCustomizeThemesConfigArea.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
 
   before { sign_in(admin) }
@@ -53,6 +54,17 @@ describe "Admin Customize Themes", type: :system do
         I18n.t("admin_js.admin.customize.theme.edit_colors"),
         href: "/admin/customize/colors/#{color_scheme.id}",
       )
+    end
+
+    it "allows a theme to be deleted" do
+      theme_page.visit(theme).click_delete_button_and_confirm
+
+      expect(PageObjects::Components::Toasts.new).to have_success(
+        I18n.t("admin_js.admin.customize.theme.delete_success", theme: theme.name),
+      )
+
+      expect(page).to have_current_path("/admin/config/customize/themes")
+      expect(themes_page).to have_no_theme(theme.name)
     end
   end
 

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -7,6 +7,7 @@ module PageObjects
         page.visit(
           "/admin/customize/themes/#{theme_or_theme_id.is_a?(Theme) ? theme_or_theme_id.id : theme_or_theme_id}",
         )
+        self
       end
 
       def has_colors_tab?
@@ -195,8 +196,10 @@ module PageObjects
         find_button("Delete", disabled: true)
       end
 
-      def click_delete_themes_button
-        find(".btn-delete").click
+      def click_delete_button_and_confirm
+        find(".delete").click
+        PageObjects::Components::Dialog.new.click_danger
+        self
       end
 
       def click_edit_objects_theme_setting_button(setting_name)

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -36,6 +36,10 @@ module PageObjects
         expect(all(".theme-card__title").map(&:text)).to eq(names)
       end
 
+      def has_no_theme?(name)
+        has_no_css?(".theme-card.#{name.parameterize}")
+      end
+
       def toggle_selectable(theme)
         open_theme_menu(theme)
         find(".set-selectable").click


### PR DESCRIPTION
Before this change, we would redirect the user back to the admin themes
index page without any UI indication on whether the theme has been
successfully destroyed.
