### PR TITLE
FIX: ensures events have correct duration

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -407,6 +407,17 @@ module DiscoursePostEvent
       [next_starts_at, next_ends_at]
     end
 
+    def duration
+      return nil unless starts_at && ends_at
+
+      duration_seconds = (ends_at - starts_at).to_i
+      hours = (duration_seconds / 3600)
+      minutes = ((duration_seconds % 3600) / 60)
+      seconds = (duration_seconds % 60)
+
+      sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+    end
+
     private
 
     def dates_changed?

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -12,7 +12,8 @@ module DiscoursePostEvent
                :rrule,
                :show_local_time,
                :timezone,
-               :post
+               :post,
+               :duration
 
     def category_id
       object.post.topic.category_id
@@ -68,9 +69,21 @@ module DiscoursePostEvent
               object.original_starts_at.in_time_zone(object.timezone) + 1.hour
           )
       else
-        base_starts_at = object.starts_at&.in_time_zone(object.timezone)
-        base_starts_at ? (base_starts_at + 1.hour) : nil
+        if object.ends_at
+          object.ends_at&.in_time_zone(object.timezone)
+        else
+          base_starts_at = object.starts_at&.in_time_zone(object.timezone)
+          base_starts_at ? (base_starts_at + 1.hour) : nil
+        end
       end
+    end
+
+    def duration
+      object.duration
+    end
+
+    def include_duration?
+      object.duration.present?
     end
   end
 end

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -7,6 +7,7 @@ module DiscoursePostEvent
     attributes :category_id
     attributes :creator
     attributes :custom_fields
+    attributes :duration
     attributes :ends_at
     attributes :id
     attributes :is_closed
@@ -153,6 +154,14 @@ module DiscoursePostEvent
         recurrence_until: object.recurrence_until&.in_time_zone(object.timezone),
         dtstart: object.original_starts_at.in_time_zone(object.timezone),
       )
