### PR TITLE
UX: use new --danger modifier in dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-admin-menu.gjs
@@ -123,7 +123,7 @@ export default class TopicAdminMenu extends Component {
                     @label="topic.actions.delete"
                     @action={{fn this.onButtonAction "deleteTopic"}}
                     @icon="trash-can"
-                    class="popup-menu-btn-danger btn-danger"
+                    class="popup-menu-btn-danger --danger"
                   />
                 </dropdown.item>
               {{else if this.canRecover}}


### PR DESCRIPTION
Context: no longer using `btn-danger` for non-standard buttons, such as in a dropdown.
Instead, replace with the dedicated `--danger` modifier.
