### PR TITLE
UX: fix for border-radius on welcome banner

### DIFF
--- a/app/assets/stylesheets/common/components/welcome-banner.scss
+++ b/app/assets/stylesheets/common/components/welcome-banner.scss
@@ -24,9 +24,9 @@
     box-sizing: border-box;
     position: relative;
     padding: var(--space-6) 0 3em;
-    border-radius: var(--d-border-radius);
 
     .--with-bg-img & {
+      border-radius: var(--d-border-radius);
       padding-inline: var(--space-4);
       background-size: cover;
       background-position: center;


### PR DESCRIPTION
Only apply border-radius when a background-img is set.