### PR TITLE
UX: mobile user card fixes

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -292,6 +292,7 @@
   // custom user fields
   .public-user-fields {
     margin: 0;
+    text-align: left;
 
     .user-field-value-list-item:not(:last-of-type) {
       &::after {

--- a/app/assets/stylesheets/mobile/components/user-card.scss
+++ b/app/assets/stylesheets/mobile/components/user-card.scss
@@ -70,21 +70,13 @@
 .user-card {
   // badges
   .badge-section {
-    display: flex;
-    align-items: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
 
     .user-card-badge-link,
     .more-user-badges {
       display: flex;
-      flex: 0 1 50%;
-      max-width: 50%; // for text ellipsis
-      padding: 2px 0;
       box-sizing: border-box;
-
-      &:nth-child(odd) {
-        padding-right: 4px;
-      }
 
       a {
         width: 100%;


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/commit/e48df443497142f5d064e2ea43048f4c86914ecb and 6a6ef122647e14d36f2a2be24431cdc1f19d46ed

Fixes a regression with centered user field text and the way badges wrap on mobile


Before
<img width="712" height="422" alt="image" src="https://github.com/user-attachments/assets/76591192-3b0e-4a1b-8e6d-969f9be9c3ce" />


After
<img width="812" height="382" alt="image" src="https://github.com/user-attachments/assets/7cc074e8-584d-4a49-8aee-9cb3d6946973" />
