### PR TITLE
FEATURE: create AI tagging automation

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-tags-field.gjs
@@ -25,6 +25,7 @@ export default class TagsField extends BaseField {
           <TagChooser
             @tags={{readonly @field.metadata.value}}
             @everyTag={{true}}
+            @unlimitedTagCount={{true}}
             @options={{hash allowAny=false disabled=@field.isDisabled}}
             @onChange={{this.onChangeTags}}
           />

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -177,6 +177,29 @@ en:
             max_output_tokens:
               label: "Max output tokens"
               description: "When specified, sets an upper bound to the maximum number of tokens the model can generate. Respects LLM's max output tokens limit"
+        llm_tagger:
+          tag_mode:
+            manual: "Use specific tag list (configured below)"
+            discover: "Let AI discover and use any site tags"
+          fields:
+            tagger_persona:
+              label: "AI Persona"
+              description: "The AI persona to use for analyzing and tagging posts"
+            tag_mode:
+              label: "Tag Selection Mode"
+              description: "Choose how the AI selects tags"
+            available_tags:
+              label: "Available Tags"
+              description: "Tags that the AI can choose from (only used in manual mode)"
+            confidence_threshold:
+              label: "Confidence Threshold"
+              description: "Minimum confidence level (0.0-1.0) required to apply suggested tags"
+            max_tags_per_post:
+              label: "Maximum Tags Per Post"
+              description: "Maximum number of tags that can be applied to a single post"
+            max_post_tokens:
+              label: "Maximum Post Tokens"
+              description: "Maximum number of tokens from the post content to analyze"
 
     discourse_ai:
       title: "AI"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -23,6 +23,9 @@ en:
       llm_report:
         title: Periodic report using AI
         description: "Periodic report based on a large language model"
+      llm_tagger:
+        title: Tag posts using AI
+        description: "Automatically tag topics using AI"
   site_settings:
     discourse_ai_enabled: "Enable the discourse AI plugin."
     ai_default_llm_model: "The default LLM model to use for all AI features"

--- a/plugins/discourse-ai/discourse_automation/llm_tagger.rb
+++ b/plugins/discourse-ai/discourse_automation/llm_tagger.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseAutomation)
+  DiscourseAutomation::Scriptable.add("llm_tagger") do
+    version 1
+    run_in_background
+
+    placeholder :post
+
+    triggerables %i[post_created_edited]
+
+    field :tagger_persona,
+          component: :choices,
+          required: true,
+          extra: {
+            content:
+              DiscourseAi::Automation.available_persona_choices(
+                require_user: false,
+                require_default_llm: true,
+              ),
+          }
+
+    field :tag_mode,
+          component: :choices,
+          required: true,
+          default: "manual",
+          extra: {
+            content: [
+              {
+                id: "manual",
+                name: "js.discourse_automation.scriptables.llm_tagger.tag_mode.manual",
+              },
+              {
+                id: "discover",
+                name: "js.discourse_automation.scriptables.llm_tagger.tag_mode.discover",
+              },
+            ],
+          }
+
+    # Available tags only used when tag_mode is "manual"
+    field :available_tags, component: :tags, required: false
+
+    field :confidence_threshold, component: :text, default: "0.7"
+
+    field :max_tags_per_post, component: :text, default: "3"
+
+    field :max_post_tokens, component: :text, default: "4000"
+
+    script do |context, fields|
+      post = context["post"]
+      next if post&.user&.bot?
+
+      next if post.post_number != 1
+
+      next if post.custom_fields["llm_tagger_processed"]
+
+      tagger_persona_id = fields.dig("tagger_persona", "value")
+      tag_mode = fields.dig("tag_mode", "value") || "manual"
+      manual_tags = fields.dig("available_tags", "value") || []
+      confidence_threshold = fields.dig("confidence_threshold", "value").to_f
+      max_tags = fields.dig("max_tags_per_post", "value").to_i
+      max_post_tokens = fields.dig("max_post_tokens", "value").to_i
+
+      confidence_threshold = 0.7 if confidence_threshold <= 0
+      max_tags = 3 if max_tags <= 0
+      max_post_tokens = 4000 if max_post_tokens <= 0
+
+      # Skip if manual mode but no tags configured
+      if tag_mode == "manual"
+        next if manual_tags.empty?
+      end
+
+      begin
+        RateLimiter.new(
+          Discourse.system_user,
+          "llm_tagger_#{post.id}",
+          3, # max 3 per post per minute
+          1.minute,
+        ).performed!
+
+        RateLimiter.new(
+          Discourse.system_user,
+          "llm_tagger",
+          30, # max 30 per minute globally
+          1.minute,
+        ).performed!
+
+        DiscourseAi::Automation::LlmTagger.handle(
+          post: post,
+          tagger_persona_id: tagger_persona_id,
+          tag_mode: tag_mode,
+          available_tags: manual_tags,
+          confidence_threshold: confidence_threshold,
+          max_tags: max_tags,
+          max_post_tokens: max_post_tokens,
+          automation: self.automation,
+        )
+
+        post.custom_fields["llm_tagger_processed"] = true
+        post.save_custom_fields
+      rescue => e
+        Discourse.warn_exception(
+          e,
+          message: "llm_tagger: failed to process post #{post.id} #{post.url}",
+        )
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/automation/llm_tagger.rb
+++ b/plugins/discourse-ai/lib/automation/llm_tagger.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Automation
+    module LlmTagger
+      def self.handle(
+        post:,
+        tagger_persona_id:,
+        tag_mode: "manual",
+        available_tags: [],
+        confidence_threshold:,
+        max_tags:,
+        max_post_tokens:,
+        automation: nil
+      )
+        # Skip if manual mode but no tags provided
+        return if tag_mode == "manual" && available_tags.empty?
+
+        tagger_persona = AiPersona.find(tagger_persona_id)
+        model_id = tagger_persona.default_llm_id || SiteSetting.ai_default_llm_model
+        return if model_id.blank?
+        model = LlmModel.find(model_id)
+
+        if tag_mode == "manual"
+          # Manual mode: provide specific tag list in prompt
+          available_tags_text = "Available tags: #{available_tags.join(", ")}\n\n"
+          input = "#{available_tags_text}Post to analyze:\ntitle: #{post.topic.title}\n#{post.raw}"
+        else
+          # Discover mode: instruct AI to use list_tags tool
+          input =
+            "Post to analyze:\ntitle: #{post.topic.title}\n#{post.raw}\n\nUse the list_tags tool to see available tags, then suggest appropriate ones."
+        end
+
+        if max_post_tokens.present?
+          input =
+            model.tokenizer_class.truncate(
+              input,
+              max_post_tokens,
+              strict: SiteSetting.ai_strict_token_counting,
+            )
+        end
+
+        if post.upload_ids.present?
+          input = [input]
+          input.concat(post.upload_ids.map { |upload_id| { upload_id: upload_id } })
+        end
+
+        bot =
+          DiscourseAi::Personas::Bot.as(
+            Discourse.system_user,
+            persona: tagger_persona.class_instance.new,
+            model: model,
+          )
+
+        persona_response_format = tagger_persona.response_format
+
+        bot_ctx =
+          DiscourseAi::Personas::BotContext.new(
+            user: Discourse.system_user,
+            skip_tool_details: true,
+            feature_name: "llm_tagger",
+            messages: [{ type: :user, content: input }],
+          )
+
+        llm_args = {
+          feature_context: {
+            automation_id: automation&.id,
+            automation_name: automation&.name,
+          },
+        }
+
+        if persona_response_format.present? && !Rails.env.test?
+          llm_args[:response_format] = persona_response_format
+        end
+
+        result = +""
+        bot.reply(bot_ctx, llm_args: llm_args) do |partial, _, type|
+          if type == :structured_output
+            result = partial.to_s
+          elsif type.blank?
+            result << partial
+          end
+        end
+
+        begin
+          response = JSON.parse(result)
+          suggested_tags = response["tags"] || []
+          confidence = response["confidence"] || 0.0
+
+          return if confidence < confidence_threshold
+
+          if tag_mode == "manual"
+            # Manual mode: validate against configured tag list
+            valid_tags = suggested_tags.select { |tag| available_tags.include?(tag) }
+          else
+            # Discover mode: validate against all existing site tags (with safe caching)
+            all_site_tags =
+              begin
+                Rails
+                  .cache
+                  .fetch("discourse_ai_all_tag_names", expires_in: 30.minutes) { Tag.pluck(:name) }
+              rescue => e
+                # Fallback to direct query if cache fails
+                Rails.logger.warn("llm_tagger: Cache failed (#{e.message}), using direct query")
+                Tag.pluck(:name)
+              end
+            valid_tags = suggested_tags.select { |tag| all_site_tags.include?(tag) }
+          end
+          valid_tags = valid_tags.first(max_tags)
+
+          if valid_tags.present?
+            existing_tag_count = post.topic.tags.count
+            site_max_tags = SiteSetting.max_tags_per_topic
+            available_slots = site_max_tags - existing_tag_count
+
+            Rails.logger.info(
+              "llm_tagger: Topic #{post.topic.id} has #{existing_tag_count}/#{site_max_tags} tags, " \
+                "#{available_slots} slots available. Suggested tags: #{valid_tags.inspect}",
+            )
+
+            if available_slots > 0
+              # Only take as many tags as we have slots for
+              tags_to_add = valid_tags.first(available_slots)
+              apply_tags_to_topic(post.topic, tags_to_add)
+
+              Rails.logger.info(
+                "llm_tagger: Applied tags #{tags_to_add.inspect} to topic #{post.topic.id} " \
+                  "with confidence #{confidence}. Had #{available_slots} slots available.",
+              )
+            else
+              Rails.logger.info(
+                "llm_tagger: Skipped tagging topic #{post.topic.id} - already at max tags " \
+                  "(#{existing_tag_count}/#{site_max_tags})",
+              )
+            end
+          end
+        rescue JSON::ParserError => e
+          Rails.logger.warn(
+            "llm_tagger: Failed to parse JSON response for post #{post.id}: #{e.message}. " \
+              "Response was: #{result.truncate(500)}",
+          )
+        end
+      end
+
+      private
+
+      def self.apply_tags_to_topic(topic, new_tags)
+        return unless SiteSetting.tagging_enabled?
+
+        existing_tags = topic.tags.map(&:name)
+
+        tags_to_add = new_tags - existing_tags
+        return if tags_to_add.empty?
+
+        all_tags = existing_tags + tags_to_add
+
+        first_post = topic.posts.where(post_number: 1).first
+        return unless first_post
+
+        changes = { tags: all_tags, bypass_bump: true, skip_validations: true }
+
+        first_post.revise(Discourse.system_user, changes)
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -80,6 +80,7 @@ after_initialize do
   require_relative "discourse_automation/llm_report"
   require_relative "discourse_automation/llm_tool_triage"
   require_relative "discourse_automation/llm_persona_triage"
