### PR TITLE
UX: minor improvements to the admin email log layout

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/email-logs-sent.gjs
+++ b/app/assets/javascripts/admin/addon/templates/email-logs-sent.gjs
@@ -62,8 +62,6 @@ export default RouteTemplate(
               <span class="email-logs-user">
                 <LinkTo @route="adminUser" @model={{emailLog.user}}>
                   {{avatar emailLog.user imageSize="tiny"}}
-                </LinkTo>
-                <LinkTo @route="adminUser" @model={{emailLog.user}}>
                   {{emailLog.user.username}}
                 </LinkTo>
               </span>

--- a/app/assets/stylesheets/admin/emails.scss
+++ b/app/assets/stylesheets/admin/emails.scss
@@ -74,6 +74,16 @@
       color: var(--primary-high);
     }
   }
+
+  td {
+    max-width: 20em;
+    overflow-wrap: break-word;
+  }
+
+  .incoming-email-link,
+  .sent-email-post-link-with-smtp-response {
+    min-width: 19em;
+  }
 }
 
 .incoming-emails {


### PR DESCRIPTION
Some minor improvements to the table layout

Giving long columns a little min width...

Before:
<img width="186" height="209" alt="image" src="https://github.com/user-attachments/assets/d129b567-40e5-4d0c-a55b-d2252440f5e7" />

After:
<img width="332" height="291" alt="image" src="https://github.com/user-attachments/assets/3b205942-ae31-4f45-ba91-9fab999c0267" />

Putting user info within a single link...

Before:
<img width="327" height="199" alt="image" src="https://github.com/user-attachments/assets/54ece2d2-1ac5-4b9f-891a-dc62ea7a93b2" />


After: 
<img width="334" height="160" alt="image" src="https://github.com/user-attachments/assets/ba1dd821-c9f9-4846-8c9f-a4c592923d33" />
