### PR TITLE
DEV: refactor `groupNotificationsButton` to no longer rely on empty div

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
@@ -19,10 +19,6 @@ export default class extends Controller {
     return this.#linkText("unread");
   }
 
-  get navigationControlsButton() {
-    return document.getElementById("navigation-controls__button");
-  }
-
   #linkText(type) {
     const count = this.pmTopicTrackingState?.lookupCount(type, {
       inboxFilter: "group",

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages-group.js
@@ -1,5 +1,4 @@
 import Controller, { inject as controller } from "@ember/controller";
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { i18n } from "discourse-i18n";
 
@@ -30,10 +29,5 @@ export default class extends Controller {
     } else {
       return i18n(`user.messages.${type}_with_count`, { count });
     }
-  }
-
-  @action
-  changeGroupNotificationLevel(notificationLevel) {
-    this.group.setNotification(notificationLevel, this.get("user.model.id"));
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -145,4 +145,9 @@ export default class extends Controller {
   onMessagesDropdownChange(item) {
     return DiscourseURL.routeTo(item);
   }
+
+  @action
+  changeGroupNotificationLevel(notificationLevel) {
+    this.group?.setNotification(notificationLevel, this.currentUser.id);
+  }
 }

--- a/app/assets/javascripts/discourse/app/templates/user-private-messages-group.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user-private-messages-group.gjs
@@ -1,6 +1,5 @@
 import RouteTemplate from "ember-route-template";
 import DNavigationItem from "discourse/components/d-navigation-item";
-import GroupNotificationsTracking from "discourse/components/group-notifications-tracking";
 import MessagesSecondaryNav from "discourse/components/user-nav/messages-secondary-nav";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -47,13 +46,6 @@ export default RouteTemplate(
         </DNavigationItem>
       {{/if}}
     </MessagesSecondaryNav>
-
-    {{#in-element @controller.navigationControlsButton}}
-      <GroupNotificationsTracking
-        @levelId={{@controller.group.group_user.notification_level}}
-        @onChange={{@controller.changeGroupNotificationLevel}}
-      />
-    {{/in-element}}
 
     <div class="group-messages group-{{@controller.group.name}}">
       {{outlet}}

--- a/app/assets/javascripts/discourse/app/templates/user/messages.gjs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.gjs
@@ -1,6 +1,7 @@
 import RouteTemplate from "ember-route-template";
 import BulkSelectToggle from "discourse/components/bulk-select-toggle";
 import DButton from "discourse/components/d-button";
+import GroupNotificationsTracking from "discourse/components/group-notifications-tracking";
 import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import MessagesDropdown from "discourse/components/user-nav/messages-dropdown";
@@ -43,7 +44,12 @@ export default RouteTemplate(
           {{/if}}
         {{/if}}
 
-        <span id="navigation-controls__button"></span>
+        {{#if @controller.isGroup}}
+          <GroupNotificationsTracking
+            @levelId={{@controller.group.group_user.notification_level}}
+            @onChange={{@controller.changeGroupNotificationLevel}}
+          />
+        {{/if}}
 
         {{#if @controller.showNewPM}}
           <DButton

--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -136,10 +136,6 @@
       @include viewport.until(xl) {
         font-size: var(--font-down-1);
       }
-
-      span {
-        display: inline-flex;
-      }
     }
 
     .nav-pills {


### PR DESCRIPTION
This undoes an older refactor that introduced an empty div for use with `in-element` to improve the group inbox loading experience (https://github.com/discourse/discourse/pull/21930)

The empty span being always present isn't ideal, because this causes additional space to be included when the `gap` property is used to space elements within a flex or grid container. 

Large space caused by use of `gap` when empty div is present: 
<img width="603" height="130" alt="image" src="https://github.com/user-attachments/assets/78948e4b-0e7d-4ade-b6ab-b78bcc150fc8" />

Additionally, our loading experience is different than it used to be (compare to the videos in https://github.com/discourse/discourse/pull/21930... we no longer show the spinner) — *and* we hide the text for the dropdown button, so there's much less jankiness to avoid when the notification button is added: 



https://github.com/user-attachments/assets/b25fb53f-725f-4ee0-beaa-64f8aed9d3c1

