### PR TITLE
DEV: Improve errors for failed impersonation

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -179,10 +179,14 @@ export default class AdminUserIndexController extends Controller {
       .impersonate()
       .then(() => DiscourseURL.redirectTo("/"))
       .catch((e) => {
-        if (e.status === 404) {
+        const status = e.jqXHR.status;
+
+        if (status === 404) {
           this.dialog.alert(i18n("admin.impersonate.not_found"));
-        } else {
+        } else if (status === 403) {
           this.dialog.alert(i18n("admin.impersonate.invalid"));
+        } else {
+          this.dialog.alert(i18n("admin.impersonate.error"));
         }
 
         this.set("isLoading", false);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7671,6 +7671,7 @@ en:
         help: "Use this tool to impersonate a user account for debugging purposes. You will have to log out once finished."
         not_found: "That user can't be found."
         invalid: "Sorry, you may not impersonate that user."
+        error: "Oops. An unexpected error occurred."
 
       users:
         title: "Users"

--- a/spec/system/impersonation_spec.rb
+++ b/spec/system/impersonation_spec.rb
@@ -4,6 +4,8 @@ describe "Impersonation", type: :system do
   fab!(:admin)
   fab!(:user)
 
+  let(:dialog) { PageObjects::Components::Dialog.new }
+
   before do
     SiteSetting.experimental_impersonation = true
 
@@ -27,5 +29,38 @@ describe "Impersonation", type: :system do
 
     expect(page).to have_current_path("/")
     expect(page).to have_no_css(".impersonation-notice")
+  end
+
+  it "shows a helpful error when the user is not found" do
+    Admin::ImpersonateController.any_instance.stubs(:create).raises(Discourse::NotFound)
+
+    visit("/admin/users/#{user.id}/#{user.username}")
+
+    page.find(".btn-impersonate").click
+
+    expect(dialog).to be_open
+    expect(dialog).to have_content(I18n.t("admin_js.admin.impersonate.not_found"))
+  end
+
+  it "shows a helpful error when impersonation of that user is not allowed" do
+    Admin::ImpersonateController.any_instance.stubs(:create).raises(Discourse::InvalidAccess)
+
+    visit("/admin/users/#{user.id}/#{user.username}")
+
+    page.find(".btn-impersonate").click
+
+    expect(dialog).to be_open
+    expect(dialog).to have_content(I18n.t("admin_js.admin.impersonate.invalid"))
+  end
+
+  it "shows a helpful error when there's an unexpected server error" do
+    Admin::ImpersonateController.any_instance.stubs(:create).raises(StandardError)
+
+    visit("/admin/users/#{user.id}/#{user.username}")
+
+    page.find(".btn-impersonate").click
+
+    expect(dialog).to be_open
+    expect(dialog).to have_content(I18n.t("admin_js.admin.impersonate.error"))
   end
 end


### PR DESCRIPTION
### What is this change?

I wanted to have a more specific error when there's an unexpected server error (5XX).

Turns out the existing error differentiation (between `not_found` and `invalid`) was not working, because the shape of `e` is not what the developer expected.

This PR fixes that and adds another message for unexpected errors.