### PR TITLE
UX: control event display through a site setting

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -136,7 +136,6 @@ export default class CategoryCalendar extends Component {
       return {
         title: formatEventName(event, this.currentUser?.user_option?.timezone),
         start: startsAt,
-        display: "list-item",
         rrule: event.rrule,
         end: endsAt || startsAt,
         duration: event.duration,

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -62,6 +62,7 @@ export default class FullCalendar extends Component {
 
     this.calendar = new calendarModule.Calendar(element, {
       locale: getCurrentBcp47Locale(),
+      eventDisplay: this.siteSettings.calendar_event_display ?? "auto",
       buttonText: getCalendarButtonsText(),
       timeZone: this.currentUser?.user_option?.timezone || "local",
       firstDay: this.firstDayOfWeek,

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -24,6 +24,14 @@ discourse_calendar:
     list_type: simple
     client: true
     default: ""
+  calendar_event_display:
+    client: true
+    default: "auto"
+    type: enum
+    choices:
+      - auto
+      - block
+      - list-item
   calendar_categories_outlet:
     client: true
     default: "discovery-list-container-top"

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -504,4 +504,36 @@ describe "Upcoming Events", type: :system do
       end
     end
   end
+
+  describe "with calendar_event_display setting", time: Time.utc(2025, 6, 2, 19, 00) do
+    before do
+      create_post(
+        user: admin,
+        category: Fabricate(:category),
+        title: "This is a short meeting",
+        raw:
+          "[event recurrence=\"every_week\" start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+      )
+    end
+
+    context "with block" do
+      before { SiteSetting.calendar_event_display = "block" }
+
+      it "renders block" do
+        visit("/upcoming-events/month/2025/9/16")
+
+        expect(page).to have_selector(".fc-daygrid-block-event")
+      end
+    end
+
+    context "with auto" do
+      before { SiteSetting.calendar_event_display = "auto" }
+
+      it "renders dot" do
+        visit("/upcoming-events/month/2025/9/16")
+
+        expect(page).to have_selector(".fc-daygrid-dot-event")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows admins to set the `calendar_event_display` site setting to decide how full-calendar should render events.

It accepts the following values:
- auto
- block
- list-item

And will default to: auto