### PR TITLE
UX: enable refreshed review page

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4190,6 +4190,7 @@ experimental:
     type: group_list
     default: ""
     area: "experimental"
+    hidden: true
   reviewable_old_moderator_actions:
     default: true
     hidden: true

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -610,7 +610,7 @@ class Guardian
   end
 
   def can_see_reviewable_ui_refresh?
-    @user.in_any_groups?(SiteSetting.reviewable_ui_refresh_map)
+    true
   end
 
   def is_me?(other)

--- a/plugins/chat/spec/system/reviewables_spec.rb
+++ b/plugins/chat/spec/system/reviewables_spec.rb
@@ -31,13 +31,13 @@ describe "Reviewables", type: :system do
     it "does not throw an error" do
       visit("/review?type=Chat%3A%3AReviewableMessage")
 
-      expect(page).to have_selector(".reviewable-item.reviewable-chat-message")
+      expect(page).to have_selector(".review-item__post-content")
     end
 
     it "adds the option to ignore the flag" do
       visit("/review?type=Chat%3A%3AReviewableMessage")
 
-      expect(page).to have_selector(".reviewable-actions .chat-message-ignore")
+      expect(page).to have_text(I18n.t("chat.reviewables.actions.ignore.title"))
     end
   end
 end

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -10,6 +10,7 @@ describe "Flagging post", type: :system do
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:flag_modal) { PageObjects::Modals::Flag.new }
   let(:silence_user_modal) { PageObjects::Modals::PenalizeUser.new("silence") }
+  let(:refreshed_review_page) { PageObjects::Pages::RefreshedReview.new }
 
   describe "Using Take Action" do
     before { sign_in(current_user) }
@@ -31,8 +32,7 @@ describe "Flagging post", type: :system do
 
       visit "/review/#{other_flag_reviewable.id}"
 
-      expect(page).to have_content(I18n.t("js.review.statuses.approved_flag.title"))
-      expect(page).to have_css(".reviewable-meta-data .status .approved")
+      expect(refreshed_review_page).to have_reviewable_with_approved_status(other_flag_reviewable)
     end
 
     it "can choose to immediately silence the user" do
@@ -56,8 +56,7 @@ describe "Flagging post", type: :system do
 
       visit "/review/#{Reviewable.sole.id}"
 
-      expect(page).to have_content(I18n.t("js.review.statuses.approved_flag.title"))
-      expect(page).to have_css(".reviewable-meta-data .status .approved")
+      expect(refreshed_review_page).to have_reviewable_with_approved_status(Reviewable.sole)
     end
   end
 

--- a/spec/system/page_objects/pages/refreshed_review.rb
+++ b/spec/system/page_objects/pages/refreshed_review.rb
@@ -38,6 +38,10 @@ module PageObjects
         within(reviewable_by_id(reviewable.id)) { page.has_text?("Rejected by") }
       end
 
+      def has_reviewable_with_pending_status?(reviewable)
+        within(reviewable_by_id(reviewable.id)) { page.has_css?(".review-item__status.--pending") }
+      end
+
       def has_reviewable_with_approved_status?(reviewable)
         within(reviewable_by_id(reviewable.id)) { page.has_css?(".review-item__status.--approved") }
       end

--- a/spec/system/review_filters_spec.rb
+++ b/spec/system/review_filters_spec.rb
@@ -21,8 +21,8 @@ describe "Review filters", type: :system do
 
         visit("/review?claimed_by=#{moderator.username}")
 
-        expect(page).to have_css(".reviewable-item", count: 1)
-        expect(page).to have_css(".reviewable-item[data-reviewable-id='#{flagged_post_1.id}']")
+        expect(page).to have_css(".review-item", count: 1)
+        expect(page).to have_css(".review-item[data-reviewable-id='#{flagged_post_1.id}']")
       end
 
       it "shows no reviewables when filtering by a user who has not claimed any" do
@@ -60,7 +60,7 @@ describe "Review filters", type: :system do
 
     it "allows to filter review claimed by category group moderators" do
       visit("/review")
-      expect(page).to have_css(".reviewable-item", count: 3)
+      expect(page).to have_css(".review-item", count: 3)
 
       review_index_page.expand_filters
 
@@ -70,8 +70,8 @@ describe "Review filters", type: :system do
 
       review_index_page.submit_filters
 
-      expect(page).to have_css(".reviewable-item", count: 1)
-      expect(page).to have_css(".reviewable-item[data-reviewable-id='#{flagged_post_1.id}']")
+      expect(page).to have_css(".review-item", count: 1)
+      expect(page).to have_css(".review-item[data-reviewable-id='#{flagged_post_1.id}']")
     end
   end
 end


### PR DESCRIPTION
This is a small PR just enabling the refreshed review page for everyone. At this stage, I don't want to remove the site setting so we can potentially quickly revert that change.

I will create a follow-up PR that will remove the hidden site setting and all legacy code.

Some tests were irrelevant. For example, in the old layout, long posts were collapsed. In the new layout, we have an inline scroll. 

<img width="1143" height="679" alt="Screenshot 2025-12-16 at 12 37 37 pm" src="https://github.com/user-attachments/assets/3020dfd1-f84b-44ca-906f-385536bdce3d" />
