### PR TITLE
FIX: Language dropdown in wizard should filter correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/static/wizard/components/fields/dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/static/wizard/components/fields/dropdown.gjs
@@ -99,15 +99,6 @@ export default class Dropdown extends Component {
     }
   }
 
-  get nameProperty() {
-    switch (this.args.field.id) {
-      case "default_locale":
-        return "name";
-      default:
-        return "label";
-    }
-  }
-
   keyPress(event) {
     event.stopPropagation();
   }
@@ -123,9 +114,8 @@ export default class Dropdown extends Component {
       class="wizard-container__dropdown"
       value=@field.value
       content=@field.choices
-      nameProperty=this.nameProperty
+      nameProperty="label"
       tabindex="9"
-      onChange=this.onChangeValue
       options=(hash translatedNone=false)
     }}
   </template>

--- a/spec/system/page_objects/pages/wizard.rb
+++ b/spec/system/page_objects/pages/wizard.rb
@@ -35,6 +35,16 @@ module PageObjects
         find_field(field_type, field_id).fill_in(with: value)
       end
 
+      def select_dropdown_option(field_id, option_value)
+        droppdown =
+          PageObjects::Components::SelectKit.new(
+            ".wizard-container__field.dropdown-#{field_id} .wizard-container__dropdown",
+          )
+        droppdown.expand
+        droppdown.select_row_by_value(option_value)
+        droppdown.collapse
+      end
+
       def has_field_with_value?(field_type, field_id, value)
         find_field(field_type, field_id).find("input").value == value
       end

--- a/spec/system/wizard_spec.rb
+++ b/spec/system/wizard_spec.rb
@@ -11,6 +11,7 @@ describe "Wizard", type: :system do
     visit("/wizard")
     expect(wizard_page).to be_on_step("introduction")
     wizard_page.fill_field("text", "title", "My Test Site")
+    wizard_page.select_dropdown_option("default-locale", "en")
     wizard_page.go_to_next_step
     expect(wizard_page).to be_on_step("privacy")
     wizard_page.go_to_next_step


### PR DESCRIPTION
This PR fixes a filter issue on the language dropdown on wizard introduction.

Related: https://github.com/discourse/discourse/pull/34378

https://github.com/user-attachments/assets/1a1074a4-77aa-4515-8fb7-a606363a24be
