### PR TITLE
UX: Switch user selector and title input position when composing PM

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-action-title.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-action-title.gjs
@@ -39,11 +39,21 @@ export default class ComposerActionTitle extends Component {
 
   // Note we update when some other attributes like tag/category change to allow
   // text customizations to use those.
-  @discourseComputed("options", "action", "model.tags", "model.category")
+  @discourseComputed(
+    "options",
+    "action",
+    "model.tags",
+    "model.category",
+    "model.isWarning"
+  )
   actionTitle(opts, action) {
     const result = this.model.customizationFor("actionTitle");
     if (result) {
       return result;
+    }
+
+    if (action === PRIVATE_MESSAGE && this.model.isWarning) {
+      return i18n("composer.send_warning");
     }
 
     if (TITLES[action]) {

--- a/app/assets/javascripts/discourse/app/components/composer-container.gjs
+++ b/app/assets/javascripts/discourse/app/components/composer-container.gjs
@@ -212,30 +212,6 @@ export default class ComposerContainer extends Component {
                 />
                 {{#unless this.composer.model.viewFullscreen}}
                   {{#if this.composer.model.canEditTitle}}
-                    {{#if this.composer.model.creatingPrivateMessage}}
-                      <div class="user-selector">
-                        <ComposerUserSelector
-                          @topicId={{this.composer.topicModel.id}}
-                          @recipients={{this.composer.model.targetRecipients}}
-                          @hasGroups={{this.composer.model.hasTargetGroups}}
-                          @focusTarget={{this.composer.focusTarget}}
-                          class={{concatClass
-                            "users-input"
-                            (if this.composer.showWarning "can-warn")
-                          }}
-                        />
-                        {{#if this.composer.showWarning}}
-                          <label class="add-warning">
-                            <Input
-                              @type="checkbox"
-                              @checked={{this.composer.model.isWarning}}
-                            />
-                            <span>{{i18n "composer.add_warning"}}</span>
-                          </label>
-                        {{/if}}
-                      </div>
-                    {{/if}}
-
                     <div
                       class="title-and-category
                         {{if this.composer.isPreviewVisible 'with-preview'}}"
@@ -245,6 +221,18 @@ export default class ComposerContainer extends Component {
                         @lastValidatedAt={{this.composer.lastValidatedAt}}
                         @focusTarget={{this.composer.focusTarget}}
                       />
+
+                      {{#if this.composer.model.creatingPrivateMessage}}
+                        <div class="user-selector">
+                          <ComposerUserSelector
+                            @topicId={{this.composer.topicModel.id}}
+                            @recipients={{this.composer.model.targetRecipients}}
+                            @hasGroups={{this.composer.model.hasTargetGroups}}
+                            @focusTarget={{this.composer.focusTarget}}
+                            class={{concatClass "users-input"}}
+                          />
+                        </div>
+                      {{/if}}
 
                       {{#if this.composer.model.showCategoryChooser}}
                         <div class="category-input">

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -477,19 +477,8 @@ export default class ComposerService extends Service {
     "model.targetRecipients",
     "model.warningsDisabled"
   )
-  showWarning(creatingPrivateMessage, usernames, warningsDisabled) {
+  canToggleWarning(creatingPrivateMessage, usernames, warningsDisabled) {
     if (!this.get("currentUser.staff") || warningsDisabled) {
-      return false;
-    }
-
-    const hasTargetGroups = this.get("model.hasTargetGroups");
-
-    // We need exactly one user to issue a warning
-    if (
-      isEmpty(usernames) ||
-      usernames.split(",").length !== 1 ||
-      hasTargetGroups
-    ) {
       return false;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -240,6 +240,17 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
       });
     }
 
+    if (this.action === PRIVATE_MESSAGE && this.composer.canToggleWarning) {
+      items.push({
+        name: i18n("composer.composer_actions.toggle_official_warning.label"),
+        description: i18n(
+          "composer.composer_actions.toggle_official_warning.desc"
+        ),
+        icon: "circle-exclamation",
+        id: "toggle_official_warning",
+      });
+    }
+
     if (items.length === 0 && this.currentUser.can_create_topic) {
       items.push({
         name: i18n("composer.composer_actions.create_topic.label"),
@@ -278,6 +289,10 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
   _openComposer(options) {
     this.composer.closeComposer();
     this.composer.open(options);
+  }
+
+  toggleOfficialWarningSelected(options, model) {
+    model.toggleProperty("isWarning");
   }
 
   toggleWhisperSelected(options, model) {

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -296,6 +296,7 @@ html.composer-open:not(.has-full-page-chat) {
   .user-selector,
   .title-and-category {
     display: flex;
+    flex-wrap: wrap;
     width: 100%;
     align-items: center;
     position: relative;
@@ -303,13 +304,8 @@ html.composer-open:not(.has-full-page-chat) {
   }
 
   .user-selector {
-    @include viewport.until(sm) {
-      flex-wrap: wrap;
-    }
-
-    @include viewport.from(sm) {
-      margin-bottom: 0.5em;
-    }
+    flex-wrap: wrap;
+    margin-bottom: 0.4em;
   }
 
   .title-input {
@@ -395,10 +391,6 @@ html.composer-open:not(.has-full-page-chat) {
   }
 
   .with-tags.with-category {
-    .title-and-category {
-      flex-wrap: wrap;
-    }
-
     .category-input {
       margin-left: 0;
       margin-bottom: 8px;
@@ -408,25 +400,8 @@ html.composer-open:not(.has-full-page-chat) {
     }
   }
 
-  .add-warning {
-    color: var(--primary-high);
-    padding: 0.5em;
-    display: flex;
-    line-height: var(--line-height-medium);
-    margin: 0;
-
-    @include viewport.until(sm) {
-      margin-bottom: 0.15em;
-    }
-
-    input {
-      margin-right: 8px;
-    }
-  }
-
   @include viewport.until(sm) {
-    .users-input,
-    .add-warning {
+    .users-input {
       width: 100%;
     }
 
@@ -641,49 +616,22 @@ html.composer-open:not(.has-full-page-chat) {
     }
   }
 
-  @include viewport.from(sm) {
-    &.private-message {
-      .with-tags {
-        .title-and-category {
-          flex-wrap: nowrap;
-          gap: 0.5em;
-
-          .tags-input {
-            max-width: 50%;
-            flex: 1 1 auto;
-          }
-        }
-
-        .title-input {
-          max-width: 50%;
-          min-width: 0;
-
-          input {
-            min-width: 0;
-          }
-        }
+  &.private-message {
+    .with-tags {
+      .user-selector {
+        max-width: calc(50% - 4px);
       }
+    }
 
-      #private-message-users,
-      .users-input {
-        width: 100%;
-        flex: 0 0 auto;
+    .user-selector + .tags-input {
+      width: auto;
+      max-width: calc(50% - 4px);
+    }
 
-        &.can-warn {
-          // space for warning, inverse of mini-tag-chooser width
-          width: 60%;
-        }
-      }
-
-      .add-warning {
-        flex: 1 1 auto;
-        overflow: hidden;
-
-        span {
-          // protects the space of the user input in case there's a very long translation
-          @include ellipsis;
-        }
-      }
+    #private-message-users,
+    .users-input {
+      width: 100%;
+      flex: 0 0 auto;
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2895,7 +2895,7 @@ en:
       whisper: "whisper"
       unlist: "unlisted"
 
-      add_warning: "This is an official warning."
+      send_warning: "Send an official warning to user"
       toggle_whisper: "Toggle whisper"
       insert_table: "Insert table"
       posting_not_on_topic: "Which topic do you want to reply to?"
@@ -3057,6 +3057,9 @@ en:
         reply: Reply
         draft: Draft
         edit: Edit
+        toggle_official_warning:
+          label: Send Official Warning
+          desc: Create new message as an official warning to a user
         reply_to_post:
           label: Reply to a post by %{postUsername}
           desc: Reply to a specific post

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/bot-replies.scss
@@ -29,8 +29,7 @@ nav.post-controls .actions button.cancel-streaming {
   }
 
   #reply-control .composer-fields {
-    .mini-tag-chooser,
-    .add-warning {
+    .mini-tag-chooser {
       display: none;
     }
   }


### PR DESCRIPTION
This makes the composing a PM and a normal topic more consistent as the
title input will always get 100% of the width of the composing area.
