### PR TITLE
DEV: Yield from inside TopicLink

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-list/topic-link.gjs
@@ -19,7 +19,7 @@ export default class TopicLink extends Component {
         data-topic-id={{@topic.id}}
         class="title"
         ...attributes
-      >{{htmlSafe @topic.fancyTitle}}</a>
+      >{{htmlSafe @topic.fancyTitle}}{{yield}}</a>
       {{~! no whitespace ~}}
     </PluginOutlet>
     {{~! no whitespace ~}}


### PR DESCRIPTION
## ✨ What's This?

This change adds a `yield` inside the `TopicLink` component, allowing additional text to be appended to the link text.

See discourse/discourse-right-sidebar-blocks#86 for how this `yield` can be used.