### PR TITLE
FIX: Horizon topic activity username sometimes blank

### DIFF
--- a/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -4,11 +4,28 @@ import formatDate from "discourse/helpers/format-date";
 
 export default class TopicActivityColumn extends Component {
   get topicUser() {
+    const bumpedLastPostedDaysDiff = moment
+      .duration(
+        moment(this.args.topic.bumped_at).diff(
+          moment(this.args.topic.last_posted_at)
+        )
+      )
+      .asDays();
+
+    // If the bumped + last posted at are close together,
+    // then we assume someone is editing shortly after posting,
+    // in which case we should just show the last poster/first poster
+    // as normal.
+    //
+    // In other cases, it's likely an edit or a topic bump that happened
+    // a while after the last post, so we show no user.
     if (
-      moment(this.args.topic.bumped_at).isAfter(this.args.topic.last_posted_at)
+      moment(this.args.topic.bumped_at).isAfter(
+        this.args.topic.last_posted_at
+      ) &&
+      bumpedLastPostedDaysDiff > 1
     ) {
       return {
-        user: undefined,
         username: undefined,
         class: "--updated",
       };
@@ -16,13 +33,11 @@ export default class TopicActivityColumn extends Component {
 
     if (this.args.topic.posts_count > 1) {
       return {
-        user: this.args.topic.lastPosterUser,
         username: this.args.topic.last_poster_username,
         class: "--replied",
       };
     } else if (this.args.topic.posts_count === 1) {
       return {
-        user: this.args.topic.firstPosterUser,
         username: this.args.topic.last_poster_username,
         class: "--created",
       };

--- a/themes/horizon/test/acceptance/topic-activity-column-test.gjs
+++ b/themes/horizon/test/acceptance/topic-activity-column-test.gjs
@@ -1,0 +1,66 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Topic from "discourse/models/topic";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import TopicActivityColumn from "../../discourse/components/card/topic-activity-column";
+
+module(
+  "Horizon | Integration | Component | Card | TopicActivityColumn",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("formats the bumpedAt date", async function (assert) {
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-01T12:00:00Z",
+      });
+      await render(
+        <template><TopicActivityColumn @topic={{topic}} /></template>
+      );
+      assert.dom(".topic-activity__time").hasText("Jun 2024");
+    });
+
+    test("has the correct user details and class when there is only one post", async function (assert) {
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-01T12:00:00Z",
+        posts_count: 1,
+        last_poster_username: "bob",
+      });
+      await render(
+        <template><TopicActivityColumn @topic={{topic}} /></template>
+      );
+      assert.dom(".topic-activity.--created").exists();
+      assert.dom(".topic-activity__username").hasText("bob");
+    });
+
+    test("has the correct user details and class when there are multiple posts", async function (assert) {
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-01T12:00:00Z",
+        posts_count: 3,
+        last_poster_username: "alice",
+      });
+      await render(
+        <template><TopicActivityColumn @topic={{topic}} /></template>
+      );
+      assert.dom(".topic-activity.--replied").exists();
+      assert.dom(".topic-activity__username").hasText("alice");
+    });
+
+    test("shows no user and the updated class when the topic was bumped long after the last post", async function (assert) {
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-10T12:00:00Z",
+        last_posted_at: "2024-06-01T12:00:00Z",
+        posts_count: 3,
+        last_poster_username: "alice",
+      });
+      await render(
+        <template><TopicActivityColumn @topic={{topic}} /></template>
+      );
+      assert.dom(".topic-activity.--updated").exists();
+      assert.dom(".topic-activity__username").doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
For these steps:

* In Horizon, create a topic.
* You’ll notice that the topic card has the OP name.
* Make an edit to the OP after the edit grace period.

You would see no username under the topic title. This is because
we were saying that if the topic bump date was after the last post
date, then we should never show any edit details.

However this didn't handle the common case of posting then editing
soon after.

Now in this commit, if the difference is < 1 day, we still show
the same username.

A proper fix would be to know the bumped_at_user then we can tell
if the user is the same as the last poster, but that is more complex
to do.
