### PR TITLE
UX: prevent icon and text wrapping in breadcrumb

### DIFF
--- a/app/assets/stylesheets/common/components/d-breadcrumbs.scss
+++ b/app/assets/stylesheets/common/components/d-breadcrumbs.scss
@@ -1,9 +1,11 @@
 .d-breadcrumbs {
   display: flex;
+  flex-wrap: wrap;
   margin: var(--space-2) 0 var(--space-4) 0;
 
   &__item {
     list-style-type: none;
+    white-space: nowrap;
   }
 
   &__link,


### PR DESCRIPTION
We need to allow the breadcrumbs to wrap properly, to account for deep navigation layers on mobile

| BC | AC |
|--------|--------|
| <img width="668" height="842" alt="CleanShot 2025-09-26 at 08 17 42@2x" src="https://github.com/user-attachments/assets/e38400eb-b8a2-48f2-be69-089ad392d144" /> | <img width="668" height="842" alt="CleanShot 2025-09-26 at 08 17 59@2x" src="https://github.com/user-attachments/assets/b061f82a-433a-409e-903e-90b2fde35a39" /> | 