### PR TITLE
FEATURE: add support for "updating" an application on discourse id

### DIFF
--- a/app/services/discourse_id/register.rb
+++ b/app/services/discourse_id/register.rb
@@ -3,7 +3,10 @@
 class DiscourseId::Register
   include Service::Base
 
-  params { attribute :force, :boolean, default: false }
+  params do
+    attribute :force, :boolean, default: false
+    attribute :update, :boolean, default: false
+  end
 
   policy :not_already_registered?
   step :request_challenge
@@ -15,6 +18,7 @@ class DiscourseId::Register
 
   def not_already_registered?(params:)
     return true if params.force
+    return true if params.update
 
     SiteSetting.discourse_id_client_id.blank? && SiteSetting.discourse_id_client_secret.blank?
   end
@@ -73,20 +77,28 @@ class DiscourseId::Register
     Discourse.redis.setex("discourse_id_challenge_token", 600, token)
   end
 
-  def register_with_challenge(token:)
+  def register_with_challenge(token:, params:)
     uri = URI("#{discourse_id_url}/register")
     use_ssl = Rails.env.production? || uri.scheme == "https"
 
-    request = Net::HTTP::Post.new(uri)
-    request.content_type = "application/json"
-    request.body = {
+    body = {
       client_name: SiteSetting.title,
       redirect_uri: "#{Discourse.base_url}/auth/discourse_id/callback",
       challenge_token: token,
       logo_uri: SiteSetting.site_logo_url.presence,
       logo_small_uri: SiteSetting.site_logo_small_url.presence,
       description: SiteSetting.site_description.presence,
-    }.compact.to_json
+    }
+
+    if params.update
+      body[:update] = true
+      body[:client_id] = SiteSetting.discourse_id_client_id
+      body[:client_secret] = SiteSetting.discourse_id_client_secret
+    end
+
+    request = Net::HTTP::Post.new(uri)
+    request.content_type = "application/json"
+    request.body = body.compact.to_json
 
     begin
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl:) { |http| http.request(request) }
@@ -111,7 +123,9 @@ class DiscourseId::Register
     end
   end
 
-  def store_credentials(data:)
+  def store_credentials(data:, params:)
+    return if params.update
+
     SiteSetting.discourse_id_client_id = data["client_id"]
     SiteSetting.discourse_id_client_secret = data["client_secret"]
   end

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -99,4 +99,19 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
       end
     end
   end
+
+  # Update Discourse ID metadata
+  if SiteSetting.discourse_id_client_id.present? && SiteSetting.discourse_id_client_secret.present?
+    if %i[title logo logo_small site_description].include?(name)
+      Scheduler::Defer.later("Update Discourse ID metadata") do
+        begin
+          DiscourseId::Register.call(update: true)
+        rescue StandardError => e
+          Rails.logger.error(
+            "Failed to update Discourse ID metadata after #{name} change: #{e.message}",
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/services/discourse_id/register_spec.rb
+++ b/spec/services/discourse_id/register_spec.rb
@@ -349,5 +349,71 @@ RSpec.describe DiscourseId::Register do
 
       it { is_expected.to run_successfully }
     end
+
+    context "when updating metadata with update: true" do
+      let(:params) { { update: true } }
+
+      before do
+        SiteSetting.discourse_id_client_id = client_id
+        SiteSetting.discourse_id_client_secret = client_secret
+      end
+
+      context "when challenge request succeeds" do
+        before do
+          stub_request(:post, "#{discourse_id_url}/challenge").to_return(
+            status: 200,
+            body: { domain: Discourse.current_hostname, token: challenge_token }.to_json,
+          )
+        end
+
+        context "when update request succeeds" do
+          let(:response_data) { { client_id: client_id, client_name: SiteSetting.title } }
+
+          before do
+            stub_request(:post, "#{discourse_id_url}/register").with(
+              body: {
+                client_name: SiteSetting.title,
+                redirect_uri: "#{Discourse.base_url}/auth/discourse_id/callback",
+                challenge_token: challenge_token,
+                logo_uri: SiteSetting.site_logo_url,
+                logo_small_uri: SiteSetting.site_logo_small_url,
+                description: SiteSetting.site_description,
+                update: true,
+                client_id: client_id,
+                client_secret: client_secret,
+              }.to_json,
+            ).to_return(status: 200, body: response_data.to_json)
+          end
+
+          it { is_expected.to run_successfully }
+
+          it "includes client credentials in the registration request" do
+            result
+            expect(WebMock).to have_requested(:post, "#{discourse_id_url}/register").with { |req|
+              body = JSON.parse(req.body)
+              body["update"] == true && body["client_id"] == client_id &&
+                body["client_secret"] == client_secret
+            }
+          end
+
+          it "does not change stored credentials" do
+            result
+            expect(SiteSetting.discourse_id_client_id).to eq(client_id)
+            expect(SiteSetting.discourse_id_client_secret).to eq(client_secret)
+          end
+        end
+
+        context "when update request fails" do
+          before do
+            stub_request(:post, "#{discourse_id_url}/register").to_return(
+              status: 400,
+              body: "Application not found",
+            )
+          end
+
+          it { is_expected.to fail_a_step(:register_with_challenge) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This will automatically update the IDP whenever at least one of the following site setting changes

- title
- description
- logo url
- small logo url

Ref - meta/t/385471/2

---

Depends on https://github.com/discourse/discourse-login/pull/81