### PR TITLE
DEV: Remove color mode tabs from palette editor

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -9,9 +9,7 @@ import { extractError } from "discourse/lib/ajax-error";
 import { clipboardCopy } from "discourse/lib/utilities";
 import { i18n } from "discourse-i18n";
 import AdminConfigAreaCard from "admin/components/admin-config-area-card";
-import ColorPaletteEditor, {
-  LIGHT,
-} from "admin/components/color-palette-editor";
+import ColorPaletteEditor from "admin/components/color-palette-editor";
 
 export default class AdminConfigAreasColorPalette extends Component {
   @service toasts;
@@ -19,7 +17,6 @@ export default class AdminConfigAreasColorPalette extends Component {
   @service dialog;
 
   @tracked editingName = false;
-  @tracked editorMode = LIGHT;
   @tracked saving = false;
   @tracked hasChangedName = false;
   @tracked hasChangedUserSelectable = false;
@@ -56,14 +53,8 @@ export default class AdminConfigAreasColorPalette extends Component {
   }
 
   @action
-  onLightColorChange(color, value) {
+  onColorChange(color, value) {
     color.hex = value;
-    this.hasChangedColors = true;
-  }
-
-  @action
-  onDarkColorChange(color, value) {
-    color.dark_hex = value;
     this.hasChangedColors = true;
   }
 
@@ -119,11 +110,6 @@ export default class AdminConfigAreasColorPalette extends Component {
     } finally {
       this.saveNameOnly = false;
     }
-  }
-
-  @action
-  onEditorTabSwitch(newMode) {
-    this.editorMode = newMode;
   }
 
   @action
@@ -327,11 +313,8 @@ export default class AdminConfigAreasColorPalette extends Component {
             >
               <field.Custom>
                 <ColorPaletteEditor
-                  @initialMode={{this.editorMode}}
                   @colors={{transientData.colors}}
-                  @onLightColorChange={{this.onLightColorChange}}
-                  @onDarkColorChange={{this.onDarkColorChange}}
-                  @onTabSwitch={{this.onEditorTabSwitch}}
+                  @onColorChange={{this.onColorChange}}
                 />
               </field.Custom>
             </form.Field>

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show-colors.gjs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show-colors.gjs
@@ -15,7 +15,7 @@ export default RouteTemplate(
     }
 
     @action
-    onLightColorChange(color, value) {
+    onColorChange(color, value) {
       color.hex = value;
       if (color.hex !== color.originalHex) {
         this.args.controller.colorPaletteChangeTracker.addDirtyLightColor(
@@ -23,20 +23,6 @@ export default RouteTemplate(
         );
       } else {
         this.args.controller.colorPaletteChangeTracker.removeDirtyLightColor(
-          color.name
-        );
-      }
-    }
-
-    @action
-    onDarkColorChange(color, value) {
-      color.dark_hex = value;
-      if (color.dark_hex !== color.originalDarkHex) {
-        this.args.controller.colorPaletteChangeTracker.addDirtyDarkColor(
-          color.name
-        );
-      } else {
-        this.args.controller.colorPaletteChangeTracker.removeDirtyDarkColor(
           color.name
         );
       }
@@ -57,8 +43,7 @@ export default RouteTemplate(
     <template>
       <ColorPaletteEditor
         @colors={{@model.colorPalette.colors}}
-        @onLightColorChange={{this.onLightColorChange}}
-        @onDarkColorChange={{this.onDarkColorChange}}
+        @onColorChange={{this.onColorChange}}
         @hideRevertButton={{true}}
         @system={{@model.system}}
       />

--- a/app/assets/javascripts/discourse/tests/integration/components/color-palette-editor-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/color-palette-editor-test.gjs
@@ -1,4 +1,4 @@
-import { click, find, render, triggerEvent } from "@ember/test-helpers";
+import { find, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ColorPaletteEditor from "admin/components/color-palette-editor";
@@ -6,34 +6,6 @@ import ColorSchemeColor from "admin/models/color-scheme-color";
 
 function editor() {
   return {
-    isActiveModeLight() {
-      return this.lightModeNavPill().classList.contains("active");
-    },
-
-    isActiveModeDark() {
-      return this.darkModeNavPill().classList.contains("active");
-    },
-
-    lightModeNavPill() {
-      return this.navPills().querySelector(".light-tab");
-    },
-
-    darkModeNavPill() {
-      return this.navPills().querySelector(".dark-tab");
-    },
-
-    navPills() {
-      return find(".color-palette-editor__nav-pills");
-    },
-
-    async switchToLightTab() {
-      await click(this.lightModeNavPill());
-    },
-
-    async switchToDarkTab() {
-      await click(this.darkModeNavPill());
-    },
-
     color(name) {
       return {
         container() {
@@ -93,92 +65,11 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
     this.subject = editor();
   });
 
-  test("switching between light and dark modes", async function (assert) {
-    const colors = [
-      {
-        name: "primary",
-        hex: "aaaaaa",
-        dark_hex: "1e3c8a",
-      },
-      {
-        name: "header_background",
-        hex: "473921",
-        dark_hex: "f2cca9",
-      },
-    ].map((data) => ColorSchemeColor.create(data));
-
-    await render(
-      <template><ColorPaletteEditor @colors={{colors}} /></template>
-    );
-
-    assert.true(
-      this.subject.isActiveModeLight(),
-      "light mode tab is active by default"
-    );
-    assert.false(
-      this.subject.isActiveModeDark(),
-      "dark mode tab is not active by default"
-    );
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#aaaaaa",
-      "input for the primary color is showing the light color"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "aaaaaa",
-      "text input value for the primary color is showing the light color"
-    );
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#473921",
-      "input for the header_background color is showing the light color"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "473921",
-      "text input value for the header_background color is showing the light color"
-    );
-
-    await this.subject.switchToDarkTab();
-
-    assert.false(
-      this.subject.isActiveModeLight(),
-      "light mode tab is now inactive"
-    );
-    assert.true(this.subject.isActiveModeDark(), "dark mode tab is now active");
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#1e3c8a",
-      "input for the primary color is showing the dark color"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "1e3c8a",
-      "text input value for the primary color is showing the dark color"
-    );
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#f2cca9",
-      "input for the header_background color is showing the dark color"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "f2cca9",
-      "text input value for the header_background color is showing the dark color"
-    );
-  });
-
   test("uses the i18n string for the color name", async function (assert) {
     const colors = [
       {
         name: "header_background",
         hex: "473921",
-        dark_hex: "f2cca9",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
@@ -197,33 +88,25 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
       {
         name: "header_background",
         hex: "473921",
-        dark_hex: "f2cca9",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
-    const lightChanges = [];
-    const darkChanges = [];
+    const changes = [];
 
-    const onLightColorChange = (color, value) => {
-      lightChanges.push([color.name, value]);
+    const onColorChange = (color, value) => {
+      changes.push([color.name, value]);
       color.hex = value;
-    };
-    const onDarkColorChange = (color, value) => {
-      darkChanges.push([color.name, value]);
-      color.dark_hex = value;
     };
 
     await render(
       <template>
         <ColorPaletteEditor
           @colors={{colors}}
-          @onLightColorChange={{onLightColorChange}}
-          @onDarkColorChange={{onDarkColorChange}}
+          @onColorChange={{onColorChange}}
         />
       </template>
     );
@@ -241,14 +124,9 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "text input value for the primary color updates for `input` events"
     );
     assert.deepEqual(
-      lightChanges,
+      changes,
       [["primary", "abcdef"]],
-      "light color change callbacks are triggered for `input` events"
-    );
-    assert.strictEqual(
-      darkChanges.length,
-      0,
-      "dark color change callbacks aren't triggered for `input` events when the light color changes"
+      "color change callback is triggered for `input` events"
     );
 
     await this.subject.color("primary").sendColorChangeEvent("#fedcba");
@@ -264,136 +142,12 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "text input value for the primary color updates for `change` events"
     );
     assert.deepEqual(
-      lightChanges,
+      changes,
       [
         ["primary", "abcdef"],
         ["primary", "fedcba"],
       ],
-      "light color change callbacks are triggered for `change` events when the light color changes"
-    );
-
-    assert.strictEqual(
-      darkChanges.length,
-      0,
-      "dark color change callbacks aren't triggered for `change` events when the light color changes"
-    );
-
-    await this.subject.switchToDarkTab();
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#1e3c8a",
-      "the dark color isn't affected by the change to the light color"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "1e3c8a",
-      "the dark color isn't affected by the change to the light color"
-    );
-
-    lightChanges.length = 0;
-    darkChanges.length = 0;
-
-    await this.subject
-      .color("header_background")
-      .sendColorInputEvent("#776655");
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#776655",
-      "the input element for the header_background color changes its value for `input` events"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "776655",
-      "text input value for the header_background color updates for `input` events"
-    );
-    assert.strictEqual(
-      lightChanges.length,
-      0,
-      "light color change callbacks aren't triggered for `input` events when the dark color changes"
-    );
-    assert.deepEqual(
-      darkChanges,
-      [["header_background", "776655"]],
-      "dark color change callbacks are triggered for `input` events"
-    );
-
-    await this.subject
-      .color("header_background")
-      .sendColorChangeEvent("#99aaff");
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#99aaff",
-      "the input element for the header_background color changes its value for `change` events"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "99aaff",
-      "text input value for the header_background color updates for `change` events"
-    );
-    assert.deepEqual(
-      darkChanges,
-      [
-        ["header_background", "776655"],
-        ["header_background", "99aaff"],
-      ],
-      "dark color change callbacks are triggered for `change` events when the dark color changes"
-    );
-
-    assert.strictEqual(
-      lightChanges.length,
-      0,
-      "light color change callbacks aren't triggered for `change` events when the dark color changes"
-    );
-
-    await this.subject.switchToLightTab();
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#fedcba",
-      "the light color for the primary color is remembered after switching tabs"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "fedcba",
-      "the light color for the primary color is remembered after switching tabs"
-    );
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#473921",
-      "the light color for the header_background color remains unchanged"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "473921",
-      "the light color for the header_background color remains unchanged"
-    );
-
-    await this.subject.switchToDarkTab();
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#1e3c8a",
-      "the dark color for the primary color remains unchanged"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "1e3c8a",
-      "the dark color for the primary color remains unchanged"
-    );
-
-    assert.strictEqual(
-      this.subject.color("header_background").colorInput().value,
-      "#99aaff",
-      "the dark color for the header_background color is remembered after switching tabs"
-    );
-    assert.strictEqual(
-      this.subject.color("header_background").textInput().value,
-      "99aaff",
-      "the dark color for the header_background color is remembered after switching tabs"
+      "color change callback is triggered for `change` events when the color changes"
     );
   });
 
@@ -402,28 +156,21 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
-    const lightChanges = [];
-    const darkChanges = [];
+    const changes = [];
 
-    const onLightColorChange = (color, value) => {
-      lightChanges.push([color.name, value]);
+    const onColorChange = (color, value) => {
+      changes.push([color.name, value]);
       color.hex = value;
-    };
-    const onDarkColorChange = (color, value) => {
-      darkChanges.push([color.name, value]);
-      color.dark_hex = value;
     };
 
     await render(
       <template>
         <ColorPaletteEditor
           @colors={{colors}}
-          @onLightColorChange={{onLightColorChange}}
-          @onDarkColorChange={{onDarkColorChange}}
+          @onColorChange={{onColorChange}}
         />
       </template>
     );
@@ -436,37 +183,9 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "the color input reflects the text input"
     );
     assert.deepEqual(
-      lightChanges,
+      changes,
       [["primary", "9999cc"]],
-      "light color change callbacks are triggered for `change` events when the light color changes"
-    );
-
-    assert.strictEqual(
-      darkChanges.length,
-      0,
-      "no changes to dark mode colors are mode"
-    );
-
-    lightChanges.length = 0;
-
-    await this.subject.switchToDarkTab();
-
-    await this.subject.color("primary").sendTextChangeEvent("1f9c3e");
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#1f9c3e",
-      "the color input reflects the text input"
-    );
-    assert.deepEqual(
-      darkChanges,
-      [["primary", "1f9c3e"]],
-      "dark color change callbacks are triggered for `change` events when the light color changes"
-    );
-    assert.strictEqual(
-      lightChanges.length,
-      0,
-      "no changes to light mode colors are mode"
+      "color change callback is triggered for `change` events when the color changes"
     );
   });
 
