### PR TITLE
FIX: Unnecessary "Show more" link in categories modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/edit-navigation-menu/categories-modal.gjs
@@ -228,9 +228,18 @@ export default class SidebarEditNavigationMenuCategoriesModal extends Component 
       // to ensure we properly identify categories with exactly 5 subcategories
       this.partialCategoryInfos = findPartialCategories(this.fetchedCategories);
 
-      this.partialCategoryInfos.set(id, {
-        offset: offset + subcategories.length,
-      });
+      // Only show "Show more" button if exactly 5 subcategories were returned,
+      // which is the default page size and indicates there might be more to load.
+      // If we received fewer than 5, we've reached the end of the subcategories.
+      if (subcategories.length === 5) {
+        const parentCategory = this.fetchedCategories.find((c) => c.id === id);
+        if (parentCategory) {
+          this.partialCategoryInfos.set(id, {
+            level: parentCategory.level + 1,
+            offset: offset + subcategories.length,
+          });
+        }
+      }
 
       this.recomputeGroupings();
     }

--- a/spec/system/editing_sidebar_categories_navigation_spec.rb
+++ b/spec/system/editing_sidebar_categories_navigation_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       end
     end
 
-    it "shows the 'Show more' link after loading additional subcategories via intersection observer" do
+    it "shows the 'Show more' link after loading additional subcategories via intersection observer and hides it after loading all subcategories" do
       visit "/latest"
 
       modal = sidebar.click_edit_categories_button
@@ -267,10 +267,13 @@ RSpec.describe "Editing sidebar categories navigation", type: :system do
       expect(modal).to have_show_more_button
 
       # We need to briefly wait for things to settle, otherwise clicking the button doesn't work.
-      wait_for_timeout(200)
+      wait_for_timeout(300)
       modal.click_show_more_button
 
       expect(page).to have_content(subcategory6.name)
+
+      # The 'Show more' button should disappear after loading all subcategories
+      expect(modal).to have_no_show_more_button
     end
   end
 


### PR DESCRIPTION
Followup 6b3c4385165fa1927141faba61df22a5530dea96

When clicking "Show more" for subcategories in this modal,
if there are no more subcategories left to show we do not
need to show this button anymore.
