### PR TITLE
UX: Fix padding for no-ember pages

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -808,6 +808,11 @@ form {
       padding-left: env(safe-area-inset-left);
     }
   }
+
+  .no-ember & {
+    padding-left: max(var(--space-4), var(--main-outlet-padding-x));
+    padding-right: max(var(--space-4), var(--main-outlet-padding-x));
+  }
 }
 
 #main {

--- a/themes/horizon/scss/main.scss
+++ b/themes/horizon/scss/main.scss
@@ -137,8 +137,6 @@ aside.onebox {
 .no-ember {
   #main-outlet {
     border-radius: var(--d-border-radius-large);
-    margin: 0 var(--main-grid-gap) var(--main-grid-gap) var(--main-grid-gap);
-    padding: 2em;
     max-height: calc(100vh - 50px - 1em - var(--main-grid-gap));
   }
 }


### PR DESCRIPTION
This regressed recently. We need to make sure non-ember pages have a minimum left/right padding, otherwise content is hugging the device edges.

Before: 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ed371459-056c-4a08-8456-8680c7d48a0c" /> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1beca619-2f78-46d3-b865-2bbe2593a13f" />


After: 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/51d65340-4c93-4740-8845-371c4fe18b62" /> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8124bf4f-85ea-4ee9-a2e2-f9da636895de" />

