### PR TITLE
FIX: Disable replies button until replies are loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/components/post.gjs
+++ b/app/assets/javascripts/discourse/app/components/post.gjs
@@ -54,7 +54,7 @@ export default class Post extends Component {
   /**
    * @type {boolean}
    */
-  @tracked isToggleRepliesInFlight = false;
+  @tracked isTogglingReplies = false;
 
   decoratorState = new TrackedMap();
 
@@ -321,26 +321,18 @@ export default class Post extends Component {
 
   @action
   async toggleReplies() {
-    if (this.isToggleRepliesInFlight) {
+    if (this.isTogglingReplies) {
       return;
     }
 
-    const isExpanding = this.filteredRepliesView
-      ? !this.filteredRepliesShown
-      : this.repliesBelow.length === 0;
-
-    if (isExpanding) {
-      this.isToggleRepliesInFlight = true;
-    }
+    this.isTogglingReplies = true;
 
     try {
       return this.filteredRepliesView
         ? await this.toggleFilteredRepliesView()
         : await this.toggleRepliesBelow();
     } finally {
-      if (isExpanding) {
-        this.isToggleRepliesInFlight = false;
-      }
+      this.isTogglingReplies = false;
     }
   }
 
@@ -608,7 +600,7 @@ export default class Post extends Component {
                           @rebakePost={{@rebakePost}}
                           @recoverPost={{@recoverPost}}
                           @repliesShown={{this.repliesShown}}
-                          @repliesButtonDisabled={{this.isToggleRepliesInFlight}}
+                          @repliesButtonDisabled={{this.isTogglingReplies}}
                           @replyToPost={{@replyToPost}}
                           @share={{this.share}}
                           @showFlags={{@showFlags}}

--- a/app/assets/javascripts/discourse/app/components/post.gjs
+++ b/app/assets/javascripts/discourse/app/components/post.gjs
@@ -51,6 +51,11 @@ export default class Post extends Component {
   @tracked repliesAbove;
   @tracked repliesBelow = new TrackedArray();
 
+  /**
+   * @type {boolean}
+   */
+  @tracked isToggleRepliesInFlight = false;
+
   decoratorState = new TrackedMap();
 
   addEventListeners = modifier((element, [listeners]) => {
@@ -316,9 +321,27 @@ export default class Post extends Component {
 
   @action
   async toggleReplies() {
-    return this.filteredRepliesView
-      ? await this.toggleFilteredRepliesView()
-      : await this.toggleRepliesBelow();
+    if (this.isToggleRepliesInFlight) {
+      return;
+    }
+
+    const isExpanding = this.filteredRepliesView
+      ? !this.filteredRepliesShown
+      : this.repliesBelow.length === 0;
+
+    if (isExpanding) {
+      this.isToggleRepliesInFlight = true;
+    }
+
+    try {
+      return this.filteredRepliesView
+        ? await this.toggleFilteredRepliesView()
+        : await this.toggleRepliesBelow();
+    } finally {
+      if (isExpanding) {
+        this.isToggleRepliesInFlight = false;
+      }
+    }
   }
 
   @action
@@ -585,6 +608,7 @@ export default class Post extends Component {
                           @rebakePost={{@rebakePost}}
                           @recoverPost={{@recoverPost}}
                           @repliesShown={{this.repliesShown}}
+                          @repliesButtonDisabled={{this.isToggleRepliesInFlight}}
                           @replyToPost={{@replyToPost}}
                           @share={{this.share}}
                           @showFlags={{@showFlags}}

--- a/app/assets/javascripts/discourse/app/components/post/menu.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu.gjs
@@ -598,6 +598,7 @@ export default class PostMenu extends Component {
       isWhoReadVisible: this.isWhoReadVisible,
       isWikiMode: this.isWikiMode,
       repliesShown: this.args.repliesShown,
+      repliesButtonDisabled: this.args.repliesButtonDisabled,
       replyDirectlyBelow:
         this.args.nextPost?.reply_to_post_number ===
           this.args.post.post_number &&

--- a/app/assets/javascripts/discourse/app/components/post/menu/buttons/replies.gjs
+++ b/app/assets/javascripts/discourse/app/components/post/menu/buttons/replies.gjs
@@ -26,7 +26,7 @@ export default class PostMenuRepliesButton extends Component {
   @service site;
 
   get disabled() {
-    return !!this.args.post.deleted;
+    return !!this.args.post.deleted || this.args.state?.repliesButtonDisabled;
   }
 
   get translatedTitle() {


### PR DESCRIPTION
This prevents users from clicking multiple times and causing replies to be shown more than once while expansion is in progress.