### PR TITLE
FIX: AI usage doesn't refresh custom date ranges correctly

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-usage.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-usage.gjs
@@ -331,6 +331,16 @@ export default class AiUsage extends Component {
     this.startDate = this._startDate;
     this.endDate = this._endDate;
     this.fetchData();
+    this._startDate = null;
+    this._endDate = null;
+  }
+
+  get fromDate() {
+    return this._startDate || this.startDate;
+  }
+
+  get toDate() {
+    return this._endDate || this.endDate;
   }
 
   totalSpending(inputSpending, cachedSpending, outputSpending) {
@@ -370,8 +380,8 @@ export default class AiUsage extends Component {
             <div class="ai-usage__custom-date-pickers">
 
               <DateTimeInputRange
-                @from={{this.startDate}}
-                @to={{this.endDate}}
+                @from={{this.fromDate}}
+                @to={{this.toDate}}
                 @onChange={{this.onChangeDateRange}}
                 @showFromTime={{false}}
                 @showToTime={{false}}

--- a/plugins/discourse-ai/spec/system/ai_usage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_usage_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "AI Usage Admin Page", type: :system do
+  fab!(:admin)
+
+  before do
+    enable_current_plugin
+    sign_in(admin)
+  end
+
+  context "when using custom date range functionality" do
+    it "allows selecting custom date range without JavaScript errors" do
+      visit "/admin/plugins/discourse-ai/ai-usage"
+      expect(page).to have_css(".ai-usage")
+
+      # Click custom date button to show date picker
+      find(".ai-usage__period-buttons .btn-default:last-child").click
+      expect(page).to have_css(".ai-usage__custom-date-pickers")
+
+      # Set dates
+      date_inputs = all(".ai-usage__custom-date-pickers input[type='date']")
+      date_inputs[0].set("2025-07-01")
+      date_inputs[1].set("2025-07-31")
+
+      # Verify dates are set correctly (preview functionality)
+      expect(date_inputs[0].value).to eq("2025-07-01")
+      expect(date_inputs[1].value).to eq("2025-07-31")
+
+      # Click refresh - this used to cause visual glitches and date reversion
+      find(".ai-usage__custom-date-pickers .btn", text: I18n.t("js.refresh")).click
+
+      # Wait for any potential async operations
+      sleep(1)
+
+      expect(page).to have_css(".ai-usage__summary")
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/system/page_objects/pages/ai_usage.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/ai_usage.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AiUsage < PageObjects::Pages::Base
+      def visit
+        page.visit "/admin/plugins/discourse-ai/ai-usage"
+      end
+
+      def has_usage_content?
+        page.has_css?(".ai-usage")
+      end
+
+      def click_custom_date_button
+        find(".ai-usage__period-buttons .btn-default:last-child").click
+      end
+
+      def has_custom_date_picker?
+        page.has_css?(".ai-usage__custom-date-pickers")
+      end
+
+      def set_start_date(date_string)
+        # Find the first date input (from date)
+        date_inputs = all(".ai-usage__custom-date-pickers input[type='date']")
+        date_inputs[0].set(date_string)
+      end
+
+      def set_end_date(date_string)
+        # Find the second date input (to date)
+        date_inputs = all(".ai-usage__custom-date-pickers input[type='date']")
+        date_inputs[1].set(date_string)
+      end
+
+      def get_start_date_value
+        all(".ai-usage__custom-date-pickers input[type='date']")[0].value
+      end
+
+      def get_end_date_value
+        all(".ai-usage__custom-date-pickers input[type='date']")[1].value
+      end
+
+      def click_refresh
+        find(".ai-usage__custom-date-pickers .btn", text: I18n.t("js.refresh")).click
+      end
+
+      def has_loading_spinner?
+        page.has_css?(".conditional-loading-spinner .spinner")
+      end
+
+      def wait_for_data_load
+        # Wait for loading spinner to disappear
+        expect(page).not_to have_css(".conditional-loading-spinner .spinner", wait: 10)
+      end
+
+      def has_summary_data?
+        page.has_css?(".ai-usage__summary .d-stat-tiles")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## :mag: Overview 
Fixes custom date range functionality in AI usage admin page where:
  - Users experienced visual glitches when selecting dates
  - Date picker would show incorrect dates after refresh
  - Users had to refresh multiple times to get correct date range

  **Changes:**
  - Added fromDate/toDate getters with fallback logic for preview functionality
  - Updated DateTimeInputRange to use preview-aware getters
  - Clear temporary dates after refresh to prevent stale state
  - Added system test to prevent regression

  The date picker now immediately shows selected dates (preview) and
  maintains correct values after refresh, eliminating user confusion.

  This addresses the exact issue reported in [the meta topic](https://meta.discourse.org/t/discourse-ai-admin-usage-page-custom-date-range-issues/378959) and provides a clean solution with test coverage to prevent regression.