### PR TITLE
FIX: Add a debounce lock to the show reply button to avoid showing replies multiple times.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/replies.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/replies.gjs
@@ -5,6 +5,7 @@ import { and, not } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import { tracked } from "@glimmer/tracking";
 
 export default class PostMenuRepliesButton extends Component {
   static extraControls = true;
@@ -25,8 +26,12 @@ export default class PostMenuRepliesButton extends Component {
 
   @service site;
 
+  // Processing lock, so repeated clicks are ignored
+  @tracked _isProcessing = false;
+
   get disabled() {
-    return !!this.args.post.deleted;
+    // while processing a toggle, disable the button to avoid duplicate clicks
+    return !!this.args.post.deleted || this._isProcessing;
   }
 
   get translatedTitle() {
@@ -41,12 +46,68 @@ export default class PostMenuRepliesButton extends Component {
         });
   }
 
+  // Wait until this.args.state.repliesShown changes from `initial`.
+  // The lock will be released when the UI actually updates.
+  _waitForRepliesShownChange(initial) {
+    return new Promise((resolve) => {
+      const check = () => {
+        const current = this.args.state && this.args.state.repliesShown;
+        if (current !== initial) {
+          resolve();
+        } else {
+          this._pollTimer = setTimeout(check, 30);
+        }
+      };
+      check();
+    }).finally(() => {
+      if (this._pollTimer) {
+        clearTimeout(this._pollTimer);
+        this._pollTimer = null;
+      }
+    });
+  }
+
+  // Sets a lock, calls the original action, and only releases
+  // the lock after the repliesShown state actually changes.
+  _debouncedToggle = async () => {
+    if (this._isProcessing) {
+      return;
+    }
+
+    const toggle =
+      this.args.buttonActions && this.args.buttonActions.toggleReplies;
+    if (typeof toggle !== "function") {
+      return;
+    }
+
+    const initialRepliesShown =
+      (this.args.state && this.args.state.repliesShown) ?? null;
+
+    this._isProcessing = true;
+
+    try {
+      const result = toggle();
+
+      // If the action returns a Promise, wait for it too, but still require the state change.
+      const actionPromise =
+        result && typeof result.then === "function" ? result : null;
+
+      if (actionPromise) {
+        await Promise.all([actionPromise, this._waitForRepliesShownChange(initialRepliesShown)]);
+      } else {
+        await this._waitForRepliesShownChange(initialRepliesShown);
+      }
+    } finally {
+      this._isProcessing = false;
+    }
+  };
+
   <template>
     <DButton
       class="post-action-menu__show-replies show-replies btn-icon-text"
       ...attributes
       disabled={{this.disabled}}
-      @action={{@buttonActions.toggleReplies}}
+      @action={{this._debouncedToggle}}
       @ariaControls={{concat "embedded-posts__bottom--" @post.post_number}}
       @ariaExpanded={{and @state.repliesShown (not @state.filteredRepliesView)}}
       @ariaPressed={{unless @state.filteredRepliesView @state.repliesShown}}


### PR DESCRIPTION
For these steps:

Create a topic, add a post and another multiple posts using reply button to the post.
A `x Reply(Repies) button will show at the end of a post.

When you click it multiple times instantly, there will be duplicate replies under the post (seen from the attached video, I clicked the button more than three times in less than 1 sec).

https://github.com/user-attachments/assets/cc314399-8087-4252-be79-184adc533de4

The issue is related to the bounce of js script, which works multiple times, to add more than one reply to the list.

Now in this commit, we add a debounce lock. When the button is clicked, a lock will be added to prevent further clicks, until the status changes, so as to work as a mitigation for the issue.
