### PR TITLE
DEV: add ical format response for discourse-post-events index route

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -18,7 +18,7 @@ module DiscoursePostEvent
 
       respond_to do |format|
         format.ics do
-          filename = "events-#{@events.map(&:id).join("-")}"
+          filename = "events-#{Digest::SHA1.hexdigest(@events.map(&:id).sort.join("-"))}"
           response.headers[
             "Content-Disposition"
           ] = "attachment; filename=\"#{filename}.#{request.format.symbol}\""

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -18,10 +18,8 @@ module DiscoursePostEvent
 
       respond_to do |format|
         format.ics do
-          filename = "events-#{Digest::SHA1.hexdigest(@events.map(&:id).sort.join("-"))}"
-          response.headers[
-            "Content-Disposition"
-          ] = "attachment; filename=\"#{filename}.#{request.format.symbol}\""
+          filename = "events-#{Digest::SHA1.hexdigest(@events.map(&:id).sort.join("-"))}.ics"
+          response.headers["Content-Disposition"] = "attachment; filename=\"#{filename}\""
         end
 
         format.json do

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -141,10 +141,10 @@ module DiscoursePostEvent
         :category_id,
         :include_subcategories,
         :limit,
-        :before,
         :attending_user,
         :before,
         :after,
+        :order,
       )
     end
   end

--- a/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
+++ b/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
@@ -1,0 +1,15 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Discourse//<%= Discourse.current_hostname %>//<%= Discourse.full_version %>//EN
+<% @events.each do |event| %>
+  BEGIN:VEVENT
+  UID:calendar_event_#<%= event.id %>@<%= Discourse.current_hostname %>
+  DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
+  DTSTART:<%= event.starts_at.strftime("%Y%m%dT%H%M%SZ") %>
+  DTEND:<%= event.ends_at.presence ? event.ends_at.strftime("%Y%m%dT%H%M%SZ") : (event.starts_at + 1.hour).strftime("%Y%m%dT%H%M%SZ") %>
+  SUMMARY:<%= event.name.presence || event.post.topic.title %>
+  DESCRIPTION:<%= PrettyText.format_for_email(event.post.excerpt, event.post).html_safe %>
+  URL:<%= Discourse.base_url %>/t/-/<%= event.post.topic_id %>/<%= event.post.post_number %>
+  END:VEVENT
+<% end %>
+END:VCALENDAR

--- a/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
+++ b/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
@@ -2,14 +2,14 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Discourse//<%= Discourse.current_hostname %>//<%= Discourse.full_version %>//EN
 <% @events.each do |event| %>
-  BEGIN:VEVENT
-  UID:calendar_event_#<%= event.id %>@<%= Discourse.current_hostname %>
-  DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
-  DTSTART:<%= event.starts_at.strftime("%Y%m%dT%H%M%SZ") %>
-  DTEND:<%= event.ends_at.presence ? event.ends_at.strftime("%Y%m%dT%H%M%SZ") : (event.starts_at + 1.hour).strftime("%Y%m%dT%H%M%SZ") %>
-  SUMMARY:<%= event.name.presence || event.post.topic.title %>
-  DESCRIPTION:<%= PrettyText.format_for_email(event.post.excerpt, event.post).html_safe %>
-  URL:<%= Discourse.base_url %>/t/-/<%= event.post.topic_id %>/<%= event.post.post_number %>
-  END:VEVENT
+BEGIN:VEVENT
+UID:calendar_event_#<%= event.id %>@<%= Discourse.current_hostname %>
+DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
+DTSTART:<%= event.starts_at.strftime("%Y%m%dT%H%M%SZ") %>
+DTEND:<%= event.ends_at.presence ? event.ends_at.strftime("%Y%m%dT%H%M%SZ") : (event.starts_at + 1.hour).strftime("%Y%m%dT%H%M%SZ") %>
+SUMMARY:<%= event.name.presence || event.post.topic.title %>
+DESCRIPTION:<%= PrettyText.format_for_email(event.post.excerpt, event.post).html_safe.gsub(/\r?\n/, '\n') %>
+URL:<%= Discourse.base_url %>/t/-/<%= event.post.topic_id %>/<%= event.post.post_number %>
+END:VEVENT
 <% end %>
 END:VCALENDAR

--- a/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
+++ b/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
@@ -2,14 +2,14 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Discourse//<%= Discourse.current_hostname %>//<%= Discourse.full_version %>//EN
 <% @events.each do |event| %>
