### PR TITLE
FIX: Allow aws mediaconvert to use iam profile

### DIFF
--- a/app/services/video_conversion/aws_media_convert_adapter.rb
+++ b/app/services/video_conversion/aws_media_convert_adapter.rb
@@ -191,12 +191,16 @@ module VideoConversion
     end
 
     def create_basic_client(endpoint: nil)
-      Aws::MediaConvert::Client.new(
-        region: SiteSetting.s3_region,
-        credentials:
-          Aws::Credentials.new(SiteSetting.s3_access_key_id, SiteSetting.s3_secret_access_key),
-        endpoint: endpoint,
-      )
+      client_options = { region: SiteSetting.s3_region, endpoint: endpoint }
+
+      if !SiteSetting.s3_use_iam_profile
+        client_options[:credentials] = Aws::Credentials.new(
+          SiteSetting.s3_access_key_id,
+          SiteSetting.s3_secret_access_key,
+        )
+      end
+
+      Aws::MediaConvert::Client.new(client_options)
     end
 
     def update_posts_with_optimized_video

--- a/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
+++ b/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
     allow(SiteSetting).to receive(:s3_region).and_return(s3_region)
     allow(SiteSetting).to receive(:s3_access_key_id).and_return("test-key")
     allow(SiteSetting).to receive(:s3_secret_access_key).and_return("test-secret")
+    allow(SiteSetting).to receive(:s3_use_iam_profile).and_return(false)
     allow(SiteSetting).to receive(:s3_use_acls).and_return(true)
 
     allow(Aws::MediaConvert::Client).to receive(:new).and_return(mediaconvert_client)
@@ -184,6 +185,29 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
           "Invalid parameters for upload #{upload.id}: Upload URL domain for upload ID #{upload.id} does not contain expected bucket name: #{s3_bucket}",
         )
         expect(adapter.convert).to be false
+      end
+    end
+
+    context "when using IAM profile" do
+      before do
+        allow(SiteSetting).to receive(:s3_use_iam_profile).and_return(true)
+        allow(SiteSetting).to receive(:s3_access_key_id).and_return("")
+        allow(SiteSetting).to receive(:s3_secret_access_key).and_return("")
+        upload.update!(
+          url: "//#{s3_bucket}.s3.#{s3_region}.amazonaws.com/uploads/default/original/test.mp4",
+          original_filename: "test.mp4",
+        )
+        allow(mediaconvert_job).to receive(:id).and_return(job_id)
+        allow(mediaconvert_client).to receive(:create_job).and_return(mediaconvert_job_response)
+      end
+
+      it "creates MediaConvert client without explicit credentials" do
+        expected_client_options = { region: s3_region, endpoint: "https://mediaconvert.endpoint" }
+
+        adapter.convert
+
+        expect(Aws::MediaConvert::Client).to have_received(:new).with(expected_client_options)
+        expect(adapter.convert).to be true
       end
     end
   end


### PR DESCRIPTION
When authenticating to aws mediaconvert we need to also allow the use of
`iam_profile` and not just assume `s3_access_key_id` and
`s3_secret_access_key` are being used.
