### PR TITLE
DEV: Ensure prebuilt assets are compiled for the `beta` tag

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - stable
+    tags:
+      - beta
 
 concurrency:
   group: publish-assets-${{ format('{0}-{1}', github.run_number, github.job) }}


### PR DESCRIPTION
Our current release process involves pushing two commits to `main` simultaneously. The first is tagged `beta`, and then the second begins the new `-latest` cycle for the next beta version. Since they're pushed together, GitHub only triggers a single 'push' event for the most recent commit.

This commit updates the publish-assets workflow so that it's also triggered when the `beta` tag is attached to a new commit. That'll ensure that assets are built & published for that specific commit.