### PR TITLE
PERF: Improve performance of SiteSetting.humanize_name + all_settings

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -85,6 +85,11 @@ module SiteSettingExtension
     @theme_site_settings[provider.current_site] ||= {}
   end
 
+  def humanized_names(name)
+    @humanized_names ||= {}
+    @humanized_names[name] ||= humanized_name(name)
+  end
+
   def defaults
     @defaults ||= SiteSettings::DefaultsProvider.new(self)
   end
@@ -197,7 +202,7 @@ module SiteSettingExtension
       setting:,
       default: SiteSetting.defaults[setting],
       description: SiteSetting.description(setting),
-      humanized_name: SiteSetting.humanized_name(setting),
+      humanized_name: humanized_names(setting),
     }.merge(type_supervisor.type_hash(setting))
   end
 
@@ -285,7 +290,7 @@ module SiteSettingExtension
   )
     locale_setting_hash = {
       setting: "default_locale",
-      humanized_name: humanized_name("default_locale"),
+      humanized_name: humanized_names("default_locale"),
       default: SiteSettings::DefaultsProvider::DEFAULT_LOCALE,
       category: "required",
       description: description("default_locale"),
@@ -351,7 +356,7 @@ module SiteSettingExtension
 
         opts = {
           setting: s,
-          humanized_name: humanized_name(s),
+          humanized_name: humanized_names(s),
           description: description(s),
           keywords: keywords(s),
           category: categories[s],


### PR DESCRIPTION
Followup 5b236ccc0774e3b0f5e0b34c99c1c36d9ea9604e

The humanize_name method was introducing some slowness and also more
objects in memory to GC. This commit improves the performance by
memoizing and moving work to hash lookup instead of array.include?
checks, and making sure we compile regexes only once.

As well as this, we memoize the humanized names for all settings
so we don't have to recompute them every time we call all_settings.

Results are as follows:

**Current perf:**

```
Results:
Total time: 36.8178 seconds
Average time per call: 368.1783 ms
Calls per second: 2.72

Detailed timing:
User CPU time: 36.432 seconds
System CPU time: 0.2607 seconds
Total CPU time: 36.6926 seconds
Real time: 36.8178 seconds

Memory Report:
Total allocations: 10932505
Total retained: 985
```

**Humanize improvements:**

```
Results:
Total time: 27.7318 seconds
Average time per call: 277.3178 ms
Calls per second: 3.61

Detailed timing:
User CPU time: 27.3635 seconds
System CPU time: 0.2078 seconds
Total CPU time: 27.5713 seconds
Real time: 27.7318 seconds

Memory Report:
Total allocations: 5535404
Total retained: 1098
```

**Humanize improvements + memoization of humanized names:**

```
Results:
Total time: 24.5924 seconds
Average time per call: 245.9237 ms
Calls per second: 4.07

Detailed timing:
User CPU time: 24.2941 seconds
System CPU time: 0.2019 seconds
Total CPU time: 24.496 seconds
Real time: 24.5924 seconds

Memory Report:
Total allocations: 4417243
Total retained: 1184
```
