### PR TITLE
FEATURE: add support for google image model

### DIFF
--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -643,6 +643,7 @@ en:
           google-gemini-2-0-flash: "Lightweight, fast, and cost-efficient with multimodal reasoning (previous generation)"
           google-gemini-2-5-flash: "Lightweight, fast, and cost-efficient with multimodal reasoning"
           google-gemini-2-0-flash-lite: "Cost efficient and low latency model"
+          google-gemini-2-5-flash-image-preview: "Latest image generation model with vision capabilities"
           open_ai-o3: "OpenAI's most capable reasoning model"
           open_ai-o4-mini: "Advanced Cost-efficient reasoning model"
           open_ai-gpt-5: "OpenAI's flagship model. It is well suited for problem solving across domains"

--- a/plugins/discourse-ai/lib/completions/dialects/chat_gpt.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/chat_gpt.rb
@@ -96,7 +96,7 @@ module DiscourseAi
         end
 
         def model_msg(msg)
-          { role: "assistant", content: msg[:content] }
+          message_for_role("assistant", msg)
         end
 
         def tool_call_msg(msg)
@@ -116,9 +116,13 @@ module DiscourseAi
         end
 
         def user_msg(msg)
+          message_for_role("user", msg)
+        end
+
+        def message_for_role(role, msg)
           content_array = []
 
-          user_message = { role: "user" }
+          user_message = { role: }
 
           if msg[:id]
             if embed_user_ids?

--- a/plugins/discourse-ai/lib/completions/dialects/chat_gpt.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/chat_gpt.rb
@@ -134,12 +134,15 @@ module DiscourseAi
 
           content_array << msg[:content]
 
+          allow_vision = vision_support?
+          allow_vision = false if responses_api? && role == "assistant"
+
           content_array =
             to_encoded_content_array(
               content: content_array.flatten,
               image_encoder: ->(details) { image_node(details) },
-              text_encoder: ->(text) { text_node(text) },
-              allow_vision: vision_support?,
+              text_encoder: ->(text) { text_node(text, role) },
+              allow_vision:,
             )
 
           user_message[:content] = no_array_if_only_text(content_array)
@@ -154,9 +157,9 @@ module DiscourseAi
           end
         end
 
-        def text_node(text)
+        def text_node(text, role)
           if responses_api?
-            { type: "input_text", text: text }
+            { type: role == "user" ? "input_text" : "output_text", text: text }
           else
             { type: "text", text: text }
           end

--- a/plugins/discourse-ai/lib/completions/dialects/dialect.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/dialect.rb
@@ -79,8 +79,66 @@ module DiscourseAi
           self.class.no_more_tool_calls_text_user
         end
 
+        # supported options are :none/:all/:model_only
+        def strip_upload_markdown_mode
+          :none
+        end
+
+        def strip_upload_markdown(messages, strip_mode: nil)
+          return messages if strip_mode == :none
+
+          eligible_types =
+            case strip_mode
+            when :all
+              %i[user model]
+            when :model_only
+              %i[model]
+            else
+              []
+            end
+
+          return messages if eligible_types.empty?
+
+          upload_ids =
+            messages
+              .flat_map do |m|
+                next [] if eligible_types.exclude?(m[:type].to_sym)
+                content = m[:content]
+                content = [content] unless content.is_a?(Array)
+                content.filter_map { |c| c.is_a?(Hash) && c[:upload_id] ? c[:upload_id] : nil }
+              end
+              .uniq
+
+          return messages if upload_ids.empty?
+
+          shas = Upload.where(id: upload_ids).pluck(:sha1).compact
+
+          messages.map do |m|
+            next m if eligible_types.exclude?(m[:type].to_sym)
+
+            content = m[:content]
+            content = [content] unless content.is_a?(Array)
+
+            new_content =
+              content.map do |c|
+                if c.is_a?(String)
+                  strip_upload_markers(c, shas)
+                else
+                  c
+                end
+              end
+
+            new_content = new_content[0] if new_content.length == 1
+            m.merge(content: new_content)
+          end
+        end
+
         def translate
