### PR TITLE
FEATURE: adds calendar_upcoming_events_default_view setting

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-index.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-index.js
@@ -4,6 +4,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 
 export default class PostEventUpcomingEventsDefaultIndexRoute extends DiscourseRoute {
   @service router;
+  @service siteSettings;
 
   beforeModel() {
     const today = moment();
@@ -13,7 +14,7 @@ export default class PostEventUpcomingEventsDefaultIndexRoute extends DiscourseR
 
     this.router?.replaceWith?.(
       "discourse-post-event-upcoming-events.index",
-      "month",
+      this.siteSettings.calendar_upcoming_events_default_view,
       year,
       month,
       day

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -126,3 +126,8 @@ discourse_calendar:
     enum: "CalendarFirstDayOfWeek"
     default: monday
     client: true
+  calendar_upcoming_events_default_view:
+    type: enum
+    enum: "CalendarUpcomingEventsDefaultView"
+    default: month
+    client: true

--- a/plugins/discourse-calendar/lib/calendar_upcoming_events_default_view.rb
+++ b/plugins/discourse-calendar/lib/calendar_upcoming_events_default_view.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_dependency "enum_site_setting"
+
+class CalendarUpcomingEventsDefaultView < EnumSiteSetting
+  def self.valid_value?(val)
+    values.any? { |v| v[:value].to_s == val.to_s }
+  end
+
+  def self.values
+    @values ||= [
+      { name: "discourse_calendar.toolbar_button.day", value: "day" },
+      { name: "discourse_calendar.toolbar_button.week", value: "week" },
+      { name: "discourse_calendar.toolbar_button.month", value: "month" },
+      { name: "discourse_calendar.toolbar_button.year", value: "year" },
+    ]
+  end
+
+  def self.translate_names?
+    true
+  end
+end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -12,6 +12,7 @@ $LOAD_PATH.unshift(libdir) if $LOAD_PATH.exclude?(libdir)
 
 require_relative "lib/calendar_settings_validator"
 require_relative "lib/calendar_first_day_of_week"
+require_relative "lib/calendar_upcoming_events_default_view"
 
 enabled_site_setting :calendar_enabled
 

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -495,9 +495,10 @@ describe "Upcoming Events", type: :system do
     end
 
     describe "configurable view" do
+      before { SiteSetting.calendar_upcoming_events_default_view = "day" }
+
       it "default view is controlled by calendar_upcoming_events_default_view setting",
          time: Time.utc(2025, 9, 15) do
-        SiteSetting.calendar_upcoming_events_default_view = "day"
         upcoming_events.visit
 
         upcoming_events.expect_content("September 15, 2025")

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -495,9 +495,9 @@ describe "Upcoming Events", type: :system do
     end
 
     describe "configurable view" do
-      SiteSetting.calendar_upcoming_events_default_view = "day"
       it "default view is controlled by calendar_upcoming_events_default_view setting",
          time: Time.utc(2025, 9, 15) do
+        SiteSetting.calendar_upcoming_events_default_view = "day"
         upcoming_events.visit
 
         upcoming_events.expect_content("September 15, 2025")

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -12,6 +12,7 @@ describe "Upcoming Events", type: :system do
   before do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.calendar_upcoming_events_default_view = "month"
     sign_in(admin)
   end
 

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -493,6 +493,17 @@ describe "Upcoming Events", type: :system do
       end
     end
 
+    describe "configurable view" do
+      SiteSetting.calendar_upcoming_events_default_view = "day"
+      it "default view is controlled by calendar_upcoming_events_default_view setting",
+         time: Time.utc(2025, 9, 15) do
+        upcoming_events.visit
+
+        upcoming_events.expect_content("September 15, 2025")
+        upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/9/15")
+      end
+    end
+
     describe "view switching" do
       it "switching from month to week view keeps the same day" do
         visit("/upcoming-events/month/2025/9/16")


### PR DESCRIPTION
Adds a new admin calendar setting `calendar_upcoming_events_default_view` to control the default view for `/upcoming-events`.

### Details
Admins can now set the default Upcoming events view (`Day`, `Week`, `Month`, or `Year`) in `Admin -> Plugins -> Calendar and Events > Settings`.

<img width="892" height="218" alt="Calendar and Events - Settings" src="https://github.com/user-attachments/assets/2a737bc4-7efc-4142-be98-9f84bf2ae7c3" />

Source: https://meta.discourse.org/t/add-admin-setting-to-change-default-calendar-view-month-week-year/387389.