### PR TITLE
UX: Show remove password button without suspense

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -118,15 +118,23 @@ export default class SecurityController extends Controller {
     "model.no_password",
     "siteSettings",
     "model.user_passkeys",
-    "model.associated_accounts"
+    "model.associated_accounts",
+    "model.can_remove_password"
   )
   canRemovePassword(
     isAnonymous,
     noPassword,
     siteSettings,
     userPasskeys,
-    associatedAccounts
+    associatedAccounts,
+    canRemove
   ) {
+    // Hint returned from staff-info controller that
+    // works even if staff hasn't revealed e-mails.
+    if (canRemove) {
+      return true;
+    }
+
     if (
       isAnonymous ||
       noPassword ||

--- a/app/assets/javascripts/discourse/app/routes/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences/security.js
@@ -1,7 +1,3 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default class PreferencesSecurity extends RestrictedUserRoute {
-  afterModel(model) {
-    model.checkEmail();
-  }
-}
+export default class PreferencesSecurity extends RestrictedUserRoute {}

--- a/app/assets/javascripts/discourse/app/routes/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences/security.js
@@ -1,3 +1,7 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 
-export default class PreferencesSecurity extends RestrictedUserRoute {}
+export default class PreferencesSecurity extends RestrictedUserRoute {
+  afterModel(model) {
+    model.checkEmail();
+  }
+}

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -51,7 +51,7 @@ export default RouteTemplate(
               {{on "click" @controller.removePassword}}
               disabled={{not @controller.canRemovePassword}}
               hidden={{@controller.removePasswordInProgress}}
-              class="btn"
+              class="btn btn-transparent"
               id="remove-password-link"
             >
               {{icon "trash-can"}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -11,7 +11,6 @@ import UserPasskeys from "discourse/components/user-preferences/user-passkeys";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import lazyHash from "discourse/helpers/lazy-hash";
-import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -47,30 +46,24 @@ export default RouteTemplate(
         </div>
 
         {{#unless @controller.model.no_password}}
-          {{#if @controller.associatedAccountsLoaded}}
-            {{#if @controller.canRemovePassword}}
-              <div class="controls">
-                <a
-                  href
-                  {{on "click" @controller.removePassword}}
-                  hidden={{@controller.removePasswordInProgress}}
-                  id="remove-password-link"
-                >
-                  {{icon "trash-can"}}
-                  {{i18n "user.change_password.remove"}}
-                </a>
-              </div>
-            {{/if}}
-          {{else}}
-            <div class="controls">
-              <DButton
-                @action={{fn (routeAction "checkEmail") @controller.model}}
-                @title="admin.users.check_email.title"
-                @icon="envelope"
-                @label="admin.users.check_email.text"
-              />
+          <div class="controls">
+            <button
+              {{on "click" @controller.removePassword}}
+              disabled={{not @controller.canRemovePassword}}
+              hidden={{@controller.removePasswordInProgress}}
+              class="btn"
+              id="remove-password-link"
+            >
+              {{icon "trash-can"}}
+              {{i18n "user.change_password.remove"}}
+            </button>
+          </div>
+
+          {{#unless @controller.canRemovePassword}}
+            <div class="instructions">
+              {{i18n "user.change_password.remove_disabled"}}
             </div>
-          {{/if}}
+          {{/unless}}
         {{/unless}}
       </div>
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1529,7 +1529,8 @@ class UsersController < ApplicationController
       number_of_suspensions
       warnings_received_count
       number_of_rejected_posts
-    ].each { |info| result[info] = @user.public_send(info) }
+      can_remove_password?
+    ].each { |info| result[info.delete_suffix("?")] = @user.public_send(info) }
 
     render json: result
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -929,8 +929,12 @@ class User < ActiveRecord::Base
     @raw_password = pw # still required to maintain compatibility with usage of password-related User interface
   end
 
+  def can_remove_password?
+    associated_accounts.present? || passkey_credential_ids.present?
+  end
+
   def remove_password
-    raise Discourse::InvalidAccess if associated_accounts.blank? && passkey_credential_ids.blank?
+    raise Discourse::InvalidAccess if !can_remove_password?
 
     user_password.destroy if user_password
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1799,6 +1799,7 @@ en:
         verify_identity: "To continue, please verify your identity."
         title: "Password Reset"
         remove: "Remove Password"
+        remove_disabled: "The account needs at least one other login method (e.g. a passkey or a linked external account) before removing the password."
         remove_detail: "Your account will no longer be accessible with a password unless you reset it."
 
       second_factor_backup:

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -8023,9 +8023,10 @@ RSpec.describe UsersController do
           number_of_suspensions
           warnings_received_count
           number_of_rejected_posts
+          can_remove_password?
         ].each do |info|
           user_instance.expects(info).returns(user.public_send(info))
-          result[info.to_s] = user.public_send(info)
+          result[info.to_s.delete_suffix("?")] = user.public_send(info)
         end
 
         sign_in(admin)


### PR DESCRIPTION
### What is this change?

We have this slightly awkward UX on the <kbd>Preferences</kbd> > <kbd>Security</kbd> page, where we offer to remove the password from an account if it has other means of signing in. You need to first click a cryptic <kbd>Show</kbd> button which may or may not lead you to the button you want. This button loads the associated accounts so we can evaluate whether to show the <kbd>Remove password</kbd> button or not.

This PR loads that data when entering the route, so that we can just show the button up-front. If removing password isn't possible, the button is disabled and shows an explainer underneath.

**Before:**

![password-show-noop](https://github.com/user-attachments/assets/81857495-548a-4942-911d-248f59263ace)

**After:**

<img width="446" height="167" alt="Screenshot 2025-08-29 at 4 01 42 PM" src="https://github.com/user-attachments/assets/b52049d4-30b9-4af8-b819-50f9e798b595" />
