### PR TITLE
FIX: escapes `account-created` routes on Welcome banner page visibility

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -46,7 +46,7 @@ export default class AdminRoute extends DiscourseRoute {
       [`${PLATFORM_KEY_MODIFIER}+/`]: this.showAdminSearchModal,
     });
 
-    if (!transition?.to.name.startsWith("admin.")) {
+    if (!transition?.to.name.startsWith("admin")) {
       this.adminSidebarStateManager.stopForcingAdminSidebar();
     }
   }

--- a/app/assets/javascripts/admin/addon/routes/admin.js
+++ b/app/assets/javascripts/admin/addon/routes/admin.js
@@ -46,7 +46,7 @@ export default class AdminRoute extends DiscourseRoute {
       [`${PLATFORM_KEY_MODIFIER}+/`]: this.showAdminSearchModal,
     });
 
-    if (!transition?.to.name.startsWith("admin")) {
+    if (!transition?.to.name.startsWith("admin.")) {
       this.adminSidebarStateManager.stopForcingAdminSidebar();
     }
   }

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -48,7 +48,8 @@ export default class Contents extends Component {
       ALL_PAGES_EXCLUDED_ROUTES.some(
         (name) => name === this.router.currentRouteName
       ) ||
-      this.search.welcomeBannerSearchInViewport
+      this.search.welcomeBannerSearchInViewport ||
+      this.router.currentRouteName.startsWith("admin")
     ) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -49,7 +49,7 @@ export default class Contents extends Component {
         (name) => name === this.router.currentRouteName
       ) ||
       this.search.welcomeBannerSearchInViewport ||
-      this.router.currentRouteName.startsWith("admin")
+      this.router.currentRouteName.startsWith("admin.")
     ) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/components/header/contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/contents.gjs
@@ -49,7 +49,7 @@ export default class Contents extends Component {
         (name) => name === this.router.currentRouteName
       ) ||
       this.search.welcomeBannerSearchInViewport ||
-      this.router.currentRouteName.startsWith("admin.")
+      this.router.currentRouteName.startsWith("admin")
     ) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -4,6 +4,7 @@ import { service } from "@ember/service";
 import { eq } from "truth-helpers";
 import InterfaceColorSelector from "discourse/components/interface-color-selector";
 import LanguageSwitcher from "discourse/components/language-switcher";
+import { ALL_PAGES_EXCLUDED_ROUTES } from "discourse/components/welcome-banner";
 import DAG from "discourse/lib/dag";
 import getURL from "discourse/lib/get-url";
 import Dropdown from "./dropdown";
