### PR TITLE
DEV: suppress noisy warning from system test runs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -664,8 +664,26 @@ RSpec.configure do |config|
       # To work around this problem, we are going to preload all the model schemas before running any system tests so that
       # the lock in ActiveRecord::ModelSchema is not acquired at runtime. This is a temporary workaround while we report
       # the issue to the Rails.
+
+      # TODO: halfvec in AI embedding tables is not supported by Rails
+      # it causes a noisy stderr warning cause it is missing from the PG
+      # typemap.
+      #
+      # This workaround will suppress the noise until Rails adds support
+      suppress_embedding_warnings =
+        proc do |&blk|
+          stderr_orig = $stderr
+          $stderr = StringIO.new
+          blk.call
+          warning = $stderr.string
+          if warning.present? && !warning.include?("failed to recognize type of 'embeddings'")
+            stderr_orig.print warning
+          end
+          $stderr = stderr_orig
+        end
+
       ActiveRecord::Base.connection.data_sources.map do |table|
-        ActiveRecord::Base.connection.schema_cache.add(table)
+        suppress_embedding_warnings.call { ActiveRecord::Base.connection.schema_cache.add(table) }
       end
 
       system_tests_initialized = true


### PR DESCRIPTION
The halfvec type is not recognized by Rails, this is not normally an issue
cause we do not use Active Record to query this anyway.

However a workaround we have in place adds all data_sources to schema_cache
forcing the PG gem to try to resolve the type.

This workaround suppresses this specific warning on STDERR so we don't infect
our test results.

This is particularly confusing to AI agents that see the text:

"failed to recognize type of ..." which leads them to think a system spec run
failed.
