### PR TITLE
FIX: Add missing translation for stop_impersonating

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7476,6 +7476,7 @@ en:
             tag_group_change: "change tag group"
             delete_associated_accounts: "delete associated accounts"
             change_theme_site_setting: "change theme site setting"
+            stop_impersonating: "stop impersonating"
         screened_emails:
           title: "Screened emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."


### PR DESCRIPTION
Followup b24a3d81edfe14f90975ad12ce28239f1189d6a7

<img width="481" height="189" alt="image" src="https://github.com/user-attachments/assets/00209998-b97d-45e7-9e20-bb593bc797f1" />

