### PR TITLE
FIX: Remove unnecessary words in user-menu-billing to align with other buttons

### DIFF
--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
@@ -4,7 +4,6 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { classNames, tagName } from "@ember-decorators/component";
 import icon from "discourse/helpers/d-icon";
-import { i18n } from "discourse-i18n";
 
 @tagName("li")
 @classNames("user-main-nav-outlet", "billing")
@@ -23,7 +22,6 @@ export default class Billing extends Component {
     {{#if this.viewingSelf}}
       <LinkTo @route="user.billing">
         {{icon "far-credit-card"}}
-        {{i18n "discourse_subscriptions.navigation.billing"}}
       </LinkTo>
     {{/if}}
   </template>


### PR DESCRIPTION
<img width="898" height="48" alt="image" src="https://github.com/user-attachments/assets/563baec7-9d6f-430b-a800-feee40b1b867" />

Seen from the screenshot, all of the other buttons except "Billing" only includes a svg icon without words, but Billing has words, it causes a visual mismatch.

This commit removes the words to keep aligned.