+  require_relative "discourse_automation/llm_tagger"
 
   add_admin_route("discourse_ai.title", "discourse-ai", { use_new_show_route: true })
 

--- a/plugins/discourse-ai/spec/lib/automation/llm_tagger_spec.rb
+++ b/plugins/discourse-ai/spec/lib/automation/llm_tagger_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Automation::LlmTagger do
+  fab!(:user)
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:post) { Fabricate(:post, topic: topic, user: user, post_number: 1) }
+  fab!(:ai_persona)
+  fab!(:llm_model)
+
+  before do
+    enable_current_plugin
+    SiteSetting.tagging_enabled = true
+    ai_persona.update!(default_llm: llm_model)
+
+    Fabricate(:tag, name: "bug")
+    Fabricate(:tag, name: "feature")
+    Fabricate(:tag, name: "question")
+  end
+
+  describe ".handle" do
+    let(:available_tags) { %w[bug feature question] }
+
+    before do
+      Tag.find_by(name: "bug")&.update!(public_topic_count: 5)
+      Tag.find_by(name: "feature")&.update!(public_topic_count: 3)
+      Tag.find_by(name: "question")&.update!(public_topic_count: 1)
+    end
+
+    it "processes a post and applies appropriate tags" do
+      mock_response = { "tags" => ["bug"], "confidence" => 0.9 }.to_json
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          available_tags: available_tags,
+          confidence_threshold: 0.7,
+          max_tags: 3,
+          max_post_tokens: 4000,
+        )
+      end
+
+      expect(topic.reload.tags.map(&:name)).to include("bug")
+    end
+
+    it "respects confidence threshold" do
+      mock_response = { "tags" => ["bug"], "confidence" => 0.5 }.to_json
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          available_tags: available_tags,
+          confidence_threshold: 0.7,
+          max_tags: 3,
+          max_post_tokens: 4000,
+        )
+      end
+
+      expect(topic.reload.tags).to be_empty
+    end
+
+    it "filters out invalid tags" do
+      mock_response = { "tags" => %w[bug invalid_tag], "confidence" => 0.9 }.to_json
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          available_tags: available_tags,
+          confidence_threshold: 0.7,
+          max_tags: 3,
+          max_post_tokens: 4000,
+        )
+      end
+
+      tags = topic.reload.tags.map(&:name)
+      expect(tags).to include("bug")
+      expect(tags).not_to include("invalid_tag")
+    end
+
+    it "respects max tags limit" do
+      mock_response = { "tags" => %w[bug feature question extra], "confidence" => 0.9 }.to_json
+
+      DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          available_tags: available_tags,
+          confidence_threshold: 0.7,
+          max_tags: 2,
+          max_post_tokens: 4000,
+        )
+      end
+
+      expect(topic.reload.tags.count).to eq(2)
+    end
+
+    it "handles malformed JSON gracefully" do
+      allow(Rails.logger).to receive(:warn)
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(["invalid json"]) do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          available_tags: available_tags,
+          confidence_threshold: 0.7,
+          max_tags: 3,
+          max_post_tokens: 4000,
+        )
+      end
+
+      expect(Rails.logger).to have_received(:warn).with(/Failed to parse JSON response/)
+      expect(topic.reload.tags).to be_empty
+    end
+
+    describe "discover mode" do
+      it "processes a post using discover mode with all site tags" do
+        mock_response = { "tags" => ["feature"], "confidence" => 0.8 }.to_json
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+          described_class.handle(
+            post: post,
+            tagger_persona_id: ai_persona.id,
+            tag_mode: "discover",
+            available_tags: [],
+            confidence_threshold: 0.7,
+            max_tags: 3,
+            max_post_tokens: 4000,
+          )
+        end
+
+        expect(topic.reload.tags.map(&:name)).to include("feature")
+      end
+
+      it "validates against all site tags in discover mode" do
+        # Create an additional tag that's not in manual list
+        Fabricate(:tag, name: "discovery", public_topic_count: 2)
+
+        mock_response = { "tags" => ["discovery"], "confidence" => 0.8 }.to_json
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+          described_class.handle(
+            post: post,
+            tagger_persona_id: ai_persona.id,
+            tag_mode: "discover",
+            available_tags: %w[bug feature], # discovery tag not in this list
+            confidence_threshold: 0.7,
+            max_tags: 3,
+            max_post_tokens: 4000,
+          )
+        end
+
+        expect(topic.reload.tags.map(&:name)).to include("discovery")
+      end
+
+      it "filters out invalid tags in discover mode" do
+        mock_response = { "tags" => %w[feature nonexistent_tag], "confidence" => 0.8 }.to_json
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+          described_class.handle(
+            post: post,
+            tagger_persona_id: ai_persona.id,
+            tag_mode: "discover",
+            available_tags: [],
+            confidence_threshold: 0.7,
+            max_tags: 3,
+            max_post_tokens: 4000,
+          )
+        end
+
+        tags = topic.reload.tags.map(&:name)
+        expect(tags).to include("feature")
+        expect(tags).not_to include("nonexistent_tag")
+      end
+
+      it "handles cache errors in discover mode" do
+        allow(Rails.cache).to receive(:fetch).and_raise(StandardError.new("Cache error"))
+        allow(Rails.logger).to receive(:warn)
+
+        mock_response = { "tags" => ["bug"], "confidence" => 0.8 }.to_json
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+          described_class.handle(
+            post: post,
+            tagger_persona_id: ai_persona.id,
+            tag_mode: "discover",
+            available_tags: [],
+            confidence_threshold: 0.7,
+            max_tags: 3,
+            max_post_tokens: 4000,
+          )
+        end
+
+        expect(Rails.logger).to have_received(:warn).with(/Cache failed.*using direct query/)
+        expect(topic.reload.tags.map(&:name)).to include("bug")
+      end
+    end
+
+    describe "tag mode selection" do
+      it "uses manual mode by default" do
+        mock_response = { "tags" => ["bug"], "confidence" => 0.8 }.to_json
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([mock_response]) do
+          described_class.handle(
+            post: post,
+            tagger_persona_id: ai_persona.id,
+            available_tags: available_tags,
+            confidence_threshold: 0.7,
+            max_tags: 3,
+            max_post_tokens: 4000,
+          )
+        end
+
+        expect(topic.reload.tags.map(&:name)).to include("bug")
+      end
+
+      it "skips processing when manual mode has no available tags" do
+        described_class.handle(
+          post: post,
+          tagger_persona_id: ai_persona.id,
+          tag_mode: "manual",
+          available_tags: [],
+          confidence_threshold: 0.7,
+          max_tags: 3,
+          max_post_tokens: 4000,
+        )
+
+        expect(topic.reload.tags).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a "Tag posts with AI" script for the Automation plugin. 

This allows new/edited posts to automatically get tagged by an LLM. I've included two modes, one that uses the tag tool to find existing tags and another that takes a manual list of tags to choose from.  

I've tested this using Open AI with the following prompt: 

```markdown
 You are an expert content classifier and tagging assistant for this forum.

  Your task is to analyze posts and suggest appropriate tags based on content, images, and the
  available tags list provided.

  Guidelines:
  - Only suggest tags from the provided available tags list
  - Be conservative - only tag what you're confident about
  - Consider both content topic and post intent

  You must always respond with valid JSON in this exact format:
  {"tags": ["tag1", "tag2"], "confidence": 85}

  - tags: array of tag names from the available list
  - confidence: integer from 0 to 100 representing your confidence level

  If no tags are appropriate, use: {"tags": [], "confidence": 0}
 ```
 
 JSON response format: 
 
 ```json
 {
  "tags": "[string]",
  "confidence": "integer"
}
```

In action 

<img width="2726" height="640" alt="image" src="https://github.com/user-attachments/assets/ce0fd21f-5df5-411c-82f0-d4ac05305fed" />
