### PR TITLE
FEATURE: Add format_for_email_modifier plugin modifier and keep_img_tags parameter to ExcerptParser to preserve images in excerpts and email notifications

### DIFF
--- a/app/helpers/user_notifications_helper.rb
+++ b/app/helpers/user_notifications_helper.rb
@@ -78,6 +78,10 @@ module UserNotificationsHelper
 
   def format_for_email(post, use_excerpt)
     html = use_excerpt ? post.excerpt : post.cooked
+
+    html =
+      DiscoursePluginRegistry.apply_modifier(:format_for_email_modifier, html, post, use_excerpt)
+
     PrettyText.format_for_email(html, post).html_safe
   end
 

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -21,6 +21,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     @keep_quotes = options[:keep_quotes] == true
     @keep_svg = options[:keep_svg] == true
     @remap_emoji = options[:remap_emoji] == true
+    @keep_img_tags = options[:keep_img_tags] == true
     @start_excerpt = false
     @start_hashtag_icon = false
     @in_details_depth = 0
@@ -76,6 +77,8 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
           return characters(attributes["alt"])
         end
       end
+
+      return include_tag(name, attributes) if @keep_img_tags
 
       unless @strip_images
         # If include_images is set, include the image in markdown

--- a/spec/helpers/user_notifications_helper_spec.rb
+++ b/spec/helpers/user_notifications_helper_spec.rb
@@ -186,4 +186,19 @@ RSpec.describe UserNotificationsHelper do
       end
     end
   end
+
+  describe "#format_for_email" do
+    let!(:plugin) { Plugin::Instance.new }
+    let!(:modify_html) { Proc.new { |html, post, use_excerpt| html = "modified html" } }
+    fab!(:post)
+
+    it "allows plugins to control #email_excerpt" do
+      DiscoursePluginRegistry.register_modifier(plugin, :format_for_email_modifier, &modify_html)
+
+      html = helper.format_for_email(post, true)
+      expect(html).to eq("modified html")
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(plugin, :format_for_email_modifier, &modify_html)
+    end
+  end
 end

--- a/spec/lib/excerpt_parser_spec.rb
+++ b/spec/lib/excerpt_parser_spec.rb
@@ -152,4 +152,27 @@ RSpec.describe ExcerptParser do
       )
     end
   end
+
+  describe "keep_img_tags parameter" do
+    it "should keep the images in the html" do
+      html = <<~HTML.strip
+        <img src="/uploads/default/original/1X/10c0f1565ee5b6ca3fe43f3183529bc0afd26003.jpeg" class="thumbnail">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        <a href="https://github.com/oblakeerickson" target="_blank" rel="noopener">
+          <img alt="oblakeerickson" src="//localhost:3000/uploads/default/original/1X/741ac99d6a66d71cdd46dd99fb5156506e13fdf2.jpeg" class="onebox-avatar-inline" width="20" height="20" data-dominant-color="3C3C3C">
+          oblakeerickson
+        </a>
+      HTML
+
+      # Using squish here to normalize output and ignore added whitespace added when processing p tags
+      expect(ExcerptParser.get_excerpt(html, 200, keep_img_tags: true).squish).to eq(<<~HTML.squish)
+        <img src="/uploads/default/original/1X/10c0f1565ee5b6ca3fe43f3183529bc0afd26003.jpeg" class="thumbnail">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <a href="https://github.com/oblakeerickson" target="_blank" rel="noopener">
+          <img alt="oblakeerickson" src="//localhost:3000/uploads/default/original/1X/741ac99d6a66d71cdd46dd99fb5156506e13fdf2.jpeg" class="onebox-avatar-inline" width="20" height="20" data-dominant-color="3C3C3C">
+          oblakeerickson
+        </a>
+      HTML
+    end
+  end
 end


### PR DESCRIPTION
**Description** 
Currently, `ExcerptParser ` can't preserve images in excerpts; we only preserve links, markdown, or a text stub where the image was located. The `keep_img_tags` parameter allows users to preserve images on excerpts if desired, and when used along with the `format_for_email_modifier`, allows preserving images on email notifications