-          messages = trim_messages(prompt.messages)
+          messages = prompt.messages
+          if strip_upload_markdown_mode != :none
+            messages = strip_upload_markdown(messages, strip_mode: strip_upload_markdown_mode)
+          end
+          messages = trim_messages(messages)
           last_message = messages.last
           inject_done_on_last_tool_call = false
 
@@ -129,6 +187,19 @@ module DiscourseAi
         private
 
         attr_reader :opts, :llm_model
+
+        def strip_upload_markers(markdown, upload_shas)
+          return markdown if markdown.blank? || upload_shas.blank?
+          base62_set = upload_shas.compact.map { |sha| Upload.base62_sha1(sha) }.to_set
+          markdown.gsub(%r{!\[([^\]|]+)(?:\|[^\]]*)?\]\(upload://([a-zA-Z0-9]+)[^)]+\)}) do
+            b62 = Regexp.last_match(2)
+            if base62_set.include?(b62)
+              ""
+            else
+              Regexp.last_match(0)
+            end
+          end
+        end
 
         def trim_messages(messages)
           prompt_limit = max_prompt_tokens

--- a/plugins/discourse-ai/lib/completions/dialects/dialect.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/dialect.rb
@@ -244,13 +244,16 @@ module DiscourseAi
           content.each do |c|
             if c.is_a?(String)
               current_string << c
-            elsif c.is_a?(Hash) && c.key?(:upload_id) && allow_vision
-              if !current_string.empty?
-                result << text_encoder.call(current_string)
-                current_string = +""
+            elsif c.is_a?(Hash) && c.key?(:upload_id)
+              # this ensurse we skip uploads if vision is not supported
+              if allow_vision
+                if !current_string.empty?
+                  result << text_encoder.call(current_string)
+                  current_string = +""
+                end
+                encoded = prompt.encode_upload(c[:upload_id])
+                result << image_encoder.call(encoded) if encoded
               end
-              encoded = prompt.encode_upload(c[:upload_id])
-              result << image_encoder.call(encoded) if encoded
             elsif other_encoder
               encoded = other_encoder.call(c)
               result << encoded if encoded

--- a/plugins/discourse-ai/lib/completions/dialects/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/gemini.rb
@@ -10,6 +10,14 @@ module DiscourseAi
           end
         end
 
+        def strip_upload_markdown_mode
+          if llm_model.name.include?("image")
+            :all
+          else
+            :model_only
+          end
+        end
+
         def native_tool_support?
           !llm_model.lookup_custom_param("disable_native_tools")
         end

--- a/plugins/discourse-ai/lib/completions/dialects/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/gemini.rb
@@ -84,14 +84,14 @@ module DiscourseAi
         end
 
         def model_msg(msg)
-          if beta_api?
-            { role: "model", parts: [{ text: msg[:content] }] }
-          else
-            { role: "model", parts: { text: msg[:content] } }
-          end
+          message_for_role("model", msg)
         end
 
         def user_msg(msg)
+          message_for_role("user", msg)
+        end
+
+        def message_for_role(role, msg)
           content_array = []
           content_array << "#{msg[:id]}: " if msg[:id]
 
@@ -107,9 +107,9 @@ module DiscourseAi
             )
 
           if beta_api?
-            { role: "user", parts: content_array }
+            { role:, parts: content_array }
           else
-            { role: "user", parts: content_array.first }
+            { role:, parts: content_array.first }
           end
         end
 

--- a/plugins/discourse-ai/lib/completions/llm.rb
+++ b/plugins/discourse-ai/lib/completions/llm.rb
@@ -102,6 +102,13 @@ module DiscourseAi
                       input_cost: 0.075,
                       output_cost: 0.30,
                     },
+                    {
+                      name: "gemini-2.5-flash-image-preview",
+                      tokens: 800_000,
+                      endpoint:
+                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image-preview",
+                      display_name: "Gemini 2.5 Flash Image",
+                    },
                   ],
                   tokenizer: DiscourseAi::Tokenizer::GeminiTokenizer,
                   provider: "google",

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -532,6 +532,61 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
       )
     end
 
