### PR TITLE
FIX: ensures user notes routes are correctly defined

### DIFF
--- a/plugins/discourse-user-notes/config/routes.rb
+++ b/plugins/discourse-user-notes/config/routes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+DiscourseUserNotes::Engine.routes.draw do
+  get "/" => "user_notes#index"
+  post "/" => "user_notes#create"
+  delete "/:id" => "user_notes#destroy"
+end

--- a/plugins/discourse-user-notes/plugin.rb
+++ b/plugins/discourse-user-notes/plugin.rb
@@ -27,12 +27,6 @@ after_initialize do
 
   Discourse::Application.routes.append { mount ::DiscourseUserNotes::Engine, at: "/user_notes" }
 
-  DiscourseUserNotes::Engine.routes.draw do
-    get "/" => "user_notes#index"
-    post "/" => "user_notes#create"
-    delete "/:id" => "user_notes#destroy"
-  end
-
   allow_staff_user_custom_field(DiscourseUserNotes::COUNT_FIELD)
 
   add_to_class(Guardian, :can_delete_user_notes?) do

--- a/plugins/discourse-user-notes/spec/system/user_notes_spec.rb
+++ b/plugins/discourse-user-notes/spec/system/user_notes_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User Notes", type: :system do
+  fab!(:admin)
+  fab!(:user)
+
+  before { SiteSetting.user_notes_enabled = true }
+
+  it "allows admin to manage user notes" do
+    sign_in(admin)
+
+    visit("/admin/users/#{user.id}/#{user.username}")
+
+    expect(page).to have_css(".show-user-notes-btn")
+    click_button(class: "show-user-notes-btn")
+
+    expect(page).to have_css(".user-notes-modal")
+
+    form = PageObjects::Components::FormKit.new(".user-notes-modal .form-kit")
+    form.field("content").fill_in("A NOTE")
+    form.submit
+
+    expect(page).to have_css(".user-note", text: "A NOTE")
+
+    find(".user-note .btn-danger").click
+
+    PageObjects::Components::Dialog.new.click_danger
+
+    expect(page).to have_no_css(".user-note", text: "A NOTE")
+  end
+end


### PR DESCRIPTION
A previous commit https://github.com/discourse/discourse/commit/9b998f10ce2e4d655a26adce37db40d5b852be89 has been causing an error where routes were not defined.

This commit follows an established pattern and adds a spec to ensure basic behavior is working correctly.