### PR TITLE
FIX: can not click any reaction on ios

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker/content.gjs
@@ -168,9 +168,7 @@ export default class EmojiPicker extends Component {
 
   @action
   focusFilter(target) {
-    if (
-      this.capabilities.isIOS
-    ) {
+    if (this.capabilities.isIOS) {
       return;
     }
 


### PR DESCRIPTION
Prevents a bug on iOS which would cause some unexpected scroll and ultimately close the modal preventing the use of any reaction.