### PR TITLE
DEV: Remove `theme_color_schemes` table from Intermediate DB config

### DIFF
--- a/migrations/config/intermediate_db.yml
+++ b/migrations/config/intermediate_db.yml
@@ -349,7 +349,6 @@ schema:
         - "tag_search_data"
         - "tag_users"
         - "tags_web_hooks"
-        - "theme_color_schemes"
         - "theme_fields"
         - "theme_modifier_sets"
         - "theme_settings"


### PR DESCRIPTION
The `theme_color_schemes` table was dropped in https://github.com/discourse/discourse/commit/7ee52c8f859eadbe7c1526c936bd480ebda61c71