### PR TITLE
Ux remove b tag

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
@@ -227,7 +227,7 @@ export default class MoveToTopic extends Component {
                   @value="new_message"
                   @selection={{this.selection}}
                 />
-                <b>{{i18n "topic.move_to_new_message.radio_label"}}</b>
+                {{i18n "topic.move_to_new_message.radio_label"}}
               </label>
             {{/if}}
 
@@ -238,7 +238,7 @@ export default class MoveToTopic extends Component {
                 @value="existing_message"
                 @selection={{this.selection}}
               />
-              <b>{{i18n "topic.move_to_existing_message.radio_label"}}</b>
+              {{i18n "topic.move_to_existing_message.radio_label"}}
             </label>
           </div>
 

--- a/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/move-to-topic.gjs
@@ -317,7 +317,7 @@ export default class MoveToTopic extends Component {
                   @value="new_topic"
                   @selection={{this.selection}}
                 />
-                <b>{{i18n "topic.split_topic.radio_label"}}</b>
+                {{i18n "topic.split_topic.radio_label"}}
               </label>
             {{/if}}
 
@@ -328,7 +328,7 @@ export default class MoveToTopic extends Component {
                 @value="existing_topic"
                 @selection={{this.selection}}
               />
-              <b>{{i18n "topic.merge_topic.radio_label"}}</b>
+              {{i18n "topic.merge_topic.radio_label"}}
             </label>
 
             {{#if this.canSplitToPM}}
@@ -339,7 +339,7 @@ export default class MoveToTopic extends Component {
                   @value="new_message"
                   @selection={{this.selection}}
                 />
-                <b>{{i18n "topic.move_to_new_message.radio_label"}}</b>
+                {{i18n "topic.move_to_new_message.radio_label"}}
               </label>
             {{/if}}
           </div>


### PR DESCRIPTION
When a bold font is used within a `b` tag, some browsers will apply a faux bold that's *too* bold — since we're already applying a bold font-weight in CSS we don't need these `b` tags anyway 

too bold:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/731dee00-d3bd-41a2-9c19-c6104c9edcf5" />
