### PR TITLE
FEATURE: Allow picking first day of week in the Calendar plugin

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -29,6 +29,7 @@ export default class FullCalendar extends Component {
   @service capabilities;
   @service tooltip;
   @service menu;
+  @service siteSettings;
 
   @controller topic;
 
@@ -40,6 +41,23 @@ export default class FullCalendar extends Component {
     super.willDestroy(...arguments);
   }
 
+  /**
+   * Converts the first day of week site setting to the appropriate number
+   * @returns {number} The first day of week (0=Sunday, 1=Monday, 6=Saturday)
+   */
+  get firstDayOfWeek() {
+    const setting = this.siteSettings.calendar_first_day_of_week;
+    switch (setting) {
+      case "Saturday":
+        return 6;
+      case "Sunday":
+        return 0;
+      case "Monday":
+      default:
+        return 1;
+    }
+  }
+
   @action
   async setupCalendar(element) {
     const calendarModule = await loadFullCalendar();
@@ -48,7 +66,7 @@ export default class FullCalendar extends Component {
       locale: getCurrentBcp47Locale(),
       buttonText: getCalendarButtonsText(),
       timeZone: this.currentUser?.user_option?.timezone || "local",
-      firstDay: 1,
+      firstDay: this.firstDayOfWeek,
       displayEventTime: true,
       weekends: this.args.weekends ?? true,
       initialDate: this.args.initialDate,

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -57,6 +57,7 @@ en:
     calendar_automatic_holidays_enabled: "Automatically set holiday status based on a users region (note: you can disable specific automatic holidays in plugin settings)"
     event_participation_buttons: "List of event participation buttons users can use."
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
+    calendar_first_day_of_week: "Set the first day of the week for calendar display. Options are Saturday, Sunday, or Monday."
 
   discourse_calendar:
     invite_user_notification: "%{username} invited you to: %{description}"

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -113,3 +113,11 @@ discourse_calendar:
     client: true
     default: ""
     json_schema: DiscourseCalendar::SiteSettings::MapEventsTitleJsonSchema
+  calendar_first_day_of_week:
+    type: enum
+    choices:
+      - Saturday
+      - Sunday
+      - Monday
+    default: Monday
+    client: true

--- a/plugins/discourse-calendar/spec/lib/calendar_first_day_of_week_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/calendar_first_day_of_week_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SiteSetting do
+  before { SiteSetting.calendar_enabled = true }
+
+  it "has the correct default value" do
+    expect(SiteSetting.calendar_first_day_of_week).to eq("Monday")
+  end
+
+  it "accepts valid enum values" do
+    expect { SiteSetting.calendar_first_day_of_week = "Saturday" }.not_to raise_error
+    expect { SiteSetting.calendar_first_day_of_week = "Sunday" }.not_to raise_error
+    expect { SiteSetting.calendar_first_day_of_week = "Monday" }.not_to raise_error
+  end
+
+  it "rejects invalid enum values" do
+    expect { SiteSetting.calendar_first_day_of_week = "Tuesday" }.to raise_error(
+      Discourse::InvalidParameters,
+    )
+    expect { SiteSetting.calendar_first_day_of_week = "Friday" }.to raise_error(
+      Discourse::InvalidParameters,
+    )
+    expect { SiteSetting.calendar_first_day_of_week = "Invalid" }.to raise_error(
+      Discourse::InvalidParameters,
+    )
+  end
+
+  it "is accessible to clients" do
+    # This test ensures the setting is marked as client: true in the YAML
+    # The actual client access is tested in the JavaScript tests
+    expect(SiteSetting.calendar_first_day_of_week).to be_present
+  end
+end

--- a/plugins/discourse-calendar/test/javascripts/unit/components/full-calendar-test.js
+++ b/plugins/discourse-calendar/test/javascripts/unit/components/full-calendar-test.js
@@ -1,0 +1,77 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import FullCalendar from "discourse/plugins/discourse-calendar/components/full-calendar";
+
+module("Unit | Component | full-calendar", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("firstDayOfWeek getter returns correct values", async function (assert) {
+    const component = new FullCalendar();
+    component.siteSettings = this.owner.lookup("service:site-settings");
+
+    // Test Monday (default)
+    component.siteSettings.calendar_first_day_of_week = "Monday";
+    assert.strictEqual(component.firstDayOfWeek, 1, "Monday should return 1");
+
+    // Test Sunday
+    component.siteSettings.calendar_first_day_of_week = "Sunday";
+    assert.strictEqual(component.firstDayOfWeek, 0, "Sunday should return 0");
+
+    // Test Saturday
+    component.siteSettings.calendar_first_day_of_week = "Saturday";
+    assert.strictEqual(component.firstDayOfWeek, 6, "Saturday should return 6");
+
+    // Test default fallback
+    component.siteSettings.calendar_first_day_of_week = "Invalid";
+    assert.strictEqual(
+      component.firstDayOfWeek,
+      1,
+      "Invalid value should default to Monday (1)"
+    );
+  });
+
+  test("calendar configuration uses firstDayOfWeek setting", async function () {
+    // Mock the calendar module
+    const mockCalendarModule = {
+      Calendar: class MockCalendar {
+        constructor(element, options) {
+          this.element = element;
+          this.options = options;
+        }
+
+        render() {}
+
+        destroy() {}
+      },
+      DayGrid: {},
+      TimeGrid: {},
+      List: {},
+      RRULE: {},
+      MomentTimezone: {},
+    };
+
+    // Mock loadFullCalendar to return our mock
+    this.owner.register("service:load-full-calendar", {
+      loadFullCalendar() {
+        return Promise.resolve(mockCalendarModule);
+      },
+    });
+
+    // Test with Monday
+    this.siteSettings.calendar_first_day_of_week = "Monday";
+    await render(hbs`<FullCalendar />`);
+
+    // The calendar should be created with firstDay: 1
+    // We can't easily test this without more complex mocking, but the getter test above covers the logic
+
+    // Test with Sunday
+    this.siteSettings.calendar_first_day_of_week = "Sunday";
+    await render(hbs`<FullCalendar />`);
+
+    // Test with Saturday
+    this.siteSettings.calendar_first_day_of_week = "Saturday";
+    await render(hbs`<FullCalendar />`);
+  });
+});


### PR DESCRIPTION
Different countries treat first day of week differently. For now this is a
per-community setting, we may consider it a per user setting later on.
