### PR TITLE
DEV: Clean up `require`s

### DIFF
--- a/lib/onebox/engine/flickr_onebox.rb
+++ b/lib/onebox/engine/flickr_onebox.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./opengraph_image"
+require_relative "opengraph_image"
 
 module Onebox
   module Engine

--- a/lib/onebox/engine/flickr_shortened_onebox.rb
+++ b/lib/onebox/engine/flickr_shortened_onebox.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./opengraph_image"
+require_relative "opengraph_image"
 
 module Onebox
   module Engine

--- a/plugins/discourse-affiliate/plugin.rb
+++ b/plugins/discourse-affiliate/plugin.rb
@@ -10,7 +10,7 @@
 enabled_site_setting :affiliate_enabled
 
 after_initialize do
-  require File.expand_path(File.dirname(__FILE__) + "/lib/affiliate_processor")
+  require_relative "lib/affiliate_processor"
 
   on(:post_process_cooked) do |doc, post|
     doc.css("a[href]").each { |a| a["href"] = AffiliateProcessor.apply(a["href"]) }

--- a/plugins/discourse-assign/spec/integration/assign_spec.rb
+++ b/plugins/discourse-assign/spec/integration/assign_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../support/assign_allowed_group"
-require_relative "../fabricators/assign_hook_fabricator.rb"
+require_relative "../fabricators/assign_hook_fabricator"
 
 describe "integration tests" do
   before { SiteSetting.assign_enabled = true }

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -10,8 +10,8 @@
 libdir = File.join(File.dirname(__FILE__), "vendor/holidays/lib")
 $LOAD_PATH.unshift(libdir) if $LOAD_PATH.exclude?(libdir)
 
-require_relative "lib/calendar_settings_validator.rb"
-require_relative "lib/calendar_first_day_of_week.rb"
+require_relative "lib/calendar_settings_validator"
+require_relative "lib/calendar_first_day_of_week"
 
 enabled_site_setting :calendar_enabled
 

--- a/plugins/discourse-chat-integration/app/serializers/channel_serializer.rb
+++ b/plugins/discourse-chat-integration/app/serializers/channel_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./rule_serializer"
+require_relative "rule_serializer"
 
 class DiscourseChatIntegration::ChannelSerializer < ApplicationSerializer
   attributes :id, :provider, :error_key, :error_info, :data, :rules

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -105,4 +105,4 @@ module DiscourseChatIntegration
   end
 end
 
-require_relative "mattermost_command_controller.rb"
+require_relative "mattermost_command_controller"

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -122,4 +122,4 @@ module DiscourseChatIntegration
   end
 end
 
-require_relative "telegram_command_controller.rb"
+require_relative "telegram_command_controller"

--- a/plugins/discourse-github/plugin.rb
+++ b/plugins/discourse-github/plugin.rb
@@ -11,8 +11,8 @@ require "sawyer"
 require "octokit"
 
 # Site setting validators must be loaded before initialize
-require_relative "app/lib/github_badges_repo_setting_validator.rb"
-require_relative "app/lib/github_linkback_access_token_setting_validator.rb"
+require_relative "app/lib/github_badges_repo_setting_validator"
+require_relative "app/lib/github_linkback_access_token_setting_validator"
 
 enabled_site_setting :enable_discourse_github_plugin
 

--- a/plugins/discourse-hcaptcha/plugin.rb
+++ b/plugins/discourse-hcaptcha/plugin.rb
@@ -22,6 +22,6 @@ require_relative "lib/discourse_hcaptcha/engine"
 after_initialize do
   reloadable_patch { UsersController.include(DiscourseHcaptcha::CreateUsersControllerPatch) }
 
-  require_relative "app/services/problem_check/hcaptcha_configuration.rb"
+  require_relative "app/services/problem_check/hcaptcha_configuration"
   register_problem_check ProblemCheck::HcaptchaConfiguration
 end

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -16,8 +16,8 @@ register_asset "stylesheets/mobile/discourse-reactions.scss", :mobile
 register_svg_icon "star"
 register_svg_icon "far-star"
 
