### PR TITLE
FIX: Required confirmations not showing up

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -91,8 +91,7 @@ export default class ProfileController extends Controller {
     return siteFields
       .filter(
         (siteField) =>
-          siteField.requirement === "for_all_users" &&
-          isEmpty(userFields[siteField.id])
+          siteField.requirement === "for_all_users" && !userFields[siteField.id]
       )
       .map((field) => EmberObject.create({ field, value: "" }));
   }

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -154,11 +154,11 @@ export default class ProfileController extends Controller {
 
     return this.model
       .save(this.saveAttrNames)
-      .then(({ user }) => this.model.set("bio_cooked", user.bio_cooked))
-      .catch(popupAjaxError)
-      .finally(() => {
+      .then(({ user }) => {
+        this.model.set("bio_cooked", user.bio_cooked);
         this.currentUser.set("needs_required_fields_check", false);
         this.set("saved", true);
-      });
+      })
+      .catch(popupAjaxError);
   }
 }

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -4,6 +4,7 @@ describe "User preferences | Profile", type: :system do
   fab!(:user) { Fabricate(:user, active: true) }
   let(:user_preferences_profile_page) { PageObjects::Pages::UserPreferencesProfile.new }
   let(:user_preferences_page) { PageObjects::Pages::UserPreferences.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
 
   before { sign_in(user) }
 
@@ -97,6 +98,23 @@ describe "User preferences | Profile", type: :system do
       visit("/")
 
       expect(page).to have_current_path("/")
+    end
+
+    it "does not allow submitting blank values for required fields" do
+      user_preferences_profile_page.visit(user)
+
+      find(".user-field-updated-terms input").check
+      find(".save-button .btn-primary").click
+
+      expect(dialog).to be_open
+      expect(dialog).to have_content(I18n.t("login.missing_user_field"))
+
+      dialog.click_yes
+
+      expect(page).to have_selector(
+        ".alert-error",
+        text: I18n.t("js.user.preferences.profile.enforced_required_fields"),
+      )
     end
 
     it "allows enabling safe-mode" do

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -42,6 +42,13 @@ describe "User preferences | Profile", type: :system do
         requirement: :for_all_users,
         editable: true,
       )
+      UserField.create!(
+        field_type: "confirm",
+        name: "Updated terms",
+        description: "Please accept our updated our terms of service.",
+        requirement: :for_all_users,
+        editable: true,
+      )
     end
 
     it "server-side redirects to the profile page to fill up required fields" do
@@ -82,6 +89,7 @@ describe "User preferences | Profile", type: :system do
       user_preferences_profile_page.visit(user)
 
       find(".user-field-favourite-pokemon input").fill_in(with: "Mudkip")
+      find(".user-field-updated-terms input").check
       find(".save-button .btn-primary").click
 
       expect(page).to have_selector(".pref-bio")


### PR DESCRIPTION
### What is the problem?

When adding a new field required "for all users", and the field is of "confirmation" type, it does not show up:

<img width="500" height="133" alt="Screenshot 2025-08-25 at 10 12 40 AM" src="https://github.com/user-attachments/assets/6e830b60-5a8b-4c41-ae9d-e7685efc888c" />

This is happening because we're checking for fields using `isEmpty`, assuming the value will be `null` before it is filled up, but for confirmation type fields it is in fact cast to `false`.

### How does this fix it?

`isEmpty(value)` -> `!value`

This PR also fixes an issue where we'd "unlock" the user in the front-end even if the call to update the required fields failed.