### PR TITLE
DEV: Ensure unsilenced deprecations raise errors in core tests

### DIFF
--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -171,14 +171,17 @@ export class DiscourseDeprecationWorkflow {
   /**
    * Checks if a deprecation should throw an error.
    * @param {string} deprecationId - ID of the deprecation
-   * @param {boolean} [includeUnhandled=false] - Whether to throw for unhandled deprecations
+   * @param {boolean} [includeUnsilenced=false] - Whether to throw for unsilenced deprecations
    * @return {boolean} True if deprecation should throw
    */
-  shouldThrow(deprecationId, includeUnhandled = false) {
+  shouldThrow(deprecationId, includeUnsilenced = false) {
     const workflow = this.#find(deprecationId);
-    return (
-      (!workflow && includeUnhandled) || !!workflow?.handler?.includes("throw")
-    );
+
+    if (includeUnsilenced) {
+      return !this.shouldSilence(deprecationId);
+    }
+
+    return !!workflow?.handler?.includes("throw");
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/unit/deprecation-workflow-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/deprecation-workflow-test.js
@@ -307,21 +307,45 @@ module("Unit | deprecation-workflow", function (hooks) {
       assert.true(wf.shouldCount("empty"), "empty handler -> count");
     });
 
-    test("shouldThrow handles throw and includeUnhandled", function (assert) {
+    test("shouldThrow handles throw and includeUnsilenced", function (assert) {
       const wf = new DiscourseDeprecationWorkflow([
         { handler: "throw", matchId: "t" },
         { handler: "log", matchId: "l" },
+        { handler: "silence", matchId: "s" },
       ]);
 
-      assert.true(wf.shouldThrow("t"), "throw handler -> true");
-      assert.false(wf.shouldThrow("l"), "non-throw handler -> false");
+      assert.true(
+        wf.shouldThrow("t"),
+        "throw handler without includeUnsilenced -> true"
+      );
+      assert.false(
+        wf.shouldThrow("l"),
+        "non-throw handler without includeUnsilenced -> false"
+      );
+      assert.false(
+        wf.shouldThrow("s"),
+        "silenced handler without includeUnsilenced -> false"
+      );
       assert.false(
         wf.shouldThrow("unhandled"),
-        "unhandled without includeUnhandled -> false"
+        "unhandled without includeUnsilenced -> false"
+      );
+
+      assert.true(
+        wf.shouldThrow("t", true),
+        "throw handler with includeUnsilenced -> true"
       );
       assert.true(
-        wf.shouldThrow("unhandled", true),
-        "unhandled with includeUnhandled -> true"
+        wf.shouldThrow("l", true),
+        "non-throw handler with includeUnsilenced -> false"
+      );
+      assert.false(
+        wf.shouldThrow("s", true),
+        "silenced handler with includeUnsilenced -> false"
+      );
+      assert.true(
+        wf.shouldThrow("unhandled with includeUnsilenced", true),
+        "unhandled without includeUnsilenced -> false"
       );
     });
   });


### PR DESCRIPTION
Refine `shouldThrow` behavior by replacing `includeUnhandled` parameter with `includeUnsilenced` to improve clarity and semantics. Adjust logic to integrate unsilenced deprecations handling, ensuring more precise deprecation workflows.