### PR TITLE
UX: Do not include PWA/mobile app footer nav on some routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/footer-nav.gjs
+++ b/app/assets/javascripts/discourse/app/components/footer-nav.gjs
@@ -14,6 +14,15 @@ export default class FooterNav extends Component {
   @service composer;
   @service modal;
   @service historyStore;
+  @service router;
+
+  EXCLUDE_IN_ROUTES = [
+    "activate-account",
+    "invites.show",
+    "login",
+    "password-reset",
+    "signup",
+  ];
 
   _modalOn() {
     postRNWebviewMessage("headerBg", "rgb(0, 0, 0)");
@@ -65,12 +74,15 @@ export default class FooterNav extends Component {
   }
 
   get isVisible() {
+    const { currentRouteName } = this.router;
+
     return (
       [UNSCROLLED, SCROLLED_UP].includes(
         this.scrollDirection.lastScrollDirection
       ) &&
       !this.composer.isOpen &&
-      (this.capabilities.isAppWebview || this.canGoBack || this.canGoForward)
+      (this.capabilities.isAppWebview || this.canGoBack || this.canGoForward) &&
+      !this.EXCLUDE_IN_ROUTES.includes(currentRouteName)
     );
   }
 

--- a/app/assets/stylesheets/mobile/login-signup-page.scss
+++ b/app/assets/stylesheets/mobile/login-signup-page.scss
@@ -30,6 +30,7 @@
     font-size: var(--font-down-1);
     padding: 1rem;
     padding-top: 0;
+    padding-bottom: calc(env(safe-area-inset-bottom) + 1rem);
 
     &__buttons {
       display: flex;


### PR DESCRIPTION
In login/signup routes in particular, the footer nav blocks access to the main CTA. It's important to both remove it from those screens and add appropriate padding to the CTA wrapper.


Before (PWA on iOS)

<img width="300" height="630" alt="Simulator Screenshot - iPhone 16 - 2025-08-28 at 12 12 13" src="https://github.com/user-attachments/assets/783172a5-af87-4e53-ba94-3ac703b870b7" />

After (PWA on iOS)

<img width="300" height="630" alt="Simulator Screenshot - iPhone 16 - 2025-08-28 at 12 17 25" src="https://github.com/user-attachments/assets/42818a2c-c0b4-4fb0-991c-cbe56ba493b5" />

