### PR TITLE
DEV: Allow pasting color codes with leading hash sign in palettes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/color-input.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-input.gjs
@@ -60,6 +60,14 @@ export default class ColorInput extends Component {
   }
 
   @action
+  handlePaste(event) {
+    event.preventDefault();
+    const colorCode = event.clipboardData.getData("text/plain") ?? "";
+
+    this.set("hexValue", colorCode.replace(/^#/, ""));
+  }
+
+  @action
   handleBlur() {
     this.onBlur?.(this.normalize(this.hexValue));
   }
@@ -89,6 +97,7 @@ export default class ColorInput extends Component {
       class="hex-input"
       aria-labelledby={{this.ariaLabelledby}}
       {{on "blur" this.handleBlur}}
+      {{on "paste" this.handlePaste}}
     />
     <input
       class="picker"

--- a/app/assets/javascripts/admin/addon/components/color-palette-editor.gjs
+++ b/app/assets/javascripts/admin/addon/components/color-palette-editor.gjs
@@ -103,12 +103,16 @@ const Picker = class extends Component {
 
   @action
   onTextPaste(event) {
-    const content = (event.clipboardData || window.clipboardData).getData(
-      "text"
-    );
+    event.preventDefault();
 
-    if (!this.isValidHex(content)) {
-      event.preventDefault();
+    const content = (event.clipboardData || window.clipboardData)
+      .getData("text")
+      .trim()
+      .replace(/^#/, "");
+
+    if (this.isValidHex(content)) {
+      this.args.onChange(this.ensureSixDigitsHex(content));
+    } else {
       this.toasts.error({
         data: {
           message: i18n(
@@ -116,7 +120,6 @@ const Picker = class extends Component {
           ),
         },
       });
-      return;
     }
   }
 

--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -84,6 +84,20 @@ describe "Admin Color Palette Config Area Page", type: :system do
     expect(color_scheme.colors.find_by(name: "primary").hex).to eq("abcdef")
   end
 
+  it "supports pasting color codes with and without leading #" do
+    config_area.visit(color_scheme.id)
+
+    config_area.color_palette_editor.input_for_hex("primary").click
+    cdp.copy_paste("#888888")
+
+    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#888888")
+
+    config_area.color_palette_editor.input_for_hex("primary").click
+    cdp.copy_paste("#777777")
+
+    expect(config_area.color_palette_editor.input_for_color("primary").value).to eq("#777777")
+  end
+
   it "allows reverting colors to their default values" do
     color_scheme.update!(base_scheme_id: ColorScheme::NAMES_TO_ID_MAP["Dark"])
     color_scheme.colors.create!(name: "primary", hex: "aaaaaa")

--- a/spec/system/page_objects/components/color_palette_editor.rb
+++ b/spec/system/page_objects/components/color_palette_editor.rb
@@ -15,6 +15,12 @@ module PageObjects
         )
       end
 
+      def input_for_hex(name)
+        component.find(
+          ".color-palette-editor__colors-item[data-color-name=\"#{name}\"] input[type=\"text\"]",
+        )
+      end
+
       def get_color_value(name)
         input_for_color(name).value
       end


### PR DESCRIPTION
### What is this change?

This change allows pasting hex codes with leading hash sign, e.g. `#888888` in color palette inputs.

**Before:**

![paste-hash-fail](https://github.com/user-attachments/assets/9b64f012-3841-4676-a9c3-f7c465d103a1)

**After:**

![paste-hash-success](https://github.com/user-attachments/assets/be41549b-8b59-4a71-adbc-de51755eb0e4)

### Things to note

It applies the same change to the old color palettes UI, but doesn't add any system tests for that one, since it will be removed later.