### PR TITLE
DEV: Fix chat user option extension enum check

### DIFF
--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -50,7 +50,7 @@ module Chat
                   prefix: "chat_separate_sidebar_mode"
       end
 
-      if !base.method_defined?(:chat_send_shortcut_default?)
+      if !base.method_defined?(:chat_send_shortcut_enter?)
         base.enum :chat_send_shortcut, base.chat_send_shortcut, prefix: "chat_send_shortcut"
       end
 


### PR DESCRIPTION
`chat_send_shortcut` enum doesn't have a `default` option, so this code always ran, which could cause issues with autoloader