### PR TITLE
UX: prevent unnecessary safari auto-sizing in filter dropdown

### DIFF
--- a/app/assets/stylesheets/common/components/filter-navigation.scss
+++ b/app/assets/stylesheets/common/components/filter-navigation.scss
@@ -3,7 +3,7 @@
 .fk-d-menu[data-identifier="filter-navigation-menu-list"] {
   max-height: 300px;
 
-  @include viewport.until(sm) {
+  @include viewport.until(md) {
     -webkit-text-size-adjust: 100%; /* stylelint-disable-line */
   }
 


### PR DESCRIPTION
Title says it all