### PR TITLE
DEV: Properly clean up global setting overrides in specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -943,7 +943,11 @@ def global_setting(name, value)
 
   GlobalSetting.stubs(name).returns(value)
 
-  before_next_spec { GlobalSetting.reset_s3_cache! }
+  before_next_spec do
+    SiteSetting.hidden_settings_provider.remove_hidden(name)
+    SiteSetting.shadowed_settings.delete(name)
+    GlobalSetting.reset_s3_cache!
+  end
 end
 
 def set_cdn_url(cdn_url)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -939,6 +939,8 @@ def before_next_spec(&callback)
 end
 
 def global_setting(name, value)
+  SiteSetting.hidden_settings_provider.remove_hidden(name)
+  SiteSetting.shadowed_settings.delete(name)
   GlobalSetting.reset_s3_cache!
 
   GlobalSetting.stubs(name).returns(value)


### PR DESCRIPTION
In the `SiteSettingExtension`, when calling `SiteSetting.send(:setting_name, value)`,
if the setting counts as a global one, we add it to the list of hidden
and shadowed site settings in memory. However, when using the
`global_setting` helper in specs, we were not cleaning up these
overrides after the spec finished, leading to potential flakiness
in tests that rely on the visibility of site settings.

The fix is to just remove the setting from the hidden and shadowed
list after the spec is done.
