### PR TITLE
FIX: force update size on full calendar

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -5,6 +5,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { modifier as modifierFn } from "ember-modifier";
 import loadFullCalendar from "discourse/lib/load-full-calendar";
 import DiscourseURL from "discourse/lib/url";
 import DiscoursePostEvent from "discourse/plugins/discourse-calendar/discourse/components/discourse-post-event";
@@ -36,6 +37,19 @@ export default class FullCalendar extends Component {
   @controller topic;
 
   calendar = null;
+
+  // TODO: remove this workaround when updating to fullcalendar v7
+  forceUpdateSize = modifierFn((element) => {
+    const observer = new ResizeObserver(() => {
+      this.calendar?.updateSize?.();
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  });
 
   willDestroy() {
     this.calendar?.destroy?.();
@@ -187,6 +201,7 @@ export default class FullCalendar extends Component {
     <div
       {{didInsert this.setupCalendar}}
       {{didUpdate this.updateCalendar @events this.capabilities.viewport.md}}
+      {{this.forceUpdateSize}}
       ...attributes
     >
       {{! The calendar will be rendered inside this div by the library }}


### PR DESCRIPTION
We are not sure of the reasons but there are multiple similar (yet not exactly the same) reports of resizing issues with calendar causing this exact same `width: 0` state we have experienced.