### PR TITLE
DEV: Add initializer to deprecate Ember native array extensions

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/deprecate-ember-array-extensions.js
+++ b/app/assets/javascripts/discourse/app/initializers/deprecate-ember-array-extensions.js
@@ -1,0 +1,33 @@
+import { NativeArray } from "@ember/array";
+
+export default {
+  before: "discourse-bootstrap",
+
+  // Ember native array extensions are deprecated and were dropped in Ember 6.0. We need to add deprecation warnings to
+  // each method to collect data about their usage and make it easier to track them in the source code.
+  initialize() {
+    Array.from(NativeArray.keys())
+      .filter(
+        (k) =>
+          NativeArray._without.indexOf(k) === -1 &&
+          Array.prototype[k] &&
+          k !== "[]" // TODO (ember-native-array-extensions) remove this exception
+      )
+      .forEach((k) => {
+        const deprecatedMethod = Array.prototype[k];
+        // eslint-disable-next-line no-extend-native
+        Array.prototype[k] = function () {
+          // deprecated(
+          //   "[]." +
+          //     k +
+          //     " is an Ember native array extension and is deprecated. Use the native array methods or an Ember array instead.",
+          //   {
+          //     id: `discourse.ember.native-array-extensions`,
+          //     since: "3.6.0.beta1-dev",
+          //   }
+          // );
+          return deprecatedMethod.apply(this, arguments);
+        };
+      });
+  },
+};

--- a/app/assets/javascripts/discourse/app/lib/source-identifier.js
+++ b/app/assets/javascripts/discourse/app/lib/source-identifier.js
@@ -28,7 +28,7 @@ export default function identifySource(error) {
     ""
   );
 
-  if (BROWSER_EXTENSION_PROTOCOLS.any((p) => stack.includes(p))) {
+  if (BROWSER_EXTENSION_PROTOCOLS.some((p) => stack.includes(p))) {
     return {
       type: "browser-extension",
     };


### PR DESCRIPTION
Introduce an initializer to log deprecation warnings for Ember native array extensions, preparing for their removal in Ember 6.0. This helps track legacy usage and guides the transition to native alternatives or Ember arrays. The initializer modifies `Array.prototype` to wrap legacy methods with warnings.