### PR TITLE
Add a few helpful tips to the installation guide

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -1,3 +1,5 @@
+# Self-Host Discourse On Your Own Infrastructure
+
 > To install and self-host Discourse, follow the steps below. But if you'd rather skip the setup, maintenance, and server management, our official Discourse hosting takes care of everything for you.
 > 
 > 👉 [Learn more about Discourse hosting](https://discourse.org/pricing)
@@ -75,6 +77,8 @@ Create your new Droplet. You may receive an email with the root password, howeve
 
 > ⚠️ Now you have created your cloud server! Go back to your DNS controls and use the IP address to set up an `A record` for your `discourse.example.com` hostname.
 
+> ⚠️ Note: DigitalOcean now [blocks SMTP ports](https://docs.digitalocean.com/support/why-is-smtp-blocked/) on Droplets by default. You'll need to open a support ticket to get them unblocked before you can install Discourse.
+
 ### 4. Access Your Cloud Server
 
 Connect to your server via its IP address using SSH, or [Putty][put] on Windows:
@@ -117,6 +121,12 @@ Answer the following questions when prompted:
     Optional Maxmind License key () [xxxxxxxxxxxxxxxx]:
 
 You'll get the SMTP details from your [email](#2-setting-up-email) setup, be sure to complete that section.
+
+> ⚠️ If your email provider uses SMTP port 465 (SMTP over SSL) then you might need to make a small change to your `app.yml` configuration file in order for emails to send properly:
+> - Check out [this section](https://meta.discourse.org/t/troubleshoot-email-on-a-new-discourse-install/16326#p-55742-did-you-enter-email-settings-correctly-2) of the email troubleshooting guide.
+> - Edit app.yml with nano or your favorite editor.
+> - Find the "DISCOURSE_SMTP_" settings
+> - Add `DISCOURSE_SMTP_FORCE_TLS=true` on its own line
 
 Let's Encrypt account setup is to give you a free HTTPS certificate for your site, be sure to set that up if you want your site secure.
 

--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -1,4 +1,4 @@
-# Self-Host Discourse On Your Own Infrastructure
+# Install Discourse on a Cloud Server 
 
 > To install and self-host Discourse, follow the steps below. But if you'd rather skip the setup, maintenance, and server management, our official Discourse hosting takes care of everything for you.
 > 

--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -77,7 +77,7 @@ Create your new Droplet. You may receive an email with the root password, howeve
 
 > ⚠️ Now you have created your cloud server! Go back to your DNS controls and use the IP address to set up an `A record` for your `discourse.example.com` hostname.
 
-> ⚠️ Note: DigitalOcean now [blocks SMTP ports](https://docs.digitalocean.com/support/why-is-smtp-blocked/) on Droplets by default. You'll need to open a support ticket to get them unblocked before you can install Discourse.
+> ⚠️ Note: DigitalOcean now [blocks SMTP ports](https://docs.digitalocean.com/support/why-is-smtp-blocked/) on Droplets by default. You'll need to open a support ticket to get them unblocked before you can install Discourse. (Or try another port, for example, port 2525.) 
 
 ### 4. Access Your Cloud Server
 


### PR DESCRIPTION
This PR adds three individual changes to the self-hosting installation guide:

1. A note on DigitalOcean blocking SMTP ports
1. A preemptive bit of troubleshooting for SMTP port 465
1. A nice title!

**A note on DigitalOcean blocking SMTP ports**
DigitalOcean is recommended in the self-hosting guide, but they block SMTP ports in all droplets by default now. This change formally occurred in March/April 2025. You can have them unblocked, but it requires a support ticket. I added this information right below the recommendation on using DigitalOcean.

**A preemptive bit of troubleshooting for SMTP port 465**
I don’t have the ability to edit the email troubleshooting guide, but since the self-hosting guide has a few helpful tips on setting up your email properly, I felt this was appropriate to add as well. The TLDR is you simply can’t use port 465 without adding `DISCOURSE_SMTP_FORCE_TLS=true` to the SMTP settings in `app.yml`. It’s an easy fix once you know about it, but the two days I spent trying to get to that point were not fun!

**A nice title!**
The guide felt a little naked without a bold title to kick things off.