### PR TITLE
PERF: Fix slow topic loading when posts have many reactions

### DIFF
--- a/plugins/discourse-reactions/lib/discourse_reactions/post_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_extension.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 module DiscourseReactions::PostExtension
-  attr_accessor :post_actions_with_reaction_users
-
   def self.prepended(base)
     base.has_many :reactions, class_name: "DiscourseReactions::Reaction"
     base.has_many :reactions_user, class_name: "DiscourseReactions::ReactionUser"
-    base.attr_accessor :user_positively_reacted, :reaction_users_count
+    base.attr_accessor :user_positively_reacted,
+                       :reaction_users_count,
+                       :current_user_reaction,
+                       :current_user_like,
+                       :likes_count_for_reactions,
+                       :reactions_data_preloaded
   end
 
   def emoji_reactions

--- a/plugins/discourse-reactions/lib/discourse_reactions/posts_reaction_loader.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/posts_reaction_loader.rb
@@ -2,24 +2,95 @@
 
 module DiscourseReactions::PostsReactionLoader
   def posts_with_reactions
-    if SiteSetting.discourse_reactions_enabled
-      posts = object.posts
+    return unless SiteSetting.discourse_reactions_enabled
 
-      ActiveRecord::Associations::Preloader.new(
-        records: posts,
-        associations: [:post_actions, { reactions: { reaction_users: :user } }],
-      ).call
+    posts = object.posts
+    post_ids = posts.map(&:id).uniq
 
-      post_ids = posts.map(&:id).uniq
-      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
-      post_actions_with_reaction_users =
-        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-          post_ids,
+    # Preload reactions (for counter_cache reaction_users_count)
+    ActiveRecord::Associations::Preloader.new(records: posts, associations: [:reactions]).call
+
+    # Batch query: get reaction_users_count for all posts
+    posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
+
+    # Batch query: get current user's reaction_users for all posts (if logged in)
+    current_user_reactions = {}
+    if scope&.user
+      DiscourseReactions::ReactionUser
+        .joins(:reaction)
+        .where(post_id: post_ids, user_id: scope.user.id)
+        .where("discourse_reactions_reactions.reaction_users_count IS NOT NULL")
+        .select(
+          "discourse_reactions_reaction_users.post_id",
+          "discourse_reactions_reaction_users.created_at",
+          "discourse_reactions_reactions.reaction_value",
         )
-      posts.each do |post|
-        post.reaction_users_count = posts_reaction_users_count[post.id].to_i
-        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
-      end
+        .each { |ru| current_user_reactions[ru.post_id] = ru }
+    end
+
+    # Batch query: get current user's likes for all posts (if logged in)
+    current_user_likes = {}
+    if scope&.user
+      PostAction
+        .where(
+          post_id: post_ids,
+          user_id: scope.user.id,
+          post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+          deleted_at: nil,
+        )
+        .each { |pa| current_user_likes[pa.post_id] = pa }
+    end
+
+    # Batch query: get filtered likes count for all posts
+    # This excludes likes from users who have a reaction (to avoid double-counting)
+    excluded_reactions = DiscourseReactions::Reaction.reactions_excluded_from_like
+    main_reaction = DiscourseReactions::Reaction.main_reaction_id
+    excluded_list = excluded_reactions + [main_reaction]
+
+    posts_likes_count =
+      DB
+        .query(
+          <<~SQL,
+          SELECT post_actions.post_id, COUNT(*) as likes_count
+          FROM post_actions
+          WHERE post_actions.post_id IN (:post_ids)
+            AND post_actions.post_action_type_id = :like_type
+            AND post_actions.deleted_at IS NULL
+            AND post_actions.user_id NOT IN (
+              SELECT discourse_reactions_reaction_users.user_id
+              FROM discourse_reactions_reaction_users
+              INNER JOIN discourse_reactions_reactions
+                ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
+              WHERE discourse_reactions_reactions.post_id = post_actions.post_id
+                AND discourse_reactions_reactions.reaction_value NOT IN (:excluded_list)
+            )
+            AND post_actions.id NOT IN (
+              SELECT pa.id
+              FROM post_actions pa
+              INNER JOIN discourse_reactions_reaction_users
+                ON discourse_reactions_reaction_users.post_id = pa.post_id
+                AND discourse_reactions_reaction_users.user_id = pa.user_id
+              INNER JOIN discourse_reactions_reactions
+                ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
+              WHERE pa.post_id = post_actions.post_id
+                AND pa.post_action_type_id = :like_type
+                AND discourse_reactions_reactions.reaction_value = :main_reaction
+            )
+          GROUP BY post_actions.post_id
+        SQL
+          post_ids:,
+          like_type: PostActionType::LIKE_POST_ACTION_ID,
+          excluded_list:,
+          main_reaction:,
+        )
+        .to_h { |row| [row.post_id, row.likes_count] }
+
+    posts.each do |post|
+      post.reaction_users_count = posts_reaction_users_count[post.id].to_i
+      post.current_user_reaction = current_user_reactions[post.id]
+      post.current_user_like = current_user_likes[post.id]
+      post.likes_count_for_reactions = posts_likes_count[post.id].to_i
+      post.reactions_data_preloaded = true
     end
   end
 end

