### PR TITLE
UX: Timeline fix

### DIFF
--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -117,7 +117,8 @@
 }
 
 .container.posts .topic-navigation {
-  @include viewport.until(lg) {
+  @media screen and (width <= 924px) {
+    // at 925px viewport width and above the timeline is visible (see topic-navigation.js)
     display: flex;
     justify-content: flex-end;
     align-items: center;


### PR DESCRIPTION
This PR adjusts some topic-timeline changes from https://github.com/discourse/discourse/pull/34886 which introduced a bug where the timeline moved to the bottom of the post stream before it should.

|Before|After|
|--|--|
|<img width="1982" height="1866" alt="CleanShot 2025-09-24 at 10 49 18@2x" src="https://github.com/user-attachments/assets/afd97830-4a84-4877-81e8-114e897ee329" />|<img width="1986" height="1862" alt="CleanShot 2025-09-24 at 10 48 42@2x" src="https://github.com/user-attachments/assets/faac2daf-1ccf-400e-99a1-112b21493b89" />|