### PR TITLE
UX: hide time in month view on mobile

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -33,6 +33,7 @@ export default class FullCalendar extends Component {
   @service menu;
   @service siteSettings;
   @service loadingSlider;
+  @service site;
 
   @controller topic;
 
@@ -84,6 +85,12 @@ export default class FullCalendar extends Component {
       weekends: this.args.weekends ?? true,
       initialDate: this.args.initialDate,
       height: this.args.height ?? "100%",
+      views: {
+        dayGridMonth: {
+          displayEventTime: this.site.desktopView,
+        },
+      },
+
       events: async (info, successCallback, failureCallback) => {
         if (this.args.onLoadEvents) {
           try {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -33,7 +33,6 @@ export default class FullCalendar extends Component {
   @service menu;
   @service siteSettings;
   @service loadingSlider;
-  @service site;
 
   @controller topic;
 
@@ -85,12 +84,6 @@ export default class FullCalendar extends Component {
       weekends: this.args.weekends ?? true,
       initialDate: this.args.initialDate,
       height: this.args.height ?? "100%",
-      views: {
-        dayGridMonth: {
-          displayEventTime: this.site.desktopView,
-        },
-      },
-
       events: async (info, successCallback, failureCallback) => {
         if (this.args.onLoadEvents) {
           try {

--- a/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
@@ -55,8 +55,16 @@
   opacity: 0.3;
 }
 
-.fc-dayGridMonth-view .fc-event-time {
-  overflow: visible !important;
+.fc-dayGridMonth-view {
+  .fc-event-time {
+    overflow: visible !important;
+  }
+
+  @include viewport.until(md) {
+    .fc-event-time {
+      display: none;
+    }
+  }
 }
 
 #upcoming-events-calendar {


### PR DESCRIPTION
We have limited space and removing the time in this case allows to have more space for the text of the event.