### PR TITLE
DEV: Fix draft spec

### DIFF
--- a/spec/system/composer/drafts_spec.rb
+++ b/spec/system/composer/drafts_spec.rb
@@ -42,15 +42,16 @@ describe "Composer - Drafts", type: :system do
       end
     end
 
-    context "when only title is specified" do
+    context "when only title is specified and it is too short" do
       it "does not save the draft or show a toast" do
         visit "/new-topic"
 
         expect(composer).to be_opened
-        composer.fill_title("this is a test topic")
+        composer.fill_title("test")
         composer.close
+        expect(composer).to be_closed
 
-        expect(toasts).to have_no_message(I18n.t("js.composer.draft_saved"))
+        expect(toasts).to have_no_message
         expect(Draft.where(user: current_user).count).to eq(0)
       end
     end

--- a/spec/system/page_objects/components/toasts.rb
+++ b/spec/system/page_objects/components/toasts.rb
@@ -27,8 +27,8 @@ module PageObjects
         has_css?(".fk-d-default-toast.-error", text: message)
       end
 
-      def has_no_message?(message)
-        has_no_css?(".fk-d-default-toast", text: message)
+      def has_no_message?
+        has_no_css?(".fk-d-default-toast__message")
       end
     end
   end


### PR DESCRIPTION
This spec was not testing the right thing, the draft
is not supposed to save if the topic title is too short,
but the way the expectations were written (checking the
float message) made it pass incorrectly.
