### PR TITLE
FIX: wildcard watched word and regexps

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -86,6 +86,8 @@ class WordWatcher
             .select { |r| r.present? }
             .join("|")
 
+        next if regexp.blank?
+
         # Add word boundaries to the regexp for regular watched words
         regexp =
           match_word_regexp(
@@ -96,6 +98,7 @@ class WordWatcher
         # Add case insensitive flag if needed
         Regexp.new(regexp, group_key == :case_sensitive ? nil : Regexp::IGNORECASE)
       end
+      .compact
   end
 
   def self.serialized_regexps_for_action(action, engine: :ruby)


### PR DESCRIPTION
If you have a watched word with a wildcard and then enable the "watched words regexp" site setting, you might end up in a situation where you can't post anymore because of the invalid regexp.

This ensures we correctly skip invalid regexps.

Ref - https://meta.discourse.org/t/-/382417