### PR TITLE
DEV: Skip loading login/signup controller when redirecting

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/signup.js
+++ b/app/assets/javascripts/discourse/app/controllers/signup.js
@@ -10,7 +10,7 @@ import { observes } from "@ember-decorators/object";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { setting } from "discourse/lib/computed";
-import cookie, { removeCookie } from "discourse/lib/cookie";
+import { removeCookie } from "discourse/lib/cookie";
 import discourseDebounce from "discourse/lib/debounce";
 import discourseComputed, { bind } from "discourse/lib/decorators";
 import NameValidationHelper from "discourse/lib/name-validation-helper";
@@ -69,16 +69,6 @@ export default class SignupPageController extends Controller {
   @notEmpty("authOptions") hasAuthOptions;
   @setting("enable_local_logins") canCreateLocal;
   @setting("require_invite_code") requireInviteCode;
-
-  init() {
-    super.init(...arguments);
-
-    if (cookie("email")) {
-      this.accountEmail = cookie("email");
-    }
-
-    this.fetchConfirmationValue();
-  }
 
   @dependentKeyCompat
   get userFields() {

--- a/app/assets/javascripts/discourse/app/routes/signup.js
+++ b/app/assets/javascripts/discourse/app/routes/signup.js
@@ -18,8 +18,6 @@ export default class extends DiscourseRoute {
   @service site;
   @service siteSettings;
 
-  #isRedirecting = false;
-
   beforeModel(transition) {
     const { from, wantsTo } = transition;
     const { currentUser, dialog, router } = this;
@@ -74,18 +72,18 @@ export default class extends DiscourseRoute {
     // Automatically kick off the external login if it's the only one available
     if (enable_discourse_connect) {
       if (redirect) {
-        this.#isRedirecting = true;
         const returnPath = cookie("destination_url")
           ? getURL("/")
           : encodeURIComponent(url);
         window.location = getURL(`/session/sso?return_path=${returnPath}`);
+        return new Promise(() => {}); // Prevents the transition from completing
       } else {
         router.replaceWith("discovery.login-required");
       }
     } else if (isOnlyOneExternalLoginMethod) {
       if (redirect) {
-        this.#isRedirecting = true;
         singleExternalLogin({ signup: true });
+        return new Promise(() => {}); // Prevents the transition from completing
       } else {
         router.replaceWith("discovery.login-required");
       }
@@ -95,12 +93,10 @@ export default class extends DiscourseRoute {
   setupController(controller) {
     super.setupController(...arguments);
 
-    // We're in the middle of an authentication flow
-    if (document.getElementById("data-authentication")) {
-      return;
+    if (cookie("email")) {
+      controller.accountEmail = cookie("email");
     }
 
-    // Shows the loading spinner while waiting for the redirection to external auth
-    controller.isRedirectingToExternalAuth = this.#isRedirecting;
+    controller.fetchConfirmationValue();
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/login.gjs
+++ b/app/assets/javascripts/discourse/app/templates/login.gjs
@@ -13,7 +13,6 @@ import concatClass from "discourse/helpers/concat-class";
 import hideApplicationHeaderButtons from "discourse/helpers/hide-application-header-buttons";
 import hideApplicationSidebar from "discourse/helpers/hide-application-sidebar";
 import lazyHash from "discourse/helpers/lazy-hash";
-import loadingSpinner from "discourse/helpers/loading-spinner";
 import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
@@ -23,163 +22,155 @@ export default RouteTemplate(
     {{bodyClass "login-page"}}
 
     <div class="login-fullpage">
-      {{#if @controller.isRedirectingToExternalAuth}}
-        {{loadingSpinner size="large"}}
-      {{else}}
-        <FlashMessage
-          @flash={{@controller.flash}}
-          @type={{@controller.flashType}}
+      <FlashMessage
+        @flash={{@controller.flash}}
+        @type={{@controller.flashType}}
+      />
+
+      <div class={{concatClass "login-body" @controller.bodyClasses}}>
+        <PluginOutlet
+          @name="login-before-modal-body"
+          @connectorTagName="div"
+          @outletArgs={{lazyHash
+            flashChanged=this.flashChanged
+            flashTypeChanged=this.flashTypeChanged
+          }}
         />
 
-        <div class={{concatClass "login-body" @controller.bodyClasses}}>
-          <PluginOutlet
-            @name="login-before-modal-body"
-            @connectorTagName="div"
-            @outletArgs={{lazyHash
-              flashChanged=this.flashChanged
-              flashTypeChanged=this.flashTypeChanged
-            }}
-          />
-
-          {{#if @controller.hasNoLoginOptions}}
-            <div class={{if @controller.site.desktopView "login-left-side"}}>
-              <div class="login-welcome-header no-login-methods-configured">
-                <h1 class="login-title">{{i18n
-                    "login.no_login_methods.title"
-                  }}</h1>
-                <img />
-                <p class="login-subheader">
-                  {{htmlSafe
-                    (i18n
-                      "login.no_login_methods.description"
-                      (hash adminLoginPath=@controller.adminLoginPath)
-                    )
-                  }}
-                </p>
-              </div>
+        {{#if @controller.hasNoLoginOptions}}
+          <div class={{if @controller.site.desktopView "login-left-side"}}>
+            <div class="login-welcome-header no-login-methods-configured">
+              <h1 class="login-title">{{i18n
+                  "login.no_login_methods.title"
+                }}</h1>
+              <img />
+              <p class="login-subheader">
+                {{htmlSafe
+                  (i18n
+                    "login.no_login_methods.description"
+                    (hash adminLoginPath=@controller.adminLoginPath)
+                  )
+                }}
+              </p>
             </div>
-          {{else}}
-            {{#if @controller.site.mobileView}}
-              <WelcomeHeader @header={{i18n "login.header_title"}}>
-                <PluginOutlet
-                  @name="login-header-bottom"
-                  @outletArgs={{lazyHash
-                    createAccount=@controller.createAccount
-                  }}
-                />
-              </WelcomeHeader>
-              {{#if @controller.showLoginButtons}}
+          </div>
+        {{else}}
+          {{#if @controller.site.mobileView}}
+            <WelcomeHeader @header={{i18n "login.header_title"}}>
+              <PluginOutlet
+                @name="login-header-bottom"
+                @outletArgs={{lazyHash createAccount=@controller.createAccount}}
+              />
+            </WelcomeHeader>
+            {{#if @controller.showLoginButtons}}
 
+              <LoginButtons
+                @externalLogin={{@controller.externalLogin}}
+                @passkeyLogin={{@controller.passkeyLogin}}
+                @context="login"
+              />
+
+            {{/if}}
+          {{/if}}
+
+          {{#if @controller.canLoginLocal}}
+            <div class={{if @controller.site.desktopView "login-left-side"}}>
+              {{#if @controller.site.desktopView}}
+                <WelcomeHeader @header={{i18n "login.header_title"}}>
+                  <PluginOutlet
+                    @name="login-header-bottom"
+                    @outletArgs={{lazyHash
+                      createAccount=@controller.createAccount
+                    }}
+                  />
+                </WelcomeHeader>
+              {{/if}}
+
+              <PluginOutlet
+                @name="login-wrapper"
+                @outletArgs={{lazyHash externalLogin=@controller.externalLogin}}
+              >
+                <LocalLoginForm
+                  @loginName={{@controller.loginName}}
+                  @loginNameChanged={{@controller.loginNameChanged}}
+                  @canLoginLocalWithEmail={{@controller.canLoginLocalWithEmail}}
+                  @canUsePasskeys={{@controller.canUsePasskeys}}
+                  @passkeyLogin={{@controller.passkeyLogin}}
+                  @loginPassword={{@controller.loginPassword}}
+                  @loginPasswordChanged={{@controller.loginPasswordChanged}}
+                  @secondFactorMethod={{@controller.secondFactorMethod}}
+                  @secondFactorToken={{@controller.secondFactorToken}}
+                  @backupEnabled={{@controller.backupEnabled}}
+                  @totpEnabled={{@controller.totpEnabled}}
+                  @securityKeyAllowedCredentialIds={{@controller.securityKeyAllowedCredentialIds}}
+                  @securityKeyChallenge={{@controller.securityKeyChallenge}}
+                  @showSecurityKey={{@controller.showSecurityKey}}
+                  @otherMethodAllowed={{@controller.otherMethodAllowed}}
+                  @showSecondFactor={{@controller.showSecondFactor}}
+                  @handleForgotPassword={{@controller.handleForgotPassword}}
+                  @login={{@controller.localLogin}}
+                  @flashChanged={{@controller.flashChanged}}
+                  @flashTypeChanged={{@controller.flashTypeChanged}}
+                  @securityKeyCredentialChanged={{@controller.securityKeyCredentialChanged}}
+                />
+              </PluginOutlet>
+
+              {{#if @controller.site.desktopView}}
+                <LoginPageCta
+                  @canLoginLocal={{@controller.canLoginLocal}}
+                  @showSecurityKey={{@controller.showSecurityKey}}
+                  @login={{@controller.localLogin}}
+                  @loginButtonLabel={{@controller.loginButtonLabel}}
+                  @loginDisabled={{@controller.loginDisabled}}
+                  @showSignupLink={{@controller.showSignupLink}}
+                  @createAccount={{@controller.createAccount}}
+                  @loggingIn={{@controller.loggingIn}}
+                  @showSecondFactor={{@controller.showSecondFactor}}
+                />
+              {{/if}}
+            </div>
+          {{/if}}
+
+          {{#if
+            (and @controller.showLoginButtons @controller.site.desktopView)
+          }}
+
+            {{#unless @controller.canLoginLocal}}
+              <div class="login-left-side">
+                <WelcomeHeader @header={{i18n "login.header_title"}} />
+              </div>
+            {{/unless}}
+            {{#if @controller.hasAtLeastOneLoginButton}}
+              <div class="login-right-side">
                 <LoginButtons
                   @externalLogin={{@controller.externalLogin}}
                   @passkeyLogin={{@controller.passkeyLogin}}
                   @context="login"
                 />
-
-              {{/if}}
-            {{/if}}
-
-            {{#if @controller.canLoginLocal}}
-              <div class={{if @controller.site.desktopView "login-left-side"}}>
-                {{#if @controller.site.desktopView}}
-                  <WelcomeHeader @header={{i18n "login.header_title"}}>
-                    <PluginOutlet
-                      @name="login-header-bottom"
-                      @outletArgs={{lazyHash
-                        createAccount=@controller.createAccount
-                      }}
-                    />
-                  </WelcomeHeader>
-                {{/if}}
-
-                <PluginOutlet
-                  @name="login-wrapper"
-                  @outletArgs={{lazyHash
-                    externalLogin=@controller.externalLogin
-                  }}
-                >
-                  <LocalLoginForm
-                    @loginName={{@controller.loginName}}
-                    @loginNameChanged={{@controller.loginNameChanged}}
-                    @canLoginLocalWithEmail={{@controller.canLoginLocalWithEmail}}
-                    @canUsePasskeys={{@controller.canUsePasskeys}}
-                    @passkeyLogin={{@controller.passkeyLogin}}
-                    @loginPassword={{@controller.loginPassword}}
-                    @loginPasswordChanged={{@controller.loginPasswordChanged}}
-                    @secondFactorMethod={{@controller.secondFactorMethod}}
-                    @secondFactorToken={{@controller.secondFactorToken}}
-                    @backupEnabled={{@controller.backupEnabled}}
-                    @totpEnabled={{@controller.totpEnabled}}
-                    @securityKeyAllowedCredentialIds={{@controller.securityKeyAllowedCredentialIds}}
-                    @securityKeyChallenge={{@controller.securityKeyChallenge}}
-                    @showSecurityKey={{@controller.showSecurityKey}}
-                    @otherMethodAllowed={{@controller.otherMethodAllowed}}
-                    @showSecondFactor={{@controller.showSecondFactor}}
-                    @handleForgotPassword={{@controller.handleForgotPassword}}
-                    @login={{@controller.localLogin}}
-                    @flashChanged={{@controller.flashChanged}}
-                    @flashTypeChanged={{@controller.flashTypeChanged}}
-                    @securityKeyCredentialChanged={{@controller.securityKeyCredentialChanged}}
-                  />
-                </PluginOutlet>
-
-                {{#if @controller.site.desktopView}}
-                  <LoginPageCta
-                    @canLoginLocal={{@controller.canLoginLocal}}
-                    @showSecurityKey={{@controller.showSecurityKey}}
-                    @login={{@controller.localLogin}}
-                    @loginButtonLabel={{@controller.loginButtonLabel}}
-                    @loginDisabled={{@controller.loginDisabled}}
-                    @showSignupLink={{@controller.showSignupLink}}
-                    @createAccount={{@controller.createAccount}}
-                    @loggingIn={{@controller.loggingIn}}
-                    @showSecondFactor={{@controller.showSecondFactor}}
-                  />
-                {{/if}}
               </div>
             {{/if}}
 
-            {{#if
-              (and @controller.showLoginButtons @controller.site.desktopView)
-            }}
-
-              {{#unless @controller.canLoginLocal}}
-                <div class="login-left-side">
-                  <WelcomeHeader @header={{i18n "login.header_title"}} />
-                </div>
-              {{/unless}}
-              {{#if @controller.hasAtLeastOneLoginButton}}
-                <div class="login-right-side">
-                  <LoginButtons
-                    @externalLogin={{@controller.externalLogin}}
-                    @passkeyLogin={{@controller.passkeyLogin}}
-                    @context="login"
-                  />
-                </div>
-              {{/if}}
-
-            {{/if}}
           {{/if}}
+        {{/if}}
 
-          {{#if @controller.site.mobileView}}
-            {{#unless @controller.hasNoLoginOptions}}
-              <LoginPageCta
-                @canLoginLocal={{@controller.canLoginLocal}}
-                @showSecurityKey={{@controller.showSecurityKey}}
-                @login={{@controller.localLogin}}
-                @loginButtonLabel={{@controller.loginButtonLabel}}
-                @loginDisabled={{@controller.loginDisabled}}
-                @showSignupLink={{@controller.showSignupLink}}
-                @createAccount={{@controller.createAccount}}
-                @loggingIn={{@controller.loggingIn}}
-                @showSecondFactor={{@controller.showSecondFactor}}
-              />
-            {{/unless}}
-          {{/if}}
+        {{#if @controller.site.mobileView}}
+          {{#unless @controller.hasNoLoginOptions}}
+            <LoginPageCta
+              @canLoginLocal={{@controller.canLoginLocal}}
+              @showSecurityKey={{@controller.showSecurityKey}}
+              @login={{@controller.localLogin}}
+              @loginButtonLabel={{@controller.loginButtonLabel}}
+              @loginDisabled={{@controller.loginDisabled}}
+              @showSignupLink={{@controller.showSignupLink}}
+              @createAccount={{@controller.createAccount}}
+              @loggingIn={{@controller.loggingIn}}
+              @showSecondFactor={{@controller.showSecondFactor}}
+            />
+          {{/unless}}
+        {{/if}}
 
-        </div>
-        <PluginOutlet @name="below-login-page" />
-      {{/if}}
+      </div>
+      <PluginOutlet @name="below-login-page" />
     </div>
   </template>
 );

--- a/app/assets/javascripts/discourse/app/templates/signup.gjs
+++ b/app/assets/javascripts/discourse/app/templates/signup.gjs
@@ -34,331 +34,325 @@ export default RouteTemplate(
     {{bodyClass "signup-page"}}
 
     <div class="signup-fullpage">
-      {{#if @controller.isRedirectingToExternalAuth}}
-        {{loadingSpinner size="large"}}
-      {{else}}
-        <FlashMessage
-          @flash={{@controller.flash}}
-          @type={{@controller.flashType}}
+      <FlashMessage
+        @flash={{@controller.flash}}
+        @type={{@controller.flashType}}
+      />
+
+      <div class={{concatClass "signup-body" @controller.bodyClasses}}>
+        <PluginOutlet
+          @name="create-account-before-modal-body"
+          @connectorTagName="div"
         />
 
-        <div class={{concatClass "signup-body" @controller.bodyClasses}}>
-          <PluginOutlet
-            @name="create-account-before-modal-body"
-            @connectorTagName="div"
-          />
-
-          <div
-            class={{concatClass
-              (if @controller.site.desktopView "login-left-side")
-              @controller.authOptions.auth_provider
-            }}
-          >
-            {{#unless @controller.skipConfirmation}}
-              <SignupProgressBar @step={{@controller.progressBarStep}} />
-              <WelcomeHeader
-                id="create-account-title"
-                @header={{i18n "create_account.header_title"}}
-              >
-                <PluginOutlet
-                  @name="create-account-header-bottom"
-                  @outletArgs={{lazyHash showLogin=(routeAction "showLogin")}}
+        <div
+          class={{concatClass
+            (if @controller.site.desktopView "login-left-side")
+            @controller.authOptions.auth_provider
+          }}
+        >
+          {{#unless @controller.skipConfirmation}}
+            <SignupProgressBar @step={{@controller.progressBarStep}} />
+            <WelcomeHeader
+              id="create-account-title"
+              @header={{i18n "create_account.header_title"}}
+            >
+              <PluginOutlet
+                @name="create-account-header-bottom"
+                @outletArgs={{lazyHash showLogin=(routeAction "showLogin")}}
+              />
+            </WelcomeHeader>
+          {{/unless}}
+          {{#if @controller.showCreateForm}}
+            <form id="login-form">
+              {{#if @controller.associateHtml}}
+                <div class="input-group create-account-associate-link">
+                  <span>{{htmlSafe @controller.associateHtml}}</span>
+                </div>
+              {{/if}}
+              <div class="input-group create-account-email">
+                <Input
+                  {{on "focusout" @controller.checkEmailAvailability}}
+                  {{on "focusin" @controller.scrollInputIntoView}}
+                  @type="email"
+                  @value={{@controller.accountEmail}}
+                  disabled={{@controller.emailDisabled}}
+                  autofocus="autofocus"
+                  aria-describedby="account-email-validation account-email-validation-more-info"
+                  aria-invalid={{@controller.emailValidation.failed}}
+                  name="email"
+                  id="new-account-email"
+                  class={{valueEntered @controller.accountEmail}}
                 />
-              </WelcomeHeader>
-            {{/unless}}
-            {{#if @controller.showCreateForm}}
-              <form id="login-form">
-                {{#if @controller.associateHtml}}
-                  <div class="input-group create-account-associate-link">
-                    <span>{{htmlSafe @controller.associateHtml}}</span>
-                  </div>
-                {{/if}}
-                <div class="input-group create-account-email">
-                  <Input
-                    {{on "focusout" @controller.checkEmailAvailability}}
-                    {{on "focusin" @controller.scrollInputIntoView}}
-                    @type="email"
-                    @value={{@controller.accountEmail}}
-                    disabled={{@controller.emailDisabled}}
-                    autofocus="autofocus"
-                    aria-describedby="account-email-validation account-email-validation-more-info"
-                    aria-invalid={{@controller.emailValidation.failed}}
-                    name="email"
-                    id="new-account-email"
-                    class={{valueEntered @controller.accountEmail}}
+                <label class="alt-placeholder" for="new-account-email">
+                  {{i18n "user.email.title"}}
+                </label>
+                {{#if @controller.showEmailValidation}}
+                  <InputTip
+                    @validation={{@controller.emailValidation}}
+                    id="account-email-validation"
                   />
-                  <label class="alt-placeholder" for="new-account-email">
-                    {{i18n "user.email.title"}}
-                  </label>
-                  {{#if @controller.showEmailValidation}}
-                    <InputTip
-                      @validation={{@controller.emailValidation}}
-                      id="account-email-validation"
-                    />
-                  {{else}}
-                    <span
-                      class="more-info"
-                      id="account-email-validation-more-info"
-                    >
-                      {{#if
-                        @controller.siteSettings.show_signup_form_email_instructions
-                      }}
-                        {{i18n "user.email.instructions"}}
-                      {{/if}}
-                    </span>
-                  {{/if}}
-
-                  <PluginOutlet
-                    @name="create-account-after-email"
-                    @outletArgs={{lazyHash
-                      accountEmail=@controller.accountEmail
+                {{else}}
+                  <span
+                    class="more-info"
+                    id="account-email-validation-more-info"
+                  >
+                    {{#if
+                      @controller.siteSettings.show_signup_form_email_instructions
                     }}
-                  />
-                </div>
+                      {{i18n "user.email.instructions"}}
+                    {{/if}}
+                  </span>
+                {{/if}}
 
-                <div class="input-group create-account__username">
-                  <input
-                    {{on "focusin" @controller.scrollInputIntoView}}
-                    {{on "input" @controller.setAccountUsername}}
-                    type="text"
-                    value={{@controller.accountUsername}}
-                    disabled={{@controller.usernameDisabled}}
-                    maxlength={{@controller.maxUsernameLength}}
-                    aria-describedby="username-validation username-validation-more-info"
-                    aria-invalid={{@controller.usernameValidation.failed}}
-                    autocomplete="off"
-                    name="username"
-                    id="new-account-username"
-                    class={{valueEntered @controller.accountUsername}}
-                  />
-                  <label class="alt-placeholder" for="new-account-username">
-                    {{i18n "user.username.title"}}
-                  </label>
+                <PluginOutlet
+                  @name="create-account-after-email"
+                  @outletArgs={{lazyHash accountEmail=@controller.accountEmail}}
+                />
+              </div>
 
-                  {{#if @controller.showUsernameInstructions}}
-                    <span class="more-info" id="username-validation-more-info">
-                      {{i18n "user.username.instructions"}}
-                    </span>
+              <div class="input-group create-account__username">
+                <input
+                  {{on "focusin" @controller.scrollInputIntoView}}
+                  {{on "input" @controller.setAccountUsername}}
+                  type="text"
+                  value={{@controller.accountUsername}}
+                  disabled={{@controller.usernameDisabled}}
+                  maxlength={{@controller.maxUsernameLength}}
+                  aria-describedby="username-validation username-validation-more-info"
+                  aria-invalid={{@controller.usernameValidation.failed}}
+                  autocomplete="off"
+                  name="username"
+                  id="new-account-username"
+                  class={{valueEntered @controller.accountUsername}}
+                />
+                <label class="alt-placeholder" for="new-account-username">
+                  {{i18n "user.username.title"}}
+                </label>
 
-                  {{else}}
-                    <InputTip
-                      @validation={{@controller.usernameValidation}}
-                      id="username-validation"
-                    />
-                  {{/if}}
+                {{#if @controller.showUsernameInstructions}}
+                  <span class="more-info" id="username-validation-more-info">
+                    {{i18n "user.username.instructions"}}
+                  </span>
 
-                  <PluginOutlet
-                    @name="create-account-after-username"
-                    @outletArgs={{lazyHash
-                      accountUsername=@controller.accountUsername
-                    }}
-                  />
-                </div>
-
-                {{#if
-                  (and @controller.showFullname @controller.fullnameRequired)
-                }}
-                  <FullnameInput
-                    @nameValidation={{@controller.nameValidation}}
-                    @nameTitle={{@controller.nameTitle}}
-                    @accountName={{@controller.accountName}}
-                    @nameDisabled={{@controller.nameDisabled}}
-                    @onFocusIn={{@controller.scrollInputIntoView}}
-                    class="input-group create-account__fullname required"
+                {{else}}
+                  <InputTip
+                    @validation={{@controller.usernameValidation}}
+                    id="username-validation"
                   />
                 {{/if}}
 
                 <PluginOutlet
-                  @name="create-account-before-password"
+                  @name="create-account-after-username"
                   @outletArgs={{lazyHash
-                    accountName=@controller.accountName
                     accountUsername=@controller.accountUsername
-                    accountPassword=@controller.accountPassword
-                    userFields=@controller.userFields
-                    authOptions=@controller.authOptions
                   }}
                 />
+              </div>
 
-                <div class="input-group create-account__password">
-                  {{#if @controller.passwordRequired}}
-                    <PasswordField
-                      {{on "focusin" @controller.scrollInputIntoView}}
-                      @value={{@controller.accountPassword}}
-                      @capsLockOn={{@controller.capsLockOn}}
-                      type={{if @controller.maskPassword "password" "text"}}
-                      autocomplete="current-password"
-                      aria-describedby="password-validation password-validation-more-info"
-                      aria-invalid={{@controller.passwordValidation.failed}}
-                      id="new-account-password"
-                      class={{valueEntered @controller.accountPassword}}
-                    />
-                    <label class="alt-placeholder" for="new-account-password">
-                      {{i18n "user.password.title"}}
-                    </label>
-                    <TogglePasswordMask
-                      @maskPassword={{@controller.maskPassword}}
-                      @togglePasswordMask={{@controller.togglePasswordMask}}
-                    />
-                    <div class="create-account__password-info">
-                      <div class="create-account__password-tip-validation">
-                        {{#if @controller.showPasswordValidation}}
-                          <InputTip
-                            @validation={{@controller.passwordValidation}}
-                            id="password-validation"
-                          />
-                        {{else if
-                          @controller.siteSettings.show_signup_form_password_instructions
-                        }}
-                          <span
-                            class="more-info"
-                            id="password-validation-more-info"
-                          >
-                            {{@controller.passwordValidationHelper.passwordInstructions}}
-                          </span>
-                        {{/if}}
-                        <div
-                          class={{concatClass
-                            "caps-lock-warning"
-                            (unless @controller.capsLockOn "hidden")
-                          }}
-                        >
-                          {{icon "triangle-exclamation"}}
-                          {{i18n "login.caps_lock_warning"}}
-                        </div>
-                      </div>
-                    </div>
-                  {{/if}}
-
-                  <div class="password-confirmation">
-                    <label for="new-account-password-confirmation">
-                      {{i18n "user.password_confirmation.title"}}
-                    </label>
-                    <HoneypotInput
-                      @id="new-account-confirmation"
-                      @autocomplete="new-password"
-                      @value={{@controller.accountHoneypot}}
-                    />
-                    <Input
-                      @value={{@controller.accountChallenge}}
-                      id="new-account-challenge"
-                    />
-                  </div>
-                </div>
-
-                {{#if @controller.requireInviteCode}}
-                  <div class="input-group create-account__invite-code">
-                    <Input
-                      {{on "focusin" @controller.scrollInputIntoView}}
-                      @value={{@controller.inviteCode}}
-                      id="inviteCode"
-                      class={{valueEntered @controller.inviteCode}}
-                    />
-                    <label class="alt-placeholder" for="invite-code">
-                      {{i18n "user.invite_code.title"}}
-                    </label>
-                    <span class="more-info">
-                      {{i18n "user.invite_code.instructions"}}
-                    </span>
-                  </div>
-                {{/if}}
-
-                <PluginOutlet
-                  @name="create-account-after-password"
-                  @outletArgs={{lazyHash
-                    accountName=@controller.accountName
-                    accountUsername=@controller.accountUsername
-                    accountPassword=@controller.accountPassword
-                    userFields=@controller.userFields
-                  }}
-                />
-
-                {{#if
-                  (and
-                    @controller.showFullname (not @controller.fullnameRequired)
-                  )
-                }}
-                  <FullnameInput
-                    @nameValidation={{@controller.nameValidation}}
-                    @nameTitle={{@controller.nameTitle}}
-                    @accountName={{@controller.accountName}}
-                    @nameDisabled={{@controller.nameDisabled}}
-                    @onFocusIn={{@controller.scrollInputIntoView}}
-                    class="input-group create-account__fullname"
-                  />
-                  <PluginOutlet
-                    @name="create-account-after-fullname"
-                    @outletArgs={{lazyHash accountName=@controller.accountName}}
-                  />
-                {{/if}}
-
-                {{#if @controller.userFields}}
-                  <div class="user-fields">
-                    {{#each @controller.userFields as |f|}}
-                      <div class="input-group">
-                        <UserField
-                          {{on "focusin" @controller.scrollInputIntoView}}
-                          @field={{f.field}}
-                          @value={{f.value}}
-                          @validation={{f.validation}}
-                          class={{valueEntered f.value}}
-                        />
-                      </div>
-                    {{/each}}
-                  </div>
-                {{/if}}
-
-                <PluginOutlet
-                  @name="create-account-after-user-fields"
-                  @outletArgs={{lazyHash
-                    accountName=@controller.accountName
-                    accountUsername=@controller.accountUsername
-                    accountPassword=@controller.accountPassword
-                    userFields=@controller.userFields
-                  }}
-                />
-              </form>
-
-              {{#if @controller.site.desktopView}}
-                <SignupPageCta
-                  @formSubmitted={{@controller.formSubmitted}}
-                  @hasAuthOptions={{@controller.hasAuthOptions}}
-                  @createAccount={{@controller.createAccount}}
-                  @submitDisabled={{@controller.submitDisabled}}
-                  @disclaimerHtml={{@controller.disclaimerHtml}}
+              {{#if
+                (and @controller.showFullname @controller.fullnameRequired)
+              }}
+                <FullnameInput
+                  @nameValidation={{@controller.nameValidation}}
+                  @nameTitle={{@controller.nameTitle}}
+                  @accountName={{@controller.accountName}}
+                  @nameDisabled={{@controller.nameDisabled}}
+                  @onFocusIn={{@controller.scrollInputIntoView}}
+                  class="input-group create-account__fullname required"
                 />
               {{/if}}
-            {{/if}}
 
-            {{#if @controller.skipConfirmation}}
-              {{loadingSpinner size="large"}}
-            {{/if}}
-          </div>
-
-          {{#if @controller.showRightSide}}
-            {{#if @controller.site.mobileView}}
-              <div class="login-or-separator">
-                <span>{{i18n "login.or"}}</span>
-              </div>
-            {{/if}}
-            <div class="login-right-side">
-              <LoginButtons
-                @externalLogin={{@controller.externalLogin}}
-                @context="create-account"
+              <PluginOutlet
+                @name="create-account-before-password"
+                @outletArgs={{lazyHash
+                  accountName=@controller.accountName
+                  accountUsername=@controller.accountUsername
+                  accountPassword=@controller.accountPassword
+                  userFields=@controller.userFields
+                  authOptions=@controller.authOptions
+                }}
               />
-            </div>
+
+              <div class="input-group create-account__password">
+                {{#if @controller.passwordRequired}}
+                  <PasswordField
+                    {{on "focusin" @controller.scrollInputIntoView}}
+                    @value={{@controller.accountPassword}}
+                    @capsLockOn={{@controller.capsLockOn}}
+                    type={{if @controller.maskPassword "password" "text"}}
+                    autocomplete="current-password"
+                    aria-describedby="password-validation password-validation-more-info"
+                    aria-invalid={{@controller.passwordValidation.failed}}
+                    id="new-account-password"
+                    class={{valueEntered @controller.accountPassword}}
+                  />
+                  <label class="alt-placeholder" for="new-account-password">
+                    {{i18n "user.password.title"}}
+                  </label>
+                  <TogglePasswordMask
+                    @maskPassword={{@controller.maskPassword}}
+                    @togglePasswordMask={{@controller.togglePasswordMask}}
+                  />
+                  <div class="create-account__password-info">
+                    <div class="create-account__password-tip-validation">
+                      {{#if @controller.showPasswordValidation}}
+                        <InputTip
+                          @validation={{@controller.passwordValidation}}
+                          id="password-validation"
+                        />
+                      {{else if
+                        @controller.siteSettings.show_signup_form_password_instructions
+                      }}
+                        <span
+                          class="more-info"
+                          id="password-validation-more-info"
+                        >
+                          {{@controller.passwordValidationHelper.passwordInstructions}}
+                        </span>
+                      {{/if}}
+                      <div
+                        class={{concatClass
+                          "caps-lock-warning"
+                          (unless @controller.capsLockOn "hidden")
+                        }}
+                      >
+                        {{icon "triangle-exclamation"}}
+                        {{i18n "login.caps_lock_warning"}}
+                      </div>
+                    </div>
+                  </div>
+                {{/if}}
+
+                <div class="password-confirmation">
+                  <label for="new-account-password-confirmation">
+                    {{i18n "user.password_confirmation.title"}}
+                  </label>
+                  <HoneypotInput
+                    @id="new-account-confirmation"
+                    @autocomplete="new-password"
+                    @value={{@controller.accountHoneypot}}
+                  />
+                  <Input
+                    @value={{@controller.accountChallenge}}
+                    id="new-account-challenge"
+                  />
+                </div>
+              </div>
+
+              {{#if @controller.requireInviteCode}}
+                <div class="input-group create-account__invite-code">
+                  <Input
+                    {{on "focusin" @controller.scrollInputIntoView}}
+                    @value={{@controller.inviteCode}}
+                    id="inviteCode"
+                    class={{valueEntered @controller.inviteCode}}
+                  />
+                  <label class="alt-placeholder" for="invite-code">
+                    {{i18n "user.invite_code.title"}}
+                  </label>
+                  <span class="more-info">
+                    {{i18n "user.invite_code.instructions"}}
+                  </span>
+                </div>
+              {{/if}}
+
+              <PluginOutlet
+                @name="create-account-after-password"
+                @outletArgs={{lazyHash
+                  accountName=@controller.accountName
+                  accountUsername=@controller.accountUsername
+                  accountPassword=@controller.accountPassword
+                  userFields=@controller.userFields
+                }}
+              />
+
+              {{#if
+                (and
+                  @controller.showFullname (not @controller.fullnameRequired)
+                )
+              }}
+                <FullnameInput
+                  @nameValidation={{@controller.nameValidation}}
+                  @nameTitle={{@controller.nameTitle}}
+                  @accountName={{@controller.accountName}}
+                  @nameDisabled={{@controller.nameDisabled}}
+                  @onFocusIn={{@controller.scrollInputIntoView}}
+                  class="input-group create-account__fullname"
+                />
+                <PluginOutlet
+                  @name="create-account-after-fullname"
+                  @outletArgs={{lazyHash accountName=@controller.accountName}}
+                />
+              {{/if}}
+
+              {{#if @controller.userFields}}
+                <div class="user-fields">
+                  {{#each @controller.userFields as |f|}}
+                    <div class="input-group">
+                      <UserField
+                        {{on "focusin" @controller.scrollInputIntoView}}
+                        @field={{f.field}}
+                        @value={{f.value}}
+                        @validation={{f.validation}}
+                        class={{valueEntered f.value}}
+                      />
+                    </div>
+                  {{/each}}
+                </div>
+              {{/if}}
+
+              <PluginOutlet
+                @name="create-account-after-user-fields"
+                @outletArgs={{lazyHash
+                  accountName=@controller.accountName
+                  accountUsername=@controller.accountUsername
+                  accountPassword=@controller.accountPassword
+                  userFields=@controller.userFields
+                }}
+              />
+            </form>
+
+            {{#if @controller.site.desktopView}}
+              <SignupPageCta
+                @formSubmitted={{@controller.formSubmitted}}
+                @hasAuthOptions={{@controller.hasAuthOptions}}
+                @createAccount={{@controller.createAccount}}
+                @submitDisabled={{@controller.submitDisabled}}
+                @disclaimerHtml={{@controller.disclaimerHtml}}
+              />
+            {{/if}}
           {{/if}}
 
-          {{#if (and @controller.showCreateForm @controller.site.mobileView)}}
-            <SignupPageCta
-              @formSubmitted={{@controller.formSubmitted}}
-              @hasAuthOptions={{@controller.hasAuthOptions}}
-              @createAccount={{@controller.createAccount}}
-              @submitDisabled={{@controller.submitDisabled}}
-              @disclaimerHtml={{@controller.disclaimerHtml}}
-            />
+          {{#if @controller.skipConfirmation}}
+            {{loadingSpinner size="large"}}
           {{/if}}
         </div>
-      {{/if}}
+
+        {{#if @controller.showRightSide}}
+          {{#if @controller.site.mobileView}}
+            <div class="login-or-separator">
+              <span>{{i18n "login.or"}}</span>
+            </div>
+          {{/if}}
+          <div class="login-right-side">
+            <LoginButtons
+              @externalLogin={{@controller.externalLogin}}
+              @context="create-account"
+            />
+          </div>
+        {{/if}}
+
+        {{#if (and @controller.showCreateForm @controller.site.mobileView)}}
+          <SignupPageCta
+            @formSubmitted={{@controller.formSubmitted}}
+            @hasAuthOptions={{@controller.hasAuthOptions}}
+            @createAccount={{@controller.createAccount}}
+            @submitDisabled={{@controller.submitDisabled}}
+            @disclaimerHtml={{@controller.disclaimerHtml}}
+          />
+        {{/if}}
+      </div>
     </div>
   </template>
 );


### PR DESCRIPTION
Loading the controller and its template causes a request to `hp.json`, which can then trigger a race condition with `/session/csrf.json` if an external auth is in-progress. This commit updates the redirect behavior so that the the `beforeModel` hook never resolves, and therefore the transition remains in a pending state until the redirect updates `window.location`.

This also improves the UX, since there is no need for a flash of a loading spinner. Instead, the normal route transition animation will keep running until the redirect is complete.