### PR TITLE
DEV: Don't apply .modal-open class for inline modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -312,9 +312,9 @@ export default class DModal extends Component {
       @inline={{@inline}}
       @append={{true}}
     >
-      {{#if (not @inline)}}
+      {{#unless @inline}}
         {{htmlClass "modal-open"}}
-      {{/if}}
+      {{/unless}}
       <this.dynamicElement
         class={{concatClass
           "modal"


### PR DESCRIPTION
This fixes scrolling on /styleguide/organisms/modal