### PR TITLE
DEV: Move admin-api-keys outlet wrapper

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-api-keys.gjs
+++ b/app/assets/javascripts/admin/addon/templates/admin-api-keys.gjs
@@ -7,42 +7,42 @@ import { i18n } from "discourse-i18n";
 
 export default RouteTemplate(
   <template>
-    <PluginOutlet @name="admin-api-keys">
-      <DPageHeader
-        @titleLabel={{i18n "admin.config.api_keys.title"}}
-        @descriptionLabel={{i18n "admin.config.api_keys.header_description"}}
-        @hideTabs={{@controller.hideTabs}}
-      >
-        <:breadcrumbs>
-          <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
-          <DBreadcrumbsItem
-            @path="/admin/api/keys"
-            @label={{i18n "admin.config.api_keys.title"}}
-          />
-        </:breadcrumbs>
-        <:actions as |actions|>
-          <actions.Primary
-            @route="adminApiKeys.new"
-            @label="admin.api_keys.add"
-          />
-        </:actions>
-        <:tabs>
-          <NavItem
-            @route="adminApiKeys.settings"
-            @label="settings"
-            class="admin-api-keys-tabs__settings"
-          />
-          <NavItem
-            @route="adminApiKeys.index"
-            @label="admin.config.api_keys.title"
-            class="admin-api-keys-tabs__index"
-          />
-        </:tabs>
-      </DPageHeader>
+    <DPageHeader
+      @titleLabel={{i18n "admin.config.api_keys.title"}}
+      @descriptionLabel={{i18n "admin.config.api_keys.header_description"}}
+      @hideTabs={{@controller.hideTabs}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin/api/keys"
+          @label={{i18n "admin.config.api_keys.title"}}
+        />
+      </:breadcrumbs>
+      <:actions as |actions|>
+        <actions.Primary
+          @route="adminApiKeys.new"
+          @label="admin.api_keys.add"
+        />
+      </:actions>
+      <:tabs>
+        <NavItem
+          @route="adminApiKeys.settings"
+          @label="settings"
+          class="admin-api-keys-tabs__settings"
+        />
+        <NavItem
+          @route="adminApiKeys.index"
+          @label="admin.config.api_keys.title"
+          class="admin-api-keys-tabs__index"
+        />
+      </:tabs>
+    </DPageHeader>
 
-      <div class="admin-container admin-config-page__main-area">
+    <div class="admin-container admin-config-page__main-area">
+      <PluginOutlet @name="admin-api-keys">
         {{outlet}}
-      </div>
-    </PluginOutlet>
+      </PluginOutlet>
+    </div>
   </template>
 );


### PR DESCRIPTION
When overriding, we should keep the breadcrumb and header. This change ensures consistency with other outlets (webhooks, themes).

See also internal ticket t/161658