### PR TITLE
FIX: Check conditions for mobile bulk select

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
+++ b/app/assets/javascripts/discourse/app/components/discovery/filter-navigation.gjs
@@ -28,7 +28,7 @@ export default class DiscoveryFilterNavigation extends Component {
       { site: this.site }
     );
 
-    return this.site.mobileView || (enableOnDesktop && this.args.canBulkSelect);
+    return this.args.canBulkSelect && (this.site.mobileView || enableOnDesktop);
   }
 
   <template>


### PR DESCRIPTION
Addresses an issue where the bulk select button appeared on the moblile /filter page for users who cannot bulk select. Reported on meta [here](https://meta.discourse.org/t/bulk-select-button-appears-on-mobile-even-if-you-are-not-a-mod/383361.

The fix adjusts the logic for displaying the bulk select button to always require `canBulkSelect`.

Follow-up fix for https://github.com/discourse/discourse/pull/34237