### PR TITLE
UX: fix timeline handle color in dark mode palettes

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -147,5 +147,8 @@
   --float-kit-arrow-stroke-color: var(--primary-low);
   --float-kit-arrow-fill-color: var(--secondary);
   --topic-timeline-border-color: #{$tertiary-low-or-tertiary-high};
-  --topic-timeline-handle-color: var(--tertiary-400);
+  --topic-timeline-handle-color: light-dark(
+    var(--tertiary-400),
+    var(--tertiary)
+  );
 }


### PR DESCRIPTION
Follow-up to 30ee375ee6f147f874cb36182d0db0fa22afb39c

We improved contrast of the light mode handle, but this wasn't ideal in dark mode... this fixes it 

Before: 
<img width="100" alt="image" src="https://github.com/user-attachments/assets/144cc340-836e-4abf-b10c-a59c8d478e20" /><img width="100" alt="image" src="https://github.com/user-attachments/assets/bc1d4103-ce3b-4b5e-95ba-4a6428d1b003" /><img width="100" alt="image" src="https://github.com/user-attachments/assets/29bdcda1-677a-45de-8148-949101662bcd" />


After: 
<img width="100" alt="image" src="https://github.com/user-attachments/assets/e503e867-f707-4e85-809b-a5136e3cc743" /> <img width="100"  alt="image" src="https://github.com/user-attachments/assets/fa5185ba-5fb9-49d8-96dd-a908ef07dada" /> <img width="100"  alt="image" src="https://github.com/user-attachments/assets/3430fd4b-ebaf-4049-a648-88a0293bcbdd" />
