### PR TITLE
FIX: Respect long_polling_base_url setting for message bus configuration

### DIFF
--- a/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
@@ -110,14 +110,21 @@ export default {
     messageBus.callbackInterval = siteSettings.anon_polling_interval;
     messageBus.backgroundCallbackInterval =
       siteSettings.background_polling_interval;
-    messageBus.baseUrl =
-      siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
+    
+    // Set messageBus.baseUrl
+    // If a custom long_polling_base_url is configured (not the default "/"), use it
+    // Otherwise use the application's relative path
+    if (siteSettings.long_polling_base_url && siteSettings.long_polling_base_url !== "/") {
+      // Use custom long polling URL (e.g., for separate message server or CDN)
+      messageBus.baseUrl = siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
+    } else {
+      // Use default relative path
+      messageBus.baseUrl = getURL("/");
+    }
 
     messageBus.enableChunkedEncoding = siteSettings.enable_chunked_encoding;
 
     messageBus.ajax = (opts) => mbAjax(messageBus, opts);
-
-    messageBus.baseUrl = getURL("/");
 
     if (user) {
       messageBus.callbackInterval = siteSettings.polling_interval;

--- a/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
@@ -110,7 +110,7 @@ export default {
     messageBus.callbackInterval = siteSettings.anon_polling_interval;
     messageBus.backgroundCallbackInterval =
       siteSettings.background_polling_interval;
-    
+
     if (
       siteSettings.long_polling_base_url &&
       siteSettings.long_polling_base_url !== "/"

--- a/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
@@ -111,14 +111,11 @@ export default {
     messageBus.backgroundCallbackInterval =
       siteSettings.background_polling_interval;
     
-    // Set messageBus.baseUrl
-    // If a custom long_polling_base_url is configured (not the default "/"), use it
-    // Otherwise use the application's relative path
-    if (siteSettings.long_polling_base_url && siteSettings.long_polling_base_url !== "/") {
-      // Use custom long polling URL (e.g., for separate message server or CDN)
-      messageBus.baseUrl = siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
+    if (siteSettings.long_polling_base_url && 
+        siteSettings.long_polling_base_url !== "/") {
+      messageBus.baseUrl = 
+        siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
     } else {
-      // Use default relative path
       messageBus.baseUrl = getURL("/");
     }
 

--- a/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/instance-initializers/message-bus.js
@@ -111,9 +111,11 @@ export default {
     messageBus.backgroundCallbackInterval =
       siteSettings.background_polling_interval;
     
-    if (siteSettings.long_polling_base_url && 
-        siteSettings.long_polling_base_url !== "/") {
-      messageBus.baseUrl = 
+    if (
+      siteSettings.long_polling_base_url &&
+      siteSettings.long_polling_base_url !== "/"
+    ) {
+      messageBus.baseUrl =
         siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
     } else {
       messageBus.baseUrl = getURL("/");


### PR DESCRIPTION
## Problem

The message bus initialization code has a bug where `messageBus.baseUrl` is set twice:
1. First set from `siteSettings.long_polling_base_url`
2. Immediately overwritten with `getURL("/")`

This makes the `long_polling_base_url` site setting ineffective, preventing users from configuring a separate message server or CDN for long polling.

## Solution

This PR fixes the issue by:
- Adding conditional logic to check if `long_polling_base_url` is configured with a non-default value
- Using the configured URL when available, otherwise falling back to `getURL("/")`
- Removing the duplicate assignment that was overwriting the setting

## Changes

- Modified `app/assets/javascripts/discourse/app/initializers/message-bus.js`
- Added proper conditional check for `long_polling_base_url` setting
- Preserved the URL normalization logic (removing trailing slash and adding it back)