### PR TITLE
UX: more consistent use of d-hover in menus

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -334,7 +334,7 @@
         background: none;
 
         .d-icon {
-          background-color: var(--d-sidebar-highlight-background);
+          background-color: var(--d-hover);
         }
       }
     }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -32,7 +32,7 @@
   --d-sidebar-suffix-color: var(--tertiary-med-or-tertiary);
 
   // highlight applies to both hover and focus states
-  --d-sidebar-highlight-background: var(--primary-low);
+  --d-sidebar-highlight-background: var(--d-hover);
   --d-sidebar-highlight-color: var(--primary-high);
   --d-sidebar-highlight-prefix-background: var(--primary-300);
   --d-sidebar-highlight-prefix-color: var(--d-sidebar-highlight-color);


### PR DESCRIPTION
We have some inconsistent use of hover colors in the sidebar and user menu dropdown... this cleans it up a bit by using our `d-hover` color


Before (note the sidebar hover, menu item, and tab item... they're all slightly different): 
<img width="1880" height="622" alt="image" src="https://github.com/user-attachments/assets/3c7d589f-d307-4927-9622-cee42bc768e4" />


After:
<img width="1882" height="1064" alt="image" src="https://github.com/user-attachments/assets/e0d82467-51fe-4862-9b64-7dd682c9d74f" />



