### PR TITLE
DEV: Polyfill component-template-resolving for Ember 6

### DIFF
--- a/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
+++ b/app/assets/javascripts/discourse/app/services/deprecation-warning-handler.js
@@ -29,16 +29,14 @@ export const CRITICAL_DEPRECATIONS = [
   "discourse.post-stream.trigger-new-post",
   "discourse.plugin-outlet-classic-args-clash",
   "discourse.decorate-plugin-outlet",
-  "component-template-resolving",
+  "discourse.component-template-resolving",
   "discourse.script-tag-hbs",
   "discourse.script-tag-discourse-plugin",
   "discourse.post-stream-widget-overrides",
   "discourse.widgets-end-of-life",
 ];
 
-const REPLACEMENT_URLS = {
-  "component-template-resolving": "https://meta.discourse.org/t/370019",
-};
+const REPLACEMENT_URLS = {};
 
 if (DEBUG) {
   // used in system specs

--- a/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
@@ -56,7 +56,7 @@ module("Integration | Initializers | plugin-component-templates", function () {
         .dom("div.test-class")
         .hasText(
           "non-colocated component",
-          "renders split component/template "
+          "renders split component/template"
         );
     });
   });

--- a/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
@@ -54,10 +54,7 @@ module("Integration | Initializers | plugin-component-templates", function () {
       await render(hbs`<PluginSplitComponent class='test-class'/>`);
       assert
         .dom("div.test-class")
-        .hasText(
-          "non-colocated component",
-          "renders split component/template"
-        );
+        .hasText("non-colocated component", "renders split component/template");
     });
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/component-templates-test.gjs
@@ -1,3 +1,4 @@
+import Component from "@glimmer/component";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { module, test } from "qunit";
@@ -7,25 +8,56 @@ import { registerTemporaryModule } from "../helpers/temporary-module-helper";
 
 module("Integration | Initializers | plugin-component-templates", function () {
   module("template-only component definition behaviour", function (hooks) {
+    let restoreDeprecation;
+
     hooks.beforeEach(() => {
+      withSilencedDeprecationsAsync(
+        "discourse.component-template-resolving",
+        () => new Promise((resolve) => (restoreDeprecation = resolve))
+      );
+
       registerTemporaryModule(
         `discourse/plugins/some-plugin-name/discourse/templates/components/plugin-template-only-definition`,
         hbs`classic component`
       );
+
+      registerTemporaryModule(
+        `discourse/plugins/some-plugin-name/discourse/components/plugin-split-component`,
+        class extends Component {
+          get message() {
+            return "non-colocated component";
+          }
+        }
+      );
+
+      registerTemporaryModule(
+        `discourse/plugins/some-plugin-name/discourse/templates/components/plugin-split-component`,
+        hbs`<div class='test-class'>{{this.message}}</div>`
+      );
+    });
+
+    hooks.afterEach(() => {
+      restoreDeprecation();
     });
 
     setupRenderingTest(hooks);
 
     test("treats plugin template-only definition as classic component", async function (assert) {
-      await withSilencedDeprecationsAsync(
-        "component-template-resolving",
-        async () => {
-          await render(hbs`<PluginTemplateOnlyDefinition class='test-class'/>`);
-          assert
-            .dom("div.test-class")
-            .hasText("classic component", "renders as classic component");
-        }
-      );
+      await render(hbs`<PluginTemplateOnlyDefinition class='test-class'/>`);
+      assert
+        .dom("div.test-class")
+        .hasText(
+          "classic component",
+          "renders lone template as classic component"
+        );
+
+      await render(hbs`<PluginSplitComponent class='test-class'/>`);
+      assert
+        .dom("div.test-class")
+        .hasText(
+          "non-colocated component",
+          "renders split component/template "
+        );
     });
   });
 });


### PR DESCRIPTION
Switches from Ember's deprecation to our own