### PR TITLE
DEV: Replace `without` usage and update deprecation handling

### DIFF
--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -259,6 +259,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
     matchId: "discourse.native-array-extensions.findBy",
   },
   {
+    handler: "log",
+    matchId: "discourse.native-array-extensions.without",
+  },
+  {
     handler: ["silence", "counter"],
     matchId: /^discourse\.native-array-extensions\..+$/,
     env: ["test"],

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -272,7 +272,7 @@ export function updateRecentSearches(currentUser, term) {
   let recentSearches = Object.assign(currentUser.recent_searches || []);
 
   if (recentSearches.includes(term)) {
-    recentSearches = recentSearches.without(term);
+    recentSearches = recentSearches.filter((item) => item !== term);
   } else if (recentSearches.length === MAX_RECENT_SEARCHES) {
     recentSearches.popObject();
   }


### PR DESCRIPTION
Refactor `recentSearches` logic in `search.js` to replace the deprecated `without` with a `filter` function. Update deprecation workflow to log usages of the `discourse.native-array-extensions.without` method.