### PR TITLE
Revert "DEV: Debug cookie overflows"

### DIFF
--- a/lib/action_dispatch/session/discourse_cookie_store.rb
+++ b/lib/action_dispatch/session/discourse_cookie_store.rb
@@ -22,9 +22,6 @@ class ActionDispatch::Session::DiscourseCookieStore < ActionDispatch::Session::C
       end
     end
     cookie_jar(request)[@key] = cookie
-  rescue ActionDispatch::Cookies::CookieOverflow
-    Rails.logger.error("Cookie overflow occurred for #{@key}: #{request.session.to_h.inspect}")
-    raise
   end
 
   def session_has_changed?(request, session)

--- a/spec/integration/discourse_cookie_store_spec.rb
+++ b/spec/integration/discourse_cookie_store_spec.rb
@@ -13,24 +13,4 @@ describe ActionDispatch::Session::DiscourseCookieStore, type: :request do
     expect(response.cookies["_forum_session"]).not_to be_present
     expect(session[:_csrf_token]).to eq(csrf_token)
   end
-
-  describe "Cookie overflow" do
-    context "when cookie size exceeds limit" do
-      let(:fake_logger) { FakeLogger.new }
-
-      before do
-        Rails.logger.broadcast_to(fake_logger)
-        allow_any_instance_of(ActionController::RequestForgeryProtection).to receive(
-          :generate_csrf_token,
-        ).and_return(SecureRandom.urlsafe_base64(4097))
-      end
-
-      after { Rails.logger.stop_broadcasting_to(fake_logger) }
-
-      it "logs an error" do
-        get "/session/csrf.json"
-        expect(fake_logger.errors).to include(/Cookie overflow occurred.*"_csrf_token"=>/)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Reverts discourse/discourse#34639

We understood the main culprit for cookie overflows was storing `destination_url` in the session, so we don’t really need that debug code anymore.