### PR TITLE
FIX: Opening category dropdown should not reset translated name

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -73,33 +73,20 @@ class Site
         categories =
           begin
             query =
-              Category.includes(
-                :uploaded_logo,
-                :uploaded_logo_dark,
-                :uploaded_background,
-                :uploaded_background_dark,
-                :tags,
-                :tag_groups,
-                :form_templates,
-                category_required_tag_groups: :tag_group,
-              ).joins("LEFT JOIN topics t on t.id = categories.topic_id")
-
-            if SiteSetting.content_localization_enabled
-              locale = I18n.locale.to_s
-              query =
-                query.joins(
-                  "LEFT JOIN category_localizations cl ON cl.category_id = categories.id AND cl.locale = '#{ActiveRecord::Base.connection.quote_string(locale)}'",
-                ).select(
-                  "categories.*,
-                      t.slug topic_slug,
-                      COALESCE(cl.name, categories.name) AS name,
-                      COALESCE(cl.description, categories.description) AS description",
+              Category
+                .includes(
+                  :uploaded_logo,
+                  :uploaded_logo_dark,
+                  :uploaded_background,
+                  :uploaded_background_dark,
+                  :tags,
+                  :tag_groups,
+                  :form_templates,
+                  category_required_tag_groups: :tag_group,
                 )
-            else
-              query = query.select("categories.*, t.slug topic_slug")
-            end
-
-            query = query.order(:position)
+                .joins("LEFT JOIN topics t on t.id = categories.topic_id")
+                .select("categories.*, t.slug topic_slug")
+                .order(:position)
             query =
               DiscoursePluginRegistry.apply_modifier(:site_all_categories_cache_query, query, self)
             query.to_a

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BasicCategorySerializer < ApplicationSerializer
+  include BasicCategoryAttributes
   attributes :id,
              :name,
              :color,
@@ -45,27 +46,11 @@ class BasicCategorySerializer < ApplicationSerializer
     parent_category_id
   end
 
-  def name
-    if object.uncategorized?
-      I18n.t("uncategorized_category_name", locale: SiteSetting.default_locale)
-    else
-      object.name
-    end
-  end
-
   def description_text
     if object.uncategorized?
       I18n.t("category.uncategorized_description", locale: SiteSetting.default_locale)
     else
       object.description_text
-    end
-  end
-
-  def description
-    if object.uncategorized?
-      I18n.t("category.uncategorized_description", locale: SiteSetting.default_locale)
-    else
-      object.description
     end
   end
 

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CategorySerializer < SiteCategorySerializer
+  include BasicCategoryAttributes
+
   class CategorySettingSerializer < ApplicationSerializer
     attributes :auto_bump_cooldown_days,
                :num_auto_bump_daily,

--- a/app/serializers/concerns/basic_category_attributes.rb
+++ b/app/serializers/concerns/basic_category_attributes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BasicCategoryAttributes
+  def name
+    if object.uncategorized?
+      I18n.t("uncategorized_category_name", locale: SiteSetting.default_locale)
+    else
+      object.name
+    end
+  end
+
+  def description
+    if object.uncategorized?
+      I18n.t("category.uncategorized_description", locale: SiteSetting.default_locale)
+    else
+      object.description
+    end
+  end
+end

--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -36,4 +36,28 @@ class SiteCategorySerializer < BasicCategorySerializer
   def include_required_tag_groups?
     SiteSetting.tagging_enabled
   end
+
+  def name
+    return I18n.t("uncategorized_category_name") if object.uncategorized?
+
+    translated_name =
+      if (ContentLocalization.show_translated_category?(object, scope))
+        object.get_localization&.name
+      else
+        object.name
+      end
+
+    translated_name || object.name
+  end
+
+  def description
+    translated_description =
+      if (ContentLocalization.show_translated_category?(object, scope))
+        object.get_localization&.description
+      else
+        object.description
+      end
+
+    translated_description || object.description
+  end
 end

--- a/spec/system/category_localizations_spec.rb
+++ b/spec/system/category_localizations_spec.rb
@@ -29,8 +29,7 @@ describe "Category Localizations", type: :system do
   def get_category_dropdown(nth)
     selector = ".category-breadcrumb li:nth-child(#{nth}) .category-drop"
     expect(page).to have_css(selector)
-    el = find(selector, visible: :all)
-    PageObjects::Components::SelectKit.new(el)
+    PageObjects::Components::SelectKit.new(selector)
   end
 
   context "when content localization setting is disabled" do
@@ -138,20 +137,14 @@ describe "Category Localizations", type: :system do
             count: 2,
           )
           expect(
-            category_page.find("#control-localizations-0-locale option.--selected"),
-          ).to have_content("Spanish (Español)")
-          expect(
-            category_page.find("#control-localizations-1-locale option.--selected"),
-          ).to have_content("Japanese (日本語)")
+            page.all(".form-kit__control-select option.--selected").map(&:text),
+          ).to contain_exactly("Spanish (Español)", "Japanese (日本語)")
 
           page.find(".edit-category-tab-localizations .remove-localization", match: :first).click
           category_page.save_settings
           page.refresh
 
           expect(category_page).to_not have_css("#control-localizations-0-locale option.--selected")
