### PR TITLE
FEATURE: disable chat DM threads by default

### DIFF
--- a/plugins/chat/app/models/chat/direct_message_channel.rb
+++ b/plugins/chat/app/models/chat/direct_message_channel.rb
@@ -4,8 +4,6 @@ module Chat
   class DirectMessageChannel < Channel
     alias_method :direct_message, :chatable
 
-    before_validation(on: :create) { self.threading_enabled = true }
-
     def direct_message_channel?
       true
     end

--- a/plugins/chat/spec/fabricators/chat_fabricator.rb
+++ b/plugins/chat/spec/fabricators/chat_fabricator.rb
@@ -44,7 +44,6 @@ Fabricator(:direct_message_channel, from: :chat_channel) do
   end
   status { :open }
   name nil
-  threading_enabled true
   after_create do |channel, attrs|
     if attrs[:with_membership]
       channel.chatable.users.each do |user|

--- a/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
+++ b/plugins/chat/spec/models/chat/direct_message_channel_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Chat::DirectMessageChannel do
   end
 
   describe "#threading_enabled" do
-    it "defaults to true" do
-      expect(channel.threading_enabled).to be(true)
+    it "defaults to false" do
+      expect(channel.threading_enabled).to be(false)
     end
   end
 

--- a/plugins/chat/spec/services/chat/create_thread_spec.rb
+++ b/plugins/chat/spec/services/chat/create_thread_spec.rb
@@ -14,7 +14,13 @@ RSpec.describe Chat::CreateThread do
     fab!(:another_user, :user)
     fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: true) }
     fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
-    fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user, another_user]) }
+    fab!(:dm_channel) do
+      Fabricate(
+        :direct_message_channel,
+        users: [current_user, another_user],
+        threading_enabled: true,
+      )
+    end
     fab!(:dm_message) { Fabricate(:chat_message, chat_channel: dm_channel) }
 
     let(:guardian) { Guardian.new(current_user) }

--- a/plugins/chat/spec/system/channel_settings_page_spec.rb
+++ b/plugins/chat/spec/system/channel_settings_page_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "Channel - Info - Settings page", type: :system do
         expect {
           PageObjects::Components::DToggleSwitch.new(".c-channel-settings__threading-switch").toggle
           expect(toasts).to have_success(I18n.t("js.saved"))
-        }.to change { channel_1.reload.threading_enabled }.from(true).to(false)
+        }.to change { channel_1.reload.threading_enabled }.from(false).to(true)
       end
     end
   end

--- a/plugins/chat/spec/system/chat_footer_spec.rb
+++ b/plugins/chat/spec/system/chat_footer_spec.rb
@@ -121,7 +121,9 @@ RSpec.describe "Mobile Chat footer", type: :system, mobile: true do
     end
 
     context "for direct messages" do
-      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user]) }
+      fab!(:dm_channel) do
+        Fabricate(:direct_message_channel, users: [current_user], threading_enabled: true)
+      end
       fab!(:dm_message) { Fabricate(:chat_message, chat_channel: dm_channel, user: current_user) }
 
       it "is urgent" do

--- a/plugins/chat/spec/system/list_channels/drawer_spec.rb
+++ b/plugins/chat/spec/system/list_channels/drawer_spec.rb
@@ -123,8 +123,12 @@ RSpec.describe "List channels | Drawer", type: :system do
       fab!(:user_3, :user)
       fab!(:dm_channel_1) { Fabricate(:direct_message_channel, users: [current_user]) }
       fab!(:dm_channel_2) { Fabricate(:direct_message_channel, users: [current_user, user_1]) }
-      fab!(:dm_channel_3) { Fabricate(:direct_message_channel, users: [current_user, user_2]) }
-      fab!(:dm_channel_4) { Fabricate(:direct_message_channel, users: [current_user, user_3]) }
+      fab!(:dm_channel_3) do
+        Fabricate(:direct_message_channel, users: [current_user, user_2], threading_enabled: true)
+      end
+      fab!(:dm_channel_4) do
+        Fabricate(:direct_message_channel, users: [current_user, user_3], threading_enabled: true)
+      end
 
       it "sorts them by latest activity" do
         Fabricate(

--- a/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
@@ -261,7 +261,11 @@ RSpec.describe "Message notifications - with sidebar", type: :system do
 
         context "with direct message channels" do
           fab!(:dm_channel) do
-            Fabricate(:direct_message_channel, users: [current_user, other_user])
+            Fabricate(
+              :direct_message_channel,
+              users: [current_user, other_user],
+              threading_enabled: true,
+            )
           end
           fab!(:thread) do
             chat_thread_chain_bootstrap(channel: dm_channel, users: [current_user, other_user])


### PR DESCRIPTION
Previously we introduced threads in Chat DMs in #29170 - however setting the default to false seems like a better fit.

This will take effect for all new DM chats initiated, existing chats are not changed but threads can still be turned off manually within each channel's settings.