### PR TITLE
FIX: Always show the translation post menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/add-translation.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/add-translation.gjs
@@ -30,23 +30,19 @@ export default class PostMenuAddTranslationButton extends Component {
   }
 
   get addTranslationsLabel() {
-    if (this.showAsMenu) {
-      return i18n("post.localizations.manage", {
-        count: this.args.post.post_localizations_count,
-      });
-    }
+    return i18n("post.localizations.manage", {
+      count: this.args.post.post_localizations_count,
+    });
+  }
 
-    return i18n("post.localizations.add");
+  get showViewTranslations() {
+    return this.args.post.post_localizations_count > 0;
   }
 
   get viewTranslationLabel() {
     return i18n("post.localizations.view", {
       count: this.args.post.post_localizations_count,
     });
-  }
-
-  get showAsMenu() {
-    return this.args.post.post_localizations_count > 0;
   }
 
   @action
@@ -88,22 +84,22 @@ export default class PostMenuAddTranslationButton extends Component {
 
   <template>
     {{#if this.showTranslationButton}}
-      {{#if this.showAsMenu}}
-        <DMenu
-          ...attributes
-          @identifier="post-action-menu-edit-translations"
-          class="update-translations-menu"
-          @title={{this.addTranslationsLabel}}
-          @icon="discourse-add-translation"
-          @onRegisterApi={{this.onRegisterApi}}
-          @arrow={{false}}
-        >
-          <:content>
-            <DropdownMenu as |dropdown|>
-              <PluginOutlet
-                @name="post-menu-translations-dropdown"
-                @outletArgs={{lazyHash dropdown=dropdown post=@post}}
-              >
+      <DMenu
+        ...attributes
+        @identifier="post-action-menu-edit-translations"
+        class="update-translations-menu"
+        @title={{this.addTranslationsLabel}}
+        @icon="discourse-add-translation"
+        @onRegisterApi={{this.onRegisterApi}}
+        @arrow={{false}}
+      >
+        <:content>
+          <DropdownMenu as |dropdown|>
+            <PluginOutlet
+              @name="post-menu-translations-dropdown"
+              @outletArgs={{lazyHash dropdown=dropdown post=@post}}
+            >
+              {{#if this.showViewTranslations}}
                 <dropdown.item class="update-translations-menu__view">
                   <DButton
                     class="post-action-menu__view-translation"
@@ -112,27 +108,19 @@ export default class PostMenuAddTranslationButton extends Component {
                     @action={{this.viewTranslations}}
                   />
                 </dropdown.item>
-                <dropdown.item class="update-translations-menu__add">
-                  <DButton
-                    class="post-action-menu__add-translation"
-                    @label="post.localizations.add"
-                    @icon="plus"
-                    @action={{this.addTranslation}}
-                  />
-                </dropdown.item>
-              </PluginOutlet>
-            </DropdownMenu>
-          </:content>
-        </DMenu>
-      {{else}}
-        <DButton
-          class="post-action-menu__add-translation"
-          @title="post.localizations.add"
-          @icon="discourse-add-translation"
-          @action={{this.addTranslation}}
-          ...attributes
-        />
-      {{/if}}
+              {{/if}}
+              <dropdown.item class="update-translations-menu__add">
+                <DButton
+                  class="post-action-menu__add-translation"
+                  @label="post.localizations.add"
+                  @icon="plus"
+                  @action={{this.addTranslation}}
+                />
+              </dropdown.item>
+            </PluginOutlet>
+          </DropdownMenu>
+        </:content>
+      </DMenu>
     {{/if}}
   </template>
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/post/menu/buttons/add-translation-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/post/menu/buttons/add-translation-test.gjs
@@ -1,0 +1,106 @@
+import { getOwner } from "@ember/owner";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import AddTranslation from "discourse/components/post/menu/buttons/add-translation";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender from "discourse/tests/helpers/create-pretender";
+import { i18n } from "discourse-i18n";
+
+module(
+  "Integration | Component | Post Menu Add Translation Button",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      const store = getOwner(this).lookup("service:store");
+      const post = store.createRecord("post", {
+        id: 1,
+        topic_id: 1,
+        post_localizations_count: 0,
+      });
+
+      this.post = post;
+      this.set("post", post);
+
+      // positive case for menu to always show
+      this.siteSettings.content_localization_enabled = true;
+      this.currentUser.admin = true;
+      this.currentUser.can_localize_content = true;
+
+      pretender.get("/posts/1.json", () => {
+        return [200, {}, { raw: "Test post content" }];
+      });
+      pretender.get("/t/1.json", () => {
+        return [200, {}, { raw: "Test post content" }];
+      });
+    });
+
+    test("renders menu button when user can localize", async function (assert) {
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      assert
+        .dom(".update-translations-menu")
+        .exists("Menu button rendered when user can localize");
+    });
+
+    test("does not render when user cannot localize", async function (assert) {
+      this.currentUser.can_localize_content = false;
+
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      assert
+        .dom(".update-translations-menu")
+        .doesNotExist("No menu when user cannot localize");
+    });
+
+    test("does not render when localization is disabled", async function (assert) {
+      this.siteSettings.content_localization_enabled = false;
+
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      assert
+        .dom(".update-translations-menu")
+        .doesNotExist("No menu when localization disabled");
+    });
+
+    test("shows both view and add buttons when localizations exist", async function (assert) {
+      this.post.post_localizations_count = 2;
+
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      await click(".update-translations-menu");
+
+      assert
+        .dom(".update-translations-menu__view")
+        .exists("View button shown when localizations exist");
+      assert
+        .dom(".update-translations-menu__add")
+        .exists("Add button always shown");
+    });
+
+    test("shows only add button when no localizations", async function (assert) {
+      this.post.post_localizations_count = 0;
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      await click(".update-translations-menu");
+
+      assert
+        .dom(".update-translations-menu__view")
+        .doesNotExist("View button hidden when no localizations");
+      assert
+        .dom(".update-translations-menu__add")
+        .exists("Add button always shown");
+    });
+
+    test("view translation label includes count", async function (assert) {
+      this.post.post_localizations_count = 5;
+      await render(<template><AddTranslation @post={{this.post}} /></template>);
+
+      await click(".update-translations-menu");
+
+      assert
+        .dom(".post-action-menu__view-translation")
+        .hasText(i18n("post.localizations.view", { count: 5 }));
+    });
+  }
+);

--- a/spec/system/post_translation_spec.rb
+++ b/spec/system/post_translation_spec.rb
@@ -30,7 +30,8 @@ describe "Post translations", type: :system do
       post.update!(locale: "en")
 
       topic_page.visit_topic(topic)
-      find("#post_#{post.post_number} .post-action-menu__add-translation").click
+      find("#post_1 .post-action-menu-edit-translations-trigger").click
+      find(".update-translations-menu__add .post-action-menu__add-translation").click
       translation_selector.expand
       expect(all(".translation-selector-dropdown .select-kit-collection li").count).to eq(3)
       expect(translation_selector).to have_option_value("fr")
@@ -41,7 +42,8 @@ describe "Post translations", type: :system do
 
     it "allows a user to translate a post" do
       topic_page.visit_topic(topic)
-      find("#post_#{post.post_number} .post-action-menu__add-translation").click
+      find("#post_1 .post-action-menu-edit-translations-trigger").click
+      find(".update-translations-menu__add .post-action-menu__add-translation").click
       expect(composer).to be_opened
       translation_selector.expand
       translation_selector.select_row_by_value("fr")


### PR DESCRIPTION
The Add Translation post menu will now always be shown. Previously, it immediately opened the translation composer when there are 0 translations.

<img width="304" height="202" alt="Screenshot 2025-09-24 at 3 34 20 AM" src="https://github.com/user-attachments/assets/46074701-c386-465d-810a-ce0cde4c5571" />
