### PR TITLE
A11Y: include small post content as headings for screenreaders

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/small-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/small-action.gjs
@@ -153,7 +153,7 @@ export default class PostSmallAction extends Component {
           {{icon this.icon}}
         </div>
         <div class="small-action-desc">
-          <div class="small-action-contents">
+          <div class="small-action-contents" role="heading" aria-level="2">
             <UserAvatar
               @ariaHidden={{false}}
               @size="small"


### PR DESCRIPTION
Concerns "small posts" like this one

<img width="1564" height="176" alt="image" src="https://github.com/user-attachments/assets/652188fd-a7bd-4363-96fb-0ba8f7541e51" />

When navigating posts via heading-to-heading navigation in a screenreader, sometimes you can run into situations where there's no next heading to be found towards the bottom of the infinite loading page... and this can stop more posts from loading, even when more exist. 

Marking up the small post content as a heading allows it to be navigated like regular posts, and avoids this issue. So when a small post is near the bottom of a page, it can be navigated to and trigger more posts to load. 

This also has the benefit of making the small post content a more natural part of the post stream while navigating with a screen reader. 