### PR TITLE
FIX: discourse_id_challenge response when using subfolder

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -33,9 +33,12 @@ class MetadataController < ApplicationController
     token = Discourse.redis.get("discourse_id_challenge_token")
     raise Discourse::NotFound if token.blank?
 
+    domain = Discourse.current_hostname
+    path = Discourse.base_path.presence
+
     expires_in 5.minutes
 
-    render json: { token:, domain: Discourse.current_hostname }
+    render json: { token:, domain:, path: }.compact
   end
 
   private

--- a/spec/requests/metadata_controller_spec.rb
+++ b/spec/requests/metadata_controller_spec.rb
@@ -223,6 +223,24 @@ RSpec.describe MetadataController do
         json = response.parsed_body
         expect(json["token"]).to eq(token)
         expect(json["domain"]).to eq(Discourse.current_hostname)
+        expect(json).to_not have_key("path")
+      end
+
+      context "when using subfolder" do
+        before { set_subfolder "/f" }
+
+        it "also returns the path" do
+          get "/.well-known/discourse-id-challenge"
+
+          expect(response.status).to eq(200)
+          expect(response.media_type).to eq("application/json")
+          expect(response.headers["Cache-Control"]).to eq("max-age=300, private")
+
+          json = response.parsed_body
+          expect(json["token"]).to eq(token)
+          expect(json["domain"]).to eq(Discourse.current_hostname)
+          expect(json["path"]).to eq(Discourse.base_path)
+        end
       end
     end
 


### PR DESCRIPTION
Added subfolder support for #discourse-id automated registration in 874c875e02794aa but we were missing returning the "path" in the response from the "discourse_id_challenge".

This ensures we also return the "path" field in the challenge so it can properly be validatated by id.discourse.com.

Internal ref - t/161934/21