### PR TITLE
DEV: Add Ember `test-helpers` settled check to system tests actions

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/rails-testing.js
+++ b/app/assets/javascripts/discourse/app/initializers/rails-testing.js
@@ -1,0 +1,107 @@
+import { _backburner } from "@ember/runloop";
+import { getSettledState, waitUntil } from "@ember/test-helpers";
+import { getPendingWaiterState } from "@ember/test-waiters";
+import $ from "jquery";
+import { isRailsTesting } from "discourse/lib/environment";
+
+export default {
+  after: ["discourse-bootstrap"],
+
+  initialize() {
+    if (isRailsTesting()) {
+      const setupDataElement = document.getElementById("data-discourse-setup");
+      const isSettledDebugEnabled =
+        setupDataElement?.dataset.capybaraPlaywrightDebugEmberSettled ===
+        "true";
+
+      if (isSettledDebugEnabled) {
+        _backburner.DEBUG = true;
+      }
+
+      const logSettledDebug = (...args) => {
+        if (!isSettledDebugEnabled) {
+          return;
+        }
+
+        // eslint-disable-next-line no-console
+        console.log(`[${Date.now() / 1000}]`, ...args);
+      };
+
+      const pendingRequests = [];
+
+      const incrementAjaxPendingRequests = (_event, xhr, settings) => {
+        if (
+          // Ignore MessageBus and Presence requests as they are long-running and continuous respectively
+          settings.url.includes("/message-bus") ||
+          settings.url.includes("/presence/")
+        ) {
+          return;
+        }
+
+        logSettledDebug("AJAX request initiated", settings.url);
+        pendingRequests.push(xhr);
+      };
+
+      const decrementAjaxPendingRequests = (_event, xhr, settings) => {
+        for (let i = 0; i < pendingRequests.length; i++) {
+          if (xhr === pendingRequests[i]) {
+            logSettledDebug("AJAX request completed", settings.url);
+            pendingRequests.splice(i, 1);
+            break;
+          }
+        }
+      };
+
+      $(document)
+        .on("ajaxSend", incrementAjaxPendingRequests)
+        .on("ajaxComplete ajaxError", decrementAjaxPendingRequests);
+
+      window.emberSettled = async (timeoutSeconds) => {
+        // Wait for two request animation frames to workaround the limitation where we can't exactly determine
+        // when Ember's event dispatcher has dispatched an event as a result of a browser interaction.
+        await new Promise((r) =>
+          requestAnimationFrame(() => requestAnimationFrame(r))
+        );
+
+        timeoutSeconds = timeoutSeconds || 10;
+        const start = Date.now();
+
+        return waitUntil(
+          () => {
+            if ((Date.now() - start) / 1000 > timeoutSeconds) {
+              // eslint-disable-next-line no-console
+              console.error("Timed out waiting for Ember to settle");
+              return true;
+            }
+
+            const state = getSettledState();
+
+            logSettledDebug({
+              hasRunLoop: state.hasRunLoop,
+              hasPendingTransitions: state.hasPendingTransitions,
+              isRenderPending: state.isRenderPending,
+              pendingRequests: pendingRequests.length,
+              hasPendingWaiters: state.hasPendingWaiters,
+              pendingWaiters: getPendingWaiterState().waiters,
+              backBurnerDebugInfo: _backburner.getDebugInfo(),
+            });
+
+            const settled =
+              !state.hasRunLoop &&
+              !state.hasPendingTransitions &&
+              !state.isRenderPending &&
+              !state.hasPendingWaiters &&
+              pendingRequests.length === 0;
+
+            if (settled) {
+              logSettledDebug("SETTLED!");
+            }
+
+            return settled;
+          },
+          { timeout: Infinity }
+        ).then(() => {});
+      };
+    }
+  },
+};

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -828,6 +828,10 @@ module ApplicationHelper
       setup_data[:mb_last_file_change_id] = MessageBus.last_id("/file-change")
     end
 
+    if Rails.env.test? && ENV["CAPYBARA_PLAYWRIGHT_DEBUG_EMBER_SETTLED"].present?
+      setup_data[:capybara_playwright_debug_ember_settled] = true
+    end
+
     if guardian.can_enable_safe_mode? && params["safe_mode"]
       setup_data[:safe_mode] = normalized_safe_mode
     end

