### PR TITLE
UX: remove margin from navigation-controls children in favor of gap

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -19,14 +19,10 @@
   flex-wrap: wrap;
   align-items: stretch;
   margin-bottom: var(--nav-space);
-  gap: var(--nav-space) 0; // used if the buttons wrap
+  gap: var(--nav-space) 0.5em;
 
   > * {
     white-space: nowrap;
-
-    &:not(:last-child) {
-      margin-right: var(--space-2);
-    }
   }
 
   .select-kit-header {

--- a/app/assets/stylesheets/common/components/drafts-dropdown-menu.scss
+++ b/app/assets/stylesheets/common/components/drafts-dropdown-menu.scss
@@ -1,6 +1,6 @@
 // Styles for the drafts dropdown menu
 .topic-drafts-menu-trigger {
-  margin-left: -0.3em;
+  margin-left: -0.25em;
 }
 
 .topic-drafts-menu-content {

--- a/themes/horizon/scss/mobile-stuff.scss
+++ b/themes/horizon/scss/mobile-stuff.scss
@@ -85,12 +85,6 @@
           margin-bottom: 0;
         }
       }
-
-      .navigation-controls {
-        @include viewport.until(sm) {
-          gap: var(--space-2);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Concerns this section of the nav:


![Untitled 4](https://github.com/user-attachments/assets/95317bfa-7ae2-443d-8184-50810a5b571b)

This switches the margin between buttons to `gap` which is more predictable and avoids situations where an extension might need to add its own margin, like this:

<img width="242" height="59" alt="image" src="https://github.com/user-attachments/assets/fb8155de-6b3d-43e6-a0e8-af61c5a5555f" />

After this change:

<img width="258" height="65" alt="image" src="https://github.com/user-attachments/assets/ebd77447-d9cb-4333-b6ab-2d2c8156c876" />

Ideally shouldn't be merged until https://github.com/discourse/discourse/pull/34770 is, because the empty div removed in that PR causes too much space when `gap` is utilized 