### PR TITLE
DEV: Add support for converting and importing `site_settings`

### DIFF
--- a/migrations/config/importer.yml
+++ b/migrations/config/importer.yml
@@ -1,3 +1,7 @@
 intermediate_db: /shared/import/intermediate.db
 mappings_db: /shared/import/mappings.db
 uploads_db: /shared/import/uploads.db
+
+config:
+  # if false, allows reserved usernames only for admins
+  always_allow_reserved_usernames: true

--- a/migrations/config/intermediate_db.yml
+++ b/migrations/config/intermediate_db.yml
@@ -92,6 +92,19 @@ schema:
       columns:
         exclude:
           - "id"
+    site_settings:
+      primary_key_column_names: [ "name" ]
+      columns:
+        include:
+          - "name"
+          - "value"
+        add:
+          - name: "import_mode"
+            enum: site_setting_import_mode
+            nullable: false
+          - name: "last_changed_at"
+            datatype: datetime
+            nullable: true
     tag_group_memberships:
       primary_key_column_names: [ "tag_group_id", "tag_id" ]
       columns:
@@ -462,7 +475,6 @@ schema:
         - "sidebar_urls"
         - "silenced_assignments"
         - "single_sign_on_records"
-        - "site_settings"
         - "sitemaps"
         - "skipped_email_logs"
         - "stylesheet_cache"
@@ -536,6 +548,15 @@ schema:
         - "web_hook_events"
         - "web_hook_events_daily_aggregates"
         - "web_hooks"
+
+  enums:
+    site_setting_import_mode:
+      values:
+        - auto
+        - override
+        - append
+    site_setting_datatype:
+      source: "::SiteSettings::TypeSupervisor.types"
 
 plugins:
   - "automation"

--- a/migrations/config/locales/migrations.en.yml
+++ b/migrations/config/locales/migrations.en.yml
@@ -23,6 +23,7 @@ en:
     default_step_title: "Importing %{type}"
     loading_required_data: "Loading required data..."
     done: "Done. Total runtime: %{runtime}"
+    site_setting_log_message: "Updated by import script"
     fallback_names:
       user: "user"
       group: "group"

--- a/migrations/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/db/intermediate_db_schema/100-base-schema.sql
@@ -148,6 +148,14 @@ CREATE TABLE muted_users
     user_id       NUMERIC  NOT NULL
 );
 
