### PR TITLE
DEV: Show back to queue link in header on new review UI

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/review-index.gjs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.gjs
@@ -7,6 +7,7 @@ import ConditionalLoadingSpinner from "discourse/components/conditional-loading-
 import DButton from "discourse/components/d-button";
 import DateTimeInputRange from "discourse/components/date-time-input-range";
 import LoadMore from "discourse/components/load-more";
+import NavItem from "discourse/components/nav-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import ReviewableItem from "discourse/components/reviewable-item";
 import icon from "discourse/helpers/d-icon";
@@ -18,6 +19,17 @@ import EmailGroupUserChooser from "select-kit/components/email-group-user-choose
 
 export default RouteTemplate(
   <template>
+    <ul class="nav nav-pills reviewable-title">
+      <NavItem @route="review.index" @label="review.view_all" />
+      <NavItem @route="review.topics" @label="review.grouped_by_topic" />
+      {{#if @controller.currentUser.admin}}
+        <NavItem
+          @route="review.settings"
+          @label="review.settings.title"
+          @icon="wrench"
+        />
+      {{/if}}
+    </ul>
     {{#if @controller.displayUnknownReviewableTypesWarning}}
       <div class="alert alert-info unknown-reviewables">
         <span class="text">{{i18n

--- a/app/assets/javascripts/discourse/app/templates/review-show.gjs
+++ b/app/assets/javascripts/discourse/app/templates/review-show.gjs
@@ -1,10 +1,14 @@
 import Component from "@glimmer/component";
 import { getOwner } from "@ember/owner";
+import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import RouteTemplate from "ember-route-template";
+import NavItem from "discourse/components/nav-item";
 import ReviewableItem from "discourse/components/reviewable-item";
 import ReviewableItemRefresh from "discourse/components/reviewable-refresh/item";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
   class extends Component {
@@ -39,8 +43,25 @@ export default RouteTemplate(
 
     <template>
       {{#if this.shouldUseRefreshUI}}
+        <div class="reviewable-top-nav">
+          <LinkTo @route="review.index">
+            {{icon "arrow-left"}}
+            {{i18n "review.back_to_queue"}}
+          </LinkTo>
+        </div>
         <ReviewableItemRefresh @reviewable={{@controller.reviewable}} />
       {{else}}
+        <ul class="nav nav-pills reviewable-title">
+          <NavItem @route="review.index" @label="review.view_all" />
+          <NavItem @route="review.topics" @label="review.grouped_by_topic" />
+          {{#if @controller.currentUser.admin}}
+            <NavItem
+              @route="review.settings"
+              @label="review.settings.title"
+              @icon="wrench"
+            />
+          {{/if}}
+        </ul>
         <ReviewableItem @reviewable={{@controller.reviewable}} />
       {{/if}}
     </template>

--- a/app/assets/javascripts/discourse/app/templates/review.gjs
+++ b/app/assets/javascripts/discourse/app/templates/review.gjs
@@ -1,21 +1,8 @@
 import RouteTemplate from "ember-route-template";
-import NavItem from "discourse/components/nav-item";
 
 export default RouteTemplate(
   <template>
     <div class="reviewable">
-      <ul class="nav nav-pills reviewable-title">
-        <NavItem @route="review.index" @label="review.view_all" />
-        <NavItem @route="review.topics" @label="review.grouped_by_topic" />
-        {{#if @controller.currentUser.admin}}
-          <NavItem
-            @route="review.settings"
-            @label="review.settings.title"
-            @icon="wrench"
-          />
-        {{/if}}
-      </ul>
-
       {{outlet}}
     </div>
   </template>

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -3,6 +3,10 @@
 .reviewable {
   background: var(--d-content-background);
 
+  .reviewable-top-nav {
+    margin-bottom: 1em;
+  }
+
   .flagged-post-header {
     width: 100%;
     display: flex;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -691,6 +691,7 @@ en:
     review:
       show_more: "Show more"
       show_less: "Show less"
+      back_to_queue: "Back to queue"
       order_by: "Order by"
       date_filter: "Posted between"
       in_reply_to: "in reply to"


### PR DESCRIPTION
### What is this change?

This PR adds the "Back to queue" link for the new review UI, while reserving the old header for the old UI index and show.

### Screenshots

**Old review UI index:**

<img width="450" height="250" alt="Screenshot 2025-09-19 at 11 48 59 AM" src="https://github.com/user-attachments/assets/536823c8-4895-4b6c-b36c-50beaabd8c42" />

**Old review UI show:**

<img width="408" height="205" alt="Screenshot 2025-09-19 at 11 49 07 AM" src="https://github.com/user-attachments/assets/b907aa48-0724-4b15-aba9-6854d901834d" />

**New review UI index:**

<img width="405" height="225" alt="Screenshot 2025-09-19 at 3 13 59 PM" src="https://github.com/user-attachments/assets/382f500a-0078-4f75-a888-7df45183591a" />

**New review UI show:**

<img width="437" height="218" alt="Screenshot 2025-09-19 at 3 14 05 PM" src="https://github.com/user-attachments/assets/121848d2-4bfc-491b-b643-516fa9223fd2" />
