### PR TITLE
FIX: supports description for post events in rich editor

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -25,6 +25,7 @@ const extension = {
     event: {
       attrs: EVENT_ATTRIBUTES,
       group: "block",
+      content: "block*",
       defining: true,
       isolating: true,
       draggable: true,
@@ -81,17 +82,21 @@ const extension = {
 
   serializeNode: {
     event(state, node) {
-      let bbcode = "[event";
+      state.write("[event");
 
       Object.entries(node.attrs).forEach(([key, value]) => {
         if (value !== null) {
-          bbcode += ` ${key}="${value}"`;
+          state.write(` ${key}="${value}"`);
         }
       });
 
-      bbcode += "]\n[/event]\n";
+      state.write("]\n");
 
-      state.write(bbcode);
+      if (node.content.size > 0) {
+        state.renderContent(node);
+      }
+
+      state.write("[/event]\n");
     },
   },
 };

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -9,7 +9,7 @@ module("Integration | Component | rich-editor-extension", function (hooks) {
     "event alone": [
       [
         `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\n`,
-        `<div class="discourse-post-event discourse-post-event-preview ProseMirror-selectednode" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div>`,
+        `<div class="discourse-post-event discourse-post-event-preview" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div>`,
         `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\n`,
       ],
     ],
@@ -18,6 +18,13 @@ module("Integration | Component | rich-editor-extension", function (hooks) {
         `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\nGoodbye world`,
         `<p>Hello world</p><div class="discourse-post-event discourse-post-event-preview" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div><p>Goodbye world</p>`,
         `Hello world\n\n[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\n[/event]\nGoodbye world`,
+      ],
+    ],
+    "event with content inside": [
+      [
+        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\ntest\n[/event]\n`,
+        `<div class="discourse-post-event discourse-post-event-preview" data-start="2025-03-21 15:41" data-status="public" data-timezone="Europe/Paris" contenteditable="false" draggable="true"><div class="event-preview-status">Public</div><div class="event-preview-dates"><span class="start">March 21, 2025 2:41 PM</span></div></div>`,
+        `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris"]\ntest\n\n[/event]\n`,
       ],
     ],
   };


### PR DESCRIPTION
Prior to this fix events with a description wouldn't show in the composer when they contain a description. This was particularly problematic as saving the post in this state would remove the event.