### PR TITLE
DEV: Replace deprecated Ember's array `.clear()`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/about-page.gjs
+++ b/app/assets/javascripts/discourse/app/components/about-page.gjs
@@ -19,7 +19,7 @@ export function addAboutPageActivity(name, func) {
 }
 
 export function clearAboutPageActivities() {
-  pluginActivitiesFuncs.clear();
+  pluginActivitiesFuncs.length = 0;
 }
 
 export default class AboutPage extends Component {

--- a/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
+++ b/app/assets/javascripts/discourse/app/components/search-menu/search-term.gjs
@@ -16,7 +16,7 @@ export function addOnKeyUpCallback(fn) {
   onKeyUpCallbacks.push(fn);
 }
 export function resetOnKeyUpCallbacks() {
-  onKeyUpCallbacks.clear();
+  onKeyUpCallbacks.length = 0;
 }
 
 export default class SearchTerm extends Component {

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.gjs
@@ -22,7 +22,7 @@ export function addUserMenuProfileTabItem(item) {
 }
 
 export function resetUserMenuProfileTabItems() {
-  _extraItems.clear();
+  _extraItems.length = 0;
 }
 
 export default class UserMenuProfileTabContent extends Component {

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -385,7 +385,7 @@ export default class FullPageSearchController extends Controller {
     if (args.page === 1) {
       this.set("bulkSelectEnabled", false);
 
-      this.bulkSelectHelper.selected.clear();
+      this.bulkSelectHelper.clear();
       this.set("searching", true);
       scrollTop();
     } else {

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -267,6 +267,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   },
   {
     handler: "log",
+    matchId: "discourse.native-array-extensions.clear",
+  },
+  {
+    handler: "log",
     matchId: "discourse.native-array-extensions.compact",
   },
   {

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -29,7 +29,7 @@ export function addLogSearchLinkClickedCallbacks(fn) {
 }
 
 export function resetLogSearchLinkClickedCallbacks() {
-  logSearchLinkClickedCallbacks.clear();
+  logSearchLinkClickedCallbacks.length = 0;
 }
 
 export function addSearchResultsCallback(callback) {

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -341,9 +341,9 @@ export function customNavItemHref(cb) {
 }
 
 export function clearNavItems() {
-  NavItem.customNavItemHrefs.clear();
-  NavItem.extraArgsCallbacks.clear();
-  NavItem.extraNavItemDescriptors.clear();
+  NavItem.customNavItemHrefs.length = 0;
+  NavItem.extraArgsCallbacks.length = 0;
+  NavItem.extraNavItemDescriptors.length = 0;
 }
 
 export function addNavItem(item) {

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -990,5 +990,5 @@ export function registerCustomLastUnreadUrlCallback(fn) {
 
 // Should only be used in tests
 export function clearCustomLastUnreadUrlCallbacks() {
-  _customLastUnreadUrlCallbacks.clear();
+  _customLastUnreadUrlCallbacks.length = 0;
 }

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -339,7 +339,7 @@ export default class TopicRoute extends DiscourseRoute {
 
   setupParams(topic, params) {
     const postStream = topic.get("postStream");
-    postStream.set("filter", get(params, "filter"));
+    postStream.filter = get(params, "filter");
 
     const usernames = get(params, "username_filters");
 

--- a/app/assets/javascripts/discourse/tests/helpers/temporary-module-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/temporary-module-helper.js
@@ -38,5 +38,5 @@ export function cleanupTemporaryModuleRegistrations() {
     expireConnectorCache();
     DiscourseTemplateMap.setModuleNames(Object.keys(requirejs.entries));
   }
-  modifications.clear();
+  modifications.length = 0;
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
@@ -43,7 +43,7 @@ module(
     });
 
     test("empty state when there are no notifications", async function (assert) {
-      notificationsData.clear();
+      notificationsData.length = 0;
       await render(<template><NotificationsList /></template>);
       assert.dom(".empty-state .empty-state__title").exists();
       assert.dom(".empty-state .empty-state__body").exists();

--- a/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
@@ -274,7 +274,7 @@ module("Unit | Service | presence | entering and leaving", function (hooks) {
   });
 
   hooks.afterEach(function () {
-    requests.clear();
+    requests.length = 0;
     responseWaitPromise = null;
     responseStartPromise = null;
   });

--- a/app/assets/javascripts/discourse/tests/unit/utils/multi-cache-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/multi-cache-test.js
@@ -21,7 +21,7 @@ module("Unit | Utils | multi-cache", function (hooks) {
     assert.strictEqual(requests.length, 1, "one triggered request");
 
     const [request] = requests;
-    requests.clear();
+    requests.length = 0;
 
     assert.deepEqual(request.ids, [10], "request has correct ids");
 
@@ -52,7 +52,7 @@ module("Unit | Utils | multi-cache", function (hooks) {
 
     assert.strictEqual(requests.length, 1);
     const [request1] = requests;
-    requests.clear();
+    requests.length = 0;
     assert.deepEqual(request1.ids, [10]);
 
     request1.reject();

--- a/app/assets/javascripts/pretty-text/addon/oneboxer.js
+++ b/app/assets/javascripts/pretty-text/addon/oneboxer.js
@@ -16,7 +16,7 @@ const loadingQueue = [];
 export const LOADING_ONEBOX_CSS_CLASS = "loading-onebox";
 
 export function resetCache() {
-  loadingQueue.clear();
+  loadingQueue.length = 0;
   resetLocalCache();
   resetFailedCache();
 }


### PR DESCRIPTION
Refactor array-clearing logic across the codebase by replacing `.clear()`
with `.length = 0` for improved clarity and compatibility with standard
JavaScript arrays. Updated relevant tests and utilities to ensure consistency.

These changes align array management with modern JavaScript practices
while preserving existing functionality.