### PR TITLE
DEV: Log `HTTP_ACCEPT_LANGUAGE` header in Rails logs

### DIFF
--- a/config/initializers/101-lograge.rb
+++ b/config/initializers/101-lograge.rb
@@ -108,6 +108,13 @@ if ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
               database: RailsMultisite::ConnectionManagement.current_db,
             }
 
+            if (
+                 http_accept_language_request_header =
+                   event.payload[:headers]["HTTP_ACCEPT_LANGUAGE"]
+               ).present?
+              output[:http_accept_language] = http_accept_language_request_header
+            end
+
             if data = (Thread.current[:_method_profiler] || event.payload[:timings])
               if sql = data[:sql]
                 output[:db] = sql[:duration] * 1000


### PR DESCRIPTION
This commit logs the `HTTP_ACCEPT_LANGUAGE` header in the log line when
`ENABLE_LOGSTASH_LOGGER` is set to `1`
