### PR TITLE
FIX: Do not send empty content when detecting language

### DIFF
--- a/plugins/discourse-ai/lib/translation/language_detector.rb
+++ b/plugins/discourse-ai/lib/translation/language_detector.rb
@@ -13,6 +13,7 @@ module DiscourseAi
 
       def detect
         return nil if !SiteSetting.ai_translation_enabled
+        return nil if @text.blank?
         if (
              ai_persona = AiPersona.find_by(id: SiteSetting.ai_translation_locale_detector_persona)
            ).blank?

--- a/plugins/discourse-ai/lib/translation/post_locale_detector.rb
+++ b/plugins/discourse-ai/lib/translation/post_locale_detector.rb
@@ -7,8 +7,14 @@ module DiscourseAi
         return if post.blank?
 
         text = PostDetectionText.get_text(post)
-        detected_locale = LanguageDetector.new(text, post:).detect
-        locale = LocaleNormalizer.normalize_to_i18n(detected_locale)
+
+        if text.blank?
+          locale = SiteSetting.default_locale
+        else
+          detected_locale = LanguageDetector.new(text, post:).detect
+          locale = LocaleNormalizer.normalize_to_i18n(detected_locale)
+        end
+
         post.update_column(:locale, locale)
         locale
       end

--- a/plugins/discourse-ai/spec/lib/translation/language_detector_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/language_detector_spec.rb
@@ -54,5 +54,13 @@ describe DiscourseAi::Translation::LanguageDetector do
         locale_detector.detect
       end
     end
+
+    it "skips detection when provided blank text" do
+      blank_detector = described_class.new("    ")
+      allow(AiPersona).to receive(:find_by).and_call_original
+
+      expect(blank_detector.detect).to eq(nil)
+      expect(AiPersona).not_to have_received(:find_by)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/translation/post_locale_detector_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_locale_detector_spec.rb
@@ -25,6 +25,13 @@ describe DiscourseAi::Translation::PostLocaleDetector do
       )
     end
 
+    it "returns site default locale if post is empty" do
+      post.update_column(:cooked, "")
+      expect { described_class.detect_locale(post) }.to change { post.reload.locale }.from(nil).to(
+        "en",
+      )
+    end
+
     it "bypasses validations when updating locale" do
       post.update_column(:cooked, "A")
 


### PR DESCRIPTION
Seeing many errors about

```
DiscourseAi::Completions::Endpoints::Gemini: status: 400 - body: {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.contents: contents is not specified\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

This is triggered due to posts with images and no text.

The solution here is to set the locale to site default locale.