### PR TITLE
DEV: Move convert video job to upload after create

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -30,6 +30,7 @@ class Upload < ActiveRecord::Base
   has_many :posts, through: :upload_references, source: :target, source_type: "Post"
   has_many :topic_thumbnails
   has_many :badges, foreign_key: :image_upload_id, dependent: :nullify
+  after_create :enqueue_video_conversion_job, if: :should_convert_video?
 
   attr_accessor :for_group_message
   attr_accessor :for_theme
@@ -659,6 +660,15 @@ class Upload < ActiveRecord::Base
 
   def short_url_basename
     "#{Upload.base62_sha1(sha1)}#{extension.present? ? ".#{extension}" : ""}"
+  end
+
+  def should_convert_video?
+    SiteSetting.video_conversion_enabled && SiteSetting.Upload.enable_s3_uploads &&
+      FileHelper.is_supported_video?(original_filename) && !OptimizedVideo.exists?(upload_id: id)
+  end
+
+  def enqueue_video_conversion_job
+    Jobs.enqueue(:convert_video, upload_id: id)
   end
 end
 

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -116,11 +116,6 @@ module FileStore
         path, etag = s3_helper.upload(file, path, options)
       end
 
-      if opts[:upload_id] && FileHelper.is_supported_video?(opts[:filename]) &&
-           SiteSetting.video_conversion_enabled
-        Jobs.enqueue(:convert_video, upload_id: opts[:upload_id])
-      end
-
       # return the upload url and etag
       [File.join(absolute_base_url, path), etag]
     end


### PR DESCRIPTION
This moves the logic for creating the convert_video job to the upload
after_create hook so that we ensure there is an upload_id. When this logic
was in the s3 store and direct to s3 uploads was enabled the convert video job
would never fire because we didn't have an upload_id.