+CREATE TABLE site_settings
+(
+    name            TEXT         NOT NULL PRIMARY KEY,
+    import_mode     ENUM_INTEGER NOT NULL,
+    last_changed_at DATETIME,
+    value           TEXT
+);
+
 CREATE TABLE tag_group_memberships
 (
     tag_group_id NUMERIC  NOT NULL,

--- a/migrations/lib/converters/base/step.rb
+++ b/migrations/lib/converters/base/step.rb
@@ -3,6 +3,7 @@
 module Migrations::Converters::Base
   class Step
     IntermediateDB = ::Migrations::Database::IntermediateDB
+    Enums = ::Migrations::Database::IntermediateDB::Enums
 
     attr_accessor :settings
     attr_reader :tracker

--- a/migrations/lib/converters/discourse/steps/site_settings.rb
+++ b/migrations/lib/converters/discourse/steps/site_settings.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Migrations::Converters::Discourse
+  class SiteSettings < ::Migrations::Converters::Base::ProgressStep
+    attr_accessor :source_db
+
+    def execute
+      super
+
+      @upload_creator = UploadCreator.new
+
+      @uploads_by_id = @source_db.query(<<~SQL).index_by { |row| row[:id] }
+        SELECT u.id,
+               u.url,
+               u.original_filename AS filename,
+               u.origin,
+               u.user_id
+        FROM site_settings s
+             JOIN LATERAL (
+                      SELECT u.*
+                      FROM uploads u
+                      WHERE (s.data_type = 17 AND u.id = ANY (STRING_TO_ARRAY(s.value, '|')::int[]))
+                         OR (s.data_type = 18 AND u.id = s.value::int)
+                      ) u ON TRUE
+        WHERE s.value <> ''
+      SQL
+    end
+
+    def max_progress
+      @source_db.count <<~SQL
+        SELECT COUNT(*)
+        FROM site_settings
+        WHERE name <> 'permalink_normalizations'
+      SQL
+    end
+
+    def items
+      @source_db.query <<~SQL
+        SELECT name, value, data_type, updated_at
+        FROM site_settings
+        WHERE name <> 'permalink_normalizations'
+        ORDER BY name
+      SQL
+    end
+
+    def process_item(item)
+      value =
+        case item[:data_type]
+        when Enums::SiteSettingDatatype::UPLOAD
+          create_uploads([item[:value]])
+        when Enums::SiteSettingDatatype::UPLOADED_IMAGE_LIST
+          create_uploads(item[:value].split("|"))
+        else
+          item[:value]
+        end
+
+      IntermediateDB::SiteSetting.create(
+        name: item[:name],
+        value:,
+        last_changed_at: item[:updated_at],
+        import_mode: Enums::SiteSettingImportMode::AUTO,
+      )
+    end
+
+    private
+
+    def create_uploads(upload_ids)
+      upload_ids
+        .map do |upload_id|
+          upload = @uploads_by_id[upload_id.to_i]
+          upload ? @upload_creator.create_for(upload) : nil
+        end
+        .compact
+        .join("|")
+    end
+  end
+end

--- a/migrations/lib/converters/discourse/utilities/upload_creator.rb
+++ b/migrations/lib/converters/discourse/utilities/upload_creator.rb
@@ -2,11 +2,13 @@
 
 module Migrations::Converters::Discourse
   class UploadCreator
-    def initialize(column_prefix:, upload_type: nil)
-      @url_column = :"#{column_prefix}_url"
-      @filename_column = :"#{column_prefix}_filename"
-      @origin_column = :"#{column_prefix}_origin"
-      @user_id_column = :"#{column_prefix}_user_id"
+    def initialize(column_prefix: nil, upload_type: nil)
+      column_prefix = "#{column_prefix}_" if column_prefix.present?
+
+      @url_column = :"#{column_prefix}url"
+      @filename_column = :"#{column_prefix}filename"
+      @origin_column = :"#{column_prefix}origin"
+      @user_id_column = :"#{column_prefix}user_id"
 
       @upload_type = upload_type # TODO Enum
     end

--- a/migrations/lib/database/intermediate_db/enums/site_setting_datatype.rb
+++ b/migrations/lib/database/intermediate_db/enums/site_setting_datatype.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the "config/intermediate_db.yml" configuration file and then run
+# `bin/cli schema generate` to regenerate this file.
+
+module Migrations::Database::IntermediateDB::Enums
+  module SiteSettingDatatype
+    extend ::Migrations::Enum
+
+    STRING = 1
+    TIME = 2
+    INTEGER = 3
+    FLOAT = 4
+    BOOL = 5
+    NULL = 6
+    ENUM = 7
+    LIST = 8
+    URL_LIST = 9
+    HOST_LIST = 10
+    CATEGORY_LIST = 11
+    VALUE_LIST = 12
+    REGEX = 13
+    EMAIL = 14
+    USERNAME = 15
+    CATEGORY = 16
+    UPLOADED_IMAGE_LIST = 17
+    UPLOAD = 18
+    GROUP = 19
+    GROUP_LIST = 20
+    TAG_LIST = 21
+    COLOR = 22
+    SIMPLE_LIST = 23
+    EMOJI_LIST = 24
+    HTML_DEPRECATED = 25
+    TAG_GROUP_LIST = 26
+    FILE_SIZE_RESTRICTION = 27
+    OBJECTS = 28
+    LOCALE_ENUM = 29
+  end
+end

--- a/migrations/lib/database/intermediate_db/enums/site_setting_import_mode.rb
+++ b/migrations/lib/database/intermediate_db/enums/site_setting_import_mode.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the "config/intermediate_db.yml" configuration file and then run
+# `bin/cli schema generate` to regenerate this file.
+
+module Migrations::Database::IntermediateDB::Enums
+  module SiteSettingImportMode
+    extend ::Migrations::Enum
+
+    AUTO = 0
+    OVERRIDE = 1
+    APPEND = 2
+  end
+end

--- a/migrations/lib/database/intermediate_db/site_setting.rb
+++ b/migrations/lib/database/intermediate_db/site_setting.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the "config/intermediate_db.yml" configuration file and then run
+# `bin/cli schema generate` to regenerate this file.
+
+module Migrations::Database::IntermediateDB
+  module SiteSetting
+    SQL = <<~SQL
+      INSERT INTO site_settings (
+        name,
+        import_mode,
+        last_changed_at,
+        value
+      )
+      VALUES (
+        ?, ?, ?, ?
+      )
+    SQL
+    private_constant :SQL
+
+    # Creates a new `site_settings` record in the IntermediateDB.
+    #
+    # @param name              [String]
+    # @param import_mode       [Integer]
+    #   Any constant from SiteSettingImportMode (e.g. SiteSettingImportMode::AUTO)
+    # @param last_changed_at   [Time, nil]
+    # @param value             [String, nil]
+    #
+    # @return [void]
+    #
+    # @see Migrations::Database::IntermediateDB::Enums::SiteSettingImportMode
+    def self.create(name:, import_mode:, last_changed_at: nil, value: nil)
+      ::Migrations::Database::IntermediateDB.insert(
+        SQL,
+        name,
+        import_mode,
+        ::Migrations::Database.format_datetime(last_changed_at),
+        value,
+      )
+    end
+  end
+end

--- a/migrations/lib/importer/copy_step.rb
+++ b/migrations/lib/importer/copy_step.rb
@@ -2,8 +2,6 @@
 
 module Migrations::Importer
   class CopyStep < Step
-    MappingType = ::Migrations::Importer::MappingType
-
     NOW = "NOW()"
     SYSTEM_USER_ID = Discourse::SYSTEM_USER_ID
 

--- a/migrations/lib/importer/step.rb
+++ b/migrations/lib/importer/step.rb
@@ -2,6 +2,9 @@
 
 module Migrations::Importer
   class Step
+    MappingType = ::Migrations::Importer::MappingType
+    Enums = ::Migrations::Database::IntermediateDB::Enums
+
     class << self
       # stree-ignore
       def title(value = (getter = true; nil))

--- a/migrations/lib/importer/steps/base/site_settings.rb
+++ b/migrations/lib/importer/steps/base/site_settings.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps::Base
+  class SiteSettings < ::Migrations::Importer::Step
+    class << self
+      def inherited(klass)
+        super
+        klass.requires_mapping :last_change_dates, "SELECT name, updated_at FROM site_settings"
+      end
+    end
+
+    DATATYPES_WITH_DEPENDENCY =
+      [
+        Enums::SiteSettingDatatype::CATEGORY,
+        Enums::SiteSettingDatatype::CATEGORY_LIST,
+        Enums::SiteSettingDatatype::EMOJI_LIST,
+        Enums::SiteSettingDatatype::GROUP,
+        Enums::SiteSettingDatatype::GROUP_LIST,
+        Enums::SiteSettingDatatype::TAG_GROUP_LIST,
+        Enums::SiteSettingDatatype::TAG_LIST,
+        Enums::SiteSettingDatatype::UPLOAD,
+        Enums::SiteSettingDatatype::UPLOADED_IMAGE_LIST,
+        Enums::SiteSettingDatatype::USERNAME,
+      ].map { |number| ::SiteSettings::TypeSupervisor.types[number].to_s }
+
+    DISALLOWED_SITE_SETTINGS = Set.new([:permalink_normalizations]).freeze
+    LIST_SEPARATOR = "|"
+
+    private_constant :DATATYPES_WITH_DEPENDENCY, :DISALLOWED_SITE_SETTINGS
+
+    def execute
+      super
+
+      @log_messages = []
+      @audit_message = I18n.t("importer.site_setting_log_message")
+      @failed_settings = []
+
+      @settings_index =
+        silence_deprecation_warnings do
+          SiteSetting.all_settings(include_hidden: true)
+        end.index_by { |hash| hash[:setting] }
+
+      import_rows = fetch_rows.reject { |row| skip_row?(row) }
+
+      with_progressbar(import_rows.size) do
+        capture_deprecation_warnings { process_rows(import_rows) }
+      end
+
+      # TODO: Replace with logging when available
+      @log_messages.each { |message| puts "      #{message}" }
+    end
+
+    private
+
+    # Override in subclasses to skip rows that should be handled in a later step.
+    def skip_row?(_row)
+      false
+    end
+
+    # Override in subclasses to adapt/normalize values by type.
+    def transform_value(_setting_name, value, _type)
+      value
+    end
+
+    private
+
+    def fetch_rows
+      @intermediate_db.query <<~SQL
+        SELECT name, value, last_changed_at, import_mode
+        FROM site_settings
+        ORDER BY ROWID
+      SQL
+    end
+
+    def process_rows(rows)
+      rows.each do |row|
+        @stats.reset
+        before_fail_count = @failed_settings.size
+
+        import_row(row) if row_importable?(row)
+
+        # Only advance the progress bar if the row didn't get deferred due to failure.
+        update_progressbar if before_fail_count == @failed_settings.size
+      end
+
+      # Re-attempt failed updates (often due to dependency ordering).
+      failures_before_retry = @failed_settings.size
+      retry_failed_updates
+      update_progressbar(increment_by: failures_before_retry)
+    end
+
+    def row_importable?(row)
+      row in { name:, import_mode: }
+      name_symbol = row[:name].to_sym
+      setting = @settings_index[name_symbol]
+
+      if setting.nil?
+        log_warning "Ignoring unknown site setting: #{name}"
+        return false
+      end
+
+      if DISALLOWED_SITE_SETTINGS.include?(name_symbol)
+        log_warning "Ignoring disallowed site setting: #{name}"
+        return false
+      end
+
+      if setting[:themeable]
+        log_warning "Can't modify themeable site setting: #{name}"
+        return false
+      end
+
+      if SiteSetting.shadowed_settings.include?(name)
+        log_warning "Can't modify shadowed site setting: #{name}"
+        return false
+      end
+
+      type = setting[:type]
+      if import_mode == Enums::SiteSettingImportMode::APPEND && !type.end_with?("list")
+        log_warning "Can't append to a site setting of type '#{type}': #{name}"
+        return false
+      end
+
+      true
+    end
+
+    def import_row(row)
+      row in { name:, value:, last_changed_at:, import_mode: }
+      setting = @settings_index[name.to_sym]
+
+      case import_mode
+      when Enums::SiteSettingImportMode::AUTO
+        auto_import(setting, value, last_changed_at)
+      when Enums::SiteSettingImportMode::APPEND
+        append_to_list(setting, value)
+      when Enums::SiteSettingImportMode::OVERRIDE
+        set_and_log(setting, transform_value(name, value, setting[:type]))
+      end
+    end
+
+    def auto_import(setting, value, last_changed_at)
+      name = setting[:setting]
+      last_changed_at ||= Time.now
+      existing_last_changed_at = @last_change_dates[name]
+
+      if !existing_last_changed_at || existing_last_changed_at < last_changed_at
+        set_and_log(setting, transform_value(name, value, setting[:type]))
+      else
+        @stats.skip_count += 1
+      end
+    end
+
+    def append_to_list(setting, value)
+      name = setting[:setting]
+      type = setting[:type]
+      existing_values = (SiteSetting.get(name) || "").split(LIST_SEPARATOR).to_set
+
+      values_to_append =
+        (value || "").split(LIST_SEPARATOR).map { |v| transform_value(name, v, type) }
+      values = existing_values.merge(values_to_append)
+
+      set_and_log(setting, values.join(LIST_SEPARATOR))
+    end
+
+    def set_and_log(setting, value)
+      if setting[:value] == value
+        @stats.skip_count += 1
+        return
+      end
+
+      name = setting[:setting]
+
+      begin
+        SiteSetting.set_and_log(name, value, Discourse.system_user, @audit_message)
+      rescue StandardError => exception
+        @failed_settings << { setting:, value:, exception: }
+      end
+    end
+
+    def retry_failed_updates
+      previous_count = nil
+
+      while @failed_settings.any? && @failed_settings.size != previous_count
+        previous_count = @failed_settings.size
+        shuffled = @failed_settings.shuffle
+        @failed_settings = []
+        shuffled.each { |f| set_and_log(f[:setting], f[:value]) }
+      end
+
+      @failed_settings.each do |failed|
+        name = failed[:setting][:setting]
+        exception = failed[:exception]
+        log_error "Failed to update site setting '#{name}': #{exception.message}"
+      end
+    end
+
+    def with_temporary_deprecate_handler(impl)
+      original = Discourse.method(:deprecate)
+      Discourse.define_singleton_method(:deprecate, impl)
+      begin
+        yield
+      ensure
+        Discourse.define_singleton_method(:deprecate, original)
+      end
+    end
+
+    def silence_deprecation_warnings
+      with_temporary_deprecate_handler(->(_warning, **_kwargs) {}) { yield }
+    end
+
+    def capture_deprecation_warnings
+      logged_settings = Set.new
+
+      with_temporary_deprecate_handler(
+        ->(warning, **_kwargs) do
+          setting_name = warning[/`SiteSetting\.(.*?)=?`.*/, 1]
+          log_warning warning if setting_name && logged_settings.add?(setting_name)
+        end,
+      ) { yield }
+    end
+
+    def log_warning(warning)
+      @log_messages << warning
+      @stats.warning_count += 1
+    end
+
+    def log_error(error)
+      @log_messages << error
+      @stats.error_count += 1
+    end
+  end
+end

--- a/migrations/lib/importer/steps/site_settings.rb
+++ b/migrations/lib/importer/steps/site_settings.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps
+  class SiteSettings < Base::SiteSettings
+    title "Importing basic site settings"
+    priority 0
+
+    private
+
+    def skip_row?(row)
+      name = row[:name].to_sym
+      setting = @settings_index[name]
+
+      # Can't skip unknown settings here; we need to count them in the progress bar.
+      return false if setting.nil?
+
+      DATATYPES_WITH_DEPENDENCY.include?(setting[:type])
+    end
+  end
+end

--- a/migrations/lib/importer/steps/site_settings_with_dependencies.rb
+++ b/migrations/lib/importer/steps/site_settings_with_dependencies.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Migrations::Importer::Steps
+  class SiteSettingsWithDependencies < Base::SiteSettings
+    title "Importing site settings with dependencies"
+
+    # TODO Add :emojis as dependency
+    depends_on :categories, :groups, :tags, :uploads, :users
+
+    private
+
+    def skip_row?(row)
+      name = row[:name].to_sym
+      setting = @settings_index[name]
+      return true if setting.nil?
+
+      DATATYPES_WITH_DEPENDENCY.exclude?(setting[:type])
+    end
+
+    def transform_value(setting_name, value, type)
+      case ::SiteSettings::TypeSupervisor.types[type.to_sym]
+      when Enums::SiteSettingDatatype::CATEGORY, Enums::SiteSettingDatatype::CATEGORY_LIST
+        map_ids(setting_name, value, MappingType::CATEGORIES, "category")
+      when Enums::SiteSettingDatatype::EMOJI_LIST
+        value # TODO Figure out, if we need to map emojis
+      when Enums::SiteSettingDatatype::GROUP
+        value # TODO Map group name (and update documentation in site_settings.yml which states it's an ID, not name)
+      when Enums::SiteSettingDatatype::GROUP_LIST
+        map_ids(setting_name, value, MappingType::GROUPS, "group")
+      when Enums::SiteSettingDatatype::TAG_GROUP_LIST
+        # TODO Map tag group names
+        value
+      when Enums::SiteSettingDatatype::TAG_LIST
+        value # TODO Map tag names
+      when Enums::SiteSettingDatatype::UPLOAD
+        map_ids(setting_name, value, MappingType::UPLOADS, "upload").to_i
+      when Enums::SiteSettingDatatype::UPLOADED_IMAGE_LIST
+        map_ids(setting_name, value, MappingType::UPLOADS, "upload")
+      when Enums::SiteSettingDatatype::USERNAME
+        map_username(setting_name, value)
+      else
+        raise "Unknown type: #{type}"
+      end
+    end
+
+    private
+
+    def map_ids(setting_name, value, mapping_type, type_name)
+      value
+        .split(LIST_SEPARATOR)
+        .map do |original_id|
+          unless (discourse_id = query_discourse_id(mapping_type, original_id))
+            log_error(
+              "Failed to update site setting '#{setting_name}': " \
+                "Could not map original #{type_name} ID '#{original_id}' to Discourse ID",
+            )
+          end
+          discourse_id
+        end
+        .compact
+        .join(LIST_SEPARATOR)
+    end
+
+    def query_discourse_id(mapping_type, original_id)
+      @intermediate_db.query_value(<<~SQL, mapping_type, original_id)
+        SELECT discourse_id
+        FROM mapped.ids
+        WHERE type = ?1
+          AND original_id = ?2
+      SQL
+    end
+
+    def map_username(setting_name, original_username)
+      original_username = User.normalize_username(original_username)
+      discourse_username = @intermediate_db.query_value(<<~SQL, original_username)
+        SELECT discourse_username
+        FROM mapped.usernames
+        WHERE original_username = ?
+      SQL
+
+      if discourse_username.blank?
+        if !(discourse_username = User.where(username_lower: original_username).pick(:username))
+          log_error(
+            "Failed to update site setting '#{setting_name}': " \
+              "Could not map original username '#{original_username}' to Discourse username",
+          )
+        end
+      end
+
+      discourse_username
+    end
+  end
+end

--- a/migrations/migrations.rb
+++ b/migrations/migrations.rb
@@ -25,6 +25,7 @@ module Migrations
     # rubocop:disable Discourse/NoChdir
     Dir.chdir(rails_root) do
       begin
+        ENV["DISCOURSE_DEV_ALLOW_HTTPS"] = "1" # suppress warning
         require File.join(rails_root, "config/environment")
       rescue LoadError => e
         $stderr.puts e.message

--- a/migrations/spec/lib/database/intermediate_db/all_entities_spec.rb
+++ b/migrations/spec/lib/database/intermediate_db/all_entities_spec.rb
@@ -3,6 +3,7 @@
 Migrations::Database::IntermediateDB.constants.each do |const|
   mod = Migrations::Database::IntermediateDB.const_get(const)
   next unless mod.is_a?(Module)
+  next if mod == Migrations::Database::IntermediateDB::Enums
 
   RSpec.describe mod do
     it_behaves_like "a database entity"


### PR DESCRIPTION
The import is split into basic site settings (imported at the beginning) and settings that depend on other data