### PR TITLE
UX: improve kbd shortcut appearance on macOS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
+++ b/app/assets/javascripts/discourse/app/components/toolbar-popup-menu-options.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { array, concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import DButton from "discourse/components/d-button";
 import DropdownMenu from "discourse/components/dropdown-menu";
@@ -13,6 +14,8 @@ import { i18n } from "discourse-i18n";
 import DMenu from "float-kit/components/d-menu";
 
 export default class ToolbarPopupmenuOptions extends Component {
+  @service capabilities;
+
   willDestroy() {
     super.willDestroy();
     this.dMenu?.destroy();
@@ -84,10 +87,13 @@ export default class ToolbarPopupmenuOptions extends Component {
 
     let htmlLabel = `<span class="d-button-label__text">${label}</span>`;
     if (content.shortcut) {
-      htmlLabel += ` <kbd class="shortcut ${
+      const separator = this.capabilities.isApple ? "" : " ";
+      const platformClass = this.capabilities.isApple ? "--apple" : "";
+      htmlLabel += ` <kbd class="shortcut ${platformClass} ${
         content.alwaysShowShortcut ? "--always-visible" : ""
       }">${translateModKey(
-        PLATFORM_KEY_MODIFIER + " " + content.shortcut.replace(/\+/g, " ")
+        PLATFORM_KEY_MODIFIER + "+" + content.shortcut,
+        separator
       )}</kbd>`;
     }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -182,7 +182,8 @@ blockquote {
 }
 
 code,
-pre {
+pre,
+kbd {
   font-family: var(--d-font-family--monospace);
 }
 

--- a/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
@@ -20,8 +20,6 @@
   }
 
   .shortcut {
-    font-size: var(--font-down-2);
-
     &.--apple {
       letter-spacing: 0.25em;
     }

--- a/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/toolbar-popup-menu-options.scss
@@ -20,6 +20,12 @@
   }
 
   .shortcut {
+    font-size: var(--font-down-2);
+
+    &.--apple {
+      letter-spacing: 0.25em;
+    }
+
     @include viewport.until(sm) {
       display: none;
     }


### PR DESCRIPTION
This switches to our monospace font variable, our default monospace font (JetBrains Mono) has much better glyph alignment than macOS' default monospace font, Menlo

Before:
<img width="566" height="124" alt="image" src="https://github.com/user-attachments/assets/aeb761d2-1402-4273-92fb-68dce8a5df49" />


After: 
<img width="582" height="122" alt="image" src="https://github.com/user-attachments/assets/b13bcfc8-bb55-432e-a4c9-a1a2b961daf5" />

I've also added an Apple specific class so we can tighten up the spacing between glyphs. 
