### PR TITLE
UX: improve AI translations chart colors in dark mode

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-translations.gjs
@@ -40,15 +40,22 @@ export default class AiTranslations extends Component {
       : "discourse_ai.translations.stats.incomplete_language_detection_description";
   }
 
+  get chartColors() {
+    const styles = getComputedStyle(document.querySelector(".ai-translations"));
+    return {
+      progress: styles.getPropertyValue("--chart-progress-color").trim(),
+      remaining: styles.getPropertyValue("--chart-remaining-color").trim(),
+      text: styles.getPropertyValue("--chart-text-color").trim(),
+      label: styles.getPropertyValue("--chart-label-color").trim(),
+    };
+  }
+
   get chartConfig() {
     if (!this.data?.length) {
       return {};
     }
 
-    const chartEl = document.querySelector(".ai-translations");
-    const backgroundColor = getComputedStyle(chartEl)
-      .getPropertyValue("--chart-progress-color")
-      .trim();
+    const colors = this.chartColors;
 
     const processedData = this.data.map(({ locale, total, done }) => {
       const donePercentage = (total > 0 ? (done / total) * 100 : 0).toFixed(0);
@@ -71,7 +78,7 @@ export default class AiTranslations extends Component {
           tooltip: processedData.map(({ tooltip }) => tooltip),
           data: processedData.map(({ donePercentage }) => donePercentage),
           totalItems: processedData.map(({ done }) => done),
-          backgroundColor,
+          backgroundColor: colors.progress,
           barThickness: 30,
           borderRadius: 4,
         },
@@ -87,6 +94,7 @@ export default class AiTranslations extends Component {
           afterDraw: ({ ctx, data, scales }) => {
             ctx.save();
             ctx.textBaseline = "middle";
+            ctx.fillStyle = colors.text;
             const items = data.datasets[0].totalItems;
             items.forEach((count, i) => {
               ctx.fillText(
@@ -115,6 +123,7 @@ export default class AiTranslations extends Component {
               display: false,
             },
             ticks: {
+              color: colors.text,
               callback: (percentage) =>
                 i18n("discourse_ai.translations.progress_chart.data_label", {
                   percentage,
@@ -124,6 +133,9 @@ export default class AiTranslations extends Component {
           y: {
             grid: {
               display: false,
+            },
+            ticks: {
+              color: colors.text,
             },
           },
         },
@@ -143,7 +155,7 @@ export default class AiTranslations extends Component {
                 : i18n("discourse_ai.translations.progress_chart.data_label", {
                     percentage,
                   }),
-            color: "white",
+            color: colors.label,
           },
         },
       },

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/common/admin-translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/common/admin-translations.scss
@@ -1,4 +1,6 @@
 .ai-translations {
-  --chart-progress-color: rgb(153, 102, 255, 0.8);
-  --chart-remaining-color: rgb(153, 102, 255, 0.4);
+  --chart-progress-color: var(--tertiary);
+  --chart-remaining-color: var(--tertiary-low);
+  --chart-text-color: var(--primary);
+  --chart-label-color: var(--secondary);
 }


### PR DESCRIPTION
Adds variables for chart colors so we can support dark mode 

Before:
<img width="2216" height="694" alt="image" src="https://github.com/user-attachments/assets/ff496b40-0032-4158-9b0c-d9250736b0aa" />


After:
<img width="1720" height="1014" alt="image" src="https://github.com/user-attachments/assets/d62297ee-f28d-40cd-bc79-69cf14d2d41e" />
