### PR TITLE
Add 'svg' to authorized default file extensions

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2023,7 +2023,7 @@ files:
     list_type: file_types
   authorized_extensions:
     client: true
-    default: "jpg|jpeg|png|gif|heic|heif|webp|avif"
+    default: "jpg|jpeg|png|gif|heic|heif|webp|avif|svg"
     refresh: true
     type: list
     list_type: file_types


### PR DESCRIPTION
Seems like having SVG as a default makes sense now?

https://meta.discourse.org/t/add-the-svg-file-extension-to-image-files/212333/8?u=pfaffman