### PR TITLE
FEATURE: add configurable age penalty for semantic related topics

### DIFF
--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -102,8 +102,8 @@ en:
     ai_embeddings_semantic_search_use_hyde: "Use HyDE for semantic full page search. Uses an LLM to create an hypothetical post from the user search term to help with matches."
     ai_embeddings_semantic_quick_search_enabled: "Enable semantic search option in search menu popup."
     ai_embeddings_semantic_related_include_closed_topics: "Include closed topics in semantic search results"
-    ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to older topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward newer content, 1.0+ = strong recency bias."
-    ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics this age receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
+    ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to less recently active topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward recently active content, 1.0+ = strong recency bias."
+    ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics this inactive receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
     ai_embeddings_semantic_search_hyde_model: "Model used to expand keywords to get better results during a semantic search"
     ai_embeddings_per_post_enabled: Generate embeddings for each post
 

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -102,6 +102,8 @@ en:
     ai_embeddings_semantic_search_use_hyde: "Use HyDE for semantic full page search. Uses an LLM to create an hypothetical post from the user search term to help with matches."
     ai_embeddings_semantic_quick_search_enabled: "Enable semantic search option in search menu popup."
     ai_embeddings_semantic_related_include_closed_topics: "Include closed topics in semantic search results"
+    ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to older topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward newer content, 1.0+ = strong recency bias."
+    ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics this age receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
     ai_embeddings_semantic_search_hyde_model: "Model used to expand keywords to get better results during a semantic search"
     ai_embeddings_per_post_enabled: Generate embeddings for each post
 

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -103,7 +103,7 @@ en:
     ai_embeddings_semantic_quick_search_enabled: "Enable semantic search option in search menu popup."
     ai_embeddings_semantic_related_include_closed_topics: "Include closed topics in semantic search results"
     ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward recently active content, 1.0+ = strong recency bias."
-    ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics this inactive receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
+    ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics inactive this many days receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
     ai_embeddings_semantic_search_hyde_model: "Model used to expand keywords to get better results during a semantic search"
     ai_embeddings_per_post_enabled: Generate embeddings for each post
 

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -102,7 +102,7 @@ en:
     ai_embeddings_semantic_search_use_hyde: "Use HyDE for semantic full page search. Uses an LLM to create an hypothetical post from the user search term to help with matches."
     ai_embeddings_semantic_quick_search_enabled: "Enable semantic search option in search menu popup."
     ai_embeddings_semantic_related_include_closed_topics: "Include closed topics in semantic search results"
-    ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to less recently active topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward recently active content, 1.0+ = strong recency bias."
+    ai_embeddings_semantic_related_age_penalty: "Apply exponential age penalty to topics in semantic search results. 0.0 = no penalty, 0.3 = gentle bias toward recently active content, 1.0+ = strong recency bias."
     ai_embeddings_semantic_related_age_time_scale: "Time scale in days for age penalty calculation. Topics this inactive receive ~50% penalty with penalty=1.0. Use 365 for yearly scale, 90 for quarterly scale."
     ai_embeddings_semantic_search_hyde_model: "Model used to expand keywords to get better results during a semantic search"
     ai_embeddings_per_post_enabled: Generate embeddings for each post

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -250,6 +250,18 @@ discourse_ai:
   ai_embeddings_semantic_related_include_closed_topics:
     default: true
     area: "ai-features/embeddings"
+  ai_embeddings_semantic_related_age_penalty:
+    default: 0.3
+    type: float
+    min: 0.0
+    max: 2.0
+    area: "ai-features/embeddings"
+  ai_embeddings_semantic_related_age_time_scale:
+    default: 365
+    type: integer
+    min: 1
+    max: 3650
+    area: "ai-features/embeddings"
   ai_embeddings_backfill_batch_size:
     default: 250
     hidden: true

--- a/plugins/discourse-ai/lib/embeddings/schema.rb
+++ b/plugins/discourse-ai/lib/embeddings/schema.rb
@@ -214,7 +214,7 @@ module DiscourseAi
             )
             SELECT #{target_column} FROM (
               SELECT
-                #{target_column}, embeddings, topics.created_at
+                #{target_column}, embeddings, topics.bumped_at
               FROM
                 #{table}
               INNER JOIN topics ON topics.id = #{table}.#{target_column}
@@ -237,7 +237,7 @@ module DiscourseAi
                 FROM
                   le_target
                 LIMIT 1
-              )) / POWER(EXTRACT(EPOCH FROM NOW() - created_at) / 86400 / :time_scale + 1, :age_penalty)
+              )) / POWER(EXTRACT(EPOCH FROM NOW() - bumped_at) / 86400 / :time_scale + 1, :age_penalty)
             LIMIT #{limit / 2};
           SQL
         else

--- a/plugins/discourse-ai/lib/embeddings/semantic_related.rb
+++ b/plugins/discourse-ai/lib/embeddings/semantic_related.rb
@@ -94,7 +94,7 @@ module DiscourseAi
       private
 
       def semantic_suggested_key(topic_id)
-        "#{CACHE_PREFIX}#{topic_id}"
+        "#{CACHE_PREFIX}#{topic_id}-#{SiteSetting.ai_embeddings_semantic_related_age_penalty}-#{SiteSetting.ai_embeddings_selected_model}-#{SiteSetting.ai_embeddings_semantic_related_age_time_scale}"
       end
 
       def build_semantic_suggested_key(topic_id)