--- a/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -3,25 +3,6 @@
 module DiscourseReactions::TopicViewSerializerExtension
   include DiscourseReactions::PostsReactionLoader
 
-  def self.load_post_action_reaction_users_for_posts(post_ids)
-    PostAction
-      .joins(
-        "LEFT JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.post_id = post_actions.post_id AND discourse_reactions_reaction_users.user_id = post_actions.user_id",
-      )
-      .where(post_id: post_ids)
-      .where("post_actions.deleted_at IS NULL")
-      .where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
-      .where(
-        "post_actions.post_id IN (#{DiscourseReactions::PostActionExtension.post_action_with_reaction_user_sql})",
-        valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like,
-      )
-      .reduce({}) do |hash, post_action|
-        hash[post_action.post_id] ||= {}
-        hash[post_action.post_id][post_action.id] = post_action
-        hash
-      end
-  end
-
   def posts
     posts_with_reactions
     super

--- a/plugins/discourse-reactions/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/topics_controller_spec.rb
@@ -22,15 +22,14 @@ describe TopicsController do
     it "does not generate N+1 queries" do
       sign_in(user_1)
 
-      queries = track_sql_queries { get "/t/#{post.topic_id}.json" }
-      count = queries.filter { |q| q.include?("reactions") }.size
-
+      # Add some reaction_users first to establish baseline
       Fabricate(:reaction_user, reaction: laughing_reaction, user: user_1, post: post)
       Fabricate(:reaction_user, reaction: laughing_reaction, user: user_2, post: post)
 
       queries = track_sql_queries { get "/t/#{post.topic_id}.json" }
-      expect(queries.filter { |q| q.include?("reactions") }.size).to eq(count)
+      count = queries.filter { |q| q.include?("reactions") }.size
 
+      # Add more reaction_users - query count should stay the same
       Fabricate(:reaction_user, reaction: hugs_reaction, user: user_3, post: post)
       Fabricate(:reaction_user, reaction: open_mouth_reaction, user: user_4, post: post)
 

--- a/plugins/discourse-reactions/spec/serializers/op_reactions_data_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/op_reactions_data_serializer_spec.rb
@@ -67,15 +67,7 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
     end
 
     context "when first_post is loaded and modifier is true" do
-      before do
-        topic.association(:first_post).target = first_post
-        first_post.post_actions_with_reaction_users =
-          DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-            [first_post.id],
-          )[
-            first_post.id
-          ]
-      end
+      before { topic.association(:first_post).target = first_post }
 
       it "includes all required fields" do
         json = serializer_class.new(topic, scope: Guardian.new(user_1), root: false).as_json
