### PR TITLE
FIX: show AI gists in mobile messages

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-gist-connector.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-gist-connector.gjs
@@ -88,7 +88,7 @@ export default apiInitializer((api) => {
 
   if (settings.discourse_ai_enabled && settings.ai_summarization_enabled) {
     const OUTLETS = {
-      mobile: "topic-list-before-category",
+      mobile: "topic-list-main-link-bottom",
       desktop: "topic-list-topic-cell-link-bottom-line__before",
     };
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/summarization/common/ai-gists.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/summarization/common/ai-gists.scss
@@ -61,8 +61,10 @@
 
   .mobile-view & {
     .topic-list-item .excerpt {
-      margin-top: -0.25em;
-      margin-bottom: 0.25em;
+      display: block;
+      margin-top: 0.5em;
+      margin-bottom: 0;
+      font-size: var(--font-down-1);
     }
 
     .topic-item-stats .num.activity {

--- a/plugins/discourse-ai/spec/system/summarization/gists_toggle_spec.rb
+++ b/plugins/discourse-ai/spec/system/summarization/gists_toggle_spec.rb
@@ -136,7 +136,24 @@ describe "Gists Toggle Functionality - Mobile", type: :system, mobile: true do
         text: I18n.t("js.discourse_ai.summarization.topic_list_layout.button.expanded"),
       ).click
 
-      expect(page).to have_css(".topic-item-stats__category-tags .excerpt__contents")
+      expect(page).to have_css(".main-link .excerpt__contents")
+    end
+  end
+
+  context "when viewing PMs on mobile" do
+    fab!(:pm_topic) { Fabricate(:private_message_topic, user: admin, recipient: Fabricate(:user)) }
+    fab!(:pm_gist) { Fabricate(:topic_ai_gist, target: pm_topic) }
+
+    it "renders gist component in mobile PM list" do
+      visit("/u/#{admin.username}/messages/new")
+
+      find(".topic-list-layout-trigger").click
+      find(
+        ".dropdown-menu__item .d-button-label",
+        text: I18n.t("js.discourse_ai.summarization.topic_list_layout.button.expanded"),
+      ).click
+
+      expect(page).to have_css(".main-link .excerpt__contents")
     end
   end
 end


### PR DESCRIPTION
The outlet used previously doesn't render when there's no category (in message topic lists) so here I'm moving it to an outlet that does. Also added a spec to check for this case. 



Before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/831cd17f-db6b-49d8-a2eb-88a668854e2b" />
 
 
 
After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f1e5c672-ca0f-4b84-9241-c0211f12c5e7" />
