### PR TITLE
DEV: new API endpoint for data explorer query running

### DIFF
--- a/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
+++ b/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
@@ -5,12 +5,12 @@ module ::DiscourseDataExplorer
     requires_plugin PLUGIN_NAME
 
     before_action :set_group, only: %i[group_reports_index group_reports_show group_reports_run]
-    before_action :set_query, only: %i[group_reports_show group_reports_run show update]
+    before_action :set_query, only: %i[group_reports_show group_reports_run show update public_run]
     before_action :ensure_admin
 
-    skip_before_action :check_xhr, only: %i[show group_reports_run run]
+    skip_before_action :check_xhr, only: %i[show group_reports_run run public_run]
     skip_before_action :ensure_admin,
-                       only: %i[group_reports_index group_reports_show group_reports_run]
+                       only: %i[group_reports_index group_reports_show group_reports_run public_run]
 
     def index
       queries = Query.where(hidden: false).order(:last_run_at, :name).includes(:groups).to_a
@@ -79,6 +79,13 @@ module ::DiscourseDataExplorer
       if !guardian.group_and_user_can_access_query?(@group, @query) || @query.hidden
         return raise Discourse::NotFound
       end
+
+      run
+    end
+
+    # Public GET endpoint to run a query by ID for users with access
+    def public_run
+      return raise Discourse::NotFound if !guardian.user_can_access_query?(@query) || @query.hidden
 
       run
     end

--- a/plugins/discourse-data-explorer/config/routes.rb
+++ b/plugins/discourse-data-explorer/config/routes.rb
@@ -20,5 +20,11 @@ Discourse::Application.routes.draw do
   get "/g/:group_name/reports/:id" => "discourse_data_explorer/query#group_reports_show"
   post "/g/:group_name/reports/:id/run" => "discourse_data_explorer/query#group_reports_run"
 
+  # Public API to fetch query results via GET with permission checks
+  get "/data-explorer/queries/:id/run" => "discourse_data_explorer/query#public_run",
+      :constraints => {
+        format: /(json|csv)/,
+      }
+
   mount DiscourseDataExplorer::Engine, at: "/admin/plugins/explorer"
 end

--- a/plugins/discourse-data-explorer/plugin.rb
+++ b/plugins/discourse-data-explorer/plugin.rb
@@ -68,7 +68,12 @@ after_initialize do
 
   add_api_key_scope(
     :discourse_data_explorer,
-    { run_queries: { actions: %w[discourse_data_explorer/query#run], params: %i[id] } },
+    {
+      run_queries: {
+        actions: %w[discourse_data_explorer/query#run discourse_data_explorer/query#public_run],
+        params: %i[id],
+      },
+    },
   )
 
   reloadable_patch do

--- a/plugins/discourse-data-explorer/spec/integration/custom_api_key_scopes_spec.rb
+++ b/plugins/discourse-data-explorer/spec/integration/custom_api_key_scopes_spec.rb
@@ -109,4 +109,26 @@ describe "API keys scoped to query#run" do
     expect(response.parsed_body["success"]).to eq(true)
     expect(response.parsed_body["columns"]).to eq(["query2_res"])
   end
+
+  it "can run queries via GET public route when allowed" do
+    expect {
+      get "/data-explorer/queries/#{query1.id}/run.json",
+          headers: {
+            "Api-Key" => single_query_api_key.key,
+            "Api-Username" => admin.username,
+          }
+    }.to change { query1.reload.last_run_at }
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["success"]).to eq(true)
+    expect(response.parsed_body["columns"]).to eq(["query1_res"])
+
+    expect {
+      get "/data-explorer/queries/#{query2.id}/run.json",
+          headers: {
+            "Api-Key" => single_query_api_key.key,
+            "Api-Username" => admin.username,
+          }
+    }.not_to change { query2.reload.last_run_at }
+    expect(response.status).to eq(403)
+  end
 end


### PR DESCRIPTION
New GET endpoint at /data-explorer/queries/ID/run.json

Allows for simple execution of queries based on ID

Previous endpoint was POST and required group name, which makes it harder to use via API
