### PR TITLE
UX: Polish for topic list controls

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-select-toggle.gjs
+++ b/app/assets/javascripts/discourse/app/components/bulk-select-toggle.gjs
@@ -4,6 +4,7 @@ const BulkSelectToggle = <template>
   <DButton
     class="btn-default bulk-select"
     @action={{@bulkSelectHelper.toggleBulkSelect}}
+    @title="topics.bulk.select"
     @icon="list"
   />
 </template>;

--- a/app/assets/javascripts/discourse/app/components/d-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.gjs
@@ -311,7 +311,16 @@ export default class DNavigation extends Component {
         {{#if this.showToggleInfo}}
           <DButton
             @icon={{if this.currentUser.canEditTags "wrench" "circle-info"}}
-            @ariaLabel="tagging.info"
+            @ariaLabel={{if
+              this.currentUser.canEditTags
+              "tagging.edit"
+              "tagging.info"
+            }}
+            @title={{if
+              this.currentUser.canEditTags
+              "tagging.edit"
+              "tagging.info"
+            }}
             @action={{this.toggleInfo}}
             id="show-tag-info"
             class="btn-default"

--- a/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
+++ b/app/assets/javascripts/discourse/app/components/notifications-tracking.gjs
@@ -48,6 +48,7 @@ class NotificationsTrackingTrigger extends Component {
         "btn btn-default"
         (if this.showFullTitle "btn-icon-text" "no-text")
       }}
+      title={{i18n "user.preferences_nav.tracking"}}
       ...attributes
     >
       {{icon @selectedLevel.icon}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5065,7 +5065,7 @@ en:
         one: "Its synonym will also be deleted."
         other: "Its %{count} synonyms will also be deleted."
       edit_tag: "Edit tag name and description"
-      edit: "Edit tag"
+      edit: "Edit this tag"
       description: "Description (max 1000 characters)"
       sort_by: "Sort by:"
       sort_by_count: "count"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5034,7 +5034,7 @@ en:
       choose_for_topic_required_group:
         one: "select %{count} tag from '%{name}'…"
         other: "select %{count} tags from '%{name}'…"
-      info: "Info"
+      info: "Show tag info"
       default_info: "This tag isn't restricted to any categories, and has no synonyms."
       staff_info: "To add restrictions, put this tag in a <a href=%{basePath}/tag_groups>tag group</a>."
       category_restricted: "This tag is restricted to categories you don't have permission to access."
@@ -5065,6 +5065,7 @@ en:
         one: "Its synonym will also be deleted."
         other: "Its %{count} synonyms will also be deleted."
       edit_tag: "Edit tag name and description"
+      edit: "Edit tag"
       description: "Description (max 1000 characters)"
       sort_by: "Sort by:"
       sort_by_count: "count"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3445,6 +3445,7 @@ en:
     topics:
       new_messages_marker: "last visit"
       bulk:
+        select: "Bulk select"
         confirm: "Confirm"
         select_all: "Select All"
         clear_all: "Clear All"

--- a/themes/horizon/scss/hiddenstuff.scss
+++ b/themes/horizon/scss/hiddenstuff.scss
@@ -1,5 +1,5 @@
 .sidebar__panel-switch-button,
-.list-controls #create-topic,
+.list-controls .fk-d-button-tooltip:has(#create-topic),
 .notifications-button-footer .reason .text,
 .pinned-button .reason .text,
 .more-topics__browse-more {


### PR DESCRIPTION
## What is this change?

Some small polish.

### Add title texts for topic list controls:

<img width="147" height="68" alt="Screenshot 2025-09-04 at 10 31 28 AM" src="https://github.com/user-attachments/assets/2a279320-8323-45d6-8ebd-aa7f7174ca8d" />
<img width="154" height="74" alt="Screenshot 2025-09-04 at 10 29 12 AM" src="https://github.com/user-attachments/assets/2bdb4107-308c-4df7-93c5-a60704696a28" />
<img width="177" height="71" alt="Screenshot 2025-09-04 at 10 29 19 AM" src="https://github.com/user-attachments/assets/bad933d4-5f00-49f4-9905-877c6c737f9c" />

### Remove extra space between topic list controls in Horizon:

**Before:**

<img width="158" height="60" alt="Screenshot 2025-09-04 at 10 28 15 AM" src="https://github.com/user-attachments/assets/a8f4d333-9850-4460-95d9-4f159b212d7e" />

**After:**

<img width="166" height="67" alt="Screenshot 2025-09-04 at 10 22 48 AM" src="https://github.com/user-attachments/assets/8c9619ac-ad8e-4d2f-bfaa-a6efe79df3bc" />

  