### PR TITLE
DEV: Improvements to DiscourseConnect spec helpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -379,6 +379,8 @@ RSpec.configure do |config|
       minio_runner_config.minio_console_port = 9_001 + 2 * test_i
     end
 
+    DiscourseConnectHelpers.provider_port = 9100 + ENV["TEST_ENV_NUMBER"].to_i
+
     WebMock.disable_net_connect!(
       allow_localhost: true,
       allow: [

--- a/spec/system/discourse_connect_spec.rb
+++ b/spec/system/discourse_connect_spec.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
 describe "Discourse Connect", type: :system do
-  include SsoHelpers
+  include DiscourseConnectHelpers
 
   let(:sso_secret) { SecureRandom.alphanumeric(32) }
-  let(:sso_port) { 9876 }
+  let!(:sso_port) { setup_test_discourse_connect_server(user:, sso_secret:) }
   let(:sso_url) { "http://localhost:#{sso_port}/sso" }
 
-  before do
-    configure_discourse_connect
-    setup_test_sso_server(user:, sso_secret:, sso_port:, sso_url:)
-  end
-
-  after { shutdown_test_sso_server }
+  before { configure_discourse_connect }
 
   shared_examples "redirects to SSO" do
     it "redirects to SSO" do


### PR DESCRIPTION
- Rename SSO -> DiscourseConnect. SSO is the general term for all external login methods. DiscourseConnect is the name for this protocol
- Allocate different IP for each parallel spec environment, so they don't clash. This will resolve some flaky specs we're seeing
- Only bind to localhost. No need to make this available from other machines