### PR TITLE
DEV: Allow AI tagging automation to tag system-created topics

### DIFF
--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -3,7 +3,8 @@
 module DiscourseAutomation
   module EventHandlers
     def self.handle_post_created_edited(post, action)
-      return if post.post_type != Post.types[:regular] || post.user_id < 0
+      return if post.post_type != Post.types[:regular]
+
       topic = post.topic
       return if topic.blank?
 
@@ -12,6 +13,8 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
+          # allow scripts to opt-in to system posts via allow_system_posts setting
+          next if post.user_id < 0 && !automation.script_field("allow_system_posts")&.dig("value")
           action_type = automation.trigger_field("action_type")
           selected_action = action_type["value"]&.to_sym
 

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -217,7 +217,7 @@ en:
               description: "Maximum number of posts from the topic to include for analysis context (default: 5)"
             allow_system_posts:
               label: "Allow System Posts"
-              description: "Allow tagging of posts created by system users (user_id < 0). This is useful for automated content imports."
+              description: "Allow tagging of posts created by the system user."
 
     discourse_ai:
       title: "AI"

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -215,6 +215,9 @@ en:
             max_posts_for_context:
               label: "Maximum Posts for Context"
               description: "Maximum number of posts from the topic to include for analysis context (default: 5)"
+            allow_system_posts:
+              label: "Allow System Posts"
+              description: "Allow tagging of posts created by system users (user_id < 0). This is useful for automated content imports."
 
     discourse_ai:
       title: "AI"

--- a/plugins/discourse-ai/discourse_automation/llm_tagger.rb
+++ b/plugins/discourse-ai/discourse_automation/llm_tagger.rb
@@ -50,6 +50,8 @@ if defined?(DiscourseAutomation)
 
     field :max_posts_for_context, component: :text, default: "5"
 
+    field :allow_system_posts, component: :boolean, default: false
+
     script do |context, fields|
       post = context["post"]
       next if post&.user&.bot?


### PR DESCRIPTION
I want to use the AI llm_tagger script on https://discover.discourse.com, but in order to do this the automation needs to be allowed to run on posts created by the system user. 

To accomplish this, I've added the ability for scripts to add a `allow_system_posts` setting. Existing scripts will still ignore system posts, but this allows script authors to add a setting to opt-in to processing them. 