### PR TITLE
FIX: reset category styles for ancestor recursion

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -35,6 +35,9 @@ export function addExtraIconRenderer(renderer) {
     @param {Number}  [opts.depth] Current category depth, used for limiting recursive calls
     @param {Boolean} [opts.previewColor] If true, category color will be set as an inline style.
     @param {Array}   [opts.ancestors] The ancestors of the category to generate the badge for.
+    @param {String}  [opts.styleType] Badge style, either "icon", "emoji" or "square" (default).
+    @param {String}  [opts.emoji] The emoji to use for the badge (if styleType is "emoji").
+    @param {String}  [opts.icon] The icon to use for the badge (if styleType is "icon").
 **/
 export function categoryBadgeHTML(category, opts) {
   const { site, siteSettings } = helperContext();
@@ -62,10 +65,14 @@ export function categoryBadgeHTML(category, opts) {
   const depth = (opts.depth || 1) + 1;
   if (opts.ancestors) {
     const { ancestors, ...otherOpts } = opts;
+
+    // allow each ancestor to use its own styles
+    ["styleType", "icon", "emoji"].forEach((k) => delete otherOpts[k]);
+
     return [category, ...ancestors]
       .reverse()
       .map((c) => {
-        return categoryBadgeHTML(c, { ...otherOpts, styleType: null });
+        return categoryBadgeHTML(c, { ...otherOpts });
       })
       .join("");
   } else if (opts.recursive && depth <= siteSettings.max_category_nesting) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -196,7 +196,7 @@ module("Unit | Utility | category-badge", function (hooks) {
 
     const badge = categoryBadgeHTML(emojiChild, { ancestors: [emojiParent] });
 
-    assert.true(badge.includes("d-icon-book"), "has parent with icon style");
-    assert.true(badge.includes("d-icon-file"), "has child with file style");
+    assert.true(badge.includes("d-icon-book"), "has parent with book icon");
+    assert.true(badge.includes("d-icon-file"), "has child with file icon");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -150,4 +150,53 @@ module("Unit | Utility | category-badge", function (hooks) {
     assert.true(categoryBadgeHTML(baz, { recursive: true }).includes("bar"));
     assert.true(categoryBadgeHTML(baz, { recursive: true }).includes("foo"));
   });
+
+  test("category style types", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const category = store.createRecord("category", { name: "hello", id: 123 });
+
+    assert.true(
+      categoryBadgeHTML(category).includes("--style-square"),
+      "has square style by default"
+    );
+
+    assert.true(
+      categoryBadgeHTML(category, {
+        styleType: "icon",
+        icon: "book",
+      }).includes("--style-icon"),
+      "has icon style"
+    );
+
+    assert.true(
+      categoryBadgeHTML(category, {
+        styleType: "emoji",
+        emoji: "wave",
+      }).includes("--style-emoji"),
+      "has emoji style"
+    );
+  });
+
+  test("category style with ancestors", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+
+    const emojiParent = store.createRecord("category", {
+      name: "hello",
+      id: 123,
+      style_type: "icon",
+      icon: "book",
+    });
+    const emojiChild = store.createRecord("category", {
+      name: "world",
+      id: 456,
+      style_type: "icon",
+      icon: "file",
+      parent_category_id: emojiParent.id,
+    });
+
+    const badge = categoryBadgeHTML(emojiChild, { ancestors: [emojiParent] });
+
+    assert.true(badge.includes("d-icon-book"), "has parent with icon style");
+    assert.true(badge.includes("d-icon-file"), "has child with file style");
+  });
 });


### PR DESCRIPTION
When both parent and child categories had the same style type, the icon and emoji values would leak from the child to the parent when generating the category badge html. When processing categories recursively in this way we should unset these values to ensure they are taken from the ancestor category directly rather than from an option.

### Before

<img width="459" height="81" alt="Screenshot 2025-09-03 at 3 30 39 PM" src="https://github.com/user-attachments/assets/476b10ed-b9f9-4d84-bae2-6cd0dfbbf507" />


### After

<img width="461" height="73" alt="Screenshot 2025-09-03 at 3 30 24 PM" src="https://github.com/user-attachments/assets/55960899-f0db-43d1-9831-c6087c42349e" />
