### PR TITLE
DEV: Replace deprecated Ember native array methods in the post-stream

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -553,7 +553,7 @@ export default class TopicController extends Controller {
     }
 
     const postStream = this.get("model.postStream");
-    const firstLoadedPost = postStream.get("posts.firstObject");
+    const firstLoadedPost = postStream.posts[0];
 
     if (post.get && post.get("post_number") === 1) {
       return;
@@ -570,7 +570,7 @@ export default class TopicController extends Controller {
     const { post, refresh } = event;
 
     const postStream = this.get("model.postStream");
-    const lastLoadedPost = postStream.get("posts.lastObject");
+    const lastLoadedPost = postStream.posts.at(-1);
 
     if (
       lastLoadedPost &&

--- a/app/assets/javascripts/discourse/app/lib/posts-with-placeholders.js
+++ b/app/assets/javascripts/discourse/app/lib/posts-with-placeholders.js
@@ -4,7 +4,7 @@ import {
 } from "@ember/-internals/metal";
 import EmberArray from "@ember/array";
 import EmberObject from "@ember/object";
-import discourseComputed from "discourse/lib/decorators";
+import { trackedArray } from "discourse/lib/tracked-tools";
 
 export function Placeholder(viewName) {
   this.viewName = viewName;
@@ -13,14 +13,11 @@ export function Placeholder(viewName) {
 export default class PostsWithPlaceholders extends EmberObject.extend(
   EmberArray
 ) {
-  posts = null;
+  @trackedArray posts = null;
   _appendingIds = {};
 
-  @discourseComputed
-  length() {
-    return (
-      this.get("posts.length") + Object.keys(this._appendingIds || {}).length
-    );
+  get length() {
+    return this.posts.length + Object.keys(this._appendingIds || {}).length;
   }
 
   nextObject(index) {
@@ -35,15 +32,15 @@ export default class PostsWithPlaceholders extends EmberObject.extend(
   }
 
   clear(cb) {
-    this._changeArray(cb, 0, this.get("posts.length"), 0);
+    this._changeArray(cb, 0, this.posts.length, 0);
   }
 
   appendPost(cb) {
-    this._changeArray(cb, this.get("posts.length"), 0, 1);
+    this._changeArray(cb, this.posts.length, 0, 1);
   }
 
   removePost(cb) {
-    this._changeArray(cb, this.get("posts.length") - 1, 1, 0);
+    this._changeArray(cb, this.posts.length - 1, 1, 0);
   }
 
   insertPost(insertAtIndex, cb) {
@@ -51,7 +48,7 @@ export default class PostsWithPlaceholders extends EmberObject.extend(
   }
 
   refreshAll(cb) {
-    const length = this.get("posts.length");
+    const length = this.posts.length;
     this._changeArray(cb, 0, length, length);
   }
 
@@ -73,7 +70,7 @@ export default class PostsWithPlaceholders extends EmberObject.extend(
         const appendingIds = this._appendingIds;
         postIds.forEach((pid) => delete appendingIds[pid]);
       },
-      this.get("posts.length") - postIds.length,
+      this.posts.length - postIds.length,
       postIds.length,
       postIds.length
     );

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -20,6 +20,8 @@ const CATEGORY_ASYNC_SEARCH_CACHE = {};
 const CATEGORY_ASYNC_HIERARCHICAL_SEARCH_CACHE = {};
 const pluginSaveProperties = new Set();
 
+let _uncategorized;
+
 /**
  * @internal
  * Adds a tracked property to the post model.
@@ -40,7 +42,7 @@ export default class Category extends RestModel {
     categories.forEach((category) => {
       const parentId = parseInt(category.parent_category_id, 10) || -1;
       const group = children.get(parentId) || [];
-      group.pushObject(category);
+      group.push(category);
 
       children.set(parentId, group);
     });
@@ -907,8 +909,6 @@ export default class Category extends RestModel {
     );
   }
 }
-
-let _uncategorized;
 
 const categoryMultiCache = new MultiCache(async (ids) => {
   const result = await ajax("/categories/find", { data: { ids } });

--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -1,4 +1,4 @@
-import { tracked } from "@glimmer/tracking";
+import { cached } from "@glimmer/tracking";
 import EmberObject, { computed, get } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { alias, sort } from "@ember/object/computed";
@@ -12,6 +12,7 @@ import { getOwnerWithFallback } from "discourse/lib/get-owner";
 import Mobile from "discourse/lib/mobile";
 import PreloadStore from "discourse/lib/preload-store";
 import singleton from "discourse/lib/singleton";
+import { trackedArray } from "discourse/lib/tracked-tools";
 import Archetype from "discourse/models/archetype";
 import Category from "discourse/models/category";
 import PostActionType from "discourse/models/post-action-type";
@@ -85,7 +86,7 @@ export default class Site extends RestModel {
   @service currentUser;
   @service capabilities;
 
-  @tracked categories;
+  @trackedArray categories;
 
   @alias("is_readonly") isReadOnly;
 
@@ -279,9 +280,9 @@ export default class Site extends RestModel {
   }
 
   // Sort subcategories under parents
-  @discourseComputed("categoriesByCount", "categories.[]")
-  sortedCategories(categories) {
-    return Category.sortCategories(categories);
+  @cached
+  get sortedCategories() {
+    return Category.sortCategories(this.categories);
   }
 
   // Returns it in the correct order, by setting

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -303,6 +303,9 @@ export default class Topic extends RestModel {
 
   @tracked deleted_by;
   @tracked deleted_at;
+  @tracked highest_post_number;
+  @tracked last_read_post_number;
+  @tracked posts_count;
 
   message = null;
   errorLoading = false;
@@ -666,7 +669,7 @@ export default class Topic extends RestModel {
 
   firstPost() {
     const postStream = this.postStream;
-    let firstPost = postStream.get("posts.firstObject");
+    let firstPost = postStream.posts[0];
 
     if (firstPost && firstPost.post_number === 1) {
       return Promise.resolve(firstPost);

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -341,12 +341,12 @@ export default class TopicRoute extends DiscourseRoute {
     const postStream = topic.get("postStream");
     postStream.set("filter", get(params, "filter"));
 
-    const usernames = get(params, "username_filters"),
-      userFilters = postStream.get("userFilters");
+    const usernames = get(params, "username_filters");
 
-    userFilters.clear();
     if (!isEmpty(usernames) && usernames !== "undefined") {
-      userFilters.addObjects(usernames.split(","));
+      postStream.userFilters = [...new Set(usernames.split(","))];
+    } else {
+      postStream.userFilters = [];
     }
 
     return topic;

--- a/app/assets/javascripts/discourse/app/services/composer.js
+++ b/app/assets/javascripts/discourse/app/services/composer.js
@@ -859,7 +859,7 @@ export default class ComposerService extends Service {
 
     // If there is no current post, use the first post id from the stream
     if (!postId && postStream) {
-      postId = postStream.get("stream.firstObject");
+      postId = postStream.firstPostId;
     }
 
     // If we're editing a post, fetch the reply when importing a quote

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -352,7 +352,7 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
       const stream = this.get("composerModel.topic.postStream");
 
       if (stream.get("firstPostPresent")) {
-        const post = stream.get("posts.firstObject");
+        const post = stream.posts[0];
         if (post && !post.get("yours") && post.get("username")) {
           usernames = post.get("username");
         }


### PR DESCRIPTION
Replaced `discourseComputed` and `.get()` calls with modern JavaScript getter syntax and updated arrays to use `@trackedArray` from `tracked-tools`. This improves readability and aligns with current Ember best practices.

Ensured all dependencies and derived properties function correctly post-refactor.