@@ -105,14 +97,7 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
           Fabricate(:reaction_user, reaction: reaction_otter, user: user_1, post: first_post)
           Fabricate(:reaction_user, reaction: reaction_otter, user: user_2, post: first_post)
           Fabricate(:reaction_user, reaction: reaction_plus_1, user: user_3, post: first_post)
-
           first_post.reload
-          first_post.post_actions_with_reaction_users =
-            DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-              [first_post.id],
-            )[
-              first_post.id
-            ]
         end
 
         it "includes reactions sorted by count and current user data" do
@@ -137,14 +122,7 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
             user: user_2,
             post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           )
-
           first_post.reload
-          first_post.post_actions_with_reaction_users =
-            DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-              [first_post.id],
-            )[
-              first_post.id
-            ]
         end
 
         it "shows likes as main_reaction_id" do
@@ -177,15 +155,7 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
           )
         end
 
-        before do
-          first_post.reload
-          first_post.post_actions_with_reaction_users =
-            DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-              [first_post.id],
-            )[
-              first_post.id
-            ]
-        end
+        before { first_post.reload }
 
         it "shows canToggle correctly based on permissions and undo window" do
           json_with_like =
@@ -228,12 +198,6 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
 
             topic.reload
             topic.association(:first_post).target = first_post.reload
-            first_post.post_actions_with_reaction_users =
-              DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-                [first_post.id],
-              )[
-                first_post.id
-              ]
           end
 
           it "can see all reactions and counts from other users" do
@@ -264,12 +228,6 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
 
             topic.reload
             topic.association(:first_post).target = first_post.reload
-            first_post.post_actions_with_reaction_users =
-              DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-                [first_post.id],
-              )[
-                first_post.id
-              ]
           end
 
           it "can see likes as main_reaction_id" do
@@ -295,14 +253,7 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
             user: user_2,
             post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
           )
-
           first_post.reload
-          first_post.post_actions_with_reaction_users =
-            DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-              [first_post.id],
-            )[
-              first_post.id
-            ]
         end
 
         it "correctly combines reactions and likes with proper user states" do

--- a/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
@@ -42,13 +42,6 @@ describe PostSerializer do
     SiteSetting.discourse_reactions_like_icon = "heart"
 
     reaction_user_1 && reaction_user_2 && reaction_user_3 && like
-
-    post_1.post_actions_with_reaction_users =
-      DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-        [post_1.id],
-      )[
-        post_1.id
-      ]
   end
 
   it "renders custom reactions which should be sorted by count" do


### PR DESCRIPTION
Viewing topics where posts have thousands of reactions was painfully slow. The root cause: we were eager-loading ALL reaction_users into memory with `{ reactions: { reaction_users: :user } }`. On a post with 8000 reactions, that's 8000 ActiveRecord objects instantiated just to figure out if the current user reacted and to count likes.

The fix replaces this "load everything" approach with targeted batch queries that fetch only what we need:

1. Current user's reactions across all posts (1 query instead of N)
2. Current user's likes across all posts (1 query instead of N)
3. Filtered likes count via GROUP BY (1 query instead of N)

The tricky part was the likes count - we can't just count PostActions because users who reacted with a custom emoji also have a like record (for backwards compatibility). The original code loaded all user_ids into a Set to filter them out. Now we do this filtering directly in SQL with a correlated subquery, which lets us batch across all posts.

Added a `reactions_data_preloaded` flag on posts so serializers know when to use the preloaded data vs falling back to per-post queries (for single post views and other non-batch contexts).

Net result: topic view queries drop from O(N) to O(1) where N is the number of posts, and we no longer load thousands of reaction_users into memory regardless of how many reactions exist.

Ref - /t/139516

**BEFORE**

<img width="1570" height="1322" alt="BEFORE" src="https://github.com/user-attachments/assets/c9d5020c-4cfe-490f-8561-cb5f5ec4e16f" />

**AFTER**

<img width="1570" height="1322" alt="AFTER" src="https://github.com/user-attachments/assets/21c98611-6455-405b-b551-d2b6cbf90f5e" />