### PR TITLE
FIX: Allow users in content_localization_allowed_groups to delete translations

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -213,7 +213,6 @@ export default class Post extends RestModel {
   @trackedPostProperty wiki;
   @trackedPostProperty yours;
   @trackedPostProperty user_custom_fields;
-  @trackedPostProperty has_post_localizations;
   @trackedPostProperty post_localizations;
 
   @alias("can_edit") canEdit; // for compatibility with existing code

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -95,7 +95,6 @@ class PostSerializer < BasicPostSerializer
              :user_status,
              :mentioned_users,
              :post_url,
-             :has_post_localizations,
              :post_localizations_count,
              :locale,
              :is_localized,
@@ -655,20 +654,12 @@ class PostSerializer < BasicPostSerializer
     SiteSetting.enable_user_status
   end
 
-  def has_post_localizations
-    object.localizations.any?
-  end
-
   def post_localizations_count
     object.localizations.size
   end
 
-  def include_has_post_localizations?
-    object&.user&.guardian&.can_localize_content?
-  end
-
   def include_post_localizations_count?
-    object&.user&.guardian&.can_localize_content?
+    scope.can_localize_content?
   end
 
   def raw

--- a/lib/guardian/localization_guardian.rb
+++ b/lib/guardian/localization_guardian.rb
@@ -3,6 +3,6 @@
 module LocalizationGuardian
   def can_localize_content?
     return false if !SiteSetting.content_localization_enabled
-    user.in_any_groups?(SiteSetting.content_localization_allowed_groups_map)
+    @user.in_any_groups?(SiteSetting.content_localization_allowed_groups_map)
   end
 end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -199,9 +199,6 @@ RSpec.describe "posts" do
                        reviewable_score_pending_count: {
                          type: :integer,
                        },
-                       has_post_localizations: {
-                         type: :boolean,
-                       },
                        post_localizations: {
                          type: :array,
                          items: {

--- a/spec/requests/api/schemas/json/post_update_response.json
+++ b/spec/requests/api/schemas/json/post_update_response.json
@@ -211,9 +211,6 @@
         "post_url": {
           "type": "string"
         },
-        "has_post_localizations": {
-          "type": "boolean"
-        },
         "post_localizations": {
           "type": "array",
           "items": {}

--- a/spec/requests/api/schemas/json/topic_create_response.json
+++ b/spec/requests/api/schemas/json/topic_create_response.json
@@ -219,9 +219,6 @@
     "post_url": {
       "type": "string"
     },
-    "has_post_localizations": {
-      "type": "boolean"
-    },
     "post_localizations": {
       "type": "array",
       "items": {}

--- a/spec/system/post_translation_spec.rb
+++ b/spec/system/post_translation_spec.rb
@@ -5,7 +5,7 @@ describe "Post translations", type: :system do
 
   fab!(:admin)
   fab!(:topic)
-  fab!(:post) { Fabricate(:post, topic: topic, user: admin) }
+  fab!(:post) { Fabricate(:post, topic:) }
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:composer) { PageObjects::Components::Composer.new }
   let(:translation_selector) do
@@ -17,13 +17,12 @@ describe "Post translations", type: :system do
   let(:view_translations_modal) { PageObjects::Modals::ViewTranslationsModal.new }
 
   before do
-    sign_in(admin)
     SiteSetting.default_locale = "en"
     SiteSetting.content_localization_supported_locales = "fr|es|pt_BR"
     SiteSetting.content_localization_enabled = true
-    SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
     SiteSetting.post_menu =
       "read|like|copyLink|flag|edit|bookmark|delete|admin|reply|addTranslation"
+    sign_in(admin)
   end
 
   context "when a post does not have translations" do
@@ -133,7 +132,7 @@ describe "Post translations", type: :system do
       end
     end
 
-    it "allows a user to delete a translation" do
+    it "allows a user in content_localization_allowed_groups to delete a translation" do
       topic_page.visit_topic(topic)
       expect(PostLocalization.exists?(post_id: post.id, locale: "fr")).to be true
 


### PR DESCRIPTION
Currently the following is erroneously shown only if the post author is in the `content_localization_allowed_groups` setting. It should actually be shown based on the current_user, not the post's user. This bug prevents the privileged user from deleting translations.

<img width="706" height="221" alt="Screenshot 2025-08-18 at 8 30 59 PM" src="https://github.com/user-attachments/assets/69ebc364-c69f-4d8f-8c58-2216bec7ba8e" />
