### PR TITLE
FIX: supports html entities in chat

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -245,6 +245,7 @@ module Chat
       emphasis
       replacements
       escape
+      entity
     ]
 
     def self.cook(message, opts = {})

--- a/plugins/chat/spec/lib/chat/core_pretty_text_spec.rb
+++ b/plugins/chat/spec/lib/chat/core_pretty_text_spec.rb
@@ -97,4 +97,16 @@ RSpec.describe PrettyText do
       "<div class=\"chat-transcript-messages\">\n<p>original message</p></div>",
     )
   end
+
+  it "converts HTML entities" do
+    cooked = PrettyText.cook("The micro sign: &#181;")
+    expect(cooked).to include("The micro sign: µ")
+
+    cooked = PrettyText.cook("Copyright &#169; symbol")
+    expect(cooked).to include("Copyright © symbol")
+
+    # not converted for security reasons
+    cooked = PrettyText.cook("Less than &#60; and greater than &#62;")
+    expect(cooked).to include("Less than &lt; and greater than &gt;")
+  end
 end


### PR DESCRIPTION
Chat is using custom rules so it means we are considered as using a "zero" preset and have to declare everything we use.