### PR TITLE
DEV: Migrate from byebug to debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,6 @@ gem "oj"
 gem "pg"
 gem "mini_sql"
 gem "pry-rails", require: false
-gem "pry-byebug", require: false
 gem "rtlcss", require: false
 gem "messageformat-wrapper", require: false
 gem "rake"
@@ -144,7 +143,7 @@ group :test, :development do
   gem "shoulda-matchers", require: false
   gem "rspec-html-matchers"
   gem "pry-stack_explorer", require: false
-  gem "byebug", require: ENV["RM_INFO"].nil?, platform: :mri
+  gem "debug", require: ENV["RM_INFO"].nil?, platform: :mri
   gem "rubocop-discourse", require: false
   gem "parallel_tests"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
     bullet (8.0.8)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (12.0.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -131,6 +130,9 @@ GEM
       addressable
     csv (3.3.5)
     date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
     diffy (3.4.4)
@@ -418,9 +420,6 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     pry-stack_explorer (0.6.1)
@@ -741,7 +740,6 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bullet
-  byebug
   capybara
   capybara-playwright-driver
   cbor
@@ -752,6 +750,7 @@ DEPENDENCIES
   cppjieba_rb
   css_parser
   csv
+  debug
   diffy
   digest
   digest-xxhash
@@ -822,7 +821,6 @@ DEPENDENCIES
   pdf-reader
   pg
   propshaft
-  pry-byebug
   pry-rails
   pry-stack_explorer
   puma
@@ -915,7 +913,6 @@ CHECKSUMS
   bootsnap (1.18.6) sha256=0ae2393c1e911e38be0f24e9173e7be570c3650128251bf06240046f84a07d00
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.0.8) sha256=b4b9905eb6b803d9a0ba620944ed79c8bb27ff3ca90ef8f8e39ff21db5b7c542
-  byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.7) sha256=875a1928077d56be8b484f84674901a2374752d7842d93de2045bbede1aad242
   cbor (0.5.10.1) sha256=79cdf79f18dcd9ee97e0b849c6d573e5a2e3ddc1954d180f384d6ed2612b6df0
@@ -933,6 +930,7 @@ CHECKSUMS
   css_parser (1.21.1) sha256=6cfd3ffc0a97333b39d2b1b49c95397b05e0e3b684d68f77ec471ba4ec2ef7c7
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.4.1) sha256=bf268e14ef7158009bfeaec40b5fa3c7271906e88b196d958a89d4b408abe64f
+  debug (1.11.0) sha256=1425db64cfa0130c952684e3dc974985be201dd62899bf4bbe3f8b5d6cf1aef2
   debug_inspector (1.2.0) sha256=9bdfa02eebc3da163833e6a89b154084232f5766087e59573b70521c77ea68a2
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   diffy (3.4.4) sha256=79384ab5ca82d0e115b2771f0961e27c164c456074bd2ec46b637ebf7b6e47e3
@@ -1089,7 +1087,6 @@ CHECKSUMS
   progress (3.6.0) sha256=360ed306dfa43d6174e847d563c70736dca249e2333cfec4b0387306c86cd573
   propshaft (1.2.1) sha256=e9b91daf52f21152f851a59f8621af53ffb4dc4401f9b5f8fe16065190b98654
   pry (0.15.2) sha256=12d54b8640d3fa29c9211dd4ffb08f3fd8bf7a4fd9b5a73ce5b59c8709385b6b
-  pry-byebug (3.11.0) sha256=0b0abb7d309bc7f00044d512a3c8567274f7012b944b38becc8440439a1cea72
   pry-rails (0.3.11) sha256=a69e28e24a34d75d1f60bcf241192a54253f8f7ef8a62cba1e75750a9653593d
   pry-stack_explorer (0.6.1) sha256=a2dbea9b47c4ad00cf5c1ce21499f8128b915089e90015f7bafb6e9453baf340
   psych (5.2.6) sha256=814328aa5dcb6d604d32126a20bc1cbcf05521a5b49dbb1a8b30a07e580f316e

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,7 @@ require "rails_failover/active_record" if !GlobalSetting.skip_db?
 require "rails_failover/redis" if !GlobalSetting.skip_redis?
 
 require "pry-rails" if Rails.env.development?
-require "pry-byebug" if Rails.env.development?
+require "debug" if Rails.env.development?
 
 require "discourse_fonts"
 

--- a/config/initializers/000-trace_pg_connections.rb
+++ b/config/initializers/000-trace_pg_connections.rb
@@ -52,9 +52,9 @@ if ENV["TRACE_PG_CONNECTIONS"]
             #{Thread.current&.backtrace&.join("\n")}
           TEXT
 
-            if ENV["ON_PG_CLASH"] == "byebug"
-              require "byebug"
-              byebug # rubocop:disable Lint/Debugger
+            if ENV["ON_PG_CLASH"] == "debug"
+              require "debug"
+              binding.break # rubocop:disable Lint/Debugger
             end
           end
           @accessor_thread = Thread.current

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,6 @@ end
 require "rubygems"
 require "rbtrace" if RUBY_ENGINE == "ruby"
 require "pry"
-require "pry-byebug"
 require "pry-rails"
 require "pry-stack_explorer"
 require "fabrication"


### PR DESCRIPTION
This commit migrates the project from the `byebug` gem to the official `debug` gem for debugging.