### PR TITLE
UX: only show AI persona dropdown with multiple options

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-persona-llm-selector.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-persona-llm-selector.gjs
@@ -129,6 +129,10 @@ export default class AiPersonaLlmSelector extends Component {
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 
+  get showPersonaSelector() {
+    return this.botOptions?.length > 1;
+  }
+
   get showLLMSelector() {
     return this.allowLLMSelector && this.llmOptions.length > 1;
   }
@@ -200,20 +204,22 @@ export default class AiPersonaLlmSelector extends Component {
 
   <template>
     <div class="persona-llm-selector">
-      <div class="persona-llm-selector__selection-wrapper gpt-persona">
-        {{#if @showLabels}}
-          <label>{{i18n "discourse_ai.ai_bot.persona"}}</label>
-        {{/if}}
-        <DropdownSelectBox
-          class="persona-llm-selector__persona-dropdown"
-          @value={{this.value}}
-          @content={{this.botOptions}}
-          @options={{hash
-            icon=(if @showLabels "angle-down" "robot")
-            filterable=this.filterable
-          }}
-        />
-      </div>
+      {{#if this.showPersonaSelector}}
+        <div class="persona-llm-selector__selection-wrapper gpt-persona">
+          {{#if @showLabels}}
+            <label>{{i18n "discourse_ai.ai_bot.persona"}}</label>
+          {{/if}}
+          <DropdownSelectBox
+            class="persona-llm-selector__persona-dropdown"
+            @value={{this.value}}
+            @content={{this.botOptions}}
+            @options={{hash
+              icon=(if @showLabels "angle-down" "robot")
+              filterable=this.filterable
+            }}
+          />
+        </div>
+      {{/if}}
       {{#if this.showLLMSelector}}
         <div class="persona-llm-selector__selection-wrapper llm-selector">
           {{#if @showLabels}}

--- a/plugins/discourse-ai/spec/system/ai_bot/ai_bot_helper_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/ai_bot_helper_spec.rb
@@ -28,21 +28,26 @@ RSpec.describe "AI chat channel summarization", type: :system do
     allowed_persona = AiPersona.last
     allowed_persona.update!(allowed_group_ids: [group.id], enabled: true)
 
+    # second persona to ensure dropdown shows (requires >1 option)
+    second_persona = Fabricate(:ai_persona, allowed_group_ids: [group.id], enabled: true)
+    second_persona.update!(allow_personal_messages: true)
+
     visit "/latest"
     expect(page).to have_selector(".ai-bot-button")
     find(".ai-bot-button").click
 
     find(".gpt-persona").click
-    expect(page).to have_css(".gpt-persona ul li", count: 1)
+    expect(page).to have_css(".gpt-persona ul li", count: 2)
 
     find(".llm-selector").click
     expect(page).to have_css(".llm-selector ul li", count: 2)
 
     expect(page).to have_selector(".d-editor-container")
 
-    # lets disable bots but still allow 1 persona
     allowed_persona.create_user!
     allowed_persona.update!(default_llm_id: gpt_4.id)
+    second_persona.create_user!
+    second_persona.update!(default_llm_id: gpt_4.id)
 
     gpt_4.update!(enabled_chat_bot: false)
     gpt_3_5_turbo.update!(enabled_chat_bot: false)
@@ -51,7 +56,7 @@ RSpec.describe "AI chat channel summarization", type: :system do
     find(".ai-bot-button").click
 
     find(".gpt-persona").click
-    expect(page).to have_css(".gpt-persona ul li", count: 1)
+    expect(page).to have_css(".gpt-persona ul li", count: 2)
     expect(page).not_to have_selector(".llm-selector")
 
     SiteSetting.ai_bot_add_to_header = false


### PR DESCRIPTION
Currently we show the AI persona dropdown on the AI conversations page if there's only one option:

<img width="2192" height="828" alt="image" src="https://github.com/user-attachments/assets/79316217-e9e8-48f6-b9de-4a61f5d8ba25" />

To simplify, we should only show it when more than one option are present: 

<img width="2202" height="1180" alt="image" src="https://github.com/user-attachments/assets/baff1bab-da85-4e9f-9091-a5df544b3762" />

and it appears again with multiple options: 

<img width="880" height="354" alt="image" src="https://github.com/user-attachments/assets/e666916f-b958-4370-9e5e-bf7558f48f52" />