-require_relative "lib/reaction_for_like_site_setting_enum.rb"
-require_relative "lib/reactions_excluded_from_like_site_setting_validator.rb"
+require_relative "lib/reaction_for_like_site_setting_enum"
+require_relative "lib/reactions_excluded_from_like_site_setting_validator"
 
 after_initialize do
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-reactions", "db", "fixtures").to_s

--- a/plugins/discourse-reactions/spec/models/reaction_spec.rb
+++ b/plugins/discourse-reactions/spec/models/reaction_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
 
 describe DiscourseReactions::Reaction do
   before { SiteSetting.discourse_reactions_enabled = true }

--- a/plugins/discourse-reactions/spec/models/reaction_user_spec.rb
+++ b/plugins/discourse-reactions/spec/models/reaction_user_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
+require_relative "../fabricators/reaction_user_fabricator"
 
 describe DiscourseReactions::ReactionUser do
   before { SiteSetting.discourse_reactions_enabled = true }

--- a/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
+require_relative "../fabricators/reaction_user_fabricator"
 
 describe PostSerializer do
   fab!(:user_1, :user)

--- a/plugins/discourse-reactions/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/topic_view_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
+require_relative "../fabricators/reaction_user_fabricator"
 
 describe TopicViewSerializer do
   before { SiteSetting.discourse_reactions_enabled = true }

--- a/plugins/discourse-reactions/spec/services/badge_granter_spec.rb
+++ b/plugins/discourse-reactions/spec/services/badge_granter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
+require_relative "../fabricators/reaction_user_fabricator"
 
 describe BadgeGranter do
   fab!(:user)

--- a/plugins/discourse-reactions/spec/services/reaction_notification_spec.rb
+++ b/plugins/discourse-reactions/spec/services/reaction_notification_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../fabricators/reaction_fabricator.rb"
-require_relative "../fabricators/reaction_user_fabricator.rb"
+require_relative "../fabricators/reaction_fabricator"
+require_relative "../fabricators/reaction_user_fabricator"
 
 describe DiscourseReactions::ReactionNotification do
   before do

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -21,7 +21,7 @@ module ::DiscourseSolved
   ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD = "enable_accepted_answers"
 end
 
-require_relative "lib/discourse_solved/engine.rb"
+require_relative "lib/discourse_solved/engine"
 
 after_initialize do
   SeedFu.fixture_paths << Rails.root.join("plugins", "discourse-solved", "db", "fixtures").to_s

--- a/plugins/discourse-user-notes/plugin.rb
+++ b/plugins/discourse-user-notes/plugin.rb
@@ -22,8 +22,8 @@ require_relative "lib/discourse_user_notes/engine"
 after_initialize do
   require_dependency "user"
 
-  require_relative "app/serializers/user_note_serializer.rb"
-  require_relative "app/controllers/discourse_user_notes/user_notes_controller.rb"
+  require_relative "app/serializers/user_note_serializer"
+  require_relative "app/controllers/discourse_user_notes/user_notes_controller"
 
   Discourse::Application.routes.append { mount ::DiscourseUserNotes::Engine, at: "/user_notes" }
 

--- a/script/import_scripts/askbot.rb
+++ b/script/import_scripts/askbot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "pg"
 
 class ImportScripts::MyAskBot < ImportScripts::Base

--- a/script/import_scripts/bbpress.rb
+++ b/script/import_scripts/bbpress.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Bbpress < ImportScripts::Base
   BB_PRESS_HOST = ENV["BBPRESS_HOST"] || "localhost"

--- a/script/import_scripts/bespoke_1.rb
+++ b/script/import_scripts/bespoke_1.rb
@@ -3,7 +3,7 @@
 # bespoke importer for a customer, feel free to borrow ideas
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Call it like this:
 #   RAILS_ENV=production bundle exec ruby script/import_scripts/bespoke_1.rb

--- a/script/import_scripts/csv_importer.rb
+++ b/script/import_scripts/csv_importer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 # Make sure to follow the right format in your CSV files.

--- a/script/import_scripts/csv_restore_staged_users.rb
+++ b/script/import_scripts/csv_restore_staged_users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 

--- a/script/import_scripts/discuz_x.rb
+++ b/script/import_scripts/discuz_x.rb
@@ -12,7 +12,7 @@
 require "php_serialize"
 require "miro"
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::DiscuzX < ImportScripts::Base
   DISCUZX_DB = "ultrax"

