### PR TITLE
DEV: Resolve flaky admin-themes spec

### DIFF
--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -23,7 +23,10 @@ module PageObjects
       def mark_as_default(theme)
         open_theme_menu(theme)
         find(".set-default").click
-        expect(page).to have_css("meta[name=discourse_theme_id][content='#{theme.id}']", visible: false) # wait for reload
+        expect(page).to have_css(
+          "meta[name=discourse_theme_id][content='#{theme.id}']",
+          visible: false, # wait for reload
+        )
       end
 
       def delete_theme(theme)


### PR DESCRIPTION
Changing the default causes a page reload, so we need to wait for that before continuing