### PR TITLE
fix: when date locale isnt ascii

### DIFF
--- a/app/assets/javascripts/discourse/admin/controllers/admin-email/preview-digest.js
+++ b/app/assets/javascripts/discourse/admin/controllers/admin-email/preview-digest.js
@@ -3,6 +3,7 @@ import { action, get } from "@ember/object";
 import { empty, notEmpty, or } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import toASCIIDigits from "discourse/lib/to-ascii-numerals";
 import EmailPreview from "admin/models/email-preview";
 
 export default class AdminEmailPreviewDigestController extends Controller {
@@ -40,10 +41,14 @@ export default class AdminEmailPreviewDigestController extends Controller {
       this.set("username", username);
     }
 
-    EmailPreview.findDigest(username, this.lastSeen).then((email) => {
-      model.setProperties(email.getProperties("html_content", "text_content"));
-      this.set("loading", false);
-    });
+    EmailPreview.findDigest(username, toASCIIDigits(this.lastSeen)).then(
+      (email) => {
+        model.setProperties(
+          email.getProperties("html_content", "text_content")
+        );
+        this.set("loading", false);
+      }
+    );
   }
 
   @action
@@ -51,7 +56,11 @@ export default class AdminEmailPreviewDigestController extends Controller {
     this.set("sendingEmail", true);
     this.set("sentEmail", false);
 
-    EmailPreview.sendDigest(this.username, this.lastSeen, this.email)
+    EmailPreview.sendDigest(
+      this.username,
+      toASCIIDigits(this.lastSeen),
+      this.email
+    )
       .then((result) => {
         if (result.errors) {
           this.dialog.alert(result.errors);

--- a/app/assets/javascripts/discourse/app/lib/to-ascii-numerals.js
+++ b/app/assets/javascripts/discourse/app/lib/to-ascii-numerals.js
@@ -1,0 +1,44 @@
+/*
+Converts Arabic-Indic (٠١٢٣٤٥٦٧٨٩) and
+Eastern Arabic-Indic (۰۱۲۳۴۵۶۷۸۹, Persian/Urdu)
+into Western Arabic digits (0123456789).
+
+Runs conversion only if non-ASCII digits are present.
+Related ChatGPT Converseation: https://chatgpt.com/share/68c2c5f2-ba7c-8004-8d53-6b2db78a20b5
+
+*/
+
+const DIGIT_MAP = {
+  "٠": "0",
+  "١": "1",
+  "٢": "2",
+  "٣": "3",
+  "٤": "4",
+  "٥": "5",
+  "٦": "6",
+  "٧": "7",
+  "٨": "8",
+  "٩": "9",
+  "۰": "0",
+  "۱": "1",
+  "۲": "2",
+  "۳": "3",
+  "۴": "4",
+  "۵": "5",
+  "۶": "6",
+  "۷": "7",
+  "۸": "8",
+  "۹": "9",
+};
+
+const NON_ASCII_DIGITS = /[٠-٩۰-۹]/; // regex check
+
+export default function toASCIIDigits(str) {
+  if (!NON_ASCII_DIGITS.test(str)) {
+    return str; // fast path, no conversion needed
+  }
+  return str
+    .split("")
+    .map((ch) => DIGIT_MAP[ch] || ch)
+    .join("");
+}

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -5,6 +5,7 @@ import { bind } from "discourse/lib/decorators";
 import { downloadCalendar } from "discourse/lib/download-calendar";
 import { iconHTML, renderIcon } from "discourse/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import toASCIIDigits from "discourse/lib/to-ascii-numerals";
 import {
   addTagDecorateCallback,
   addTextDecorateCallback,
@@ -177,7 +178,9 @@ function initializeDiscourseLocalDates(api) {
       const time = moment().format("HH:mm:ss");
       const date = moment().format("YYYY-MM-DD");
 
-      event.addText(`[date=${date} time=${time} timezone="${timezone}"]`);
+      event.addText(
+        `[date=${toASCIIDigits(date)} time=${toASCIIDigits(time)} timezone="${timezone}"]`
+      );
     },
   });
 

--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-markup-generator.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-markup-generator.js
@@ -1,4 +1,5 @@
 import { isEmpty } from "@ember/utils";
+import toASCIIDigits from "discourse/lib/to-ascii-numerals";
 
 export default function generateDateMarkup(
   fromDateTime,
@@ -54,5 +55,5 @@ export default function generateDateMarkup(
 
   text += `]`;
 
-  return text;
+  return toASCIIDigits(text);
 }

--- a/plugins/discourse-local-dates/assets/javascripts/lib/rich-editor-extension.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/rich-editor-extension.js
@@ -1,3 +1,5 @@
+import LocalDateBuilder from "../lib/local-date-builder";
+
 /** @type {RichEditorExtension} */
 const extension = {
   // TODO(renato): the rendered date needs to be localized to better match the cooked content
@@ -20,6 +22,7 @@ const extension = {
       ],
       toDOM: (node) => {
         const optionalTime = node.attrs.time ? ` ${node.attrs.time}` : "";
+        const optionalTimeZone = node.attrs.timezone || "UTC";
         return [
           "span",
           {
@@ -28,7 +31,17 @@ const extension = {
             "data-time": node.attrs.time,
             "data-timezone": node.attrs.timezone,
           },
-          `${node.attrs.date}${optionalTime}`,
+          `${
+            new LocalDateBuilder(
+              {
+                time: optionalTime,
+                date: node.attrs.date,
+                timezone: optionalTimeZone,
+                localTimezone: optionalTimeZone,
+              },
+              optionalTimeZone
+            ).build().formatted
+          }`,
         ];
       },
     },
@@ -61,6 +74,8 @@ const extension = {
           ? ` ${node.attrs.fromTime}`
           : "";
         const toTimeStr = node.attrs.toTime ? ` ${node.attrs.toTime}` : "";
+        const optionalTimeZone = node.attrs.timezone || "UTC";
+
         return [
           "span",
           { class: "discourse-local-date-range" },
@@ -73,7 +88,17 @@ const extension = {
               "data-time": node.attrs.fromTime,
               "data-timezone": node.attrs.timezone,
             },
-            `${node.attrs.fromDate}${fromTimeStr}`,
+            `${
+              new LocalDateBuilder(
+                {
+                  time: fromTimeStr,
+                  date: node.attrs.fromDate,
+                  timezone: optionalTimeZone,
+                  localTimezone: optionalTimeZone,
+                },
+                optionalTimeZone
+              ).build().formatted
+            }`,
           ],
           " → ",
           [
@@ -85,7 +110,17 @@ const extension = {
               "data-time": node.attrs.toTime,
               "data-timezone": node.attrs.timezone,
             },
-            `${node.attrs.toDate}${toTimeStr}`,
+            `${
+              new LocalDateBuilder(
+                {
+                  time: toTimeStr,
+                  date: node.attrs.toDate,
+                  timezone: optionalTimeZone,
+                  localTimezone: optionalTimeZone,
+                },
+                optionalTimeZone
+              ).build().formatted
+            }`,
           ],
         ];
       },

--- a/plugins/discourse-local-dates/spec/system/rich_editor_extension_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/rich_editor_extension_spec.rb
@@ -29,7 +29,7 @@ describe "Composer - ProseMirror editor - Local Dates extension", type: :system 
 
       expect(rich).to have_css(
         "span.discourse-local-date[data-timezone='Asia/Singapore']",
-        text: "2022-12-15 14:19:00",
+        text: "December 15, 2022 2:19 PM",
       )
     end
 
@@ -45,11 +45,11 @@ describe "Composer - ProseMirror editor - Local Dates extension", type: :system 
       expect(rich).to have_css("span.discourse-local-date-range")
       expect(rich).to have_css(
         "span.discourse-local-date[data-timezone='Asia/Singapore'][data-range='from']",
-        text: "2022-12-15 14:19:00",
+        text: "December 15, 2022 2:19 PM",
       )
       expect(rich).to have_css(
         "span.discourse-local-date[data-timezone='Asia/Singapore'][data-range='to']",
-        text: "2022-12-16 15:20:00",
+        text: "December 16, 2022 3:20 PM",
       )
     end
   end

--- a/plugins/discourse-local-dates/test/javascripts/integration/rich-editor-extension-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/integration/rich-editor-extension-test.js
@@ -10,22 +10,22 @@ module(
     Object.entries({
       "local date": [
         "[date=2021-01-01 time=12:00:00]",
-        '<p><span class="discourse-local-date cooked-date" data-date="2021-01-01" data-time="12:00:00" contenteditable="false">2021-01-01 12:00:00</span></p>',
+        '<p><span class="discourse-local-date cooked-date" data-date="2021-01-01" data-time="12:00:00" contenteditable="false">January 1, 2021 12:00 PM</span></p>',
         "[date=2021-01-01 time=12:00:00]",
       ],
       "local date with timezone": [
         '[date=2021-01-01 time=12:00:00 timezone="America/New_York"]',
-        '<p><span class="discourse-local-date cooked-date" data-date="2021-01-01" data-time="12:00:00" data-timezone="America/New_York" contenteditable="false">2021-01-01 12:00:00</span></p>',
+        '<p><span class="discourse-local-date cooked-date" data-date="2021-01-01" data-time="12:00:00" data-timezone="America/New_York" contenteditable="false">January 1, 2021 12:00 PM</span></p>',
         '[date=2021-01-01 time=12:00:00 timezone="America/New_York"]',
       ],
       "local date range": [
         "[date-range from=2021-01-01 to=2021-01-02]",
-        '<p><span class="discourse-local-date-range" contenteditable="false"><span class="discourse-local-date cooked-date" data-range="from" data-date="2021-01-01">2021-01-01</span> → <span class="discourse-local-date cooked-date" data-range="to" data-date="2021-01-02">2021-01-02</span></span></p>',
+        '<p><span class="discourse-local-date-range" contenteditable="false"><span class="discourse-local-date cooked-date" data-range="from" data-date="2021-01-01">January 1, 2021</span> → <span class="discourse-local-date cooked-date" data-range="to" data-date="2021-01-02">January 2, 2021</span></span></p>',
         "[date-range from=2021-01-01 to=2021-01-02]",
       ],
       "local date range with time": [
         '[date-range from=2021-01-01T12:00:00 to=2021-01-02T13:00:00 timezone="America/New_York"]',
-        '<p><span class="discourse-local-date-range" contenteditable="false"><span class="discourse-local-date cooked-date" data-range="from" data-date="2021-01-01" data-time="12:00:00" data-timezone="America/New_York">2021-01-01 12:00:00</span> → <span class="discourse-local-date cooked-date" data-range="to" data-date="2021-01-02" data-time="13:00:00" data-timezone="America/New_York">2021-01-02 13:00:00</span></span></p>',
+        '<p><span class="discourse-local-date-range" contenteditable="false"><span class="discourse-local-date cooked-date" data-range="from" data-date="2021-01-01" data-time="12:00:00" data-timezone="America/New_York">January 1, 2021 12:00 PM</span> → <span class="discourse-local-date cooked-date" data-range="to" data-date="2021-01-02" data-time="13:00:00" data-timezone="America/New_York">January 2, 2021 1:00 PM</span></span></p>',
         '[date-range from=2021-01-01T12:00:00 to=2021-01-02T13:00:00 timezone="America/New_York"]',
       ],
     }).forEach(([name, [markdown, html, expectedMarkdown]]) => {


### PR DESCRIPTION
 This change does two things related to rich editor

  1: it forces date and time to be saved in ASCI
  2:[improv] it renders local date @ toDOM rich editor method
  3: forces date value in digest to form to transform into ASCI
   before it being trasfered through AJAX

 1 and 3 were reported at:
 https://meta.discourse.org/t/internal-server-error-when-previewing-digest-emails/380954

It might needed to write tests while overriding locale `siteSettings.defaule_locale` to `ar`, `fa`, and `en_SG`.  