### PR TITLE
FIX: URL encode usernames in grant admin redirect

### DIFF
--- a/lib/second_factor/actions/grant_admin.rb
+++ b/lib/second_factor/actions/grant_admin.rb
@@ -16,7 +16,8 @@ module SecondFactor::Actions
         callback_params: {
           user_id: user.id,
         },
-        redirect_url: admin_user_show_path(id: user.id, username: user.username),
+        redirect_url:
+          CGI.unescape(admin_user_show_path(id: user.id, username: CGI.escape(user.username))),
         description: description,
       }
     end

--- a/spec/lib/second_factor/actions/grant_admin_spec.rb
+++ b/spec/lib/second_factor/actions/grant_admin_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe SecondFactor::Actions::GrantAdmin do
       )
     end
 
+    it "respects allowed_unicode_username_characters in username" do
+      SiteSetting.unicode_usernames = true
+      SiteSetting.allowed_unicode_username_characters = "[äöüßÄÖÜẞ]"
+
+      user.update!(username: "Anführerin")
+
+      instance = create_instance(admin)
+      hash = instance.second_factor_auth_required!(params({ user_id: user.id }))
+      expect(hash[:callback_params]).to eq({ user_id: user.id })
+      expect(hash[:redirect_url]).to eq("/admin/users/#{user.id}/Anf%C3%BChrerin")
+    end
+
     it "ensures the acting user is admin" do
       instance = create_instance(user)
       expect { instance.second_factor_auth_required!(params({ user_id: user.id })) }.to raise_error(


### PR DESCRIPTION
The grant admin action was not properly URL encoding usernames containing unicode characters, causing broken redirect URLs when usernames include special characters allowed by the allowed_unicode_username_characters site setting.

https://meta.discourse.org/t/granting-admin-rights-fails-for-usernames-with-special-characters-when-admin-account-has-2fa-enabled/378063