### PR TITLE
FIX: Support `light-dark` on older browsers (stable)

### DIFF
--- a/app/assets/javascripts/theme-transpiler/package.json
+++ b/app/assets/javascripts/theme-transpiler/package.json
@@ -35,6 +35,7 @@
     "postcss": "^8.5.6",
     "postcss-js": "^4.0.1",
     "postcss-media-minmax": "^5.0.0",
+    "postcss-nesting": "^13.0.2",
     "readable-stream": "^4.7.0",
     "source-map-js": "^1.2.1",
     "terser": "^5.43.1"

--- a/app/assets/javascripts/theme-transpiler/postcss.js
+++ b/app/assets/javascripts/theme-transpiler/postcss.js
@@ -3,6 +3,7 @@ import postcssLightDark from "@csstools/postcss-light-dark-function";
 import autoprefixer from "autoprefixer";
 import postcss from "postcss";
 import minmax from "postcss-media-minmax";
+import postcssNesting from "postcss-nesting";
 import { browsers } from "../discourse/config/targets";
 import postcssVariablePrefixer from "./postcss-variable-prefixer";
 
@@ -12,6 +13,7 @@ const postCssProcessor = postcss([
   }),
   minmax(),
   postcssLightDark,
+  postcssNesting, // Un-nests the native css nesting from postcssLightDark
   postcssVariablePrefixer(),
 ]);
 let lastPostcssError, lastPostcssResult;

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -8,7 +8,7 @@ end
 
 class Stylesheet::Manager
   # Bump this number to invalidate all stylesheet caches (e.g. if you change something inside the compiler)
-  BASE_COMPILER_VERSION = 5
+  BASE_COMPILER_VERSION = 6
 
   # Add any dependencies here which should automatically cause a global cache invalidation.
   BASE_CACHE_KEY = "#{BASE_COMPILER_VERSION}::#{DiscourseFonts::VERSION}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,6 +1105,9 @@ importers:
       postcss-media-minmax:
         specifier: ^5.0.0
         version: 5.0.0(postcss@8.5.6)
+      postcss-nesting:
+        specifier: ^13.0.2
+        version: 13.0.2(postcss@8.5.6)
       readable-stream:
         specifier: ^4.7.0
         version: 4.7.0
@@ -1779,6 +1782,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
+
+  '@csstools/selector-resolve-nested@3.1.0':
+    resolution: {integrity: sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss-selector-parser: ^7.0.0
 
   '@csstools/selector-specificity@5.0.0':
     resolution: {integrity: sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==}
@@ -7407,6 +7416,12 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  postcss-nesting@13.0.2:
+    resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
   postcss-resolve-nested-selector@0.1.6:
     resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
 
@@ -10103,6 +10118,10 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
+
+  '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.0)':
+    dependencies:
+      postcss-selector-parser: 7.1.0
 
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.0)':
     dependencies:
@@ -17082,6 +17101,13 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
+
+  postcss-nesting@13.0.2(postcss@8.5.6):
+    dependencies:
+      '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.0)
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
+      postcss: 8.5.6
+      postcss-selector-parser: 7.1.0
 
   postcss-resolve-nested-selector@0.1.6: {}
 

--- a/spec/lib/stylesheet/compiler_spec.rb
+++ b/spec/lib/stylesheet/compiler_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe Stylesheet::Compiler do
 
       expect(css).to include("-webkit-min-device-pixel-ratio")
       expect(css).to include("csstools-light-dark-toggle")
+      expect(css).not_to include("& * {") # No native nesting
       expect(map.size).to be > 10
     end
 


### PR DESCRIPTION
We were already polyfilling `light-dark` for older browsers. However, that polyfill makes use of native CSS nesting, which is also unsupported by older browsers. This commit adds the `postcssNesting` transform to turn that nesting back into flat CSS.

This became a noticable problem since light-dark was added to a critical core stylesheet in 1ec69c3f2f32c48b68596d639e1e495dc031f4ed, which then caused the whole file to be a syntax error under Safari 16.