### PR TITLE
DEV: Improve turbo_rspec and flaky-test output

### DIFF
--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -82,7 +82,7 @@ if ARGV.empty?
 
   run_system_tests = !!enable_system_tests
 
-  files = Dir.glob("#{Rails.root}/spec/**/*_spec.rb")
+  files = Dir.glob("spec/**/*_spec.rb")
   files.reject! { |file| File.fnmatch("*spec/system*", file) } if !run_system_tests
 
   use_runtime_info = true if use_runtime_info.nil?

--- a/lib/turbo_tests/flaky/failed_example.rb
+++ b/lib/turbo_tests/flaky/failed_example.rb
@@ -57,7 +57,13 @@ module TurboTests
       end
 
       def rerun_command
-        @failed_example.command_string
+        @failed_example
+          .command_string
+          .sub(/TEST_ENV_NUMBER=\d*\s*/, "")
+          .sub("RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1", "")
+          .sub("DISCOURSE_RSPEC_PROFILE_EACH_EXAMPLE=1", "")
+          .gsub(/--format \S+/, "")
+          .gsub(/--out \S+/, "")
       end
 
       def to_h


### PR DESCRIPTION
1. Use relative paths instead of absolute. This will make the commands portable to other machines, and matches the out-the-box behavior of the regular rspec command

2. Strip out some 'infrastructure' ENV and params from the rerun_command, so that it's easier to copy/paste and run locally