### PR TITLE
DEV: Use common candidate helper for backfill job

### DIFF
--- a/plugins/discourse-ai/app/jobs/scheduled/posts_locale_detection_backfill.rb
+++ b/plugins/discourse-ai/app/jobs/scheduled/posts_locale_detection_backfill.rb
@@ -12,28 +12,12 @@ module Jobs
       limit = SiteSetting.ai_translation_backfill_hourly_rate / (60 / 5) # this job runs in 5-minute intervals
 
       posts =
-        Post
+        DiscourseAi::Translation::PostCandidates
+          .get()
           .where(locale: nil)
-          .where(deleted_at: nil)
-          .where("posts.user_id > 0")
-          .where("posts.created_at > ?", SiteSetting.ai_translation_backfill_max_age_days.days.ago)
-          .where.not(raw: [nil, ""])
+          .order(updated_at: :desc)
+          .limit(limit)
 
-      if SiteSetting.ai_translation_backfill_limit_to_public_content
-        posts =
-          posts
-            .joins(:topic)
-            .where(topics: { category_id: Category.where(read_restricted: false).select(:id) })
-            .where("archetype != ?", Archetype.private_message)
-      else
-        posts =
-          posts.joins(:topic).where(
-            "topics.archetype != ? OR EXISTS (SELECT 1 FROM topic_allowed_groups WHERE topic_id = topics.id)",
-            Archetype.private_message,
-          )
-      end
-
-      posts = posts.order(updated_at: :desc).limit(limit)
       return if posts.empty?
 
       posts.each do |post|


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/33927

This is already tested in the job itself and is a refactor to use the new class.