### PR TITLE
UX: Some translation progress chart refinements

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -39,7 +39,10 @@ module DiscourseAi
       def base_result
         {
           translation_id: DiscourseAi::Configuration::Module::TRANSLATION_ID,
-          enabled: DiscourseAi::Translation.enabled?,
+          # the progress chart will be empty if max_age_days is 0
+          enabled:
+            DiscourseAi::Translation.enabled? &&
+              SiteSetting.ai_translation_backfill_max_age_days > 0,
           backfill_enabled: DiscourseAi::Translation.backfill_enabled?,
         }
       end

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -11,13 +11,10 @@ module DiscourseAi
 
         if supported_locales.empty?
           return(
-            render json: {
-                     translation_progress: [],
-                     translation_id: DiscourseAi::Configuration::Module::TRANSLATION_ID,
-                     enabled: DiscourseAi::Translation.backfill_enabled?,
-                     total: 0,
-                     posts_with_detected_locale: 0,
-                   }
+            render json:
+                     base_result.merge(
+                       { translation_progress: [], total: 0, posts_with_detected_locale: 0 },
+                     )
           )
         end
 
@@ -31,20 +28,20 @@ module DiscourseAi
 
         candidates.get_total_and_with_locale_count in { total:, posts_with_detected_locale: }
 
-        render json: {
-                 translation_progress: result,
-                 translation_id: DiscourseAi::Configuration::Module::TRANSLATION_ID,
-                 enabled: DiscourseAi::Translation.backfill_enabled?,
-                 total:,
-                 posts_with_detected_locale:,
-               }
+        render json:
+                 base_result.merge(
+                   { translation_progress: result, total:, posts_with_detected_locale: },
+                 )
       end
 
       private
 
-      def safe_percentage(part, total)
-        return 0.0 if total <= 0
-        (part / total) * 100
+      def base_result
+        {
+          translation_id: DiscourseAi::Configuration::Module::TRANSLATION_ID,
+          enabled: DiscourseAi::Translation.enabled?,
+          backfill_enabled: DiscourseAi::Translation.backfill_enabled?,
+        }
       end
     end
   end

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
@@ -137,13 +137,12 @@ export default class AiTranslations extends Component {
             },
           },
           datalabels: {
-            formatter: (percentage) => {
-              return this.site.mobileView && percentage < 20
+            formatter: (percentage) =>
+              this.site.mobileView && percentage < 20
                 ? ""
                 : i18n("discourse_ai.translations.progress_chart.data_label", {
                     percentage,
-                  });
-            },
+                  }),
             color: "white",
           },
         },

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import DPageSubheader from "discourse/components/d-page-subheader";
 import DTooltip from "discourse/components/d-tooltip";
