### PR TITLE
PERF: Fix performance regression in `SvgSprite.settings_icons`

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -153,6 +153,22 @@ module SiteSettingExtension
       end
   end
 
+  def settings_hash
+    result = {}
+
+    defaults.all.keys.each do |s|
+      next if themeable[s]
+
+      result[s] = if deprecated_settings.include?(s.to_s)
+        public_send(s, warn: false).to_s
+      else
+        public_send(s).to_s
+      end
+    end
+
+    result
+  end
+
   def deprecated_settings
     @deprecated_settings ||= SiteSettings::DeprecatedSettings::SETTINGS.map(&:first).to_set
   end

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -489,13 +489,9 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
       # includes svg_icon_subset and any settings containing _icon (incl. plugin settings)
       site_setting_icons = []
 
-      SiteSetting
-        .all_settings(include_locale_setting: false)
-        .select do |setting|
-          site_setting_icons |= setting[:value].split("|") if setting[:setting].to_s.include?(
-            "_icon",
-          ) && String === setting[:value]
-        end
+      SiteSetting.settings_hash.each do |key, value|
+        site_setting_icons |= value.split("|") if key.to_s.include?("_icon") && String === value
+      end
 
       site_setting_icons
     end


### PR DESCRIPTION
This commit reverts the changes made to `SvgSprite.settings_icons` in 19af83d39e6c06cdc31df2c203623b47bef9c252
which resulted in significantly slower boot times on multisite clusters
since `SvgSprite.settings_icons` is called during application preload.
