### PR TITLE
DEV: Define user-notes namespace earlier

### DIFF
--- a/plugins/discourse-user-notes/lib/discourse_user_notes/engine.rb
+++ b/plugins/discourse-user-notes/lib/discourse_user_notes/engine.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ::DiscourseUserNotes
+  COUNT_FIELD = "user_notes_count"
+
+  class Engine < ::Rails::Engine
+    engine_name PLUGIN_NAME
+    isolate_namespace DiscourseUserNotes
+  end
+
+  def self.key_for(user_id)
+    "notes:#{user_id}"
+  end
+
+  def self.notes_for(user_id)
+    PluginStore.get("user_notes", key_for(user_id)) || []
+  end
+
+  def self.add_note(user, raw, created_by, opts = nil)
+    opts ||= {}
+
+    notes = notes_for(user.id)
+    record = {
+      id: SecureRandom.hex(16),
+      user_id: user.id,
+      raw: raw,
+      created_by: created_by,
+      created_at: Time.now,
+    }.merge(opts)
+
+    notes << record
+    ::PluginStore.set("user_notes", key_for(user.id), notes)
+
+    user.custom_fields[DiscourseUserNotes::COUNT_FIELD] = notes.size
+    user.save_custom_fields
+
+    record
+  end
+
+  def self.remove_note(user, note_id)
+    notes = notes_for(user.id)
+    notes.reject! { |n| n[:id] == note_id }
+
+    if notes.size > 0
+      ::PluginStore.set("user_notes", key_for(user.id), notes)
+    else
+      ::PluginStore.remove("user_notes", key_for(user.id))
+    end
+    user.custom_fields[DiscourseUserNotes::COUNT_FIELD] = notes.size
+    user.save_custom_fields
+  end
+end

--- a/plugins/discourse-user-notes/plugin.rb
+++ b/plugins/discourse-user-notes/plugin.rb
@@ -13,60 +13,14 @@ register_asset "stylesheets/user_notes.scss"
 
 register_svg_icon "pen-to-square"
 
+module ::DiscourseUserNotes
+  PLUGIN_NAME = "discourse-user-notes"
+end
+
+require_relative "lib/discourse_user_notes/engine"
+
 after_initialize do
   require_dependency "user"
-
-  module ::DiscourseUserNotes
-    PLUGIN_NAME = "discourse-user-notes"
-    COUNT_FIELD = "user_notes_count"
-
-    class Engine < ::Rails::Engine
-      engine_name PLUGIN_NAME
-      isolate_namespace DiscourseUserNotes
-    end
-
-    def self.key_for(user_id)
-      "notes:#{user_id}"
-    end
-
-    def self.notes_for(user_id)
-      PluginStore.get("user_notes", key_for(user_id)) || []
-    end
-
-    def self.add_note(user, raw, created_by, opts = nil)
-      opts ||= {}
-
-      notes = notes_for(user.id)
-      record = {
-        id: SecureRandom.hex(16),
-        user_id: user.id,
-        raw: raw,
-        created_by: created_by,
-        created_at: Time.now,
-      }.merge(opts)
-
-      notes << record
-      ::PluginStore.set("user_notes", key_for(user.id), notes)
-
-      user.custom_fields[DiscourseUserNotes::COUNT_FIELD] = notes.size
-      user.save_custom_fields
-
-      record
-    end
-
-    def self.remove_note(user, note_id)
-      notes = notes_for(user.id)
-      notes.reject! { |n| n[:id] == note_id }
-
-      if notes.size > 0
-        ::PluginStore.set("user_notes", key_for(user.id), notes)
-      else
-        ::PluginStore.remove("user_notes", key_for(user.id))
-      end
-      user.custom_fields[DiscourseUserNotes::COUNT_FIELD] = notes.size
-      user.save_custom_fields
-    end
-  end
 
   require_relative "app/serializers/user_note_serializer.rb"
   require_relative "app/controllers/discourse_user_notes/user_notes_controller.rb"


### PR DESCRIPTION
Defining it inside `after_initialize` meant that other plugins couldn't always see it and interact with it during initalization.