### PR TITLE
DEV: Convert `showSidebar` to a tracked property with getter and setter

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -18,11 +19,22 @@ export default class ApplicationController extends Controller {
   queryParams = [{ navigationMenuQueryParamOverride: "navigation_menu" }];
   showTop = true;
 
-  showSidebar = this.calculateShowSidebar();
   sidebarDisabledRouteOverride = false;
   navigationMenuQueryParamOverride = null;
   showSiteHeader = true;
   showSkipToContent = true;
+
+  @tracked _showSidebar;
+
+  // Some themes may need to override the default value provided by `calculateShowSidebar` using viewport properties.
+  // Accessing the value in a getter prevents static viewport initialization warnings.
+  get showSidebar() {
+    return this._showSidebar ?? this.calculateShowSidebar();
+  }
+
+  set showSidebar(value) {
+    this._showSidebar = value;
+  }
 
   get showFooter() {
     return this.footer.showFooter;


### PR DESCRIPTION
Refactor `showSidebar` in `application.js` to use a tracked property, allowing dynamic updates and configurable overrides. This supports themes that rely on viewport properties to adjust the sidebar's visibility.

Testing should be covered by existing tests, e.g: https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js