### PR TITLE
DEV: Return finished and total number of candidates needed for translation rather than a percentage

### DIFF
--- a/plugins/discourse-ai/lib/translation/base_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/base_candidates.rb
@@ -19,8 +19,8 @@ module DiscourseAi
           .cache
           .fetch(get_completion_cache_key(locale), expires_in: COMPLETION_CACHE_TTL) do
             done, total = calculate_completion_per_locale(locale)
-            return 1.0 if total.zero?
-            done / total.to_f
+            return { done: 0, total: 0 } if total.zero?
+            { done:, total: }
           end
       end
 


### PR DESCRIPTION


To better support https://github.com/discourse/discourse/pull/34239, we return the raw values here instead of a derived percentage.