### PR TITLE
FIX: add finished to modal animateBackdropOpacity promise

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -267,7 +267,7 @@ export default class DModal extends Component {
     waitForPromise(
       backdrop.animate([{ opacity: Math.max(0, Math.min(opacity, 0.6)) }], {
         fill: "forwards",
-      })
+      }).finished
     );
   }
 


### PR DESCRIPTION
Fixes an error when closing modals on mobile because a promise wasn't being returned

`Uncaught (in promise) TypeError: promise.then is not a function`