### PR TITLE
FIX: check if _cardClickListenerSelectors selector exists before adding listener

### DIFF
--- a/app/assets/javascripts/discourse/app/components/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/components/card-contents-base.js
@@ -112,7 +112,7 @@ export default class CardContentsBase extends Component {
     _cardClickListenerSelectors.forEach((selector) => {
       document
         .querySelector(selector)
-        .addEventListener("click", this._cardClickHandler);
+        ?.addEventListener("click", this._cardClickHandler);
     });
 
     this.appEvents.on(
@@ -279,7 +279,7 @@ export default class CardContentsBase extends Component {
     _cardClickListenerSelectors.forEach((selector) => {
       document
         .querySelector(selector)
-        .removeEventListener("click", this._cardClickHandler);
+        ?.removeEventListener("click", this._cardClickHandler);
     });
 
     this.appEvents.off(


### PR DESCRIPTION
There's an error that happens when there's a required user field on an existing account, 

```
Uncaught TypeError: can't access property "addEventListener", document.querySelector(...) is null
    didInsertElement card-contents-base.js:114
    didInsertElement card-contents-base.js:112
```

This should help avoid it 