### PR TITLE
FEATURE: Link to "All settings" for real in the admin sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/admin-nav-map.js
@@ -30,7 +30,8 @@ export const ADMIN_NAV_MAP = [
       },
       {
         name: "admin_all_site_settings",
-        route: "adminSiteSettings",
+        route: "adminSiteSettingsCategory",
+        routeModels: ["all_settings"],
         label: "admin.config.site_settings.title",
         description: "admin.config.site_settings.header_description",
         icon: "gear",


### PR DESCRIPTION
This will take admins to the full list of settings, not just the
Required category, saving a click.

c.f. https://meta.discourse.org/t/menu-item-all-site-settings-please-point-to-admin-site-settings-category-all-results/384952
