### PR TITLE
FIX: add support for subfolder in discourse-id registration

### DIFF
--- a/app/services/discourse_id/register.rb
+++ b/app/services/discourse_id/register.rb
@@ -23,9 +23,12 @@ class DiscourseId::Register
     uri = URI("#{discourse_id_url}/challenge")
     use_ssl = Rails.env.production? || uri.scheme == "https"
 
+    body = { domain: Discourse.current_hostname }
+    body[:path] = Discourse.base_path if Discourse.base_path.present?
+
     request = Net::HTTP::Post.new(uri)
     request.content_type = "application/json"
-    request.body = { domain: Discourse.current_hostname }.to_json
+    request.body = body.to_json
 
     begin
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl:) { |http| http.request(request) }
@@ -45,6 +48,10 @@ class DiscourseId::Register
 
     if json["domain"] != Discourse.current_hostname
       return fail!(error: "Domain mismatch in challenge response")
+    end
+
+    if Discourse.base_path.present? && json["path"] != Discourse.base_path
+      return fail!(error: "Path mismatch in challenge response")
     end
 
     context[:token] = json["token"]

--- a/spec/services/discourse_id/register_spec.rb
+++ b/spec/services/discourse_id/register_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe DiscourseId::Register do
         it { is_expected.to fail_a_step(:request_challenge) }
       end
 
+      context "when challenge response has path mismatch" do
+        before do
+          allow(Discourse).to receive(:base_path).and_return("/forum")
+          stub_request(:post, "#{discourse_id_url}/challenge").to_return(
+            status: 200,
+            body: {
+              domain: Discourse.current_hostname,
+              path: "/wrong-path",
+              token: challenge_token,
+            }.to_json,
+          )
+        end
+
+        it { is_expected.to fail_a_step(:request_challenge) }
+      end
+
       context "when challenge request succeeds" do
         before do
           stub_request(:post, "#{discourse_id_url}/challenge").with(
@@ -265,6 +281,41 @@ RSpec.describe DiscourseId::Register do
         expect(WebMock).to have_requested(:post, "#{custom_url}/challenge")
         expect(WebMock).to have_requested(:post, "#{custom_url}/register")
       end
+    end
+
+    context "when site has a base_path" do
+      let(:path) { "/forum" }
+
+      before do
+        allow(Discourse).to receive(:base_path).and_return(path)
+        SiteSetting.discourse_id_client_id = ""
+        SiteSetting.discourse_id_client_secret = ""
+
+        stub_request(:post, "#{discourse_id_url}/challenge").with(
+          body: { domain: Discourse.current_hostname, path: }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        ).to_return(
+          status: 200,
+          body: { domain: Discourse.current_hostname, path:, token: challenge_token }.to_json,
+        )
+
+        stub_request(:post, "#{discourse_id_url}/register").to_return(
+          status: 200,
+          body: { client_id:, client_secret: }.to_json,
+        )
+      end
+
+      it "includes path in challenge request and validates path in response" do
+        result
+
+        expect(WebMock).to have_requested(:post, "#{discourse_id_url}/challenge").with { |req|
+          JSON.parse(req.body)["path"] == path
+        }
+      end
+
+      it { is_expected.to run_successfully }
     end
   end
 end


### PR DESCRIPTION
This ensures the automated registration process for #discourse-id
correctly supports Discourse running in a subfolder by adding a "path"
value in the data sent.

Internal ref - t/161934/15

Related - https://github.com/discourse/discourse-login/pull/74