### PR TITLE
FIX: in chat messages, filter uploads by `UserUpload`, not by `Upload.user`

### DIFF
--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -151,7 +151,10 @@ module Chat
 
     def fetch_uploads(params:, guardian:)
       return [] if !SiteSetting.chat_allow_uploads
-      guardian.user.uploads.where(id: params.upload_ids)
+      Upload
+        .where(id: params.upload_ids)
+        .joins(:user_uploads)
+        .where(user_uploads: { user: guardian.user })
     end
 
     def instantiate_message(channel:, guardian:, params:, uploads:, thread:, reply:, options:)

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -90,7 +90,10 @@ module Chat
 
     def fetch_uploads(params:, guardian:)
       return if !SiteSetting.chat_allow_uploads
-      guardian.user.uploads.where(id: params.upload_ids)
+      Upload
+        .where(id: params.upload_ids)
+        .joins(:user_uploads)
+        .where(user_uploads: { user: guardian.user })
     end
 
     def can_modify_channel_message(guardian:, message:)

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -41,21 +41,26 @@ RSpec.describe Chat::CreateMessage do
     fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
     fab!(:thread) { Fabricate(:chat_thread, channel: channel) }
     fab!(:upload) { Fabricate(:upload, user: user) }
+    fab!(:user_upload) { Fabricate(:user_upload, upload:, user:) }
     fab!(:draft) { Fabricate(:chat_draft, user: user, chat_channel: channel) }
+
+    fab!(:another_upload) { Fabricate(:upload, user: other_user) }
+    fab!(:another_user_upload) { Fabricate(:user_upload, upload: another_upload, user:) }
 
     let(:guardian) { user.guardian }
     let(:content) { "A new message @#{other_user.username_lower}" }
     let(:context_topic_id) { nil }
     let(:context_post_ids) { nil }
+    let(:upload_ids) { [upload.id] }
     let(:blocks) { nil }
     let(:params) do
       {
         chat_channel_id: channel.id,
         message: content,
-        upload_ids: [upload.id],
-        context_topic_id: context_topic_id,
-        context_post_ids: context_post_ids,
-        blocks: blocks,
+        upload_ids:,
+        context_topic_id:,
+        context_post_ids:,
+        blocks:,
       }
     end
     let(:options) { { enforce_membership: false, force_thread: false } }
@@ -512,6 +517,14 @@ RSpec.describe Chat::CreateMessage do
                         instance_of(Chat::Message),
                       )
                       result
+                    end
+
+                    context "when upload was created by another user" do
+                      let(:upload_ids) { [upload.id, another_upload.id] }
+
+                      it "attaches the upload created by the other user" do
+                        expect(message.uploads).to contain_exactly(upload, another_upload)
+                      end
                     end
 
                     context "when client_created_at is provided" do

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe Chat::CreateMessage do
     fab!(:channel) { Fabricate(:chat_channel, threading_enabled: true) }
     fab!(:thread) { Fabricate(:chat_thread, channel: channel) }
     fab!(:upload) { Fabricate(:upload, user: user) }
-    fab!(:user_upload) { Fabricate(:user_upload, upload:, user:) }
     fab!(:draft) { Fabricate(:chat_draft, user: user, chat_channel: channel) }
-
-    fab!(:another_upload) { Fabricate(:upload, user: other_user) }
-    fab!(:another_user_upload) { Fabricate(:user_upload, upload: another_upload, user:) }
 
     let(:guardian) { user.guardian }
     let(:content) { "A new message @#{other_user.username_lower}" }
@@ -520,6 +516,10 @@ RSpec.describe Chat::CreateMessage do
                     end
 
                     context "when upload was created by another user" do
+                      fab!(:another_upload) do
+                        Fabricate(:upload, user: other_user, uploaders: [user])
+                      end
+
                       let(:upload_ids) { [upload.id, another_upload.id] }
 
                       it "attaches the upload created by the other user" do

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -628,12 +628,7 @@ RSpec.describe Chat::UpdateMessage do
     describe "uploads" do
       fab!(:upload1) { Fabricate(:upload, user: user1) }
       fab!(:upload2) { Fabricate(:upload, user: user1) }
-      fab!(:upload3) { Fabricate(:upload, user: user3) }
-
-      fab!(:user_upload1) { Fabricate(:user_upload, upload: upload1, user: user1) }
-      fab!(:user_upload2) { Fabricate(:user_upload, upload: upload2, user: user1) }
-      fab!(:user_upload3) { Fabricate(:user_upload, upload: upload3, user: user3) }
-      fab!(:user_upload3_for_user1) { Fabricate(:user_upload, upload: upload3, user: user1) }
+      fab!(:upload3) { Fabricate(:upload, user: user3, uploaders: [user1]) }
 
       it "does nothing if the passed in upload_ids match the existing upload_ids" do
         chat_message =

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -120,3 +120,8 @@ Fabricator(:optimized_video_upload, from: :upload) do
     sequence(:url) { |n| "//bucket.s3.region.amazonaws.com/original/1X/#{attrs[:sha1]}.mp4" }
   end
 end
+
+Fabricator(:user_upload) do
+  upload
+  user
+end

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -22,6 +22,15 @@ Fabricator(:upload) do
   end
 
   extension "png"
+
+  transient :uploaders
+
+  after_create do |upload, transients|
+    UserUpload.find_or_create_by!(upload:, user: upload.user)
+    transients[:uploaders]&.each do |uploader|
+      UserUpload.find_or_create_by!(upload:, user: uploader)
+    end
+  end
 end
 
 Fabricator(:large_image_upload, from: :upload) do


### PR DESCRIPTION
When creating or updating a chat message, uploads attached to the message are filtered so as to only keep uploads created by the message creator using `Upload.user`. This field, however, only points to the _original_ user that created the upload, but since uploads are de-duplicated, other users might have also uploaded the file. This PR fixes this by looking at the `UserUpload`s instead (as suggested by @SamSaffron).

Reported here: https://meta.discourse.org/t/chat-upload-bug/379253
