### PR TITLE
DEV: Update `PageObjects::Components::FormKit#submit` to click submit

### DIFF
--- a/spec/system/admin_about_config_area_spec.rb
+++ b/spec/system/admin_about_config_area_spec.rb
@@ -105,7 +105,8 @@ describe "Admin About Config Area Page", type: :system do
       expect(config_area.general_settings_section.banner_image_uploader).to have_uploaded_image
 
       config_area.general_settings_section.banner_image_uploader.toggle_lightbox_preview
-      expect(config_area.general_settings_section.banner_image_uploader).to have_lighbox_preview
+      expect(config_area.general_settings_section.banner_image_uploader).to have_lightbox_preview
+      config_area.general_settings_section.banner_image_uploader.close_lightbox_preview
 
       config_area.general_settings_section.submit
 

--- a/spec/system/page_objects/components/form_kit.rb
+++ b/spec/system/page_objects/components/form_kit.rb
@@ -202,10 +202,7 @@ module PageObjects
       end
 
       def submit
-        page.execute_script(
-          "var form = arguments[0]; form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));",
-          find(component),
-        )
+        find("#{component} button[type='submit']").click
       end
 
       def reset

--- a/spec/system/page_objects/components/uppy_image_uploader.rb
+++ b/spec/system/page_objects/components/uppy_image_uploader.rb
@@ -39,7 +39,11 @@ module PageObjects
         @element.find(".image-uploader-lightbox-btn").click
       end
 
-      def has_lighbox_preview?
+      def close_lightbox_preview
+        find(".mfp-close").click
+      end
+
+      def has_lightbox_preview?
         has_css?(".mfp-container")
       end
     end


### PR DESCRIPTION
I don't see a good reason why we should be executing a script to submit
a form when we can just click the submit button.
