### PR TITLE
UX: add missing button class to secret toggle

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-setting.gjs
+++ b/app/assets/javascripts/admin/addon/components/site-setting.gjs
@@ -504,7 +504,7 @@ export default class SiteSettingComponent extends Component {
             @action={{this.toggleSecret}}
             @icon={{if this.isSecret "far-eye" "far-eye-slash"}}
             @ariaLabel="admin.settings.unmask"
-            class="setting-toggle-secret"
+            class="btn-default setting-toggle-secret"
           />
         {{/if}}
 


### PR DESCRIPTION
Minor follow-up to 759fc04

This 👁️  button was missing the btn-default class, so it wasn't getting a border-radius


Before
<img width="1076" height="180" alt="image" src="https://github.com/user-attachments/assets/1e1f70f3-8e93-476b-a790-081ec36c18ea" />


After
<img width="1052" height="314" alt="image" src="https://github.com/user-attachments/assets/ded22c08-ed1e-4cbe-a5d9-ac31c02b9764" />
