### PR TITLE
UX: only remove paragaph padding in banner if it's the last child

### DIFF
--- a/app/assets/stylesheets/common/components/banner.scss
+++ b/app/assets/stylesheets/common/components/banner.scss
@@ -47,7 +47,7 @@
     margin-top: 0;
   }
 
-  > p:last-of-type {
+  > p:last-child {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
Using `last-of-type` means the margin is removed from the last paragraph, even if there are other elements that fall at the end of the banner... so we lose some needed space here:

<img width="977" height="258" alt="image" src="https://github.com/user-attachments/assets/48195d9f-37b7-4a36-8ea6-96849d248b1e" />

if we use `last-child` it will ensure the `p` is actually the last node, so space is retained 

<img width="973" height="269" alt="image" src="https://github.com/user-attachments/assets/763975d3-d184-4c22-ad8b-393aac9b5ee4" />

