### PR TITLE
UX: Use search padding for discoveries

### DIFF
--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-discobot-discoveries.scss
@@ -146,7 +146,7 @@
         grid-column-start: 2;
         grid-row: 1 / -1;
         box-sizing: border-box;
-        padding: 0 0.5em 0 2em;
+        padding: var(--search-result-element-padding);
         margin: 0.75em 0 0 0;
         border-left: 1px solid var(--primary-low);
 


### PR DESCRIPTION
| 📸 | before | after |
|----|---|---|
| narrow desktop |  <img width="786" height="967" alt="Screenshot 2025-09-26 at 4 53 36 PM" src="https://github.com/user-attachments/assets/639b4e01-6822-4599-9985-a75d82be05d6" /> | <img width="787" height="968" alt="Screenshot 2025-09-26 at 4 54 32 PM" src="https://github.com/user-attachments/assets/1c2d9c96-43a4-47ac-9a99-52a9f40023a9" /> |
| wide desktop | <img width="1075" height="1013" alt="Screenshot 2025-09-26 at 4 53 14 PM" src="https://github.com/user-attachments/assets/66c21999-9113-44a5-9369-9ea6c06a6159" /> | <img width="1075" height="1013" alt="Screenshot 2025-09-26 at 4 54 54 PM" src="https://github.com/user-attachments/assets/4adf580c-dd93-43ee-89bc-28a5a92f1f8a" /> |