### PR TITLE
DEV: Replace deprecated Ember's native array.get and .set

### DIFF
--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -259,6 +259,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   },
   {
     handler: "log",
+    matchId: "discourse.native-array-extensions.get",
+  },
+  {
+    handler: "log",
     matchId: "discourse.native-array-extensions.findBy",
   },
   {
@@ -268,6 +272,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   {
     handler: "log",
     matchId: "discourse.native-array-extensions.rejectBy",
+  },
+  {
+    handler: "log",
+    matchId: "discourse.native-array-extensions.set",
   },
   {
     handler: "log",


### PR DESCRIPTION
Add deprecation handling for `discourse.native-array-extensions.get` and `set` to the workflow. This ensures consistent logging of deprecated array extension usage, aiding in eventual cleanup and migration efforts.