### PR TITLE
FIX: Run scheduled problem checks even when no tracker exists yet

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -112,6 +112,11 @@ class ProblemCheck
     Collection.new(checks.select(&:realtime?))
   end
 
+  def self.tracker(target = NO_TARGET)
+    ProblemCheckTracker[identifier, target]
+  end
+  delegate :tracker, to: :class
+
   def self.identifier
     name.demodulize.underscore.to_sym
   end
@@ -136,6 +141,11 @@ class ProblemCheck
     inline
   end
   delegate :inline?, to: :class
+
+  def self.ready_to_run?
+    tracker.ready_to_run?
+  end
+  delegate :ready_to_run?, to: :class
 
   def self.call(data = {})
     new(data).call
@@ -179,10 +189,6 @@ class ProblemCheck
   end
 
   private
-
-  def tracker(target = NO_TARGET)
-    ProblemCheckTracker[identifier, target]
-  end
 
   def targets
     [NO_TARGET]

--- a/spec/jobs/run_problem_checks_spec.rb
+++ b/spec/jobs/run_problem_checks_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe Jobs::RunProblemChecks do
     ProblemCheck.send(:remove_const, "DisabledCheck")
   end
 
+  context "when a tracker hasn't been created yet" do
+    it "still schedules checks" do
+      expect_enqueued_with(
+        job: :run_problem_check,
+        args: {
+          check_identifier: "scheduled_check",
+        },
+      ) { described_class.new.execute([]) }
+    end
+  end
+
   context "when the tracker determines the check is ready to run" do
     before do
       ProblemCheckTracker.create!(identifier: "scheduled_check", next_run_at: 5.minutes.ago)


### PR DESCRIPTION
### What is this change?

Scheduled problem checks without trackers weren't being run. This is because we directly tried to look for trackers instead of going through the checks.