### PR TITLE
DEV: Serialize cookies using MessagePack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -89,7 +89,7 @@ module Discourse
       Symbol,
     ]
     config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
-    config.action_dispatch.cookies_serializer = :hybrid
+    config.action_dispatch.cookies_serializer = :message_pack_allow_marshal
     config.action_controller.wrap_parameters_by_default = false
     config.active_support.cache_format_version = 7.1
 

--- a/lib/freedom_patches/message_pack_extensions.rb
+++ b/lib/freedom_patches/message_pack_extensions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Patch from https://github.com/rails/rails/pull/54584.
+# TODO: Drop this once Rails 8.1 is released.
+
+require "active_support/message_pack"
+require "active_support/core_ext/string/output_safety"
+
+module MessagePackExtensions
+  def install(registry)
+    super
+    registry.register_type 18, ActiveSupport::SafeBuffer, packer: :to_s, unpacker: :new
+  end
+end
+
+ActiveSupport::MessagePack::Extensions.prepend(MessagePackExtensions)


### PR DESCRIPTION
This PR uses MessagePack instead of JSON for serializing our cookies.

MessagePack is almost as fast as Marshal but without the security issues. It’s also able to serialize more objects than JSON (like Time, Symbol, etc.). As it’s a binary format, it takes less space than JSON, sometimes half less. Finally, MessagePack isn’t Ruby-specific and implementations exist in every existing language.

Regarding the cookies Discourse is using, we can see a small improvement on the `_forum_session` one when it’s almost empty (around 2%), but the more things are put into it, the more we’ll see savings. For the `_t` cookie, we’re saving around 20% for free.
