### PR TITLE
FIX: Refresh palettes list when navigating back to palettes list page

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors.js
@@ -28,12 +28,10 @@ export default class AdminCustomizeColorsController extends Controller {
     return this.defaultTheme?.dark_color_scheme_id === scheme.id;
   };
 
-  @tracked _initialSortedSchemes = [];
   _initialUserLightColorSchemeId = undefined;
   _initialUserDarkColorSchemeId = undefined;
   _initialDefaultThemeLightColorSchemeId = null;
   _initialDefaultThemeDarkColorSchemeId = null;
-  _sortPerformed = false;
 
   canPreviewColorScheme(mode) {
     const usingDefaultTheme = currentThemeId() === this.defaultTheme?.id;
@@ -151,13 +149,10 @@ export default class AdminCustomizeColorsController extends Controller {
     );
   }
 
-  get sortedColorSchemes() {
-    // only sort initially, this avoids position jumps when state changes on interaction
-    if (!this._sortPerformed && this.model?.length > 0) {
-      this._doInitialSort();
-    }
-
-    return [...this._initialSortedSchemes];
+  get displayedPalettes() {
+    return this.model.filter(
+      (palette) => !palette.is_base || palette.is_builtin_default
+    );
   }
 
   get searchableProps() {
@@ -184,91 +179,6 @@ export default class AdminCustomizeColorsController extends Controller {
     ];
   }
 
-  _doInitialSort() {
-    let schemes = this.model.filter((scheme) => !scheme.is_base);
-
-    // built-in "Light (default)"
-    const lightBaseScheme = this.allBaseColorSchemes.find(
-      (scheme) => scheme.base_scheme_id === "Light" || scheme.name === "Light"
-    );
-    if (lightBaseScheme) {
-      const builtInDefault = {
-        ...lightBaseScheme,
-        id: null,
-        name: i18n("admin.customize.theme.default_light_scheme"),
-        description: i18n("admin.customize.theme.default_light_scheme"),
-        is_builtin_default: true,
-        user_selectable: false,
-        theme_id: -1,
-      };
-      schemes.unshift(builtInDefault);
-    }
-
-    const defaultThemeId = this.defaultTheme?.id;
-    const defaultLightId = this.defaultTheme?.color_scheme_id;
-    const defaultDarkId = this.defaultTheme?.dark_color_scheme_id;
-
-    schemes.sort((a, b) => {
-      // 1. Display active light
-      if (
-        defaultLightId === null &&
-        (a.is_builtin_default || b.is_builtin_default)
-      ) {
-        return a.is_builtin_default ? -1 : 1;
-      }
-      if (
-        (defaultLightId === a.id && !a.is_builtin_default) ||
-        (defaultLightId === b.id && !b.is_builtin_default)
-      ) {
-        return defaultLightId === a.id ? -1 : 1;
-      }
-
-      // 2. Display active dark
-      if (
-        defaultDarkId === null &&
-        (a.is_builtin_default || b.is_builtin_default)
-      ) {
-        return a.is_builtin_default ? -1 : 1;
-      }
-      if (
-        (defaultDarkId === a.id && !a.is_builtin_default) ||
-        (defaultDarkId === b.id && !b.is_builtin_default)
-      ) {
-        return defaultDarkId === a.id ? -1 : 1;
-      }
-
-      // 3. Sort by user selectable first
-      if (a.user_selectable !== b.user_selectable) {
-        return a.user_selectable ? -1 : 1;
-      }
-
-      // 4. Sort custom schemes (no theme) before themed schemes
-      const aIsCustom = !a.theme_id && !a.is_builtin_default;
-      const bIsCustom = !b.theme_id && !b.is_builtin_default;
-      if (aIsCustom !== bIsCustom) {
-        return aIsCustom ? -1 : 1;
-      }
-
-      // 5. Prioritize schemes from the current default theme
-      const aIsFromDefaultTheme = a.theme_id === defaultThemeId;
-      const bIsFromDefaultTheme = b.theme_id === defaultThemeId;
-      if (aIsFromDefaultTheme !== bIsFromDefaultTheme) {
-        return aIsFromDefaultTheme ? -1 : 1;
-      }
-
-      // 6. Finally, sort alphabetically by name
-      return (a.originals.name || "").localeCompare(b.originals.name || "");
-    });
-
-    this._initialSortedSchemes = schemes;
-    this._sortPerformed = true;
-  }
-
-  _resetSortedSchemes() {
-    this._sortPerformed = false;
-    this._initialSortedSchemes = [];
-  }
-
   @action
   newColorSchemeWithBase(baseKey) {
     const base = this.allBaseColorSchemes.findBy("base_scheme_id", baseKey);
@@ -280,8 +190,6 @@ export default class AdminCustomizeColorsController extends Controller {
     newColorScheme.save().then(() => {
       this.model.pushObject(newColorScheme);
       newColorScheme.set("savingStatus", null);
-
-      this._resetSortedSchemes();
 
       this.router.replaceWith("adminCustomize.colors-show", newColorScheme);
     });
@@ -354,8 +262,6 @@ export default class AdminCustomizeColorsController extends Controller {
             .destroy()
             .then(() => {
               this.model.removeObject(scheme);
-
-              this._resetSortedSchemes();
 
               resolve();
             })

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-colors.js
@@ -21,5 +21,9 @@ export default class AdminCustomizeColorsRoute extends Route {
       model.palettes.map((palette) => ColorScheme.create(palette))
     );
     controller.set("defaultTheme", defaultTheme);
+
+    if (defaultTheme) {
+      controller._captureInitialState();
+    }
   }
 }

--- a/app/assets/javascripts/admin/addon/routes/admin-customize-colors.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-colors.js
@@ -1,28 +1,25 @@
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
-import { hash } from "rsvp";
+import { ajax } from "discourse/lib/ajax";
 import ColorScheme from "admin/models/color-scheme";
+import Theme from "admin/models/theme";
 
 export default class AdminCustomizeColorsRoute extends Route {
   @service store;
 
-  model() {
-    return hash({
-      colorSchemes: ColorScheme.findAll(),
-      themes: this.store.findAll("theme"),
-    });
+  async model() {
+    return await ajax("/admin/config/colors");
   }
 
   setupController(controller, model) {
     super.setupController(controller, model);
-    controller.set("model", model.colorSchemes);
-
-    const themes = model.themes || [];
-    const defaultTheme = themes.find((theme) => theme.default === true);
+    const defaultTheme = model.extras.default_theme
+      ? Theme.create(model.extras.default_theme)
+      : null;
+    controller.set(
+      "model",
+      model.palettes.map((palette) => ColorScheme.create(palette))
+    );
     controller.set("defaultTheme", defaultTheme);
-
-    if (defaultTheme) {
-      controller._captureInitialState();
-    }
   }
 }

--- a/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors.gjs
@@ -68,7 +68,7 @@ export default RouteTemplate(
     {{/if}}
 
     <AdminFilterControls
-      @array={{@controller.sortedColorSchemes}}
+      @array={{@controller.displayedPalettes}}
       @minItemsForFilter={{FILTER_MINIMUM}}
       @searchableProps={{@controller.searchableProps}}
       @dropdownOptions={{@controller.dropdownOptions}}

--- a/app/controllers/admin/config/color_palettes_controller.rb
+++ b/app/controllers/admin/config/color_palettes_controller.rb
@@ -1,6 +1,57 @@
 # frozen_string_literal: true
+
 class Admin::Config::ColorPalettesController < Admin::AdminController
   def index
+    palettes = ColorScheme.without_theme_owned_palettes.to_a
+    palettes.unshift(ColorScheme.base)
+    default_theme = Theme.find_default
+    default_light_palette = default_theme&.color_scheme_id
+    default_dark_palette = default_theme&.dark_color_scheme_id
+
+    palettes.sort! do |a, b|
+      # 1. Display active light
+      if default_light_palette.blank? && (a.is_builtin_default || b.is_builtin_default)
+        next a.is_builtin_default ? -1 : 1
+      end
+      if (default_light_palette == a.id && !a.is_builtin_default) ||
+           (default_light_palette == b.id && !b.is_builtin_default)
+        next default_light_palette == a.id ? -1 : 1
+      end
+
+      # 2. Display active dark
+      if default_dark_palette.blank? && (a.is_builtin_default || b.is_builtin_default)
+        next a.is_builtin_default ? -1 : 1
+      end
+      if (default_dark_palette == a.id && !a.is_builtin_default) ||
+           (default_dark_palette == b.id && !b.is_builtin_default)
+        next default_dark_palette == a.id ? -1 : 1
+      end
+
+      # 3. Sort by user selectable first
+      next a.user_selectable ? -1 : 1 if a.user_selectable != b.user_selectable
+
+      # 4. Sort custom palettes (no theme) before themed palettes
+      a_is_custom = a.theme_id.blank? && !a.is_builtin_default
+      b_is_custom = b.theme_id.blank? && !b.is_builtin_default
+      next a_is_custom ? -1 : 1 if a_is_custom != b_is_custom
+
+      # 5. Prioritize palettes from the current default theme
+      a_is_from_default_theme = a.theme_id.present? && (a.theme_id == default_theme&.id)
+      b_is_from_default_theme = b.theme_id.present? && (b.theme_id == default_theme&.id)
+      next a_is_from_default_theme ? -1 : 1 if a_is_from_default_theme != b_is_from_default_theme
+
+      # 6. Finally, sort alphabetically by name
+      next (a.name&.downcase || "") <=> (b.name&.downcase || "")
+    end
+
+    palettes.unshift(*ColorScheme.base_color_schemes.reject(&:is_builtin_default))
+
+    render json: {
+             palettes: serialize_data(palettes, ColorSchemeSerializer, root: false),
+             extras: {
+               default_theme: serialize_data(default_theme, ThemeSerializer, root: false),
+             },
+           }
   end
 
   def show

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -315,6 +315,7 @@ class ColorScheme < ActiveRecord::Base
 
   attr_accessor :is_base
   attr_accessor :skip_publish
+  attr_accessor :is_builtin_default
 
   has_many :color_scheme_colors, -> { order("id ASC") }, dependent: :destroy
 
@@ -381,15 +382,17 @@ class ColorScheme < ActiveRecord::Base
         )
       scheme.colors = hash[:colors].map { |k| { name: k[:name], hex: k[:hex] } }
       scheme.is_base = true
+      scheme.is_builtin_default = hash[:id] == LIGHT_THEME_ID
       scheme
     end
   end
 
   def self.base
     return @base_color_scheme if @base_color_scheme
-    @base_color_scheme = new(name: I18n.t("color_schemes.base_theme_name"))
+    @base_color_scheme = new(name: I18n.t("admin_js.admin.customize.theme.default_light_scheme"))
     @base_color_scheme.colors = base_colors.map { |name, hex| { name: name, hex: hex } }
     @base_color_scheme.is_base = true
+    @base_color_scheme.is_builtin_default = true
     @base_color_scheme
   end
 

--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class ColorSchemeSerializer < ApplicationSerializer
-  attributes :id, :name, :is_base, :base_scheme_id, :theme_id, :theme_name, :user_selectable
+  attributes :id,
+             :name,
+             :is_base,
+             :base_scheme_id,
+             :theme_id,
+             :theme_name,
+             :user_selectable,
+             :is_builtin_default
   has_many :colors, serializer: ColorSchemeColorSerializer, embed: :objects
 
   def theme_name

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -862,7 +862,7 @@ RSpec.describe ApplicationHelper do
 
         color_stylesheets = helper.discourse_color_scheme_stylesheets
         expect(color_stylesheets).not_to include("color_definitions_flamboyant")
-        expect(color_stylesheets).to include("color_definitions_base")
+        expect(color_stylesheets).to include("color_definitions_light-default")
       end
     end
 

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -617,19 +617,19 @@ RSpec.describe Stylesheet::Manager do
   describe "color_scheme_stylesheets" do
     it "returns something by default" do
       href = manager.color_scheme_stylesheet_link_tag_href
-      expect(href).to include("color_definitions_base")
+      expect(href).to include("color_definitions_light-default")
     end
 
     it "does not crash when no default theme is set" do
       SiteSetting.default_theme_id = -1
       href = manager.color_scheme_stylesheet_link_tag_href
 
-      expect(href).to include("color_definitions_base")
+      expect(href).to include("color_definitions_light-default")
     end
 
     it "loads base scheme when defined scheme id is missing" do
       href = manager.color_scheme_stylesheet_link_tag_href(125)
-      expect(href).to include("color_definitions_base")
+      expect(href).to include("color_definitions_light-default")
     end
 
     it "loads nothing when fallback_to_base is false" do
@@ -656,7 +656,7 @@ RSpec.describe Stylesheet::Manager do
 
       href =
         manager(user_theme.id).color_scheme_stylesheet_link_tag_href(nil, fallback_to_base: true)
-      expect(href).to include("/stylesheets/color_definitions_base_")
+      expect(href).to include("/stylesheets/color_definitions_light-default_")
 
       stylesheet =
         Stylesheet::Manager::Builder.new(

--- a/spec/requests/admin/config/color_palettes_controller_spec.rb
+++ b/spec/requests/admin/config/color_palettes_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::Config::ColorPalettesController do
+  fab!(:admin)
+  fab!(:theme)
+
+  before { sign_in(admin) }
+
+  fab!(:palette_1) do
+    Fabricate(:color_scheme, user_selectable: false, theme_id: nil, name: "A palette")
+  end
+
+  fab!(:palette_2) do
+    Fabricate(:color_scheme, user_selectable: false, theme_id: nil, name: "B palette")
+  end
+
+  fab!(:user_selectable_palette) { Fabricate(:color_scheme, user_selectable: true, theme_id: nil) }
+
+  fab!(:user_selectable_theme_palette) do
+    Fabricate(:color_scheme, user_selectable: true, theme_id: theme.id)
+  end
+
+  fab!(:user_selectable_default_theme_palette) do
+    Fabricate(:color_scheme, user_selectable: true, theme_id: Theme.find_default.id)
+  end
+
+  describe "#index" do
+    before do
+      ColorScheme.where(theme_id: Theme.horizon_theme.id).destroy_all
+      ColorScheme.where(via_wizard: true).destroy_all
+    end
+
+    it "sorts non-base palettes in a certain way" do
+      get "/admin/config/colors.json"
+
+      expect(response.status).to eq(200)
+
+      non_base_palettes = response.parsed_body["palettes"].select { |palette| !palette["is_base"] }
+      expect(non_base_palettes.size).to eq(5)
+      expect(non_base_palettes.map { |p| p["id"] }).to eq(
+        [
+          user_selectable_palette.id,
+          user_selectable_default_theme_palette.id,
+          user_selectable_theme_palette.id,
+          palette_1.id,
+          palette_2.id,
+        ],
+      )
+    end
+
+    it "includes base palettes at the start" do
+      get "/admin/config/colors.json"
+
+      expect(response.status).to eq(200)
+
+      base_palettes = response.parsed_body["palettes"].select { |palette| palette["is_base"] }
+      expect(base_palettes.size).to be > 0
+      expect(response.parsed_body["palettes"].first).to eq(base_palettes.first)
+    end
+
+    it "includes default theme in extras" do
+      get "/admin/config/colors.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["extras"]["default_theme"]).to be_present
+      expect(response.parsed_body["extras"]["default_theme"]["id"]).to eq(Theme.find_default.id)
+    end
+  end
+end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1659,7 +1659,7 @@ RSpec.describe ApplicationController do
       it "includes stylesheet links in the header" do
         get "/"
 
-        expect(response.headers["Link"]).to include("color_definitions_base")
+        expect(response.headers["Link"]).to include("color_definitions_light-default")
         expect(response.headers["Link"]).to include("color_definitions_dark")
       end
     end


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/checkbox-in-color-palettes-user-selectable-yes-no-doesnt-work/378545?u=osama

This PR moves the sorting logic to server-side to avoid caching issues where the (sorted) palettes list, which was stored as a property on the controller, would need to be invalidated each time the user navigated to the palettes list page because changes to palettes could've been made between the last and new visits to the page. This PR also eliminates an AJAX request that the palettes list page makes to fetch the default theme by including the default theme in the same response that includes the color palettes list.