### PR TITLE
FIX: Allow mediaconvert client without endpoint

### DIFF
--- a/app/services/video_conversion/aws_media_convert_adapter.rb
+++ b/app/services/video_conversion/aws_media_convert_adapter.rb
@@ -191,7 +191,8 @@ module VideoConversion
     end
 
     def create_basic_client(endpoint: nil)
-      client_options = { region: SiteSetting.s3_region, endpoint: endpoint }
+      client_options = { region: SiteSetting.s3_region }
+      client_options[:endpoint] = endpoint if endpoint.present?
 
       if !SiteSetting.s3_use_iam_profile
         client_options[:credentials] = Aws::Credentials.new(


### PR DESCRIPTION
We need to initially create a MediaConvert client without an endpoint.
Rather than passing in nil for the endpoint just don't pass the endpoint
parameter at all otherwise you will get an error from aws.
