### PR TITLE
UX: fix cmd-k bottom padding

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -19,9 +19,9 @@ html.keyboard-visible.mobile-view {
   }
 }
 
-html:not(.keyboard-visible.mobile-view) {
+html:not(.keyboard-visible).mobile-device {
   .d-modal__container {
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: env(safe-area-inset-bottom, 1rem);
   }
 }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-creator.scss
@@ -6,6 +6,10 @@
     box-sizing: border-box;
   }
 
+  &__list-container {
+    margin-top: var(--space-4);
+  }
+
   &__add-members {
     display: flex;
     gap: 1rem;
@@ -99,6 +103,7 @@
       flex-grow: 1;
       padding-bottom: 0.5rem;
       border-bottom: 1px solid var(--content-border-color);
+      margin-bottom: var(--space-4);
     }
 
     &__input {

--- a/plugins/chat/assets/stylesheets/common/chat-modal-new-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-modal-new-message.scss
@@ -8,7 +8,6 @@
   .chat-message-creator__new-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
   }
 
   .chat-message-creator__add-members-header-container {


### PR DESCRIPTION
Moved some things around to fix the lack of bottom padding while searching for results:
<img width="1706" height="398" alt="CleanShot 2025-08-20 at 15 58 32@2x" src="https://github.com/user-attachments/assets/c67f2c35-719d-4a3d-98ee-191353a476e2" />

🔽 
<img width="1706" height="398" alt="CleanShot 2025-08-20 at 15 52 13@2x" src="https://github.com/user-attachments/assets/65869c9d-06b7-4dd9-b5ef-156e320a798a" />

