### PR TITLE
DEV: Resolve flaky chat preferences spec

### DIFF
--- a/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
+++ b/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
@@ -34,13 +34,7 @@ module PageObjects
         button_element = page.find(".save-changes")
         button_element.click
 
-        try_until_success do
-          # When page reloads, the old reference to the button will be stale
-          expect { button_element == page.find(".save-changes") }.to raise_error(
-            Playwright::Error,
-            /handle from a different document/,
-          )
-        end
+        wait_until_hidden(button_element)
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
+++ b/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
@@ -36,7 +36,7 @@ module PageObjects
 
         run_until_success do
           # When page reloads, the element will have been replaced
-          expect(find(".save-changes")).not_to eq(page.find(".save-changes"))
+          expect(find(".save-changes")).not_to eq(button_element)
         end
       end
     end

--- a/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
+++ b/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
@@ -31,11 +31,13 @@ module PageObjects
       end
 
       def save_changes_and_refresh
-        page.find(".save-changes").click
-        # reloading the page happens in JS on save but capybara doesnt wait for it
-        # which can mess up navigating away too soon in tests
-        # so doing a manual refresh here to mimic
-        page.refresh
+        button_element = page.find(".save-changes")
+        button_element.click
+
+        run_until_success do
+          # When page reloads, the element will have been replaced
+          expect(find(".save-changes")).not_to eq(page.find(".save-changes"))
+        end
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
+++ b/plugins/chat/spec/system/page_objects/pages/user_preferences_chat.rb
@@ -34,9 +34,12 @@ module PageObjects
         button_element = page.find(".save-changes")
         button_element.click
 
-        run_until_success do
-          # When page reloads, the element will have been replaced
-          expect(find(".save-changes")).not_to eq(button_element)
+        try_until_success do
+          # When page reloads, the old reference to the button will be stale
+          expect { button_element == page.find(".save-changes") }.to raise_error(
+            Playwright::Error,
+            /handle from a different document/,
+          )
         end
       end
     end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -357,4 +357,12 @@ module SystemHelpers
   def wait_for_timeout(ms = 100)
     page.driver.with_playwright_page { |pw_page| pw_page.wait_for_timeout(ms) }
   end
+
+  def wait_until_hidden(element)
+    element.with_playwright_element_handle do |playwright_element|
+      playwright_element.wait_for_element_state("hidden")
+    rescue Playwright::Error => e
+      raise e unless e.message.match?(/Element is not attached to the DOM/)
+    end
+  end
 end


### PR DESCRIPTION
Clicking save and then immediately refreshing can cause a race condition, because the refresh may cancel the ajax request which is performing the save.

Instead, we can wait for the built-in refresh, which will only be triggered after the save is completed successfully.