### PR TITLE
FIX: Remove btn-default from the DActionButton component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-page-action-button.gjs
+++ b/app/assets/javascripts/discourse/app/components/d-page-action-button.gjs
@@ -3,7 +3,7 @@ import DButton from "discourse/components/d-button";
 
 export const DPageActionButton = <template>
   <DButton
-    class="d-page-action-button btn-small btn-default"
+    class="d-page-action-button btn-small"
     ...attributes
     @action={{@action}}
     @route={{@route}}


### PR DESCRIPTION
This was unnecessarily added in 759fc040419d30a52885bbc71065de98013b3033
and caused some strange styling issues.
