### PR TITLE
FIX: ensures quick reactions usage shows in frequently

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";
-import { concat, fn } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
@@ -640,7 +640,7 @@ export default class ChatMessage extends Component {
 
                       {{#if this.shouldRenderOpenEmojiPickerButton}}
                         <EmojiPicker
-                          @context={{concat "channel_" @message.channel.id}}
+                          @context="chat"
                           @didSelectEmoji={{this.messageInteractor.selectReaction}}
                           @btnClass="btn-flat react-btn chat-message-react-btn"
                           @onClose={{this.onEmojiPickerClose}}

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -334,6 +334,9 @@ export default class ChatemojiReactions {
         emoji,
         reactAction
       )
+      .then(() => {
+        this.emojiStore.trackEmojiForContext(emoji, "chat");
+      })
       .catch((errResult) => {
         popupAjaxError(errResult);
         this.message.react(

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -142,6 +142,16 @@ module PageObjects
         within(message_reactions_list(message)) { return find("[data-emoji-name=\"#{emoji}\"]") }
       end
 
+      def click_quick_reaction(message, emoji_name)
+        hover_message(message)
+        find(".chat-message-actions [data-emoji-name=\"#{emoji_name}\"]").click
+      end
+
+      def open_emoji_picker(message)
+        hover_message(message)
+        find(".chat-message-react-btn").click
+      end
+
       def find_quick_reaction(emoji_name)
         find(".chat-message-actions [data-emoji-name=\"#{emoji_name}\"]")
       end

--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -233,4 +233,18 @@ RSpec.describe "React to message", type: :system do
       end
     end
   end
+
+  context "when using one click reaction" do
+    before { current_user.user_option.update!(chat_quick_reactions_custom: "tada|smiley") }
+
+    it "appears in frequently used" do
+      sign_in(current_user)
+      chat.visit_channel(category_channel_1)
+
+      channel.click_quick_reaction(message_1, "tada")
+      channel.open_emoji_picker(message_1)
+
+      expect(page).to have_selector(".emoji-picker [data-emoji=\"tada\"]")
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change we would have different context for quick reactions and for channels this commit just move everything into one context which is less surprising.