### PR TITLE
DEV: Fix flaky system test

### DIFF
--- a/spec/system/composer/drafts_spec.rb
+++ b/spec/system/composer/drafts_spec.rb
@@ -21,7 +21,7 @@ describe "Composer - Drafts", type: :system do
       composer.close
 
       expect(toasts).to have_success(I18n.t("js.composer.draft_saved"))
-      expect(Draft.where(user: current_user).count).to eq(1)
+      try_until_success { expect(Draft.where(user: current_user).count).to eq(1) }
     end
 
     context "when only a title and category is specified" do
@@ -37,7 +37,8 @@ describe "Composer - Drafts", type: :system do
         composer.close
 
         expect(toasts).to have_success(I18n.t("js.composer.draft_saved"))
-        expect(Draft.where(user: current_user).count).to eq(1)
+
+        try_until_success { expect(Draft.where(user: current_user).count).to eq(1) }
       end
     end
   end
@@ -94,7 +95,7 @@ describe "Composer - Drafts", type: :system do
         expect(discard_draft_modal).to be_closed
         expect(composer).to be_closed
 
-        expect(Draft.where(user: current_user).count).to eq(1)
+        try_until_success { expect(Draft.where(user: current_user).count).to eq(1) }
       end
     end
   end


### PR DESCRIPTION
Asserting for the database's state is not encouraged in system tests but when we do, we
need to wrap it up in a `try_until_success` block
