### PR TITLE
DEV: Add more logging to mediaconvert check_status

### DIFF
--- a/app/services/video_conversion/aws_media_convert_adapter.rb
+++ b/app/services/video_conversion/aws_media_convert_adapter.rb
@@ -102,7 +102,10 @@ module VideoConversion
       when "COMPLETE"
         STATUS_COMPLETE
       when "ERROR"
-        Rails.logger.error("MediaConvert job #{job_id} failed")
+        Rails.logger.error(
+          "MediaConvert job #{job_id} failed. Error Code: #{response.job.error_code}, " \
+            "Error Message: #{response.job.error_message}, Upload ID: #{@upload.id}",
+        )
         STATUS_ERROR
       when "SUBMITTED", "PROGRESSING"
         STATUS_PENDING

--- a/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
+++ b/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
@@ -229,12 +229,17 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
     context "when job has error" do
       before do
         allow(mediaconvert_job).to receive(:status).and_return("ERROR")
+        allow(mediaconvert_job).to receive(:error_code).and_return("1517")
+        allow(mediaconvert_job).to receive(:error_message).and_return("S3 Write Error")
+        allow(mediaconvert_job).to receive(:settings).and_return(nil)
         allow(mediaconvert_client).to receive(:get_job).and_return(mediaconvert_job_response)
       end
 
       it "returns :error and logs the error" do
         adapter.check_status(job_id)
-        expect(Rails.logger).to have_received(:error).with(/MediaConvert job #{job_id} failed/)
+        expect(Rails.logger).to have_received(:error).with(
+          /MediaConvert job #{job_id} failed\. Error Code: 1517, Error Message: S3 Write Error, Upload ID: #{upload.id}/,
+        )
         expect(adapter.check_status(job_id)).to eq(:error)
       end
     end


### PR DESCRIPTION
When converting videos if there is an error we need some more details to
debug what is going on.