--- a/script/import_scripts/disqus.rb
+++ b/script/import_scripts/disqus.rb
@@ -2,7 +2,7 @@
 
 require "nokogiri"
 require "optparse"
-require File.expand_path(File.dirname(__FILE__) + "/base")
+require_relative "base"
 
 class ImportScripts::Disqus < ImportScripts::Base
   # CHANGE THESE BEFORE RUNNING THE IMPORTER

--- a/script/import_scripts/drupal-6.rb
+++ b/script/import_scripts/drupal-6.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Drupal < ImportScripts::Base
   DRUPAL_DB = ENV["DRUPAL_DB"] || "newsite3"

--- a/script/import_scripts/drupal.rb
+++ b/script/import_scripts/drupal.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 require "htmlentities"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Drupal < ImportScripts::Base
   DRUPAL_DB = ENV["DRUPAL_DB"] || "drupal"

--- a/script/import_scripts/drupal_json.rb
+++ b/script/import_scripts/drupal_json.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 

--- a/script/import_scripts/drupal_qa.rb
+++ b/script/import_scripts/drupal_qa.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
-require File.expand_path(File.dirname(__FILE__) + "/drupal.rb")
+require_relative "base"
+require_relative "drupal"
 
 class ImportScripts::DrupalQA < ImportScripts::Drupal
   def categories_query

--- a/script/import_scripts/elgg.rb
+++ b/script/import_scripts/elgg.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Elgg < ImportScripts::Base
   BATCH_SIZE = 1000

--- a/script/import_scripts/flarum_import.rb
+++ b/script/import_scripts/flarum_import.rb
@@ -4,7 +4,7 @@ require "mysql2"
 require "time"
 require "date"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::FLARUM < ImportScripts::Base
   #SET THE APPROPRIATE VALUES FOR YOUR MYSQL CONNECTION

--- a/script/import_scripts/fluxbb.rb
+++ b/script/import_scripts/fluxbb.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Before running this script, paste these lines into your shell,
 # then use arrow keys to edit the values

--- a/script/import_scripts/friendsmegplus.rb
+++ b/script/import_scripts/friendsmegplus.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 require "csv"
 

--- a/script/import_scripts/fusionforge.rb
+++ b/script/import_scripts/fusionforge.rb
@@ -2,7 +2,7 @@
 
 require "pg"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Call it like this:
 #   RAILS_ENV=production bundle exec ruby script/import_scripts/fusionforge.rb

--- a/script/import_scripts/getsatisfaction.rb
+++ b/script/import_scripts/getsatisfaction.rb
@@ -23,7 +23,7 @@
 # You should run `rake posts:reorder_posts` after the import.
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "reverse_markdown" # gem 'reverse_markdown'
 
 # Call it like this:

--- a/script/import_scripts/higher_logic.rb
+++ b/script/import_scripts/higher_logic.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::HigherLogic < ImportScripts::Base
   HIGHERLOGIC_DB = "higherlogic"

--- a/script/import_scripts/ipboard.rb
+++ b/script/import_scripts/ipboard.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 begin
   require "reverse_markdown" # https://github.com/jqr/php-serialize

--- a/script/import_scripts/ipboard3.rb
+++ b/script/import_scripts/ipboard3.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 require "reverse_markdown"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::IPBoard3 < ImportScripts::Base
   BATCH_SIZE = 5000

--- a/script/import_scripts/jive.rb
+++ b/script/import_scripts/jive.rb
@@ -3,7 +3,7 @@
 # Jive importer
 require "nokogiri"
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Jive < ImportScripts::Base
   BATCH_SIZE = 1000

--- a/script/import_scripts/jive_api.rb
+++ b/script/import_scripts/jive_api.rb
@@ -2,7 +2,7 @@
 
 require "nokogiri"
 require "htmlentities"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # https://developers.jivesoftware.com/api/v3/cloud/rest/index.html
 

--- a/script/import_scripts/json_generic.rb
+++ b/script/import_scripts/json_generic.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 

--- a/script/import_scripts/kunena.rb
+++ b/script/import_scripts/kunena.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Kunena < ImportScripts::Base
   KUNENA_DB = "kunena"

