### PR TITLE
Spike: expose bypass_bump param on PUT /posts/:id

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -279,6 +279,14 @@ class PostsController < ApplicationController
       opts[:skip_validations] = true
     end
 
+    # Allow API clients to skip bumping the topic when updating a post.
+    # Accept either ?bypass_bump=true or post[bypass_bump]=true
+    if params.key?(:bypass_bump) || (params[:post] && params[:post].key?(:bypass_bump))
+      opts[:bypass_bump] = ActiveModel::Type::Boolean.new.cast(
+        params[:bypass_bump].presence || params.dig(:post, :bypass_bump)
+      )
+    end
+
     topic = post.topic
     topic = Topic.with_deleted.find(post.topic_id) if guardian.is_staff?
 


### PR DESCRIPTION
This PR adds an optional `bypass_bump` parameter to the post update API and
plumbs it through to `PostRevisor`.

**Use case**
Automated integrations (e.g., ICS → Discourse sync) often need to update
content or tags without bumping the topic. An explicit flag makes this
deterministic, without relying on heuristics.

**Behavior**
- `bypass_bump=true` can be sent as a top-level param or nested under `post[bypass_bump]`.
- If omitted, behavior is unchanged.
- Only affects whether the topic’s `bumped_at` is updated.

**Status**
Opening as a spike for discussion. I’m aware of PR #34681 which changes
bumping semantics more broadly; this PR demonstrates an explicit alternative
for API clients.
