### PR TITLE
DEV: Disable reset password button for staged users

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -42,6 +42,11 @@ export default class SecurityController extends Controller {
     ).canCheckEmails;
   }
 
+  @computed("model.staged")
+  get canResetPassword() {
+    return !this.model.staged;
+  }
+
   get isCurrentUser() {
     return this.currentUser?.id === this.model.id;
   }

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -2,6 +2,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { htmlSafe } from "@ember/template";
 import RouteTemplate from "ember-route-template";
+import { not } from "truth-helpers";
 import AuthTokenDropdown from "discourse/components/auth-token-dropdown";
 import DButton from "discourse/components/d-button";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -22,9 +23,9 @@ export default RouteTemplate(
       >
         <label class="control-label">{{i18n "user.password.title"}}</label>
         <div class="controls">
-          <a
-            href
+          <button
             {{on "click" @controller.changePassword}}
+            disabled={{not @controller.canResetPassword}}
             class="btn btn-default"
             id="change-password-button"
           >
@@ -34,7 +35,13 @@ export default RouteTemplate(
             {{else}}
               {{i18n "user.change_password.action"}}
             {{/if}}
-          </a>
+          </button>
+
+          {{#unless @controller.canResetPassword}}
+            <div class="instructions">
+              {{i18n "user.change_password.staged_user"}}
+            </div>
+          {{/unless}}
 
           {{@controller.passwordProgress}}
         </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1786,6 +1786,7 @@ en:
         in_progress: "(sending email)"
         error: "(error)"
         action: "Send Password Reset Email"
+        staged_user: "Staged users can not receive password reset emails."
         set_password: "Set Password"
         choose_new: "Choose a new password"
         choose: "Choose a password"


### PR DESCRIPTION
### What is this change?

By design, staged users can't receive reset password e-mails. From documentation:

> Forgot password will do nothing …when you attempt to send a password reset to a staged account

This PR just disables the button in the UI to avoid confusion.

I also took the liberty to add a text explanation when it is disabled, because I kind of anticipate the question.

**Non-staged user:**

<img width="265" height="133" alt="Screenshot 2025-08-29 at 9 55 41 AM" src="https://github.com/user-attachments/assets/691c215a-2155-4bfc-81bf-c07fe798e69b" />

**Staged user:**

<img width="351" height="104" alt="Screenshot 2025-08-29 at 9 54 51 AM" src="https://github.com/user-attachments/assets/96c09eaa-13b0-4c9f-8c8d-d45869fa87bb" />
