### PR TITLE
UX: Remove shadow, implement space variables

### DIFF
--- a/themes/horizon/common/color_definitions.scss
+++ b/themes/horizon/common/color_definitions.scss
@@ -66,12 +66,6 @@ html {
     oklch(from #{$tertiary} calc(l * 1.5) calc(c * 0.25) h)
   ) !important;
 
-  // Topic Card Colors
-  --topic-card-shadow: light-dark(
-    oklch(from #{$tertiary} calc(l * 1.85) calc(c * 0.5) h),
-    oklch(from #{$tertiary} calc(l * 0.2) calc(c * 0.01) h / 0.25)
-  ) !important;
-
   // Button Colors
   --button-box-shadow: light-dark(
     oklch(from #{$tertiary} calc(l * 1.5) calc(c * 0.35) h),

--- a/themes/horizon/scss/nav-pills.scss
+++ b/themes/horizon/scss/nav-pills.scss
@@ -36,11 +36,6 @@
       }
     }
   }
-
-  .select-kit.combo-box.category-drop.has-selection
-    .category-drop-header:hover {
-    border-color: transparent;
-  }
 }
 
 .select-kit.is-expanded .select-kit-body {

--- a/themes/horizon/scss/topic-cards.scss
+++ b/themes/horizon/scss/topic-cards.scss
@@ -2,6 +2,8 @@
 
 :root {
   --d-border-radius-small: calc(var(--d-border-radius) * 0.5);
+  --topic-list-item-background-color: var(--d-content-background);
+  --topic-list-item-background-color--visited: var(--d-content-background);
 }
 
 .topic-list .topic-list-item-separator {
@@ -57,10 +59,10 @@
   border: none;
   display: flex;
   flex-direction: column;
-  gap: 1.25em;
+  gap: var(--space-4);
 
   @include viewport.until(lg) {
-    gap: 0.5em;
+    gap: var(--space-2);
   }
 
   @include viewport.until(sm) {
@@ -71,8 +73,6 @@
 
 .topic-list-body .topic-list-item {
   position: relative;
-  background: var(--d-content-background);
-  box-shadow: 0 0 12px 1px var(--topic-card-shadow);
   text-overflow: ellipsis;
   padding: var(--space-3);
   border: 1px solid var(--primary-300);


### PR DESCRIPTION
Removing the shadow from `topic-list-item` for a cleaner look.

|Before|After|
|--|--|
|<img width="2304" height="1864" alt="CleanShot 2025-09-19 at 14 50 39@2x" src="https://github.com/user-attachments/assets/0d8d4af7-7eeb-4d4b-9b74-37ddb0722e67" />|<img width="2306" height="1866" alt="CleanShot 2025-09-19 at 14 44 45@2x" src="https://github.com/user-attachments/assets/7cc5e91b-35f1-4e93-8f47-261524d6ce36" />| 