### PR TITLE
UX: Horizon > unhide create topic btn

### DIFF
--- a/themes/horizon/scss/sidebar-new-topic-button.scss
+++ b/themes/horizon/scss/sidebar-new-topic-button.scss
@@ -1,6 +1,5 @@
 .navigation-controls {
-  .topic-drafts-menu-trigger,
-  .fk-d-button-tooltip {
+  .topic-drafts-menu-trigger {
     display: none;
   }
 }


### PR DESCRIPTION
After consideration of the feedback we've received, we decided to offer the `Create topic` again on the mobile topic list page for ease of use. The sidebar button remains present too.