### PR TITLE
FIX: correct argument passing for small action post value transformer and custom component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/small-action.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/small-action.gjs
@@ -125,7 +125,7 @@ export default class PostSmallAction extends Component {
   }
 
   get username() {
-    return this.args.post.action_code_who;
+    return this.args.post.user.username;
   }
 
   <template>
@@ -162,7 +162,7 @@ export default class PostSmallAction extends Component {
             {{#if this.CustomComponent}}
               <this.CustomComponent
                 @code={{this.code}}
-                @post={{this.post}}
+                @post={{this.args.post}}
                 @createdAt={{this.createdAt}}
                 @path={{this.path}}
                 @username={{this.username}}


### PR DESCRIPTION
As explained [here ](https://meta.discourse.org/t/small-action-customcomponent-argument-issue/383606) there are various bugs in the code for CustomComponent usage in a small action post.

This PR aims to fix those issues.