--- a/script/import_scripts/kunena3.rb
+++ b/script/import_scripts/kunena3.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # If you change this script's functionality, please consider making a note here:
 # https://meta.discourse.org/t/importing-from-kunena-3/43776

--- a/script/import_scripts/lithium.rb
+++ b/script/import_scripts/lithium.rb
@@ -15,7 +15,7 @@
 require "mysql2"
 require "csv"
 require "reverse_markdown"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 
 # remove table conversion

--- a/script/import_scripts/modx.rb
+++ b/script/import_scripts/modx.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 
 class ImportScripts::Modx < ImportScripts::Base

--- a/script/import_scripts/muut.rb
+++ b/script/import_scripts/muut.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 

--- a/script/import_scripts/mybb.rb
+++ b/script/import_scripts/mybb.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Before running this script, paste these lines into your shell,
 # then use arrow keys to edit the values

--- a/script/import_scripts/mybbru.rb
+++ b/script/import_scripts/mybbru.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Import script for forums created via mybb.ru service (or anything else that uses this simple JSON format),
 # using export format produced by https://github.com/AlexP11223/MybbRuUserscripts

--- a/script/import_scripts/mylittleforum.rb
+++ b/script/import_scripts/mylittleforum.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 
 # Before running this script, paste these lines into your shell,

--- a/script/import_scripts/nabble.rb
+++ b/script/import_scripts/nabble.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "pg"
 require_relative "base/uploader"
 

--- a/script/import_scripts/ning.rb
+++ b/script/import_scripts/ning.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Edit the constants and initialize method for your import data.
 

--- a/script/import_scripts/nodebb/nodebb.rb
+++ b/script/import_scripts/nodebb/nodebb.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "../base"
-require_relative "./redis"
-require_relative "./mongo"
+require_relative "redis"
+require_relative "mongo"
 
 class ImportScripts::NodeBB < ImportScripts::Base
   # CHANGE THESE BEFORE RUNNING THE IMPORTER

--- a/script/import_scripts/phorum.rb
+++ b/script/import_scripts/phorum.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Phorum < ImportScripts::Base
   PHORUM_DB = "piwik"

--- a/script/import_scripts/punbb.rb
+++ b/script/import_scripts/punbb.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # Call it like this:
 #   RAILS_ENV=production bundle exec ruby script/import_scripts/punbb.rb

--- a/script/import_scripts/quandora/import.rb
+++ b/script/import_scripts/quandora/import.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "./quandora_question.rb"
-require File.expand_path(File.dirname(__FILE__) + "/../base.rb")
+require_relative "quandora_question"
+require_relative "../base"
 
 class ImportScripts::Quandora < ImportScripts::Base
   JSON_FILES_DIR = "output"

--- a/script/import_scripts/quandora/test/test_quandora_api.rb
+++ b/script/import_scripts/quandora/test/test_quandora_api.rb
@@ -2,8 +2,8 @@
 
 require "minitest/autorun"
 require "yaml"
-require_relative "../quandora_api.rb"
-require_relative "./test_data.rb"
+require_relative "../quandora_api"
+require_relative "test_data"
 
 class TestQuandoraApi < Minitest::Test
   DEBUG = false

--- a/script/import_scripts/quandora/test/test_quandora_question.rb
+++ b/script/import_scripts/quandora/test/test_quandora_question.rb
@@ -3,8 +3,8 @@
 require "minitest/autorun"
 require "cgi"
 require "time"
-require_relative "../quandora_question.rb"
-require_relative "./test_data.rb"
+require_relative "../quandora_question"
+require_relative "test_data"
 
 class TestQuandoraQuestion < Minitest::Test
   def setup

--- a/script/import_scripts/question2answer.rb
+++ b/script/import_scripts/question2answer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 require "php_serialize" # https://github.com/jqr/php-serialize
 

--- a/script/import_scripts/sfn.rb
+++ b/script/import_scripts/sfn.rb
@@ -5,7 +5,7 @@
 require "csv"
 require "mysql2"
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Sfn < ImportScripts::Base
   BATCH_SIZE = 100_000

--- a/script/import_scripts/simplepress.rb
+++ b/script/import_scripts/simplepress.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::SimplePress < ImportScripts::Base
   SIMPLE_PRESS_DB = ENV["SIMPLEPRESS_DB"] || "simplepress"

