### PR TITLE
FEATURE: auto-trigger uploads for <img>s with src=data:* content

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -338,7 +338,9 @@ export default class UppyComposerUpload {
             })
           );
 
-          this.placeholderHandler.insert(file);
+          if (!file.meta.skipPlaceholder) {
+            this.placeholderHandler.insert(file);
+          }
 
           this.appEvents.trigger(
             `${this.composerEventPrefix}:upload-started`,
@@ -379,7 +381,9 @@ export default class UppyComposerUpload {
           () => {
             this.#removeInProgressUpload(file.id);
 
-            this.placeholderHandler.success(file, markdown);
+            if (!file.meta.skipPlaceholder) {
+              this.placeholderHandler.success(file, markdown);
+            }
 
             this.appEvents.trigger(
               `${this.composerEventPrefix}:upload-success`,
@@ -581,7 +585,10 @@ export default class UppyComposerUpload {
             name: file.name,
             type: file.type,
             data: file,
-            meta: { pasted: opts.pasted },
+            meta: {
+              pasted: opts.pasted,
+              skipPlaceholder: opts.skipPlaceholder,
+            },
           };
         })
       );

--- a/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
+++ b/app/assets/javascripts/discourse/app/static/prosemirror/extensions/image.js
@@ -5,6 +5,7 @@ import {
 import { ajax } from "discourse/lib/ajax";
 import discourseDebounce from "discourse/lib/debounce";
 import { isNumeric } from "discourse/lib/utilities";
+import { i18n } from "discourse-i18n";
 import ImageNodeView from "../components/image-node-view";
 import GlimmerNodeView from "../lib/glimmer-node-view";
 import { getChangedRanges } from "../lib/plugin-utils";
@@ -13,6 +14,8 @@ const PLACEHOLDER_IMG = "/images/transparent.png";
 
 const ALT_TEXT_REGEX =
   /^(.*?)(?:\|(\d{1,4}x\d{1,4}))?(?:,\s*(\d{1,3})%)?(?:\|(.*))?$/;
+
+const UPLOAD_TIMEOUT = 30_000;
 
 const createImageNodeView =
   ({ getContext }) =>
@@ -57,7 +60,7 @@ const extension = {
       draggable: true,
       parseDOM: [
         {
-          tag: 'img[src]:not([src^="data:"])',
+          tag: "img[src]",
           getAttrs(dom) {
             const originalSrc =
               dom.dataset.origSrc ??
@@ -196,7 +199,7 @@ const extension = {
     };
   },
 
-  plugins({ pmState: { Plugin, NodeSelection, TextSelection } }) {
+  plugins({ pmState: { Plugin, NodeSelection, TextSelection }, getContext }) {
     const shortUrlResolver = new Plugin({
       state: {
         init() {
@@ -307,7 +310,146 @@ const extension = {
       },
     });
 
-    return [shortUrlResolver, avoidTextInputRemoval];
+    const dataImageUploader = new Plugin({
+      state: {
+        init() {
+          return new Map();
+        },
+        apply(tr, uriNodesMap) {
+          getChangedRanges(tr).forEach(({ new: { from, to } }) => {
+            tr.doc.nodesBetween(from, to, (node, pos) => {
+              if (
+                node.type.name === "image" &&
+                node.attrs.src?.startsWith("data:")
+              ) {
+                if (!uriNodesMap.has(node.attrs.src)) {
+                  uriNodesMap.set(node.attrs.src, []);
+                }
+                uriNodesMap.get(node.attrs.src).push({ node, pos });
+              } else if (node.type.name === "image" && node.attrs.src) {
+                for (const [dataURI, nodes] of uriNodesMap) {
+                  uriNodesMap.set(
+                    dataURI,
+                    nodes.filter((n) => n.pos !== pos)
+                  );
+                  if (uriNodesMap.get(dataURI).length === 0) {
+                    uriNodesMap.delete(dataURI);
+                  }
+                }
+              }
+            });
+          });
+
+          return uriNodesMap;
+        },
+      },
+
+      view() {
+        const { appEvents } = getContext();
+        const pendingUploads = new Set();
+
+        const uploadDataImage = async (dataURI, nodes, view) => {
+          const mimeMatch = dataURI.match(/data:image\/([^;]+)/);
+          let fileExtension = "png";
+          if (mimeMatch) {
+            const remap = { jpeg: "jpg" };
+            const ext = mimeMatch[1].toLowerCase();
+            fileExtension = remap[ext] || ext;
+          }
+
+          const fileName = `image-${Date.now()}-${Math.random().toString(36).substr(2, 9)}.${fileExtension}`;
+
+          const res = await fetch(dataURI);
+          const blob = await res.blob();
+          const file = new File([blob], fileName, { type: blob.type });
+          file.id = fileName;
+          pendingUploads.add(fileName);
+
+          const handleSuccess = (uploadedFileName, upload) => {
+            if (uploadedFileName === fileName && pendingUploads.has(fileName)) {
+              if (!upload?.short_url && !upload?.url) {
+                return handleError(fileName);
+              }
+
+              const tr = view.state.tr;
+
+              nodes.forEach(({ pos }) => {
+                const node = view.state.doc.nodeAt(pos);
+                if (node && node.type.name === "image") {
+                  tr.setNodeMarkup(pos, null, {
+                    ...node.attrs,
+                    alt:
+                      node.attrs.alt ||
+                      i18n("upload_selector.default_image_alt_text"),
+                    src: upload.url || upload.short_url,
+                    originalSrc: upload.short_url || upload.url,
+                  });
+                }
+              });
+
+              if (tr.docChanged) {
+                view.dispatch(tr);
+              }
+              cleanup();
+            }
+          };
+
+          const handleError = (uploadedFileName) => {
+            if (
+              (uploadedFileName === fileName || !uploadedFileName) &&
+              pendingUploads.has(fileName)
+            ) {
+              const tr = view.state.tr;
+              nodes.forEach(({ pos }) => {
+                const node = view.state.doc.nodeAt(pos);
+                if (node && node.type.name === "image") {
+                  tr.replaceWith(
+                    pos,
+                    pos + node.nodeSize,
+                    view.state.schema.text("[Upload failed]")
+                  );
+                }
+              });
+              if (tr.docChanged) {
+                view.dispatch(tr);
+              }
+              cleanup();
+            }
+          };
+
+          const cleanup = () => {
+            pendingUploads.delete(fileName);
+            appEvents.off("composer:upload-success", handleSuccess);
+            appEvents.off("composer:upload-error", handleError);
+          };
+
+          appEvents.on("composer:upload-success", handleSuccess);
+          appEvents.on("composer:upload-error", handleError);
+
+          appEvents.trigger("composer:add-files", [file], {
+            skipPlaceholder: true,
+          });
+
+          setTimeout(() => {
+            if (pendingUploads.has(fileName)) {
+              handleError(fileName);
+            }
+          }, UPLOAD_TIMEOUT);
+        };
+
+        return {
+          update(view) {
+            dataImageUploader
+              .getState(view.state)
+              .forEach((nodes, dataURI) =>
+                uploadDataImage(dataURI, nodes, view)
+              );
+          },
+        };
+      },
+    });
+
+    return [shortUrlResolver, avoidTextInputRemoval, dataImageUploader];
   },
 };
 


### PR DESCRIPTION
Automatically triggers uploads for existing images in the current ProseMirror document when they contain a `data:*` `src`, replacing them inline when the upload completes.

Images in the form `<img src="data:image/png;base64,...">` are often the result of copying from other authoring tools, like Google Docs.

With this change, instead of skipping them entirely, they'll be uploaded and the resulting `upload://hash` identifier will be used.