### PR TITLE
UX: Disabled restore backup title included link HTML

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-backups-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-backups-index.js
@@ -25,7 +25,7 @@ export default class AdminBackupsIndexController extends Controller {
   @discourseComputed("status.allowRestore", "status.isOperationRunning")
   restoreTitle(allowRestore, isOperationRunning) {
     if (!allowRestore) {
-      return "admin.backups.operations.restore.is_disabled";
+      return "admin.backups.operations.restore.is_disabled_title";
     } else if (isOperationRunning) {
       return "admin.backups.operations.is_running";
     } else {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6822,6 +6822,7 @@ en:
             confirm: "Are you sure you want to destroy this backup?"
           restore:
             is_disabled: "Restore is currently disabled. To enable it, visit the <a href='%{url}'>site settings</a>."
+            is_disabled_title: "Restore is currently disabled. To enable it, search for 'allow restore' in site settings."
             label: "Restore"
             title: "Restore the backup"
             confirm: "Are you sure you want to restore this backup?"


### PR DESCRIPTION
Followup https://github.com/discourse/discourse/pull/28452

The title for the "Restore" backup button was using HTML, the
same as the alert for admins telling them that restoring is disabled.
This fixes  the issue by adding a plain text title a reference to the
relevant site setting.

c.f. https://meta.discourse.org/t/restore-backup-tooltip-link-broken/345620
