### PR TITLE
DEV: Enable Goldiloader by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "digest", require: false
 
-gem "goldiloader", require: false
+gem "goldiloader"
 
 group :test do
   gem "capybara", require: false

--- a/config/initializers/000-goldiloader.rb
+++ b/config/initializers/000-goldiloader.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require "goldiloader" if (Rails.env.test? || GlobalSetting.try(:load_goldiloader))


### PR DESCRIPTION
As things are going well with Goldiloader enabled, we can now enable it by default.