### PR TITLE
FIX: reset hashtags when pressing return in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/core/keymap.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/core/keymap.js
@@ -47,10 +47,24 @@ export function buildKeymap(
     return false;
   };
 
+  const unsetHashtags = (state) => {
+    const { $from } = state.selection;
+
+    if ($from.parent.type.name === "paragraph") {
+      $from.parent.descendants((node) => {
+        if (node.type.name !== "hashtag") {
+          return;
+        }
+        node.attrs.processed = false;
+      });
+    }
+  };
+
   chainWithExisting(
     "Backspace",
     undoInputRule,
     backspaceUnset,
+    unsetHashtags,
     joinTextblockBackward
   );
 
@@ -102,6 +116,7 @@ export function buildKeymap(
   chainWithExisting(
     "Enter",
     doubleSpaceHardBreak,
+    unsetHashtags,
     splitListItem(schema.nodes.list_item)
   );
 

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -9,6 +9,9 @@ describe "Composer - ProseMirror editor", type: :system do
     )
   end
   fab!(:tag)
+  fab!(:category_with_emoji) do
+    Fabricate(:category, slug: "cat", emoji: "cat", style_type: "emoji")
+  end
 
   let(:cdp) { PageObjects::CDP.new }
   let(:composer) { PageObjects::Components::Composer.new }
@@ -645,6 +648,33 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(rich).to have_css("ol li", text: "Item 2Item 3")
     end
 
+    it "supports hashtag decoration when pressing return" do
+      open_composer
+
+      composer.type_content("##{category_with_emoji.slug}")
+      composer.send_keys(:space)
+      composer.send_keys(:home)
+      wait_for_timeout
+      composer.send_keys(:enter)
+
+      expect(rich).to have_css("a.hashtag-cooked .emoji[alt='#{category_with_emoji.emoji}']")
+    end
+
+    it "supports hashtag decoration when backspacing to combine paragraphs" do
+      open_composer
+
+      composer.type_content("some text ")
+      composer.send_keys(:enter)
+
+      composer.type_content("##{category_with_emoji.slug}")
+      composer.send_keys(:space)
+      composer.send_keys(:home)
+      wait_for_timeout
+      composer.send_keys(:backspace)
+
+      expect(rich).to have_css("a.hashtag-cooked .emoji[alt='#{category_with_emoji.emoji}']")
+    end
+
     it "supports Ctrl + M to toggle between rich and markdown editors" do
       open_composer
 
@@ -1062,8 +1092,8 @@ describe "Composer - ProseMirror editor", type: :system do
   end
 
   describe "with mentions" do
-    fab!(:post)
-    fab!(:topic) { post.topic }
+    fab!(:topic) { Fabricate(:topic, category: category_with_emoji) }
+    fab!(:post) { Fabricate(:post, topic: topic) }
     fab!(:mixed_case_user) { Fabricate(:user, username: "TestUser_123") }
     fab!(:mixed_case_group) do
       Fabricate(:group, name: "TestGroup_ABC", mentionable_level: Group::ALIAS_LEVELS[:everyone])


### PR DESCRIPTION
Fixes an issue where a hashtag is decorated in composer and we try to either:

- press return in middle of a paragraph to move the hashtag onto the next line
- press backspace at beginning of a paragraph containing emojis

In both scenarios the hashtag decoration was lost but the data attributes were retained (ie. `processed` was set to `true`). By setting `processed` to `false` we can force hashtags to be processed again after breaking into a new paragraph or when pressing backspace at the start of the line to combine two paragraphs.

Demo:


https://github.com/user-attachments/assets/755f8619-ed04-4b65-bdd3-e14c0c591583



Internal ref: /t/-/159535