### PR TITLE
DEV: Query human users in "discourse" converter correctly

### DIFF
--- a/migrations/lib/converters/discourse/steps/category_users.rb
+++ b/migrations/lib/converters/discourse/steps/category_users.rb
@@ -8,7 +8,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM category_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
@@ -16,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT *
         FROM category_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 

--- a/migrations/lib/converters/discourse/steps/tag_users.rb
+++ b/migrations/lib/converters/discourse/steps/tag_users.rb
@@ -8,14 +8,14 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM tag_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
     def items
       @source_db.query <<~SQL
         SELECT * FROM tag_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY tag_id, user_id
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/topic_allowed_users.rb
+++ b/migrations/lib/converters/discourse/steps/topic_allowed_users.rb
@@ -8,7 +8,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM topic_allowed_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
@@ -16,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT *
         FROM topic_allowed_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY topic_id, user_id
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/topic_users.rb
+++ b/migrations/lib/converters/discourse/steps/topic_users.rb
@@ -8,7 +8,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM topic_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
@@ -16,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT *
         FROM topic_users
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY topic_id, user_id
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/user_associated_accounts.rb
+++ b/migrations/lib/converters/discourse/steps/user_associated_accounts.rb
@@ -6,7 +6,9 @@ module Migrations::Converters::Discourse
 
     def max_progress
       @source_db.count <<~SQL
-        SELECT COUNT(*) FROM user_associated_accounts
+        SELECT COUNT(*)
+        FROM user_associated_accounts
+        WHERE user_id > 0
       SQL
     end
 
@@ -14,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT *
         FROM user_associated_accounts
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY id
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/user_emails.rb
+++ b/migrations/lib/converters/discourse/steps/user_emails.rb
@@ -8,7 +8,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM user_emails
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
@@ -16,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT user_id, email, "primary", created_at
         FROM user_emails
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY user_id, email
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/user_field_values.rb
+++ b/migrations/lib/converters/discourse/steps/user_field_values.rb
@@ -10,7 +10,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM user_custom_fields
-        WHERE user_id >= 0
+        WHERE user_id > 0
           AND name LIKE '#{USER_FIELD_PREFIX}%'
       SQL
     end
@@ -21,7 +21,7 @@ module Migrations::Converters::Discourse
                CAST(REPLACE(name, '#{USER_FIELD_PREFIX}', '') AS INTEGER) AS field_id,
                (COUNT(*) OVER (PARTITION BY user_id, name) > 1)           AS is_multiselect_field
         FROM user_custom_fields
-        WHERE user_id >= 0
+        WHERE user_id > 0
           AND name LIKE '#{USER_FIELD_PREFIX}%'
         ORDER BY user_id, name
       SQL

--- a/migrations/lib/converters/discourse/steps/user_options.rb
+++ b/migrations/lib/converters/discourse/steps/user_options.rb
@@ -8,7 +8,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM user_options
-        WHERE user_id >= 0
+        WHERE user_id > 0
       SQL
     end
 
@@ -16,7 +16,7 @@ module Migrations::Converters::Discourse
       @source_db.query <<~SQL
         SELECT *
         FROM user_options
-        WHERE user_id >= 0
+        WHERE user_id > 0
         ORDER BY user_id
       SQL
     end

--- a/migrations/lib/converters/discourse/steps/users.rb
+++ b/migrations/lib/converters/discourse/steps/users.rb
@@ -14,7 +14,7 @@ module Migrations::Converters::Discourse
       @source_db.count <<~SQL
         SELECT COUNT(*)
         FROM users
-        WHERE id >= 0
+        WHERE id > 0
       SQL
     end
 

--- a/migrations/lib/importer/steps/category_users.rb
+++ b/migrations/lib/importer/steps/category_users.rb
@@ -34,7 +34,7 @@ module Migrations::Importer::Steps
       @existing_category_users = Hash.new { |h, k| h[k] = Set.new }
 
       @discourse_db
-        .query_array("SELECT category_id, user_id FROM category_users WHERE user_id >= 0")
+        .query_array("SELECT category_id, user_id FROM category_users WHERE user_id > 0")
         .each { |row| @existing_category_users[row[0]].add(row[1]) }
 
       super


### PR DESCRIPTION
Human users are defined as `id > 0`

see https://github.com/discourse/discourse/blob/73e13fc63b792f440ef9c23fa274bdd6fa3b2b83/app/models/user.rb#L274-L281