### PR TITLE
DEV: Add an `after_copy_data` hook to CopyStep

### DIFF
--- a/migrations/lib/importer/copy_step.rb
+++ b/migrations/lib/importer/copy_step.rb
@@ -67,6 +67,7 @@ module Migrations::Importer
     def execute
       super
       with_progressbar(total_count) { copy_data }
+      after_copy_data
       nil
     end
 
@@ -134,6 +135,9 @@ module Migrations::Importer
       end
 
       nil
+    end
+
+    def after_copy_data
     end
 
     def transform_row(row)


### PR DESCRIPTION
Allow CopyStep implementations to perform finalization actions after all rows have been copied