+    it "handles uploads correctly in topic style messages (and times)" do
+      freeze_time 1.month.ago
+
+      # Use Discourse's upload format in the post raw content
+      upload_markdown = "![test1|658x372](#{image_upload1.short_url})"
+
+      post1 =
+        Fabricate(
+          :post,
+          topic: pm,
+          user: admin,
+          raw: "This is the original #{upload_markdown} I just added",
+        )
+
+      UploadReference.create!(target: post1, upload: image_upload1)
+
+      upload2_markdown = "![test2|658x372](#{image_upload2.short_url})"
+
+      freeze_time 1.month.from_now
+
+      post2_with_upload =
+        Fabricate(
+          :post,
+          topic: pm,
+          user: admin,
+          raw: "This post has a different image #{upload2_markdown} I just added",
+        )
+
+      UploadReference.create!(target: post2_with_upload, upload: image_upload2)
+
+      messages =
+        described_class.messages_from_post(
+          post2_with_upload,
+          style: :topic,
+          max_posts: 3,
+          bot_usernames: [bot_user.username],
+          include_uploads: true,
+        )
+
+      expect(messages.length).to eq(1)
+      content = messages[0][:content]
+
+      # Ensure both uploads are present with sha info and alt text kept (without dimensions)
+      upload_hashes = content.select { |c| c.is_a?(Hash) }
+      expect(upload_hashes).to include(
+        { upload_id: image_upload1.id },
+        { upload_id: image_upload2.id },
+      )
+
+      # Ensure timestamps and surrounding text are still present
+      expect(content.join).to include("This is the original test1 I just added")
+      expect(content.join).to include("(1 month ago)")
+      expect(content.join).to include("different image test2 I just added")
+    end
+
     it "only include regular posts" do
       first_post.update!(post_type: Post.types[:whisper])
 

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -575,7 +575,6 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
       expect(messages.length).to eq(1)
       content = messages[0][:content]
 
-      # Ensure both uploads are present with sha info and alt text kept (without dimensions)
       upload_hashes = content.select { |c| c.is_a?(Hash) }
       expect(upload_hashes).to include(
         { upload_id: image_upload1.id },
@@ -586,7 +585,8 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
 
       expect(text).to include("This is the original")
       expect(text).to include("(1 month ago)")
-      expect(text).to include("#{long_title}")
+      expect(text).to include("#{upload_markdown}")
+      expect(text).to include("#{upload2_markdown}")
     end
 
     it "only include regular posts" do

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -548,7 +548,8 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
 
       UploadReference.create!(target: post1, upload: image_upload1)
 
-      upload2_markdown = "![test2|658x372](#{image_upload2.short_url})"
+      long_title = "A" * 40
+      upload2_markdown = "![#{long_title}|658x372](#{image_upload2.short_url})"
 
       freeze_time 1.month.from_now
 
@@ -581,10 +582,11 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
         { upload_id: image_upload2.id },
       )
 
-      # Ensure timestamps and surrounding text are still present
-      expect(content.join).to include("This is the original test1 I just added")
-      expect(content.join).to include("(1 month ago)")
-      expect(content.join).to include("different image test2 I just added")
+      text = content.select { |c| c.is_a?(String) }.join(" ")
+
+      expect(text).to include("This is the original")
+      expect(text).to include("(1 month ago)")
+      expect(text).to include("#{long_title}")
     end
 
     it "only include regular posts" do


### PR DESCRIPTION
Adds support for: https://blog.google/products/gemini/updated-image-editing-model/

This mode generates images natively, we updated the Gemini endpoint to support handling image output.

Additionally, there is a refinement to how we provide image context to models, we avoid very short descriptions and simply
inline images in the context, prior to this fix image generating models could get confused and start generating markdown blobs.

This takes care to properly omit images from context in model responses for anthropic and open ai in responses api.  
