### PR TITLE
FIX: Navigating via topic filters should not untranslate a category name

### DIFF
--- a/app/serializers/category_badge_serializer.rb
+++ b/app/serializers/category_badge_serializer.rb
@@ -17,11 +17,16 @@ class CategoryBadgeSerializer < ApplicationSerializer
   end
 
   def name
-    if object.uncategorized?
-      I18n.t("uncategorized_category_name", locale: SiteSetting.default_locale)
-    else
-      object.name
-    end
+    return I18n.t("uncategorized_category_name") if object.uncategorized?
+
+    translated =
+      if (ContentLocalization.show_translated_category?(object, scope))
+        object.get_localization&.name
+      else
+        object.name
+      end
+
+    translated || object.name
   end
 
   def description_text

--- a/spec/serializers/topic_list_serializer_spec.rb
+++ b/spec/serializers/topic_list_serializer_spec.rb
@@ -2,8 +2,10 @@
 
 RSpec.describe TopicListSerializer do
   fab!(:user)
+  fab!(:category)
+  fab!(:topic) { Fabricate(:topic, user:, category:) }
 
-  let(:topic) { Fabricate(:topic).tap { |t| t.allowed_user_ids = [t.user_id] } }
+  before { topic.allowed_user_ids = [topic.user_id] }
 
   it "should return the right payload" do
     topic_list = TopicList.new(nil, user, [topic])
@@ -22,5 +24,65 @@ RSpec.describe TopicListSerializer do
     serializer = described_class.new(topic_list, scope: Guardian.new(user))
 
     expect(serializer.options[:filter]).to eq(filter)
+  end
+
+  describe "has categories" do
+    describe "when lazy loading categories enabled" do
+      before { SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}" }
+
+      it "serializes categories when lazy loading" do
+        topic_list = TopicList.new(nil, user, [topic])
+        guardian = Guardian.new(user)
+
+        serialized = described_class.new(topic_list, scope: guardian).as_json
+
+        expect(serialized[:topic_list][:categories].first[:id]).to eq(topic.category.id)
+      end
+
+      describe "content localization" do
+        fab!(:category_localization) do
+          Fabricate(:category_localization, category:, locale: "es", name: "Solicitudes")
+        end
+
+        describe "when enabled" do
+          it "returns localized category name and description when locale param is passed" do
+            SiteSetting.content_localization_enabled = true
+            topic_list = TopicList.new(nil, user, [topic])
+            guardian = Guardian.new(user)
+
+            I18n.locale = "es"
+            serialized =
+              described_class.new(topic_list, scope: guardian, params: { locale: "es" }).as_json
+
+            expect(serialized[:topic_list][:categories].first[:name]).to eq("Solicitudes")
+          end
+        end
+
+        describe "when disabled" do
+          it "returns default category name and description" do
+            SiteSetting.content_localization_enabled = false
+            topic_list = TopicList.new(nil, user, [topic])
+            guardian = Guardian.new(user)
+
+            I18n.locale = "es"
+            serialized = described_class.new(topic_list, scope: guardian).as_json
+
+            expect(serialized[:topic_list][:categories].first[:name]).to eq(category.name)
+          end
+        end
+      end
+    end
+
+    describe "when lazy loading categories disabled" do
+      it "does not serialize categories when not lazy loading" do
+        SiteSetting.lazy_load_categories_groups = ""
+        topic_list = TopicList.new(nil, user, [topic])
+        guardian = Guardian.new(user)
+
+        serialized = described_class.new(topic_list, scope: guardian).as_json
+
+        expect(serialized[:topic_list]).not_to have_key(:categories)
+      end
+    end
   end
 end

--- a/spec/system/category_localizations_spec.rb
+++ b/spec/system/category_localizations_spec.rb
@@ -175,7 +175,7 @@ describe "Category Localizations", type: :system do
 
       before { SiteSetting.content_localization_language_switcher = "all" }
 
-      describe "for anonymous users" do
+      shared_examples_for "navigating the site via various category links" do
         it "keeps the translated category name when navigating sidebar" do
           visit("/")
           switcher.expand
@@ -221,6 +221,30 @@ describe "Category Localizations", type: :system do
           sidebar.click_topics_button
 
           expect(topic_list.topic(cat_topic)).to have_text("Solicitudes")
+        end
+      end
+
+      describe "for anonymous users" do
+        it_behaves_like "navigating the site via various category links"
+      end
+
+      describe "logged in users" do
+        describe "lazy loaded categories" do
+          before do
+            SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
+            sign_in(admin)
+          end
+
+          it_behaves_like "navigating the site via various category links"
+        end
+
+        describe "no lazy loaded categories" do
+          before do
+            SiteSetting.lazy_load_categories_groups = ""
+            sign_in(admin)
+          end
+
+          it_behaves_like "navigating the site via various category links"
         end
       end
     end


### PR DESCRIPTION
There's a bug now that translated category names get replaced. This applies to logged in users on sites where `SiteSetting.content_localization_enabled` and `SiteSetting.lazy_load_categories_groups` are enabled for the user.

The fix here has been checked for N+1s, and it was covered before in https://github.com/discourse/discourse/pull/34212/files#diff-a064afa7c610321917d3edfd0a462197d7cb3b76191552dfb770f3b9fb11db18.


## Before

See sidebar category name getting replaced:

https://github.com/user-attachments/assets/f8ac44a4-a134-44d0-8f07-b44d711eda32


## After

Sidebar category name and visiting /latest does not get replaced.

https://github.com/user-attachments/assets/437ff0c9-65e2-4d65-873c-fc77da4a1a33