@@ -475,7 +194,6 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "a8c",
-        dark_hex: "971",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
@@ -493,19 +211,6 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "aa88cc",
       "the text input value shows the 6 digits format"
     );
-
-    await this.subject.switchToDarkTab();
-
-    assert.strictEqual(
-      this.subject.color("primary").colorInput().value,
-      "#997711",
-      "the input field has the equivalent 6 digits value"
-    );
-    assert.strictEqual(
-      this.subject.color("primary").textInput().value,
-      "997711",
-      "the text input value shows the 6 digits format"
-    );
   });
 
   test("validates hex color input", async function (assert) {
@@ -513,14 +218,13 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
-    const lightChanges = [];
+    const changes = [];
 
-    const onLightColorChange = (color, value) => {
-      lightChanges.push([color.name, value]);
+    const onColorChange = (color, value) => {
+      changes.push([color.name, value]);
       color.hex = value;
     };
 
@@ -528,7 +232,7 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       <template>
         <ColorPaletteEditor
           @colors={{colors}}
-          @onLightColorChange={{onLightColorChange}}
+          @onColorChange={{onColorChange}}
         />
       </template>
     );
@@ -540,11 +244,11 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "valid 6-digit hex color is accepted"
     );
     assert.deepEqual(
-      lightChanges,
+      changes,
       [["primary", "333333"]],
-      "light color change callback is called with the expanded value"
+      "color change callback is called with the expanded value"
     );
-    lightChanges.length = 0;
+    changes.length = 0;
 
     await this.subject.color("primary").sendTextChangeEvent("abc");
     assert.strictEqual(
@@ -553,11 +257,11 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "valid 3-digit hex color is accepted and expanded"
     );
     assert.deepEqual(
-      lightChanges,
+      changes,
       [["primary", "aabbcc"]],
-      "light color change callback is called with the expanded value"
+      "color change callback is called with the expanded value"
     );
-    lightChanges.length = 0;
+    changes.length = 0;
 
     await this.subject.color("primary").sendTextChangeEvent("gggggg");
     assert.strictEqual(
@@ -566,9 +270,9 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       "invalid hex color is rejected"
     );
     assert.strictEqual(
-      lightChanges.length,
+      changes.length,
       0,
-      "light color change callback is not called"
+      "color change callback is not called"
     );
   });
 
