### PR TITLE
FIX: compute correct date with local time

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -461,12 +461,16 @@ module DiscoursePostEvent
     end
 
     def calculate_next_recurring_date
+      rrule_timezone = show_local_time ? "UTC" : timezone
+      timezone_starts_at = original_starts_at.in_time_zone(timezone)
+      timezone_recurrence_until = recurrence_until&.in_time_zone(timezone)
+
       RRuleGenerator.generate(
-        starts_at: original_starts_at.in_time_zone(timezone),
-        timezone: timezone,
+        starts_at: timezone_starts_at,
+        timezone: rrule_timezone,
         recurrence: recurrence,
-        recurrence_until: recurrence_until,
-        dtstart: original_starts_at.in_time_zone(timezone),
+        recurrence_until: timezone_recurrence_until,
+        dtstart: timezone_starts_at,
       ).first
     end
 

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -38,42 +38,54 @@ module DiscoursePostEvent
     def rrule
       return nil unless include_rrule?
 
-      # Use the original event time (same as the frontend display) for rrule generation
+      rrule_timezone = object.show_local_time ? "UTC" : object.timezone
       timezone_starts_at = object.original_starts_at.in_time_zone(object.timezone)
       timezone_recurrence_until = object.recurrence_until&.in_time_zone(object.timezone)
 
       RRuleGenerator.generate_string(
         starts_at: timezone_starts_at,
-        timezone: object.timezone,
+        timezone: rrule_timezone,
         recurrence: object.recurrence,
         recurrence_until: timezone_recurrence_until,
         dtstart: timezone_starts_at,
+        show_local_time: object.show_local_time,
       )
     end
 
     def starts_at
-      # For recurring events, use UTC to match RRULE
-      # For non-recurring events, use the event's timezone
-      if object.recurring?
-        object.original_starts_at&.in_time_zone(object.timezone)
+      if object.show_local_time
+        timezone_time = object.original_starts_at&.in_time_zone(object.timezone)
+        timezone_time&.strftime("%Y-%m-%dT%H:%M:%S")
       else
-        object.starts_at&.in_time_zone(object.timezone)
+        if object.recurring?
+          object.original_starts_at&.in_time_zone(object.timezone)
+        else
+          object.starts_at&.in_time_zone(object.timezone)
+        end
       end
     end
 
     def ends_at
-      if object.recurring?
-        object.original_ends_at&.in_time_zone(object.timezone) ||
-          (
-            object.original_starts_at &&
-              object.original_starts_at.in_time_zone(object.timezone) + 1.hour
-          )
+      if object.show_local_time
+        ends_at =
+          object.original_ends_at ||
+            (object.original_starts_at && object.original_starts_at + 1.hour)
+        timezone_ends_at = ends_at&.in_time_zone(object.timezone)
+        timezone_ends_at&.strftime("%Y-%m-%dT%H:%M:%S")
       else
-        if object.ends_at
-          object.ends_at&.in_time_zone(object.timezone)
+        if object.recurring?
+          object.original_ends_at&.in_time_zone(object.timezone) ||
+            (
+              object.original_starts_at &&
+                object.original_starts_at.in_time_zone(object.timezone) + 1.hour
+            )
         else
