### PR TITLE
DEV: Update `@embroider/router` to 3.0.2

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -75,7 +75,7 @@
     "@embroider/compat": "^3.8.5",
     "@embroider/core": "^3.5.5",
     "@embroider/macros": "^1.16.12",
-    "@embroider/router": "^2.1.8",
+    "@embroider/router": "^3.0.2",
     "@embroider/webpack": "^4.1.0",
     "@floating-ui/dom": "^1.7.3",
     "@glimmer/component": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ importers:
         specifier: ^1.16.12
         version: 1.16.12(@glint/template@1.6.0-alpha.2)
       '@embroider/router':
-        specifier: ^2.1.8
-        version: 2.1.8(@embroider/core@3.5.5(@glint/template@1.6.0-alpha.2))
+        specifier: ^3.0.2
+        version: 3.0.2(@embroider/core@3.5.5(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)
       '@embroider/webpack':
         specifier: ^4.1.0
         version: 4.1.0(@embroider/core@3.5.5(@glint/template@1.6.0-alpha.2))(webpack@5.101.3(@swc/core@1.13.3)(esbuild@0.25.9))
@@ -1936,10 +1936,6 @@ packages:
   '@ember/test-helpers@5.2.2':
     resolution: {integrity: sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==}
 
-  '@ember/test-waiters@3.1.0':
-    resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
-    engines: {node: 10.* || 12.* || >= 14.*}
-
   '@ember/test-waiters@4.1.1':
     resolution: {integrity: sha512-HbK70JYCDJcGI0CrwcbjeL2QHAn0HLwa3oGep7mr6l/yO95U7JYA8VN+/9VTsWJTmKueLtWayUqEmGS3a3mVOg==}
 
@@ -1980,10 +1976,10 @@ packages:
       '@glint/template':
         optional: true
 
-  '@embroider/router@2.1.8':
-    resolution: {integrity: sha512-Dvp8YdqAWT6T0yzBZfUe6SyaVNH7xoXBlrxF1LbqoF/Q2buNzDy9oAQ5tTnbX1x+5KOrM0ryOjfeF0GoqkfobA==}
+  '@embroider/router@3.0.2':
+    resolution: {integrity: sha512-zNGJ61mCwab+rCQh2YBcuGeZwebf+OHiKpJVNCqX5ZOm0RK9nL3S7aXTf22GtvP+SBtRNCQhRKrJE5a7lvNiRQ==}
     peerDependencies:
-      '@embroider/core': ^2.0.0||^3.0.0
+      '@embroider/core': ^2.0.0||^3.0.0||^4.0.0-alpha.0
     peerDependenciesMeta:
       '@embroider/core':
         optional: true
@@ -11090,15 +11086,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember/test-waiters@3.1.0':
-    dependencies:
-      calculate-cache-key-for-tree: 2.0.0
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      semver: 7.7.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@ember/test-waiters@4.1.1(@glint/template@1.6.0-alpha.2)':
     dependencies:
       '@embroider/addon-shim': 1.10.0
@@ -11232,13 +11219,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/router@2.1.8(@embroider/core@3.5.5(@glint/template@1.6.0-alpha.2))':
+  '@embroider/router@3.0.2(@embroider/core@3.5.5(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)':
     dependencies:
-      '@ember/test-waiters': 3.1.0
+      '@ember/test-waiters': 4.1.1(@glint/template@1.6.0-alpha.2)
       '@embroider/addon-shim': 1.10.0
     optionalDependencies:
       '@embroider/core': 3.5.5(@glint/template@1.6.0-alpha.2)
     transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
 
   '@embroider/shared-internals@2.9.0(supports-color@8.1.1)':


### PR DESCRIPTION
this unblocks dropping `@ember/test-waiters@3.x`