### PR TITLE
FIX: display a generic message when email is auth'ed without a provider

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -268,15 +268,21 @@ export default class SignupPageController extends Controller {
       );
     }
 
-    if (this.authOptions?.email === email && this.authOptions?.email_valid) {
-      return EmberObject.create({
-        ok: true,
-        reason: i18n("user.email.authenticated", {
-          provider: this.authProviderDisplayName(
-            this.authOptions?.auth_provider
-          ),
-        }),
-      });
+    if (
+      this.authOptions?.email === email &&
+      this.authOptions?.email_valid &&
+      !isEmpty(this.authOptions?.auth_provider)
+    ) {
+      const provider = this.authProviderDisplayName(
+        this.authOptions.auth_provider
+      );
+
+      if (!isEmpty(provider)) {
+        return EmberObject.create({
+          ok: true,
+          reason: i18n("user.email.authenticated", { provider }),
+        });
+      }
     }
 
     return EmberObject.create({
@@ -345,11 +351,12 @@ export default class SignupPageController extends Controller {
     );
   }
 
-  authProviderDisplayName(providerName) {
-    const matchingProvider = findAll().find((provider) => {
-      return provider.name === providerName;
-    });
-    return matchingProvider ? matchingProvider.get("prettyName") : providerName;
+  authProviderDisplayName(name) {
+    return (
+      findAll()
+        .find((p) => p.name === name)
+        ?.get("prettyName") || name
+    );
   }
 
   @observes("emailValidation", "accountEmail")


### PR DESCRIPTION
In some rare instance the provider of the "authOptions" might not be set correctly. Instead of showing an string like "authenticated by [missing %{provider value}]" we show a generic "ok" message.

Internal ref - /t/154880/58