### PR TITLE
Add a plugin outlet after preferences > security password section

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.gjs
@@ -95,6 +95,8 @@ export default RouteTemplate(
       {{/if}}
     {{/if}}
 
+    <PluginOutlet @name="user-preferences-security-after-password" />
+
     {{#if @controller.canCheckEmails}}
       <div
         class="control-group pref-auth-tokens"


### PR DESCRIPTION
Needed to implement additional/replacement instructions or functionality where the password change buttons usually live.