### PR TITLE
DEV: Update deprecation workflow and regenerate `pnpm-lock.yaml`

### DIFF
--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -275,6 +275,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   },
   {
     handler: "log",
+    matchId: "discourse.native-array-extensions.replace",
+  },
+  {
+    handler: "log",
     matchId: "discourse.native-array-extensions.sortBy",
   },
   {

--- a/patches/ember-source@6.6.0.patch
+++ b/patches/ember-source@6.6.0.patch
@@ -1,39 +1,39 @@
-diff --git a/dist/packages/@ember/-internals/deprecations/index.js b/dist/packages/@ember/-internals/deprecations/index.js
-index 894cd5c5e28db30f8798ee828b8364c94d488964..bffb6b1c0d22d3611f8e85414c0f34f0e416e4f4 100644
---- a/dist/packages/@ember/-internals/deprecations/index.js
-+++ b/dist/packages/@ember/-internals/deprecations/index.js
-@@ -123,7 +123,7 @@ function deprecateUntil(message, deprecation) {
-   if (deprecation.isRemoved) {
-     throw new Error(`The API deprecated by ${options.id} was removed in ember-source ${options.until}. The message was: ${message}. Please see ${options.url} for more details.`);
-   }
--  (isDevelopingApp() && !(deprecation.test) && deprecate(message, deprecation.test, options));
-+  (true && !(deprecation.test) && deprecate(message, deprecation.test, options));
+diff --git a/dist/ember.debug.js b/dist/ember.debug.js
+index d205f434b0dd2bbb124ddcc62d6e2284b3910f32..e2044b16e7df230ff31a9df1703ffb22c9dad3d0 100644
+--- a/dist/ember.debug.js
++++ b/dist/ember.debug.js
+@@ -9298,7 +9298,7 @@ var define, require;
+           // Ideally, we'd use MutableArray.detect but for unknown reasons this causes
+           // the node tests to fail strangely.
+           function isMutableArray(obj) {
+-            return obj != null && typeof obj.replace === 'function';
++            return obj != null && typeof obj.replace === 'function' && !Array.isArray(obj);
+           }
+           function replace(array, start, deleteCount, items = EMPTY_ARRAY$3) {
+             if (isMutableArray(array)) {
+diff --git a/dist/ember.prod.js b/dist/ember.prod.js
+index 93026b57ac2527ab05a483c168211318b039a7c9..76a03c798f5226a7fd3de69c114381b559bdae0a 100644
+--- a/dist/ember.prod.js
++++ b/dist/ember.prod.js
+@@ -8042,7 +8042,7 @@ var define, require;
+           // Ideally, we'd use MutableArray.detect but for unknown reasons this causes
+           // the node tests to fail strangely.
+           function isMutableArray(obj) {
+-            return obj != null && typeof obj.replace === 'function';
++            return obj != null && typeof obj.replace === 'function' && !Array.isArray(obj);
+           }
+           function replace(array, start, deleteCount, items = EMPTY_ARRAY$3) {
+             if (isMutableArray(array)) {
+diff --git a/dist/packages/shared-chunks/array-BGH9y76r.js b/dist/packages/shared-chunks/array-BGH9y76r.js
+index 47fa056e935d4ddeae71a9a2d9ad801c4df21195..a8140f87cd68ab678a69a32921bcf70e93839b3f 100644
+--- a/dist/packages/shared-chunks/array-BGH9y76r.js
++++ b/dist/packages/shared-chunks/array-BGH9y76r.js
+@@ -67,7 +67,7 @@ const EMPTY_ARRAY = Object.freeze([]);
+ // Ideally, we'd use MutableArray.detect but for unknown reasons this causes
+ // the node tests to fail strangely.
+ function isMutableArray(obj) {
+-  return obj != null && typeof obj.replace === 'function';
++  return obj != null && typeof obj.replace === 'function' && !Array.isArray(obj);
  }
- const {
-   EXTEND_PROTOTYPES
-diff --git a/dist/packages/@ember/debug/lib/deprecate.js b/dist/packages/@ember/debug/lib/deprecate.js
-index 2a40f7cca607ab80beb267d79243fc30f16c92a1..9c15e205f3fb1661b8f1ae397c2338c42a3cc601 100644
---- a/dist/packages/@ember/debug/lib/deprecate.js
-+++ b/dist/packages/@ember/debug/lib/deprecate.js
-@@ -50,7 +50,7 @@ let missingOptionsDeprecation;
- let missingOptionsIdDeprecation;
- let missingOptionDeprecation = () => '';
- let deprecate = () => {};
--if (isDevelopingApp()) {
-+if (true) {
-   registerHandler = function registerHandler(handler) {
-     registerHandler$1('deprecate', handler);
-   };
-diff --git a/dist/packages/@ember/debug/lib/handlers.js b/dist/packages/@ember/debug/lib/handlers.js
-index cd68afe479229ed77b4e4c93759aa90913cdc49c..6e7d71bbeb28f18259fa8afb48ef78279f25c531 100644
---- a/dist/packages/@ember/debug/lib/handlers.js
-+++ b/dist/packages/@ember/debug/lib/handlers.js
-@@ -3,7 +3,7 @@ import { isDevelopingApp } from '@embroider/macros';
- let HANDLERS = {};
- let registerHandler = function registerHandler(_type, _callback) {};
- let invoke = () => {};
--if (isDevelopingApp()) {
-+if (true) {
-   registerHandler = function registerHandler(type, callback) {
-     let nextHandler = HANDLERS[type] || (() => {});
-     HANDLERS[type] = (message, options) => {
+ function replace(array, start, deleteCount, items = EMPTY_ARRAY) {
+   if (isMutableArray(array)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ patchedDependencies:
     hash: wki6cycbrrm5sscamn5w4cujby
     path: patches/babel-plugin-debug-macros@0.3.4.patch
   ember-source@6.6.0:
-    hash: tyhbf7f4uxnr3gt4x2tdcudbva
+    hash: jjggzpti2fmeyuaihs7wrnhfxq
     path: patches/ember-source@6.6.0.patch
   ember-this-fallback@0.4.0:
     hash: znalyv6akdxlqfpmxunrdi3osa
@@ -187,13 +187,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -413,7 +413,7 @@ importers:
         version: 2.2.0
       '@ember/render-modifiers':
         specifier: ^3.0.0
-        version: 3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
@@ -527,19 +527,19 @@ importers:
         version: 2.1.1(@babel/core@7.28.4)
       ember-cached-decorator-polyfill:
         specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli:
         specifier: ~6.6.0
         version: 6.6.0(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-app-version:
         specifier: ^7.0.0
-        version: 7.0.0(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 7.0.0(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.4)
       ember-cli-deprecation-workflow:
         specifier: ^3.4.0
-        version: 3.4.0(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.4.0(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-htmlbars:
         specifier: ^6.3.0
         version: 6.3.0
@@ -560,10 +560,10 @@ importers:
         version: 6.1.1
       ember-exam:
         specifier: ^10.0.0
-        version: 10.0.0(@glint/template@1.6.0-alpha.2)(ember-qunit@9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1))(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10))
+        version: 10.0.0(@glint/template@1.6.0-alpha.2)(ember-qunit@9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1))(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10))
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.2.2
         version: 4.2.2(@babel/core@7.28.4)
@@ -572,7 +572,7 @@ importers:
         version: 9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1)
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-template-imports:
         specifier: ^4.3.0
         version: 4.3.0
@@ -707,7 +707,7 @@ importers:
         version: 4.3.0
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
     devDependencies:
       ember-cli:
         specifier: ~6.6.0
@@ -763,13 +763,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -789,7 +789,7 @@ importers:
         version: 7.28.4(supports-color@8.1.1)
       '@ember/render-modifiers':
         specifier: ^3.0.0
-        version: 3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       '@floating-ui/dom':
         specifier: ^1.7.4
         version: 1.7.4
@@ -850,13 +850,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -926,13 +926,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -965,7 +965,7 @@ importers:
         version: 2.10.1(@glint/template@1.6.0-alpha.2)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10))
       ember-cached-decorator-polyfill:
         specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.28.4)
@@ -1020,13 +1020,13 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -1089,10 +1089,10 @@ importers:
         version: 6.3.0
       ember-source:
         specifier: ~6.6.0
-        version: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+        version: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-this-fallback:
         specifier: ^0.4.0
-        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))
+        version: 0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))
       fastestsmallesttextencoderdecoder:
         specifier: ^1.0.22
         version: 1.0.22
@@ -10209,13 +10209,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
+  '@ember/render-modifiers@3.0.0(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))':
     dependencies:
       '@babel/core': 7.28.4(supports-color@8.1.1)
       '@embroider/macros': 1.18.1(@glint/template@1.6.0-alpha.2)
       ember-cli-babel: 8.2.0(@babel/core@7.28.4)
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.4)
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
     optionalDependencies:
       '@glint/template': 1.6.0-alpha.2
     transitivePeerDependencies:
@@ -13404,7 +13404,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@embroider/macros': 1.18.1(@glint/template@1.6.0-alpha.2)
       '@glimmer/tracking': 1.1.2
@@ -13412,16 +13412,16 @@ snapshots:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.4)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  ember-cli-app-version@7.0.0(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cli-app-version@7.0.0(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -13496,11 +13496,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-deprecation-workflow@3.4.0(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-cli-deprecation-workflow@3.4.0(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/core': 7.28.4(supports-color@8.1.1)
       ember-cli-babel: 8.2.0(@babel/core@7.28.4)
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -13815,7 +13815,7 @@ snapshots:
       - eslint
       - typescript
 
-  ember-exam@10.0.0(@glint/template@1.6.0-alpha.2)(ember-qunit@9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1))(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10)):
+  ember-exam@10.0.0(@glint/template@1.6.0-alpha.2)(ember-qunit@9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1))(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5))(qunit@2.24.1)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10)):
     dependencies:
       '@babel/core': 7.28.4(supports-color@8.1.1)
       chalk: 5.6.0
@@ -13824,7 +13824,7 @@ snapshots:
       ember-auto-import: 2.10.1(@glint/template@1.6.0-alpha.2)(webpack@5.101.3(@swc/core@1.13.19)(esbuild@0.25.10))
       ember-cli-babel: 8.2.0(@babel/core@7.28.4)
       ember-qunit: 9.0.4(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.6.0-alpha.2))(@glint/template@1.6.0-alpha.2)(qunit@2.24.1)
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       execa: 8.0.1
       fs-extra: 11.3.1
       js-yaml: 4.1.0
@@ -13838,9 +13838,9 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-load-initializers@3.0.1(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-load-initializers@3.0.1(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
 
   ember-modifier-manager-polyfill@1.2.0(@babel/core@7.28.4):
     dependencies:
@@ -13900,7 +13900,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5):
+  ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.4(supports-color@8.1.1)
       '@ember/edition-utils': 1.2.0
@@ -13969,7 +13969,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-this-fallback@0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
+  ember-this-fallback@0.4.0(patch_hash=znalyv6akdxlqfpmxunrdi3osa)(ember-cli-htmlbars@6.3.0)(ember-source@6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       '@glimmer/syntax': 0.84.3
       babel-plugin-ember-template-compilation: 2.4.1
@@ -13977,7 +13977,7 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 5.3.0
-      ember-source: 6.6.0(patch_hash=tyhbf7f4uxnr3gt4x2tdcudbva)(@glimmer/component@2.0.0)(rsvp@4.8.5)
+      ember-source: 6.6.0(patch_hash=jjggzpti2fmeyuaihs7wrnhfxq)(@glimmer/component@2.0.0)(rsvp@4.8.5)
       lodash: 4.17.21
       winston: 3.14.2
       zod: 3.25.76


### PR DESCRIPTION
* Add new deprecation entry for `discourse.native-array-extensions.replace` to improve logging and maintain compatibility.
* Patch Ember to detect correctly instances of MutableArray discarding native arrays