### PR TITLE
DEV: Fix flaky system test

### DIFF
--- a/spec/system/admin_customize_components_config_area_spec.rb
+++ b/spec/system/admin_customize_components_config_area_spec.rb
@@ -326,7 +326,7 @@ describe "Admin Customize Themes Config Area Page", type: :system do
       Fabricate.times(4, :theme, component: true)
 
       stub_const(Admin::Config::CustomizeController, "PAGE_SIZE", 4) do
-        resize_window(height: 800) do
+        resize_window(height: 400) do
           config_area.visit
 
           expect(config_area).to have_exactly_n_components(4)


### PR DESCRIPTION
This commit fixes the flaky "Admin Customize Themes Config Area Page when there are components installed loads more components when scrolling to the bottom"
system test by reducing the height of the window to totally prevent infinite
loading from triggering until we scroll.
