### PR TITLE
DEV: Remove unnecessary `topic_timers_topic_id_trigger` trigger

### DIFF
--- a/db/migrate/20250902014817_add_timerable_id_to_topic_timer.rb
+++ b/db/migrate/20250902014817_add_timerable_id_to_topic_timer.rb
@@ -10,26 +10,6 @@ class AddTimerableIdToTopicTimer < ActiveRecord::Migration[8.0]
     add_index :topic_timers, :timerable_id, where: "deleted_at IS NULL"
     change_column_null :topic_timers, :topic_id, true
     Migration::ColumnDropper.mark_readonly(:topic_timers, :topic_id)
-
-    # Mirror new `topic_id` values to `timerable_id`
-    execute(<<~SQL)
-      CREATE FUNCTION mirror_topic_timers_topic_id()
-      RETURNS trigger AS
-      $$
-      BEGIN
-        IF NEW.topic_id IS NOT NULL THEN
-          NEW.timerable_id = NEW.topic_id;
-        END IF;
-        RETURN NEW;
-      END;
-      $$
-      LANGUAGE plpgsql
-    SQL
-
-    execute(<<~SQL)
-      CREATE TRIGGER topic_timers_topic_id_trigger BEFORE INSERT ON topic_timers
-      FOR EACH ROW EXECUTE PROCEDURE mirror_topic_timers_topic_id()
-    SQL
   end
 
   def down

--- a/db/migrate/20250919010400_remove_trigger_on_topic_timers.rb
+++ b/db/migrate/20250919010400_remove_trigger_on_topic_timers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveTriggerOnTopicTimers < ActiveRecord::Migration[8.0]
+  def up
+    execute("DROP FUNCTION IF EXISTS mirror_topic_timers_topic_id() CASCADE;")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This was causing restores to fail. The trigger is also unnecessary
because the `topic_id` column is already marked as read-only.

Follow-up to eeeb7d302f2683731a1e2eb60158963b6c7b7d96
