### PR TITLE
DEV: Comment about the header components order

### DIFF
--- a/app/assets/javascripts/discourse/app/components/header.gjs
+++ b/app/assets/javascripts/discourse/app/components/header.gjs
@@ -225,6 +225,9 @@ export default class GlimmerHeader extends Component {
           @topicInfoVisible={{@topicInfoVisible}}
           @narrowDesktop={{this.site.narrowDesktopView}}
         >
+          {{! WARNING: Do not modify the order of `div.header-buttons` and the `<Icons />` component.
+          These components have DAG plugin APIs for the header, and changing their order will break
+          the layout of themes and Theme Components that use these APIs. }}
           <span class="header-buttons">
             {{#each (headerButtons.resolve) as |entry|}}
               {{#if (and (eq entry.key "auth") (not this.currentUser))}}


### PR DESCRIPTION
Add a warning comment in the `header.gjs` file to clarify that the order of `div.header-buttons` and the `<Icons />` component must not be modified. This ensures compatibility with existing themes and Theme Components leveraging the DAG plugin APIs.