### PR TITLE
DEV: Manually fix Rails/UnusedRenderContent offenses

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -282,7 +282,7 @@ class Admin::ThemesController < Admin::AdminController
 
   def destroy
     Themes::Destroy.call(service_params) do
-      on_success { render status: :no_content }
+      on_success { head :no_content }
       on_failed_contract do |contract|
         render json: failed_json.merge(errors: contract.errors.full_messages), status: 400
       end
@@ -292,7 +292,7 @@ class Admin::ThemesController < Admin::AdminController
 
   def bulk_destroy
     Themes::BulkDestroy.call(service_params) do
-      on_success { render status: :no_content }
+      on_success { head :no_content }
       on_failed_contract do |contract|
         render json: failed_json.merge(errors: contract.errors.full_messages), status: 400
       end

--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -72,7 +72,7 @@ class StylesheetsController < ApplicationController
     handle_missing_cache(location, target, digest) if !stylesheet_time
 
     if cache_time.present? && stylesheet_time && stylesheet_time <= cache_time
-      return render status: 304
+      return head :not_modified
     end
 
     unless File.exist?(location)

--- a/app/controllers/theme_javascripts_controller.rb
+++ b/app/controllers/theme_javascripts_controller.rb
@@ -17,7 +17,7 @@ class ThemeJavascriptsController < ApplicationController
 
   def show
     raise Discourse::NotFound if last_modified.blank?
-    return render status: 304 if not_modified?
+    return head :not_modified if not_modified?
 
     # Security: safe due to route constraint
     cache_file = "#{DISK_CACHE_PATH}/#{params[:digest]}.js"
@@ -36,7 +36,7 @@ class ThemeJavascriptsController < ApplicationController
 
   def show_map
     raise Discourse::NotFound if last_modified.blank?
-    return render status: 304 if not_modified?
+    return head :not_modified if not_modified?
 
     # Security: safe due to route constraint
     cache_file = "#{DISK_CACHE_PATH}/#{params[:digest]}.map"
@@ -57,7 +57,7 @@ class ThemeJavascriptsController < ApplicationController
     raise Discourse::NotFound if content.blank? || content_digest != digest
 
     @cache_file = "#{TESTS_DISK_CACHE_PATH}/#{digest}.js"
-    return render status: 304 if not_modified?
+    return head :not_modified if not_modified?
 
     write_if_not_cached(@cache_file) { content }
 

--- a/plugins/discourse-zendesk-plugin/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/plugins/discourse-zendesk-plugin/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -40,7 +40,7 @@ module DiscourseZendeskPlugin
         end
       end
 
-      render status: 204
+      head :no_content
     end
 
     private


### PR DESCRIPTION
(no autofix for this one)

From [rubocop docs](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedrendercontent):

> If you try to render content along with a non-content status code (100-199, 204, 205, or 304), it will be dropped from the response.