### PR TITLE
FIX: post voting comments editing UX

### DIFF
--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-comment-actions.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-comment-actions.gjs
@@ -16,7 +16,7 @@ export default class PostVotingCommentActions extends Component {
 
   comment = this.args.comment;
 
-  hasPermission() {
+  get hasPermission() {
     return (
       this.comment.user_id === this.currentUser.id ||
       this.currentUser.admin ||
@@ -83,7 +83,6 @@ export default class PostVotingCommentActions extends Component {
           @action={{this.deleteConfirm}}
           @icon="far-trash-can"
         />
-
         {{#if this.canFlag}}
           <DButton
             @display="link"

--- a/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
+++ b/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
@@ -231,6 +231,10 @@ function setupPostVoting(needs, postStreamMode) {
             "displays the right number of comments for the second post"
           );
 
+        assert
+          .dom("#post_2 .post-voting-comment-action")
+          .doesNotExist("does not display comment action to anon users");
+
         await click(".post-voting-comments-menu-show-more-link");
 
         assert
@@ -492,6 +496,44 @@ function setupPostVoting(needs, postStreamMode) {
         assert
           .dom("#post_1 .post-voting-comment")
           .exists({ count: 3 }, "should add the new comment");
+      });
+
+      test("regular user can't edit other people's comments", async function (assert) {
+        updateCurrentUser({ id: 9876, admin: false, moderator: false }); // hasn't commented
+
+        await visit("/t/280");
+
+        assert
+          .dom("#post_2 .post-voting-comment-actions")
+          .doesNotExist(
+            "does not display edit link on other people's comments"
+          );
+      });
+
+      test("moderator can edit other people's comments", async function (assert) {
+        updateCurrentUser({ id: 9876, admin: false, moderator: true }); // hasn't commented
+
+        await visit("/t/280");
+
+        assert
+          .dom("#post_2 .post-voting-comment-actions")
+          .exists(
+            { count: 5 },
+            "displays edit link on other people's comments"
+          );
+      });
+
+      test("admin can edit other people's comments", async function (assert) {
+        updateCurrentUser({ id: 9876, admin: true, moderator: false }); // hasn't commented
+
+        await visit("/t/280");
+
+        assert
+          .dom("#post_2 .post-voting-comment-actions")
+          .exists(
+            { count: 5 },
+            "displays edit link on other people's comments"
+          );
       });
 
       test("editing a comment", async function (assert) {


### PR DESCRIPTION
was showing up inconditionnaly even if you didn't have the permissions to edit other people's comments.

This was only a UX issue as the server is doing the correct check.

The issue was the `hasPermission` method which wasn't a getter so it wasn't checked for all the instances of the post comments but rather once.

Also added some acceptance tests to ensure we don't regress.

Internal ref - t/163347