### PR TITLE
PERF: do not fetch thread data when we have it

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
@@ -215,8 +215,13 @@ export default class ChatChannelSubscriptionManager {
 
   handleNewThreadCreated(data) {
     this.channel.threadsManager
-      .find(this.channel.id, data.thread_id, { fetchIfNotFound: true })
+      .find(this.channel.id, data.thread_id, { fetchIfNotFound: false })
       .then((thread) => {
+        thread ??= this.channel.threadsManager.add(
+          this.channel,
+          data.chat_message.thread
+        );
+
         const channelOriginalMessage = this.channel.messagesManager.findMessage(
           thread.originalMessage.id
         );

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-threads-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-threads-manager.js
@@ -61,7 +61,7 @@ export default class ChatThreadsManager {
     if (existingThread) {
       return Promise.resolve(existingThread);
     } else if (options.fetchIfNotFound) {
-      return this.#fetchFromServer(channelId, threadId);
+      return await this.#fetchFromServer(channelId, threadId);
     } else {
       return Promise.resolve();
     }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -30,7 +30,7 @@ export default class ChatChannelsManager extends Service {
     if (existingChannel) {
       return Promise.resolve(existingChannel);
     } else if (options.fetchIfNotFound) {
-      return this.#find(id);
+      return await this.#find(id);
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
Prior to this fix we would fetch thread data even if it was present in the bus data, that's already unnecessary work in a normal situation but that's even worse when a user is coming back to their computer as we will have to catchup multiple new threads at once.

Also ensures we correctly await fetching data from server when necessary.

No test as there are not behavior change.