### PR TITLE
UX: restyling of the solved popup

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -60,19 +60,25 @@
       top: 0;
       overflow-y: auto;
       z-index: z("timeline");
-      padding: 10px 10px 35px 10px;
+      padding: var(--space-4);
       box-shadow: var(--shadow-dropdown);
       background: var(--tertiary-low);
+
+      h2 {
+        font-size: var(--font-0);
+        padding-right: calc(
+          1em + 0.65em - var(--space-2)
+        ); // more or less reserved space for floating close button
+      }
 
       .close {
         display: flex;
         align-items: center;
         position: absolute;
         right: 0;
-        top: 8px;
+        top: 0;
         color: var(--primary);
         opacity: 0.5;
-        font-size: var(--font-up-1);
       }
     }
   }

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -388,7 +388,6 @@
 
   &.close {
     background: var(--d-button-flat-close-bg-color);
-    font-size: var(--font-up-2);
 
     .d-icon {
       color: var(--d-button-flat-close-icon-color);

--- a/plugins/discourse-solved/assets/javascripts/discourse/connectors/topic-navigation/no-answer.gjs
+++ b/plugins/discourse-solved/assets/javascripts/discourse/connectors/topic-navigation/no-answer.gjs
@@ -56,7 +56,7 @@ export default class NoAnswer extends Component {
         @popupId="solved-notice"
         @dismissDuration={{this.oneWeek}}
       >
-        <h3>{{i18n "solved.no_answer.title"}}</h3>
+        <h2>{{i18n "solved.no_answer.title"}}</h2>
         <p>{{i18n "solved.no_answer.description"}}</p>
       </TopicNavigationPopup>
     {{/if}}


### PR DESCRIPTION
This commit aims to polish the popup a tiny bit by subduing the title size and close button, and making sure they play better together.

| Header | After |
|--------|--------|
| <img width="1956" height="1400" alt="CleanShot 2025-08-25 at 16 19 59@2x" src="https://github.com/user-attachments/assets/d2eeddaa-7c99-433f-b70c-ccca1fb0a5bd" /> | <img width="1956" height="1400" alt="CleanShot 2025-08-25 at 16 20 30@2x" src="https://github.com/user-attachments/assets/0c8614c1-96c3-4c24-a185-bc5b4570f31d" /> |