### PR TITLE
FIX: check for label arg in create-topic-button component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -6,7 +6,7 @@ import concatClass from "discourse/helpers/concat-class";
 
 export default class CreateTopicButton extends Component {
   @tracked btnTypeClass = this.args.btnTypeClass || "btn-default";
-  @tracked label = this.args.label || "topic.create";
+  @tracked label = this.args.label ?? "topic.create";
 
   <template>
     {{#if @canCreateTopic}}


### PR DESCRIPTION
follow-up fix to 3a945f3663cb2ce9785d36ddf2e0d04b7a0de3c1

When this was converted to glimmer I incorrectly assumed that `label = "topic.create";` was all we needed, but we actually allow the label to be passed in (and be empty!) so we need to check the arg before falling back to `topic.create` 

Fixes this issue with the label appearing on mobile...

Before:
<img width="379" height="62" alt="image" src="https://github.com/user-attachments/assets/6f8d161c-9ce3-406d-ac8e-f9a0dc0e4111" />


After:
<img width="376" height="71" alt="image" src="https://github.com/user-attachments/assets/f15d5506-80e2-4e4f-be3a-4bf02ea3226f" />
