### PR TITLE
FIX: Include TOS and Privacy Policy URLs in signup when login required

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -227,6 +227,8 @@ class Site
             end,
           full_name_required_for_signup:,
           full_name_visible_in_signup:,
+          tos_url: Discourse.tos_url,
+          privacy_policy_url: Discourse.privacy_policy_url,
         }.to_json
       )
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -284,6 +284,17 @@ RSpec.describe Site do
     expect(data["auth_providers"].map { |a| a["name"] }).to contain_exactly("facebook", "twitter")
   end
 
+  it "includes tos_url and privacy_policy_url when login_required" do
+    SiteSetting.login_required = true
+    SiteSetting.tos_url = "https://discourse.org"
+    SiteSetting.privacy_policy_url = "https://discourse.org/privacy"
+
+    data = JSON.parse(Site.json_for(Guardian.new))
+
+    expect(data["tos_url"]).to eq(SiteSetting.tos_url)
+    expect(data["privacy_policy_url"]).to eq(SiteSetting.privacy_policy_url)
+  end
+
   describe ".all_categories_cache" do
     fab!(:category)
     fab!(:category2, :category)


### PR DESCRIPTION
When the site setting `login_required` is enabled, the signup page should include links to the TOS and Privacy Policy.