+    end
+
+    def duration
+      object.duration
+    end
+
+    def include_duration?
+      object.duration.present?
     end
 
     def ends_at

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -137,6 +137,7 @@ export default class CategoryCalendar extends Component {
         display: "list-item",
         rrule: event.rrule,
         end: endsAt || startsAt,
+        duration: event.duration,
         allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),
         url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
         backgroundColor,

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -95,6 +95,7 @@ export default class UpcomingEventsCalendar extends Component {
         rrule: event.rrule,
         start: startsAt,
         end: endsAt || startsAt,
+        duration: event.duration,
         allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),
         url: getURL(`/t/-/${post.topic.id}/${post.post_number}`),
         backgroundColor,

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -29,6 +29,7 @@ export default class DiscoursePostEventEvent {
   @tracked categoryId;
   @tracked startsAt;
   @tracked endsAt;
+  @tracked duration;
   @tracked rawInvitees;
   @tracked location;
   @tracked url;
@@ -63,6 +64,7 @@ export default class DiscoursePostEventEvent {
     this.categoryId = args.category_id;
     this.startsAt = args.starts_at;
     this.endsAt = args.ends_at;
+    this.duration = args.duration;
     this.rawInvitees = args.raw_invitees;
     this.sampleInvitees = args.sample_invitees || [];
     this.location = args.location;
@@ -148,6 +150,7 @@ export default class DiscoursePostEventEvent {
     this.name = event.name;
     this.startsAt = event.startsAt;
     this.endsAt = event.endsAt;
+    this.duration = event.duration;
     this.location = event.location;
     this.url = event.url;
     this.timezone = event.timezone;

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -500,6 +500,45 @@ describe DiscoursePostEvent::Event do
     end
   end
 
+  describe "#duration" do
+    let!(:post_1) { Fabricate(:post) }
+
+    context "when event has both starts_at and ends_at" do
+      it "returns duration in HH:MM:SS format" do
+        event = DiscoursePostEvent::Event.create!(
+          id: post_1.id,
+          original_starts_at: "2022-01-15 10:00:00 UTC",
+          original_ends_at: "2022-01-15 11:30:00 UTC"
+        )
+
+        expect(event.duration).to eq("01:30:00")
+      end
+    end
+
+    context "when event only has starts_at" do
+      it "returns nil" do
+        event = DiscoursePostEvent::Event.create!(
+          id: post_1.id,
+          original_starts_at: "2022-01-15 10:00:00 UTC"
+        )
+
+        expect(event.duration).to be_nil
+      end
+    end
+
+    context "when event spans multiple days" do
+      it "returns correct duration" do
+        event = DiscoursePostEvent::Event.create!(
+          id: post_1.id,
+          original_starts_at: "2022-01-15 10:00:00 UTC",
+          original_ends_at: "2022-01-16 12:30:00 UTC"
+        )
+
+        expect(event.duration).to eq("26:30:00")
+      end
+    end
+  end
+
   describe "#update_with_params!" do
     let!(:post_1) { Fabricate(:post) }
     let!(:user_1) { Fabricate(:user) }

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -505,11 +505,12 @@ describe DiscoursePostEvent::Event do
 
     context "when event has both starts_at and ends_at" do
       it "returns duration in HH:MM:SS format" do
-        event = DiscoursePostEvent::Event.create!(
-          id: post_1.id,
-          original_starts_at: "2022-01-15 10:00:00 UTC",
-          original_ends_at: "2022-01-15 11:30:00 UTC"
-        )
+        event =
+          DiscoursePostEvent::Event.create!(
+            id: post_1.id,
+            original_starts_at: "2022-01-15 10:00:00 UTC",
+            original_ends_at: "2022-01-15 11:30:00 UTC",
+          )
 
         expect(event.duration).to eq("01:30:00")
       end
@@ -517,10 +518,11 @@ describe DiscoursePostEvent::Event do
 
     context "when event only has starts_at" do
       it "returns nil" do
-        event = DiscoursePostEvent::Event.create!(
-          id: post_1.id,
-          original_starts_at: "2022-01-15 10:00:00 UTC"
-        )
+        event =
+          DiscoursePostEvent::Event.create!(
+            id: post_1.id,
+            original_starts_at: "2022-01-15 10:00:00 UTC",
+          )
 
         expect(event.duration).to be_nil
       end
@@ -528,11 +530,12 @@ describe DiscoursePostEvent::Event do
 
     context "when event spans multiple days" do
       it "returns correct duration" do
-        event = DiscoursePostEvent::Event.create!(
-          id: post_1.id,
-          original_starts_at: "2022-01-15 10:00:00 UTC",
-          original_ends_at: "2022-01-16 12:30:00 UTC"
-        )
+        event =
+          DiscoursePostEvent::Event.create!(
+            id: post_1.id,
+            original_starts_at: "2022-01-15 10:00:00 UTC",
+            original_ends_at: "2022-01-16 12:30:00 UTC",
+          )
 
         expect(event.duration).to eq("26:30:00")
       end

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -55,12 +55,13 @@ describe DiscoursePostEvent::EventSerializer do
           :event,
           post: post_with_duration,
           original_starts_at: "2022-01-15 10:00:00 UTC",
-          original_ends_at: "2022-01-15 11:30:00 UTC"
+          original_ends_at: "2022-01-15 11:30:00 UTC",
         )
       end
 
       it "includes duration in serialized output" do
-        json = DiscoursePostEvent::EventSerializer.new(event_with_duration, scope: Guardian.new).as_json
+        json =
+          DiscoursePostEvent::EventSerializer.new(event_with_duration, scope: Guardian.new).as_json
         expect(json[:event][:duration]).to eq("01:30:00")
       end
     end
@@ -72,7 +73,7 @@ describe DiscoursePostEvent::EventSerializer do
           :event,
           post: post_no_end,
           original_starts_at: "2022-01-15 10:00:00 UTC",
-          original_ends_at: nil
+          original_ends_at: nil,
         )
       end
 

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -47,5 +47,39 @@ describe DiscoursePostEvent::EventSerializer do
       json = DiscoursePostEvent::EventSerializer.new(event, scope: Guardian.new).as_json
       expect(json[:event][:category_id]).to eq(category.id)
     end
+
+    context "when event has duration" do
+      fab!(:post_with_duration) { Fabricate(:post, topic: topic) }
+      fab!(:event_with_duration) do
+        Fabricate(
+          :event,
+          post: post_with_duration,
+          original_starts_at: "2022-01-15 10:00:00 UTC",
+          original_ends_at: "2022-01-15 11:30:00 UTC"
+        )
+      end
+
+      it "includes duration in serialized output" do
+        json = DiscoursePostEvent::EventSerializer.new(event_with_duration, scope: Guardian.new).as_json
+        expect(json[:event][:duration]).to eq("01:30:00")
+      end
+    end
+
+    context "when event has no end time" do
+      fab!(:post_no_end) { Fabricate(:post, topic: topic) }
+      fab!(:event_no_end) do
+        Fabricate(
+          :event,
+          post: post_no_end,
+          original_starts_at: "2022-01-15 10:00:00 UTC",
+          original_ends_at: nil
+        )
+      end
+
+      it "does not include duration in serialized output" do
+        json = DiscoursePostEvent::EventSerializer.new(event_no_end, scope: Guardian.new).as_json
+        expect(json[:event]).not_to have_key(:duration)
+      end
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -115,6 +115,23 @@ module PageObjects
         def expect_event_at_position(title, row:, col:)
           expect(self).to have_event_at_position(title, row: row, col: col)
         end
+
+        def find_event_by_title(title)
+          find(".fc-event", text: title)
+        end
+
+        def get_event_height(title)
+          find_event_by_title(title).native.bounding_box["height"]
+        end
+
+        def find_all_events_by_title(title)
+          all(".fc-event", text: title)
+        end
+
+        def has_event_height?(title, expected_height)
+          height = get_event_height(title)
+          height >= expected_height - 1 && height <= expected_height + 1
+        end
       end
     end
   end

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -261,6 +261,60 @@ describe "Upcoming Events", type: :system do
           end
         end
       end
+
+      describe "event duration display" do
+        context "with recurring event" do
+          it "displays longer events with appropriate visual height in time grid view",
+             time: Time.utc(2025, 6, 2, 19, 00) do
+            short_event_post =
+              PostCreator.create!(
+                admin,
+                title: "Short meeting",
+                raw:
+                  "[event recurrence=\"every_week\" start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+              )
+
+            long_event_post =
+              PostCreator.create!(
+                admin,
+                title: "Long workshop",
+                raw:
+                  "[event recurrence=\"every_week\" start=\"2025-06-03 14:00\" end=\"2025-06-03 17:00\"]\n[/event]",
+              )
+
+            upcoming_events.visit
+            visit("/upcoming-events/week/2025/6/2")
+
+            expect(upcoming_events).to have_event_height("Short meeting", 47)
+            expect(upcoming_events).to have_event_height("Long workshop", 143)
+          end
+        end
+
+        context "with non recurring event" do
+          it "displays longer events with appropriate visual height in time grid view",
+             time: Time.utc(2025, 6, 2, 19, 00) do
+            short_event_post =
+              PostCreator.create!(
+                admin,
+                title: "Short meeting",
+                raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+              )
+
+            long_event_post =
+              PostCreator.create!(
+                admin,
+                title: "Long workshop",
+                raw: "[event start=\"2025-06-03 14:00\" end=\"2025-06-03 17:00\"]\n[/event]",
+              )
+
+            upcoming_events.visit
+            visit("/upcoming-events/week/2025/6/2")
+
+            expect(upcoming_events).to have_event_height("Short meeting", 47)
+            expect(upcoming_events).to have_event_height("Long workshop", 143)
+          end
+        end
+      end
     end
 
     describe "view switching" do


### PR DESCRIPTION
rrule doesn't support duration so we have to ensure we can communicate the duration to the frontend.

We were also making a mistake for the end date of non recurring events.