### PR TITLE
DEV: Fix Unicorn reloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,7 @@ group :test, :development do
   gem "shoulda-matchers", require: false
   gem "rspec-html-matchers"
   gem "pry-stack_explorer", require: false
-  gem "debug", ">= 1.0.0"
+  gem "debug", ">= 1.0.0", require: "debug/prelude"
   gem "rubocop-discourse", require: false
   gem "parallel_tests"
 


### PR DESCRIPTION
Recently we replaced the `pry-byebug` gem by the `debug` one. It broke the auto-reload mechanism we have in the development environment for Unicorn.

Indeed, the `debug` gem by default will add an `at_exit` hook that will wait for all its children to exit. It clashes with our own mechanism.

The workaround is to require `debug/prelude` instead of `debug`: the `debugger` command and breakpoints will still work but without the hook being set.