### PR TITLE
UX: use more specific language for dynamic polls

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -114,7 +114,7 @@ div.poll-outer {
 
       @include viewport.from(sm) {
         gap: 0 1em;
-        padding: 1em;
+        padding: var(--space-2);
         border-left: 1px solid var(--content-border-color);
         flex-direction: column;
         justify-content: center;

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -7,7 +7,7 @@ en:
   js:
     poll:
       dynamic:
-        enabled_hint: "This poll is dynamic. Options can be edited after posting."
+        enabled_hint: "Options can be added or removed."
       voters:
         one: "voter"
         other: "voters"
@@ -164,7 +164,7 @@ en:
         poll_public:
           label: Show who voted
         poll_dynamic:
-          label: Allow editing options after posting (dynamic poll)
+          label: Allow options to be added or removed after posting
         poll_title:
           label: Title (optional)
         poll_options:

--- a/plugins/poll/config/locales/server.en.yml
+++ b/plugins/poll/config/locales/server.en.yml
@@ -45,7 +45,7 @@ en:
       cannot_edit_default_poll_with_votes: "You cannot change a poll after the first %{minutes} minutes."
       cannot_edit_named_poll_with_votes: "You cannot change the poll named <strong>${name}</strong> after the first %{minutes} minutes."
     dynamic_poll:
-      enabled_hint: "This poll is dynamic. Options can be edited after posting."
+      enabled_hint: "Options can be added or removed."
 
     no_poll_with_this_name: "No poll named <strong>%{name}</strong> associated with this post."
 


### PR DESCRIPTION
"Editing" can be a little misleading, because we technically only allow adding/removing — if you edit an existing option the votes are reset. 

This shortens the text by removing the "dynamic poll" text (seems self-explanatory without naming it), and also specifies adding/removing


Before:
<img width="1252" height="878" alt="image" src="https://github.com/user-attachments/assets/c583fa91-5b06-476e-b220-d9d86026e0de" />
<img width="1160" height="856" alt="image" src="https://github.com/user-attachments/assets/16314712-71e2-4590-8093-b837b194fc32" />


After: 
<img width="1170" height="826" alt="image" src="https://github.com/user-attachments/assets/8725a789-c2dd-44e0-8881-7b31871a4e58" />
<img width="1162" height="1012" alt="image" src="https://github.com/user-attachments/assets/7ebacfee-1785-4d6f-8bca-73025db9a924" />


I also reduced padding to the poll info slightly to give text a little more space before wrapping. 