### PR TITLE
UX: user inbox styling fix

### DIFF
--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -101,18 +101,14 @@
       font-size: var(--font-up-1);
     }
 
-    .user-nav-messages-dropdown {
-      // manage long group names
-      max-width: 20vw;
-      min-width: 7em;
-
-      .select-kit-selected-name,
-      .name {
-        @include ellipsis;
+    .messages-dropdown-trigger {
+      @include viewport.from(sm) {
+        max-width: clamp(100px, 20vw, 200px);
       }
+      box-sizing: border-box;
 
-      .name {
-        min-width: 0;
+      .d-button-label {
+        @include ellipsis;
       }
     }
 


### PR DESCRIPTION
The inbox element was missing some styling, probably due to a conversion from selectkit to DMenu in https://github.com/discourse/discourse/pull/33889

This commit address the UX issue reported in https://meta.discourse.org/t/inbox-multi-word-styling-issue/384870