### PR TITLE
FEATURE: allow non staff to create and manage events behind settings

### DIFF
--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -37,6 +37,8 @@ en:
     display_post_event_date_on_topic_title: "Displays the date of the event after the topic title."
     use_local_event_date: "Use local date after topic title instead of relative time."
     discourse_post_event_allowed_on_groups: "Groups that are allowed to create events."
+    discourse_post_event_manage_groups: "Groups that can manage all events (edit, delete, invite). Defaults to staff."
+    discourse_post_event_create_groups: "Groups that can create events they manage. Defaults to staff."
     discourse_post_event_allowed_custom_fields: "Allows to let each event to set the value of custom fields."
     discourse_post_event_edit_notifications_time_extension: "Extends (in minutes) the period after the end of an event when `going` invitees are still being notified from edit in the original post."
     holiday_calendar_topic_id: "Topic ID of staffs holiday / absence calendar."

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -71,6 +71,20 @@ discourse_calendar:
     default: ""
     allow_any: false
     refresh: true
+  discourse_post_event_manage_groups:
+    client: true
+    type: group_list
+    list_type: compact
+    default: "3"
+    allow_any: false
+    refresh: true
+  discourse_post_event_create_groups:
+    client: true
+    type: group_list
+    list_type: compact
+    default: "3"
+    allow_any: false
+    refresh: true
   displayed_invitees_limit:
     default: 10
     client: false

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
@@ -93,6 +93,124 @@ describe User do
           expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(false)
         end
       end
+
+      context "when user is in manage groups" do
+        let(:manage_group) do
+          Fabricate(:group).tap do |g|
+            g.add(user_1)
+            g.save!
+          end
+        end
+
+        before { SiteSetting.discourse_post_event_manage_groups = manage_group.id }
+
+        context "when user didn't create the event" do
+          let(:user_2) { Fabricate(:user) }
+          let(:topic_1) { Fabricate(:topic, user: user_2) }
+          let(:post_1) { Fabricate(:post, topic: topic_1, user: user_2) }
+          let(:post_event_1) { Fabricate(:event, post: post_1) }
+
+          it "can act on the event" do
+            expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
+          end
+        end
+
+        context "when manage group is 'everyone'" do
+          let(:user_2) { Fabricate(:user) }
+          let(:topic_1) { Fabricate(:topic, user: user_2) }
+          let(:post_1) { Fabricate(:post, topic: topic_1, user: user_2) }
+          let(:post_event_1) { Fabricate(:event, post: post_1) }
+
+          it "can act on the event" do
+            SiteSetting.discourse_post_event_manage_groups = Group::AUTO_GROUPS[:everyone]
+            expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#can_create_discourse_post_event?" do
+    context "when user is staff" do
+      let(:user_1) { Fabricate(:user, admin: true) }
+
+      it "can create events" do
+        expect(user_1.can_create_discourse_post_event?).to eq(true)
+      end
+    end
+
+    context "when user is not staff" do
+      let(:user_1) { Fabricate(:user, refresh_auto_groups: true) }
+
+      context "when user is in create groups" do
+        let(:create_group) do
+          Fabricate(:group).tap do |g|
+            g.add(user_1)
+            g.save!
+          end
+        end
+
+        before { SiteSetting.discourse_post_event_create_groups = create_group.id }
+
+        it "can create events" do
+          expect(user_1.can_create_discourse_post_event?).to eq(true)
+        end
+
+        context "when create group is 'everyone'" do
+          it "can create events" do
+            SiteSetting.discourse_post_event_create_groups = Group::AUTO_GROUPS[:everyone]
+            expect(user_1.can_create_discourse_post_event?).to eq(true)
+          end
+        end
+      end
+
+      context "when user is in legacy allowed groups" do
+        let(:allowed_group) do
+          Fabricate(:group).tap do |g|
+            g.add(user_1)
+            g.save!
+          end
+        end
+
+        before { SiteSetting.discourse_post_event_allowed_on_groups = allowed_group.id }
+
+        it "can create events" do
+          expect(user_1.can_create_discourse_post_event?).to eq(true)
+        end
+
+        context "when allowed group is 'everyone'" do
+          it "can create events" do
+            SiteSetting.discourse_post_event_allowed_on_groups = Group::AUTO_GROUPS[:everyone]
+            expect(user_1.can_create_discourse_post_event?).to eq(true)
+          end
+        end
+      end
+
+      context "when user is not in any allowed groups" do
+        it "cannot create events" do
+          expect(user_1.can_create_discourse_post_event?).to eq(false)
+        end
+      end
+
+      context "when both create and allowed groups are set" do
+        let(:create_group) do
+          Fabricate(:group).tap do |g|
+            g.add(user_1)
+            g.save!
+          end
+        end
+
+        let(:allowed_group) { Fabricate(:group) }
+
+        before do
+          SiteSetting.discourse_post_event_create_groups = create_group.id
+          SiteSetting.discourse_post_event_allowed_on_groups = allowed_group.id
+        end
+
+        it "prioritizes create groups over allowed groups" do
+          expect(user_1.can_create_discourse_post_event?).to eq(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Two new settings:

discourse_post_event_manage_groups (users that can manage any event)
discourse_post_event_create_groups (users that can create a specific event and manage it)
