### PR TITLE
DEV: Allow `ServerSession` to store arbitrary data

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -33,7 +33,7 @@ class SessionController < ApplicationController
       return_path = "#{uri.path}#{uri.query ? "?#{uri.query}" : ""}"
     end
 
-    server_session[:destination_url] = nil
+    server_session.delete(:destination_url)
     cookies.delete(:destination_url)
 
     sso = DiscourseConnect.generate_sso(return_path, server_session:)
@@ -895,7 +895,7 @@ class SessionController < ApplicationController
       email: sso.email,
       redeeming_user: redeeming_user,
     ).redeem
-    server_session["invite-key"] = nil
+    server_session.delete("invite-key")
 
     # note - more specific errors are handled in the sso_login method
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e

--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -25,7 +25,7 @@ class Users::AssociateAccountsController < ApplicationController
     auth_result = authenticator.after_authenticate(auth_hash, existing_account: current_user)
     DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies, request)
 
-    server_session[self.class.key(params[:token])] = nil
+    server_session.delete(self.class.key(params[:token]))
 
     render json: success_json
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -42,7 +42,7 @@ class Users::OmniauthCallbacksController < ApplicationController
     session.delete(:destination_url) # Clean up old values. TODO: Remove after March 2026
     if server_session[:destination_url].present?
       preferred_origin = server_session[:destination_url]
-      server_session[:destination_url] = nil
+      server_session.delete(:destination_url)
     elsif SiteSetting.enable_discourse_connect_provider && payload = cookies.delete(:sso_payload)
       preferred_origin = session_sso_provider_url + "?" + payload
     elsif cookies[:destination_url].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -763,8 +763,8 @@ class UsersController < ApplicationController
       associations.each { |a| a.update!(user: user) }
       user.update_timezone_if_missing(params[:timezone])
 
-      server_session[HONEYPOT_KEY] = nil
-      server_session[CHALLENGE_KEY] = nil
+      server_session.delete(HONEYPOT_KEY)
+      server_session.delete(CHALLENGE_KEY)
 
       # save user email in session, to show on account-created page
       session["user_created_message"] = activation.message
@@ -918,8 +918,8 @@ class UsersController < ApplicationController
 
         if @user.save
           Invite.invalidate_for_email(@user.email) # invite link can't be used to log in anymore
-          server_session["password-#{token}"] = nil
-          server_session["second-factor-#{token}"] = nil
+          server_session.delete("password-#{token}")
+          server_session.delete("second-factor-#{token}")
 
           if SiteSetting.delete_associated_accounts_on_password_reset
             @user.user_associated_accounts.destroy_all

--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -74,9 +74,9 @@ class DiscourseConnect < DiscourseConnectBase
   def expire_nonce!
     if nonce
       if SiteSetting.discourse_connect_csrf_protection
-        @server_session[nonce_key] = nil
+        @server_session.delete(nonce_key)
       else
-        Discourse.cache.delete nonce_key
+        Discourse.cache.delete(nonce_key)
       end
 
       Discourse.cache.write(

--- a/lib/discourse_webauthn.rb
+++ b/lib/discourse_webauthn.rb
@@ -82,7 +82,7 @@ module DiscourseWebauthn
   # @param user [User] the user to clear the challenge for
   # @param server_session [ServerSession] the session to clear the challenge from
   def self.clear_challenge(user, server_session)
-    server_session[self.session_challenge_key(user)] = nil
+    server_session.delete(session_challenge_key(user))
   end
 
   def self.allowed_credentials(user, server_session)
@@ -90,12 +90,12 @@ module DiscourseWebauthn
 
     {
       allowed_credential_ids: user.second_factor_security_key_credential_ids,
-      challenge: self.challenge(user, server_session),
+      challenge: challenge(user, server_session),
     }
   end
 
   def self.challenge(user, server_session)
-    server_session[self.session_challenge_key(user)]
+    server_session[session_challenge_key(user)]
   end
 
   def self.rp_id

--- a/lib/second_factor/auth_manager.rb
+++ b/lib/second_factor/auth_manager.rb
@@ -216,7 +216,7 @@ class SecondFactor::AuthManager
             )
     end
 
-    server_session["current_second_factor_auth_challenge"] = nil
+    server_session.delete("current_second_factor_auth_challenge")
     callback_params = challenge[:callback_params]
     data = @action.second_factor_auth_completed!(callback_params)
     data

--- a/spec/lib/server_session_spec.rb
+++ b/spec/lib/server_session_spec.rb
@@ -23,4 +23,42 @@ RSpec.describe ServerSession do
     session.set(key, "test2")
     expect(session.ttl(key)).to be_within(1.second).of(described_class.expiry)
   end
+
+  describe "#[]" do
+    let(:hash) { { symbol: :value, integer: 1, time: Time.current }.with_indifferent_access }
+
+    before { session[:my_hash] = hash }
+
+    it "returns complex objects properly" do
+      expect(session[:my_hash]).to eq(hash)
+    end
+
+    context "when key is a string" do
+      it "returns the proper value" do
+        expect(session["my_hash"]).to eq(hash)
+      end
+    end
+
+    context "when key is not found" do
+      it "returns nil" do
+        expect(session[:non_existent_key]).to be_nil
+      end
+    end
+
+    context "when accessing an old value that wasn't serialized" do
+      before { Discourse.redis.setex("abcoldvalue", 1.minute.to_i, "non-serialized value") }
+
+      it "returns the old value" do
+        expect(session[:oldvalue]).to eq("non-serialized value")
+      end
+    end
+  end
+
+  describe "#delete" do
+    before { session[:key] = "value" }
+
+    it "deletes the key from Redis" do
+      expect { session.delete(:key) }.to change { Discourse.redis.exists?("abckey") }.to(false)
+    end
+  end
 end


### PR DESCRIPTION
Currently, the server session can only store strings. As we want to move more things into it (like with a proper session object), we need to be able to store arbitrary data.

This PR serializes data using Message Pack, as it’s almost as flexible as Marshal but without the potential security issues.
