### PR TITLE
FIX: truncate long names for autocomplete results

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete/category-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete/category-tag.js
@@ -8,12 +8,12 @@ export function renderCategory(option) {
     link: false,
   });
 
-  return `<li><a href>${link}</a></li>`;
+  return `<li><a href><span class='text-content'>${link}</span></a></li>`;
 }
 
 export function renderTag(option) {
   const text = `${escapeExpression(option.name)} x ${escapeExpression(option.count)}`;
-  return `<li><a href>${iconHTML("tag")}${text}</a></li>`;
+  return `<li><a href>${iconHTML("tag")}<span class='text-content'>${text}</span></a></li>`;
 }
 
 export function renderOption(option) {

--- a/app/assets/javascripts/discourse/app/lib/autocomplete/emoji.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete/emoji.js
@@ -6,7 +6,7 @@ function renderOption({ src, code, label }) {
       `<span class='emoji-shortname'>${escapeExpression(code)}</span>`
     : escapeExpression(label);
 
-  return `<li><a href>${content}</a></li>`;
+  return `<li><a href><span class='text-content'>${content}</span></a></li>`;
 }
 
 export default function renderEmojiAutocomplete({ options }) {

--- a/app/assets/javascripts/discourse/app/lib/autocomplete/group.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete/group.js
@@ -1,7 +1,7 @@
 import { escapeExpression } from "discourse/lib/utilities";
 
 function renderOption(option) {
-  return `<li><a href>${escapeExpression(option.name)}</a></li>`;
+  return `<li><a href><span class='text-content'>${escapeExpression(option.name)}</span></a></li>`;
 }
 
 export default function groupAutocomplete({ options }) {

--- a/app/assets/javascripts/discourse/app/lib/autocomplete/user.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete/user.js
@@ -7,9 +7,11 @@ function renderUserItem(item) {
     <li data-index="${escapeExpression(item.index?.toString())}">
       <a href title="${escapeExpression(item.name)}" class="${escapeExpression(item.cssClasses)}">
         ${avatar(item, { imageSize: "tiny" })}
-        <span class='username'>${escapeExpression(formatUsername(item.username))}</span>
-        ${item.name ? `<span class='name'>${escapeExpression(item.name)}</span>` : ""}
-        ${item.status ? `<span class='user-status'></span>` : ""}
+        <span class="text-content">
+          <span class="username">${escapeExpression(formatUsername(item.username))}</span>
+          ${item.name ? `<span class="name">${escapeExpression(item.name)}</span>` : ""}
+        </span>
+        ${item.status ? `<span class="user-status"></span>` : ""}
       </a>
     </li>
   `;
@@ -20,7 +22,7 @@ function renderEmailItem(item) {
     <li>
       <a href title="${escapeExpression(item.username)}">
         ${iconHTML("envelope")}
-        <span class='username'>${escapeExpression(formatUsername(item.username))}</span>
+        <span class="text-content username">${escapeExpression(formatUsername(item.username))}</span>
       </a>
     </li>
   `;
@@ -31,8 +33,10 @@ function renderGroupItem(item) {
     <li>
       <a href title="${escapeExpression(item.full_name)}">
         ${iconHTML("users")}
-        <span class='username'>${escapeExpression(item.name)}</span>
-        <span class='name'>${escapeExpression(item.full_name)}</span>
+        <span class="text-content">
+          <span class="username">${escapeExpression(item.name)}</span>
+          <span class="name">${escapeExpression(item.full_name)}</span>
+        </span>
       </a>
     </li>
   `;
@@ -52,7 +56,7 @@ function renderItem(item) {
 
 export default function userAutocomplete({ options }) {
   return `
-    <div class='autocomplete ac-user'>
+    <div class="autocomplete ac-user">
       <ul>
         ${options.map(renderItem).join("")}
       </ul>

--- a/app/assets/stylesheets/common/components/autocomplete.scss
+++ b/app/assets/stylesheets/common/components/autocomplete.scss
@@ -30,7 +30,6 @@
       }
 
       a {
-        @include ellipsis;
         align-items: center;
         color: var(--primary);
         display: flex;
@@ -72,6 +71,22 @@
         .relative-date {
           font-size: var(--font-down-3);
         }
+
+        .text-content {
+          @include ellipsis;
+          display: inline-block;
+          max-width: 100%;
+          vertical-align: top;
+
+          .username,
+          .name {
+            display: inline;
+          }
+        }
+
+        .d-icon + .text-content {
+          max-width: calc(100% - 1em);
+        }
       }
 
       .d-icon-users {
@@ -84,6 +99,10 @@
   &.ac-user {
     li a {
       padding: 0.5em 1em;
+
+      .text-content {
+        max-width: calc(100% - 24px); // 24px is for `tiny` avatar width
+      }
     }
 
     .emoji {


### PR DESCRIPTION
The current way we try to style text spans that are too long is to apply the custom style `ellipsis` on the `a` element that wraps around text spans for each autocomplete item. However, this is being positioned with `flex` which does not apply that styling well on child elements. 

We need to apply it directly on text spans and orient them with `inline`/`inline-block`. As some of these autocomplete items have more than 1 span element in the same line, we use a wrapper `.text-content` as the target selector for this `ellipsis` styling.

#### Current:
<img width="524" height="276" alt="current" src="https://github.com/user-attachments/assets/6f988106-8ac4-431c-bf97-e9f4e52643ef" />

#### Expected:
Older Autocomplete:
<img width="542" height="321" alt="jquery-autocomplete" src="https://github.com/user-attachments/assets/da0bcc92-3916-4131-930a-65e8e844d3bc" />

Floatkit Autocomplete:

https://github.com/user-attachments/assets/0a999d37-2486-4939-8def-f0716841a953

