### PR TITLE
DEV: Simplify automation post editors

### DIFF
--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-pms-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-pms-field.gjs
@@ -70,7 +70,11 @@ export default class PmsField extends BaseField {
             <DAFieldLabel @label={{this.rawLabel}} @field={{@field}} />
             <div class="controls">
               <div class="field-wrapper">
-                <DEditor @value={{pm.raw}} />
+                <DEditor
+                  @value={{pm.raw}}
+                  @forceEditorMode="rich"
+                  @processPreview={{false}}
+                />
 
                 {{#if this.displayPlaceholders}}
                   <PlaceholdersList

--- a/plugins/automation/admin/assets/javascripts/admin/components/fields/da-post-field.gjs
+++ b/plugins/automation/admin/assets/javascripts/admin/components/fields/da-post-field.gjs
@@ -12,7 +12,11 @@ export default class PostField extends BaseField {
 
         <div class="controls">
           <div class="field-wrapper">
-            <DEditor @value={{@field.metadata.value}} />
+            <DEditor
+              @value={{@field.metadata.value}}
+              @forceEditorMode="rich"
+              @processPreview={{false}}
+            />
 
             <DAFieldDescription @description={{@description}} />
 


### PR DESCRIPTION
### What is this change?

These automation setups use a full-fledged editor where you can toggle between markdown and rich editing, but they don't have the logic that the composer comes with, that decides whether to display the preview or not, so it still (incorrectly) displays the preview when rich editor mode is selected.

This PR restricts the editor to just rich mode, and disables the preview.