### PR TITLE
DEV: Update invite spec for DST handling

### DIFF
--- a/spec/system/create_invite_spec.rb
+++ b/spec/system/create_invite_spec.rb
@@ -126,7 +126,7 @@ describe "Creating Invites", type: :system do
       expect(user_invited_pending_page.latest_invite).to have_group(group)
       expect(user_invited_pending_page.latest_invite).to have_topic(topic)
       expect(user_invited_pending_page.latest_invite.expiry_date).to be_within(2.minutes).of(
-        Time.zone.now + 90.days,
+        Time.find_zone(user.user_option.timezone).now + 90.days,
       )
     end
 


### PR DESCRIPTION
The invite system uses the inviter's timezone to determine the expiration time (see https://github.com/discourse/discourse/commit/0dd1ee2e092dc1da99cfe304f37e53a7b710bee6)

Now that DST change is less than 90 days away for me, the spec started failing locally. We should update the spec to use the inviter's timezone, just like core's own logic