### PR TITLE
FIX: Include subcategories in upcoming events list, add `after` param

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -96,7 +96,7 @@ export default class UpcomingEventsList extends Component {
     const data = {
       limit: this.count,
       before: moment().add(this.upcomingDays, "days").toISOString(),
-      after: moment().add(-2, "hours").toISOString(),
+      after: moment().subtract(2, "hours").toISOString(),
     };
 
     if (this.includeSubcategories) {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -36,6 +36,7 @@ export default class UpcomingEventsList extends Component {
   timeFormat = this.args.params?.timeFormat ?? DEFAULT_TIME_FORMAT;
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
+  includeSubcategories = this.args.params?.includeSubcategories ?? false;
 
   emptyMessage = i18n("discourse_post_event.upcoming_events_list.empty");
   allDayLabel = i18n("discourse_post_event.upcoming_events_list.all_day");
@@ -95,7 +96,12 @@ export default class UpcomingEventsList extends Component {
     const data = {
       limit: this.count,
       before: moment().add(this.upcomingDays, "days").toISOString(),
+      after: moment().add(-2, "hours").toISOString(),
     };
+
+    if (this.includeSubcategories) {
+      data.include_subcategories = true;
+    }
 
     if (this.categoryId) {
       data.category_id = this.categoryId;


### PR DESCRIPTION
Addresses two issues. On sites with many old events, we would not show the correct items because the query would return the older events first.

Adds `includeSubcategories` parameter to include events from subcategories in the list.

No tests for now, we might refactor this component very soon.