### PR TITLE
FIX: prevent group chat when cannot see group members

### DIFF
--- a/plugins/chat/app/services/chat/search_chatable.rb
+++ b/plugins/chat/app/services/chat/search_chatable.rb
@@ -93,6 +93,7 @@ module Chat
     def search_groups(params, guardian)
       Group
         .visible_groups(guardian.user)
+        .members_visible_groups(guardian.user)
         .includes(users: :user_option)
         .where(
           "groups.name ILIKE :term_like OR groups.full_name ILIKE :term_like",

--- a/plugins/chat/spec/services/chat/search_chatable_spec.rb
+++ b/plugins/chat/spec/services/chat/search_chatable_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe Chat::SearchChatable do
       end
 
       context "when including groups" do
+        fab!(:hidden_group) do
+          Fabricate(
+            :group,
+            name: "hidden-group-1",
+            visibility_level: Group.visibility_levels[:members],
+          )
+        end
+
+        fab!(:hidden_members_group) do
+          Fabricate(
+            :group,
+            name: "hidden-group-2",
+            members_visibility_level: Group.visibility_levels[:members],
+          )
+        end
+
         let(:include_groups) { true }
 
         it "fetches groups" do
@@ -126,6 +142,18 @@ RSpec.describe Chat::SearchChatable do
         it "excludes groups not matching the search term" do
           params[:term] = "nonexistent"
           expect(result.groups).to be_empty
+        end
+
+        it "excludes groups that user cannot see by default" do
+          expect(result.groups).to_not include(hidden_group)
+          expect(result.groups).to_not include(hidden_members_group)
+        end
+
+        it "excludes groups that user cannot see when searching" do
+          params[:term] = "hidden-group"
+
+          expect(result.groups).to_not include(hidden_group)
+          expect(result.groups).to_not include(hidden_members_group)
         end
       end
 


### PR DESCRIPTION
This change prevents the user from starting a group chat with groups when the current user does not have permission to view the group's members.

The group is omitted from both the default list and results list when searching.

Internal ref: /t/-/145343