### PR TITLE
FIX: Don't leave blank additional_tag_ids param after removing dups in intersection

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -166,7 +166,12 @@ class TagsController < ::ApplicationController
         additional_tags_trimmed = additional_tags_trimmed&.uniq
 
         if additional_tags_trimmed != @additional_tags
-          params[:additional_tag_ids] = additional_tags_trimmed&.join("/")
+          if additional_tags_trimmed.present?
+            params[:additional_tag_ids] = additional_tags_trimmed&.join("/")
+          else
+            params[:additional_tag_ids] = nil
+          end
+
           return redirect_to url_for(params.to_unsafe_hash)
         end
       end

--- a/spec/system/tags_intersection_spec.rb
+++ b/spec/system/tags_intersection_spec.rb
@@ -38,6 +38,9 @@ describe "Tags intersection", type: :system do
 
     visit("/tags/intersection/sour/tangy/sour/sour")
     expect(page).to have_current_path("/tags/intersection/sour/tangy")
+
+    visit("/tags/intersection/sour/sour")
+    expect(page).to have_current_path("/tag/sour")
   end
 
   it "removes duplicates from the additional tags list" do


### PR DESCRIPTION
My [previous fix](https://github.com/discourse/discourse/commit/459a5f2d8b0ec89d00e81a8caeae239730ac2ab3) would leave behind a blank `additional_tag_ids=` query param when redirecting to /tag if all additional_tags in the intersection route were removed due to being duplicates. For instance, `/tags/intersection/tag1/tag1` would redirect to `/tag/tag1?additional_tag_ids=`. Probably harmless but not intentional.

With this fix the additional_tag_ids param is removed if it ends up being cleared during the duplicate check, so the above example will redirect to `/tag/tag1` with the `additional_tag_ids` param omitted.