### PR TITLE
FIX: Define the typical AFL Grand Final date.

### DIFF
--- a/plugins/discourse-calendar/vendor/holidays/definitions/au.yaml
+++ b/plugins/discourse-calendar/vendor/holidays/definitions/au.yaml
@@ -180,21 +180,22 @@ months:
 
 methods:
   afl_grand_final:
+    # The AFL Grand Final is typically held on the last Saturday in September.
+    # Starting 2015, the day before the Grand Final is observed as a public holiday in Victoria.
+    # Some years are exceptions, these are defined manually.
     arguments: year
     ruby: |
       case year
+      when year < 2015
+        nil
       when 2015
         Date.civil(2015, 10, 2)
       when 2016
         Date.civil(2016, 9, 30)
-      when 2017
-        Date.civil(2017, 9, 29)
-      when 2018
-        Date.civil(2018, 9, 28)
-      when 2019
-        Date.civil(2019,9, 27)
       when 2020
         Date.civil(2020, 10, 23)
+      else
+        Date.civil(year, 9, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 9, :last, :saturday) - 1)
       end
   qld_queens_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates

--- a/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/au.rb
+++ b/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/au.rb
@@ -61,18 +61,16 @@ module Holidays
       {
           "afl_grand_final(year)" => Proc.new { |year|
 case year
+when year < 2015
+  nil
 when 2015
   Date.civil(2015, 10, 2)
 when 2016
   Date.civil(2016, 9, 30)
-when 2017
-  Date.civil(2017, 9, 29)
-when 2018
-  Date.civil(2018, 9, 28)
-when 2019
-  Date.civil(2019,9, 27)
 when 2020
   Date.civil(2020, 10, 23)
+else
+  Date.civil(year, 9, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 9, :last, :saturday) - 1)
 end
 },
 


### PR DESCRIPTION
## ✨ What's This?

The AFL Grand Final is typically help on the last Saturday of September, though there are occasional exceptions. Since 2015, the Friday before the Grand Final is a public holiday in Victoria, Australia.

This change defines the typical date for the public holiday, but allows exceptions to be defined where necessary.

Source: https://en.wikipedia.org/wiki/List_of_VFL/AFL_premiers#List_of_premiers