### PR TITLE
UX: improve user card badge wrapping for higher max_favorite_badges setting

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -304,12 +304,16 @@
   // badges
   .badge-section {
     line-height: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
 
     .user-badge {
       @include ellipsis;
       background: var(--primary-very-low);
       border: 1px solid var(--content-border-color);
       color: var(--primary);
+      border-radius: var(--d-border-radius);
     }
 
     .user-card-badge-link {


### PR DESCRIPTION
When the `max_favorite_badges` setting is higher than 2 these tend to wrap. Also noticed that badges on /badges have a border radius and these do not, so I fixed that too 

Before:
<img width="1314" height="240" alt="image" src="https://github.com/user-attachments/assets/36d6d6e5-8d65-4824-9695-b994353fb5ef" />


After:
<img width="1312" height="256" alt="image" src="https://github.com/user-attachments/assets/0748185f-95f4-4691-8e0e-60b04cd4df52" />
