### PR TITLE
DEV: Replace deprecated Ember's array `.[]`

### DIFF
--- a/app/assets/javascripts/admin/addon/models/admin-user.js
+++ b/app/assets/javascripts/admin/addon/models/admin-user.js
@@ -5,6 +5,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { propertyNotEqual } from "discourse/lib/computed";
 import discourseComputed from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
+import { trackedArray } from "discourse/lib/tracked-tools";
 import { userPath } from "discourse/lib/url";
 import Group from "discourse/models/group";
 import User from "discourse/models/user";
@@ -25,6 +26,8 @@ export default class AdminUser extends User {
   }
 
   adminUserView = true;
+
+  @trackedArray groups;
 
   @filter("groups", (g) => !g.automatic && Group.create(g)) customGroups;
   @filter("groups", (g) => g.automatic && Group.create(g)) automaticGroups;
@@ -84,10 +87,7 @@ export default class AdminUser extends User {
     return ajax(`/admin/users/${this.id}/groups/${groupId}`, {
       type: "DELETE",
     }).then(() => {
-      this.set(
-        "groups.[]",
-        this.groups.filter((group) => group.id !== groupId)
-      );
+      this.groups = this.groups.filter((group) => group.id !== groupId);
       if (this.primary_group_id === groupId) {
         this.set("primary_group_id", null);
       }

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -259,6 +259,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   },
   {
     handler: "log",
+    matchId: "discourse.native-array-extensions.[]",
+  },
+  {
+    handler: "log",
     matchId: "discourse.native-array-extensions.any",
   },
   {

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
@@ -1,6 +1,9 @@
 const environment = require("discourse/lib/environment");
+const { withSilencedDeprecations } = require("discourse/lib/deprecated");
 
 environment.setEnvironment("qunit-testing");
 require("discourse/deprecation-workflow").default.setEnvironment(environment);
 
-require("discourse/tests/test-boot-ember-cli");
+withSilencedDeprecations("discourse.native-array-extensions.[]", () => {
+  require("discourse/tests/test-boot-ember-cli");
+});

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -48,7 +48,7 @@ const MORE_COLLECTION = "MORE_COLLECTION";
 @pluginApiIdentifiers(["category-drop"])
 export default class CategoryDrop extends ComboBoxComponent {
   @readOnly("category.id") value;
-  @readOnly("categoriesWithShortcuts.[]") content;
+  @readOnly("categoriesWithShortcuts") content;
   @readOnly("selectKit.options.parentCategory.displayName") parentCategoryName;
   @readOnly("selectKit.options.shouldDisplayIcon") shouldDisplayIcon;
   @setting("allow_uncategorized_topics") allowUncategorized;


### PR DESCRIPTION
Update deprecation workflows across several modules to handle specific deprecations, such as `discourse.native-array-extensions.[]`. Replace obsolete usage of array extensions in `CategoryDrop` and `AdminUser` components with modern alternatives (`trackedArray`). Enhancements ensure compatibility with future Ember versions, reducing technical debt.