### PR TITLE
UX: fix user profile wrapping on smaller screens

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -430,15 +430,17 @@
     background: var(--primary);
     color: var(--secondary);
     display: flex;
+    flex-wrap: wrap;
     padding: 10px;
     margin-bottom: 16px;
+    gap: var(--space-2);
 
     > div,
     > div a {
       display: flex;
       align-items: baseline;
       flex: 0 1 auto;
-      margin: 0 10px 0 0;
+      margin: 0;
       color: var(--secondary);
 
       span {
@@ -1101,6 +1103,10 @@
   min-width: 0;
   word-break: break-word;
   max-width: 100%;
+
+  @include viewport.until(md) {
+    width: 100%;
+  }
 
   @include viewport.from(md) {
     margin-right: auto;


### PR DESCRIPTION
A couple follow-up fixes to 6a6ef122647e14d36f2a2be24431cdc1f19d46ed

Before:
<img width="379" height="461" alt="image" src="https://github.com/user-attachments/assets/959b425b-015b-42e6-8d71-cda9d89109c6" />


After:
<img width="764" height="1158" alt="image" src="https://github.com/user-attachments/assets/aab73020-89f5-4006-8ca0-852e698394ae" />
