### PR TITLE
FIX: Remove error section when viewing details for received emails

### DIFF
--- a/app/assets/javascripts/admin/addon/components/modal/incoming-email.gjs
+++ b/app/assets/javascripts/admin/addon/components/modal/incoming-email.gjs
@@ -10,17 +10,25 @@ const IncomingEmail = <template>
     @bodyClass="incoming-emails"
   >
     <:body>
-      <div class="control-group">
-        <label>{{i18n "admin.email.incoming_emails.modal.error"}}</label>
-        <div class="controls">
-          <p>{{@model.error}}</p>
-          {{#if @model.error_description}}
-            <p class="error-description">{{@model.error_description}}</p>
-          {{/if}}
-        </div>
-      </div>
+      {{#if @model.error}}
+        <div class="control-group admin-incoming-email-modal__error">
+          <label>{{i18n "admin.email.incoming_emails.modal.error"}}</label>
 
-      <hr />
+          <div class="controls admin-incoming-email-modal__error-content">
+            <p
+              class="admin-incoming-email-modal__error-message"
+            >{{@model.error}}</p>
+
+            {{#if @model.error_description}}
+              <p
+                class="error-description admin-incoming-email-modal__error-description"
+              >{{@model.error_description}}</p>
+            {{/if}}
+          </div>
+        </div>
+
+        <hr />
+      {{/if}}
 
       <div class="control-group">
         <label>{{i18n "admin.email.incoming_emails.modal.headers"}}</label>

--- a/app/serializers/incoming_email_details_serializer.rb
+++ b/app/serializers/incoming_email_details_serializer.rb
@@ -15,13 +15,17 @@ class IncomingEmailDetailsSerializer < ApplicationSerializer
     @error_string.presence || I18n.t("emails.incoming.unrecognized_error")
   end
 
+  def include_error?
+    !object.error.nil?
+  end
+
   def error_description
     error_name = @error_string.sub(EMAIL_RECEIVER_ERROR_PREFIX, "").underscore
     I18n.t("emails.incoming.errors.#{error_name}")
   end
 
   def include_error_description?
-    @error_string && @error_string[EMAIL_RECEIVER_ERROR_PREFIX]
+    !object.error.nil? && @error_string && @error_string[EMAIL_RECEIVER_ERROR_PREFIX]
   end
 
   def headers

--- a/app/serializers/incoming_email_serializer.rb
+++ b/app/serializers/incoming_email_serializer.rb
@@ -31,6 +31,10 @@ class IncomingEmailSerializer < ApplicationSerializer
   end
 
   def error
-    @object.error.presence || I18n.t("emails.incoming.unrecognized_error")
+    object.error.presence || I18n.t("emails.incoming.unrecognized_error")
+  end
+
+  def include_error?
+    !object.error.nil?
   end
 end

--- a/spec/fabricators/incoming_email_fabricator.rb
+++ b/spec/fabricators/incoming_email_fabricator.rb
@@ -25,5 +25,5 @@ end
 
 Fabricator(:rejected_incoming_email, from: :incoming_email) do
   is_bounce false
-  error { sequence(:error) { |n| "Error #{n}" } }
+  error "Email::Receiver::BadDestinationAddress"
 end

--- a/spec/serializers/incoming_email_details_serializer_spec.rb
+++ b/spec/serializers/incoming_email_details_serializer_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe IncomingEmailDetailsSerializer do
+  fab!(:admin)
+  fab!(:rejected_incoming_email)
+  fab!(:incoming_email)
+
+  describe "#error" do
+    it "includes the error attribute when the incoming email is errored" do
+      serialized =
+        described_class.new(
+          rejected_incoming_email,
+          scope: Guardian.new(admin),
+          root: false,
+        ).as_json
+
+      expect(serialized[:error]).to eq(rejected_incoming_email.error)
+    end
+
+    it "does not include the error attribute when the incoming email is not errored" do
+      serialized =
+        described_class.new(incoming_email, scope: Guardian.new(admin), root: false).as_json
+
+      expect(serialized[:error]).to be_nil
+    end
+  end
+
+  describe "#error_description" do
+    it "does not include the error_description attribute when the incoming email is not errored" do
+      serialized =
+        described_class.new(incoming_email, scope: Guardian.new(admin), root: false).as_json
+
+      expect(serialized[:error_description]).to be_nil
+    end
+
+    it "includes the error_description attribute when the incoming email is errored with a known error" do
+      serialized =
+        described_class.new(
+          rejected_incoming_email,
+          scope: Guardian.new(admin),
+          root: false,
+        ).as_json
+
+      expect(serialized[:error_description]).to eq(
+        I18n.t("emails.incoming.errors.bad_destination_address"),
+      )
+    end
+  end
+end

--- a/spec/serializers/incoming_email_serializer_spec.rb
+++ b/spec/serializers/incoming_email_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe IncomingEmailSerializer do
+  fab!(:admin)
+  fab!(:rejected_incoming_email)
+  fab!(:incoming_email)
+
+  describe "#error" do
+    it "includes the error attribute when the incoming email is errored" do
+      serialized =
+        described_class.new(
+          rejected_incoming_email,
+          scope: Guardian.new(admin),
+          root: false,
+        ).as_json
+
+      expect(serialized[:error]).to eq(rejected_incoming_email.error)
+    end
+
+    it "does not include the error attribute when the incoming email is not errored" do
+      serialized =
+        described_class.new(incoming_email, scope: Guardian.new(admin), root: false).as_json
+
+      expect(serialized[:error]).to be_nil
+    end
+  end
+end

--- a/spec/system/admin_email_logs_spec.rb
+++ b/spec/system/admin_email_logs_spec.rb
@@ -25,7 +25,14 @@ RSpec.describe "Admin viewing email logs" do
 
       row = admin_email_logs_page.row_for(rejected_incoming_email)
 
-      expect(row.open_incoming_email).to be_open
+      details_modal = row.open_incoming_email
+
+      expect(details_modal).to be_open
+      expect(details_modal).to have_error_message(rejected_incoming_email.error)
+
+      expect(details_modal).to have_error_description(
+        I18n.t("emails.incoming.errors.bad_destination_address"),
+      )
     end
   end
 
@@ -46,7 +53,10 @@ RSpec.describe "Admin viewing email logs" do
 
       row = admin_email_logs_page.row_for(incoming_email)
 
-      expect(row.open_incoming_email).to be_open
+      details_modal = row.open_incoming_email
+
+      expect(details_modal).to be_open
+      expect(details_modal).to have_no_error
     end
   end
 

--- a/spec/system/page_objects/modals/admin_incoming_email_details_modal.rb
+++ b/spec/system/page_objects/modals/admin_incoming_email_details_modal.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class AdminIncomingEmailDetailsModal < PageObjects::Modals::Base
+      MODAL_SELECTOR = ".admin-incoming-email-modal"
+
+      def has_no_error?
+        has_no_css?(".admin-incoming-email-modal__error")
+      end
+
+      def has_error_message?(message)
+        has_css?(".admin-incoming-email-modal__error-message", text: message)
+      end
+
+      def has_error_description?(description)
+        has_css?(".admin-incoming-email-modal__error-description", text: description)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/admin_incoming_email_modal.rb
+++ b/spec/system/page_objects/modals/admin_incoming_email_modal.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module PageObjects
-  module Modals
-    class AdminIncomingEmailModal < PageObjects::Modals::Base
-      MODAL_SELECTOR = ".admin-incoming-email-modal"
-    end
-  end
-end

--- a/spec/system/page_objects/pages/admin_email_logs.rb
+++ b/spec/system/page_objects/pages/admin_email_logs.rb
@@ -30,7 +30,7 @@ module PageObjects
 
         def open_incoming_email
           element.find(".incoming-email-link").click
-          PageObjects::Modals::AdminIncomingEmailModal.new
+          PageObjects::Modals::AdminIncomingEmailDetailsModal.new
         end
       end
 


### PR DESCRIPTION
Prior to this change, "Unrecognized error" was displayed when viewing
the details for a incoming email that has not bounced or encountered any
error in the `incoming-email` modal.
