### PR TITLE
FIX: Ensure ember version in cache key is coupled to compiler

### DIFF
--- a/app/assets/javascripts/theme-transpiler/transpiler.js
+++ b/app/assets/javascripts/theme-transpiler/transpiler.js
@@ -3,8 +3,13 @@ import "./postcss";
 import "./theme-rollup";
 import { transform as babelTransform } from "@babel/standalone";
 import DecoratorTransforms from "decorator-transforms";
+import EMBER_PACKAGE from "ember-source/package.json";
 import { minify as terserMinify } from "terser";
 import { browsers } from "../discourse/config/targets";
+
+globalThis.emberVersion = function () {
+  return EMBER_PACKAGE.version;
+};
 
 globalThis.transpile = function (source, options = {}) {
   const { moduleId, filename, skipModule, generateMap } = options;

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 98
+  BASE_COMPILER_VERSION = 99
   CORE_THEMES = { "foundation" => -1, "horizon" => -2 }
   EDITABLE_SYSTEM_ATTRIBUTES = %w[
     child_theme_ids
@@ -244,7 +244,7 @@ class Theme < ActiveRecord::Base
     get_set_cache "compiler_version" do
       dependencies = [
         BASE_COMPILER_VERSION,
-        EmberCli.ember_version,
+        DiscourseJsProcessor::Transpiler.new.ember_version,
         GlobalSetting.cdn_url,
         GlobalSetting.s3_cdn_url,
         GlobalSetting.s3_endpoint,

--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -168,5 +168,9 @@ class DiscourseJsProcessor
         fetch_result_call: "getPostCssResult",
       )
     end
+
+    def ember_version
+      self.class.v8_call("emberVersion")
+    end
   end
 end

--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -38,17 +38,6 @@ class EmberCli < ActiveSupport::CurrentAttributes
     assets.include?(name) || script_chunks.values.flatten.include?(name.delete_suffix(".js"))
   end
 
-  def self.ember_version
-    @version ||=
-      begin
-        ember_source_package_raw =
-          File.read(
-            "#{Rails.root}/app/assets/javascripts/discourse/node_modules/ember-source/package.json",
-          )
-        JSON.parse(ember_source_package_raw)["version"]
-      end
-  end
-
   def self.has_tests?
     File.exist?("#{dist_dir}/tests/index.html")
   end

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -318,4 +318,8 @@ RSpec.describe DiscourseJsProcessor do
 
     expect(result["code"]).not_to include("../components/my-component")
   end
+
+  it "returns the ember version" do
+    expect(DiscourseJsProcessor::Transpiler.new.ember_version).to match(/\A\d+\.\d+\.\d+\z/)
+  end
 end

--- a/spec/lib/ember_cli_spec.rb
+++ b/spec/lib/ember_cli_spec.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 describe EmberCli do
-  describe ".ember_version" do
-    it "works" do
-      expect(EmberCli.ember_version).to match(/\A\d+\.\d+/)
-    end
-  end
-
   describe "cache" do
     after { EmberCli.clear_cache! }
 


### PR DESCRIPTION
During in-container updates, the old version of the application continues running while an update is applied. That means that it's possible for the `node_modules/ember-source` version to be different to the version currently loaded in the transpiler. That means it's theoretically possible for theme assets to be built with the old compiler, and then stored against the new version.

This commit removes that race condition by adding an `ember_version` method to the JS transpiler. This is guaranteed to give us an accurate version number for the template-compiler currently being used for themes.

This commit also bumps the BASE_COMPILER_VERSION to force a recompile on any sites affected by this race condition.