### PR TITLE
FIX: correctly replace emojis in bookmark reminder

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.gjs
@@ -24,6 +24,7 @@ import icon from "discourse/helpers/d-icon";
 import discourseTags from "discourse/helpers/discourse-tags";
 import formatDate from "discourse/helpers/format-date";
 import lazyHash from "discourse/helpers/lazy-hash";
+import replaceEmoji from "discourse/helpers/replace-emoji";
 import topicLink from "discourse/helpers/topic-link";
 import { ajax } from "discourse/lib/ajax";
 import { BookmarkFormData } from "discourse/lib/bookmark-form-data";
@@ -314,7 +315,9 @@ export default class BookmarkList extends Component {
                         {{/if}}
                         {{#if bookmark.name}}
                           <span class="bookmark-metadata-item">
-                            {{icon "circle-info"}}<span>{{bookmark.name}}</span>
+                            {{icon "circle-info"}}<span>{{replaceEmoji
+                                bookmark.name
+                              }}</span>
                           </span>
                         {{/if}}
                       </div>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.gjs
@@ -2,11 +2,9 @@ import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import { htmlSafe } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import icon from "discourse/helpers/d-icon";
-import { emojiUnescape } from "discourse/lib/text";
-import { escapeExpression } from "discourse/lib/utilities";
+import replaceEmoji from "discourse/helpers/replace-emoji";
 
 export default class UserMenuItem extends Component {
   get className() {
@@ -36,12 +34,7 @@ export default class UserMenuItem extends Component {
   get description() {
     const description = this.#item.description;
     if (description) {
-      if (typeof description === "string") {
-        // do emoji unescape on all items
-        return htmlSafe(emojiUnescape(escapeExpression(description)));
-      }
-      // it's probably an htmlSafe object, don't try to unescape emojis
-      return description;
+      return replaceEmoji(description);
     }
   }
 


### PR DESCRIPTION
- The menu item logic was incorrect as it was bypassing replacing emoji if we already had a `safeString` object but in this case the emojis had not been replaced yet. We now have the superior `replaceEmoji` pattern which will handle this complexity correctly.

- `replaceEmoji` was not called in `bookmark-list`