### PR TITLE
UX: update the copy in settings for the mobile logo

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1805,7 +1805,7 @@ en:
     logo: "The logo image at the top left of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the site title text will be shown."
     logo_small: "The small logo image at the top left of your site, seen when scrolling down. Use a square 120 × 120 image. If left blank, a home glyph will be shown."
     digest_logo: "The alternate logo image used at the top of your site's email summary. Use a wide rectangle image. Don't use an SVG image. If left blank, the image from the `logo` setting will be used."
-    mobile_logo: "The logo used on mobile version of your site. You can use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1, but we recommend a square icon to avoid crowding the header. If left blank, the image from the `logo` setting will be used."
+    mobile_logo: "The logo used on the mobile version of your site. We recommend a square icon to avoid crowding the header, but you can use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the image from the logo setting will be used."
     logo_dark: "Dark scheme alternative for the 'logo' site setting."
     logo_small_dark: "Dark scheme alternative for the 'logo small' site setting."
     mobile_logo_dark: "Dark scheme alternative for the 'mobile logo' site setting."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1805,7 +1805,7 @@ en:
     logo: "The logo image at the top left of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the site title text will be shown."
     logo_small: "The small logo image at the top left of your site, seen when scrolling down. Use a square 120 × 120 image. If left blank, a home glyph will be shown."
     digest_logo: "The alternate logo image used at the top of your site's email summary. Use a wide rectangle image. Don't use an SVG image. If left blank, the image from the `logo` setting will be used."
-    mobile_logo: "The logo used on mobile version of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the image from the `logo` setting will be used."
+    mobile_logo: "The logo used on mobile version of your site. You can use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1, but we recommend a square icon to avoid crowding the header. If left blank, the image from the `logo` setting will be used."
     logo_dark: "Dark scheme alternative for the 'logo' site setting."
     logo_small_dark: "Dark scheme alternative for the 'logo small' site setting."
     mobile_logo_dark: "Dark scheme alternative for the 'mobile logo' site setting."


### PR DESCRIPTION
The settings text doesn't reflect reality, as wide rectangular logo isn't a requirement. A square one works just as well, and is recommended to optimise header space.
