### PR TITLE
DEV: Fix PostDestroyer deprecations in specs

### DIFF
--- a/plugins/discourse-assign/spec/plugin_spec.rb
+++ b/plugins/discourse-assign/spec/plugin_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe DiscourseAssign do
       let!(:assignment) { Fabricate(:post_assignment) }
       let(:post) { assignment.target }
 
-      before { PostDestroyer.new(Discourse.system_user, post).destroy }
+      before { PostDestroyer.new(Discourse.system_user, post, context: "spec").destroy }
 
       it "deactivates the existing assignment" do
         assignment.reload
@@ -174,7 +174,7 @@ RSpec.describe DiscourseAssign do
       before do
         SiteSetting.reassign_on_open = true
         post.trash!
-        PostDestroyer.new(Discourse.system_user, post).recover
+        PostDestroyer.new(Discourse.system_user, post, context: "spec").recover
       end
 
       it "reactivates the existing assignment" do

--- a/plugins/discourse-calendar/spec/models/calendar_event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/calendar_event_spec.rb
@@ -67,9 +67,9 @@ describe CalendarEvent do
     raw = %{Rome [date="2018-06-05" time="10:20:00"]}
     post = create_post(raw: raw, topic: calendar_post.topic)
 
-    PostDestroyer.new(Discourse.system_user, post).destroy
-    PostDestroyer.new(Discourse.system_user, calendar_post).destroy
-    PostDestroyer.new(Discourse.system_user, post.reload).recover
+    PostDestroyer.new(Discourse.system_user, post, context: "spec").destroy
+    PostDestroyer.new(Discourse.system_user, calendar_post, context: "spec").destroy
+    PostDestroyer.new(Discourse.system_user, post.reload, context: "spec").recover
 
     expect(post.deleted_at).to eq(nil)
   end
@@ -78,10 +78,10 @@ describe CalendarEvent do
     post = create_post(raw: 'Rome [date="2018-06-05" time="10:20:00"]', topic: calendar_post.topic)
     expect(CalendarEvent.count).to eq(1)
 
-    PostDestroyer.new(Discourse.system_user, calendar_post.reload).destroy
+    PostDestroyer.new(Discourse.system_user, calendar_post.reload, context: "spec").destroy
     expect(CalendarEvent.count).to eq(0)
 
-    PostDestroyer.new(Discourse.system_user, calendar_post.reload).recover
+    PostDestroyer.new(Discourse.system_user, calendar_post.reload, context: "spec").recover
     expect(CalendarEvent.count).to eq(1)
   end
 
@@ -150,7 +150,7 @@ describe CalendarEvent do
 
       expect(CalendarEvent.find_by(post_id: post.id)).to be_present
 
-      PostDestroyer.new(Discourse.system_user, post).destroy
+      PostDestroyer.new(Discourse.system_user, post, context: "spec").destroy
 
       expect(CalendarEvent.find_by(post_id: post.id)).to_not be_present
     end

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/post_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/post_serializer_spec.rb
@@ -19,7 +19,7 @@ describe PostSerializer do
     end
 
     context "when the post has been destroyed" do
-      before { PostDestroyer.new(Discourse.system_user, post_1).destroy }
+      before { PostDestroyer.new(Discourse.system_user, post_1, context: "spec").destroy }
 
       it "doesn’t serialize the associated event" do
         json = PostSerializer.new(post_1, scope: Guardian.new).as_json

--- a/plugins/discourse-policy/spec/serializers/post_serializer_spec.rb
+++ b/plugins/discourse-policy/spec/serializers/post_serializer_spec.rb
@@ -58,8 +58,6 @@ describe PostSerializer do
     group.destroy!
 
     json = PostSerializer.new(post, scope: Guardian.new).as_json
-    puts json.inspect
-
     not_accepted = json[:post][:policy_not_accepted_by]
 
     expect(not_accepted).to eq(nil)

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -283,7 +283,7 @@ describe DiscourseReactions::CustomReactionsController do
         parsed = response.parsed_body
         expect(parsed.length).to eq(2)
 
-        PostDestroyer.new(Discourse.system_user, deleted_post).destroy
+        PostDestroyer.new(Discourse.system_user, deleted_post, context: "spec").destroy
 
         get "/discourse-reactions/posts/reactions.json", params: { username: user.username }
         parsed = response.parsed_body
@@ -305,7 +305,7 @@ describe DiscourseReactions::CustomReactionsController do
 
         expect(response.parsed_body.length).to eq(2)
 
-        PostDestroyer.new(Discourse.system_user, op).destroy
+        PostDestroyer.new(Discourse.system_user, op, context: "spec").destroy
         get "/discourse-reactions/posts/reactions.json", params: { username: user_1.username }
 
         parsed = response.parsed_body

--- a/plugins/discourse-solved/spec/integration/solved_spec.rb
+++ b/plugins/discourse-solved/spec/integration/solved_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe "Managing Posts solved status" do
 
       expect(topic.solved.answer_post_id).to eq(reply.id)
 
-      PostDestroyer.new(Discourse.system_user, reply).destroy
+      PostDestroyer.new(Discourse.system_user, reply, context: "spec").destroy
       reply.topic.reload
 
       expect(topic.solved).to be(nil)


### PR DESCRIPTION
…and remove a stray `puts` in a spec