### PR TITLE
FIX: Spec ambiguity when selecting category dropdowns

### DIFF
--- a/spec/system/category_localizations_spec.rb
+++ b/spec/system/category_localizations_spec.rb
@@ -26,12 +26,11 @@ describe "Category Localizations", type: :system do
     SiteSetting.desktop_category_page_style = "categories_boxes"
   end
 
-  def get_parent_category_dropdown
-    PageObjects::Components::SelectKit.new(".category-breadcrumb li:nth-child(1) .category-drop")
-  end
-
-  def get_sub_category_dropdown
-    PageObjects::Components::SelectKit.new(".category-breadcrumb li:nth-child(2) .category-drop")
+  def get_category_dropdown(nth)
+    selector = ".category-breadcrumb li:nth-child(#{nth}) .category-drop"
+    expect(page).to have_css(selector)
+    el = find(selector, visible: :all)
+    PageObjects::Components::SelectKit.new(el)
   end
 
   context "when content localization setting is disabled" do
@@ -192,7 +191,7 @@ describe "Category Localizations", type: :system do
           expect(sidebar).to have_section_link("Solicitudes")
           sidebar.click_section_link("Solicitudes")
 
-          category_dropdown = get_parent_category_dropdown
+          category_dropdown = get_category_dropdown(1)
           expect(category_dropdown).to have_selected_name("Solicitudes")
           expect(category_page.category_box(subcat)).to have_text("Subcategoría")
           expect(category_page.category_box(subcat)).to have_text("Una subcategoría de un padre")
@@ -201,8 +200,8 @@ describe "Category Localizations", type: :system do
 
           category_page.category_box(subcat).click
 
-          parent_category_dropdown = get_parent_category_dropdown
-          sub_category_dropdown = get_sub_category_dropdown
+          parent_category_dropdown = get_category_dropdown(1)
+          sub_category_dropdown = get_category_dropdown(2)
           expect(parent_category_dropdown).to have_selected_name("Solicitudes")
           expect(sub_category_dropdown).to have_selected_name("Subcategoría")
         end

--- a/spec/system/category_localizations_spec.rb
+++ b/spec/system/category_localizations_spec.rb
@@ -26,6 +26,14 @@ describe "Category Localizations", type: :system do
     SiteSetting.desktop_category_page_style = "categories_boxes"
   end
 
+  def get_parent_category_dropdown
+    PageObjects::Components::SelectKit.new(".category-breadcrumb li:nth-child(1) .category-drop")
+  end
+
+  def get_sub_category_dropdown
+    PageObjects::Components::SelectKit.new(".category-breadcrumb li:nth-child(2) .category-drop")
+  end
+
   context "when content localization setting is disabled" do
     before { SiteSetting.content_localization_enabled = false }
 
@@ -184,7 +192,7 @@ describe "Category Localizations", type: :system do
           expect(sidebar).to have_section_link("Solicitudes")
           sidebar.click_section_link("Solicitudes")
 
-          category_dropdown = PageObjects::Components::SelectKit.new(".category-drop")
+          category_dropdown = get_parent_category_dropdown
           expect(category_dropdown).to have_selected_name("Solicitudes")
           expect(category_page.category_box(subcat)).to have_text("Subcategoría")
           expect(category_page.category_box(subcat)).to have_text("Una subcategoría de un padre")
@@ -193,14 +201,8 @@ describe "Category Localizations", type: :system do
 
           category_page.category_box(subcat).click
 
-          parent_category_dropdown =
-            PageObjects::Components::SelectKit.new(
-              ".category-breadcrumb li:nth-child(1) .category-drop",
-            )
-          sub_category_dropdown =
-            PageObjects::Components::SelectKit.new(
-              ".category-breadcrumb li:nth-child(2) .category-drop",
-            )
+          parent_category_dropdown = get_parent_category_dropdown
+          sub_category_dropdown = get_sub_category_dropdown
           expect(parent_category_dropdown).to have_selected_name("Solicitudes")
           expect(sub_category_dropdown).to have_selected_name("Subcategoría")
         end


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/35211 introduced some specs that require selecting parent category dropdown, but there are two dropdowns and spec is confoosed.

<img width="1400" height="1400" alt="failures_r_spec_example_groups_category_localizations_when_content_localization_setting_is_enabled_navigating_categories_for_anonymous_users_behaves_like_navigating_the_site_via_various_category_links_keeps_th_25" src="https://github.com/user-attachments/assets/3246092d-6c0d-4861-a1bc-bf08d8b50f46" />
