### PR TITLE
DEV: new env var to disable browser sandbox

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -3,6 +3,13 @@ const fs = require("fs");
 const displayUtils = require("testem/lib/utils/displayutils");
 const colors = require("@colors/colors/safe");
 
+const SANDBOX_DISABLE_VALUES = ["1", "true"];
+const sandboxDisabled =
+  process.env.CI ||
+  SANDBOX_DISABLE_VALUES.includes(
+    (process.env.DISCOURSE_DISABLE_BROWSER_SANDBOX || "").toLowerCase()
+  );
+
 class Reporter extends TapReporter {
   failReports = [];
   deprecationCounts = new Map();
@@ -140,8 +147,8 @@ module.exports = {
   browser_start_timeout: 120,
   browser_args: {
     Chromium: [
-      // --no-sandbox is needed when running Chromium inside a container
-      process.env.CI ? "--no-sandbox" : null,
+      // --no-sandbox is needed when running Chromium inside a container or when explicitly requested
+      sandboxDisabled ? "--no-sandbox" : null,
       "--headless=new",
       "--disable-dev-shm-usage",
       "--disable-software-rasterizer",
@@ -153,8 +160,8 @@ module.exports = {
       "--js-flags=--max_old_space_size=4096",
     ].filter(Boolean),
     Chrome: [
-      // --no-sandbox is needed when running Chrome inside a container
-      process.env.CI ? "--no-sandbox" : null,
+      // --no-sandbox is needed when running Chrome inside a container or when explicitly requested
+      sandboxDisabled ? "--no-sandbox" : null,
       "--headless=new",
       "--disable-dev-shm-usage",
       "--disable-software-rasterizer",


### PR DESCRIPTION
In non CI environments running Docker we also want to disable browser sandboxing

This adds a new environment var

DISCOURSE_DISABLE_BROWSER_SANDBOX which can be set to 1 to disable sandboxing

This allows us to easily run qunit tests.
