### PR TITLE
DEV: Allow specifying a new feature by a commit hash

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -171,7 +171,8 @@ module DiscourseUpdates
         begin
           valid_version =
             item["discourse_version"].nil? ||
-              Discourse.has_needed_version?(current_version, item["discourse_version"])
+              Discourse.has_needed_version?(current_version, item["discourse_version"]) ||
+              GitUtils.has_commit?(item["discourse_version"])
 
           valid_plugin_name =
             item["plugin_name"].blank? || Discourse.plugins_by_name[item["plugin_name"]].present?

--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -14,6 +14,12 @@ class GitUtils
     self.try_git('git describe --dirty --match "v[0-9]*" 2> /dev/null', "unknown")
   end
 
+  def self.has_commit?(hash)
+    return false if !hash.match?(/\A[a-f0-9]{40}\Z/)
+
+    self.try_git("git cat-file -t #{hash} 2> /dev/null", false) == "commit"
+  end
+
   def self.last_commit_date
     git_cmd = 'git log -1 --format="%ct"'
     seconds = self.try_git(git_cmd, nil)

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -249,6 +249,34 @@ RSpec.describe DiscourseUpdates do
       expect(result[2]["title"]).to eq("Bells")
     end
 
+    it "correctly shows features by commit hash" do
+      features_with_versions = [
+        { "emoji" => "🤾", "title" => "Bells", "created_at" => 2.days.ago },
+        {
+          "emoji" => "🙈",
+          "title" => "Whistles",
+          "created_at" => 120.minutes.ago,
+          "discourse_version" => "208cc7b0dd4bcd134297ce076e7263d2898740e9",
+        },
+        {
+          "emoji" => "🙈",
+          "title" => "Confetti",
+          "created_at" => 15.minutes.ago,
+          "discourse_version" => "05a7fc954a620800ee99ecdbabcfd41572706674",
+        },
+      ]
+
+      GitUtils.stubs(:has_commit?).with("208cc7b0dd4bcd134297ce076e7263d2898740e9").returns(true)
+      GitUtils.stubs(:has_commit?).with("05a7fc954a620800ee99ecdbabcfd41572706674").returns(false)
+
+      Discourse.redis.set("new_features", MultiJson.dump(features_with_versions))
+      result = DiscourseUpdates.new_features
+
+      expect(result.length).to eq(2)
+      expect(result[0]["title"]).to eq("Whistles")
+      expect(result[1]["title"]).to eq("Bells")
+    end
+
     it "correctly shows features with correct boolean site settings" do
       features_with_versions = [
         {


### PR DESCRIPTION
### What is this change?

This allows using commit hashes in addition to Discourse versions to decide whether to show a feature in the "What's new?" feed or not.

<img width="360" height="225" alt="Screenshot 2025-08-28 at 3 21 19 PM" src="https://github.com/user-attachments/assets/687d3db6-1dcd-413f-baac-0f158c12fa6d" />

### Performance

The command `git cat-file -t` uses Git's index, and is `0.01s` with 60k commits. The results are also cached.

### Security

I considered a case where the version could be spoofed, e.g. using DNS poisoning, leading to a possible command injection.

I'm sanitizing the version to just `a-z` and `0-9`. No spaces, special characters, etc. To my understanding that is not sufficient to be used maliciously, but would love a second set of eyes. 👀 