### PR TITLE
FIX: Don't update last_seen_at when impersonating a user

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -209,7 +209,7 @@ class Auth::DefaultCurrentUserProvider
     # under no conditions to suspended or inactive accounts get current_user
     current_user = nil if current_user && (current_user.suspended? || !current_user.active)
 
-    if current_user && should_update_last_seen?
+    if current_user && !current_user.is_impersonating && should_update_last_seen?
       ip = request.ip
       user_id = current_user.id
       old_ip = current_user.ip_address

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -285,6 +285,19 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
       end
     end
 
+    describe "when impersonating another user" do
+      it "should not update User#last_seen_at" do
+        old_timestamp = 1.week.ago
+        user.update!(last_seen_at: old_timestamp)
+        User.any_instance.stubs(:is_impersonating).returns(true)
+
+        provider2 = provider("/", "HTTP_COOKIE" => "_t=#{cookie}")
+        u = provider2.current_user
+
+        expect(u.reload.last_seen_at).to eq_time(old_timestamp)
+      end
+    end
+
     it "should not cache an invalid user when Rails hasn't set `path_parameters` on the request yet" do
       SiteSetting.login_required = true
       user = Fabricate(:user)


### PR DESCRIPTION
### What is this change?

Before this change, impersonating a user would result in that user's `last_seen_at` being updated. This PR fixes that for the new impersonation feature gated behind the `experimental_impersonation` site setting.

### Limitations

The old impersonation feature that logs in as the impersonated user has a completely separate code path. If we decide to backport this change it will be in a separate PR.