### PR TITLE
DEV: Add back lost admin problem notification

### DIFF
--- a/app/jobs/scheduled/notify_admins_of_problems.rb
+++ b/app/jobs/scheduled/notify_admins_of_problems.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Jobs
+  class NotifyAdminsOfProblems < ::Jobs::Scheduled
+    every 30.minutes
+
+    def execute(_args)
+      Notification
+        .where(notification_type: Notification.types[:admin_problems])
+        .where("created_at < ?", 7.days.ago)
+        .destroy_all
+
+      return if !persistent_problems?
+
+      notified_user_ids =
+        Notification.where(notification_type: Notification.types[:admin_problems]).pluck(:user_id)
+
+      users = Group[:admins].users.where.not(id: notified_user_ids)
+
+      users.each do |user|
+        Notification.create!(
+          notification_type: Notification.types[:admin_problems],
+          user_id: user.id,
+          data: "{}",
+        )
+      end
+    end
+
+    private
+
+    def persistent_problems?
+      ProblemCheckTracker.where(
+        "last_problem_at > last_success_at AND last_success_at < ?",
+        2.days.ago,
+      ).exists?
+    end
+  end
+end

--- a/spec/jobs/scheduled/notify_admins_of_problems_spec.rb
+++ b/spec/jobs/scheduled/notify_admins_of_problems_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe ::Jobs::NotifyAdminsOfProblems do
+  fab!(:admin)
+
+  it "creates notification when problems persist for at least 2 days" do
+    ProblemCheckTracker.create!(
+      identifier: "bad_favicon_url",
+      last_success_at: 3.days.ago,
+      last_problem_at: 1.hour.ago,
+    )
+
+    expect { described_class.new.execute({}) }.to change { Notification.count }.by(1)
+  end
+
+  it "does not replace old notification created in last 7 days" do
+    ProblemCheckTracker.create!(
+      identifier: "bad_favicon_url",
+      last_success_at: 3.days.ago,
+      last_problem_at: 1.hour.ago,
+    )
+    old_notification =
+      Notification.create!(
+        notification_type: Notification.types[:admin_problems],
+        user_id: admin.id,
+        data: "{}",
+      )
+
+    expect { described_class.new.execute({}) }.not_to change { Notification.count }
+    new_notification = Notification.last
+
+    expect(old_notification.id).to equal(new_notification.id)
+  end
+
+  it "replaces old notification created more than 7 days ago" do
+    ProblemCheckTracker.create!(
+      identifier: "bad_favicon_url",
+      last_success_at: 3.days.ago,
+      last_problem_at: 1.hour.ago,
+    )
+    old_notification =
+      Notification.create!(
+        notification_type: Notification.types[:admin_problems],
+        user_id: admin.id,
+        data: "{}",
+        created_at: 2.weeks.ago,
+      )
+
+    expect { described_class.new.execute({}) }.not_to change { Notification.count }
+    new_notification = Notification.last
+
+    expect(old_notification.id).not_to equal(new_notification.id)
+  end
+end


### PR DESCRIPTION
### What is this change?

When we revamped the problem check system, we lost [this job](https://github.com/discourse/discourse/pull/34403) that creates admin notifications when there are lingering problems. This PR adds it back.

It is almost a line-for-line copy of the original job and its tests, except for the implementation of `#persistent_problems?`.