### PR TITLE
DEV: add deprecation console warning to jquery autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -2,6 +2,7 @@ import { cancel } from "@ember/runloop";
 import { createPopper } from "@popperjs/core";
 import $ from "jquery";
 import discourseDebounce from "discourse/lib/debounce";
+import deprecated from "discourse/lib/deprecated";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import { iconHTML } from "discourse/lib/icon-library";
 import discourseLater from "discourse/lib/later";
@@ -10,10 +11,10 @@ import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipul
 import Site from "discourse/models/site";
 
 /**
-  This is a jQuery plugin to support autocompleting values in our text fields.
+ This is a jQuery plugin to support autocompleting values in our text fields.
 
-  @module $.fn.autocomplete
-**/
+ @module $.fn.autocomplete
+ **/
 
 export const SKIP = "skip";
 export const CANCELLED_STATUS = "__CANCELLED";
@@ -48,6 +49,14 @@ const keys = {
 };
 
 export default function (options) {
+  deprecated(
+    "$.fn.autocomplete is deprecated and will be removed in a future release. Please use the DMultiSelect component or the DAutocomplete modifier instead.",
+    {
+      id: "discourse.jquery-autocomplete",
+      since: "3.6.0.beta1-dev",
+    }
+  );
+
   if (this.length === 0) {
     return;
   }
@@ -178,7 +187,7 @@ export default function (options) {
 
     const divs = transformed.map((itm) => {
       let d = $(
-        `<div class='item'><span>${itm}<a class='remove' href>${iconHTML(
+        `<div class="item"><span>${itm}<a class="remove" href>${iconHTML(
           "xmark"
         )}</a></span></div>`
       );

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -11,10 +11,10 @@ import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipul
 import Site from "discourse/models/site";
 
 /**
- This is a jQuery plugin to support autocompleting values in our text fields.
+  This is a jQuery plugin to support autocompleting values in our text fields.
 
- @module $.fn.autocomplete
- **/
+  @module $.fn.autocomplete
+**/
 
 export const SKIP = "skip";
 export const CANCELLED_STATUS = "__CANCELLED";


### PR DESCRIPTION
We are deprecating this jquery-based autocomplete library, replaced by DAutocomplete modifier for text field usage and DMultiSelect for input selector usage.



