### PR TITLE
FIX: Fix test time to timezone when asserting

### DIFF
--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -63,7 +63,7 @@ describe "Post event", type: :system do
     it "correctly builds a multiline description", timezone: "Europe/Paris" do
       visit("/new-topic")
 
-      time = Time.now.strftime("%Y-%m-%d %H:%M")
+      time = Time.now.in_time_zone("Europe/Paris").strftime("%Y-%m-%d %H:%M")
 
       EXPECTED_BBCODE = <<~EVENT
         [event start="#{time}" status="public" timezone="Europe/Paris"]


### PR DESCRIPTION
Currently seeing:

```
expected: "[event start=\"2025-08-25 12:17\" status=\"public\" timezone=\"Europe/Paris\"]\nfoo\nbar\n[/event]"
     got: "[event start=\"2025-08-25 06:17\" status=\"public\" timezone=\"Europe/Paris\"]\nfoo\nbar\n[/event]"
```

The fix here is to include timezone when getting `Time.now`.