### PR TITLE
FIX: `Default Locale` site setting not included in admin search

### DIFF
--- a/app/controllers/admin/search_controller.rb
+++ b/app/controllers/admin/search_controller.rb
@@ -13,7 +13,8 @@ class Admin::SearchController < Admin::AdminController
               filter_area: params[:filter_area],
               filter_plugin: params[:plugin],
               filter_categories: Array.wrap(params[:categories]),
-              include_locale_setting: params[:filter_area] == "localization",
+              include_locale_setting:
+                params[:filter_area].blank? || params[:filter_area] == "localization",
               basic_attributes: true,
             ),
           themes_and_components:

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -293,6 +293,7 @@ module SiteSettingExtension
       humanized_name: humanized_names("default_locale"),
       default: SiteSettings::DefaultsProvider::DEFAULT_LOCALE,
       category: "required",
+      primary_area: "localization",
       description: description("default_locale"),
       type: SiteSetting.types[SiteSetting.types[:locale_enum]],
       preview: nil,

--- a/spec/requests/admin/search_controller_spec.rb
+++ b/spec/requests/admin/search_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::SearchController do
+  fab!(:admin)
+
+  before { sign_in(admin) }
+
+  describe "#index" do
+    it "includes default_locale setting in search results for general searches" do
+      get "/admin/search/all.json"
+
+      expect(response.status).to eq(200)
+
+      locale_setting =
+        response.parsed_body["settings"].find { |s| s["setting"] == "default_locale" }
+
+      expect(locale_setting).to be_present
+    end
+  end
+end


### PR DESCRIPTION
### Before
<img width="1079" height="981" alt="Screenshot 2025-08-27 at 12 20 30 PM" src="https://github.com/user-attachments/assets/8b38ef86-e602-440f-8d59-321af1677c95" />

### After

<img width="1106" height="1059" alt="Screenshot 2025-08-27 at 12 20 01 PM" src="https://github.com/user-attachments/assets/1f9e3c61-5a17-4067-ad67-2c9a2e1ba382" />