### PR TITLE
FIX: stop double encoding URLs when pasting via link UI

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/upsert-hyperlink.gjs
@@ -145,7 +145,15 @@ export default class UpsertHyperlink extends Component {
   @action
   onFormSubmit(data) {
     const origLink = data.linkUrl;
-    const linkUrl = encodeURI(prefixProtocol(origLink));
+    let linkUrl = prefixProtocol(origLink);
+
+    if (typeof linkUrl === "string") {
+      try {
+        linkUrl = encodeURI(decodeURI(linkUrl));
+      } catch {
+        linkUrl = encodeURI(linkUrl.replace(/%(?![0-9A-Fa-f]{2})/g, "%25"));
+      }
+    }
     const sel = this.args.model.toolbarEvent.selected;
 
     if (isEmpty(linkUrl)) {

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -1251,6 +1251,24 @@ describe "Composer - ProseMirror editor", type: :system do
       )
     end
 
+    it "preserves existing percent escapes when inserting a link" do
+      open_composer
+
+      composer.click_toolbar_button("link")
+
+      expect(upsert_hyperlink_modal).to be_open
+
+      upsert_hyperlink_modal.fill_in_link_text("Encoded URL")
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com/%20test")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css("a[href='https://example.com/%20test']", text: "Encoded URL")
+
+      composer.toggle_rich_editor
+
+      expect(composer).to have_value("[Encoded URL](https://example.com/%20test)")
+    end
+
     it "allows copying a link URL via toolbar" do
       cdp.allow_clipboard
       open_composer


### PR DESCRIPTION
Regressed in: a24107dd15588b10fd7fb1c06bcfafdfef0b6d0e
