### PR TITLE
FIX: crash in Admin::PluginsController when plugin has nil commit URL path

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -624,7 +624,7 @@ class Plugin::Instance
   def discourse_owned?
     return false if commit_hash.blank?
     parsed_commit_url = UrlHelper.relaxed_parse(self.commit_url)
-    return false if parsed_commit_url.blank?
+    return false if parsed_commit_url.blank? || parsed_commit_url.path.blank?
     github_org = parsed_commit_url.path.split("/")[1]
     (github_org == "discourse" || github_org == "discourse-org") &&
       parsed_commit_url.host == "github.com"

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -151,6 +151,16 @@ TEXT
         plugin.git_repo.stubs(:latest_local_commit).returns(nil)
         expect(plugin.discourse_owned?).to eq(false)
       end
+
+      it "returns false if the commit_url has a nil path" do
+        plugin = Plugin::Instance.find_all("#{Rails.root}/spec/fixtures/plugins")[3]
+        plugin.git_repo.stubs(:latest_local_commit).returns("123456")
+        plugin.git_repo.stubs(:url).returns("invalid://url")
+        parsed_url = URI.parse("invalid://url")
+        parsed_url.stubs(:path).returns(nil)
+        UrlHelper.stubs(:relaxed_parse).returns(parsed_url)
+        expect(plugin.discourse_owned?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
The `discourse_owned?` method in `lib/plugin/instance.rb` was calling `.split` on `parsed_commit_url.path` without checking if the path could be nil. This caused a 500 error on `/admin/plugins` when any plugin had a commit URL that parsed successfully but returned a nil path (e.g., plugins without a git remote configured).

Added a nil check for `parsed_commit_url.path` to gracefully handle this edge case and prevent the crash. Also added a test case to verify the method returns false when the parsed URL has a nil path.