### PR TITLE
FIX: Ctrl/Cmd + Enter search results should open in new tab

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/results/types.gjs
@@ -63,8 +63,7 @@ export default class Types extends Component {
       const link = event.currentTarget.querySelector("a.search-link");
       if (link?.href) {
         if (event.ctrlKey || event.metaKey) {
-          const url = new URL(link.href);
-          window.open(url.pathname, "_blank", "noopener,noreferrer");
+          window.open(link.href, "_blank", "noopener,noreferrer");
         } else {
           this.routeToSearchResult(link.href);
         }

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -685,7 +685,7 @@ acceptance("Search - Authenticated", function (needs) {
     assert.strictEqual(openedUrls.length, 1);
     assert.strictEqual(
       openedUrls[0].url,
-      "/t/development-mode-super-slow/2179"
+      `${window.location.origin}/t/development-mode-super-slow/2179`
     );
     assert.strictEqual(openedUrls[0].target, "_blank");
     assert.strictEqual(openedUrls[0].features, "noopener,noreferrer");
@@ -723,7 +723,7 @@ acceptance("Search - Authenticated", function (needs) {
     assert.strictEqual(openedUrls.length, 1);
     assert.strictEqual(
       openedUrls[0].url,
-      "/t/development-mode-super-slow/2179"
+      `${window.location.origin}/t/development-mode-super-slow/2179`
     );
     assert.strictEqual(openedUrls[0].target, "_blank");
     assert.strictEqual(openedUrls[0].features, "noopener,noreferrer");


### PR DESCRIPTION
## :mag: Overview

Fixes accessibility issue where <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Enter</kbd> on keyboard-navigated search results opened in the same tab instead of a new tab. Users can now use standard browser shortcuts when navigating search results with arrow keys.

## :heavy_plus_sign: More Details

Discourse prevents default browser behavior on Enter key events in search results to handle custom routing, analytics logging, and menu management. This custom handling needed explicit modifier key detection since the default browser <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Enter</kbd> behavior was bypassed. The fix adds proper <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Enter</kbd> handling while preserving all existing functionality.

## :camera: Screen Recordings

### ← Before
https://github.com/user-attachments/assets/3b8715bf-c5bb-4f23-87f0-ee66b088b220



### → After  
https://github.com/user-attachments/assets/e235a311-bf27-467c-93d5-a9233228fae3



### :link: References

https://meta.discourse.org/t/open-in-new-tab-browser-keybind-fails-on-search-results/384004?u=keegan