### PR TITLE
Change default text color from 'FFF' to 'FFFFFF'

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -497,7 +497,7 @@ class ImportScripts::Base
         position: opts[:position],
         parent_category_id: opts[:parent_category_id],
         color: opts[:color] || category_color(opts[:parent_category_id]),
-        text_color: opts[:text_color] || "FFF",
+        text_color: opts[:text_color] || "FFFFFF",
         read_restricted: opts[:read_restricted] || false,
       )
 


### PR DESCRIPTION
FFF isn't a legal color value.

https://meta.discourse.org/t/categories-text-color-is-wrongly-set-to-fff-instead-of-ffffff-in-import-scripts-causing-issues/383099/4