### PR TITLE
FEATURE: new topic button always enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-container.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.gjs
@@ -255,6 +255,7 @@ export default class ComposerContainer extends Component {
                               disabled=this.composer.disableCategoryChooser
                               scopedCategoryId=this.composer.scopedCategoryId
                               prioritizedCategoryId=this.composer.prioritizedCategoryId
+                              readOnlyCategoryId=this.composer.readOnlyCategoryId
                             }}
                           />
                           <PluginOutlet

--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -11,36 +11,15 @@ export default class CreateTopicButton extends Component {
   @tracked btnTypeClass = this.args.btnTypeClass || "btn-default";
   label = "topic.create";
 
-  get disallowedReason() {
-    if (this.args.canCreateTopicOnTag === false) {
-      return "topic.create_disabled_tag";
-    } else if (this.args.disabled) {
-      return "topic.create_disabled_category";
-    }
-  }
-
   <template>
     {{#if @canCreateTopic}}
-      <DButtonTooltip>
-        <:button>
-          <DButton
-            @action={{@action}}
-            @icon="far-pen-to-square"
-            @disabled={{@disabled}}
-            @label={{this.label}}
-            id="create-topic"
-            class={{concatClass @btnClass this.btnTypeClass}}
-          />
-        </:button>
-        <:tooltip>
-          {{#if @disabled}}
-            <DTooltip
-              @icon="circle-info"
-              @content={{i18n this.disallowedReason}}
-            />
-          {{/if}}
-        </:tooltip>
-      </DButtonTooltip>
+      <DButton
+        @action={{@action}}
+        @icon="far-pen-to-square"
+        @label={{this.label}}
+        id="create-topic"
+        class={{concatClass @btnClass this.btnTypeClass}}
+      />
 
       {{#if @showDrafts}}
         <TopicDraftsDropdown

--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -3,9 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import DButton from "discourse/components/d-button";
 import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
 import concatClass from "discourse/helpers/concat-class";
-import { i18n } from "discourse-i18n";
-import DButtonTooltip from "float-kit/components/d-button-tooltip";
-import DTooltip from "float-kit/components/d-tooltip";
 
 export default class CreateTopicButton extends Component {
   @tracked btnTypeClass = this.args.btnTypeClass || "btn-default";

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -5,7 +5,6 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { service } from "@ember/service";
-import { htmlSafe } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
 import { and, gt } from "truth-helpers";
 import BreadCrumbs from "discourse/components/bread-crumbs";
@@ -118,35 +117,6 @@ export default class DNavigation extends Component {
     }
   }
 
-  @discourseComputed(
-    "createTopicDisabled",
-    "categoryReadOnlyBanner",
-    "canCreateTopicOnTag",
-    "tag.id"
-  )
-  createTopicButtonDisabled(
-    createTopicDisabled,
-    categoryReadOnlyBanner,
-    canCreateTopicOnTag,
-    tagId
-  ) {
-    if (tagId && !canCreateTopicOnTag) {
-      return true;
-    } else if (categoryReadOnlyBanner) {
-      return false;
-    }
-    return createTopicDisabled;
-  }
-
-  @discourseComputed("categoryReadOnlyBanner")
-  createTopicClass(categoryReadOnlyBanner) {
-    let classNames = ["btn-default"];
-    if (categoryReadOnlyBanner) {
-      classNames.push("disabled");
-    }
-    return classNames.join(" ");
-  }
-
   @discourseComputed("category.can_edit")
   showCategoryEdit(canEdit) {
     return canEdit;
@@ -226,11 +196,7 @@ export default class DNavigation extends Component {
 
   @action
   clickCreateTopicButton() {
-    if (this.categoryReadOnlyBanner) {
-      this.dialog.alert({ message: htmlSafe(this.categoryReadOnlyBanner) });
-    } else {
-      this.createTopic();
-    }
+    this.createTopic();
   }
 
   <template>
@@ -343,10 +309,7 @@ export default class DNavigation extends Component {
       <CreateTopicButton
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
-        @disabled={{this.createTopicButtonDisabled}}
         @label={{this.createTopicLabel}}
-        @btnClass={{this.createTopicClass}}
-        @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
         @showDrafts={{if (gt this.draftCount 0) true false}}
       />
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -169,10 +169,6 @@ export default class DiscoveryListController extends Controller {
     });
   }
 
-  get tagRestricted() {
-    return this.model.tag?.staff && !this.currentUser?.staff;
-  }
-
   @action
   createTopic() {
     this.composer.openNewTopic({
@@ -181,7 +177,6 @@ export default class DiscoveryListController extends Controller {
         .filter(Boolean)
         .reject((t) => ["none", "all"].includes(t))
         .join(","),
-      tagRestricted: this.tagRestricted,
     });
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -92,21 +92,23 @@ export default class DiscoveryListController extends Controller {
 
   get createTopicTargetCategory() {
     const { category } = this.model;
-    let subcategory;
 
-    if (
-      !category?.canCreateTopic &&
-      this.siteSettings.default_subcategory_on_read_only_category
-    ) {
-      subcategory = category?.subcategoryWithCreateTopicPermission;
+    if (category?.canCreateTopic) {
+      return category;
     }
 
-    return subcategory ?? category;
+    return this.subcategoryTopic ?? category;
+  }
+
+  get subcategoryTopic() {
+    if (this.siteSettings.default_subcategory_on_read_only_category) {
+      return this.model.category?.subcategoryWithCreateTopicPermission;
+    }
   }
 
   get createTopicDisabled() {
     // We are in a category route, but user does not have permission for the category
-    return this.model.category && !this.createTopicTargetCategory;
+    return !this.model.category?.canCreateTopic && !this.subcategoryTopic;
   }
 
   get resolvedAscending() {

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -169,6 +169,10 @@ export default class DiscoveryListController extends Controller {
     });
   }
 
+  get tagRestricted() {
+    return this.model.tag?.staff && !this.currentUser?.staff;
+  }
+
   @action
   createTopic() {
     this.composer.openNewTopic({
@@ -177,6 +181,7 @@ export default class DiscoveryListController extends Controller {
         .filter(Boolean)
         .reject((t) => ["none", "all"].includes(t))
         .join(","),
+      tagRestricted: this.tagRestricted,
     });
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -97,10 +97,10 @@ export default class DiscoveryListController extends Controller {
       return category;
     }
 
-    return this.subcategoryTopic ?? category;
+    return this.subcategoryWithPermission ?? category;
   }
 
-  get subcategoryTopic() {
+  get subcategoryWithPermission() {
     if (this.siteSettings.default_subcategory_on_read_only_category) {
       return this.model.category?.subcategoryWithCreateTopicPermission;
     }
@@ -108,7 +108,9 @@ export default class DiscoveryListController extends Controller {
 
   get createTopicDisabled() {
     // We are in a category route, but user does not have permission for the category
-    return !this.model.category?.canCreateTopic && !this.subcategoryTopic;
+    return (
+      !this.model.category?.canCreateTopic && !this.subcategoryWithPermission
+    );
   }
 
   get resolvedAscending() {

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -92,13 +92,16 @@ export default class DiscoveryListController extends Controller {
 
   get createTopicTargetCategory() {
     const { category } = this.model;
-    if (category?.canCreateTopic) {
-      return category;
+    let subcategory;
+
+    if (
+      !category?.canCreateTopic &&
+      this.siteSettings.default_subcategory_on_read_only_category
+    ) {
+      subcategory = category?.subcategoryWithCreateTopicPermission;
     }
 
-    if (this.siteSettings.default_subcategory_on_read_only_category) {
-      return category?.subcategoryWithCreateTopicPermission;
-    }
+    return subcategory ?? category;
   }
 
   get createTopicDisabled() {
@@ -164,13 +167,8 @@ export default class DiscoveryListController extends Controller {
 
   @action
   createTopic() {
-    const readOnlyCategoryId = this.createTopicDisabled
-      ? this.model.category.id
-      : null;
-
     this.composer.openNewTopic({
       category: this.createTopicTargetCategory,
-      readOnlyCategoryId,
       tags: [this.model.tag?.id, ...(this.model.additionalTags ?? [])]
         .filter(Boolean)
         .reject((t) => ["none", "all"].includes(t))

--- a/app/assets/javascripts/discourse/app/controllers/discovery/list.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/list.js
@@ -164,8 +164,13 @@ export default class DiscoveryListController extends Controller {
 
   @action
   createTopic() {
+    const readOnlyCategoryId = this.createTopicDisabled
+      ? this.model.category.id
+      : null;
+
     this.composer.openNewTopic({
       category: this.createTopicTargetCategory,
+      readOnlyCategoryId,
       tags: [this.model.tag?.id, ...(this.model.additionalTags ?? [])]
         .filter(Boolean)
         .reject((t) => ["none", "all"].includes(t))

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -238,6 +238,11 @@ export function defaultCategoryLinkRenderer(category, opts) {
     )}</span>`;
   }
 
+  if (opts.readOnly) {
+    const desc = i18n("category_row.read_only");
+    html += `<span class="read-only" aria-label="${desc}">${desc}</span>`;
+  }
+
   if (href) {
     href = ` href="${href}" `;
   }

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -964,10 +964,12 @@ export default class Composer extends RestModel {
     });
 
     // We set the category id separately for topic templates on opening of composer
-    this.set(
-      "categoryId",
-      opts.topicCategoryId || opts.categoryId || this.get("topic.category.id")
-    );
+    if (!opts.readOnlyCategoryId) {
+      this.set(
+        "categoryId",
+        opts.topicCategoryId || opts.categoryId || this.get("topic.category.id")
+      );
+    }
 
     if (!this.categoryId && this.creatingTopic) {
       const categories = this.site.categories;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1468,8 +1468,17 @@ export default class ComposerService extends Service {
   }
 
   @action
-  async openNewTopic({ title, body, category, tags, formTemplate } = {}) {
+  async openNewTopic({
+    title,
+    body,
+    category,
+    tags,
+    tagRestricted,
+    formTemplate,
+  } = {}) {
     const readOnlyCategoryId = !category?.canCreateTopic ? category?.id : null;
+    tags = !tagRestricted ? tags : null;
+
     return this.open({
       prioritizedCategoryId: category?.id,
       topicCategoryId: category?.id,

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -113,6 +113,7 @@ export default class ComposerService extends Service {
   editReason = null;
   scopedCategoryId = null;
   prioritizedCategoryId = null;
+  readOnlyCategoryId = null;
   lastValidatedAt = null;
   isUploading = false;
   isProcessingUpload = false;
@@ -1345,6 +1346,7 @@ export default class ComposerService extends Service {
    @param {Boolean} [opts.disableScopedCategory]
    @param {Number} [opts.categoryId] Sets `scopedCategoryId` and `categoryId` on the Composer model
    @param {Number} [opts.prioritizedCategoryId]
+   @param {Number} [opts.readOnlyCategoryId] Shows category as read-only in category chooser, with a read-only badge
    @param {Number} [opts.formTemplateId]
    @param {String} [opts.draftSequence]
    @param {Boolean} [opts.skipJumpOnSave] Option to skip navigating to the post when saved in this composer session
@@ -1372,6 +1374,7 @@ export default class ComposerService extends Service {
       editReason: null,
       scopedCategoryId: null,
       prioritizedCategoryId: null,
+      readOnlyCategoryId: null,
       skipAutoSave: true,
     });
 
@@ -1401,6 +1404,10 @@ export default class ComposerService extends Service {
       if (category) {
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
       }
+    }
+
+    if (opts.readOnlyCategoryId) {
+      this.set("readOnlyCategoryId", opts.readOnlyCategoryId);
     }
 
     // If we want a different draft than the current composer, close it and clear our model.
@@ -1461,7 +1468,14 @@ export default class ComposerService extends Service {
   }
 
   @action
-  async openNewTopic({ title, body, category, tags, formTemplate } = {}) {
+  async openNewTopic({
+    title,
+    body,
+    category,
+    readOnlyCategoryId,
+    tags,
+    formTemplate,
+  } = {}) {
     return this.open({
       prioritizedCategoryId: category?.id,
       topicCategoryId: category?.id,
@@ -1473,6 +1487,7 @@ export default class ComposerService extends Service {
       draftKey: this.topicDraftKey,
       draftSequence: 0,
       locale: null,
+      readOnlyCategoryId,
     });
   }
 

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -1468,14 +1468,8 @@ export default class ComposerService extends Service {
   }
 
   @action
-  async openNewTopic({
-    title,
-    body,
-    category,
-    readOnlyCategoryId,
-    tags,
-    formTemplate,
-  } = {}) {
+  async openNewTopic({ title, body, category, tags, formTemplate } = {}) {
+    const readOnlyCategoryId = !category?.canCreateTopic ? category?.id : null;
     return this.open({
       prioritizedCategoryId: category?.id,
       topicCategoryId: category?.id,

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -50,10 +50,12 @@ acceptance("Category Banners", function (needs) {
     await visit("/c/test-read-only-with-banner");
 
     await click("#create-topic");
-    assert.dom(".dialog-body").exists("pops up a modal");
+    assert.dom(".d-editor").exists("opens composer");
 
-    await click(".dialog-footer .btn-primary");
-    assert.dom(".dialog-body").doesNotExist("closes the modal");
+    assert
+      .dom(".d-editor .selected-name[data-name='test-read-only-with-banner']")
+      .doesNotExist("does not show read-only category in composer");
+
     assert.dom(".category-read-only-banner").exists("shows a banner");
     assert
       .dom(".category-read-only-banner .inner")

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -228,14 +228,14 @@ acceptance("Tags listed by group", function (needs) {
       );
   });
 
-  test("new topic button is not available for staff-only tags", async function (assert) {
+  test("new topic button works when viewing staff-only tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/regular-tag");
     assert.dom("#create-topic").isEnabled();
 
     await visit("/tag/staff-only-tag");
-    assert.dom("#create-topic").isDisabled();
+    assert.dom("#create-topic").isEnabled();
 
     updateCurrentUser({ moderator: true });
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -135,16 +135,16 @@ export default class CategoryChooser extends ComboBoxComponent {
       let { scopedCategoryId, prioritizedCategoryId, readOnlyCategoryId } =
         this.selectKit.options;
 
+      if (readOnlyCategoryId) {
+        return this.categoriesByScope({ readOnlyCategoryId });
+      }
+
       if (scopedCategoryId) {
         return this.categoriesByScope({ scopedCategoryId });
       }
 
       if (prioritizedCategoryId) {
         return this.categoriesByScope({ prioritizedCategoryId });
-      }
-
-      if (readOnlyCategoryId) {
-        return this.categoriesByScope({ readOnlyCategoryId });
       }
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -21,6 +21,7 @@ import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
   excludeCategoryId: null,
   scopedCategoryId: null,
   prioritizedCategoryId: null,
+  readOnlyCategoryId: null,
 })
 @pluginApiIdentifiers(["category-chooser"])
 export default class CategoryChooser extends ComboBoxComponent {
@@ -55,6 +56,8 @@ export default class CategoryChooser extends ComboBoxComponent {
         null,
         htmlSafe(i18n(isString ? this.selectKit.options.none : "category.none"))
       );
+    } else if (this.selectKit.options.readOnlyCategoryId) {
+      return this.defaultItem(null, htmlSafe(i18n("category.choose")));
     } else if (this.selectKit.options.allowUncategorized) {
       return Category.findUncategorized();
     } else {
@@ -96,6 +99,7 @@ export default class CategoryChooser extends ComboBoxComponent {
         rejectCategoryIds: [this.selectKit.options.excludeCategoryId],
         scopedCategoryId: this.selectKit.options.scopedCategoryId,
         prioritizedCategoryId: this.selectKit.options.prioritizedCategoryId,
+        readOnlyCategoryId: this.selectKit.options.readOnlyCategoryId,
       });
     }
 
@@ -123,11 +127,13 @@ export default class CategoryChooser extends ComboBoxComponent {
   @computed(
     "selectKit.filter",
     "selectKit.options.scopedCategoryId",
-    "selectKit.options.prioritizedCategoryId"
+    "selectKit.options.prioritizedCategoryId",
+    "selectKit.options.readOnlyCategoryId"
   )
   get content() {
     if (!this.selectKit.filter) {
-      let { scopedCategoryId, prioritizedCategoryId } = this.selectKit.options;
+      let { scopedCategoryId, prioritizedCategoryId, readOnlyCategoryId } =
+        this.selectKit.options;
 
       if (scopedCategoryId) {
         return this.categoriesByScope({ scopedCategoryId });
@@ -135,6 +141,10 @@ export default class CategoryChooser extends ComboBoxComponent {
 
       if (prioritizedCategoryId) {
         return this.categoriesByScope({ prioritizedCategoryId });
+      }
+
+      if (readOnlyCategoryId) {
+        return this.categoriesByScope({ readOnlyCategoryId });
       }
     }
 
@@ -144,6 +154,7 @@ export default class CategoryChooser extends ComboBoxComponent {
   categoriesByScope({
     scopedCategoryId = null,
     prioritizedCategoryId = null,
+    readOnlyCategoryId = null,
   } = {}) {
     const categories = this.fixedCategoryPositionsOnCreate
       ? Category.list()
@@ -163,6 +174,10 @@ export default class CategoryChooser extends ComboBoxComponent {
 
     let scopedCategories = categories.filter((category) => {
       const categoryId = this.getValue(category);
+
+      if (readOnlyCategoryId === categoryId) {
+        return true;
+      }
 
       if (
         scopedCategoryId &&

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -132,12 +132,7 @@ export default class CategoryChooser extends ComboBoxComponent {
   )
   get content() {
     if (!this.selectKit.filter) {
-      let { scopedCategoryId, prioritizedCategoryId, readOnlyCategoryId } =
-        this.selectKit.options;
-
-      if (readOnlyCategoryId) {
-        return this.categoriesByScope({ readOnlyCategoryId });
-      }
+      let { scopedCategoryId, prioritizedCategoryId } = this.selectKit.options;
 
       if (scopedCategoryId) {
         return this.categoriesByScope({ scopedCategoryId });
@@ -154,11 +149,12 @@ export default class CategoryChooser extends ComboBoxComponent {
   categoriesByScope({
     scopedCategoryId = null,
     prioritizedCategoryId = null,
-    readOnlyCategoryId = null,
   } = {}) {
     const categories = this.fixedCategoryPositionsOnCreate
       ? Category.list()
       : Category.listByActivity();
+
+    let { readOnlyCategoryId } = this.selectKit.options;
 
     if (scopedCategoryId) {
       const scopedCat = Category.findById(scopedCategoryId);

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -127,8 +127,7 @@ export default class CategoryChooser extends ComboBoxComponent {
   @computed(
     "selectKit.filter",
     "selectKit.options.scopedCategoryId",
-    "selectKit.options.prioritizedCategoryId",
-    "selectKit.options.readOnlyCategoryId"
+    "selectKit.options.prioritizedCategoryId"
   )
   get content() {
     if (!this.selectKit.filter) {

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -10,10 +10,13 @@ import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import concatClass from "discourse/helpers/concat-class";
 import dirSpan from "discourse/helpers/dir-span";
 import Category from "discourse/models/category";
+import { i18n } from "discourse-i18n";
 
 export default class CategoryRow extends Component {
   @service site;
   @service siteSettings;
+
+  readOnlyDesc = i18n("category_row.read_only_description");
 
   get isNone() {
     return this.rowValue === this.args.selectKit?.noneItem;
@@ -90,7 +93,7 @@ export default class CategoryRow extends Component {
 
   get title() {
     if (this.category) {
-      return this.categoryName;
+      return this.isReadOnly ? this.readOnlyDesc : this.categoryName;
     }
   }
 

--- a/app/assets/javascripts/select-kit/addon/components/category-row.gjs
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.gjs
@@ -31,6 +31,18 @@ export default class CategoryRow extends Component {
     return this.rowValue === this.args.value;
   }
 
+  get isReadOnly() {
+    if (!this.readOnlyCategoryId) {
+      return false;
+    }
+
+    return this.rowValue === this.readOnlyCategoryId;
+  }
+
+  get readOnlyCategoryId() {
+    return this.args.selectKit.options.readOnlyCategoryId;
+  }
+
   get hideParentCategory() {
     return this.args.selectKit.options.hideParentCategory;
   }
@@ -114,6 +126,7 @@ export default class CategoryRow extends Component {
         subcategoryCount: this.args.item?.category
           ? this.category.subcategory_count
           : 0,
+        readOnly: this.isReadOnly,
       })
     );
   }
@@ -187,6 +200,11 @@ export default class CategoryRow extends Component {
   handleClick(event) {
     event.preventDefault();
     event.stopPropagation();
+
+    if (this.isReadOnly) {
+      return false;
+    }
+
     this.args.selectKit.select(this.rowValue, this.args.item);
     return false;
   }
@@ -225,11 +243,16 @@ export default class CategoryRow extends Component {
         event.preventDefault();
       } else if (event.key === "Enter") {
         event.stopImmediatePropagation();
+        event.preventDefault();
+
+        if (this.isReadOnly) {
+          return false;
+        }
+
         this.args.selectKit.select(
           this.args.selectKit.highlighted.id,
           this.args.selectKit.highlighted
         );
-        event.preventDefault();
       } else if (event.key === "Escape") {
         this.args.selectKit.close(event);
         this.args.selectKit.headerElement().focus();

--- a/app/assets/stylesheets/common/select-kit/category-row.scss
+++ b/app/assets/stylesheets/common/select-kit/category-row.scss
@@ -24,5 +24,14 @@
     .topic-count {
       white-space: nowrap;
     }
+
+    .read-only {
+      padding: 0.2em 0.5em;
+      margin: 0 0 0.25em 0.5em;
+      border-radius: 8px;
+      color: var(--secondary);
+      font-size: var(--font-down-1);
+      background: var(--primary-low-mid);
+    }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2818,6 +2818,7 @@ en:
         one: "%{count} topic in this category"
         other: "%{count} topics in this category"
       read_only: "read-only"
+      read_only_description: "This category is read-only so you cannot choose it for this topic"
 
     timezone_input:
       ambiguous_ist: "IST is ambiguous, please select a specific timezone (eg: Asia/Kolkata)"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2817,6 +2817,7 @@ en:
       topic_count:
         one: "%{count} topic in this category"
         other: "%{count} topics in this category"
+      read_only: "read-only"
 
     timezone_input:
       ambiguous_ist: "IST is ambiguous, please select a specific timezone (eg: Asia/Kolkata)"
@@ -3591,8 +3592,6 @@ en:
         one: "%{count} post in topic"
         other: "%{count} posts in topic"
       create: "New Topic"
-      create_disabled_category: "You're not allowed to create topics in this category"
-      create_disabled_tag: "You're not allowed to create topics with this tag"
       create_long: "Create a new Topic"
       open_draft: "Open Draft"
       private_message: "Start a message"

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -41,9 +41,15 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
             end
           end
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "should have the 'New Topic' button enabled and no category set in the composer" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+
+              category_page.new_topic_button.click
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+
+              expect(select_kit).to have_selected_name("category&hellip;")
             end
           end
         end
@@ -66,9 +72,14 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
         end
         describe "Can't post on parent category" do
           describe "Category does not have subcategory" do
-            it "should have the 'New Topic' button disabled" do
+            it "opens composer with no category selected" do
               category_page.visit(category_with_no_subcategory)
-              expect(category_page).to have_button("New Topic", disabled: true)
+              expect(category_page).to have_button("New Topic", disabled: false)
+
+              category_page.new_topic_button.click
+              select_kit =
+                PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+              expect(select_kit).to have_selected_name("category&hellip;")
             end
           end
         end
@@ -87,10 +98,18 @@ describe "Default to Subcategory when parent Category doesn't allow posting", ty
     end
 
     describe "Setting disabled and can't post on parent category" do
-      before { SiteSetting.default_subcategory_on_read_only_category = false }
-      it "should have 'New Topic' button disabled" do
+      before do
+        SiteSetting.default_subcategory_on_read_only_category = false
+        SiteSetting.default_composer_category = default_latest_category.id
+      end
+
+      it "opens composer with no category selected" do
         category_page.visit(category)
-        expect(category_page).to have_button("New Topic", disabled: true)
+        expect(category_page).to have_button("New Topic", disabled: false)
+
+        page.find("#create-topic").click
+        select_kit = PageObjects::Components::SelectKit.new("#reply-control.open .category-chooser")
+        expect(select_kit).to have_selected_name("category&hellip;")
       end
     end
   end

--- a/spec/system/drafts_dropdown_spec.rb
+++ b/spec/system/drafts_dropdown_spec.rb
@@ -2,6 +2,7 @@
 
 describe "Drafts dropdown", type: :system do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:category)
   let(:composer) { PageObjects::Components::Composer.new }
   let(:drafts_dropdown) { PageObjects::Components::DraftsMenu.new }
   let(:discard_draft_modal) { PageObjects::Modals::DiscardDraft.new }
@@ -110,10 +111,10 @@ describe "Drafts dropdown", type: :system do
       )
     end
 
-    it "disables the drafts dropdown menu when new topic button is disabled" do
+    it "is still enabled" do
       category_page.visit(category)
 
-      expect(category_page).to have_button("New Topic", disabled: true)
+      expect(category_page).to have_button("New Topic", disabled: false)
       expect(drafts_dropdown).to be_enabled
     end
   end

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -44,11 +44,16 @@ export default class SidebarNewTopicButton extends Component {
     return subcategory ?? this.category;
   }
 
+  get tagRestricted() {
+    return this.tag?.staff && !this.currentUser?.staff;
+  }
+
   @action
   createNewTopic() {
     this.composer.openNewTopic({
       category: this.createTopicTargetCategory,
       tags: this.tag?.id,
+      tagRestricted: this.tagRestricted,
     });
   }
 

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -32,18 +32,24 @@ export default class SidebarNewTopicButton extends Component {
   }
 
   get createTopicTargetCategory() {
-    if (this.category?.canCreateTopic) {
-      return this.category;
+    let subcategory;
+
+    if (
+      !this.category?.canCreateTopic &&
+      this.siteSettings.default_subcategory_on_read_only_category
+    ) {
+      subcategory = this.category?.subcategoryWithCreateTopicPermission;
     }
 
-    if (this.siteSettings.default_subcategory_on_read_only_category) {
-      return this.category?.subcategoryWithCreateTopicPermission;
-    }
+    return subcategory ?? this.category;
   }
 
   @action
   createNewTopic() {
-    this.composer.openNewTopic({ category: this.category, tags: this.tag?.id });
+    this.composer.openNewTopic({
+      category: this.createTopicTargetCategory,
+      tags: this.tag?.id,
+    });
   }
 
   @action

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -44,16 +44,11 @@ export default class SidebarNewTopicButton extends Component {
     return subcategory ?? this.category;
   }
 
-  get tagRestricted() {
-    return this.tag?.staff && !this.currentUser?.staff;
-  }
-
   @action
   createNewTopic() {
     this.composer.openNewTopic({
       category: this.createTopicTargetCategory,
       tags: this.tag?.id,
-      tagRestricted: this.tagRestricted,
     });
   }
 

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -5,7 +5,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import { gt, not } from "truth-helpers";
+import { gt } from "truth-helpers";
 import CreateTopicButton from "discourse/components/create-topic-button";
 
 export default class SidebarNewTopicButton extends Component {
@@ -39,30 +39,6 @@ export default class SidebarNewTopicButton extends Component {
     if (this.siteSettings.default_subcategory_on_read_only_category) {
       return this.category?.subcategoryWithCreateTopicPermission;
     }
-  }
-
-  get tagRestricted() {
-    return this.tag?.staff;
-  }
-
-  get createTopicDisabled() {
-    return (
-      (this.category && !this.createTopicTargetCategory) ||
-      (this.tagRestricted && !this.currentUser.staff)
-    );
-  }
-
-  get categoryReadOnlyBanner() {
-    if (this.category && this.currentUser && this.createTopicDisabled) {
-      return this.category.read_only_banner;
-    }
-  }
-
-  get createTopicClass() {
-    const baseClasses = "sidebar-new-topic-button";
-    return this.categoryReadOnlyBanner
-      ? `${baseClasses} disabled`
-      : baseClasses;
   }
 
   @action
@@ -104,11 +80,9 @@ export default class SidebarNewTopicButton extends Component {
         <CreateTopicButton
           @canCreateTopic={{this.canCreateTopic}}
           @action={{this.createNewTopic}}
-          @disabled={{this.createTopicDisabled}}
           @label="topic.create"
-          @btnClass={{this.createTopicClass}}
+          @btnClass="sidebar-new-topic-button"
           @btnTypeClass="btn-primary"
-          @canCreateTopicOnTag={{not this.tagRestricted}}
           @showDrafts={{gt this.draftCount 0}}
         />
       </div>

--- a/themes/horizon/spec/system/sidebar_topic_button_spec.rb
+++ b/themes/horizon/spec/system/sidebar_topic_button_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "Sidebar New Topic Button", system: true do
       expect(page).to have_css(".sidebar-new-topic-button__wrapper .topic-drafts-menu-trigger")
     end
 
-    it "disables button when visiting read-only category" do
+    it "does not disable button when visiting read-only category" do
       visit("/c/#{private_category.slug}/#{private_category.id}")
 
-      expect(page).to have_css(".sidebar-new-topic-button[disabled]")
+      expect(page).to have_no_css(".sidebar-new-topic-button[disabled]")
 
       visit("/c/#{category.slug}/#{category.id}")
 


### PR DESCRIPTION
### What is this change?

When visiting a restricted category or tag where the current user does not have permission to create a topic, we should still allow the user to write a new topic under a different category or tag. This is especially important when using the new topic button from the sidebar.

#### When the user does not have permission, the composer category defaults to:

1) Subcategory (if SiteSetting.default_subcategory_on_read_only_category is true and subcategory exists)
2) Default category chooser value of Category... prompting the user to select a category from the dropdown

This PR is a follow up to #33495 which was reverted previously due to a couple of issues which are now corrected:

- we no longer set a default category based on `default_composer_category` (previously was step 2 above)
- category banner text when a user cannot create a topic is now showing up correctly
- added a title attribute with more info for the disabled category in the category dropdown in composer
- for staff only tags, when creating a topic from the tag page as a non staff member we now automatically remove the restricted tag from the tags field in composer (as the user cannot use this tag)


Internal ref: /t/-/152613