### PR TITLE
FIX: Avoid returning duplicate voters from `/polls/voters.json` endpoint

### DIFF
--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -223,7 +223,7 @@ class DiscoursePoll::Poll
     offset = (page - 1) * limit
 
     params = {
-      offset: offset,
+      offset: offset + 1,
       offset_plus_limit: offset + limit,
       option_digest: opts[:option_id].presence,
     }


### PR DESCRIPTION
When fetching voters from the `/polls/voters.json` API endpoint, each page after the first has an extra voter (the last one from the previous page). This causes duplicate voters to be returned if loading multiple pages. This PR fixes the off-by-one error that causes this. (This fix has initially been proposed by Rob Mackenzie.)

The PR also fixes an issue that could cause non-deterministic ordering of results from that API; however, I have not been able to craft a test to reproduce the issue, so the fix is theoretical.

Reporter here: https://meta.discourse.org/t/polls-voters-json-returning-duplicate-users-across-paged-requests/376636