### PR TITLE
FIX: Token check in EmailController#unsubscribe

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -8,7 +8,7 @@ class EmailController < ApplicationController
                      :redirect_to_login_if_required,
                      :redirect_to_profile_if_required
 
-  skip_before_action :verify_authenticity_token, only: [:unsubscribe], if: :one_click_unsubscribe?
+  skip_before_action :verify_authenticity_token, if: :one_click_unsubscribe?
 
   def unsubscribe
     key = UnsubscribeKey.includes(:user).find_by(key: params[:key])
@@ -75,6 +75,6 @@ class EmailController < ApplicationController
   private
 
   def one_click_unsubscribe?
-    request.post? && params["List-Unsubscribe"] == "One-Click"
+    request.post? && params[:action] == "unsubscribe" && params["List-Unsubscribe"] == "One-Click"
   end
 end


### PR DESCRIPTION
Per rubocop-rails docs:

> The `if` option will be ignored when `if` and `only` are used together

so effectively we were skipping the validation in more cases than intended