### PR TITLE
UX: Adjust welcome banner search-menu when there are AI discoveries

### DIFF
--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -115,9 +115,19 @@
 }
 
 @include viewport.from(lg) {
-  .search-menu .menu-panel:has(.ai-search-discoveries__discoveries-title) {
+  .welcome-banner .menu-panel:has(.ai-search-discoveries__discoveries-title) {
+    width: calc(90vw - var(--d-sidebar-width) - 1em);
+    max-width: 900px;
+    min-width: 100%;
+  }
+
+  .search-menu.glimmer-search-menu
+    .menu-panel:has(.ai-search-discoveries__discoveries-title) {
     width: 80vw;
     max-width: 900px;
+  }
+
+  .search-menu .menu-panel:has(.ai-search-discoveries__discoveries-title) {
     transition: width 0.5s;
 
     .results {


### PR DESCRIPTION
<img width="1130" height="674" alt="Screenshot 2025-09-24 at 2 29 32 PM" src="https://github.com/user-attachments/assets/37178332-ca04-407b-a9f7-0c97400be9bd" />


<img width="872" height="640" alt="Screenshot 2025-09-24 at 11 04 22 AM" src="https://github.com/user-attachments/assets/e2b77770-06a9-40b6-8a28-599a42d5bf8f" />
