### PR TITLE
UX: Improve color palette layout with proper spacing

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-config-areas/color-palette.gjs
@@ -308,105 +308,107 @@ export default class AdminConfigAreasColorPalette extends Component {
             />
           </div>
         </div>
-        <AdminConfigAreaCard
-          @heading="admin.config_areas.color_palettes.color_options.title"
-        >
-          <:content>
-            <form.Row>
+        <div class="admin-config-color-palettes__sections">
+          <AdminConfigAreaCard
+            @heading="admin.config_areas.color_palettes.color_options.title"
+          >
+            <:content>
+              <form.Row>
+                <form.Field
+                  @name="default_light_on_theme"
+                  @title={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle"
+                  }}
+                  @showTitle={{false}}
+                  @description={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle_default_light_on_theme"
+                    themeName=this.defaultTheme.name
+                  }}
+                  @format="full"
+                  @onSet={{this.handleDefaultLightOnThemeChange}}
+                  as |field|
+                >
+                  <field.Toggle />
+                </form.Field>
+              </form.Row>
+              <form.Row>
+                <form.Field
+                  @name="default_dark_on_theme"
+                  @title={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle"
+                  }}
+                  @showTitle={{false}}
+                  @description={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle_default_dark_on_theme"
+                    themeName=this.defaultTheme.name
+                  }}
+                  @format="full"
+                  @onSet={{this.handleDefaultDarkOnThemeChange}}
+                  as |field|
+                >
+                  <field.Toggle />
+                </form.Field>
+              </form.Row>
+              <form.Row>
+                <form.Field
+                  @name="user_selectable"
+                  @title={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle"
+                  }}
+                  @showTitle={{false}}
+                  @description={{i18n
+                    "admin.config_areas.color_palettes.color_options.toggle_description"
+                  }}
+                  @format="full"
+                  @onSet={{this.handleUserSelectableChange}}
+                  as |field|
+                >
+                  <field.Toggle />
+                </form.Field>
+              </form.Row>
+            </:content>
+          </AdminConfigAreaCard>
+          <AdminConfigAreaCard
+            @heading="admin.config_areas.color_palettes.colors.title"
+          >
+            <:content>
               <form.Field
-                @name="default_light_on_theme"
-                @title={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle"
-                }}
+                @name="colors"
+                @title={{i18n "admin.config_areas.color_palettes.colors.title"}}
                 @showTitle={{false}}
-                @description={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle_default_light_on_theme"
-                  themeName=this.defaultTheme.name
-                }}
                 @format="full"
-                @onSet={{this.handleDefaultLightOnThemeChange}}
                 as |field|
               >
-                <field.Toggle />
+                <field.Custom>
+                  <ColorPaletteEditor
+                    @colors={{transientData.colors}}
+                    @onColorChange={{this.onColorChange}}
+                  />
+                </field.Custom>
               </form.Field>
-            </form.Row>
-            <form.Row>
-              <form.Field
-                @name="default_dark_on_theme"
-                @title={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle"
-                }}
-                @showTitle={{false}}
-                @description={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle_default_dark_on_theme"
-                  themeName=this.defaultTheme.name
-                }}
-                @format="full"
-                @onSet={{this.handleDefaultDarkOnThemeChange}}
-                as |field|
-              >
-                <field.Toggle />
-              </form.Field>
-            </form.Row>
-            <form.Row>
-              <form.Field
-                @name="user_selectable"
-                @title={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle"
-                }}
-                @showTitle={{false}}
-                @description={{i18n
-                  "admin.config_areas.color_palettes.color_options.toggle_description"
-                }}
-                @format="full"
-                @onSet={{this.handleUserSelectableChange}}
-                as |field|
-              >
-                <field.Toggle />
-              </form.Field>
-            </form.Row>
-          </:content>
-        </AdminConfigAreaCard>
-        <AdminConfigAreaCard
-          @heading="admin.config_areas.color_palettes.colors.title"
-        >
-          <:content>
-            <form.Field
-              @name="colors"
-              @title={{i18n "admin.config_areas.color_palettes.colors.title"}}
-              @showTitle={{false}}
-              @format="full"
-              as |field|
-            >
-              <field.Custom>
-                <ColorPaletteEditor
-                  @colors={{transientData.colors}}
-                  @onColorChange={{this.onColorChange}}
+            </:content>
+          </AdminConfigAreaCard>
+          <AdminConfigAreaCard>
+            <:content>
+              <div class="admin-config-color-palettes__save-card">
+                {{#if this.hasUnsavedChanges}}
+                  <span class="admin-config-color-palettes__unsaved-changes">
+                    {{i18n "admin.config_areas.color_palettes.unsaved_changes"}}
+                  </span>
+                {{/if}}
+                <DButton
+                  class="copy-to-clipboard"
+                  @label="admin.config_areas.color_palettes.copy_to_clipboard"
+                  @action={{this.copyToClipboard}}
                 />
-              </field.Custom>
-            </form.Field>
-          </:content>
-        </AdminConfigAreaCard>
-        <AdminConfigAreaCard>
-          <:content>
-            <div class="admin-config-color-palettes__save-card">
-              {{#if this.hasUnsavedChanges}}
-                <span class="admin-config-color-palettes__unsaved-changes">
-                  {{i18n "admin.config_areas.color_palettes.unsaved_changes"}}
-                </span>
-              {{/if}}
-              <DButton
-                class="copy-to-clipboard"
-                @label="admin.config_areas.color_palettes.copy_to_clipboard"
-                @action={{this.copyToClipboard}}
-              />
-              <form.Submit
-                @isLoading={{this.saving}}
-                @label="admin.config_areas.color_palettes.save_changes"
-              />
-            </div>
-          </:content>
-        </AdminConfigAreaCard>
+                <form.Submit
+                  @isLoading={{this.saving}}
+                  @label="admin.config_areas.color_palettes.save_changes"
+                />
+              </div>
+            </:content>
+          </AdminConfigAreaCard>
+        </div>
       </div>
     </Form>
   </template>

--- a/app/assets/stylesheets/admin/admin_config_color_palettes.scss
+++ b/app/assets/stylesheets/admin/admin_config_color_palettes.scss
@@ -57,6 +57,12 @@
       margin-bottom: 1em;
     }
 
+    &__sections {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+    }
+
     &__logo-and-fonts-hint {
       display: flex;
       justify-content: space-between;
@@ -69,6 +75,7 @@
     }
 
     &__save-card {
+      margin-top: -0.5rem;
       display: flex;
       justify-content: flex-end;
       gap: 1em;


### PR DESCRIPTION
- Add `.admin-config-color-palettes__sections` wrapper with flex layout
- Apply consistent `var(--space-4)` gap between sections
- Adjust save card top margin for proper alignment

Before
<img width="1104" height="1180" alt="Screenshot 2025-08-27 at 10 55 35 am" src="https://github.com/user-attachments/assets/88f420d8-0d80-49c6-a42c-66b7c91ddcc3" />

After
<img width="1110" height="1207" alt="Screenshot 2025-08-27 at 10 56 56 am" src="https://github.com/user-attachments/assets/f1d7f6c6-8779-46d7-a898-4fd2cf154dd7" />
