### PR TITLE
DEV: Hide overly technical image compression settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2210,14 +2210,17 @@ files:
     default: 95
     min: 1
     max: 100
+    hidden: true
   recompress_original_jpg_quality:
     default: 90
     min: 1
     max: 100
+    hidden: true
   image_preview_jpg_quality:
     default: 90
     min: 1
     max: 100
+    hidden: true
   allow_staff_to_upload_any_file_in_pm:
     default: true
     client: true
@@ -2261,6 +2264,7 @@ files:
   composer_media_optimization_image_encode_quality:
     default: 75
     client: true
+    hidden: true
   composer_media_optimization_debug_mode:
     default: false
     client: true


### PR DESCRIPTION
### What is this change?

In our efforts to increase the signal-to-noise ratio and discoverability of site settings, we're hiding overly technical settings that few users override.