### PR TITLE
FIX: pass ancestor data to category badge helper

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -81,9 +81,12 @@ export function categoryBadgeHTML(category, opts) {
     const parentCategory = Category.findById(category.parent_category_id);
     const lastSubcategory = !opts.depth;
     opts.depth = depth;
-    const parentBadges = categoryBadgeHTML(parentCategory, { ...newOpts });
+    const parentBadge = categoryBadgeHTML(parentCategory, {
+      depth,
+      ...newOpts,
+    });
     opts.lastSubcategory = lastSubcategory;
-    return parentBadges + _renderer(category, opts);
+    return parentBadge + _renderer(category, opts);
   }
 
   return _renderer(category, opts);

--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -62,24 +62,26 @@ export function categoryBadgeHTML(category, opts) {
     }
   }
 
+  // allow each ancestor to use its own styles
+  const newOpts = { ...opts };
+  ["styleType", "icon", "emoji"].forEach((k) => delete newOpts[k]);
+
   const depth = (opts.depth || 1) + 1;
   if (opts.ancestors) {
-    const { ancestors, ...otherOpts } = opts;
-
-    // allow each ancestor to use its own styles
-    ["styleType", "icon", "emoji"].forEach((k) => delete otherOpts[k]);
+    const { ancestors } = opts;
+    delete newOpts.ancestors;
 
     return [category, ...ancestors]
       .reverse()
       .map((c) => {
-        return categoryBadgeHTML(c, { ...otherOpts });
+        return categoryBadgeHTML(c, { ...newOpts });
       })
       .join("");
   } else if (opts.recursive && depth <= siteSettings.max_category_nesting) {
     const parentCategory = Category.findById(category.parent_category_id);
     const lastSubcategory = !opts.depth;
     opts.depth = depth;
-    const parentBadges = categoryBadgeHTML(parentCategory, opts);
+    const parentBadges = categoryBadgeHTML(parentCategory, { ...newOpts });
     opts.lastSubcategory = lastSubcategory;
     return parentBadges + _renderer(category, opts);
   }

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -83,7 +83,7 @@ export default class CategoryChooser extends ComboBoxComponent {
             link: false,
             hideParent: category ? !!category.parent_category_id : true,
             allowUncategorized: true,
-            recursive: true,
+            ancestors: category.predecessors,
           })
         )
       );

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -83,7 +83,7 @@ export default class CategoryChooser extends ComboBoxComponent {
             link: false,
             hideParent: category ? !!category.parent_category_id : true,
             allowUncategorized: true,
-            ancestors: category.predecessors,
+            ancestors: category?.predecessors,
           })
         )
       );


### PR DESCRIPTION
The badge in `CategoryChooser` is incorrectly showing the child category badge when displaying both parent and child as the selected option. This was already fixed for cases where the `ancestors` option is passed to `categoryBadgeHTML` in the category link helper.

Updating the option within CategoryChooser fixes this issue, but I have also added a fallback fix for any other components that still use the recursive option.

_Note: as part of #26638 the preferred approach was to pass `ancestors: category.predecessors` in place of `recursive: true`. That way reducing multiple calls to `Category.findById` at the component level when looping through category parents. We may want to completely remove the recursive option in the future but leaving it be for now._

### Before

The category emojis are working correctly on the top header:

<img width="448" height="68" alt="Screenshot 2025-10-03 at 2 44 02 PM" src="https://github.com/user-attachments/assets/f929cebf-3523-40cd-ac44-4c8d240793d5" />

The category chooser is showing the incorrect emoji for the parent category when editing the topic:

<img width="430" height="159" alt="Screenshot 2025-10-03 at 2 43 55 PM" src="https://github.com/user-attachments/assets/a7ed5cff-db10-4899-8096-45bd2b882eea" />

### After

<img width="451" height="153" alt="Screenshot 2025-10-03 at 2 43 02 PM" src="https://github.com/user-attachments/assets/6033c164-3451-4526-8ff0-29819f8ae3d7" />
