### PR TITLE
FIX: client based chat message timestamp

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -565,6 +565,7 @@ export default class ChatChannel extends Component {
         in_reply_to_id: message.inReplyTo?.id,
         staged_id: message.id,
         upload_ids: message.uploads.map((upload) => upload.id),
+        client_created_at: message.createdAt.toISOString(),
         ...extractCurrentTopicInfo(this),
       });
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -454,6 +454,7 @@ export default class ChatThread extends Component {
           staged_id: message.id,
           upload_ids: message.uploads.map((upload) => upload.id),
           thread_id: message.thread.id,
+          client_created_at: message.createdAt.toISOString(),
           ...extractCurrentTopicInfo(this),
         }
       );

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -266,5 +266,49 @@ describe "Single thread in side panel", type: :system do
         expect(page).to have_selector(".chat-thread .chat-message-separator__text", text: "Today")
       end
     end
+
+    context "when thread messages are sent with client timestamps" do
+      it "orders thread messages by client timestamp rather than server timestamp" do
+        first_message =
+          Chat::CreateMessage.call(
+            params: {
+              chat_channel_id: channel.id,
+              thread_id: thread.id,
+              message: "Thread message created first but should appear second",
+              client_created_at: 30.seconds.ago.iso8601,
+            },
+            guardian: current_user.guardian,
+          ).message_instance
+
+        second_message =
+          Chat::CreateMessage.call(
+            params: {
+              chat_channel_id: channel.id,
+              thread_id: thread.id,
+              message: "Thread message created second but should appear first",
+              client_created_at: 45.seconds.ago.iso8601,
+            },
+            guardian: current_user.guardian,
+          ).message_instance
+
+        chat_page.visit_thread(thread)
+
+        expect(page).to have_selector(
+          ".chat-thread .chat-message-container[data-id='#{first_message.id}'] .chat-message-text",
+          text: "Thread message created first but should appear second",
+        )
+        expect(page).to have_selector(
+          ".chat-thread .chat-message-container[data-id='#{second_message.id}'] .chat-message-text",
+          text: "Thread message created second but should appear first",
+        )
+
+        messages = page.all(".chat-thread .chat-message-container[data-id]")
+        message_ids = messages.map { |msg| msg["data-id"].to_i }
+        second_message_index = message_ids.index(second_message.id)
+        first_message_index = message_ids.index(first_message.id)
+
+        expect(second_message_index).to be < first_message_index
+      end
+    end
   end
 end


### PR DESCRIPTION
Uses the timestamp at the moment where the user hits send for the created_at value of the chat message. This should ensure very consistent ordering.

The implementation is simple:
- collects the timestamp and send it in the request (client_created_at)
- if client_created_at is present and valid, set it as created_at when creating the message

I suspect that we could end up in a situation where a message is routed to a slower worker and even if sent before an other message could end up being persisted later which would cause ordering issues.