### PR TITLE
DEV: Add `every_tag` option to tags schema-setting

### DIFF
--- a/app/assets/javascripts/admin/addon/components/schema-setting/types/tags.gjs
+++ b/app/assets/javascripts/admin/addon/components/schema-setting/types/tags.gjs
@@ -18,6 +18,7 @@ export default class SchemaSettingTypeTags extends SchemaSettingTypeModels {
       @tags={{this.value}}
       @onChange={{this.onInput}}
       @options={{this.tagChooserOption}}
+      @everyTag={{@spec.every_tag}}
       class={{if this.validationErrorMessage "--invalid"}}
     />
 


### PR DESCRIPTION
Allows for surfacing all tags by adding a `every_tag` option to the `tags` property. This value is then passed to the `everyTag` option on the `TagChooser` component

Demo:

```yml
    type: objects
    client: true
    default: "[]"
    schema:
      name: "state"
      properties:
        tags:
          type: tags
          min: 2
          every_tag: true
```

Defaults to `false` (current behavior)