### PR TITLE
UX: remove subtitle from 404 page

### DIFF
--- a/app/views/exceptions/not_found.html.erb
+++ b/app/views/exceptions/not_found.html.erb
@@ -30,7 +30,6 @@
 
 <div class="title_wrapper">
   <h1 class="title"><%= @title %></h1>
-  <p class="subtitle"><%= @subtitle %></p>
   <a class="btn btn-primary btn-large --home" href="<%= Discourse.base_url %>"> <%= SvgSprite.raw_svg('house') %> <%= I18n.t('page_not_found.home') %>
   </a>
   </div>


### PR DESCRIPTION
Removing the subtitle until we can make a better distinction between "page not found" and "no access" 404 pages.