### PR TITLE
DEV: Fix a rare bug where topic scrolls to OP unexpectedly

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1831,13 +1831,16 @@ export default class TopicController extends Controller {
     }
 
     const postStream = this.get("model.postStream");
+    const currentPostNumber = topic.get("currentPost");
+    const opts =
+      currentPostNumber > 1 ? { post_number: currentPostNumber } : {};
 
     if (data.reload_topic) {
-      topic.reload().then(() => {
-        this.send("postChangedRoute", topic.get("post_number") || 1);
+      topic.reload(opts).then(() => {
         this.appEvents.trigger("header:update-topic", topic);
         if (data.refresh_stream) {
-          postStream.refresh();
+          this.send("postChangedRoute", currentPostNumber || 1);
+          postStream.refresh({ nearPost: currentPostNumber });
         }
       });
 

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -327,7 +327,9 @@ export default class PostStream extends RestModel {
   **/
   refresh(opts) {
     opts = opts || {};
-    opts.nearPost = parseInt(opts.nearPost, 10);
+    if (opts.nearPost) {
+      opts.nearPost = parseInt(opts.nearPost, 10);
+    }
 
     if (opts.cancelFilter) {
       this.cancelFilter();

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -823,10 +823,14 @@ export default class Topic extends RestModel {
     return this;
   }
 
-  reload() {
-    return ajax(`/t/${this.id}`, { type: "GET" }).then((topic_json) =>
-      this.updateFromJson(topic_json)
-    );
+  reload(opts = {}) {
+    const url = opts.post_number
+      ? `/t/${this.id}?post_number=${opts.post_number}`
+      : `/t/${this.id}`;
+
+    return ajax(url, { type: "GET" }).then((topic_json) => {
+      this.updateFromJson(topic_json);
+    });
   }
 
   clearPin() {


### PR DESCRIPTION
Repro steps:
- enable the assign plugin
- check the `unassigned on close` and `reassign on open` site settings
- assign a topic with more than 5 posts to a user
- view the topic and scroll to post #3 or more
- close the topic
- open the topic
- repeat a few times (behaviour can be inconsistent)

Expected: topic reloads without scrolling away from the current post.

Current behaviour: topic scrolls to OP.

Why? The assign plugin passes `reload_topic: true, refresh_stream: true` via MessageBus. On the frontend code though, when we reload the topic we did not pass the `post_number` to the request, and therefore the current position was lost. Restoring that fixes the issues.

More broadly, I am not sure we should be triggering `refresh_stream=true` from MessageBus. It feels unnecessary. Worth investigating further.