### PR TITLE
FIX: Update i18n key for toggle localization button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-localized-content-toggle.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-localized-content-toggle.gjs
@@ -35,8 +35,8 @@ export default class TopicLocalizedContentToggle extends Component {
 
   get title() {
     return this.showingOriginal
-      ? "translator.content_not_translated"
-      : "translator.content_translated";
+      ? "content_localization.toggle_localized.not_translated"
+      : "content_localization.toggle_localized.translated";
   }
 
   <template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5580,6 +5580,10 @@ en:
             default: "%{filter} topics in %{category} without tags"
 
         categories: "All categories"
+    content_localization:
+      toggle_localized:
+        translated: "Page is machine-translated. Click to view original."
+        not_translated: "Page is not translated. Click to translate."
 
   # This section is exported to the javascript for i18n in the admin section
   admin_js:

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Content Localization" do
+  TOGGLE_LOCALIZE_BUTTON_SELECTOR = "button.btn-toggle-localized-content"
+
   fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
   fab!(:site_local_user) { Fabricate(:user, locale: "en") }
   fab!(:admin)
@@ -68,9 +70,16 @@ describe "Content Localization" do
       topic_list.visit_topic_with_title("孫子兵法からの人生戦略")
 
       expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
-      page.find("button.btn-toggle-localized-content").click
+
+      expect(page.find(TOGGLE_LOCALIZE_BUTTON_SELECTOR)["title"]).to eq(
+        I18n.t("js.content_localization.toggle_localized.translated"),
+      )
+      page.find(TOGGLE_LOCALIZE_BUTTON_SELECTOR).click
 
       expect(topic_page.has_topic_title?("Life strategies from The Art of War")).to eq(true)
+      expect(page.find(TOGGLE_LOCALIZE_BUTTON_SELECTOR)["title"]).to eq(
+        I18n.t("js.content_localization.toggle_localized.not_translated"),
+      )
 
       visit("/")
       topic_list.visit_topic_with_title("Life strategies from The Art of War")


### PR DESCRIPTION
When this button was moved from translator to core (https://github.com/discourse/discourse-translator/pull/308) the translations were not updated. This PR fixes the missing translation.

<img width="466" height="185" alt="Screenshot 2025-08-19 at 3 25 26 PM" src="https://github.com/user-attachments/assets/3bb46172-2017-4084-a5e0-02768742bb6b" />
