### PR TITLE
DEV: Backport commit to trigger event after user warning is created (#34997)

### DIFF
--- a/plugins/discourse-user-notes/plugin.rb
+++ b/plugins/discourse-user-notes/plugin.rb
@@ -55,6 +55,9 @@ after_initialize do
       Discourse::SYSTEM_USER_ID,
       topic_id: self.topic_id,
     )
+
+    # Fire event after note is created for other plugins to hook into
+    DiscourseEvent.trigger(:user_warning_created, self)
   end
 
   add_report("user_notes") do |report|


### PR DESCRIPTION
- Fire an event after the user warning is created to allow can allow other plugins to hook into