### PR TITLE
FIX: correctly start weeks en Monday

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/routes/upcoming-events-base-route.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/routes/upcoming-events-base-route.js
@@ -35,8 +35,8 @@ export default class UpcomingEventsBaseRoute extends DiscourseRoute {
       const day = parseInt(params.day, 10);
 
       const date = moment.utc({ year, month, day });
-      after = date.clone().startOf("week").toISOString();
-      before = date.clone().endOf("week").toISOString();
+      after = date.clone().startOf("isoWeek").toISOString();
+      before = date.clone().endOf("isoWeek").toISOString();
       initialDate = moment.utc({ year, month, day }).format("YYYY-MM-DD");
     } else if (params.view === "day") {
       const year = parseInt(params.year, 10);

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -99,6 +99,20 @@ describe "Upcoming Events", type: :system do
   end
 
   describe "event filtering" do
+    it "loads the correct range of dates", time: Time.utc(2025, 9, 1, 12, 0) do
+      post =
+        PostCreator.create!(
+          admin,
+          title: "going to the zoo",
+          raw:
+            "[event start=\"2025-09-07 18:30\" status=\"public\" timezone=\"Europe/Prague\" end=\"2025-09-07 21:00\"]\n[/event]",
+        )
+
+      visit("/upcoming-events/week/2025/9/1")
+
+      upcoming_events.expect_event_visible("zoo")
+    end
+
     it "shows only events the user is attending when filtered",
        time: Time.utc(2025, 6, 2, 19, 00) do
       attending_event =


### PR DESCRIPTION
Prior to this fix we would generate a range which would be incorrect as we would use Monday as the end of the week.