### PR TITLE
UX: apply htmlSafe to topic titles in bookmark notifications 

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/bookmark-item.js
@@ -1,3 +1,4 @@
+import { htmlSafe } from "@ember/template";
 import UserMenuBaseItem from "discourse/lib/user-menu/base-item";
 import { NO_REMINDER_ICON } from "discourse/models/bookmark";
 
@@ -32,7 +33,7 @@ export default class UserMenuBookmarkItem extends UserMenuBaseItem {
   }
 
   get description() {
-    return this.bookmark.fancy_title;
+    return htmlSafe(this.bookmark.fancy_title);
   }
 
   get topicId() {


### PR DESCRIPTION
Topic titles in bookmark notifications weren't getting html entities decoded 

Before:
<img width="147" alt="image" src="https://github.com/user-attachments/assets/79c68637-fddb-46cc-b6c7-f3db6f00cdf2" />


After:  
<img width="147" height="68" alt="image" src="https://github.com/user-attachments/assets/f911791a-a335-4180-a78c-4518532da240" />


