### PR TITLE
UX: Show a helpful error when theme preview fails

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.gjs
+++ b/app/assets/javascripts/discourse/app/components/global-notice.gjs
@@ -10,6 +10,7 @@ import cookie, { removeCookie } from "discourse/lib/cookie";
 import { bind } from "discourse/lib/decorators";
 import { DeferredTrackedSet } from "discourse/lib/tracked-tools";
 import { i18n } from "discourse-i18n";
+import { currentThemeId } from "discourse/lib/theme-selector";
 
 const _pluginNotices = new DeferredTrackedSet();
 
@@ -119,13 +120,27 @@ export default class GlobalNotice extends Component {
       );
     }
 
-    if (this.router.currentRoute?.queryParams?.preview_theme_id) {
-      notices.push(
-        Notice.create({
-          text: i18n("theme_preview_notice"),
-          id: "theme-preview",
-        })
-      );
+    const previewThemeId =
+      this.router.currentRoute?.queryParams?.preview_theme_id;
+    if (previewThemeId) {
+      if (currentThemeId() === parseInt(previewThemeId, 10)) {
+        notices.push(
+          Notice.create({
+            text: i18n("theme_preview_notice"),
+            id: "theme-preview",
+          })
+        );
+      } else {
+        notices.push(
+          Notice.create({
+            text: i18n("theme_preview_failed"),
+            id: "theme-preview-failed",
+            options: {
+              level: "error",
+            },
+          })
+        );
+      }
     }
 
     if (this.siteSettings.disable_emails === "yes") {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5174,6 +5174,7 @@ en:
       enabled: "Safe mode is enabled, to exit safe mode close this browser window"
 
     theme_preview_notice: "You are currently previewing a theme, close this browser tab or window to return to your normal site configuration."
+    theme_preview_failed: "Failed to preview theme because it doesn't exist, or you don't have permission to access it."
 
     image_removed: "(image removed)"
 


### PR DESCRIPTION
Previously we would show the "previewing theme" banner purely based on the `?preview_theme_id` parameter. This commit adds a check that it actually worked. If not, it shows an error banner instead.

<img width="1428" height="382" alt="image" src="https://github.com/user-attachments/assets/d6415c09-89de-4678-88d0-5878d60c7a6c" />
