### PR TITLE
PERF: Re-use topic-footer-button elements when rerendering

### DIFF
--- a/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/anonymous-topic-footer-buttons.gjs
@@ -30,7 +30,7 @@ export default class AnonymousTopicFooterButtons extends Component {
 
   <template>
     <div class="topic-footer-main-buttons">
-      {{#each this.buttons as |button|}}
+      {{#each this.buttons key="id" as |button|}}
         <DButton
           @action={{button.action}}
           @icon={{button.icon}}

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.gjs
@@ -136,7 +136,7 @@ export default class TopicFooterButtons extends Component {
           @buttonClasses="topic-footer-button"
         />
 
-        {{#each this.inlineActionables as |actionable|}}
+        {{#each this.inlineActionables key="id" as |actionable|}}
           {{#if (eq actionable.type "inline-button")}}
             {{#if (eq actionable.id "bookmark")}}
               <BookmarkMenu
@@ -206,7 +206,7 @@ export default class TopicFooterButtons extends Component {
               </:trigger>
               <:content>
                 <DropdownMenu as |dropdown|>
-                  {{#each this.dropdownButtons as |button|}}
+                  {{#each this.dropdownButtons key="id" as |button|}}
                     <dropdown.item>
                       <DButton
                         @action={{button.action}}


### PR DESCRIPTION
As well as improving perf, this should resolve some flaky specs we're seeing

Followup to 4d034474509011cb3c1122a0f1ad7f92e5515092