### PR TITLE
FIX: Correct user deletion wording

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7925,7 +7925,7 @@ en:
 
         merging_user: "Merging user…"
         merge_failed: "There was an error while merging the users."
-        delete_forbidden_because_staff: "Admins and moderators can't be deleted."
+        delete_forbidden_because_staff: "Admins can't be deleted."
         delete_posts_forbidden_because_staff: "Can't delete all posts of admins and moderators."
         delete_forbidden:
           one: "Users can't be deleted if they have posts. Delete all posts before trying to delete a user. (Posts older than %{count} day old can't be deleted.)"


### PR DESCRIPTION
This fixes the wording when attempting to delete an admin user to say that only admins cannot be deleted, without mentioning moderators. This means the wording will now reflect the actual behaviour.