--- a/plugins/discourse-ai/lib/embeddings/semantic_related.rb
+++ b/plugins/discourse-ai/lib/embeddings/semantic_related.rb
@@ -21,7 +21,10 @@ module DiscourseAi
           .fetch(semantic_suggested_key(topic.id), expires_in: cache_for) do
             DiscourseAi::Embeddings::Schema
               .for(Topic)
-              .symmetric_similarity_search(topic)
+              .symmetric_similarity_search(
+                topic,
+                age_penalty: SiteSetting.ai_embeddings_semantic_related_age_penalty,
+              )
               .map(&:topic_id)
               .tap do |candidate_ids|
                 # Happens when the topic doesn't have any embeddings

--- a/plugins/discourse-ai/spec/lib/modules/embeddings/semantic_related_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/embeddings/semantic_related_spec.rb
@@ -84,5 +84,67 @@ describe DiscourseAi::Embeddings::SemanticRelated do
         expect(results).to eq([])
       end
     end
+
+    describe "age penalty functionality" do
+      let(:newer_topic) { Fabricate(:topic, created_at: 1.day.ago) }
+      let(:older_topic) { Fabricate(:topic, created_at: 30.days.ago) }
+
+      before do
+        SiteSetting.ai_embeddings_semantic_related_age_penalty = 1.5
+        SiteSetting.ai_embeddings_semantic_related_age_time_scale = 30 # Use 30 days for more dramatic effect in tests
+
+        # Create embeddings for test topics
+        embedding = Array.new(1024) { rand }
+        schema = DiscourseAi::Embeddings::Schema.for(Topic)
+
+        [target, newer_topic, older_topic].each do |topic|
+          schema.store(topic, embedding, "test_digest_#{topic.id}")
+        end
+
+        described_class.clear_cache_for(target)
+      end
+
+      it "prioritizes newer topics over older ones with same similarity" do
+        # Mock the similarity search to return consistent embeddings for all topics
+        allow_any_instance_of(DiscourseAi::Embeddings::Schema).to receive(
+          :symmetric_similarity_search,
+        ).and_call_original
+
+        results = semantic_related.related_topic_ids_for(target)
+
+        expect(results).to include(newer_topic.id)
+        expect(results).to include(older_topic.id)
+
+        # Newer topic should appear before older topic due to age penalty
+        newer_index = results.index(newer_topic.id)
+        older_index = results.index(older_topic.id)
+        expect(newer_index).to be < older_index if newer_index && older_index
+      end
+
+      it "uses no age penalty when setting is 0.0" do
+        SiteSetting.ai_embeddings_semantic_related_age_penalty = 0.0
+        described_class.clear_cache_for(target)
+
+        # Should work the same as without age penalty
+        expect { semantic_related.related_topic_ids_for(target) }.not_to raise_error
+      end
+
+      it "handles age penalty parameter correctly in schema" do
+        schema = DiscourseAi::Embeddings::Schema.for(Topic)
+
+        expect { schema.symmetric_similarity_search(target, age_penalty: 1.5) }.not_to raise_error
+
+        expect { schema.symmetric_similarity_search(target, age_penalty: 0.0) }.not_to raise_error
+      end
+
+      it "respects different time scale settings" do
+        # Test with a different time scale that makes the penalty less aggressive
+        SiteSetting.ai_embeddings_semantic_related_age_time_scale = 365 # 1 year time scale
+        SiteSetting.ai_embeddings_semantic_related_age_penalty = 0.3 # Gentle penalty
+        described_class.clear_cache_for(target)
+
+        expect { semantic_related.related_topic_ids_for(target) }.not_to raise_error
+      end
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/modules/embeddings/semantic_related_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/embeddings/semantic_related_spec.rb
@@ -86,8 +86,8 @@ describe DiscourseAi::Embeddings::SemanticRelated do
     end
 
     describe "age penalty functionality" do
-      let(:newer_topic) { Fabricate(:topic, created_at: 1.day.ago) }
-      let(:older_topic) { Fabricate(:topic, created_at: 30.days.ago) }
+      let(:newer_topic) { Fabricate(:topic, bumped_at: 1.day.ago) }
+      let(:older_topic) { Fabricate(:topic, bumped_at: 30.days.ago) }
 
       before do
         SiteSetting.ai_embeddings_semantic_related_age_penalty = 1.5


### PR DESCRIPTION
Introduces two new site settings to apply exponential age-based
penalties to semantic topic suggestions, similar to algorithms
used by Reddit/HN:

* ai_embeddings_semantic_related_age_penalty (default: 0.3)
  Controls penalty strength. 0.0 = disabled, 0.3 = gentle bias
  toward newer content, 1.0+ = strong recency preference

* ai_embeddings_semantic_related_age_time_scale (default: 365 days)
  Controls time horizon. Use 365 for yearly scale, 90 for
  quarterly scale, etc.

Formula: similarity_score / POWER(age_in_days / time_scale + 1, penalty)

This allows sites to de-prioritize older topics in suggestions
while maintaining configurability for forums with different
content lifecycles. Performance optimized with conditional
JOINs only when penalty > 0.
