### PR TITLE
DEV: Configure skip_default_job_logging for Sidekiq take 2

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -10,7 +10,7 @@ Sidekiq.configure_client { |config| config.redis = Discourse.sidekiq_redis_confi
 
 Sidekiq.configure_server do |config|
   config.redis = Discourse.sidekiq_redis_config
-  config[:skip_default_job_logging] = false
+  config[:skip_default_job_logging] = true
 
   config.server_middleware do |chain|
     chain.add Sidekiq::Pausable


### PR DESCRIPTION
Set to `true` to skip not `false`...

Follow-up to 504233da6eb9b1cdb08797717c8e29c22b3d3660
