### PR TITLE
UX: Post notices part 2

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post/notice.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/notice.gjs
@@ -31,7 +31,7 @@ export default class PostNotice extends Component {
   get shouldRender() {
     const postAge = new Date() - new Date(this.args.post.created_at);
     const maxAge = this.siteSettings.old_post_notice_days * 86400000;
-    return postAge <= maxAge;
+    return this.args.post.notice.type === "custom" || postAge <= maxAge;
   }
 
   <template>

--- a/app/assets/javascripts/discourse/app/components/post/notice/returning-user.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/notice/returning-user.gjs
@@ -1,4 +1,4 @@
-import icon from "discourse/helpers/d-icon";
+import emoji from "discourse/helpers/emoji";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
 import { i18n } from "discourse-i18n";
 import PostNoticeNewUser from "./new-user";
@@ -11,7 +11,7 @@ export default class PostNoticeReturningUser extends PostNoticeNewUser {
   }
 
   <template>
-    {{icon "far-face-smile"}}
+    {{emoji "wave"}}
     <p>{{i18n "post.notice.returning_user" user=this.user time=this.time}}</p>
   </template>
 }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1532,6 +1532,10 @@ span.mention {
     gap: var(--space-2);
   }
 
+  &.custom {
+    background: var(--danger-low);
+  }
+
   .emoji {
     width: 1.5em;
     height: 1.5em;


### PR DESCRIPTION
Addition to #34988: 
* we also need to apply the new styling to the returning-user
* we need to keep the custom (= official) notices
* update the settings copy to make this clear