-BEGIN:VEVENT
-UID:calendar_event_#<%= event.id %>@<%= Discourse.current_hostname %>
-DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
-DTSTART:<%= event.starts_at.strftime("%Y%m%dT%H%M%SZ") %>
-DTEND:<%= event.ends_at.presence ? event.ends_at.strftime("%Y%m%dT%H%M%SZ") : (event.starts_at + 1.hour).strftime("%Y%m%dT%H%M%SZ") %>
-SUMMARY:<%= event.name.presence || event.post.topic.title %>
-DESCRIPTION:<%= PrettyText.format_for_email(event.post.excerpt, event.post).html_safe.gsub(/\r?\n/, '\n') %>
-URL:<%= Discourse.base_url %>/t/-/<%= event.post.topic_id %>/<%= event.post.post_number %>
-END:VEVENT
+  BEGIN:VEVENT
+  UID:calendar_event_#<%= event.id %>@<%= Discourse.current_hostname %>
+  DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
+  DTSTART:<%= event.starts_at.strftime("%Y%m%dT%H%M%SZ") %>
+  DTEND:<%= event.ends_at.presence ? event.ends_at.strftime("%Y%m%dT%H%M%SZ") : (event.starts_at + 1.hour).strftime("%Y%m%dT%H%M%SZ") %>
+  SUMMARY:<%= event.name.presence || event.post.topic.title %>
+  DESCRIPTION:<%= PrettyText.format_for_email(event.post.excerpt, event.post).html_safe.gsub(/\r?\n/, '\n') %>
+  URL:<%= event.post.topic.url(event.post.post_number) %>
+  END:VEVENT
 <% end %>
 END:VCALENDAR

--- a/plugins/discourse-calendar/config/routes.rb
+++ b/plugins/discourse-calendar/config/routes.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 DiscoursePostEvent::Engine.routes.draw do
-  get "/discourse-post-event/events" => "events#index", :format => :json
+  get "/discourse-post-event/events" => "events#index",
+      :constraints => {
+        format: /(json|ics)/,
+      },
+      :defaults => {
+        format: :json,
+      }
   get "/discourse-post-event/events/:id" => "events#show"
   delete "/discourse-post-event/events/:id" => "events#destroy"
   post "/discourse-post-event/events" => "events#create"

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -27,11 +27,15 @@ module DiscoursePostEvent
         .merge(Post.secured(guardian))
         .merge(topics.or(pms))
         .joins(latest_event_date_join)
-        .select("discourse_post_event_events.*, latest_event_dates.starts_at")
+        .select(
+          "discourse_post_event_events.*, latest_event_dates.starts_at, latest_event_dates.finished_at",
+        )
         .where(
           "(discourse_post_event_events.recurrence IS NOT NULL) OR (latest_event_dates.starts_at IS NOT NULL) OR (discourse_post_event_events.original_starts_at IS NOT NULL)",
         )
-        .distinct
+        .group(
+          "discourse_post_event_events.id, latest_event_dates.starts_at, latest_event_dates.finished_at",
+        )
     end
 
     def self.latest_event_date_join

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -10,7 +10,7 @@ module DiscoursePostEvent
         .then { |query| filter_by_attending_user(query, params, guardian, user) }
         .then { |query| filter_by_dates(query, params) }
         .then { |query| filter_by_category(query, params) }
-        .then { |query| apply_ordering(query) }
+        .then { |query| apply_ordering(query, params) }
         .then { |query| apply_limit(query, params) }
     end
 
@@ -143,8 +143,11 @@ module DiscoursePostEvent
       events.where(topics: { category_id: category_ids })
     end
 
-    def self.apply_ordering(events)
-      events.order("latest_event_dates.starts_at ASC, discourse_post_event_events.id ASC")
+    def self.apply_ordering(events, params)
+      order_direction = params[:order] == "desc" ? "DESC" : "ASC"
+      events.order(
+        "latest_event_dates.starts_at #{order_direction}, discourse_post_event_events.id #{order_direction}",
+      )
     end
 
     def self.apply_limit(events, params)

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -237,5 +237,31 @@ describe DiscoursePostEvent::EventFinder do
         expect(results).to include(current_event)
       end
     end
+
+    describe "with an order parameter provided" do
+      let!(:event1) { Fabricate(:event, original_starts_at: 3.days.from_now) }
+      let!(:event2) { Fabricate(:event, original_starts_at: 1.day.from_now) }
+      let!(:event3) { Fabricate(:event, original_starts_at: 2.days.from_now) }
+
+      it "returns events in ascending order by default" do
+        results = finder.search(current_user)
+        expect(results.pluck(:id)).to eq([event2.id, event3.id, event1.id])
+      end
+
+      it "returns events in ascending order when order=asc" do
+        results = finder.search(current_user, { order: "asc" })
+        expect(results.pluck(:id)).to eq([event2.id, event3.id, event1.id])
+      end
+
+      it "returns events in descending order when order=desc" do
+        results = finder.search(current_user, { order: "desc" })
+        expect(results.pluck(:id)).to eq([event1.id, event3.id, event2.id])
+      end
+
+      it "defaults to ascending order for invalid order values" do
+        results = finder.search(current_user, { order: "invalid" })
+        expect(results.pluck(:id)).to eq([event2.id, event3.id, event1.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
Reverts the removal of this from https://github.com/discourse/discourse-calendar/pull/231. This opens up the relative url `/discourse-post-event/events.ics` for access to an ical formatted response.

We also make available the `order` argument for this endpoint which defaults to ascending order if there is no value or invalid value passed. This maintains existing behaviour while allowing for users to specify that they want most recent events first.

### Testing

Downloaded an ical file from the endpoint and imported into my local laptop's calendar.
<img width="632" height="494" alt="imported events" src="https://github.com/user-attachments/assets/6498b982-9d22-4ea0-8fc9-edfe4ea1033d" />
