### PR TITLE
FIX: Show more button now loads additional root-level subcategories

### DIFF
--- a/spec/system/page_objects/modals/sidebar_edit_categories.rb
+++ b/spec/system/page_objects/modals/sidebar_edit_categories.rb
@@ -55,12 +55,20 @@ module PageObjects
         has_css?(".sidebar-categories-form__category-row[data-category-id='#{category.id}']")
       end
 
-      def has_no_show_more_button?
-        has_no_css?(".sidebar-categories-form__show-more-btn")
+      def has_no_category_row?(category)
+        has_no_css?(".sidebar-categories-form__category-row[data-category-id='#{category.id}']")
       end
 
-      def has_show_more_button?
-        has_css?(".sidebar-categories-form__show-more-btn")
+      def has_no_show_more_button?(level: 1)
+        has_no_css?(
+          ".sidebar-categories-form__category-row[data-category-level=\"#{level}\"] .sidebar-categories-form__show-more-btn",
+        )
+      end
+
+      def has_show_more_button?(level: 1)
+        has_css?(
+          ".sidebar-categories-form__category-row[data-category-level=\"#{level}\"] .sidebar-categories-form__show-more-btn",
+        )
       end
 
       def scroll_to_category(category)
@@ -68,8 +76,10 @@ module PageObjects
         self
       end
 
-      def click_show_more_button
-        find(".sidebar-categories-form__show-more-btn").click
+      def click_show_more_button(level: 1)
+        find(
+          ".sidebar-categories-form__category-row[data-category-level=\"#{level}\"] .sidebar-categories-form__show-more-btn",
+        ).click
         self
       end
     end


### PR DESCRIPTION
Followup 9a9a0e5c1b39956b97b2188df7c79a07cf07b4ef

The "Show more" button in the sidebar categories modal was not working
when a root-level category had more than 5 subcategories (e.g., a
grandparent category with 6+ parent categories as children).

Root-level categories have `parent_category_id: undefined`, but the
`findPartialCategories` function was checking `categoriesById.has(id)`
before creating "Show more" buttons. Since `undefined` is never in the
categoriesById map, no button was created for root-level pagination.

The fix adds special handling for `undefined` parent IDs throughout the
component, treating root-level categories as a valid case for pagination.
