### PR TITLE
FEATURE: Use an `area` for experimental settings

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/config-experimental-settings.gjs
+++ b/app/assets/javascripts/admin/addon/templates/config-experimental-settings.gjs
@@ -23,7 +23,7 @@ export default RouteTemplate(
     <div class="admin-config-page__main-area">
       <AdminAreaSettings
         @showBreadcrumb={{false}}
-        @categories="experimental"
+        @area="experimental"
         @path="/admin/config/experimental"
         @filter={{@controller.filter}}
         @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -9,6 +9,7 @@ class SiteSetting < ActiveRecord::Base
     email
     embedding
     emojis
+    experimental
     flags
     fonts
     group_permissions

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4083,20 +4083,25 @@ experimental:
   experimental_auto_grid_images:
     default: false
     client: true
+    area: "experimental"
   experimental_rename_faq_to_guidelines:
     default: false
     hidden: true
     client: true
+    area: "experimental"
   experimental_hashtag_search_result_limit:
     default: 20
     client: true
     hidden: true
+    area: "experimental"
   experimental_form_templates:
     client: true
     default: false
+    area: "experimental"
   show_preview_for_form_templates:
     client: true
     default: true
+    area: "experimental"
   experimental_new_new_view_groups:
     client: true
     type: group_list
@@ -4104,7 +4109,7 @@ experimental:
     default: ""
     allow_any: false
     refresh: true
-    area: "group_permissions|navigation"
+    area: "group_permissions|navigation|experimental"
   glimmer_post_stream_mode_auto_groups:
     client: true
     type: group_list
@@ -4112,6 +4117,7 @@ experimental:
     default: ""
     allow_any: false
     refresh: true
+    area: "experimental"
   glimmer_post_stream_mode:
     client: true
     type: enum
@@ -4120,25 +4126,31 @@ experimental:
       - auto
       - enabled
     default: "auto"
+    area: "experimental"
   deactivate_widgets_rendering:
     client: true
     default: false
+    area: "experimental"
   enable_rich_text_paste:
     client: true
     default: true
+    area: "experimental"
   google_oauth2_hd_groups:
     default: false
     validator: GoogleOauth2HdGroupsValidator
+    area: "experimental"
   lazy_load_categories_groups:
     default: ""
     type: group_list
     list_type: compact
-    area: "group_permissions"
+    area: "group_permissions|experimental"
   use_overhauled_theme_color_palette:
     default: false
     hidden: true
     client: true
+    area: "experimental"
   reviewable_ui_refresh:
     client: true
     type: group_list
     default: ""
+    area: "experimental"


### PR DESCRIPTION
This changes the setting page at `/admin/config/experimental`
to use an `area` instead of a `category`. This allows the page to
show settings from across core and plugins that are marked experimental,
instead of only the settings in the core experimental category.
