### PR TITLE
UX: remove double actions buttons in bookmark modal on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/modal/bookmark.gjs
+++ b/app/assets/javascripts/discourse/app/components/modal/bookmark.gjs
@@ -41,6 +41,7 @@ export default class BookmarkModal extends Component {
   @service currentUser;
   @service capabilities;
   @service bookmarkApi;
+  @service site;
 
   @tracked postDetectedLocalDate = null;
   @tracked postDetectedLocalTime = null;
@@ -435,13 +436,15 @@ export default class BookmarkModal extends Component {
       </:body>
 
       <:footer>
-        <DButton
-          @label="bookmarks.save"
-          @action={{this.saveAndClose}}
-          id="save-bookmark"
-          class="btn-primary"
-        />
-        <DModalCancel @close={{this.closeWithoutSavingBookmark}} />
+        {{#if this.site.desktopView}}
+          <DButton
+            @label="bookmarks.save"
+            @action={{this.saveAndClose}}
+            id="save-bookmark"
+            class="btn-primary"
+          />
+          <DModalCancel @close={{this.closeWithoutSavingBookmark}} />
+        {{/if}}
         {{#if this.showDelete}}
           <DButton
             @icon="trash-can"


### PR DESCRIPTION
On mobile, the bookmark modal uses the DMenu setup, which has cancel/save actions in the header. So we should hide the footer actions.

| BC | AC |
|--------|--------|
| <img width="658" height="1142" alt="CleanShot 2025-10-03 at 13 10 04@2x" src="https://github.com/user-attachments/assets/2e886369-9f1f-4332-a00a-812dcaf6205e" /> | <img width="660" height="1142" alt="CleanShot 2025-10-03 at 13 09 09@2x" src="https://github.com/user-attachments/assets/50527750-9252-40d7-aed3-8dd65a9df77c" /> | 

Desktop stays the same:
<img width="2430" height="1512" alt="CleanShot 2025-10-03 at 13 09 35@2x" src="https://github.com/user-attachments/assets/2feda37d-ec95-4a42-bfdc-a9ca1ea8ebb0" />
