### PR TITLE
DEV: Remove invalid options from migrations

### DIFF
--- a/db/migrate/20161202034856_add_uploads_to_categories.rb
+++ b/db/migrate/20161202034856_add_uploads_to_categories.rb
@@ -2,8 +2,8 @@
 
 class AddUploadsToCategories < ActiveRecord::Migration[4.2]
   def up
-    add_column :categories, :uploaded_logo_id, :integer, index: true
-    add_column :categories, :uploaded_background_id, :integer, index: true
+    add_column :categories, :uploaded_logo_id, :integer
+    add_column :categories, :uploaded_background_id, :integer
 
     execute <<~SQL
     UPDATE categories c1

--- a/db/migrate/20200715044833_add_delete_option_to_bookmarks.rb
+++ b/db/migrate/20200715044833_add_delete_option_to_bookmarks.rb
@@ -2,7 +2,7 @@
 
 class AddDeleteOptionToBookmarks < ActiveRecord::Migration[6.0]
   def up
-    add_column :bookmarks, :auto_delete_preference, :integer, index: true, null: false, default: 0
+    add_column :bookmarks, :auto_delete_preference, :integer, null: false, default: 0
     DB.exec("UPDATE bookmarks SET auto_delete_preference = 1 WHERE delete_when_reminder_sent")
   end
 

--- a/db/migrate/20210614232334_add_smtp_group_id_to_email_log.rb
+++ b/db/migrate/20210614232334_add_smtp_group_id_to_email_log.rb
@@ -2,6 +2,6 @@
 
 class AddSmtpGroupIdToEmailLog < ActiveRecord::Migration[6.1]
   def change
-    add_column :email_logs, :smtp_group_id, :integer, null: true, index: true
+    add_column :email_logs, :smtp_group_id, :integer, null: true
   end
 end

--- a/db/migrate/20221004122343_add_dark_mode_logo_to_categories.rb
+++ b/db/migrate/20221004122343_add_dark_mode_logo_to_categories.rb
@@ -2,6 +2,6 @@
 
 class AddDarkModeLogoToCategories < ActiveRecord::Migration[7.0]
   def change
-    add_column :categories, :uploaded_logo_dark_id, :integer, index: true
+    add_column :categories, :uploaded_logo_dark_id, :integer
   end
 end

--- a/db/migrate/20230118042740_add_sidebar_section_id_to_sidebar_section_links.rb
+++ b/db/migrate/20230118042740_add_sidebar_section_id_to_sidebar_section_links.rb
@@ -2,6 +2,6 @@
 
 class AddSidebarSectionIdToSidebarSectionLinks < ActiveRecord::Migration[7.0]
   def change
-    add_column :sidebar_section_links, :sidebar_section_id, :integer, index: true
+    add_column :sidebar_section_links, :sidebar_section_id, :integer
   end
 end

--- a/db/migrate/20231018225833_add_dark_mode_background_to_categories.rb
+++ b/db/migrate/20231018225833_add_dark_mode_background_to_categories.rb
@@ -2,6 +2,6 @@
 
 class AddDarkModeBackgroundToCategories < ActiveRecord::Migration[7.0]
   def change
-    add_column :categories, :uploaded_background_dark_id, :integer, index: true
+    add_column :categories, :uploaded_background_dark_id, :integer
   end
 end


### PR DESCRIPTION
The change is sponsored by `Rails/AddColumnIndex` rubocop rule:

> (…) add_column does not accept index, but also does not raise an error for extra keys, so it is possible to mistakenly add the key without realizing it will not actually add an index.

I opted not to add these "missing" indexes since they've proven not necessary after all.