### PR TITLE
FIX: Removes debugging line

### DIFF
--- a/app/assets/javascripts/admin/addon/components/simple-list.gjs
+++ b/app/assets/javascripts/admin/addon/components/simple-list.gjs
@@ -82,7 +82,6 @@ export default class SimpleList extends Component {
     <div class="simple-list value-list" ...attributes>
       {{#if this.collection}}
         <div class="values">
-          {{this.collection.length}}
           {{#each this.collection as |value index|}}
             <div data-index={{index}} class="value">
               <DButton


### PR DESCRIPTION
Found while working on a customization. Caused a floating integer in the admin settings.

Before:
<img width="426" height="199" alt="Screenshot 2025-10-02 at 1 08 13 PM" src="https://github.com/user-attachments/assets/98e4148f-6e80-42fd-aa00-272cc05e238e" />

After:
<img width="388" height="211" alt="Screenshot 2025-10-02 at 1 37 48 PM" src="https://github.com/user-attachments/assets/680d4c33-4d2b-44ee-ad4c-6b4ac0eb0bd2" />
