### PR TITLE
FIX: Prevent crash when invite_key is not yet populated

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2156,6 +2156,7 @@ en:
         redeemed_tab_with_count: "Redeemed (%{count})"
         invited_via: "Invitation"
         invited_via_link: "link %{key} (%{count} / %{max} redeemed)"
+        generating_link: "Generating link..."
         groups: "Groups"
         topic: "Topic"
         sent: "Created/Last Sent"

--- a/frontend/discourse/app/templates/user-invited/show.gjs
+++ b/frontend/discourse/app/templates/user-invited/show.gjs
@@ -222,12 +222,16 @@ export default <template>
                           {{invite.email}}
                         {{else}}
                           {{icon "link"}}
-                          {{i18n
-                            "user.invited.invited_via_link"
-                            key=invite.shortKey
-                            count=invite.redemption_count
-                            max=invite.max_redemptions_allowed
-                          }}
+                          {{#if invite.invite_key}}
+                            {{i18n
+                              "user.invited.invited_via_link"
+                              key=invite.shortKey
+                              count=invite.redemption_count
+                              max=invite.max_redemptions_allowed
+                            }}
+                          {{else}}
+                            <em>{{i18n "user.invited.generating_link"}}</em>
+                          {{/if}}
                         {{/if}}
                       </div>
 


### PR DESCRIPTION
Fixes a race condition where clicking "Create link" could crash with:
`TypeError: Cannot read properties of undefined (reading 'slice')`

## Root Cause
When an invite is created, the modal calls `invites.unshiftObject(this.invite)` 
immediately after [save()](cci:1://file:///discourse/app/assets/javascripts/discourse/app/models/invite.js:56:2-62:3) (in `create-invite.gjs:135`), adding it to the list 
before the server returns the populated `invite_key`. The template then tries 
to render [invite.shortKey](cci:1://file:///discourse/app/assets/javascripts/discourse/app/models/invite.js:80:2-83:3), which calls `.slice()` on an undefined value.

## Solution
Check if `invite.invite_key` exists before displaying the link text. Show a 
localized "Generating link..." placeholder until the invite is fully populated.

## Testing
The race condition can be reliably reproduced by adding a temporary delay in 
the `before_create` callback in [app/models/invite.rb](cci:7://file:///discourse/app/models/invite.rb:0:0-0:0):

```ruby
before_create do
  sleep(1)  # Temporary
  self.invite_key ||= SecureRandom.base58(10)
  self.expires_at ||= SiteSetting.invite_expiry_days.days.from_now
end