### PR TITLE
DEV: Fix flaky assign spec caused by unstable DOM

### DIFF
--- a/plugins/discourse-assign/spec/system/assign_topic_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_topic_spec.rb
@@ -141,6 +141,10 @@ describe "Assign | Assigning topics", type: :system do
             expect(page).to have_no_css("#post_4")
             expect(page).to have_no_css("#topic .assigned-to")
 
+            expect(page).to have_css(
+              "#topic-footer-button-assign",
+              text: I18n.t("js.discourse_assign.assign.title"),
+            )
             topic_page.click_assign_topic
             assign_modal.assignee = admin2
             assign_modal.confirm


### PR DESCRIPTION
### What is the problem?

This test is flaky because of DOM changes affecting the assign button. We get a stale reference and then can't click it.

### How does this fix it?

The Playwright way of fixing this is to use `click(selector)` or `locator(selector).click`, but I don't think that's available throught the Capybara DSL?

This PR explores the idea of letting the `#try_until_success` method also work on Playwright actions.
