### PR TITLE
UX: adds a start new dm link when no dms present

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -290,6 +290,15 @@ export default {
 
       api.addSidebarSection(
         (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+          const SidebarChatNewDirectMessagesSectionLink = class extends BaseCustomSidebarSectionLink {
+            route = "chat.new-message";
+            name = "new-chat-dm";
+            title = i18n("sidebar.start_new_dm.title");
+            text = i18n("sidebar.start_new_dm.text");
+            prefixType = "icon";
+            prefixValue = "plus";
+          };
+
           const SidebarChatDirectMessagesSectionLink = class extends BaseCustomSidebarSectionLink {
             route = "chat.channel";
             suffixType = "icon";
@@ -469,15 +478,29 @@ export default {
               );
             }
 
-            get sectionLinks() {
-              return this.chatChannelsManager.truncatedDirectMessageChannels.map(
-                (channel) =>
-                  new SidebarChatDirectMessagesSectionLink({
-                    channel,
-                    chatService: this.chatService,
-                    currentUser: this.currentUser,
-                  })
+            get hideSectionHeader() {
+              return (
+                this.chatChannelsManager.truncatedDirectMessageChannels
+                  .length === 0
               );
+            }
+
+            get sectionLinks() {
+              const channels =
+                this.chatChannelsManager.truncatedDirectMessageChannels;
+
+              if (channels.length > 0) {
+                return channels.map(
+                  (channel) =>
+                    new SidebarChatDirectMessagesSectionLink({
+                      channel,
+                      chatService: this.chatService,
+                      currentUser: this.currentUser,
+                    })
+                );
+              } else {
+                return [new SidebarChatNewDirectMessagesSectionLink()];
+              }
             }
 
             get name() {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-new-message.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-new-message.js
@@ -1,8 +1,10 @@
 import { service } from "@ember/service";
 import DiscourseRoute from "discourse/routes/discourse";
+import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
 
 export default class ChatNewMessageRoute extends DiscourseRoute {
   @service chat;
+  @service modal;
   @service router;
 
   beforeModel(transition) {
@@ -10,7 +12,8 @@ export default class ChatNewMessageRoute extends DiscourseRoute {
 
     if (!recipients) {
       transition.abort();
-      return this.router.transitionTo("chat");
+      this.modal.show(ChatModalNewMessage);
+      return;
     }
 
     this.chat.upsertDmChannel({ usernames: recipients }).then((channel) => {

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -290,3 +290,9 @@ html.has-full-page-chat {
     visibility: hidden;
   }
 }
+
+.sidebar-section-link-wrapper[data-list-item-name="new-chat-dm"] {
+  .prefix-icon {
+    color: var(--tertiary);
+  }
+}

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -775,6 +775,9 @@ en:
           title: Chat
 
     sidebar:
+      start_new_dm:
+        text: Start new DM
+        title: Create a personal chat
       panels:
         chat:
           label: "Chat"

--- a/plugins/chat/spec/system/list_channels/sidebar_spec.rb
+++ b/plugins/chat/spec/system/list_channels/sidebar_spec.rb
@@ -136,8 +136,8 @@ RSpec.describe "List channels | sidebar", type: :system do
   context "when no direct message channels" do
     before { visit("/") }
 
-    it "shows the section" do
-      expect(page).to have_css(".sidebar-section[data-section-name='chat-dms']")
+    it "shows the start new dm button" do
+      expect(page).to have_css(".sidebar-section[data-section-name='chat-dms'] .sidebar-section-link[data-link-name='new-chat-dm']")
     end
   end
 


### PR DESCRIPTION
Prior to this commit we would show the collapsible DMs section which has a [+] on hover to start a DM but it was not very nice visually and also had low affordance.

The new empty DMs state:

<img width="275" height="77" alt="Screenshot 2025-09-16 at 09 07 57" src="https://github.com/user-attachments/assets/99976dfd-44ec-40f8-a6d1-c0d15f550524" />