-          base_starts_at = object.starts_at&.in_time_zone(object.timezone)
-          base_starts_at ? (base_starts_at + 1.hour) : nil
+          if object.ends_at
+            object.ends_at&.in_time_zone(object.timezone)
+          else
+            base_starts_at = object.starts_at&.in_time_zone(object.timezone)
+            base_starts_at ? (base_starts_at + 1.hour) : nil
+          end
         end
       end
     end

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -15,13 +15,22 @@ export default class DiscoursePostEventDates extends Component {
   @tracked htmlDates = "";
 
   get startsAt() {
-    return moment(this.args.event.startsAt).tz(this.timezone);
+    if (this.args.event.showLocalTime) {
+      return moment(this.args.event.startsAt);
+    } else {
+      return moment(this.args.event.startsAt).tz(this.timezone);
+    }
   }
 
   get endsAt() {
-    return (
-      this.args.event.endsAt && moment(this.args.event.endsAt).tz(this.timezone)
-    );
+    if (this.args.event.showLocalTime) {
+      return this.args.event.endsAt && moment(this.args.event.endsAt);
+    } else {
+      return (
+        this.args.event.endsAt &&
+        moment(this.args.event.endsAt).tz(this.timezone)
+      );
+    }
   }
 
   get timezone() {

--- a/plugins/discourse-calendar/lib/discourse_post_event/rrule_generator.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/rrule_generator.rb
@@ -26,14 +26,17 @@ class RRuleGenerator
     max_years: nil,
     recurrence: "every_week",
     recurrence_until: nil,
-    dtstart: nil
+    dtstart: nil,
+    show_local_time: false
   )
     rrule = generate_hash(RRuleConfigurator.rule(recurrence_until:, recurrence:, starts_at:))
     rrule = set_mandatory_options(rrule, starts_at)
     rrule_line = "RRULE:#{stringify(rrule)}"
 
     if dtstart
-      if timezone == "UTC"
+      if show_local_time
+        dtstart_line = "DTSTART:#{dtstart.strftime("%Y%m%dT%H%M%S")}"
+      elsif timezone == "UTC"
         dtstart_line = "DTSTART:#{dtstart.utc.strftime("%Y%m%dT%H%M%SZ")}"
       else
         dtstart_line = "DTSTART;TZID=#{timezone}:#{dtstart.strftime("%Y%m%dT%H%M%S")}"

--- a/plugins/discourse-calendar/spec/integration/post_spec.rb
+++ b/plugins/discourse-calendar/spec/integration/post_spec.rb
@@ -799,5 +799,30 @@ describe Post do
       expect(post.event.original_starts_at).to eq_time(expected_original_datetime)
       expect(post.event.starts_at).to eq_time(expected_next_datetime)
     end
+
+    it "handles showLocalTime with non-recurring events" do
+      expected_datetime = ActiveSupport::TimeZone["Europe/Prague"].parse("2025-09-07 18:30")
+
+      post =
+        PostCreator.create!(
+          user,
+          title: "Prague dinner",
+          raw:
+            "[event start='2025-09-07 18:30' end='2025-09-07 21:00' timezone='Europe/Prague' showLocalTime='true']\n[/event]",
+        ).reload
+
+      expect(post.event.timezone).to eq("Europe/Prague")
+      expect(post.event.show_local_time).to eq(true)
+      expect(post.event.original_starts_at).to eq_time(expected_datetime)
+
+      # Test serializer output
+      serializer =
+        DiscoursePostEvent::BasicEventSerializer.new(post.event, scope: Guardian.new(user))
+      serialized = serializer.as_json
+
+      # Should return floating time (no timezone info)
+      expect(serialized[:basic_event][:starts_at]).to eq("2025-09-07T18:30:00")
+      expect(serialized[:basic_event][:ends_at]).to eq("2025-09-07T21:00:00")
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/rrule_generator_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/rrule_generator_spec.rb
@@ -33,6 +33,47 @@ describe RRuleGenerator do
     end
   end
 
+  context "when showLocalTime is enabled" do
+    it "generates floating time RRule without timezone" do
+      timezone = "Europe/Prague"
+      time = Time.utc(2020, 1, 25, 15, 36)
+
+      rrule_string =
+        RRuleGenerator.generate_string(
+          starts_at: time,
+          timezone: timezone,
+          recurrence: "every_week",
+          dtstart: time,
+          show_local_time: true,
+        )
+
+      expect(rrule_string).to include("DTSTART:20200125T153600")
+      expect(rrule_string).not_to include("TZID=Europe/Prague")
+      expect(rrule_string).to include(
+        "RRULE:FREQ=WEEKLY;BYDAY=SA;BYHOUR=15;BYMINUTE=36;INTERVAL=1;WKST=MO",
+      )
+    end
+
+    it "generates timezone-specific RRule when showLocalTime is disabled" do
+      timezone = "Europe/Prague"
+      time = Time.utc(2020, 1, 25, 15, 36)
+
+      rrule_string =
+        RRuleGenerator.generate_string(
+          starts_at: time,
+          timezone: timezone,
+          recurrence: "every_week",
+          dtstart: time,
+          show_local_time: false,
+        )
+
+      expect(rrule_string).to include("DTSTART;TZID=Europe/Prague:20200125T153600")
+      expect(rrule_string).to include(
+        "RRULE:FREQ=WEEKLY;BYDAY=SA;BYHOUR=15;BYMINUTE=36;INTERVAL=1;WKST=MO",
+      )
+    end
+  end
+
   describe "every day" do
     context "when a rule and time are given" do
       it "generates the rule" do


### PR DESCRIPTION
We were not correctly computing the dates when the option showLocalTime is enabled on an event. In this case we need to generate a floating time without a zone in the date.

This commit also refactors the serializers to avoid duplication.