### PR TITLE
UX: move border-radius to default/primary classes

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -80,7 +80,6 @@
     rgb(0, 0, 0, 0),
     rgb(0, 0, 0, 0)
   );
-  border-radius: var(--d-button-border-radius);
   transition: var(--d-button-transition);
   cursor: pointer;
 
@@ -222,6 +221,7 @@
     $hover-bg-color: var(--d-button-primary-bg-color--hover),
     $hover-icon-color: var(--d-button-primary-icon-color--hover)
   );
+  border-radius: var(--d-button-border-radius);
 }
 
 /* Danger button */
@@ -235,6 +235,7 @@
     $hover-bg-color: var(--d-button-danger-bg-color--hover),
     $hover-icon-color: var(--d-button-danger-icon-color--hover)
   );
+  border-radius: var(--d-button-border-radius);
 }
 
 /* Success button */
@@ -248,6 +249,7 @@
     $hover-bg-color: var(--d-button-success-bg-color--hover),
     $hover-icon-color: var(--d-button-success-icon-color--hover)
   );
+  border-radius: var(--d-button-border-radius);
 }
 
 /* Social buttons */


### PR DESCRIPTION
Context: The `btn` class is used for every functional button, but this includes button elements that are not, or should not be, styled like our default or primary buttons.
As a first step in making this class more generic, I'm scoping the border-radius property better. This means that non-standard buttons, which don't always work with a border-radius, also don't get it applied automatically, relieving the need for overrides.

Example of button that does not need a border-radius and would benefit from this:
<img width="464" height="184" alt="CleanShot 2025-09-19 at 12 56 04@2x" src="https://github.com/user-attachments/assets/e908b2cf-971f-4c1f-aade-7492bad2f89c" />
