### PR TITLE
UX: remove chat and message buttons on currentUser profile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user.gjs
@@ -2,6 +2,7 @@ import { array, concat, fn, hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";
+import { and, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import HtmlWithLinks from "discourse/components/html-with-links";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -403,7 +404,12 @@ export default RouteTemplate(
 
               <section class="controls">
                 <ul>
-                  {{#if @controller.model.can_send_private_message_to_user}}
+                  {{#if
+                    (and
+                      @controller.model.can_send_private_message_to_user
+                      (not @controller.viewingSelf)
+                    )
+                  }}
                     <li>
                       <DButton
                         @action={{fn

--- a/plugins/chat/assets/javascripts/discourse/connectors/user-profile-controls/chat-button.gjs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-profile-controls/chat-button.gjs
@@ -1,7 +1,10 @@
+import { and, not } from "truth-helpers";
 import ChatDirectMessageButton from "../../components/chat/direct-message-button";
 
 const ChatButton = <template>
-  {{#if @outletArgs.model.can_chat_user}}
+  {{#if
+    (and @outletArgs.model.can_chat_user (not @outletArgs.model.isCurrent))
+  }}
     <li class="user-card-below-message-button chat-button">
       <ChatDirectMessageButton @user={{@outletArgs.model}} />
     </li>


### PR DESCRIPTION
Remove the rendering of the chat and message CTA when viewing your own profile.
They serve little purpose, add to confusion, and take up valuable above the fold space on mobile.

| Before | After |
|--------|--------|
| <img width="690" height="1490" alt="CleanShot 2025-08-25 at 11 47 24@2x" src="https://github.com/user-attachments/assets/7d3539b6-5599-448b-b610-00adcacaf28b" />  | <img width="690" height="1490" alt="CleanShot 2025-08-25 at 11 46 47@2x" src="https://github.com/user-attachments/assets/1c0b4512-693d-4e39-b1ae-3ee30375e127" />  | 


