### PR TITLE
DEV: use welcome_banner.search placeholder in search banner

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu.gjs
@@ -454,6 +454,7 @@ export default class SearchMenu extends Component {
             @openSearchMenu={{this.open}}
             @autofocus={{@autofocusInput}}
             @inputId={{this.searchInputId}}
+            @placeholder={{@placeholder}}
           />
 
           {{#if this.loading}}

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
@@ -25,6 +25,10 @@ export default class SearchTerm extends Component {
   @tracked lastEnterTimestamp = null;
   @tracked searchCleared = !this.search.activeGlobalSearchTerm;
 
+  get placeholderText() {
+    return this.args.placeholder || i18n("search.title");
+  }
+
   @action
   updateSearchTerm(input) {
     this.parseAndUpdateSearchTerm(
@@ -117,8 +121,8 @@ export default class SearchTerm extends Component {
       autocomplete="off"
       enterkeyhint="search"
       value={{this.search.activeGlobalSearchTerm}}
-      placeholder={{i18n "search.title"}}
-      aria-label={{i18n "search.title"}}
+      placeholder={{this.placeholderText}}
+      aria-label={{this.placeholderText}}
       {{on "keyup" this.onKeyup}}
       {{on "keydown" this.onKeydown}}
       {{on "input" this.updateSearchTerm}}

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -159,6 +159,7 @@ export default class WelcomeBanner extends Component {
               <SearchMenu
                 @location="welcome-banner"
                 @searchInputId="welcome-banner-search-input"
+                @placeholder={{i18n "welcome_banner.search"}}
               />
             </div>
             <PluginOutlet @name="welcome-banner-below-input" />

--- a/app/assets/javascripts/discourse/tests/integration/components/welcome-banner-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/welcome-banner-test.gjs
@@ -60,6 +60,18 @@ module(
       );
       assert.dom(".welcome-banner .welcome-banner__title input").doesNotExist();
     });
+
+    test("uses the welcome_banner.search translation for placeholder", async function (assert) {
+      await render(<template><WelcomeBanner /></template>);
+
+      assert
+        .dom("#welcome-banner-search-input")
+        .hasAttribute(
+          "placeholder",
+          i18n("welcome_banner.search"),
+          "search input uses the welcome_banner.search translation as placeholder"
+        );
+    });
   }
 );
 


### PR DESCRIPTION
We had a `welcome_banner.search` string, but it wasn't being used... so it wasn't possible to replace the welcome banner placeholder independently from other search inputs.

This adds the ability to pass in a custom placeholder for the search-menu component so the text can be updated for individual cases as needed.  

Also added a test to ensure the translation is used. 