### PR TITLE
FEATURE: open the discourse-id gates

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -597,7 +597,6 @@ login:
     default: true
   enable_discourse_id:
     default: false
-    hidden: true
     validator: "EnableDiscourseIdValidator"
   discourse_id_client_id:
     default: ""

--- a/lib/validators/enable_discourse_id_validator.rb
+++ b/lib/validators/enable_discourse_id_validator.rb
@@ -7,7 +7,7 @@ class EnableDiscourseIdValidator
 
   def valid_value?(val)
     return true if val == "f"
-    return false if credentials_missing?
+    return DiscourseId::Register.call(params: { force: true }).success? if credentials_missing?
     true
   end
 

--- a/spec/lib/validators/enable_discourse_id_validator_spec.rb
+++ b/spec/lib/validators/enable_discourse_id_validator_spec.rb
@@ -33,12 +33,32 @@ RSpec.describe EnableDiscourseIdValidator do
       end
 
       describe "when value is true" do
-        it "should not be valid" do
-          expect(validator.valid_value?("t")).to eq(false)
+        context "when DiscourseId::Register service succeeds" do
+          before do
+            allow(DiscourseId::Register).to receive(:call).with(params: { force: true }).and_return(
+              instance_double("Service::Base::Context", success?: true),
+            )
+          end
 
-          expect(validator.error_message).to eq(
-            I18n.t("site_settings.errors.discourse_id_credentials"),
-          )
+          it "should be valid" do
+            expect(validator.valid_value?("t")).to eq(true)
+          end
+        end
+
+        context "when DiscourseId::Register service fails" do
+          before do
+            allow(DiscourseId::Register).to receive(:call).with(params: { force: true }).and_return(
+              instance_double("Service::Base::Context", success?: false),
+            )
+          end
+
+          it "should not be valid" do
+            expect(validator.valid_value?("t")).to eq(false)
+
+            expect(validator.error_message).to eq(
+              I18n.t("site_settings.errors.discourse_id_credentials"),
+            )
+          end
         end
       end
     end
@@ -53,12 +73,32 @@ RSpec.describe EnableDiscourseIdValidator do
       end
 
       describe "when value is true" do
-        it "should not be valid" do
-          expect(validator.valid_value?("t")).to eq(false)
+        context "when DiscourseId::Register service succeeds" do
+          before do
+            allow(DiscourseId::Register).to receive(:call).with(params: { force: true }).and_return(
+              instance_double("Service::Base::Context", success?: true),
+            )
+          end
 
-          expect(validator.error_message).to eq(
-            I18n.t("site_settings.errors.discourse_id_credentials"),
-          )
+          it "should be valid" do
+            expect(validator.valid_value?("t")).to eq(true)
+          end
+        end
+
+        context "when DiscourseId::Register service fails" do
+          before do
+            allow(DiscourseId::Register).to receive(:call).with(params: { force: true }).and_return(
+              instance_double("Service::Base::Context", success?: false),
+            )
+          end
+
+          it "should not be valid" do
+            expect(validator.valid_value?("t")).to eq(false)
+
+            expect(validator.error_message).to eq(
+              I18n.t("site_settings.errors.discourse_id_credentials"),
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
- Unhide the 'enable_discourse_id' site setting so people can toggle it via the standard "site setting" admin page rather than via the CLI
- Update the "EnableDiscourseIdValidator" to automatically register when enabling the site setting
- Update the "DiscourseId::Register" service to also support registering via a _secret_ "discourse login api key" (that will bypass the challenge flow)
- Update all the specs according to the changes

Internal ref - t/161934