### PR TITLE
DEV: prevent pnpm to ask for update

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 engine-strict = true
 auto-install-peers = false
 ignore-workspace-cycles = true
+update-notifier = false


### PR DESCRIPTION
We set the version of `pnpm` in `package.json` so it's not desirable to prompt people for an update, even if updated it won't be used.

https://docs.npmjs.com/cli/v8/using-npm/config#update-notifier

https://github.com/pnpm/pnpm/pull/4285