-          expect(
-            category_page.find("#control-localizations-0-locale option.--selected"),
-          ).to have_content("Japanese (日本語)")
         end
       end
     end
@@ -223,6 +216,26 @@ describe "Category Localizations", type: :system do
 
           expect(topic_list.topic(cat_topic)).to have_text("Solicitudes")
         end
+
+        it "keeps the translated category name when navigating category dropdown" do
+          visit("/latest")
+          switcher.expand
+          switcher.option("[data-menu-option-id='es']").click
+
+          category_dropdown = get_category_dropdown("1")
+
+          expect(category_dropdown.component).to have_text(
+            I18n.t("js.categories.categories_label", locale: "es"),
+          )
+          category_dropdown.component.click
+          expect(category_dropdown.component).to have_css(".is-expanded")
+          expect(category_dropdown.component.find(".select-kit-body")).to have_css(
+            ".select-kit-collection",
+          )
+          expect(page.find(".select-kit-collection div[data-name='Solicitudes']")).to have_text(
+            "Solicitudes",
+          )
+        end
       end
 
       describe "for anonymous users" do
@@ -230,6 +243,20 @@ describe "Category Localizations", type: :system do
       end
 
       describe "logged in users" do
+        shared_examples_for "editing category settings" do
+          it "shows the original category name in the category edit page" do
+            sign_in(admin)
+            category_page.visit_general(category)
+
+            switcher.expand
+            switcher.option("[data-menu-option-id='es']").click
+
+            expect(find(".edit-category-tab-general input.category-name").value).to eq(
+              category.name,
+            )
+          end
+        end
+
         describe "lazy loaded categories" do
           before do
             SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
@@ -237,6 +264,8 @@ describe "Category Localizations", type: :system do
           end
 
           it_behaves_like "navigating the site via various category links"
+
+          it_behaves_like "editing category settings"
         end
 
         describe "no lazy loaded categories" do
@@ -246,6 +275,8 @@ describe "Category Localizations", type: :system do
           end
 
           it_behaves_like "navigating the site via various category links"
+
+          it_behaves_like "editing category settings"
         end
       end
     end


### PR DESCRIPTION
This fix affects
- /categories/find?slug_path_with_id=support (invoked by sidebar category)
- /categories/search (invoked by category dropdown)
- /categories/hierarchical_search?term=&include_uncategorized=false (invoked by editing category sidebar)

## Before

https://github.com/user-attachments/assets/ce724de4-6c7e-49a7-a106-5a418c33e193

## After

https://github.com/user-attachments/assets/f2083746-61aa-43b0-b133-fc3464f23ffe