### PR TITLE
DEV: fix flakey spec

### DIFF
--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -23,9 +23,7 @@ describe Chat::Mailer do
   end
 
   def expect_enqueued
-    expect {
-      expect_enqueued_with(job:, args:) { described_class.send_unread_mentions_summary }
-    }.to_not output.to_stderr_from_any_process
+    expect_enqueued_with(job:, args:) { described_class.send_unread_mentions_summary }
     expect(Jobs::UserEmail.jobs.size).to eq(1)
   end
 


### PR DESCRIPTION
It doesn’t appear this expectation is necessary and it was causing random failure as sometimes we will have an error from promotheus in the log totally unrelated:

```
expected block to not output to stderr, but output "E, [2025-09-19T07:16:59.199016 #2050] ERROR -- : Prometheus Exporter, failed to send message Connection refused - connect(2) for \"localhost\" port 9405\n"
```


/t/-/149729