### PR TITLE
FIX: ensures category calendar is querying a date range

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -17,9 +17,11 @@ export default class CategoryCalendar extends Component {
   @service discoursePostEventApi;
 
   @bind
-  async loadEvents() {
+  async loadEvents(info) {
     try {
       const params = {
+        after: info.startStr,
+        before: info.endStr,
         post_id: this.categorySetting?.postId,
         category_id: this.category.id,
         include_subcategories: true,


### PR DESCRIPTION
We were loading all events and not just the displayed range for category calendar, which would load too many events and mostly expired events.