### PR TITLE
FIX: Confirmation prompt breaks when using pipe

### DIFF
--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-require "highline/import"
+require "highline"
+require "io/console"
 
 class DestroyTask
   def initialize(io = STDOUT)
     @io = io
+    @tty = IO.console
+    @hl = HighLine.new(@tty, @io)
   end
 
   def destroy_topics(category, parent_category = nil, delete_system_topics = false)
@@ -77,7 +80,7 @@ class DestroyTask
     end
 
     if require_confirmation
-      confirm_destroy = ask("Are you sure? (Y/n)")
+      confirm_destroy = @hl.ask("Are you sure? (Y/n)")
       exit 1 if confirm_destroy.downcase != "y"
     end
 


### PR DESCRIPTION
### What is the problem?

We try to prompt for a confirmation using `highline` before destroying posts. This by default tries to read the answer from `STDIN`. However, when we use a pipe, e.g. `cat post_ids.txt | rake destroy:posts`, `STDIN` is used by the pipe. This results in an error as it's already EOF.

### How does this solve it?

Initialize `highline` with an IO object pointing to TTY.

**Before:**

<img width="945" height="264" alt="Screenshot 2025-10-08 at 10 47 11 AM" src="https://github.com/user-attachments/assets/84db780d-f979-4693-a487-cc7d310e6c92" />

**After:**

<img width="840" height="202" alt="Screenshot 2025-10-08 at 10 46 54 AM" src="https://github.com/user-attachments/assets/ff2ec56d-afa6-4b81-917a-35e5a54dd8d9" />