### PR TITLE
FIX: exclude confirm user field from watch word check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1619,9 +1619,9 @@ class User < ActiveRecord::Base
   end
 
   def validatable_user_fields
-    # ignore multiselect fields since they are admin-set and thus not user generated content
+    # ignore multiselect and confirm fields since they are admin-set or don't contain text content
     @public_user_field_ids ||=
-      UserField.public_fields.where.not(field_type: "multiselect").pluck(:id)
+      UserField.public_fields.where.not(field_type: ["multiselect", "confirm"]).pluck(:id)
 
     user_fields(@public_user_field_ids)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1619,9 +1619,8 @@ class User < ActiveRecord::Base
   end
 
   def validatable_user_fields
-    # ignore multiselect and confirm fields since they are admin-set or don't contain text content
-    @public_user_field_ids ||=
-      UserField.public_fields.where.not(field_type: ["multiselect", "confirm"]).pluck(:id)
+    # only validate fields that contain text content
+    @public_user_field_ids ||= UserField.public_fields.user_editable_text_fields.pluck(:id)
 
     user_fields(@public_user_field_ids)
   end

--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -23,6 +23,7 @@ class UserField < ActiveRecord::Base
 
   scope :public_fields, -> { where(show_on_profile: true).or(where(show_on_user_card: true)) }
   scope :required, -> { not_optional }
+  scope :user_editable_text_fields, -> { where(field_type: %w[text textarea]) }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
   enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3, textarea: 4 }.freeze

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -426,9 +426,7 @@ RSpec.describe User do
       end
 
       context "with a confirm user field" do
-        fab!(:user_field) do
-          Fabricate(:user_field, field_type: "confirm", show_on_profile: true)
-        end
+        fab!(:user_field) { Fabricate(:user_field, field_type: "confirm", show_on_profile: true) }
 
         let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,6 +425,33 @@ RSpec.describe User do
         end
       end
 
+      context "with a confirm user field" do
+        fab!(:user_field) do
+          Fabricate(:user_field, field_type: "confirm", show_on_profile: true)
+        end
+
+        let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
+
+        context "with a blocked word" do
+          let(:value) { true }
+
+          it "does not block the word since it is not user generated-content" do
+            user.save!
+            expect(user_field_value).to eq true
+          end
+        end
+
+        context "with a censored word" do
+          let(:value) { true }
+          before { watched_word.action = WatchedWord.actions[:censor] }
+
+          it "does not censor the word since it is not user generated-content" do
+            user.save!
+            expect(user_field_value).to eq true
+          end
+        end
+      end
+
       context "when reseting user fields" do
         let!(:censored_word) do
           Fabricate(:watched_word, word: "censored", action: WatchedWord.actions[:censor])


### PR DESCRIPTION
A confirm field will always be a Boolean so there's no need to check for it. This was causing an error as we were trying to treat it as a string in the watched word code.

Example error:

```
NoMethodError (undefined method `gsub' for true)
app/services/word_watcher.rb:258:in `censor_text_with_regexp'
app/services/word_watcher.rb:146:in `block in censor_text'
app/services/word_watcher.rb:146:in `each'
app/services/word_watcher.rb:146:in `inject'
app/services/word_watcher.rb:146:in `censor_text'
app/models/user.rb:1612:in `block in apply_watched_words'
app/models/user.rb:1611:in `each'
app/models/user.rb:1611:in `apply_watched_words'
app/models/invite_redeemer.rb:156:in `create_user_from_invite'
app/models/invite_redeemer.rb:220:in `invited_user'
app/models/invite_redeemer.rb:277:in `add_user_to_groups'
app/models/invite_redeemer.rb:238:in `process_invitation'
app/models/invite_redeemer.rb:56:in `block in redeem'
app/models/invite_redeemer.rb:54:in `redeem'
app/models/invite.rb:239:in `redeem'
```