### PR TITLE
UX: Horizon > increase z-index for list controls

### DIFF
--- a/themes/horizon/scss/nav-pills.scss
+++ b/themes/horizon/scss/nav-pills.scss
@@ -2,7 +2,7 @@
   position: sticky;
   top: var(--header-offset);
   background: var(--d-content-background);
-  z-index: z("base");
+  z-index: calc(z("base") + 1);
   padding: 1.5rem 0 1rem 0;
   max-width: unset;
 


### PR DESCRIPTION
The clickable card layout used in the boxes+featured categories has a higher z-index, which conflicts with the sticky list-controls in Horizon. Hence the latter needs this increase.

<img width="804" height="1584" alt="CleanShot 2025-09-22 at 12 00 26@2x" src="https://github.com/user-attachments/assets/9ae057f0-cbe0-4677-b10b-550741ade7ab" />
<img width="804" height="1584" alt="CleanShot 2025-09-22 at 12 00 37@2x" src="https://github.com/user-attachments/assets/a821cb6a-e6c9-4f20-ab64-29f32829fb80" />

