### PR TITLE
DEV: Add configurable limit for page param in TopicQuery

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3641,10 +3641,16 @@ uncategorized:
   overridden_robots_txt:
     default: ""
     hidden: true
+
   show_category_definitions_in_topic_lists:
     default: false
     hidden: true
     client: true
+
+  max_topic_query_page_param:
+    default: 2000
+    min: 100
+    hidden: true
 
   create_revision_on_bulk_topic_moves:
     default: true

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -16,13 +16,15 @@ class TopicQuery
       begin
         int = lambda { |x| Integer === x || (String === x && x.match?(/\A-?[0-9]+\z/)) }
         zero_up_to_max_int = lambda { |x| int.call(x) && x.to_i.between?(0, PG_MAX_INT) }
+        zero_up_to_max_page =
+          lambda { |x| int.call(x) && x.to_i.between?(0, SiteSetting.max_topic_query_page_param) }
         one_up_to_one_hundred = lambda { |x| int.call(x) && x.to_i.between?(1, 100) }
         array_or_string = lambda { |x| Array === x || String === x }
         string = lambda { |x| String === x }
         true_or_false = lambda { |x| x == true || x == false || x == "true" || x == "false" }
 
         {
-          page: zero_up_to_max_int,
+          page: zero_up_to_max_page,
           per_page: one_up_to_one_hundred,
           before: zero_up_to_max_int,
           bumped_before: zero_up_to_max_int,

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -105,6 +105,22 @@ RSpec.describe TopicQuery do
         expect(TopicQuery.validate?(:per_page, "10")).to eq(true)
       end
     end
+
+    describe "page" do
+      it "respects SiteSetting.max_topic_query_page_param" do
+        SiteSetting.max_topic_query_page_param = 100
+
+        # Invalid values
+        expect(TopicQuery.validate?(:page, -1)).to eq(false)
+        expect(TopicQuery.validate?(:page, 101)).to eq(false)
+
+        # Valid values
+        expect(TopicQuery.validate?(:page, 0)).to eq(true)
+        expect(TopicQuery.validate?(:page, 1)).to eq(true)
+        expect(TopicQuery.validate?(:page, 100)).to eq(true)
+        expect(TopicQuery.validate?(:page, "10")).to eq(true)
+      end
+    end
   end
 
   describe "#list_topics_by" do


### PR DESCRIPTION
Prevents pathological issues with crawlers querying topic lists with very large page parameters. The new limit also allows us to tweak this under specific instances or circumstances (high traffic, for example).

A `page` parameter above the limit will through an `InvalidParameters` 400 error. 