@@ -19,6 +20,20 @@ export default class AiTranslations extends Component {
   @tracked done = this.args.model?.posts_with_detected_locale;
   @tracked total = this.args.model?.total;
 
+  get chartRightPadding() {
+    const max = Math.max(...this.data.map(({ done }) => done));
+    switch (true) {
+      case max >= 100000:
+        return 90;
+      case max >= 10000:
+        return 80;
+      case max >= 20:
+        return 70;
+      default:
+        return 50;
+    }
+  }
+
   get descriptionKey() {
     return this.done === this.total
       ? "discourse_ai.translations.stats.complete_language_detection_description"
@@ -26,7 +41,7 @@ export default class AiTranslations extends Component {
   }
 
   get chartConfig() {
-    if (!this.data || !this.data.length) {
+    if (!this.data?.length) {
       return {};
     }
 
@@ -73,10 +88,10 @@ export default class AiTranslations extends Component {
             ctx.save();
             ctx.textBaseline = "middle";
             const items = data.datasets[0].totalItems;
-            items.forEach((done, i) => {
+            items.forEach((count, i) => {
               ctx.fillText(
                 i18n("discourse_ai.translations.progress_chart.bar_done", {
-                  done,
+                  count,
                 }),
                 scales.x.getPixelForValue(100) + 10,
                 scales.y.getPixelForValue(i)
@@ -91,7 +106,7 @@ export default class AiTranslations extends Component {
         indexAxis: "y",
         responsive: true,
         maintainAspectRatio: false,
-        layout: { padding: { right: 70 } },
+        layout: { padding: { right: this.chartRightPadding } },
         scales: {
           x: {
             beginAtZero: true,
@@ -122,10 +137,13 @@ export default class AiTranslations extends Component {
             },
           },
           datalabels: {
-            formatter: (percentage) =>
-              i18n("discourse_ai.translations.progress_chart.data_label", {
-                percentage,
-              }),
+            formatter: (percentage) => {
+              return this.site.mobileView && percentage < 20
+                ? ""
+                : i18n("discourse_ai.translations.progress_chart.data_label", {
+                    percentage,
+                  });
+            },
             color: "white",
           },
         },
@@ -158,33 +176,37 @@ export default class AiTranslations extends Component {
       </DPageSubheader>
 
       {{#if @model.enabled}}
-        <AdminConfigAreaCard
-          class="ai-translation__charts"
-          @heading="discourse_ai.translations.progress_chart.title"
-        >
+        <AdminConfigAreaCard class="ai-translation__charts">
+          <:header>
+            <InterpolatedTranslation
+              @key="discourse_ai.translations.progress_chart.title"
+              as |Placeholder|
+            >
+              <Placeholder @name="tooltip">
+                <DTooltip>
+                  <:trigger>
+                    {{icon "circle-question"}}
+                  </:trigger>
+                  <:content>
+                    {{i18n
+                      "discourse_ai.translations.stats.description_tooltip"
+                    }}
+                  </:content>
+                </DTooltip>
+              </Placeholder>
+            </InterpolatedTranslation>
+          </:header>
           <:content>
             <div class="ai-translation__stats-container">
               <div class="ai-translation__stat-item">
                 <span class="ai-translation__stat-label">
-                  <InterpolatedTranslation
-                    @key={{this.descriptionKey}}
-                    as |Placeholder|
-                  >
-                    <Placeholder @name="tooltip">
-                      <DTooltip>
-                        <:trigger>
-                          {{icon "circle-question"}}
-                        </:trigger>
-                        <:content>
-                          {{i18n
-                            "discourse_ai.translations.stats.description_tooltip"
-                          }}
-                        </:content>
-                      </DTooltip>
-                    </Placeholder>
-                    <Placeholder @name="done">{{this.done}}</Placeholder>
-                    <Placeholder @name="total">{{this.total}}</Placeholder>
-                  </InterpolatedTranslation>
+                  {{i18n
+                    this.descriptionKey
+                    (hash done=this.done total=this.total)
+                  }}
+                  {{#unless @model.backfill_enabled}}
+                    {{i18n "discourse_ai.translations.stats.backfill_disabled"}}
+                  {{/unless}}
                 </span>
               </div>
             </div>

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -326,15 +326,17 @@ en:
             empty_label: "Automatic translations are disabled, click below to configure"
         stats:
           title: "Translation statistics"
-          complete_language_detection_description: "All %{total} eligible posts have their language detected %{tooltip}"
-          incomplete_language_detection_description: "%{done} of %{total} eligible posts have their language detected %{tooltip}"
+          complete_language_detection_description: "All %{total} eligible posts have their language detected."
+          incomplete_language_detection_description: "%{done} of %{total} eligible posts have their language detected."
+          backfill_disabled: "Backfilling is currently disabled."
           description_tooltip: "Eligible posts are determined by AI translation settings"
         progress_chart:
-          title: "Translation Progress"
+          title: "Translation Progress %{tooltip}"
           data_label: "%{percentage}%"
           tooltip_translated: "%{done} out of %{total} posts translated"
-          bar_done: "%{done} posts"
-
+          bar_done:
+            one: "%{count} post"
+            other: "%{count} posts"
 
       spam:
         short_title: "Spam"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -125,7 +125,7 @@ en:
     ai_translation_enabled: "Enables the AI translation feature"
     ai_translation_model: "The model to use for translation. This model must support translation. Personas can override this setting."
     ai_translation_backfill_limit_to_public_content: "When enabled, only content in public categories will be translated. When disabled, content in group PMs and private categories will also be sent for translation."
-    ai_translation_max_post_length: "The maximum length of a post to be translated. Posts longer than this will not be translated."
+    ai_translation_max_post_length: "The maximum number of characters for a post to be translated. Posts longer than this will not be translated."
     ai_translation_backfill_max_age_days: "The maximum age of a post and topic to be translated. Posts and topics older than this will not be translated. 0 disables backfilling, but will not disable translation of new posts."
 
   reviewables:

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -56,8 +56,22 @@ describe DiscourseAi::Admin::AiTranslationsController do
       end
 
       it "correctly indicates if backfill is enabled" do
-        # Enable backfill
-        SiteSetting.ai_translation_backfill_hourly_rate = 10
+        SiteSetting.ai_translation_backfill_hourly_rate = 30
+
+        get "/admin/plugins/discourse-ai/ai-translations.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["backfill_enabled"]).to eq(true)
+
+        SiteSetting.ai_translation_backfill_hourly_rate = 0
+
+        get "/admin/plugins/discourse-ai/ai-translations.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["backfill_enabled"]).to eq(false)
+      end
+
+      it "correctly indicates if feature is enabled" do
         SiteSetting.ai_translation_backfill_max_age_days = 30
 
         get "/admin/plugins/discourse-ai/ai-translations.json"
@@ -65,8 +79,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
         expect(response.status).to eq(200)
         expect(response.parsed_body["enabled"]).to eq(true)
 
-        # Disable backfill
-        SiteSetting.ai_translation_backfill_hourly_rate = 0
+        SiteSetting.ai_translation_backfill_max_age_days = 0
 
         get "/admin/plugins/discourse-ai/ai-translations.json"
 

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe "Admin AI translations", type: :system do
 
       # Verify chart container is present
       expect(page).to have_css(".ai-translation__charts")
-      expect(page).to have_content(I18n.t("js.discourse_ai.translations.progress_chart.title"))
       expect(page).to have_css(".ai-translation__chart")
     end
 
@@ -62,10 +61,8 @@ RSpec.describe "Admin AI translations", type: :system do
   describe "when translations are disabled" do
     before do
       SiteSetting.discourse_ai_enabled = true
-      SiteSetting.ai_translation_enabled = true
+      SiteSetting.ai_translation_enabled = false
       SiteSetting.content_localization_supported_locales = "en|fr|es"
-      # Disable backfill
-      SiteSetting.ai_translation_backfill_hourly_rate = 0
 
       visit "/admin/plugins/discourse-ai/ai-translations"
     end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/34643

- Pluralizes posts
- Shows the chart even if `ai_translation_backfill_hourly_rate` is zero, and indicates as such
- Appropriate paddings
- Hides labels if bar too short

| desk | mob |
|---|---|
| <img width="1264" height="831" alt="Screenshot 2025-09-02 at 2 18 25 PM" src="https://github.com/user-attachments/assets/e9462238-7ca4-4beb-a1ab-aa70b6d93036" /> | <img width="300" height="2796" alt="d loc_admin_plugins_discourse-ai_ai-translations_mobile_view=1(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/4e5047f5-9185-426a-aabf-c992f9df4d04" /> | 
