### PR TITLE
UX: fix new topic btn reappearing in Horizon

### DIFF
--- a/themes/horizon/scss/hiddenstuff.scss
+++ b/themes/horizon/scss/hiddenstuff.scss
@@ -1,7 +1,14 @@
+@use "lib/viewport";
+
 .sidebar__panel-switch-button,
-.list-controls .fk-d-button-tooltip:has(#create-topic),
 .notifications-button-footer .reason .text,
 .pinned-button .reason .text,
 .more-topics__browse-more {
   display: none;
+}
+
+@include viewport.from(md) {
+  .list-controls #create-topic {
+    display: none;
+  }
 }


### PR DESCRIPTION
Fix for https://github.com/discourse/discourse/pull/34714

Which made the new-topic-button reappear on desktop.