### PR TITLE
FIX: allow passing custom id to create topic btn

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.gjs
@@ -8,13 +8,15 @@ export default class CreateTopicButton extends Component {
   @tracked btnTypeClass = this.args.btnTypeClass || "btn-default";
   @tracked label = this.args.label ?? "topic.create";
 
+  btnId = this.args.btnId ?? "create-topic";
+
   <template>
     {{#if @canCreateTopic}}
       <DButton
         @action={{@action}}
         @icon="far-pen-to-square"
         @label={{this.label}}
-        id="create-topic"
+        id={{this.btnId}}
         class={{concatClass @btnClass this.btnTypeClass}}
       />
 


### PR DESCRIPTION
The `id` attribute should be unique, otherwise it can lead to failing specs. This change allows theme components/plugins to override the value.