@@ -37,6 +38,7 @@ export default class Icons extends Component {
   @service header;
   @service search;
   @service interfaceColor;
+  @service router;
 
   get showHamburger() {
     // NOTE: In this scenario, we are forcing the sidebar on admin users,
@@ -54,16 +56,23 @@ export default class Icons extends Component {
   }
 
   get showSearchButton() {
-    if (this.header.headerButtonsHidden.includes("search")) {
+    if (
+      this.header.headerButtonsHidden.includes("search") ||
+      ALL_PAGES_EXCLUDED_ROUTES.some(
+        (name) => name === this.router.currentRouteName
+      )
+    ) {
       return false;
     }
 
     return (
       this.site.mobileView ||
+      this.args.narrowDesktop ||
       (this.search.searchExperience === "search_icon" &&
         !this.search.welcomeBannerSearchInViewport) ||
-      this.args.topicInfoVisible ||
-      this.args.narrowDesktop
+      (this.search.searchExperience === "search_field" &&
+        this.router.currentRouteName.startsWith("admin")) ||
+      this.args.topicInfoVisible
     );
   }
 

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -71,7 +71,7 @@ export default class Icons extends Component {
       (this.search.searchExperience === "search_icon" &&
         !this.search.welcomeBannerSearchInViewport) ||
       (this.search.searchExperience === "search_field" &&
-        this.router.currentRouteName.startsWith("admin.")) ||
+        this.router.currentRouteName.startsWith("admin")) ||
       this.args.topicInfoVisible
     );
   }

--- a/app/assets/javascripts/discourse/app/components/header/icons.gjs
+++ b/app/assets/javascripts/discourse/app/components/header/icons.gjs
@@ -71,7 +71,7 @@ export default class Icons extends Component {
       (this.search.searchExperience === "search_icon" &&
         !this.search.welcomeBannerSearchInViewport) ||
       (this.search.searchExperience === "search_field" &&
-        this.router.currentRouteName.startsWith("admin")) ||
+        this.router.currentRouteName.startsWith("admin.")) ||
       this.args.topicInfoVisible
     );
   }

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -14,7 +14,11 @@ import { defaultHomepage, escapeExpression } from "discourse/lib/utilities";
 import I18n, { i18n } from "discourse-i18n";
 
 export const ALL_PAGES_EXCLUDED_ROUTES = [
+  "account-created.edit-email",
+  "account-created.index",
+  "account-created.resent",
   "activate-account",
+  "full-page-search",
   "invites.show",
   "login",
   "password-reset",
@@ -73,7 +77,6 @@ export default class WelcomeBanner extends Component {
         return currentRouteName.startsWith("discovery.");
       case "all_pages":
         return (
-          currentRouteName !== "full-page-search" &&
           !currentRouteName.startsWith("admin") &&
           !ALL_PAGES_EXCLUDED_ROUTES.some(
             (routeName) => routeName === currentRouteName

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -77,7 +77,7 @@ export default class WelcomeBanner extends Component {
         return currentRouteName.startsWith("discovery.");
       case "all_pages":
         return (
-          !currentRouteName.startsWith("admin") &&
+          !currentRouteName.startsWith("admin.") &&
           !ALL_PAGES_EXCLUDED_ROUTES.some(
             (routeName) => routeName === currentRouteName
           )

--- a/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
+++ b/app/assets/javascripts/discourse/app/components/welcome-banner.gjs
@@ -77,7 +77,7 @@ export default class WelcomeBanner extends Component {
         return currentRouteName.startsWith("discovery.");
       case "all_pages":
         return (
-          !currentRouteName.startsWith("admin.") &&
+          !currentRouteName.startsWith("admin") &&
           !ALL_PAGES_EXCLUDED_ROUTES.some(
             (routeName) => routeName === currentRouteName
           )

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -15,6 +15,10 @@ acceptance("Search - Mobile", function (needs) {
       .exists("it shows the full page search form");
 
     assert
+      .dom("#search-button")
+      .doesNotExist("does not show icon search button on the full page search");
+
+    assert
       .dom(".search-results .fps-topic")
       .doesNotExist("no results by default");
 
@@ -33,13 +37,13 @@ acceptance("Search - Mobile", function (needs) {
       .dom(".advanced-filters[open]")
       .doesNotExist("it should collapse advanced search filters");
 
-    await click("#search-button");
+    await click(".search-cta");
 
     assert
       .dom("input.full-page-search")
       .hasValue(
         "consectetur",
-        "does not reset input when hitting search icon again"
+        "does not reset input when hitting search button again"
       );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -600,13 +600,6 @@ acceptance("Search - Authenticated", function (needs) {
     assert
       .dom(".search-menu")
       .doesNotExist("search dropdown is collapsed after second Enter hit");
-
-    // new search launched, Enter key should be reset
-    await click("#search-button");
-    assert.dom(`${container} ul li`).exists("has a list of items");
-
-    await triggerKeyEvent("#icon-search-input", "keyup", "Enter");
-    assert.dom(`.search-menu`).exists("search dropdown is visible");
   });
 
   test("search menu keyboard navigation - while composer is open", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
@@ -40,7 +40,7 @@ module("Integration | Component | Header | Icons", function (hooks) {
         "it does not display when the search_experience setting is search_field"
       );
 
-    routerStub.value("admin");
+    routerStub.value("admin.dashboard.general");
 
     await render(
       <template>

--- a/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/header-icons-test.gjs
@@ -10,9 +10,17 @@ module("Integration | Component | Header | Icons", function (hooks) {
   setupRenderingTest(hooks);
 
   test("showSearchButton", async function (assert) {
-    const site = getOwner(this).lookup("service:site");
+    const siteStub = sinon.stub(
+      getOwner(this).lookup("service:site"),
+      "mobileView"
+    );
+    const routerStub = sinon.stub(
+      getOwner(this).lookup("service:router"),
+      "currentRouteName"
+    );
     const noop = () => {};
     this.siteSettings.search_experience = "search_field";
+    routerStub.value("discovery.latest");
 
     await render(
       <template>
@@ -32,7 +40,28 @@ module("Integration | Component | Header | Icons", function (hooks) {
         "it does not display when the search_experience setting is search_field"
       );
 
+    routerStub.value("admin");
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".search-dropdown")
+      .exists(
+        "it shows on admin routes even when the search_experience setting is search_field"
+      );
+
     this.siteSettings.search_experience = "search_icon";
+    routerStub.value("discovery.latest");
 
     await render(
       <template>
@@ -52,8 +81,8 @@ module("Integration | Component | Header | Icons", function (hooks) {
         "it does display when the search_experience setting is search_icon"
       );
 
-    sinon.stub(site, "mobileView").value(true);
     this.siteSettings.search_experience = "search_field";
+    siteStub.value(true);
 
     await render(
       <template>

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -192,8 +192,12 @@ describe "Search", type: :system do
         expect(search_page).to have_no_search_icon
       end
 
-      it "does not display on login, signup or activate account pages" do
+      it "does not display on login, search, signup or activate account pages" do
         visit("/login")
+        expect(search_page).to have_no_search_icon
+        expect(search_page).to have_no_search_field
+
+        visit("/search")
         expect(search_page).to have_no_search_icon
         expect(search_page).to have_no_search_field
 
@@ -214,6 +218,17 @@ describe "Search", type: :system do
           visit("/invites/#{invite.invite_key}")
           expect(search_page).to have_no_search_icon
           expect(search_page).to have_no_search_field
+        end
+      end
+
+      describe "when on admin pages" do
+        fab!(:admin)
+
+        it "displays search icon regardless of Search experience setting" do
+          sign_in(admin)
+          visit("/admin")
+          expect(search_page).to have_no_search_field
+          expect(search_page).to have_search_icon
         end
       end
     end


### PR DESCRIPTION
1. We are adding more pages that do not need a Welcome banner to be shown on:
- a sign up journey

2. Hides Header search on a `/search` page (avoids duplicate inputs)