### PR TITLE
DEV: Change to use `debugger` for pause_test

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -45,7 +45,7 @@ module SystemHelpers
       end
 
     result = ask("\n\e[33m#{msg}\e[0m")
-    binding.pry if result == "d" # rubocop:disable Lint/Debugger
+    debugger if result == "d" # rubocop:disable Lint/Debugger
     puts "\e[33mResuming...\e[0m"
     Process.kill("TERM", socat_pid) if socat_pid
     self


### PR DESCRIPTION
We now use `debugger` instead of `pry` since
https://github.com/discourse/discourse/commit/f608e0cd7e7d4785b3ecb401999cfb837cfbe783,
so we can update `pause_test` to use `debugger` as well
in system specs.
