### PR TITLE
FIX: handle lower case dark

### DIFF
--- a/db/migrate/20250818063631_migrate_color_schemes_base_scheme_id_from_string_to_int.rb
+++ b/db/migrate/20250818063631_migrate_color_schemes_base_scheme_id_from_string_to_int.rb
@@ -5,6 +5,7 @@ class MigrateColorSchemesBaseSchemeIdFromStringToInt < ActiveRecord::Migration[8
     "default" => -1,
     "Light" => -1,
     "Dark" => -2,
+    "dark" => -2,
     "Neutral" => -3,
     "Grey Amber" => -4,
     "Shades of Blue" => -5,


### PR DESCRIPTION
This has been renamed in https://github.com/discourse/discourse/commit/7a3c5410770ec0752f72ce13f87bef6601c4aa0d#diff-3498f4852039e5953487a188b9722b228d6d0bf4f054dbdcbd11c10392ac3939 and was not handled in https://github.com/discourse/discourse/pull/34351

Causing this error in migrations:

```
#<StandardError:"An error has occurred, this and all later migrations canceled:\n\nPG::InvalidTextRepresentation: ERROR:  invalid input syntax for type integer: \"dark\"\n">
```

Example record causing an issue:

```
<ColorScheme:0x00007f39e9532bc0
  id: 1,
  name: "Simple Dark",
  version: 30,
  created_at: "2017-06-06 17:26:26.281664000 +0000",
  updated_at: "2023-03-08 17:44:07.637672000 +0000",
  via_wizard: true,
  base_scheme_id: "dark",
  theme_id: nil,
  user_selectable: true>
```