### PR TITLE
DEV: Favor Upload.s3_upload_bucket for mediaconvert

### DIFF
--- a/app/services/video_conversion/aws_media_convert_adapter.rb
+++ b/app/services/video_conversion/aws_media_convert_adapter.rb
@@ -25,13 +25,13 @@ module VideoConversion
         domain, path = url.split("/", 2)
 
         # Verify the domain contains our bucket
-        if !domain&.include?(SiteSetting.s3_upload_bucket)
+        if !domain&.include?(s3_upload_bucket)
           raise Discourse::InvalidParameters.new(
-                  "Upload URL domain for upload ID #{@upload.id} does not contain expected bucket name: #{SiteSetting.s3_upload_bucket}",
+                  "Upload URL domain for upload ID #{@upload.id} does not contain expected bucket name: #{s3_upload_bucket}",
                 )
         end
 
-        input_path = "s3://#{SiteSetting.s3_upload_bucket}/#{path}"
+        input_path = "s3://#{s3_upload_bucket}/#{path}"
         settings = build_conversion_settings(input_path, output_path)
 
         begin
@@ -215,6 +215,14 @@ module VideoConversion
         end
     end
 
+    def s3_upload_bucket
+      self.class.s3_upload_bucket
+    end
+
+    def self.s3_upload_bucket
+      SiteSetting.Upload.s3_upload_bucket
+    end
+
     def build_conversion_settings(input_path, output_path)
       self.class.build_conversion_settings(input_path, output_path)
     end
@@ -230,7 +238,7 @@ module VideoConversion
             output_group_settings: {
               type: "FILE_GROUP_SETTINGS",
               file_group_settings: {
-                destination: "s3://#{SiteSetting.s3_upload_bucket}/#{output_path}",
+                destination: "s3://#{s3_upload_bucket}/#{output_path}",
               },
             },
             outputs: [

--- a/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
+++ b/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
     allow(SiteSetting).to receive(:mediaconvert_endpoint).and_return(
       "https://mediaconvert.endpoint",
     )
-    allow(SiteSetting).to receive(:s3_upload_bucket).and_return(s3_bucket)
+    allow(SiteSetting.Upload).to receive(:s3_upload_bucket).and_return(s3_bucket)
     allow(SiteSetting).to receive(:s3_region).and_return(s3_region)
     allow(SiteSetting).to receive(:s3_access_key_id).and_return("test-key")
     allow(SiteSetting).to receive(:s3_secret_access_key).and_return("test-secret")


### PR DESCRIPTION
In the aws_media_convert_adapter we were referencing
`SiteSetting.s3_upload_bucket` but that can be empty on some instances,
so we need to use the `SiteSetting.Upload.s3_upload_bucket` version,
which should always have a value when using s3.

This follows a similar pattern we used previously for other s3 related
settings.
