### PR TITLE
Check for pgvector before CREATE EXTENSION

### DIFF
--- a/plugins/discourse-ai/db/migrate/20230710171141_enable_pg_vector_extension.rb
+++ b/plugins/discourse-ai/db/migrate/20230710171141_enable_pg_vector_extension.rb
@@ -2,17 +2,19 @@
 
 class EnablePgVectorExtension < ActiveRecord::Migration[7.0]
   def change
-    begin
-      enable_extension :vector
-    rescue Exception => e
-      if DB.query_single("SELECT 1 FROM pg_available_extensions WHERE name = 'vector';").empty?
-        STDERR.puts "------------------------------DISCOURSE AI ERROR----------------------------------"
-        STDERR.puts "    Discourse AI requires the pgvector extension on the PostgreSQL database."
-        STDERR.puts "         Run a `./launcher rebuild app` to fix it on a standard install."
-        STDERR.puts "            Alternatively, you can remove Discourse AI to rebuild."
-        STDERR.puts "------------------------------DISCOURSE AI ERROR----------------------------------"
+    unless extension_enabled?(:vector)
+      begin
+        enable_extension :vector
+      rescue StandardError => e
+        if DB.query_single("SELECT 1 FROM pg_available_extensions WHERE name = 'vector';").empty?
+          STDERR.puts "------------------------------DISCOURSE AI ERROR----------------------------------"
+          STDERR.puts "    Discourse AI requires the pgvector extension on the PostgreSQL database."
+          STDERR.puts "         Run a `./launcher rebuild app` to fix it on a standard install."
+          STDERR.puts "            Alternatively, you can remove Discourse AI to rebuild."
+          STDERR.puts "------------------------------DISCOURSE AI ERROR----------------------------------"
+        end
+        raise e
       end
-      raise e
     end
   end
 end


### PR DESCRIPTION
On certain hosting environments (azure postgres flex notably) CREATE EXTENSION requires a high level of permissions if the extension in question is marked as "untrusted" by postgres. This level of permission might not be available at runtime if the database user has low privileges.

Unfortunately, the migration currently tries to CREATE EXTENSION even if the "vector" extension already exists, which causes a permission error.

This PR just adds a check to see if "vector" is already present, and skips if it is.