### PR TITLE
UX: glimmerize CreateTopicButton, make btnType class variable for Horizon

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -1,36 +1,35 @@
-/* eslint-disable ember/no-classic-components */
-import Component from "@ember/component";
-import { tagName } from "@ember-decorators/component";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import DButton from "discourse/components/d-button";
 import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
+import concatClass from "discourse/helpers/concat-class";
 import { i18n } from "discourse-i18n";
 import DButtonTooltip from "float-kit/components/d-button-tooltip";
 import DTooltip from "float-kit/components/d-tooltip";
 
-@tagName("")
 export default class CreateTopicButton extends Component {
+  @tracked btnTypeClass = this.args.btnTypeClass || "btn-default";
   label = "topic.create";
-  btnClass = "btn-default";
 
   get disallowedReason() {
-    if (this.canCreateTopicOnTag === false) {
+    if (this.args.canCreateTopicOnTag === false) {
       return "topic.create_disabled_tag";
-    } else if (this.disabled) {
+    } else if (this.args.disabled) {
       return "topic.create_disabled_category";
     }
   }
 
   <template>
-    {{#if this.canCreateTopic}}
+    {{#if @canCreateTopic}}
       <DButtonTooltip>
         <:button>
           <DButton
-            @action={{this.action}}
+            @action={{@action}}
             @icon="far-pen-to-square"
-            @disabled={{this.disabled}}
+            @disabled={{@disabled}}
             @label={{this.label}}
             id="create-topic"
-            class={{this.btnClass}}
+            class={{concatClass @btnClass this.btnTypeClass}}
           />
         </:button>
         <:tooltip>
@@ -44,7 +43,10 @@ export default class CreateTopicButton extends Component {
       </DButtonTooltip>
 
       {{#if @showDrafts}}
-        <TopicDraftsDropdown @disabled={{false}} />
+        <TopicDraftsDropdown
+          @disabled={{false}}
+          @btnTypeClass={{this.btnTypeClass}}
+        />
       {{/if}}
     {{/if}}
   </template>

--- a/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-drafts-dropdown.gjs
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
+import concatClass from "discourse/helpers/concat-class";
 import DiscourseURL from "discourse/lib/url";
 import {
   NEW_PRIVATE_MESSAGE_KEY,
@@ -105,7 +106,7 @@ export default class TopicDraftsDropdown extends Component {
       @onRegisterApi={{this.onRegisterApi}}
       @modalForMobile={{true}}
       @disabled={{@disabled}}
-      class="btn-small btn-default"
+      class={{concatClass "btn-small" @btnTypeClass}}
     >
       <:content>
         <DropdownMenu as |dropdown|>

--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -59,7 +59,7 @@ export default class SidebarNewTopicButton extends Component {
   }
 
   get createTopicClass() {
-    const baseClasses = "btn-default sidebar-new-topic-button";
+    const baseClasses = "sidebar-new-topic-button";
     return this.categoryReadOnlyBanner
       ? `${baseClasses} disabled`
       : baseClasses;
@@ -107,6 +107,7 @@ export default class SidebarNewTopicButton extends Component {
           @disabled={{this.createTopicDisabled}}
           @label="topic.create"
           @btnClass={{this.createTopicClass}}
+          @btnTypeClass="btn-primary"
           @canCreateTopicOnTag={{not this.tagRestricted}}
           @showDrafts={{gt this.draftCount 0}}
         />

--- a/themes/horizon/scss/buttons.scss
+++ b/themes/horizon/scss/buttons.scss
@@ -13,23 +13,6 @@
         var(--d-button-border-radius);
     }
   }
-
-  .topic-drafts-menu-trigger.btn.no-text {
-    background: var(--accent-color);
-
-    &:hover,
-    &:focus-visible {
-      background: light-dark(
-        oklch(from var(--accent-color) 40% c h),
-        oklch(from var(--accent-color) 50% c h)
-      ) !important;
-      box-shadow: none;
-    }
-
-    .d-icon {
-      color: var(--accent-text-color);
-    }
-  }
 }
 
 .discourse-no-touch .dropdown-menu__item .btn {
@@ -78,7 +61,6 @@
 }
 
 .btn-primary,
-#create-topic.btn,
 .discourse-no-touch .btn-default.ai-new-question-button {
   background-color: var(--accent-color);
   color: var(--accent-text-color);


### PR DESCRIPTION
The Horizon theme was overriding `btn-default` styles for the new topic button in the sidebar with custom CSS to achieve `btn-primary` styles. Ideally we should be able to swap out the class and rely on that! 

<img width="299" height="258" alt="image" src="https://github.com/user-attachments/assets/3485fb0b-4714-49ce-9ac4-7e1ac6fb358b" />

So here I

 1. Convert CreateTopicButton to Glimmer component 
  2. Add `@btnTypeClass` param - Allows parent components to specify the button type
  (`btn-primary`, `btn-default`, etc.)
  3. Separate concerns:
    * `@btnClass` handles general class name needs (and existing use) 
    * `@btnTypeClass` handles core visual style
