### PR TITLE
DEV: Debug timeout of `.join` on AI cancel_manager_spec

### DIFF
--- a/plugins/discourse-ai/spec/lib/completions/cancel_manager_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/cancel_manager_spec.rb
@@ -91,7 +91,17 @@ describe DiscourseAi::Completions::CancelManager do
       # on slow machines this may take a bit longer to cancel, usually on a fast machine this is instant
       completion_thread.join(5)
 
-      expect(completion_thread).not_to be_alive
+      begin
+        expect(completion_thread).not_to be_alive
+      rescue RSpec::Expectations::ExpectationNotMetError
+        puts "Thread still alive - dumping backtraces:"
+        Thread.list.each do |t|
+          puts "Thread #{t.object_id}: #{t.status}"
+          puts t.backtrace&.join("\n")
+          puts
+        end
+        raise
+      end
     ensure
       begin
         server.close


### PR DESCRIPTION
This spec is flaking a lot. Adding debug logs to try and identify whether this is a specific-specific problem, or something which may affect production too.