### PR TITLE
FIX: broken base_scheme_id migration when base is default

### DIFF
--- a/db/migrate/20250818063631_migrate_color_schemes_base_scheme_id_from_string_to_int.rb
+++ b/db/migrate/20250818063631_migrate_color_schemes_base_scheme_id_from_string_to_int.rb
@@ -2,6 +2,7 @@
 
 class MigrateColorSchemesBaseSchemeIdFromStringToInt < ActiveRecord::Migration[8.0]
   NAMES_TO_ID_MAP = {
+    "default" => -1,
     "Light" => -1,
     "Dark" => -2,
     "Neutral" => -3,


### PR DESCRIPTION
In this PR, migration was introduced to change the `base_scheme_id` column from a string to proper integer IDs.

https://github.com/discourse/discourse/pull/34351

However, one base type called "Default" was not covered and later conversion to an integer is failing.

<img width="973" height="56" alt="Screenshot 2025-08-20 at 12 58 04 pm" src="https://github.com/user-attachments/assets/04b193b2-e66e-4aed-ab7c-d46605f0e802" />
