### PR TITLE
DEV: Don't error out on invalid version strings to has_needed_version?

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -25,6 +25,9 @@ module Discourse
 
   def self.has_needed_version?(current, needed)
     Gem::Version.new(current) >= Gem::Version.new(needed)
+  rescue ArgumentError => e
+    Rails.logger.error(e.message)
+    false
   end
 
   # lookup an external resource (theme/plugin)'s best compatible version


### PR DESCRIPTION
### What is this change?

If you pass an invalid version number to `Discourse.has_needed_version?` it raises an exception:

```ruby
Gem::Version.new("foo")
#=> ArgumentError: Malformed version number string foo (ArgumentError)
```

This is somewhat unexpected based on the method name, and interferes with conditionals like:

```ruby
if Discourse.has_needed_version?(v) || something_else
```

I've searched around for usages, and all the call sites I can find do not handle this exception.

I also searched the logs across all our hosting, and there are no unhandled instances of this.

This PR proposes returning `false` on invalid string, and log an error.