### PR TITLE
FIX: let user recover their own deleted topics

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -362,11 +362,20 @@ export default class Post extends RestModel {
   }
 
   get canRecoverTopic() {
-    return this.firstPost && this.deleted && this.topic.details.can_recover;
+    return (
+      this.firstPost &&
+      (this.deleted || this.user_deleted) &&
+      this.topic.details.can_recover
+    );
   }
 
   get isRecoveringTopic() {
-    return this.firstPost && !this.deleted && this.topic.details.can_recover;
+    return (
+      this.firstPost &&
+      !this.deleted &&
+      !this.user_deleted &&
+      this.topic.details.can_recover
+    );
   }
 
   get canRecover() {

--- a/spec/system/post_menu_spec.rb
+++ b/spec/system/post_menu_spec.rb
@@ -305,6 +305,20 @@ describe "Post menu", type: :system do
       topic_page.click_post_action_button(post2, :recover)
       expect(topic_page).to have_no_deleted_post(post2)
     end
+
+    it "allows regular users to recover their own deleted topic" do
+      user_topic = Fabricate(:topic, user: user)
+      user_first_post = Fabricate(:post, topic: user_topic, user: user, post_number: 1)
+      PostDestroyer.new(user, user_first_post).destroy
+
+      sign_in(user)
+
+      topic_page.visit_topic(user_topic)
+
+      expect(topic_page).to have_post_action_button(user_first_post, :recover)
+      topic_page.click_post_action_button(user_first_post, :recover)
+      expect(topic_page).to have_no_deleted_post(user_first_post)
+    end
   end
 
   describe "edit" do


### PR DESCRIPTION
When a user is deleting their own topics, we don't set the "deleted_at"
timestamp but instead use the "user_deleted" boolean.

This wasn't tested against in the "canRecoverTopic()" and
"isRecoveringTopic()" method in the UI so users weren't able to recover
their own deleted topics.