### PR TITLE
FIX: Ensure base_path is correctly inserted into LLM triage messages.

### DIFF
--- a/plugins/discourse-ai/lib/automation/llm_triage.rb
+++ b/plugins/discourse-ai/lib/automation/llm_triage.rb
@@ -135,7 +135,10 @@ module DiscourseAi
           if flag_post
             score_reason =
               I18n
-                .t("discourse_automation.scriptables.llm_triage.flagged_post")
+                .t(
+                  "discourse_automation.scriptables.llm_triage.flagged_post",
+                  base_path: Discourse.base_path,
+                )
                 .sub("%%LLM_RESPONSE%%", result)
                 .sub("%%AUTOMATION_ID%%", automation&.id.to_s)
                 .sub("%%AUTOMATION_NAME%%", automation&.name.to_s)


### PR DESCRIPTION
## ✨ What's This?

When the LLM Triage automation script causes a post to be placed in the review queue, it includes a message linking to the rule responsible.

The string for this message included a placeholder for `base_path`, but didn't interpolate it in the `i18n` call.