### PR TITLE
FEATURE: Add a setting to allow disabling chat notifications from unlisted topics

### DIFF
--- a/plugins/discourse-chat-integration/app/services/manager.rb
+++ b/plugins/discourse-chat-integration/app/services/manager.rb
@@ -27,6 +27,9 @@ module DiscourseChatIntegration
       topic = post.topic
       return if topic.blank?
 
+      # Abort if we are in an unlisted topic, and the appropriate setting is true
+      return if SiteSetting.chat_integration_ignore_unlisted_topics && !topic.visible
+
       # If it's a private message, filter rules by groups, otherwise filter rules by category
       if topic.archetype == Archetype.private_message
         group_ids_with_access = topic.topic_allowed_groups.pluck(:group_id)

--- a/plugins/discourse-chat-integration/config/locales/server.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     chat_integration_enabled: 'Enable the discourse-chat-integration plugin'
     chat_integration_discourse_username: 'Username of user to act as when fetching content.'
     chat_integration_delay_seconds: 'Number of seconds to wait after post creation before sending chat notitifications'
+    chat_integration_ignore_unlisted_topics: 'Disable chat notifications from unlisted topics'
 
     #######################################
     ########## SLACK SETTINGS #############

--- a/plugins/discourse-chat-integration/config/settings.yml
+++ b/plugins/discourse-chat-integration/config/settings.yml
@@ -6,6 +6,8 @@ chat_integration:
     type: username
   chat_integration_delay_seconds:
     default: 20
+  chat_integration_ignore_unlisted_topics:
+    default: false
 
 #######################################
 ########## SLACK SETTINGS #############
@@ -53,7 +55,7 @@ chat_integration:
     default: ""
   chat_integration_discord_excerpt_length:
     default: 400
-  
+
 #######################################
 ########## GUILDED SETTINGS ###########
 #######################################
@@ -61,7 +63,7 @@ chat_integration:
     default: false
   chat_integration_guilded_excerpt_length:
     default: 400
-  
+
 
 #######################################
 ######## MATTERMOST SETTINGS ##########


### PR DESCRIPTION
It feels unintuitive that when a topic is unlisted, it could still be listed off platform. For example, a usecase of this plugin is to show all the public forum posts on a separate service, like Discord. The AI moderation tool runs after a topic is created, and if it detects spam, will unlist the post, however, this is still sent to the chat integration. Enabling this setting would prevent spam from reaching the chat service.