### PR TITLE
DEV: Add capability to pass an icon setting into auth provider registration

### DIFF
--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -42,6 +42,11 @@ export default class LoginMethod extends EmberObject {
   }
 
   @discourseComputed
+  icon() {
+    return this.icon_override || i18n(`login.${this.name}.icon`);
+  }
+
+  @discourseComputed
   screenReaderTitle() {
     return (
       this.title_override ||

--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -43,7 +43,7 @@ export default class LoginMethod extends EmberObject {
 
   @discourseComputed
   icon() {
-    return this.icon_override || i18n(`login.${this.name}.icon`);
+    return this.icon_override || "user";
   }
 
   @discourseComputed

--- a/app/serializers/auth_provider_serializer.rb
+++ b/app/serializers/auth_provider_serializer.rb
@@ -6,7 +6,7 @@ class AuthProviderSerializer < ApplicationSerializer
              :custom_url,
              :frame_height,
              :frame_width,
-             :icon,
+             :icon_override,
              :name,
              :pretty_name_override,
              :provider_url,
@@ -23,5 +23,9 @@ class AuthProviderSerializer < ApplicationSerializer
 
   def title_override
     object.title_setting ? SiteSetting.get(object.title_setting) : object.title
+  end
+
+  def icon_override
+    object.icon_setting ? SiteSetting.get(object.icon_setting) : object.icon
   end
 end

--- a/lib/auth/auth_provider.rb
+++ b/lib/auth/auth_provider.rb
@@ -14,6 +14,7 @@ class Auth::AuthProvider
       frame_height
       frame_width
       icon
+      icon_setting
       pretty_name
       pretty_name_setting
       title

--- a/spec/serializers/auth_provider_serializer_spec.rb
+++ b/spec/serializers/auth_provider_serializer_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe AuthProviderSerializer do
+  fab!(:user)
+
+  before do
+    allow(SiteSetting).to receive(:get).and_call_original
+    allow(SiteSetting).to receive(:get).with(:test_icon).and_return("bullseye")
+    allow(SiteSetting).to receive(:get).with(:test_pretty_name).and_return("new pretty name")
+    allow(SiteSetting).to receive(:get).with(:test_title).and_return("new_title")
+  end
+
+  let(:authenticator) do
+    Class
+      .new(Auth::ManagedAuthenticator) do
+        def name
+          "test_auth"
+        end
+
+        def enabled?
+          true
+        end
+      end
+      .new
+  end
+
+  let(:serializer) do
+    AuthProviderSerializer.new(auth_provider, scope: Guardian.new(user), root: false)
+  end
+
+  context "without overridden attributes" do
+    let(:auth_provider) do
+      Auth::AuthProvider.new(
+        authenticator:,
+        icon: "flash",
+        pretty_name: "old pretty name",
+        title: "old_title",
+      )
+    end
+
+    it "returns the original values" do
+      json = serializer.as_json
+      expect(json[:pretty_name_override]).to eq("old pretty name")
+      expect(json[:title_override]).to eq("old_title")
+      expect(json[:icon_override]).to eq("flash")
+    end
+  end
+
+  context "with overridden attributes" do
+    let(:auth_provider) do
+      Auth::AuthProvider.new(
+        authenticator:,
+        icon: "flash",
+        icon_setting: :test_icon,
+        pretty_name: "old pretty name",
+        pretty_name_setting: :test_pretty_name,
+        title: "old_title",
+        title_setting: :test_title,
+      )
+    end
+
+    it "returns the overridden values" do
+      json = serializer.as_json
+      expect(json[:pretty_name_override]).to eq("new pretty name")
+      expect(json[:title_override]).to eq("new_title")
+      expect(json[:icon_override]).to eq("bullseye")
+    end
+  end
+end


### PR DESCRIPTION
Add capability to pass an icon setting into auth provider registration to override the default icon with a site setting.

Matches the pattern we use for the auth provider title and pretty name. 

With this, the SAML plugin can be updated to have a site setting to override the default "user" icon.