### PR TITLE
FIX: notification reminder is deleted with bookmark

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -28,6 +28,18 @@ class Bookmark < ActiveRecord::Base
   belongs_to :user
   belongs_to :bookmarkable, polymorphic: true
 
+  has_many :reminder_notifications,
+           ->(bookmark) do
+             where(notification_type: Notification.types[:bookmark_reminder]).where(
+               "data::jsonb->>'bookmark_id' = ?",
+               bookmark.id.to_s,
+             )
+           end,
+           class_name: "Notification",
+           foreign_key: :user_id,
+           primary_key: :user_id,
+           dependent: :destroy
+
   def self.auto_delete_preferences
     @auto_delete_preferences ||=
       Enum.new(never: 0, when_reminder_sent: 1, on_owner_reply: 2, clear_reminder: 3)

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -103,6 +103,37 @@ RSpec.describe "Bookmark message", type: :system do
         )
       end
     end
+
+    context "with reminder notification cleanup" do
+      it "removes bookmark reminder notification when bookmark is deleted" do
+        chat_page.visit_channel(category_channel_1)
+        channel_page.bookmark_message(message_1)
+        bookmark_modal.fill_name("Check this out later")
+        bookmark_modal.select_preset_reminder(:tomorrow)
+
+        expect(channel_page).to have_bookmarked_message(message_1)
+
+        bookmark = Bookmark.find_by(bookmarkable: message_1, user: current_user)
+        Chat::MessageBookmarkable.send_reminder_notification(
+          bookmark,
+          data: {
+            title: bookmark.bookmarkable.chat_channel.title(current_user),
+            bookmarkable_url: bookmark.bookmarkable.url,
+          },
+        )
+
+        user_menu.open
+
+        expect(page).to have_css("#quick-access-all-notifications .bookmark-reminder")
+
+        channel_page.bookmark_message(message_1)
+        bookmark_modal.delete
+        bookmark_modal.confirm_delete
+        user_menu.open
+
+        expect(page).to have_no_css("#quick-access-all-notifications .bookmark-reminder")
+      end
+    end
   end
 
   context "when mobile", mobile: true do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7705,15 +7705,14 @@ RSpec.describe UsersController do
         expect(notifications.first["data"]["bookmark_id"]).to eq(bookmark_with_reminder.id)
       end
 
-      it "shows unread notifications even if the bookmark has been deleted if they have bookmarkable data" do
+      it "doesn’t show unread notifications when the bookmark has been deleted" do
         bookmark_with_reminder.destroy!
 
         get "/u/#{user.username}/user-menu-bookmarks"
         expect(response.status).to eq(200)
 
         notifications = response.parsed_body["notifications"]
-        expect(notifications.size).to eq(1)
-        expect(notifications.first["data"]["bookmark_id"]).to eq(bookmark_with_reminder.id)
+        expect(notifications.size).to eq(0)
       end
 
       it "does not show unread notifications if the bookmark has been deleted if they only have the bookmark_id data" do


### PR DESCRIPTION
Prior to this fix a user could delete a chat bookmark but the notification reminder if it had already fired would still show in notifications.