### PR TITLE
FIX: Use system user for email-in when staged users disabled

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -208,8 +208,13 @@ module Email
 
       if user.present?
         log_and_validate_user(user)
-      else
-        raise UserNotFoundError unless SiteSetting.enable_staged_users
+      elsif !SiteSetting.enable_staged_users
+        category = Category.find_by_email(mail.to)
+        if category&.email_in_allow_strangers == true
+          user = Discourse.system_user
+        else
+          raise UserNotFoundError
+        end
       end
 
       recipients = get_all_recipients(@mail)

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -1746,6 +1746,12 @@ RSpec.describe Email::Receiver do
       expect { process(:new_user) }.to change(Topic, :count)
     end
 
+    it "uses system user if enable_stages_users is false " do
+      SiteSetting.enable_staged_users = false
+      expect { process(:new_user) }.to change(Topic, :count)
+      expect(Topic.last.user).to eq(Discourse.system_user)
+    end
+
     it "lets an email in from a high-TL user" do
       Fabricate(:user, email: "tl4@bar.com", trust_level: TrustLevel[4])
       expect { process(:tl4_user) }.to change(Topic, :count)


### PR DESCRIPTION
When `enable_staged_users` is disabled and a category has `email_in_allow_strangers` enabled, fallback to using the system user instead of raising UserNotFoundError. This allows email-in functionality to work in categories that explicitly allow anonymous email submissions even when staged users are globally disabled.