### PR TITLE
PERF: removes N+1 when loading events list

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -5,7 +5,10 @@ module DiscoursePostEvent
     def index
       @events =
         DiscoursePostEvent::EventFinder.search(current_user, filtered_events_params).includes(
-          post: :topic,
+          :event_dates,
+          post: {
+            topic: %i[tags category],
+          },
         )
 
       # The detailed serializer is currently not used anywhere in the frontend, but available via API

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -114,6 +114,8 @@ module DiscoursePostEvent
         if association(:event_dates).loaded?
           pending = event_dates.select { |d| d.finished_at.nil? }
           pending.max_by(&:starts_at) || event_dates.max_by { |d| [d.updated_at, d.id] }
+        else
+          event_dates.where(finished_at: nil).order(:starts_at).last || event_dates.order(:updated_at, :id).last
         end
 
       date&.starts_at || original_starts_at
@@ -126,6 +128,8 @@ module DiscoursePostEvent
         if association(:event_dates).loaded?
           pending = event_dates.select { |d| d.finished_at.nil? }
           pending.max_by(&:starts_at) || event_dates.max_by { |d| [d.updated_at, d.id] }
+        else
+          event_dates.where(finished_at: nil).order(:starts_at).last || event_dates.order(:updated_at, :id).last
         end
 
       date&.ends_at || original_ends_at

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -17,6 +17,7 @@ module DiscoursePostEvent
     belongs_to :post, foreign_key: :id
 
     scope :visible, -> { where(deleted_at: nil) }
+    scope :open, -> { where(closed: false) }
 
     after_commit :destroy_topic_custom_field, on: %i[destroy]
     after_commit :create_or_update_event_date, on: %i[create update]

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -115,7 +115,8 @@ module DiscoursePostEvent
           pending = event_dates.select { |d| d.finished_at.nil? }
           pending.max_by(&:starts_at) || event_dates.max_by { |d| [d.updated_at, d.id] }
         else
-          event_dates.where(finished_at: nil).order(:starts_at).last || event_dates.order(:updated_at, :id).last
+          event_dates.where(finished_at: nil).order(:starts_at).last ||
+            event_dates.order(:updated_at, :id).last
         end
 
       date&.starts_at || original_starts_at
@@ -129,7 +130,8 @@ module DiscoursePostEvent
           pending = event_dates.select { |d| d.finished_at.nil? }
           pending.max_by(&:starts_at) || event_dates.max_by { |d| [d.updated_at, d.id] }
         else
-          event_dates.where(finished_at: nil).order(:starts_at).last || event_dates.order(:updated_at, :id).last
+          event_dates.where(finished_at: nil).order(:starts_at).last ||
+            event_dates.order(:updated_at, :id).last
         end
 
       date&.ends_at || original_ends_at

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -32,7 +32,12 @@ module DiscoursePostEvent
               ""
             end
           ),
-        topic: TopicListItemSerializer.new(object.post.topic, scope:, root: false).as_json,
+        topic:
+          DiscoursePostEvent::EventTopicSerializer.new(
+            object.post.topic,
+            scope:,
+            root: false,
+          ).as_json,
       }
     end
 

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_topic_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_topic_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class EventTopicSerializer < ApplicationSerializer
+    include TopicTagsMixin
+
+    attributes :id
+    attributes :title
+  end
+end

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -28,7 +28,7 @@ module DiscoursePostEvent
         .joins(latest_event_date_join)
         .select("discourse_post_event_events.*, latest_event_dates.starts_at")
         .where(
-          "(discourse_post_event_events.recurrence IS NOT NULL) OR (latest_event_dates.starts_at IS NOT NULL)",
+          "(discourse_post_event_events.recurrence IS NOT NULL) OR (latest_event_dates.starts_at IS NOT NULL) OR (discourse_post_event_events.original_starts_at IS NOT NULL)",
         )
         .distinct
     end

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -22,6 +22,7 @@ module DiscoursePostEvent
 
       DiscoursePostEvent::Event
         .visible
+        .open
         .includes(:event_dates, :post, post: :topic)
         .joins(post: :topic)
         .merge(Post.secured(guardian))

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -21,6 +21,7 @@ module DiscoursePostEvent
       pms = private_messages(user)
 
       DiscoursePostEvent::Event
+        .visible
         .includes(:event_dates, :post, post: :topic)
         .joins(post: :topic)
         .merge(Post.secured(guardian))

--- a/plugins/discourse-calendar/spec/fabricators/event_fabricator.rb
+++ b/plugins/discourse-calendar/spec/fabricators/event_fabricator.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 Fabricator(:event, from: "DiscoursePostEvent::Event") do
-  post { |attrs| attrs[:post] || Fabricate(:post) }
+  transient :user
+
+  post do |attrs|
+    if attrs[:post]
+      attrs[:post]
+    else
+      user = attrs[:user] || Fabricate(:user, admin: true, refresh_auto_groups: true)
+      topic = attrs[:topic] || Fabricate(:topic, user:, category: Fabricate(:category))
+      Fabricate(:post, user:, topic:)
+    end
+  end
 
   id { |attrs| attrs[:post].id }
 

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -29,6 +29,21 @@ module DiscoursePostEvent
 
         expect(queries_with_3_events.count).to eq(queries_with_1_event.count)
       end
+
+      it "should not show deleted events" do
+        active_event1 = Fabricate(:event, original_starts_at: 1.day.from_now)
+        active_event2 = Fabricate(:event, original_starts_at: 2.days.from_now)
+        deleted_event =
+          Fabricate(:event, original_starts_at: 3.days.from_now, deleted_at: 1.hour.ago)
+
+        get "/discourse-post-event/events.json"
+
+        expect(response.status).to eq(200)
+        events = response.parsed_body["events"]
+        event_ids = events.map { |e| e["id"] }
+
+        expect(event_ids).to match_array([active_event1.id, active_event2.id])
+      end
     end
 
     context "with an existing post" do

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -44,6 +44,20 @@ module DiscoursePostEvent
 
         expect(event_ids).to match_array([active_event1.id, active_event2.id])
       end
+
+      it "should not show closed events" do
+        active_event1 = Fabricate(:event, original_starts_at: 1.day.from_now)
+        active_event2 = Fabricate(:event, original_starts_at: 2.days.from_now)
+        closed_event = Fabricate(:event, original_starts_at: 3.days.from_now, closed: true)
+
+        get "/discourse-post-event/events.json"
+
+        expect(response.status).to eq(200)
+        events = response.parsed_body["events"]
+        event_ids = events.map { |e| e["id"] }
+
+        expect(event_ids).to match_array([active_event1.id, active_event2.id])
+      end
     end
 
     context "with an existing post" do

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -20,7 +20,7 @@ module DiscoursePostEvent
         expect(response.status).to eq(200)
         expect(response.parsed_body["events"].length).to eq(1)
 
-        # Test with 3 events in a fresh context
+        # Test with 3 events
         Fabricate(:event, original_starts_at: 2.days.from_now)
         Fabricate(:event, original_starts_at: 3.days.from_now)
         queries_with_3_events = track_sql_queries { get "/discourse-post-event/events.json" }


### PR DESCRIPTION
There was two issues:
- using the `TopicListItemSerializer` was fetching way more than we need and also expecting includes from other plugins (assign for example), switching to our own dedicated serializer seems a better choice here
- event dates were not preloaded
- fixed a spec which was supposed to track N+1 but was commented

I also improved our fabricator to limit the boilerplate needed.

We might need few more indices to improve perf event more here but going to merge this first.