### PR TITLE
UX: remove `barThickness` so translation bars scale naturally

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
@@ -65,7 +65,6 @@ export default class AiTranslations extends Component {
       options: {
         indexAxis: "y",
         responsive: true,
-        barThickness: 40,
         scales: {
           x: {
             stacked: true,


### PR DESCRIPTION
## :mag: Overview
When a forum has many translations, the explicit `barThickness` looks too thick. This update removes the explicit `barThickness` so that the bars scale naturally based on the amount of translations in the chart.

## 📷 Screenshots

### ← Before
<img width="1093" height="673" alt="Screenshot 2025-08-15 at 13 06 07" src="https://github.com/user-attachments/assets/030eac00-d972-40de-97d6-e266dbbe17eb" />

### → After
<img width="1095" height="704" alt="Screenshot 2025-08-15 at 13 05 41" src="https://github.com/user-attachments/assets/9fa41e63-0324-45f1-ae1f-5212ab2a770d" />

