### PR TITLE
UX: remove hover effect (not consistent)

### DIFF
--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -18,12 +18,6 @@
         font-size: var(--d-topic-list-data-font-size);
         line-height: var(--line-height-medium);
 
-        .discourse-no-touch & {
-          &:hover {
-            background: var(--d-hover);
-          }
-        }
-
         .d-icon,
         &:hover .d-icon,
         &:active .d-icon {


### PR DESCRIPTION
Noticed we're using some custom hover effect on these buttons, which we don't use with similar nav areas such as main nav or user page nav.

✅  <img width="1684" height="288" alt="CleanShot 2025-09-19 at 09 46 37@2x" src="https://github.com/user-attachments/assets/f6615210-411b-4f14-96a1-7119642dc2c1" />
✅  <img width="1060" height="210" alt="CleanShot 2025-09-19 at 09 46 56@2x" src="https://github.com/user-attachments/assets/933f4a9d-1e42-4b19-b69c-ece8114b46c0" />
❌ <img width="938" height="226" alt="CleanShot 2025-09-19 at 09 47 20@2x" src="https://github.com/user-attachments/assets/74ca8a0d-f82a-445d-a503-8f4082fa8417" />

