### PR TITLE
FIX: lazy load category badge color

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-types/category.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-types/category.js
@@ -46,9 +46,9 @@ export default class CategoryHashtagType extends HashtagTypeBase {
     let style;
     if (parentColor) {
       style = `background: linear-gradient(-90deg, #${color} 50%, #${parentColor} 50%);`;
-    } else if (categoryOrHashtag.styleType === "icon") {
+    } else if (categoryOrHashtag.style_type === "icon") {
       style = `color: #${color};`;
-    } else if (categoryOrHashtag.styleType === "square") {
+    } else if (categoryOrHashtag.style_type === "square") {
       style = `background-color: #${color};`;
     } else {
       return [];


### PR DESCRIPTION
When using lazy load categories, hashtags would lose their badge color if they were not in the preloaded category data.

This change uses `style_type` which both categories and hashtag objects respond to. However it was previously using `styleType` which only works with categories.