### PR TITLE
FIX: Skip triage on edits when unhandled flags exist

### DIFF
--- a/plugins/discourse-ai/lib/automation.rb
+++ b/plugins/discourse-ai/lib/automation.rb
@@ -2,6 +2,10 @@
 
 module DiscourseAi
   module Automation
+    def self.spam_based_flag_types
+      %w[spam spam_silence]
+    end
+
     def self.flag_types
       [
         { id: "review", translated_name: I18n.t("discourse_automation.ai.flag_types.review") },


### PR DESCRIPTION
When a post is edited, avoid re-flagging it if there’s already a flag pending in the review queue. This prevents duplicate triage runs and reduces unnecessary processing.