### PR TITLE
DEV: Bypass video thumbnail generation if events don't fire

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/composer-video-thumbnail-uppy.js
+++ b/app/assets/javascripts/discourse/app/lib/composer-video-thumbnail-uppy.js
@@ -57,13 +57,15 @@ export default class ComposerVideoThumbnailUppy {
       ? "onloadedmetadata"
       : "oncanplaythrough";
 
-    setTimeout(() => {
+    const stalledEventsTimer = setTimeout(() => {
       // in some cases, no video events are hit (for example, when browser disables autoplay)
       // we need to give up in those cases, otherwise the upload will hang
       return callback();
     }, 3000);
 
     video[eventName] = () => {
+      clearTimeout(stalledEventsTimer);
+
       const canvas = document.createElement("canvas");
       const ctx = canvas.getContext("2d");
 

--- a/app/assets/javascripts/discourse/app/lib/composer-video-thumbnail-uppy.js
+++ b/app/assets/javascripts/discourse/app/lib/composer-video-thumbnail-uppy.js
@@ -56,6 +56,13 @@ export default class ComposerVideoThumbnailUppy {
     const eventName = this.capabilities.isIOS
       ? "onloadedmetadata"
       : "oncanplaythrough";
+
+    setTimeout(() => {
+      // in some cases, no video events are hit (for example, when browser disables autoplay)
+      // we need to give up in those cases, otherwise the upload will hang
+      return callback();
+    }, 3000);
+
     video[eventName] = () => {
       const canvas = document.createElement("canvas");
       const ctx = canvas.getContext("2d");

--- a/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy/composer-upload.js
@@ -376,7 +376,7 @@ export default class UppyComposerUpload {
           file,
           upload.url,
 
-          // This callback is fired even if the thumbnail callnot be generated,
+          // This callback is fired even if the thumbnail cannot be generated,
           // e.g. if video_thumbnails_enabled is false or if the file is not a video.
           () => {
             this.#removeInProgressUpload(file.id);


### PR DESCRIPTION
In the current version of DiscourseHub on iOS 26, video uploads are stalling.
This is because the video thumbnail generation code relies on video events
and it looks like iOS 26 webviews are not firing those events.

This may require a fix in DiscourseHub, but in the meantime, we need to
tighten the logic in thumbnail generation here.
