### PR TITLE
DEV: Fix `pause_test` devtools URLs when running in container

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -27,8 +27,7 @@ module SystemHelpers
       .each do |result|
         devtools_url = result["devtoolsFrontendUrl"]
 
-        devtools_url =
-          devtools_url.gsub(":#{CHROME_REMOTE_DEBUGGING_PORT}", ":#{exposed_port}") if exposed_port
+        devtools_url.gsub!(":#{CHROME_REMOTE_DEBUGGING_PORT}", ":#{exposed_port}") if exposed_port
 
         if ENV["CODESPACE_NAME"]
           devtools_url =


### PR DESCRIPTION
The `uri` variable was replaced when we moved from selenium to playwright, so this was raising an error