### PR TITLE
DEV: Skip flaky d-assign spec

### DIFF
--- a/plugins/discourse-assign/spec/system/assign_topic_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_topic_spec.rb
@@ -154,6 +154,7 @@ describe "Assign | Assigning topics", type: :system do
             before { SiteSetting.reassign_on_open = true }
 
             it "reassigns the topic on open" do
+              skip_on_ci!("Flaky test - reassigning topic on open")
               visit "/t/#{topic.id}"
 
               topic_page.click_assign_topic

--- a/plugins/spoiler-alert/spec/system/composer_spoiler_spec.rb
+++ b/plugins/spoiler-alert/spec/system/composer_spoiler_spec.rb
@@ -165,6 +165,7 @@ describe "Composer - ProseMirror editor - Spoiler extension", type: :system do
   end
 
   it "breaks out of inline spoiler when pressing Enter" do
+    skip_on_ci!("Flaky test - breaking out of inline spoiler when pressing Enter")
     open_composer
 
     composer.type_content("Test ")


### PR DESCRIPTION
This test appears to be flaky. Specifically the last expect.

Follow up to: #34734
