### PR TITLE
DEV: Fix flake in category_templates_spec

### DIFF
--- a/spec/system/composer/category_templates_spec.rb
+++ b/spec/system/composer/category_templates_spec.rb
@@ -543,7 +543,7 @@ describe "Composer Form Templates", type: :system do
     expect(find(".d-editor-preview")).to have_content(message)
 
     attach_file("5-uploader", "#{Rails.root}/spec/fixtures/images/logo.png", make_visible: true)
-    expect(find(".d-editor-preview")).to have_css("img")
+    expect(page).to have_css(".d-editor-preview img")
   end
 
   context "when using tagchooser" do


### PR DESCRIPTION
Doing the assertion in two parts means that the `.d-editor-preview` reference might be removed from the dom before the content is checked. Making it a single selector avoids this race condition