### PR TITLE
FIX: Make selector more precise

### DIFF
--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -55,7 +55,7 @@ module PageObjects
       end
 
       def has_selected_name?(name)
-        component.find(".select-kit-header[data-name='#{name}']")
+        component.find(".select-kit-header[data-name='#{name}'] .selected-name")
       end
 
       def has_no_selection?


### PR DESCRIPTION
The page object's `has_selected_name?` selector currently doesn't actually check if the name got selected, only if the specified `name` exists as a dropdown item. This PR corrects that.