### PR TITLE
UX: remove height limit when showing preview on mobile composer

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -778,10 +778,6 @@ html.composer-open:not(.has-full-page-chat) {
       display: none;
     }
 
-    &.open.show-preview {
-      height: 70vh;
-    }
-
     &.show-preview {
       .submit-panel {
         padding-top: 0.5em;


### PR DESCRIPTION
The preview is supposed to be fullscreen on mobile.