### PR TITLE
FIX: double declarative button class names

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-modal.gjs
@@ -380,7 +380,7 @@ export default class DModal extends Component {
                     @label="cancel"
                     @action={{this.handleCloseButton}}
                     @title="modal.close"
-                    class="btn-transparent btn-primary d-modal__dismiss-action-button"
+                    class="btn-transparent d-modal__dismiss-action-button"
                   />
                 </div>
               {{/if}}

--- a/app/assets/javascripts/discourse/app/components/modal/bookmark.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bookmark.gjs
@@ -363,7 +363,7 @@ export default class BookmarkModal extends Component {
           @label="bookmarks.save"
           @action={{this.saveAndClose}}
           @title="modal.close"
-          class="btn-transparent btn-primary"
+          class="btn-transparent"
         />
       </:headerPrimaryAction>
 


### PR DESCRIPTION
Buttons can only have 1 declarative class, not a combination. 

| BC | AC |
|--------|--------|
| <img width="666" height="1214" alt="CleanShot 2025-10-03 at 07 24 22@2x" src="https://github.com/user-attachments/assets/448e4193-13a9-483c-80f7-6acc86e253d0" /> | <img width="666" height="1214" alt="CleanShot 2025-10-03 at 07 23 56@2x" src="https://github.com/user-attachments/assets/45c3abe5-a59f-4cf5-ad5e-19efb4721023" /> | 


