### PR TITLE
DEV: Add basic system spec for discourse-reaction on post

### DIFF
--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_button.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_button.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class PostReactionsButton < PageObjects::Components::Base
+      attr_reader :context
+
+      def initialize(context)
+        @context = context
+      end
+
+      def post_reactions_actions_selector(post_id, position:)
+        "#discourse-reactions-actions-#{post_id}-#{position}"
+      end
+
+      def hover_like_button(post_id)
+        context_component.find(post_reactions_actions_selector(post_id, position: "right")).hover
+      end
+
+      def has_expanded_reactions_picker?(post_id)
+        context_component.find(post_reactions_actions_selector(post_id, position: "right")).find(
+          ".discourse-reactions-picker.is-expanded",
+        )
+      end
+
+      def has_no_emoji?(emoji)
+        has_no_css?(".pickable-reaction.#{emoji}")
+      end
+
+      def has_emoji?(emoji)
+        has_css?(".pickable-reaction.#{emoji}")
+      end
+
+      def pick_reaction(emoji)
+        find(".pickable-reaction.#{emoji}").click
+      end
+
+      def pick_any_reaction(emoji)
+        open_emoji_picker
+        filter_emoji_picker(emoji)
+        find(".emoji-picker__section.filtered [data-emoji=\"#{emoji}\"]").click
+      end
+
+      def open_emoji_picker
+        find(".emoji-picker-trigger").click
+      end
+
+      def filter_emoji_picker(emoji)
+        find(".emoji-picker__filter .filter-input").fill_in(with: emoji)
+      end
+
+      def has_no_emoji_picker_emoji?(emoji)
+        has_no_css?(".emoji-picker__section.filtered [data-emoji=\"#{emoji}\"]")
+      end
+    end
+  end
+end

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
@@ -15,10 +15,6 @@ module PageObjects
         context_component.find(SELECTOR)
       end
 
-      def context_component
-        page.find(@context)
-      end
-
       def post_id
         context_component["data-post-id"]
       end

--- a/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+describe "Reactions | Post reactions", type: :system do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:topic)
+  fab!(:post_1) { Fabricate(:post, topic: topic) }
+  fab!(:post_2) { Fabricate(:post, topic: topic) }
+
+  let(:reactions_button) do
+    PageObjects::Components::PostReactionsButton.new("#post_#{post_2.post_number}")
+  end
+  let(:reactions_list) do
+    PageObjects::Components::PostReactionsList.new("#post_#{post_2.post_number}")
+  end
+
+  before do
+    SiteSetting.discourse_reactions_enabled = true
+    sign_in(current_user)
+  end
+
+  it "can do a basic post reaction with a default reaction" do
+    visit post_2.url
+    reactions_button.hover_like_button(post_2.id)
+    expect(reactions_button).to have_expanded_reactions_picker(post_2.id)
+    reactions_button.pick_reaction("laughing")
+    expect(reactions_list).to have_reaction("laughing")
+  end
+
+  it "does not show emoji_deny_list emojis for post reactions" do
+    SiteSetting.emoji_deny_list = "middle_finger"
+    visit post_2.url
+    reactions_button.hover_like_button(post_2.id)
+    expect(reactions_button).to have_expanded_reactions_picker(post_2.id)
+    expect(reactions_button).to have_no_emoji("middle_finger")
+  end
+
+  it "only shows enabled reaction emojis" do
+    SiteSetting.discourse_reactions_enabled_reactions = "clap|hugs"
+    visit post_2.url
+    reactions_button.hover_like_button(post_2.id)
+    expect(reactions_button).to have_expanded_reactions_picker(post_2.id)
+    expect(reactions_button).to have_no_emoji("open_mouth")
+    expect(reactions_button).to have_emoji("clap")
+    expect(reactions_button).to have_emoji("hugs")
+  end
+
+  context "when discourse_reactions_experimental_allow_any_emoji is enabled" do
+    before { SiteSetting.discourse_reactions_experimental_allow_any_emoji = true }
+
+    it "allows selecting any emoji for a post reaction" do
+      visit post_2.url
+      reactions_button.hover_like_button(post_2.id)
+      expect(reactions_button).to have_expanded_reactions_picker(post_2.id)
+      reactions_button.pick_any_reaction("yawning_face")
+      expect(reactions_list).to have_reaction("yawning_face")
+    end
+
+    it "does not allow selecting any emoji_deny_list emojis for post reactions" do
+      SiteSetting.emoji_deny_list = "middle_finger"
+      visit post_2.url
+      reactions_button.hover_like_button(post_2.id)
+      expect(reactions_button).to have_expanded_reactions_picker(post_2.id)
+      reactions_button.open_emoji_picker
+      reactions_button.filter_emoji_picker("middle_finger")
+      expect(reactions_button).to have_no_emoji_picker_emoji("middle_finger")
+    end
+  end
+end

--- a/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-describe "Reactions | Post reactions", type: :system do
-  fab!(:current_user) { Fabricate(:user) }
+describe "Reactions | Post reactions" do
+  fab!(:current_user, :user)
   fab!(:topic)
-  fab!(:post_1) { Fabricate(:post, topic: topic) }
-  fab!(:post_2) { Fabricate(:post, topic: topic) }
+  fab!(:post_1) { Fabricate(:post, topic:) }
+  fab!(:post_2) { Fabricate(:post, topic:) }
 
   let(:reactions_button) do
     PageObjects::Components::PostReactionsButton.new("#post_#{post_2.post_number}")

--- a/spec/system/page_objects/components/base.rb
+++ b/spec/system/page_objects/components/base.rb
@@ -6,6 +6,10 @@ module PageObjects
       include Capybara::DSL
       include RSpec::Matchers
       include SystemHelpers
+
+      def context_component
+        page.find(@context)
+      end
     end
   end
 end


### PR DESCRIPTION
Covers default reactions, `discourse_reactions_experimental_allow_any_emoji`,
`discourse_reactions_enabled_reactions`, and interaction with the `emoji_deny_list` setting from core.
