### PR TITLE
UX: Horizon > sidebar NT btn state styling

### DIFF
--- a/themes/horizon/scss/sidebar-new-topic-button.scss
+++ b/themes/horizon/scss/sidebar-new-topic-button.scss
@@ -12,11 +12,25 @@
 
 .sidebar-new-topic-button {
   flex: 1 1 auto;
-  margin-top: 4px; // hover & focus effect visibility
 
   &__wrapper {
     box-sizing: border-box;
     display: flex;
+    border-radius: 6.25em;
+    margin-top: 4px; // hover & focus effect visibility
+
+    &:focus-visible,
+    &:hover {
+      .discourse-no-touch & {
+        background-color: var(--accent-color);
+        box-shadow: 0 0 0 4px var(--button-box-shadow);
+        color: var(--accent-text-color);
+
+        .d-icon {
+          color: var(--accent-text-color);
+        }
+      }
+    }
 
     .mobile-view & {
       margin: 0 0 1rem;
@@ -31,6 +45,17 @@
             oklch(from var(--primary-300) l c h),
             oklch(from var(--primary-700) l c h)
           ) !important;
+
+        &:focus-visible,
+        &:hover {
+          .discourse-no-touch & {
+            box-shadow: none;
+            background: light-dark(
+              oklch(from var(--accent-color) 40% c h),
+              oklch(from var(--accent-color) 50% c h)
+            );
+          }
+        }
       }
     }
 
@@ -43,6 +68,17 @@
       margin: 0;
       border-radius: 0 var(--d-button-border-radius)
         var(--d-button-border-radius) 0;
+
+      &:focus-visible,
+      &:hover {
+        .discourse-no-touch & {
+          box-shadow: none;
+          background: light-dark(
+            oklch(from var(--accent-color) 40% c h),
+            oklch(from var(--accent-color) 50% c h)
+          );
+        }
+      }
     }
 
     .fk-d-button-tooltip:has(button[disabled]) {


### PR DESCRIPTION
Followup for https://github.com/discourse/discourse/commit/3762ed22db3948d95e4f960c08fe6bdf0fd9d4b3

The sidebar NT button needs some extra attention and a slight tweak to the state styling, as it's an exception combo-btn.

https://github.com/user-attachments/assets/db19915c-8020-491e-9cc0-7c8be7410ebe

