### PR TITLE
DEV: Improve rspec boot time & fix `--bisect` functionality

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -130,12 +130,7 @@ if ENV["LOAD_PLUGINS"] == "1"
   Dir[Rails.root.join("plugins/*/spec/system/page_objects/**/*.rb")].each { |f| require f }
 end
 
-# let's not run seed_fu every test
-SeedFu.quiet = true if SeedFu.respond_to? :quiet
-
 SiteSetting.automatically_download_gravatars = false
-
-SeedFu.seed
 
 # we need this env var to ensure that we can impersonate in test
 # this enable integration_helpers sign_in helper
@@ -233,6 +228,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Default is :fork, but this causes problems if any miniracer context have started
+  config.bisect_runner = :shell
 
   config.fail_fast = ENV["RSPEC_FAIL_FAST"] == "1"
   config.silence_filter_announcements = ENV["RSPEC_SILENCE_FILTER_ANNOUNCEMENTS"] == "1"


### PR DESCRIPTION
By default, RSpec's bisect uses the `:fork` strategy. This is not safe to use in Discourse, because miniracer is not fork safe. So if any contexts have been booted in the parent process, they'll be broken in the forked process. Using `:shell` solves this.

Also, since we introduced core themes, the database 'seed' step became much more expensive because it re-installs and compiles Horizon/Foundation every time. I don't think there's any need to do this every time we boot a spec. Instead, we can trust that it ran as part of `bin/rake db:migrate`, just like it does in production.

On my machine, this cuts the runtime of a single (empty) spec from 3.5s to 1.1s 🚀