### PR TITLE
FIX: exclude non-text user fields from watch word check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1619,9 +1619,8 @@ class User < ActiveRecord::Base
   end
 
   def validatable_user_fields
-    # ignore multiselect fields since they are admin-set and thus not user generated content
-    @public_user_field_ids ||=
-      UserField.public_fields.where.not(field_type: "multiselect").pluck(:id)
+    # only validate fields that contain text content
+    @public_user_field_ids ||= UserField.public_fields.user_editable_text_fields.pluck(:id)
 
     user_fields(@public_user_field_ids)
   end

--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -23,6 +23,7 @@ class UserField < ActiveRecord::Base
 
   scope :public_fields, -> { where(show_on_profile: true).or(where(show_on_user_card: true)) }
   scope :required, -> { not_optional }
+  scope :user_editable_text_fields, -> { where(field_type: %w[text textarea]) }
 
   enum :requirement, { optional: 0, for_all_users: 1, on_signup: 2 }.freeze
   enum :field_type_enum, { text: 0, confirm: 1, dropdown: 2, multiselect: 3, textarea: 4 }.freeze

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -425,6 +425,31 @@ RSpec.describe User do
         end
       end
 
+      context "with a confirm user field" do
+        fab!(:user_field) { Fabricate(:user_field, field_type: "confirm", show_on_profile: true) }
+
+        let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
+
+        context "with a blocked word" do
+          let(:value) { true }
+
+          it "does not block the word since it is not user generated-content" do
+            user.save!
+            expect(user_field_value).to eq true
+          end
+        end
+
+        context "with a censored word" do
+          let(:value) { true }
+          before { watched_word.action = WatchedWord.actions[:censor] }
+
+          it "does not censor the word since it is not user generated-content" do
+            user.save!
+            expect(user_field_value).to eq true
+          end
+        end
+      end
+
       context "when reseting user fields" do
         let!(:censored_word) do
           Fabricate(:watched_word, word: "censored", action: WatchedWord.actions[:censor])


### PR DESCRIPTION
## ✨ What's This?

This is a backport of #34646 to the stable branch.

If a user field doesn't allow user-editable text content, then there's no need to validate that the user field content passes the word watcher checks.