### PR TITLE
FIX: Also translate topic title if 'Translate Post' is on the first post

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/translation/translation_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/translation/translation_controller.rb
@@ -15,6 +15,10 @@ module DiscourseAi
 
         if DiscourseAi::Translation.enabled?
           Jobs.enqueue(:detect_translate_post, post_id: post.id, force: true)
+
+          if post.is_first_post?
+            Jobs.enqueue(:detect_translate_topic, topic_id: post.topic.id, force: true)
+          end
         else
           return(
             render json:

--- a/plugins/discourse-ai/app/jobs/regular/detect_translate_topic.rb
+++ b/plugins/discourse-ai/app/jobs/regular/detect_translate_topic.rb
@@ -14,7 +14,11 @@ module Jobs
         return
       end
 
-      if SiteSetting.ai_translation_backfill_limit_to_public_content
+      force = args[:force] || false
+
+      if force
+        # no restrictions
+      elsif SiteSetting.ai_translation_backfill_limit_to_public_content
         return if topic.category&.read_restricted? || topic.archetype == Archetype.private_message
       else
         if topic.archetype == Archetype.private_message &&

--- a/plugins/discourse-ai/spec/jobs/regular/detect_translate_topic_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/detect_translate_topic_spec.rb
@@ -170,5 +170,25 @@ describe Jobs::DetectTranslateTopic do
         job.execute({ topic_id: personal_pm_topic.id })
       end
     end
+
+    describe "force arg" do
+      it "processes private content when force is true" do
+        DiscourseAi::Translation::TopicLocaleDetector
+          .expects(:detect_locale)
+          .with(group_pm_topic)
+          .once
+
+        job.execute({ topic_id: group_pm_topic.id, force: true })
+      end
+
+      it "processes PM content when force is true" do
+        DiscourseAi::Translation::TopicLocaleDetector
+          .expects(:detect_locale)
+          .with(personal_pm_topic)
+          .once
+
+        job.execute({ topic_id: personal_pm_topic.id, force: true })
+      end
+    end
   end
 end

--- a/plugins/discourse-ai/spec/requests/translation/translation_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/translation/translation_controller_spec.rb
@@ -43,7 +43,7 @@ describe DiscourseAi::Translation::TranslationController do
         expect(response.status).to eq(404)
       end
 
-      it "successfully enqueues translation job when user can edit" do
+      it "successfully enqueues post translation job when user can edit" do
         admin_post = Fabricate(:post, user: admin)
 
         expect_enqueued_with(
@@ -53,6 +53,19 @@ describe DiscourseAi::Translation::TranslationController do
             force: true,
           },
         ) { post "/discourse-ai/translate/posts/#{admin_post.id}" }
+
+        expect(response.status).to eq(200)
+      end
+
+      it "enqueues topic translation job when translating first post" do
+        first_post = Fabricate(:post, topic: Fabricate(:topic), user: admin)
+        expect_enqueued_with(
+          job: Jobs::DetectTranslateTopic,
+          args: {
+            topic_id: first_post.topic.id,
+            force: true,
+          },
+        ) { post "/discourse-ai/translate/posts/#{first_post.id}" }
 
         expect(response.status).to eq(200)
       end


### PR DESCRIPTION
Related: https://github.com/discourse/discourse/pull/34904

We should also translate topic titles.