### PR TITLE
DEV: rich editor - don't parse html images with `data:` content

### DIFF
--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -57,7 +57,7 @@ const extension = {
       draggable: true,
       parseDOM: [
         {
-          tag: "img[src]",
+          tag: 'img[src]:not([src^="data:"])',
           getAttrs(dom) {
             const originalSrc =
               dom.dataset.origSrc ??

--- a/spec/system/composer/prosemirror_editor_spec.rb
+++ b/spec/system/composer/prosemirror_editor_spec.rb
@@ -825,6 +825,18 @@ describe "Composer - ProseMirror editor", type: :system do
       expect(composer).to have_value("![image|244x66](upload://hGLky57lMjXvqCWRhcsH31ShzmO.png)")
     end
 
+    it "ignores data URI images when pasting HTML" do
+      cdp.allow_clipboard
+      open_composer
+
+      data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+      cdp.copy_paste(%(Text <img src="#{data_uri}" alt="data uri image">), html: true)
+
+      expect(rich).to have_no_css("img[src^='data:']")
+      expect(rich).to have_no_css(".composer-image-node img")
+      expect(rich).to have_css("p", text: "Text")
+    end
+
     it "merges text with link marks created from parsing" do
       cdp.allow_clipboard
       open_composer


### PR DESCRIPTION
Avoid parsing images with `data:` content (usually with long base64) on image node's `parseDOM` (eg. when pasting).

Base64 images are unsupported when pasting on markdown mode and on other "rich" authoring tools.

A future improvement will be triggering an upload for each pasted base64 image and then replacing it, but this stops the bleeding of generating an awfully long Markdown output.