### PR TITLE
DEV: Move locale check to unified concern

### DIFF
--- a/app/models/concerns/localizable.rb
+++ b/app/models/concerns/localizable.rb
@@ -19,4 +19,8 @@ module Localizable
 
     localizations.find { |l| LocaleNormalizer.is_same?(l.locale, locale_str) }
   end
+
+  def in_user_locale?
+    LocaleNormalizer.is_same?(locale, I18n.locale)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1338,10 +1338,6 @@ class Post < ActiveRecord::Base
     get_localization(locale).present?
   end
 
-  def in_user_locale?
-    LocaleNormalizer.is_same?(locale, I18n.locale)
-  end
-
   private
 
   def parse_quote_into_arguments(quote)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2182,10 +2182,6 @@ class Topic < ActiveRecord::Base
     localizations.exists?(locale: locale.to_s.sub("-", "_"))
   end
 
-  def in_user_locale?
-    LocaleNormalizer.is_same?(locale, I18n.locale)
-  end
-
   private
 
   def invite_to_private_message(invited_by, target_user, guardian)

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -26,4 +26,12 @@ class ContentLocalization
     SiteSetting.content_localization_enabled && topic.locale.present? && !topic.in_user_locale? &&
       !show_original?(scope)
   end
+
+  # This method returns true when we should try to show the translated category.
+  # @param scope [Object] The serializer scope from which the method is called
+  # @param category [Category] The category record
+  # @return [Boolean]
+  def self.show_translated_category?(category, scope)
+    SiteSetting.content_localization_enabled && !category.in_user_locale? && !show_original?(scope)
+  end
 end

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -122,4 +122,35 @@ describe ContentLocalization do
       end
     end
   end
+
+  describe ".show_translated_category?" do
+    fab!(:category)
+
+    it "returns false when setting is disabled" do
+      SiteSetting.content_localization_enabled = false
+      category.update!(locale: "ja")
+      I18n.locale = "de"
+      scope = create_scope
+
+      expect(ContentLocalization.show_translated_category?(category, scope)).to be false
+    end
+
+    it "returns true when category locale does not match user locale" do
+      SiteSetting.content_localization_enabled = true
+      category.update!(locale: "ja")
+      I18n.locale = "de"
+      scope = create_scope
+
+      expect(ContentLocalization.show_translated_category?(category, scope)).to be true
+    end
+
+    it "returns false when category locale does not match user locale but cookie set to show original" do
+      SiteSetting.content_localization_enabled = true
+      category.update!(locale: "ja")
+      I18n.locale = "de"
+      scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
+
+      expect(ContentLocalization.show_translated_category?(category, scope)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Moves the `in_user_locale?` check to the localizable which can be used by any localized model.

2 of many

/t/163217, related https://github.com/discourse/discourse/pull/35152