### PR TITLE
DEV: Add bypass_bump parameter to post update API

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -279,6 +279,14 @@ class PostsController < ApplicationController
       opts[:skip_validations] = true
     end
 
+    if params.key?(:bypass_bump) || params[:post]&.key?(:bypass_bump)
+      if guardian.can_update_bumped_at?
+        opts[:bypass_bump] = ActiveModel::Type::Boolean.new.cast(
+          params[:bypass_bump].presence || params.dig(:post, :bypass_bump),
+        )
+      end
+    end
+
     topic = post.topic
     topic = Topic.with_deleted.find(post.topic_id) if guardian.is_staff?
 

--- a/spec/requests/api/schemas/json/post_update_request.json
+++ b/spec/requests/api/schemas/json/post_update_request.json
@@ -13,6 +13,10 @@
         }
       },
       "required": ["raw"]
+    },
+    "bypass_bump": {
+      "type": "boolean",
+      "description": "Skip bumping the topic when updating the post. Requires staff or TL4 permissions."
     }
   }
 }


### PR DESCRIPTION
Adds a new `bypass_bump` parameter to the post update endpoint that allows privileged users (staff and TL4) to update a post without bumping the topic.

The parameter can be passed as either a query param (`?bypass_bump=true`) or in the request body (`post[bypass_bump]=true`).

When omitted, behavior is unchanged - edits to the last post in a topic will bump it as usual.

Closes #34712