### PR TITLE
UX: Update topic-footer buttons automatically when viewport changes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.gjs
@@ -1,7 +1,6 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
 import { concat } from "@ember/helper";
-import { computed } from "@ember/object";
 import { compare } from "@ember/utils";
 import { attributeBindings } from "@ember-decorators/component";
 import DButton from "discourse/components/d-button";
@@ -14,9 +13,10 @@ export default class AnonymousTopicFooterButtons extends Component {
   elementId = "topic-footer-buttons";
   role = "region";
 
-  @getTopicFooterButtons() allButtons;
+  get allButtons() {
+    return getTopicFooterButtons(this);
+  }
 
-  @computed("allButtons.[]")
   get buttons() {
     return (
       this.allButtons

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
@@ -36,20 +36,24 @@ export default class TopicFooterButtons extends Component {
   elementId = "topic-footer-buttons";
   role = "region";
 
-  @getTopicFooterButtons() inlineButtons;
-  @getTopicFooterDropdowns() inlineDropdowns;
-
   @alias("currentUser.can_send_private_messages") canSendPms;
   @alias("topic.details.can_invite_to") canInviteTo;
   @alias("currentUser.user_option.enable_defer") canDefer;
   @or("topic.archived", "topic.closed", "topic.deleted") inviteDisabled;
+
+  get inlineButtons() {
+    return getTopicFooterButtons(this);
+  }
+
+  get inlineDropdowns() {
+    return getTopicFooterDropdowns(this);
+  }
 
   @discourseComputed("canSendPms", "topic.isPrivateMessage")
   canArchive(canSendPms, isPM) {
     return canSendPms && isPM;
   }
 
-  @computed("inlineButtons.[]", "inlineDropdowns.[]")
   get inlineActionables() {
     return (
       this.inlineButtons
@@ -70,15 +74,12 @@ export default class TopicFooterButtons extends Component {
     return new TopicBookmarkManager(getOwner(this), this.topic);
   }
 
-  // topic.assigned_to_user is for backward plugin support
-  @discourseComputed("inlineButtons.[]", "topic.assigned_to_user")
-  dropdownButtons(inlineButtons) {
-    return inlineButtons.filter((button) => button.dropdown);
+  get dropdownButtons() {
+    return this.inlineButtons.filter((button) => button.dropdown);
   }
 
-  @discourseComputed("dropdownButtons.[]")
-  loneDropdownButton(dropdownButtons) {
-    return dropdownButtons.length === 1 ? dropdownButtons[0] : null;
+  get loneDropdownButton() {
+    return this.dropdownButtons.length === 1 ? this.dropdownButtons[0] : null;
   }
 
   @discourseComputed("topic.isPrivateMessage")


### PR DESCRIPTION
Some topic buttons or dropdown items are displayed conditionally based on the viewport width (e.g. via `site.mobileView`). Previously, the topic-footer-button API wasn't designed to support autotracking. Instead, it required plugins to pass a list of string-based keys, which it then attached to a computed property.

This commit updates it to be fully 'autotracking-native'. Old dependent keys are accessed internally via `.get()` to maintain backwards compatibility.

Now, dependencies on autotrackable property like `site.mobileView` will be reflected in real-time.