### PR TITLE
UX: replace btn-danger with modifier class for bookmark dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-menu.gjs
@@ -313,7 +313,7 @@ export default class BookmarkMenu extends Component {
                 @icon="trash-can"
                 @label="delete"
                 @action={{this.onRemoveBookmark}}
-                class="bookmark-menu__row-btn btn-transparent btn-danger"
+                class="bookmark-menu__row-btn --danger"
               />
             </dropdown.item>
 

--- a/app/assets/stylesheets/common/components/dropdown-menu.scss
+++ b/app/assets/stylesheets/common/components/dropdown-menu.scss
@@ -10,6 +10,17 @@
       width: 100%;
       justify-content: flex-start;
       text-align: left;
+
+      &.--danger {
+        &:hover,
+        :focus-visible {
+          background: var(--danger-low);
+        }
+
+        .d-icon {
+          color: var(--danger);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
The bookmark modal should not be using `btn-danger`, as these classes are reserved for buttons following a standard format ("normal buttons"). This can cause issues when a theme styles these classes, which then conflicts with the display in a list.

This commit removes the class and replaces it with a `--danger` modifier that can be used in any dropdown.

| BC | AC |
|--------|--------|
| <img width="734" height="326" alt="CleanShot 2025-09-23 at 20 59 03@2x" src="https://github.com/user-attachments/assets/bd771908-8de2-4cfd-a648-fa880d330a09" /> | <img width="598" height="316" alt="CleanShot 2025-09-23 at 21 05 35@2x" src="https://github.com/user-attachments/assets/aba3877c-1aba-4fb3-935d-a31ec99e5fb6" /> | 