### PR TITLE
FIX: Relax Matrix room ID validation

### DIFF
--- a/plugins/discourse-chat-integration/config/locales/client.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/client.en.yml
@@ -149,7 +149,7 @@ en:
               help: "A name to describe the channel. It is not used for the connection to Matrix."
             room_id:
               title: "Room ID"
-              help: "The 'private identifier' for the room. It should look something like !abcdefg:matrix.org"
+              help: "The 'private identifier' for the room. It should look something like !abcdefghijkl"
           errors:
             unknown_token: "Access token is invalid"
             unknown_room: "Room ID is invalid"

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -8,7 +8,7 @@ module DiscourseChatIntegration
       CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
-        { key: "room_id", regex: '^\!\S+:\S+$', unique: true, hidden: true },
+        { key: "room_id", regex: '^\!\S+$', unique: true, hidden: true },
       ]
 
       def self.send_message(room_id, message)

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/matrix/matrix_provider_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/matrix/matrix_provider_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DiscourseChatIntegration::Provider::MatrixProvider do
         provider: "matrix",
         data: {
           name: "Awesome Channel",
-          room_id: "!blah:matrix.org",
+          room_id: "!blah_blah_7",
         },
       )
     end
@@ -23,7 +23,7 @@ RSpec.describe DiscourseChatIntegration::Provider::MatrixProvider do
       stub1 =
         stub_request(
           :put,
-          %r{https://matrix.org/_matrix/client/r0/rooms/!blah:matrix.org/send/m.room.message/*},
+          %r{https://matrix.org/_matrix/client/r0/rooms/!blah_blah_7/send/m.room.message/*},
         ).to_return(status: 200)
       described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
@@ -33,7 +33,7 @@ RSpec.describe DiscourseChatIntegration::Provider::MatrixProvider do
       stub1 =
         stub_request(
           :put,
-          %r{https://matrix.org/_matrix/client/r0/rooms/!blah:matrix.org/send/m.room.message/*},
+          %r{https://matrix.org/_matrix/client/r0/rooms/!blah_blah_7/send/m.room.message/*},
         ).to_return(status: 400, body: '{"errmsg":"M_UNKNOWN"}')
       expect(stub1).to have_been_requested.times(0)
       expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(


### PR DESCRIPTION
This PR relaxes the accepted format of Matrix room IDs in the Matrix chat provider. It allows the new room ID format in [Room v12](https://github.com/matrix-org/matrix-spec-proposals/blob/matthew/msc4291/proposals/4291-room-ids-as-hashes.md) to be used in Discourse.

Reported here: https://meta.discourse.org/t/new-matrix-v12-rooms-not-supported-by-chat-integration/378675