### PR TITLE
DEV: Check for setting prior to applying transformation on crawler view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,7 @@ class ApplicationController < ActionController::Base
   before_action :preload_json
   before_action :initialize_application_layout_preloader
   before_action :check_xhr
+  before_action :set_crawler_header
   after_action :add_readonly_header
   after_action :perform_refresh_session
   after_action :dont_cache_page
@@ -1054,5 +1055,9 @@ class ApplicationController < ActionController::Base
 
   def service_params
     { params: params.to_unsafe_h, guardian: }
+  end
+
+  def set_crawler_header
+    response.headers["X-Discourse-Crawler-View"] = "true" if use_crawler_layout?
   end
 end

--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -10,8 +10,9 @@ module Middleware
       request = Rack::Request.new(env)
       status, headers, response = @app.call(env)
 
-      if status == 200 && headers["Content-Type"]&.include?("text/html") &&
-           CrawlerDetection.crawler?(request.user_agent, request.get_header("HTTP_VIA"))
+      if status == 200 && headers["X-Discourse-Crawler-View"] &&
+           SiteSetting.content_localization_enabled &&
+           SiteSetting.content_localization_crawler_param
         response = transform_response(request:, response:)
       end
 

--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -29,12 +29,9 @@ module Middleware
         html_fragment = Nokogiri::HTML5.parse(response.body)
 
         html_fragment
-          .css("a")
+          .css("a[href^='/'], a[href^='#{Discourse.base_url}']")
           .each do |link|
-            href = link["href"]
-            next if href.blank? || !href.start_with?("/", Discourse.base_url)
-
-            uri = Addressable::URI.parse(href)
+            uri = Addressable::URI.parse(link["href"])
             uri.query_values = (uri.query_values || {}).merge(Discourse::LOCALE_PARAM => locale)
             link["href"] = uri.to_s
           end

--- a/spec/lib/middleware/crawler_hooks_spec.rb
+++ b/spec/lib/middleware/crawler_hooks_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Middleware::CrawlerHooks do
+describe Middleware::CrawlerHooks do
   let(:crawler_user_agent) { "GoogleBot/2.1 (+https://www.google.com/bot.html)" }
   let(:regular_user_agent) { "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
   let(:html_response) do


### PR DESCRIPTION
Follow up to comments in https://github.com/discourse/discourse/pull/34466. We apply a header to minimize duplication, and also promote the check earlier.