### PR TITLE
FIX: Sync `topic_users.bookmarked` when no bookmarks exist

### DIFF
--- a/spec/jobs/sync_topic_user_bookmarked_spec.rb
+++ b/spec/jobs/sync_topic_user_bookmarked_spec.rb
@@ -1,48 +1,65 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::SyncTopicUserBookmarked do
-  subject(:job) { described_class.new }
-
   fab!(:topic)
-  fab!(:post1) { Fabricate(:post, topic: topic) }
-  fab!(:post2) { Fabricate(:post, topic: topic) }
-  fab!(:post3) { Fabricate(:post, topic: topic) }
+  fab!(:post) { Fabricate(:post, topic:) }
 
-  fab!(:tu1) { Fabricate(:topic_user, topic: topic, bookmarked: false) }
-  fab!(:tu2) { Fabricate(:topic_user, topic: topic, bookmarked: false) }
-  fab!(:tu3) { Fabricate(:topic_user, topic: topic, bookmarked: true) }
-  fab!(:tu4) { Fabricate(:topic_user, topic: topic, bookmarked: true) }
-  fab!(:tu5) { Fabricate(:topic_user, topic: topic, bookmarked: true) }
-
-  it "corrects all topic_users.bookmarked records for the topic" do
-    Fabricate(:bookmark, user: tu1.user, bookmarkable: topic.posts.sample)
-    Fabricate(:bookmark, user: tu4.user, bookmarkable: topic.posts.sample)
-
-    job.execute(topic_id: topic.id)
-
-    expect(tu1.reload.bookmarked).to eq(true)
-    expect(tu2.reload.bookmarked).to eq(false)
-    expect(tu3.reload.bookmarked).to eq(false)
-    expect(tu4.reload.bookmarked).to eq(true)
-    expect(tu5.reload.bookmarked).to eq(false)
+  def execute
+    described_class.new.execute(topic_id: topic.id)
   end
 
-  it "does not consider topic as bookmarked if the bookmarked post is deleted" do
-    Fabricate(:bookmark, user: tu1.user, bookmarkable: post1)
-    Fabricate(:bookmark, user: tu2.user, bookmarkable: post1)
+  it "sets bookmarked to false when no bookmarks exist for the topic" do
+    tu = Fabricate(:topic_user, topic:, bookmarked: true)
 
-    post1.trash!
+    execute
 
-    job.execute(topic_id: topic.id)
-
-    expect(tu1.reload.bookmarked).to eq(false)
-    expect(tu2.reload.bookmarked).to eq(false)
+    expect(tu.reload.bookmarked).to eq(false)
   end
 
-  it "still considers the topic bookmarked if it has a Topic bookmarkable" do
-    expect(tu1.reload.bookmarked).to eq(false)
-    Fabricate(:bookmark, user: tu1.user, bookmarkable: topic)
-    job.execute(topic_id: topic.id)
-    expect(tu1.reload.bookmarked).to eq(true)
+  it "does not count bookmarks on deleted posts" do
+    tu = Fabricate(:topic_user, topic:, bookmarked: true)
+    Fabricate(:bookmark, user: tu.user, bookmarkable: post)
+    post.trash!
+
+    execute
+
+    expect(tu.reload.bookmarked).to eq(false)
+  end
+
+  it "sets bookmarked to true when user has both a Topic and a Post bookmark" do
+    tu = Fabricate(:topic_user, topic:, bookmarked: false)
+    Fabricate(:bookmark, user: tu.user, bookmarkable: topic)
+    Fabricate(:bookmark, user: tu.user, bookmarkable: post)
+
+    execute
+
+    expect(tu.reload.bookmarked).to eq(true)
+  end
+
+  it "does not count bookmarks from other topics" do
+    other_post = Fabricate(:post)
+    tu = Fabricate(:topic_user, topic:, bookmarked: true)
+    Fabricate(:bookmark, user: tu.user, bookmarkable: other_post)
+
+    execute
+
+    expect(tu.reload.bookmarked).to eq(false)
+  end
+
+  it "correctly syncs multiple users with different bookmark states" do
+    bookmarked_via_post = Fabricate(:topic_user, topic:, bookmarked: false)
+    bookmarked_via_topic = Fabricate(:topic_user, topic:, bookmarked: false)
+    stale = Fabricate(:topic_user, topic:, bookmarked: true)
+    no_bookmark = Fabricate(:topic_user, topic:, bookmarked: false)
+
+    Fabricate(:bookmark, user: bookmarked_via_post.user, bookmarkable: post)
+    Fabricate(:bookmark, user: bookmarked_via_topic.user, bookmarkable: topic)
+
+    execute
+
+    expect(bookmarked_via_post.reload.bookmarked).to eq(true)
+    expect(bookmarked_via_topic.reload.bookmarked).to eq(true)
+    expect(stale.reload.bookmarked).to eq(false)
+    expect(no_bookmark.reload.bookmarked).to eq(false)
   end
 end


### PR DESCRIPTION
The `SyncTopicUserBookmarked` job uses a denormalized `bookmarked` column on `topic_users` to track whether a user has any bookmarks in a topic. This column was sometimes stuck as `true` even after all bookmarks were removed, causing phantom bookmark icons in the topic list.

The old query materialized bookmark data into a temp table then ran two UPDATE statements (one for true, one for false). The "set false" UPDATE used `FROM tmp_table` which performs a cross join — when no bookmarks existed for a topic, the temp table was empty, the cross join produced zero rows, and stale `bookmarked = true` values were never corrected.

```sql
UPDATE topic_users
SET bookmarked = false
FROM tmp_sync_topic_user_bookmarks  -- cross join with empty table = no-op
WHERE ... user_id NOT IN (SELECT ... FROM tmp_sync_topic_user_bookmarks)
```

Replace the temp table approach with a single UPDATE that computes an EXISTS subquery for each `topic_users` row. This correctly handles all cases including the empty-bookmarks scenario, avoids temp table overhead, and uses `IS DISTINCT FROM` to skip no-op writes.

```sql
UPDATE topic_users tu
SET bookmarked = computed.has_bookmark
FROM (SELECT id, EXISTS(...) AS has_bookmark ...) computed
WHERE tu.id = computed.id
AND tu.bookmarked IS DISTINCT FROM computed.has_bookmark
```

Also add `TopicUser.update_bookmarked` called from `ensure_consistency!` (every 12 hours) to globally fix any stale `bookmarked = true` values that accumulated over time.

Ref - t/77267