### PR TITLE
FIX: Welcome banner: excludes all admin routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -74,7 +74,7 @@ export default class WelcomeBanner extends Component {
       case "all_pages":
         return (
           currentRouteName !== "full-page-search" &&
-          !currentRouteName.startsWith("admin.") &&
+          !currentRouteName.startsWith("admin") &&
           !ALL_PAGES_EXCLUDED_ROUTES.some(
             (routeName) => routeName === currentRouteName
           )

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -231,6 +231,12 @@ describe "Welcome banner", type: :system do
 
           visit "/admin"
           expect(banner).to be_hidden
+
+          visit "/admin/config/site-admin"
+          expect(banner).to be_hidden
+
+          visit "/admin/customize"
+          expect(banner).to be_hidden
         end
       end
 


### PR DESCRIPTION
Fixes the admin route name checking to include all admin routes.