--- a/script/import_scripts/smf1.rb
+++ b/script/import_scripts/smf1.rb
@@ -2,7 +2,7 @@
 
 require "mysql2"
 require "htmlentities"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::Smf1 < ImportScripts::Base
   BATCH_SIZE = 5000

--- a/script/import_scripts/smf2.rb
+++ b/script/import_scripts/smf2.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 require "htmlentities"
 require "tsort"

--- a/script/import_scripts/socialcast/import.rb
+++ b/script/import_scripts/socialcast/import.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "./socialcast_message.rb"
-require_relative "./socialcast_user.rb"
-require File.expand_path(File.dirname(__FILE__) + "/../base.rb")
+require_relative "socialcast_message"
+require_relative "socialcast_user"
+require_relative "../base"
 
 class ImportScripts::Socialcast < ImportScripts::Base
   MESSAGES_DIR = "output/messages"

--- a/script/import_scripts/socialcast/socialcast_message.rb
+++ b/script/import_scripts/socialcast/socialcast_message.rb
@@ -3,7 +3,7 @@
 require "json"
 require "cgi"
 require "time"
-require_relative "create_title.rb"
+require_relative "create_title"
 
 class SocialcastMessage
   DEFAULT_CATEGORY = "Socialcast Import"

--- a/script/import_scripts/socialcast/test/test_create_title.rb
+++ b/script/import_scripts/socialcast/test/test_create_title.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
-require_relative "../create_title.rb"
+require_relative "../create_title"
 
 class TestCreateTitle < Minitest::Test
   def test_create_title_1

--- a/script/import_scripts/socialcast/test/test_socialcast_api.rb
+++ b/script/import_scripts/socialcast/test/test_socialcast_api.rb
@@ -2,8 +2,8 @@
 
 require "minitest/autorun"
 require "yaml"
-require_relative "../socialcast_api.rb"
-require_relative "./test_data.rb"
+require_relative "../socialcast_api"
+require_relative "test_data"
 
 class TestSocialcastApi < Minitest::Test
   DEBUG = false

--- a/script/import_scripts/socialcast/title.rb
+++ b/script/import_scripts/socialcast/title.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "./socialcast_message.rb"
-require_relative "./socialcast_user.rb"
-require File.expand_path(File.dirname(__FILE__) + "/../base.rb")
+require_relative "socialcast_message"
+require_relative "socialcast_user"
+require_relative "../base"
 
 MESSAGES_DIR = "output/messages"
 

--- a/script/import_scripts/sourceforge.rb
+++ b/script/import_scripts/sourceforge.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "base.rb"
+require_relative "base"
 
 # Import script for SourceForge discussions.
 #

--- a/script/import_scripts/stack_overflow.rb
+++ b/script/import_scripts/stack_overflow.rb
@@ -2,7 +2,7 @@
 
 # cf. https://github.com/rails-sqlserver/tiny_tds#install
 require "tiny_tds"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 class ImportScripts::StackOverflow < ImportScripts::Base
   BATCH_SIZE = 1000

--- a/script/import_scripts/vanilla.rb
+++ b/script/import_scripts/vanilla.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 
 # NOTE: this importer expects a text file obtained through Vanilla Porter
 # user documentation: https://meta.discourse.org/t/how-to-migrate-import-from-vanilla-to-discourse/27273

--- a/script/import_scripts/vanilla_mysql.rb
+++ b/script/import_scripts/vanilla_mysql.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 require "reverse_markdown"
 require_relative "vanilla_body_parser"

--- a/script/import_scripts/vbulletin.rb
+++ b/script/import_scripts/vbulletin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 begin
   require "php_serialize" # https://github.com/jqr/php-serialize

--- a/script/import_scripts/vbulletin3.rb
+++ b/script/import_scripts/vbulletin3.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 begin
   require "php_serialize" # https://github.com/jqr/php-serialize
