### PR TITLE
UX: Make add_email.email uppercase

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1900,7 +1900,7 @@ en:
 
       add_email:
         title: "Add Email"
-        add: "add"
+        add: "Add"
 
       change_email:
         title: "Change Email"


### PR DESCRIPTION
Reported at https://meta.discourse.org/t/capitalise-the-a-on-the-add-button/383257, this changes the Add email button from 'add' (lowercase) to 'Add' (uppercase).