### PR TITLE
UX: use ColorPalettePicker in base palette modal

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/color-scheme-select-base.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/color-scheme-select-base.gjs
@@ -5,7 +5,7 @@ import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import { i18n } from "discourse-i18n";
-import ComboBox from "select-kit/components/combo-box";
+import ColorPalettePicker from "select-kit/components/color-palette-picker";
 
 export default class ColorSchemeSelectBase extends Component {
   @tracked selectedBaseThemeId = this.args.model.colorSchemes?.[0]?.id;
@@ -24,13 +24,11 @@ export default class ColorSchemeSelectBase extends Component {
     >
       <:body>
         {{i18n "admin.customize.colors.select_base.description"}}
-        <ComboBox
-          class="select-base-palette"
+        <ColorPalettePicker
           @content={{@model.colorSchemes}}
           @value={{this.selectedBaseThemeId}}
-          @nameProperty="name"
-          @valueProperty="id"
           @onChange={{fn (mut this.selectedBaseThemeId)}}
+          class="select-base-palette"
         />
       </:body>
       <:footer>

--- a/spec/system/admin_color_palettes_config_area_spec.rb
+++ b/spec/system/admin_color_palettes_config_area_spec.rb
@@ -38,6 +38,8 @@ describe "Admin Color Palettes Config Area Page", type: :system do
     config_area.visit
 
     config_area.create_button.click
+    create_color_palette_modal.base_dropdown.expand
+    expect(page).to have_css(".color-palette-picker-row")
     create_color_palette_modal.base_dropdown.select_row_by_name("A Test Palette 2")
 
     create_color_palette_modal.create_button.click


### PR DESCRIPTION
Replaces the generic ComboBox component with the specialized ColorPalettePicker component with preview in the color scheme base selection modal.

Demo
<img width="671" height="457" alt="Screenshot 2025-08-27 at 11 32 25 am" src="https://github.com/user-attachments/assets/cec52050-fce3-4fe9-9126-cd9eeb591ff3" />
