### PR TITLE
DEV: Add auto_track param to POST /posts.json

### DIFF
--- a/spec/requests/api/schemas/json/topic_create_request.json
+++ b/spec/requests/api/schemas/json/topic_create_request.json
@@ -45,6 +45,10 @@
     "external_id": {
       "type": "string",
       "description": "Provide an external_id from a remote system to associate a forum topic with that id."
+    },
+    "auto_track": {
+      "type": "boolean",
+      "description": "If false, the user will not track the topic. By default, the user will track the topic."
     }
   },
   "required": [


### PR DESCRIPTION
A user wanted to create a new post via API without tracking. The API was missing this attribute.

t/380436