### PR TITLE
FIX: ensures event serializer has tags info

### DIFF
--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -24,6 +24,14 @@ module DiscoursePostEvent
         id: object.post.id,
         post_number: object.post.post_number,
         url: object.post.url,
+        category_slug:
+          (
+            if object.post.topic && object.post.topic.category
+              object.post.topic.category.slug_for_url
+            else
+              ""
+            end
+          ),
         topic: TopicListItemSerializer.new(object.post.topic, scope:, root: false).as_json,
       }
     end

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -24,10 +24,7 @@ module DiscoursePostEvent
         id: object.post.id,
         post_number: object.post.post_number,
         url: object.post.url,
-        topic: {
-          id: object.post.topic.id,
-          title: object.post.topic.title,
-        },
+        topic: TopicListItemSerializer.new(object.post.topic, scope:, root: false).as_json,
       }
     end
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -122,7 +122,7 @@ export default class CategoryCalendar extends Component {
       if (!backgroundColor) {
         const categoryColorFromMap = this.tagsColorsMap.find(
           (entry) =>
-            entry.type === "category" && entry.slug === post.topic.category_slug
+            entry.type === "category" && entry.slug === post.category_slug
         )?.color;
         backgroundColor =
           categoryColorFromMap || `#${Category.findById(categoryId)?.color}`;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -75,7 +75,7 @@ export default class UpcomingEventsCalendar extends Component {
       if (!backgroundColor) {
         const categoryColorEntry = tagsColorsMap.find(
           (entry) =>
-            entry.type === "category" && entry.slug === post.topic.category_slug
+            entry.type === "category" && entry.slug === post.category_slug
         );
         backgroundColor = categoryColorEntry?.color;
       }

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -683,7 +683,11 @@ describe DiscoursePostEvent::Event do
 
       it "basic serializer handles expired recurring events correctly" do
         serializer =
-          DiscoursePostEvent::BasicEventSerializer.new(expired_recurring_event, root: false)
+          DiscoursePostEvent::BasicEventSerializer.new(
+            expired_recurring_event,
+            root: false,
+            scope: Guardian.new,
+          )
         json = JSON.parse(serializer.to_json)
 
         expect(json["starts_at"]).to be_nil

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -536,4 +536,47 @@ describe "Upcoming Events", type: :system do
       end
     end
   end
+
+  context "with tag color", time: Time.utc(2025, 6, 2, 19, 00) do
+    before do
+      SiteSetting.map_events_to_color = [
+        { type: "tag", color: "rgb(231, 76, 60)", slug: "awesome-tag" },
+      ].to_json
+
+      create_post(
+        user: admin,
+        category: Fabricate(:category),
+        topic: Fabricate(:topic, tags: [Fabricate(:tag, name: "awesome-tag")]),
+        title: "This is a short meeting",
+        raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+      )
+    end
+
+    it "display the event with the correct color" do
+      visit("/upcoming-events/month/2025/6/16")
+
+      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(231, 76, 60)")
+    end
+  end
+
+  context "with category color", time: Time.utc(2025, 6, 2, 19, 00) do
+    before do
+      SiteSetting.map_events_to_color = [
+        { type: "category", color: "rgb(140,24,193)", slug: "awesome-category" },
+      ].to_json
+
+      create_post(
+        user: admin,
+        category: Fabricate(:category, slug: "awesome-category"),
+        title: "This is a short meeting",
+        raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+      )
+    end
+
+    it "display the event with the correct color" do
+      visit("/upcoming-events/month/2025/6/16")
+
+      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(140,24,193)")
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -562,7 +562,7 @@ describe "Upcoming Events", type: :system do
   context "with category color", time: Time.utc(2025, 6, 2, 19, 00) do
     before do
       SiteSetting.map_events_to_color = [
-        { type: "category", color: "rgb(140,24,193)", slug: "awesome-category" },
+        { type: "category", color: "rgb(231, 76, 60)", slug: "awesome-category" },
       ].to_json
 
       create_post(
@@ -576,7 +576,7 @@ describe "Upcoming Events", type: :system do
     it "display the event with the correct color" do
       visit("/upcoming-events/month/2025/6/16")
 
-      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(140,24,193)")
+      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(231, 76, 60)")
     end
   end
 end

--- a/plugins/discourse-calendar/test/javascripts/acceptance/category-events-calendar-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/category-events-calendar-test.js
@@ -10,18 +10,6 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
     discourse_post_event_enabled: true,
     events_calendar_categories: "1",
     calendar_categories: "",
-    map_events_to_color: JSON.stringify([
-      {
-        type: "tag",
-        color: "rgb(231, 76, 60)",
-        slug: "awesome-tag",
-      },
-      {
-        type: "category",
-        color: "rgb(140,24,193)",
-        slug: "awesome-category",
-      },
-    ]),
   });
 
   needs.pretender((server, helper) => {
@@ -46,7 +34,6 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
               topic: {
                 id: 18449,
                 title: "This is an event",
-                tags: ["awesome-tag"],
               },
             },
             name: "Awesome Event",
@@ -70,7 +57,6 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
               topic: {
                 id: 18450,
                 title: "This is an event",
-                category_slug: "awesome-category",
               },
             },
             name: "Awesome Event 2",
@@ -93,7 +79,6 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
               topic: {
                 id: 18451,
                 title: "This is an event",
-                category_slug: "awesome-category",
               },
             },
             name: "Awesome Event 3<script>alert('my awesome event');</script>",
@@ -112,30 +97,6 @@ acceptance("Discourse Calendar - Category Events Calendar", function (needs) {
         "Awesome Event 3<script>alert('my awesome event');</script>",
         "Elements should be escaped and appear as text rather than be the actual element."
       );
-  });
-
-  test("events display the color configured in the map_events_to_color site setting", async function (assert) {
-    await visit("/c/bug/1");
-
-    assert
-      .dom(".fc-event")
-      .exists({ count: 4 }, "Events are displayed on the calendar");
-
-    assert
-      .dom(
-        ".fc-daygrid-event-harness a[href='/t/-/18449/1']  .fc-daygrid-event-dot"
-      )
-      .hasStyle({
-        "border-color": "rgb(231, 76, 60)",
-      });
-
-    assert
-      .dom(
-        ".fc-daygrid-event-harness a[href='/t/-/18450/1'] .fc-daygrid-event-dot"
-      )
-      .hasStyle({
-        "border-color": "rgb(140, 24, 193)",
-      });
   });
 
   test("shows event calendar on category page", async function (assert) {


### PR DESCRIPTION
This was preventing the `map_events_to_color` site setting to work correctly given we couldn't match on tag slug as it was not present.

This commit adds system specs and removes the js test as it was misleading and incorrectly passing due to the fixture which couldn't catch the issue in the serializer.