### PR TITLE
UX: make lightbox hover caption unselectable

### DIFF
--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -4,6 +4,7 @@
   overflow: hidden;
 
   &:hover .meta {
+    user-select: none;
     opacity: 0.9;
     transition: opacity 0.5s;
   }


### PR DESCRIPTION
When quoting an image it is easy to accidentally select the image caption as it appears on hovering the image. Because of this the caption text also appears underneath the image (within the quote).

Making the caption text unselectable when hovering the image solves this.