### PR TITLE
UX: Do not alter post styling when displaying replies below

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post.gjs
+++ b/app/assets/javascripts/discourse/app/components/post.gjs
@@ -511,7 +511,7 @@ export default class Post extends Component {
                     <div
                       class={{concatClass
                         "post__regular regular"
-                        (unless this.repliesShown "post__contents contents")
+                        "post__contents contents"
                         (if
                           this.isReplyToTabDisplayed
                           "post__contents--avoid-tab avoid-tab"


### PR DESCRIPTION
Simplify the class binding in the `post` component by always applying `post__contents contents`.

This was a regression when modernizing the post-stream, although there is a condition to remove these classes in the widget code. The state `repliesShown` was was never properly set in the old code.

This prevents styling issues when the embedded replies are displayed below the post

Before: 

<img width="413" height="848" alt="pellentesque ullamcorper pharetra non," src="https://github.com/user-attachments/assets/b859035e-5704-4d04-ba01-e9fe75466755" />

After: 

<img width="412" height="914" alt="image" src="https://github.com/user-attachments/assets/6f556f30-f416-42e7-9b0c-ae00215fa7b7" />