--- a/bin/rspec
+++ b/bin/rspec
@@ -20,5 +20,6 @@ if ENV["LOAD_PLUGINS"].nil? && ARGV.any? { |pattern| pattern.include?("plugins/"
 end
 
 ENV["PLAYWRIGHT_HEADLESS"] = "0" if ARGV.delete("--headful")
+ENV["CAPYBARA_PLAYWRIGHT_DEBUG_EMBER_SETTLED"] = "1" if ARGV.delete("--debug-ember-settled")
 
 load Gem.bin_path("rspec-core", "rspec")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -434,6 +434,7 @@ RSpec.configure do |config|
 
       def synchronize(seconds = nil, errors: nil)
         return super if session.synchronized # Nested synchronize. We only want our logic on the outermost call.
+
         begin
           super
         rescue StandardError => e
@@ -474,6 +475,71 @@ RSpec.configure do |config|
         end
       end
     end
+
+    module CapybaraPlaywrightBasePatch
+      private
+
+      def execute_async_ember_settled_script(session)
+        session.evaluate_async_script(
+          "window.emberSettled ? window.emberSettled().then(arguments[0]) : arguments[0]()",
+        )
+      end
+
+      def wait_for_ember_settled(method_name)
+        session = @driver.send(:session)
+
+        if ENV["CAPYBARA_PLAYWRIGHT_DEBUG_EMBER_SETTLED"].present?
+          now = Time.now.to_f
+          puts "[#{now}] #{method_name}: START"
+          execute_async_ember_settled_script(session)
+          puts "[#{Time.now.to_f}] #{method_name}: END IN #{Time.now.to_f - now}"
+        else
+          execute_async_ember_settled_script(session)
+        end
+      end
+    end
+
+    module CapybaraPlaywrightNodePatch
+      include CapybaraPlaywrightBasePatch
+
+      NODE_METHODS_TO_PATCH = %i[
+        click
+        right_click
+        double_click
+        send_keys
+        hover
+        drag_to
+        scroll_by
+        scroll_to
+        trigger
+        set
+      ]
+
+      NODE_METHODS_TO_PATCH.each do |method_name|
+        define_method(method_name) do |*args, **options|
+          result = super(*args, **options)
+          wait_for_ember_settled(method_name)
+          result
+        end
+      end
+    end
+
+    module CapybaraPlaywrightBrowserPatch
+      include CapybaraPlaywrightBasePatch
+
+      METHODS_TO_PATCH = %i[visit go_back go_forward refresh resize_window_to]
+
+      METHODS_TO_PATCH.each do |method_name|
+        define_method(method_name) do |*args, **options|
+          result = super(*args, **options)
+          wait_for_ember_settled(method_name)
+          result
+        end
+      end
+    end
+
+    Capybara::Playwright::Node.prepend(CapybaraPlaywrightNodePatch)
+    Capybara::Playwright::Browser.prepend(CapybaraPlaywrightBrowserPatch)
 
     config.after(:each, type: :system) do |example|
       # If test passed, but we had a capybara finder timeout, raise it now


### PR DESCRIPTION
This commit adds automatic Ember settled-state checking to system test actions, improving reliability by ensuring assertions run only after the application has fully settled (i.e., no pending requests, renders, or timers). Previously, system tests could execute assertions before AJAX requests completed, Ember finished rendering, or route transitions finalized.

This change patches various action methods in `Capybara::Playwright::Node` and `Capybara::Playwright::Browser` so that these methods execute an async JavaScript function on the client side to wait for Ember to reach a settled state before returning. The settled-state checks ensure that:

* No active run loop exists
* No pending transitions remain
* No pending renders exist
* No pending requests remain (excluding MessageBus and Presence requests)
* No pending test waiters exist

Pending timers are intentionally excluded from the settled-state check, as we do not want to artificially shorten long timer durations in system tests. Unlike the Ember acceptance test environment, the system test environment should remain as close to production as possible.

For debugging purposes, a `--debug-ember-settled` CLI flag has been added to bin/rspec. When enabled, this flag outputs detailed debugging information to both the browser console and the stdout of bin/rspec.