### PR TITLE
UX: add class to inline-footnote to display as inline-block

### DIFF
--- a/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
+++ b/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
@@ -56,6 +56,7 @@ export default apiInitializer((api) => {
       const footnoteContent = elem.querySelector(footnoteId)?.innerHTML;
 
       const expandableFootnote = document.createElement("span");
+      expandableFootnote.className = "inline-footnote";
       footnoteRef.replaceWith(expandableFootnote);
 
       helper.renderGlimmer(expandableFootnote, InlineFootnote, {

--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -16,6 +16,10 @@
     }
   }
 
+  .inline-footnote {
+    display: inline-block;
+  }
+
   // This is hack to work with lazy-loading, we will trick the browser
   // to believe the image is in the DOM and can be loaded
   .footnotes-list,


### PR DESCRIPTION
This avoids the spacing caused by line breaks.
Meta report:
https://meta.discourse.org/t/extra-spaces-around-footnote/380153