@@ -504,7 +504,7 @@ LEFT OUTER JOIN #{TABLE_PREFIX}avatar a ON a.avatarid = u.avatarid
                  (SELECT forumpermissions & 96 > 0 FROM #{TABLE_PREFIX}forumpermission fp WHERE fp.forumid = f.forumid AND usergroupid = 2) AS registered_reply,
                  (SELECT max(forumpermissions & 524288 > 0) FROM #{TABLE_PREFIX}forumpermission fp WHERE fp.forumid = f.forumid AND usergroupid IN (5,6)) AS staff_access,
                  (SELECT count(DISTINCT coalesce(fp.forumpermissions & 524288 > 0, 2)) > 1 FROM #{TABLE_PREFIX}usergroup ug LEFT OUTER JOIN #{TABLE_PREFIX}forumpermission fp ON fp.forumid = f.forumid AND fp.usergroupid = ug.usergroupid WHERE ug.ispublicgroup = 1) AS special_access
-            FROM #{TABLE_PREFIX}forum f 
+            FROM #{TABLE_PREFIX}forum f
         ORDER BY forumid
       SQL
 

--- a/script/import_scripts/vbulletin5.rb
+++ b/script/import_scripts/vbulletin5.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "mysql2"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "htmlentities"
 
 class ImportScripts::VBulletin < ImportScripts::Base

--- a/script/import_scripts/xenforo.rb
+++ b/script/import_scripts/xenforo.rb
@@ -14,7 +14,7 @@ rescue LoadError
   exit
 end
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 AVATAR_DIR = "/path/to/avatars"
 # Call it like this:
 #   RAILS_ENV=production bundle exec ruby script/import_scripts/xenforo.rb

--- a/script/import_scripts/yahoogroup.rb
+++ b/script/import_scripts/yahoogroup.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
+require_relative "base"
 require "mongo"
 
 # Import YahooGroups data as exported into MongoDB by:

--- a/script/import_scripts/zoho.rb
+++ b/script/import_scripts/zoho.rb
@@ -22,8 +22,8 @@
 #   usernames to be created.
 
 require "csv"
-require File.expand_path(File.dirname(__FILE__) + "/base.rb")
-require File.expand_path(File.dirname(__FILE__) + "/base/csv_helper.rb")
+require_relative "base"
+require_relative "base/csv_helper"
 
 # Call it like this:
 #   bundle exec ruby script/import_scripts/zoho.rb <path-to-csv-files>

--- a/script/profile_db_generator.rb
+++ b/script/profile_db_generator.rb
@@ -58,7 +58,7 @@ def create_user(seq, admin: false, username: nil)
   end
 end
 
-require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
+require_relative "../config/environment"
 
 Jobs.run_immediately!
 

--- a/script/user_simulator.rb
+++ b/script/user_simulator.rb
@@ -36,7 +36,7 @@ unless user_id
   exit
 end
 
-require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
+require_relative "../config/environment"
 
 if %w[profile development].exclude? Rails.env
   puts "Bad idea to run a script that inserts random posts in any non development environment"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -119,7 +119,7 @@ Dir[Rails.root.join("spec/system/page_objects/**/*_base.rb")].each { |f| require
 Dir[Rails.root.join("spec/system/page_objects/**/*.rb")].each { |f| require f }
 
 Dir[Rails.root.join("spec/fabricators/*.rb")].each { |f| require f }
-require_relative "./helpers/redis_snapshot_helper"
+require_relative "helpers/redis_snapshot_helper"
 
 # Require plugin helpers at plugin/[plugin]/spec/plugin_helper.rb (includes symlinked plugins).
 if ENV["LOAD_PLUGINS"] == "1"

--- a/themes/horizon/spec/system/horizon_high_level_spec.rb
+++ b/themes/horizon/spec/system/horizon_high_level_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./page_objects/components/user_color_palette_selector"
+require_relative "page_objects/components/user_color_palette_selector"
 
 describe "Horizon theme | High level", type: :system do
   let!(:theme) do

--- a/themes/horizon/spec/system/user_color_palette_selector_spec.rb
+++ b/themes/horizon/spec/system/user_color_palette_selector_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./page_objects/components/user_color_palette_selector"
+require_relative "page_objects/components/user_color_palette_selector"
 
 describe "Horizon theme | User color palette selector", type: :system do
   let(:set_theme_as_default) { true }


### PR DESCRIPTION
1. remove unnecessary `.rb` filename suffixes from `require_relative` calls
2. replace `require File.expand_path(File.dirname(__FILE__) + …` with `require_relative`
3. remove `./` prefixes from `require_relative` calls