### PR TITLE
FIX: Do not directly import `admin` module from main app

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -14,11 +14,13 @@ import {
   CATEGORY_TEXT_COLORS,
 } from "discourse/lib/constants";
 import getURL from "discourse/lib/get-url";
+import { optionalRequire } from "discourse/lib/utilities";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
-import ColorInput from "admin/components/color-input";
 import CategoryChooser from "select-kit/components/category-chooser";
 import ColorPicker from "./color-picker";
+
+const ColorInput = optionalRequire("admin/components/color-input");
 
 export default class EditCategoryGeneral extends Component {
   @service site;


### PR DESCRIPTION
This import will fail for non-admin users. Most of the time this isn't causing a problem, since `edit-category-general` isn't imported by non-admin logic. However, if a theme imports or calls `modifyClass` on it, this import will be evaluated and fail.

This was affecting an initializer in the discourse-air theme for non-admin users. However, the automatic error recovery for theme initializers caught it, so the only impact was a console log.