### PR TITLE
UX: Remove love background on hover

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -373,8 +373,6 @@ nav.post-controls {
         &.like {
           // Like button with 0 likes
           &:hover {
-            background: var(--love-low);
-
             .d-icon {
               color: var(--love);
             }


### PR DESCRIPTION
This PR adds to the previous PR fixing some hover effects on the like button. It removes the `love` background color on hover, which caused a visual bug.

|Before|After|
|--|--|
|<img width="2055" height="1213" alt="CleanShot 2025-09-30 at 15 14 25@2x" src="https://github.com/user-attachments/assets/64b8ade8-aaf9-4d9c-b304-849f06a161eb" />|<img width="1806" height="1181" alt="CleanShot 2025-09-30 at 15 13 46@2x" src="https://github.com/user-attachments/assets/10b3e2cb-9137-49ed-93e9-243cf2f2cf0b" />|