### PR TITLE
DEV: Add support for table-level constraints

### DIFF
--- a/migrations/config/json_schemas/db_schema.json
+++ b/migrations/config/json_schemas/db_schema.json
@@ -178,6 +178,29 @@
               },
               "copy_of": {
                 "type": "string"
+              },
+              "constraints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [ "check" ]
+                    },
+                    "condition": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "condition"
+                  ]
+                }
               }
             },
             "additionalProperties": false

--- a/migrations/lib/database/schema.rb
+++ b/migrations/lib/database/schema.rb
@@ -3,13 +3,14 @@
 module Migrations::Database
   module Schema
     Table =
-      Data.define(:name, :columns, :indexes, :primary_key_column_names) do
+      Data.define(:name, :columns, :indexes, :primary_key_column_names, :constraints) do
         def sorted_columns
           columns.sort_by { |c| [c.is_primary_key ? 0 : 1, c.name] }
         end
       end
     Column = Data.define(:name, :datatype, :nullable, :max_length, :is_primary_key)
     Index = Data.define(:name, :column_names, :unique, :condition)
+    Constraint = Data.define(:name, :type, :condition)
 
     class ConfigError < StandardError
     end

--- a/migrations/lib/database/schema/loader.rb
+++ b/migrations/lib/database/schema/loader.rb
@@ -51,7 +51,13 @@ module Migrations::Database::Schema
           )
         end + added_columns(config, primary_key_column_names)
 
-      Table.new(table_alias || table_name, columns, indexes(config), primary_key_column_names)
+      Table.new(
+        table_alias || table_name,
+        columns,
+        indexes(config),
+        primary_key_column_names,
+        constraints(config),
+      )
     end
 
     def filtered_columns_of(table_name, config)
@@ -119,6 +125,16 @@ module Migrations::Database::Schema
           column_names: Array.wrap(index[:columns]),
           unique: index.fetch(:unique, false),
           condition: index[:condition],
+        )
+      end
+    end
+
+    def constraints(config)
+      config[:constraints]&.map do |constraint|
+        Constraint.new(
+          name: constraint[:name],
+          type: constraint.fetch(:type, :check).to_sym,
+          condition: constraint[:condition],
         )
       end
     end


### PR DESCRIPTION
Allow table-level check constraints in the Intermediate DB


In https://github.com/discourse/discourse/pull/34339, I’ve worked on distinguishing between `user_custom_fields` tied to  `user_fields` and arbitrary `user_custom_fields` entries.

To support this, I’ve made both `field_id` and `name` nullable, which requires a table-level constraint to ensure each entry has either a `field_id` (referencing `user_fields`) or an arbitrary `name` for the value.

This first pass supports only named  table-level `CHECK` constraints.

## Usage

```yaml
user_custom_fields:
      columns:
        exclude:
          - "id"
        modify:
          - name: "name"
            nullable: true
        add:
          - name: "field_id"
            datatype: numeric
          - name: "is_multiselect_field"
            datatype: boolean
      indexes:
      # ...
      constraints:
        - name: "require_field_id_or_name"
          condition: "field_id IS NOT NULL OR name IS NOT NULL"
        - name: "disallow_both_field_id_and_name"
          type: check      # default, only `check` supported for now
          condition: "NOT (field_id IS NOT NULL AND name IS NOT NULL)"
```



```sql
CREATE TABLE user_custom_fields
(
    created_at           DATETIME,
    field_id             NUMERIC,
    is_multiselect_field BOOLEAN,
    name                 TEXT,
    user_id              NUMERIC  NOT NULL,
    value                TEXT,
    CONSTRAINT require_field_id_or_name CHECK (field_id IS NOT NULL OR name IS NOT NULL),
    CONSTRAINT disallow_both_field_id_and_name CHECK (NOT (field_id IS NOT NULL AND name IS NOT NULL))
);
```