### PR TITLE
DEV: Clear caches properly in admin_color_palette_config_area_spec

### DIFF
--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -12,6 +12,11 @@ describe "Admin Color Palette Config Area Page", type: :system do
 
   before { sign_in(admin) }
 
+  after do
+    Stylesheet::Manager.rm_cache_folder
+    Stylesheet::Manager.cache.clear
+  end
+
   it "allows editing the palette name" do
     config_area.visit(color_scheme.id)
 


### PR DESCRIPTION
This resolves the flaky spec we're seeing on `system/admin_color_palette_config_area_spec.rb:157`

`--bisect` minimal repro was:

```
bin/rspec './spec/system/admin_color_palette_config_area_spec.rb[1:9,1:12]' --tag ~type:multisite --order random:3906
```