@@ -577,7 +281,6 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
@@ -615,17 +318,14 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
       {
         name: "secondary",
         hex: "bbbbbb",
-        dark_hex: "2d4c9a",
       },
       {
         name: "tertiary",
         hex: "cccccc",
-        dark_hex: "3e5daa",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
@@ -661,7 +361,6 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
     ].map((data) => ColorSchemeColor.create(data));
 
@@ -719,7 +418,6 @@ module("Integration | Component | ColorPaletteEditor", function (hooks) {
       {
         name: "primary",
         hex: "aaaaaa",
-        dark_hex: "1e3c8a",
       },
     ].map((data) => ColorSchemeColor.create(data));
 

--- a/app/assets/stylesheets/admin/color-palette-editor.scss
+++ b/app/assets/stylesheets/admin/color-palette-editor.scss
@@ -1,18 +1,4 @@
 .color-palette-editor {
-  &__nav-pills {
-    display: flex;
-    margin-bottom: 1em;
-
-    li {
-      flex: 1 1 auto;
-
-      a {
-        width: 100%;
-        justify-content: center;
-      }
-    }
-  }
-
   &__colors-list {
     display: flex;
     flex-direction: column;

--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -70,33 +70,18 @@ describe "Admin Color Palette Config Area Page", type: :system do
   it "allows changing colors" do
     config_area.visit(color_scheme.id)
 
-    expect(config_area.color_palette_editor).to have_light_tab_active
-
     config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#abcdef")
 
     expect(config_area).to have_unsaved_changes_indicator
-
-    config_area.color_palette_editor.switch_to_dark_tab
-    expect(config_area.color_palette_editor).to have_dark_tab_active
-
-    config_area.color_palette_editor.input_for_color("primary").fill_in(with: "#fedcba")
-    config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#111222")
 
     config_area.form.submit
 
     expect(toasts).to have_success(I18n.t("js.saved"))
     expect(config_area).to have_no_unsaved_changes_indicator
-    expect(config_area.color_palette_editor).to have_dark_tab_active
-    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#fedcba")
-    expect(config_area.color_palette_editor.input_for_color("secondary").value).to eq("#111222")
 
-    config_area.color_palette_editor.switch_to_light_tab
-    expect(config_area.color_palette_editor).to have_light_tab_active
     expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#abcdef")
 
     expect(color_scheme.colors.find_by(name: "primary").hex).to eq("abcdef")
-    expect(color_scheme.colors.find_by(name: "primary").dark_hex).to eq("fedcba")
-    expect(color_scheme.colors.find_by(name: "secondary").dark_hex).to eq("111222")
   end
 
   it "allows reverting colors to their default values" do

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -305,23 +305,6 @@ describe "Admin Customize Themes", type: :system do
       expect(updated_color).to eq(original_hex)
     end
 
-    it "allows editing dark mode colors" do
-      theme_page.visit(theme.id)
-      theme_page.colors_tab.click
-
-      theme_page.color_palette_editor.switch_to_dark_tab
-
-      theme_page.color_palette_editor.change_color("primary", "#000fff")
-
-      theme_page.changes_banner.click_save
-
-      page.refresh
-      theme_page.color_palette_editor.switch_to_dark_tab
-
-      updated_dark_color = theme_page.color_palette_editor.get_color_value("primary")
-      expect(updated_dark_color).to eq("#000fff")
-    end
-
     it "shows count of unsaved colors" do
       theme_page.visit(theme.id)
       theme_page.colors_tab.click
@@ -332,17 +315,9 @@ describe "Admin Customize Themes", type: :system do
         I18n.t("admin_js.admin.customize.theme.unsaved_colors", count: 1),
       )
 
-      theme_page.color_palette_editor.switch_to_dark_tab
-
-      theme_page.color_palette_editor.change_color("primary", "#ff80ee")
-
-      expect(theme_page.changes_banner).to have_label(
-        I18n.t("admin_js.admin.customize.theme.unsaved_colors", count: 2),
-      )
-
       theme_page.color_palette_editor.change_color("secondary", "#ee30ab")
       expect(theme_page.changes_banner).to have_label(
-        I18n.t("admin_js.admin.customize.theme.unsaved_colors", count: 3),
+        I18n.t("admin_js.admin.customize.theme.unsaved_colors", count: 2),
       )
     end
 

--- a/spec/system/page_objects/components/color_palette_editor.rb
+++ b/spec/system/page_objects/components/color_palette_editor.rb
@@ -9,22 +9,6 @@ module PageObjects
         @component = component
       end
 
-      def has_light_tab_active?
-        component.has_css?(".light-tab.active")
-      end
-
-      def has_dark_tab_active?
-        component.has_css?(".dark-tab.active")
-      end
-
-      def switch_to_light_tab
-        component.find(".light-tab").click
-      end
-
-      def switch_to_dark_tab
-        component.find(".dark-tab").click
-      end
-
       def input_for_color(name)
         component.find(
           ".color-palette-editor__colors-item[data-color-name=\"#{name}\"] input[type=\"color\"]",


### PR DESCRIPTION
We've decided that we aren't going to go forward with dual-mode color palettes, so we're removing the code for it for now.

Internal topic: t/161398.