### PR TITLE
UX: always keep mobile composer at fullscreen

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -118,6 +118,10 @@ html.composer-open:not(.has-full-page-chat) {
 
     @include viewport.until(sm) {
       z-index: z("mobile-composer");
+      top: 0;
+      transform: none;
+      height: 100dvh;
+      max-height: unset;
     }
   }
 


### PR DESCRIPTION
This commit essentially removes the half-way composer state on mobile, and instead opts to keep it fullscreen. Regular minimise still works.

This has been int he design experiments for long enough that it seems safe enough (famous last words).
Meta topic: https://meta.discourse.org/t/mobile-composer-permanent-full-screen/374766
