### PR TITLE
UX: Horizon search adjustment

### DIFF
--- a/themes/horizon/scss/header.scss
+++ b/themes/horizon/scss/header.scss
@@ -9,6 +9,11 @@
   }
 }
 
+.search-menu .search-input,
+.search-menu-container .search-input {
+  border-color: var(--header_primary-low-mid);
+}
+
 .user-menu .quick-access-panel,
 .user-notifications-list {
   li {

--- a/themes/horizon/scss/welcome-banner.scss
+++ b/themes/horizon/scss/welcome-banner.scss
@@ -83,9 +83,8 @@
 
   .search-menu .search-input,
   .search-menu-container .search-input {
-    background: var(--primary-100);
-    border: 1px solid var(--primary-100);
-    border-radius: var(--d-border-radius-large);
+    border: 1px solid var(--input-border-color);
+    border-radius: var(--d-border-radius);
   }
 
   .search-menu .search-input:focus-within,

--- a/themes/horizon/scss/welcome-banner.scss
+++ b/themes/horizon/scss/welcome-banner.scss
@@ -83,21 +83,15 @@
 
   .search-menu .search-input,
   .search-menu-container .search-input {
-    background: var(--d-content-background);
-    border: 1px solid var(--search-color);
-    box-shadow: 0 4px 10px rgb(52, 6, 121, 15%);
+    background: var(--primary-100);
+    border: 1px solid var(--primary-100);
+    border-radius: var(--d-border-radius-large);
   }
 
   .search-menu .search-input:focus-within,
   .search-menu-container .search-input:focus-within {
     border: 1px solid var(--search-color);
     outline: 2px solid var(--search-color);
-  }
-
-  .search-menu .d-icon,
-  .search-menu .searching .d-icon,
-  .search-menu .searching .show-advanced-search .d-icon {
-    color: var(--search-color);
   }
 
   .panel-body {


### PR DESCRIPTION
This PR removes the prominence of the search input by removing the drop shadow from the search bar on horizon. It also adds a subtle color to the search input when it appears in the header.

|Before|After|
|--|--|
|<img width="2574" height="1584" alt="CleanShot 2025-09-22 at 17 05 36@2x" src="https://github.com/user-attachments/assets/9d2f1c2a-8137-429b-862e-69544cc4f85f" />|<img width="2580" height="1596" alt="CleanShot 2025-09-22 at 17 04 49@2x" src="https://github.com/user-attachments/assets/6c225426-1399-41d2-a378-4e0747e52efe" />|
|<img width="2576" height="852" alt="CleanShot 2025-09-22 at 17 07 15@2x" src="https://github.com/user-attachments/assets/b46c3559-7fa8-4db8-a39d-3dce67ea7763" />|<img width="2574" height="978" alt="CleanShot 2025-09-22 at 17 05 18@2x" src="https://github.com/user-attachments/assets/e5b0f4ba-f8c2-4941-b50d-19c918adb10c" />|