### PR TITLE
DEV: Add registerCategorySaveProperty to allow plugins to save other category attributes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.gjs
@@ -3,7 +3,6 @@
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
 
-import { _addCategoryPropertyForUpdate } from "discourse/models/category";
 export const PLUGIN_API_VERSION = "2.1.1";
 
 import $ from "jquery";
@@ -123,6 +122,7 @@ import {
 import { addCustomUserFieldValidationCallback } from "discourse/lib/user-fields-validation-helper";
 import { registerUserMenuTab } from "discourse/lib/user-menu/tab";
 import { replaceFormatter } from "discourse/lib/utilities";
+import { _addCategoryPropertyForSave } from "discourse/models/category";
 import Composer, {
   registerCustomizationCallback,
 } from "discourse/models/composer";
@@ -3407,14 +3407,14 @@ class PluginApi {
    * (all under the same save call), and are not using custom fields for that.
    *
    * ```
-   * api.registerCategoryUpdateProperty("property_one");
-   * api.registerCategoryUpdateProperty("property_two");
+   * api.registerCategorySaveProperty("property_one");
+   * api.registerCategorySaveProperty("property_two");
    * ```
    *
    * @param {string} property - The name of the property to include when saving a category.
    */
-  registerCategoryUpdateProperty(property) {
-    _addCategoryPropertyForUpdate(property);
+  registerCategorySaveProperty(property) {
+    _addCategoryPropertyForSave(property);
   }
 
   #deprecateModifyClass(className) {

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -17,7 +17,7 @@ import Topic from "discourse/models/topic";
 const STAFF_GROUP_NAME = "staff";
 const CATEGORY_ASYNC_SEARCH_CACHE = {};
 const CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE = {};
-const pluginProperties = new Set();
+const pluginSaveProperties = new Set();
 
 /**
  * @internal
@@ -27,8 +27,8 @@ const pluginProperties = new Set();
  *
  * @param {string} propertyKey - The key of the property to track.
  */
-export function _addCategoryPropertyForUpdate(propertyKey) {
-  pluginProperties.add(propertyKey);
+export function _addCategoryPropertyForSave(propertyKey) {
+  pluginSaveProperties.add(propertyKey);
 }
 
 export default class Category extends RestModel {
@@ -798,14 +798,14 @@ export default class Category extends RestModel {
         ...(this.siteSettings.content_localization_enabled && {
           category_localizations: this.localizations,
         }),
-        ...this._pluginPropertiesForUpdate(),
+        ...this._pluginSaveProperties(),
       }),
       type: id ? "PUT" : "POST",
     });
   }
 
-  _pluginPropertiesForUpdate() {
-    return Array.from(pluginProperties).reduce((obj, key) => {
+  _pluginSaveProperties() {
+    return Array.from(pluginSaveProperties).reduce((obj, key) => {
       obj[key] = this[key];
       return obj;
     }, {});

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -497,11 +497,11 @@ module("Unit | Model | category", function (hooks) {
     assert.deepEqual(requestedIds, [[12345, 12346], [12347]]);
   });
 
-  test("registerCategoryUpdateProperty includes property in save request", async function (assert) {
+  test("registerCategorySaveProperty includes property in save request", async function (assert) {
     const done = assert.async();
 
     withPluginApi((api) => {
-      api.registerCategoryUpdateProperty("cats_and_dogs");
+      api.registerCategorySaveProperty("cats_and_dogs");
     });
 
     const category = Category.create({


### PR DESCRIPTION
This PR introduces `registerCategorySaveProperty` that allows other plugins that are adding additional parameters to the category to save the new property alongside the default category properties (all under the same save call), and are not using custom fields for that.

```
api.registerCategorySaveProperty("property_one");
api.registerCategorySaveProperty("property_two");
```

