### PR TITLE
FIX: add minimal load-more-sentinel height

### DIFF
--- a/app/assets/stylesheets/common/components/load-more.scss
+++ b/app/assets/stylesheets/common/components/load-more.scss
@@ -1,5 +1,5 @@
 .load-more-sentinel {
-  height: 1px;
+  height: 1px; // 0px height causes issues with intersection observer in some cases
   width: 100%;
   margin: 0;
   padding: 0;

--- a/app/assets/stylesheets/common/components/load-more.scss
+++ b/app/assets/stylesheets/common/components/load-more.scss
@@ -1,5 +1,5 @@
 .load-more-sentinel {
-  height: 0;
+  height: 1px;
   width: 100%;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Based on reports in https://meta.discourse.org/t/users-list-only-partial/368793/17, some users may have issues with the LoadMore sentinel not triggering the intersection observer to load more elements due to it's `0px` height. I've not been able to reproduce this consistently myself, but adding the `1px` height appears to resolve the issue. This is an invisible element so it should not cause any inconsistency visually other than possibly causing a marginally earlier load of more elements.

Credit to `cathys` on Meta Discourse for the fix. 