### PR TITLE
UX: keep new nav underline visible

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -496,6 +496,8 @@ td .main-link {
   width: 100%;
   display: flex;
   justify-content: center;
+  z-index: 1; // making sure the underline offset is on top of the topiclist
+  position: relative;
 
   .topics-replies-toggle {
     flex-grow: 1;


### PR DESCRIPTION
Many solutions possible here. I could also just reserve some extra spacing, but I feel the z-index layer is a more elegant solution.

At the moment only an issue on Horizon, due to the absence of the table header there. But applying it globally because theres other setups without the that layout.

| Before | Now |
|--------|--------|
| <img width="832" height="502" alt="CleanShot 2025-08-28 at 13 24 12@2x" src="https://github.com/user-attachments/assets/b84b15b2-6163-4fc6-88de-378a58a4ffda" /> | <img width="832" height="502" alt="CleanShot 2025-08-28 at 13 24 40@2x" src="https://github.com/user-attachments/assets/35d4964a-ab02-425f-92bf-62ddd984e9af" /> | 