### PR TITLE
DEV: Resolve flaky cancel_manager_spec

### DIFF
--- a/plugins/discourse-ai/spec/lib/completions/cancel_manager_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/cancel_manager_spec.rb
@@ -5,7 +5,14 @@ describe DiscourseAi::Completions::CancelManager do
 
   before do
     enable_current_plugin
-    WebMock.allow_net_connect!
+    WebMock.disable!
+    FinalDestination::SSRFDetector.allow_ip_lookups_in_test!
+    SiteSetting.allowed_internal_hosts = "127.0.0.1"
+  end
+
+  after do
+    WebMock.enable!
+    FinalDestination::SSRFDetector.allow_ip_lookups_in_test!
   end
 
   it "can stop monitoring for cancellation cleanly" do


### PR DESCRIPTION
It was using `WebMock.allow_net_connect!`, which doesn't completely disable WebMock's stubbing. In the logs of our flaky failures, backtraces point to the webmock internals.

`WebMock.disable!` is more comprehensive, and matches what we do for other core specs which need to bypass it.