### PR TITLE
FIX: New features git hash version tweaks

### DIFF
--- a/lib/git_utils.rb
+++ b/lib/git_utils.rb
@@ -17,7 +17,7 @@ class GitUtils
   def self.has_commit?(hash)
     return false if !hash.match?(/\A[a-f0-9]{40}\Z/)
 
-    self.try_git("git cat-file -t #{hash} 2> /dev/null", false) == "commit"
+    self.try_git("git merge-base --is-ancestor #{hash} HEAD 2> /dev/null; echo $?", "1") == "0"
   end
 
   def self.last_commit_date

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -25,8 +25,7 @@ module Discourse
 
   def self.has_needed_version?(current, needed)
     Gem::Version.new(current) >= Gem::Version.new(needed)
-  rescue ArgumentError => e
-    Rails.logger.error(e.message)
+  rescue ArgumentError
     false
   end
 


### PR DESCRIPTION
### What is the problem?

There are two issues addressed by this PR:

1. We log an error to console when a git hash is passed to `Discourse#has_needed_version?`. This isn't correct. We should just return `false`.
2. We only check that the commit hash is in the repo, we don't check that it's actually an ancestor in the current tree. So you'd see the feature even if you're on a branch that doesn't have it.