### PR TITLE
UX: fix emoji size in post excerpts

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -136,6 +136,13 @@
     margin-bottom: var(--space-2);
     font-size: var(--font-down-2);
     word-break: break-word;
+
+    // special exception case because this class gets applied where it shouldn't, example in excerpts in bookmark pages
+    .only-emoji {
+      width: 1em;
+      height: 1em;
+      margin-block: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Context:
https://meta.discourse.org/t/large-emojis-in-post-preview-of-bookmarks/296815

| BC | AC |
|--------|--------|
| <img width="2244" height="834" alt="CleanShot 2025-09-23 at 12 01 59@2x" src="https://github.com/user-attachments/assets/7edcff24-7e3d-400e-9345-51a7f6e5c9d6" /> | <img width="2244" height="834" alt="CleanShot 2025-09-23 at 12 02 20@2x" src="https://github.com/user-attachments/assets/215894f4-2cd6-4654-9c3e-d2d634603e60" /> | 