### PR TITLE
FIX: Fix an issue in user-menu-billing to align with other buttons

### DIFF
--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/connectors/user-main-nav/billing.gjs
@@ -23,7 +23,7 @@ export default class Billing extends Component {
     {{#if this.viewingSelf}}
       <LinkTo @route="user.billing">
         {{icon "far-credit-card"}}
-        {{i18n "discourse_subscriptions.navigation.billing"}}
+        <span>{{i18n "discourse_subscriptions.navigation.billing"}}</span>
       </LinkTo>
     {{/if}}
   </template>


### PR DESCRIPTION
This PR is a revised version from #35199 , aim at fixing a visual mismatch in buttons at user-menu.
Thanks to @tyb-talks for suggestions.