### PR TITLE
UX: Improve default badge positioning on admin themes/colors index

### DIFF
--- a/app/assets/javascripts/admin/addon/components/color-palette-list-item.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-palette-list-item.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { array, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
-import { not, or } from "truth-helpers";
+import { not } from "truth-helpers";
 import ColorPalettePreview from "discourse/components/color-palette-preview";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
@@ -69,26 +69,6 @@ export default class ColorPaletteListItem extends Component {
     );
   }
 
-  get defaultBadgeTitle() {
-    if (this.isDefaultLight && this.isDefaultDark) {
-      return i18n("admin.customize.colors.default_both_badge.title");
-    }
-    if (this.isDefaultLight) {
-      return i18n("admin.customize.colors.default_light_badge.title");
-    }
-    return i18n("admin.customize.colors.default_dark_badge.title");
-  }
-
-  get defaultBadgeText() {
-    if (this.isDefaultLight && this.isDefaultDark) {
-      return i18n("admin.customize.colors.default_both_badge.text");
-    }
-    if (this.isDefaultLight) {
-      return i18n("admin.customize.colors.default_light_badge.text");
-    }
-    return i18n("admin.customize.colors.default_dark_badge.text");
-  }
-
   @bind
   setAsDefaultLabel(mode) {
     const themeName = this.args.defaultTheme?.name || "Default";
@@ -140,6 +120,28 @@ export default class ColorPaletteListItem extends Component {
           </div>
 
           <div class="color-palette__badges">
+            {{#if this.isDefaultLight}}
+              <span
+                title={{i18n
+                  "admin.customize.colors.default_light_badge.title"
+                }}
+                class="theme-card__badge --default"
+              >
+                {{icon "sun"}}
+                {{i18n "admin.customize.colors.default_light_badge.text"}}
+              </span>
+            {{/if}}
+
+            {{#if this.isDefaultDark}}
+              <span
+                title={{i18n "admin.customize.colors.default_dark_badge.title"}}
+                class="theme-card__badge --default"
+              >
+                {{icon "moon"}}
+                {{i18n "admin.customize.colors.default_dark_badge.text"}}
+              </span>
+            {{/if}}
+
             {{#if @scheme.user_selectable}}
               <span
                 title={{i18n "admin.customize.theme.user_selectable"}}
@@ -150,15 +152,6 @@ export default class ColorPaletteListItem extends Component {
               </span>
             {{/if}}
           </div>
-
-          {{#if (or this.isDefaultLight this.isDefaultDark)}}
-            <span
-              title={{this.defaultBadgeTitle}}
-              class="theme-card__badge --default"
-            >
-              {{this.defaultBadgeText}}
-            </span>
-          {{/if}}
         </div>
 
         <div class="color-palette__controls">

--- a/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
+++ b/app/assets/javascripts/admin/addon/components/themes-grid-card.gjs
@@ -134,14 +134,6 @@ export default class ThemeCard extends Component {
   <template>
     <AdminConfigAreaCard class={{this.themeCardClasses}}>
       <:content>
-        {{#if @theme.default}}
-          <span
-            class="theme-card__badge --default"
-            title={{i18n "admin.customize.theme.default_theme"}}
-          >
-            {{i18n "admin.customize.theme.default"}}
-          </span>
-        {{/if}}
 
         <div class="theme-card__image-wrapper">
           {{#if @theme.screenshot_url}}
@@ -168,6 +160,14 @@ export default class ThemeCard extends Component {
                 class="theme-card__badge"
               >{{icon "arrows-rotate"}}
                 {{i18n "admin.customize.theme.update_available"}}</span>
+            {{/if}}
+
+            {{#if @theme.default}}
+              <span
+                class="theme-card__badge --default"
+                title={{i18n "admin.customize.theme.default_theme"}}
+              >{{icon "paintbrush"}}
+                {{i18n "admin.customize.theme.default"}}</span>
             {{/if}}
 
             {{#if @theme.user_selectable}}

--- a/app/assets/stylesheets/admin/color_palettes.scss
+++ b/app/assets/stylesheets/admin/color_palettes.scss
@@ -62,6 +62,11 @@
   }
 
   &__badges {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: var(--space-1);
+    margin: var(--space-1) 0;
     min-height: 2rem;
   }
 

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -202,16 +202,6 @@
       height: 0.75em;
       color: var(--primary-high);
     }
-
-    &.--default {
-      background-color: var(--tertiary);
-      color: var(--secondary);
-      position: absolute;
-      right: 8px;
-      top: 8px;
-      font-size: var(--font-down-3);
-      text-transform: uppercase;
-    }
   }
 
   .admin-config-area-card__header-action {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6914,7 +6914,7 @@ en:
           extra_files_upload: "Export theme to view these files."
           extra_files_remote: "Export theme or check the git repository to view these files."
           preview: "Preview"
-          default: "Default"
+          default: "Default theme"
           settings_editor: "Settings Editor"
           show_advanced: "Show advanced"
           is_default: "Theme is enabled by default"
@@ -7153,9 +7153,6 @@ en:
           default_dark_badge:
             text: "Default dark"
             title: "Default dark color palette"
-          default_both_badge:
-            text: "Default light and dark"
-            title: "Default light and dark color palette"
           system_palette: "This is a built-in color palette, it cannot be edited or deleted."
           back_to_colors: "Back to color palettes"
           long_title: "Color palettes"

--- a/spec/system/admin_color_palettes_features_spec.rb
+++ b/spec/system/admin_color_palettes_features_spec.rb
@@ -161,7 +161,7 @@ describe "Admin Color Palettes Features", type: :system do
       within("[data-palette-id='#{regular_palette.id}']") do
         expect(page).to have_css(
           ".theme-card__badge.--default",
-          text: I18n.t("admin_js.admin.customize.colors.default_light_badge.text").upcase,
+          text: I18n.t("admin_js.admin.customize.colors.default_light_badge.text"),
         )
       end
 
@@ -179,7 +179,7 @@ describe "Admin Color Palettes Features", type: :system do
       within("[data-palette-id='#{regular_palette.id}']") do
         expect(page).to have_css(
           ".theme-card__badge.--default",
-          text: I18n.t("admin_js.admin.customize.colors.default_both_badge.text").upcase,
+          text: I18n.t("admin_js.admin.customize.colors.default_dark_badge.text"),
         )
       end
     end

--- a/spec/system/admin_customize_themes_config_area_spec.rb
+++ b/spec/system/admin_customize_themes_config_area_spec.rb
@@ -38,11 +38,13 @@ describe "Admin Customize Themes Config Area Page", type: :system do
 
   it "allows to mark theme as default" do
     config_area.visit
-    expect(config_area).to have_badge(foundation_theme, "--default")
-    expect(config_area).to have_no_badge(theme_2, "--default")
+    expect(config_area).to have_default_badge(foundation_theme)
+    expect(config_area).to have_no_default_badge(theme_2)
+
     config_area.mark_as_default(theme_2)
-    expect(config_area).to have_badge(theme_2, "--default")
-    expect(config_area).to have_no_badge(foundation_theme, "--default")
+
+    expect(config_area).to have_default_badge(theme_2)
+    expect(config_area).to have_no_default_badge(foundation_theme)
   end
 
   it "allows to make theme selectable by users" do

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -25,8 +25,16 @@ module PageObjects
         find(".set-default").click
       end
 
-      def has_badge?(theme, badge)
-        find_theme_card(theme).has_css?(".theme-card__badge.#{badge}")
+      def has_default_badge?(theme)
+        has_badge?(theme, "--default", text: I18n.t("admin_js.admin.customize.theme.default"))
+      end
+
+      def has_no_default_badge?(theme)
+        has_no_badge?(theme, "--default")
+      end
+
+      def has_badge?(theme, badge, **kwargs)
+        find_theme_card(theme).has_css?(".theme-card__badge.#{badge}", **kwargs)
       end
 
       def has_no_badge?(theme, badge)


### PR DESCRIPTION
### Screenshot

#### Before/After theme card default

<img width="310" height="399" alt="Screenshot 2025-08-21 at 3 55 08 PM" src="https://github.com/user-attachments/assets/50d40af9-7c6f-47df-8bca-10ec6cf98e2f" />

<img width="306" height="395" alt="Screenshot 2025-08-21 at 3 55 11 PM" src="https://github.com/user-attachments/assets/315d1cc6-9ef6-427a-b0c2-dcdd49fad2cf" />

#### Before/After color palette card -default dark
<img width="361" height="316" alt="Screenshot 2025-08-21 at 4 15 45 PM" src="https://github.com/user-attachments/assets/caeecf22-9f83-4753-8d1e-8190e103aebe" />
<img width="361" height="315" alt="Screenshot 2025-08-21 at 4 16 27 PM" src="https://github.com/user-attachments/assets/8dd0c598-149a-4b06-a9ab-9f8dd1d380f1" />

#### Before/After color palette card - default light


<img width="360" height="314" alt="Screenshot 2025-08-21 at 4 15 42 PM" src="https://github.com/user-attachments/assets/1dd51a9d-2fe1-4ead-9063-dd30ce6c7602" />

<img width="357" height="321" alt="Screenshot 2025-08-21 at 4 16 24 PM" src="https://github.com/user-attachments/assets/649846b3-8c88-451c-b7b3-d67226c740a7" />


#### Before/After color palette card - default light & dark

<img width="368" height="317" alt="Screenshot 2025-08-21 at 4 15 51 PM" src="https://github.com/user-attachments/assets/62a2ec09-7ec5-479e-a3d0-953dba6e7dc0" />

<img width="361" height="339" alt="Screenshot 2025-08-22 at 11 44 42 AM" src="https://github.com/user-attachments/assets/5ee894bf-6660-4c0f-bf18-fd95c583c341" />

