### PR TITLE
DEV: Replace deprecated Ember's array `compact`

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-table.gjs
+++ b/app/assets/javascripts/admin/addon/components/admin-report-table.gjs
@@ -37,7 +37,7 @@ export default class AdminReportTable extends Component {
     // check if we have at least one cell which contains a value
     const sum = totalsForSample
       .map((t) => t.value)
-      .compact()
+      .filter((item) => item != null)
       .reduce((s, v) => s + v, 0);
 
     return sum >= 1 && total && datesFiltering;

--- a/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-features.gjs
@@ -66,7 +66,7 @@ export default class DashboardNewFeatures extends Component {
           features: visibleFeatures,
         };
       })
-      .compact();
+      .filter((item) => item != null);
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
+++ b/app/assets/javascripts/discourse/app/components/edit-category-general.gjs
@@ -69,7 +69,7 @@ export default class EditCategoryGeneral extends Component {
           ? null
           : c.color.toUpperCase();
       })
-      .compact();
+      .filter((item) => item != null);
   }
 
   @cached

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.gjs
@@ -166,7 +166,7 @@ export default class UserCardContents extends CardContentsBase {
           const value = userFields ? userFields[field.get("id")] : null;
           return isEmpty(value) ? null : EmberObject.create({ value, field });
         })
-        .compact();
+        .filter((item) => item != null);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -169,7 +169,7 @@ export default class UserController extends Controller {
             : null;
           return isEmpty(value) ? null : EmberObject.create({ value, field });
         })
-        .compact();
+        .filter((item) => item != null);
     }
   }
 

--- a/app/assets/javascripts/discourse/app/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/app/deprecation-workflow.js
@@ -263,6 +263,10 @@ const DeprecationWorkflow = new DiscourseDeprecationWorkflow([
   },
   {
     handler: "log",
+    matchId: "discourse.native-array-extensions.compact",
+  },
+  {
+    handler: "log",
     matchId: "discourse.native-array-extensions.filterBy",
   },
   {

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -73,7 +73,7 @@ export function translateResults(results, opts) {
         (c) => c.id === (category.id || category.model.id)
       );
     })
-    .compact();
+    .filter((item) => item != null);
 
   results.grouped_search_result?.extra?.categories?.forEach((category) =>
     Site.current().updateCategory(category)
@@ -99,7 +99,7 @@ export function translateResults(results, opts) {
         url: getURL(`/g/${name}`),
       };
     })
-    .compact();
+    .filter((item) => item != null);
 
   results.tags = results.tags
     .map(function (tag) {
@@ -109,7 +109,7 @@ export function translateResults(results, opts) {
         url: getURL("/tag/" + tagName),
       });
     })
-    .compact();
+    .filter((item) => item != null);
 
   return translateResultsCallbacks
     .reduce(

--- a/app/assets/javascripts/discourse/app/lib/sharing.js
+++ b/app/assets/javascripts/discourse/app/lib/sharing.js
@@ -86,7 +86,7 @@ export default {
       .split("|")
       .concat(_customSharingIds)
       .map((s) => _sources[s])
-      .compact();
+      .filter((item) => item != null);
 
     return privateContext
       ? sources.filter((s) => s.showInPrivateContext)

--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-sidebar.js
@@ -274,7 +274,7 @@ function pluginAdminRouteLinks(router) {
                 return;
               }
             })
-            .compact();
+            .filter((item) => item != null);
         }
       }
 
@@ -336,7 +336,7 @@ export default class AdminSidebarPanel extends BaseCustomSidebarPanel {
             return pluginLink;
           }
         })
-        .compact();
+        .filter((item) => item != null);
       this.adminNavManager.amendLinksToSection("plugins", pluginLinksToAdd);
 
       this.adminSidebarStateManager.setLinkKeywords(

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -1161,7 +1161,7 @@ export default class PostStream extends RestModel {
 
     // Load our unloaded posts by id
     return this.loadIntoIdentityMap(unloaded, opts).then(() => {
-      return postIds.map((p) => identityMap[p]).compact();
+      return postIds.map((p) => identityMap[p]).filter((item) => item != null);
     });
   }
 

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -1110,7 +1110,7 @@ export default class TopicTrackingState extends EmberObject {
           return { topic, newTopic, unreadTopic };
         }
       })
-      .compact();
+      .filter((item) => item != null);
   }
 
   _stateKey(topicOrId) {

--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -365,7 +365,7 @@ export default class StoreService extends Service {
 
           const hydrated = obj[k]
             .map((id) => this._lookupSubType(subType, type, id, root))
-            .compact();
+            .filter((item) => item != null);
 
           obj[this.pluralize(subType)] = hydrated;
           if (hydrated.length !== 0) {

--- a/plugins/discourse-assign/assets/javascripts/discourse/models/topic.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/models/topic.js
@@ -46,7 +46,9 @@ export function extendTopicModel(api) {
         }
 
         assignments() {
-          return [this.topicAssignment(), ...this.postAssignments()].compact();
+          return [this.topicAssignment(), ...this.postAssignments()].filter(
+            (item) => item != null
+          );
         }
 
         postAssignments() {


### PR DESCRIPTION
Refactor all instances of `.compact()` to use `.filter(item => item != null)` for better consistency and readability across the codebase. This update ensures that null and undefined values are filtered out in a more explicit manner, adhering to modern JavaScript practices.

No functional behavior changes are expected from this modification.