### PR TITLE
UX: Show timezone when browser differs from user profile

### DIFF
--- a/frontend/discourse/app/lib/local-dates.js
+++ b/frontend/discourse/app/lib/local-dates.js
@@ -1,6 +1,6 @@
 import { optionalRequire } from "./utilities";
 
-export function applyLocalDates(dates, siteSettings, timezone) {
+export function applyLocalDates(dates, siteSettings, profileTimezone) {
   if (!siteSettings.discourse_local_dates_enabled) {
     return;
   }
@@ -10,5 +10,5 @@ export function applyLocalDates(dates, siteSettings, timezone) {
     "applyLocalDates"
   );
 
-  _applyLocalDates(dates, siteSettings, timezone);
+  _applyLocalDates(dates, siteSettings, profileTimezone);
 }

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
@@ -5,12 +5,13 @@ import { optionalRequire } from "discourse/lib/utilities";
 export default {
   name: "chat-plugin-decorators",
 
-  initializeWithPluginApi(api, siteSettings) {
+  initializeWithPluginApi(api, siteSettings, currentUser) {
     api.decorateChatMessage(
       (element) => {
         applyLocalDates(
           element.querySelectorAll(".discourse-local-date"),
-          siteSettings
+          siteSettings,
+          currentUser?.user_option?.timezone
         );
       },
       {
@@ -41,8 +42,9 @@ export default {
   initialize(container) {
     if (container.lookup("service:chat").userCanChat) {
       const siteSettings = container.lookup("service:site-settings");
+      const currentUser = container.lookup("service:current-user");
       withPluginApi((api) => {
-        this.initializeWithPluginApi(api, siteSettings);
+        this.initializeWithPluginApi(api, siteSettings, currentUser);
       });
     }
   },

--- a/plugins/discourse-calendar/assets/javascripts/discourse/helpers/format-event-name.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/helpers/format-event-name.js
@@ -1,14 +1,5 @@
 import { i18n } from "discourse-i18n";
-
-function sameTimezoneOffset(timezone1, timezone2) {
-  if (!timezone1 || !timezone2) {
-    return false;
-  }
-
-  const offset1 = moment.tz(timezone1).utcOffset();
-  const offset2 = moment.tz(timezone2).utcOffset();
-  return offset1 === offset2;
-}
+import { isEqualZones } from "discourse/plugins/discourse-local-dates/lib/local-date-builder";
 
 export function formatEventName(event, userTimezone) {
   let output = event.name || event.post.topic.title;
@@ -16,7 +7,7 @@ export function formatEventName(event, userTimezone) {
   if (
     event.showLocalTime &&
     event.timezone &&
-    !sameTimezoneOffset(event.timezone, userTimezone)
+    !isEqualZones(event.timezone, userTimezone)
   ) {
     output += ` (${i18n("discourse_calendar.local_time")})`;
   }

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -6,50 +6,77 @@ module PageObjects
       class UpcomingEvents < PageObjects::Pages::Base
         def visit(prefix = "")
           super("#{prefix}/upcoming-events")
+          self
         end
 
         def next
           find(".fc-next-button").click
+          self
         end
 
         def prev
           find(".fc-prev-button").click
+          self
         end
 
         def today
           find(".fc-today-button").click
+          self
         end
 
         def open_year_view
           find(".fc-listYear-button").click
-          expect(page).to have_css(".fc-listYear-view")
-          wait_for_timeout
+          has_css?(".fc-listYear-view", wait: 5)
+          self
         end
 
         def open_day_view
           find(".fc-timeGridDay-button").click
-          expect(page).to have_css(".fc-timeGridDay-view")
-          wait_for_timeout
+          has_css?(".fc-timeGridDay-view", wait: 5)
+          self
         end
 
         def open_week_view
           find(".fc-timeGridWeek-button").click
-          expect(page).to have_css(".fc-timeGridWeek-view")
-          wait_for_timeout
+          has_css?(".fc-timeGridWeek-view", wait: 5)
+          self
         end
 
         def open_month_view
           find(".fc-dayGridMonth-button").click
-          expect(page).to have_css(".fc-dayGridMonth-view")
-          wait_for_timeout
+          has_css?(".fc-dayGridMonth-view", wait: 5)
+          self
         end
 
         def open_mine_events
           find(".fc-mineEvents-button").click
+          self
         end
 
         def open_all_events
           find(".fc-allEvents-button").click
+          self
+        end
+
+        def click_event(title)
+          find("a", text: title).click
+          self
+        end
+
+        def click_recurring_event(occurrence:, title: nil)
+          row = occurrence * 2
+          selector = "tr.fc-list-event:nth-child(#{row}) .fc-list-event-title a"
+          if title
+            find(selector, text: title).click
+          else
+            find(selector).click
+          end
+          self
+        end
+
+        def close_event_modal
+          page.send_keys(:escape)
+          self
         end
 
         def has_calendar?
@@ -74,31 +101,11 @@ module PageObjects
         end
 
         def has_event_count?(count)
-          has_css?(".fc-daygrid-event-harness", count: count)
+          has_css?(".fc-daygrid-event-harness", count:)
         end
 
         def has_content_in_calendar?(text)
-          has_css?("#upcoming-events-calendar .fc", text: text)
-        end
-
-        def has_event_at_position?(title, row:, col:)
-          has_css?(".fc tr:nth-child(#{row}) td:nth-child(#{col}) .fc-event-title", text: title)
-        end
-
-        def find_event_by_position(position)
-          find(".fc-event:nth-child(#{position})")
-        end
-
-        def event_time_text(event_element)
-          event_element.find(".fc-list-event-time").text
-        end
-
-        def event_title_text(event_element)
-          event_element.find(".fc-list-event-title").text
-        end
-
-        def current_view_title
-          find(".fc-toolbar-title").text
+          has_css?("#upcoming-events-calendar .fc", text:)
         end
 
         def has_current_path?(path)
@@ -109,54 +116,37 @@ module PageObjects
           page.has_content?(text)
         end
 
-        def expect_to_be_on_path(path)
-          expect(self).to have_current_path(path)
-        end
-
-        def expect_content(text)
-          expect(self).to have_content(text)
-        end
-
-        def expect_event_visible(title)
-          expect(self).to have_event(title)
-        end
-
-        def expect_event_not_visible(title)
-          expect(self).to have_no_event(title)
-        end
-
-        def expect_event_count(count)
-          expect(self).to have_event_count(count)
-        end
-
-        def expect_event_at_position(title, row:, col:)
-          expect(self).to have_event_at_position(title, row: row, col: col)
-        end
-
-        def find_event_by_title(title)
-          find(".fc-event", text: title)
-        end
-
         def has_event_with_time?(title, time)
-          event = find_event_by_title(title)
-          event.has_css?(".fc-list-event-time", text: time)
+          has_css?(".fc-event", text: title) &&
+            find(".fc-event", text: title).has_css?(".fc-list-event-time", text: time)
         end
 
-        def get_event_height(title)
-          find_event_by_title(title).native.bounding_box["height"]
+        def has_event_dates?(text)
+          has_css?(".event__section.event-dates", text:)
         end
 
-        def find_all_events_by_title(title)
-          all(".fc-event", text: title)
+        def has_recurring_event_time?(occurrence:, time:)
+          # occurrence 1 = nth-child(2), occurrence 2 = nth-child(4), etc.
+          row = occurrence * 2
+          has_css?("tr.fc-list-event:nth-child(#{row}) .fc-list-event-time", text: time)
         end
 
         def has_event_height?(title, expected_height)
-          height = get_event_height(title)
+          height = find(".fc-event", text: title).native.bounding_box["height"]
           height >= expected_height - 1 && height <= expected_height + 1
         end
 
-        def first_weekday_header_text
-          find(".fc-col-header .fc-col-header-cell:nth-child(1) .fc-col-header-cell-cushion").text
+        def has_block_event_style?
+          has_css?(".fc-daygrid-block-event")
+        end
+
+        def has_dot_event_style?
+          has_css?(".fc-daygrid-dot-event")
+        end
+
+        def has_event_dot_color?(color)
+          has_css?(".fc-daygrid-event-dot") &&
+            get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor") == color
         end
 
         def has_first_column_as_sunday?

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -45,6 +45,7 @@ describe "Upcoming Events" do
   end
 
   describe "popup invitees on recurring events" do
+    fab!(:category)
     fab!(:going_recurring_user, :user)
     fab!(:going_once_user, :user)
     let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -2,11 +2,7 @@
 
 describe "Upcoming Events" do
   fab!(:admin)
-  fab!(:user)
-  fab!(:category)
 
-  let(:composer) { PageObjects::Components::Composer.new }
-  let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:upcoming_events) { PageObjects::Pages::DiscourseCalendar::UpcomingEvents.new }
 
   before do
@@ -16,14 +12,30 @@ describe "Upcoming Events" do
     sign_in(admin)
   end
 
+  def create_event(title:, start:, end_time: nil, **options)
+    attrs = ["start=\"#{start}\""]
+    attrs << "end=\"#{end_time}\"" if end_time
+    attrs << "timezone=\"#{options[:timezone]}\"" if options[:timezone]
+    attrs << "recurrence=#{options[:recurrence]}" if options[:recurrence]
+    attrs << "recurrenceUntil=\"#{options[:recurrence_until]}\"" if options[:recurrence_until]
+    attrs << "showLocalTime=#{options[:show_local_time]}" if options[:show_local_time]
+    attrs << "status=\"#{options[:status]}\"" if options[:status]
+
+    create_post(
+      user: admin,
+      category: Fabricate(:category),
+      title:,
+      raw: "[event #{attrs.join(" ")}]\n[/event]",
+    )
+  end
+
   describe "basic functionality" do
     it "displays events in the calendar", time: Time.utc(2025, 9, 10, 12, 0) do
       post =
-        create_post(
-          user: admin,
-          category: Fabricate(:category),
-          title: "A great event to join",
-          raw: "[event  start=\"2025-09-11 08:05\" end=\"2025-09-11 10:05\"]\n[/event]",
+        create_event(
+          title: "Company planning meeting for Q4",
+          start: "2025-09-11 08:05",
+          end_time: "2025-09-11 10:05",
         )
 
       upcoming_events.visit
@@ -123,563 +135,385 @@ describe "Upcoming Events" do
   end
 
   describe "event display and formatting" do
-    before { admin.user_option.update!(timezone: "America/New_York") }
+    # To avoid flaky tests, each test sets the profile timezone to match
+    # the browser timezone (set via `timezone:` metadata).
 
-    describe "non-recurring events" do
-      describe "with local time enabled" do
-        it "displays event time in event timezone with (Local time) suffix",
-           timezone: "Australia/Brisbane",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Local time event",
-            raw:
-              "[event showLocalTime=true timezone=CET start=\"2025-09-11 08:05\" end=\"2025-09-11 10:05\"]\n[/event]",
-          )
+    describe "with showLocalTime enabled" do
+      it "displays time in event timezone with suffix",
+         timezone: "Australia/Brisbane",
+         time: Time.utc(2025, 9, 10, 12, 0) do
+        admin.user_option.update!(timezone: "Australia/Brisbane")
 
-          upcoming_events.visit
-          upcoming_events.open_year_view
+        create_event(
+          title: "European conference call with partners",
+          start: "2025-09-11 08:05",
+          end_time: "2025-09-11 10:05",
+          timezone: "CET",
+          show_local_time: true,
+        )
 
-          expect(upcoming_events).to have_event_with_time(
-            "Local time event (Local time)",
-            "8:05am - 10:05am",
-          )
+        upcoming_events.visit
+        upcoming_events.open_year_view
 
-          find("a", text: "Local time event (Local time)").click
+        expect(upcoming_events).to have_event_with_time(
+          "European conference call with partners (Local time)",
+          "8:05am - 10:05am",
+        )
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Thu, Sep 11 8:05 AM (CET) → 10:05 AM (CET)",
-          )
-        end
+        upcoming_events.click_event("European conference call with partners (Local time)")
+
+        expect(upcoming_events).to have_event_dates("Thu, Sep 11 8:05 AM (CET) → 10:05 AM (CET)")
       end
+    end
 
-      describe "without local time" do
-        it "displays event time converted to user timezone",
-           timezone: "Australia/Brisbane",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Event with CET time",
-            raw:
-              "[event timezone=CET start=\"2025-09-11 19:00\" end=\"2025-09-11 21:00\"]\n[/event]",
-          )
+    describe "without showLocalTime" do
+      it "converts time to browser timezone",
+         timezone: "Australia/Brisbane",
+         time: Time.utc(2025, 9, 10, 12, 0) do
+        admin.user_option.update!(timezone: "Australia/Brisbane")
 
-          upcoming_events.visit
-          upcoming_events.open_year_view
+        create_event(
+          title: "Berlin team sync meeting",
+          start: "2025-09-11 19:00",
+          end_time: "2025-09-11 21:00",
+          timezone: "CET",
+        )
 
-          expect(upcoming_events).to have_event_with_time("Event with CET time", "1:00pm - 3:00pm")
+        upcoming_events.visit
+        upcoming_events.open_year_view
 
-          find("a", text: "Event with CET time").click
+        # 19:00 CET = 03:00+1 Brisbane
+        expect(upcoming_events).to have_event_with_time(
+          "Berlin team sync meeting",
+          "3:00am - 5:00am",
+        )
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Tomorrow 1:00 PM → 3:00 PM",
-          )
-        end
+        upcoming_events.click_event("Berlin team sync meeting")
+
+        expect(upcoming_events).to have_event_dates("Friday at 3:00 AM → 5:00 AM (Brisbane)")
       end
+    end
 
-      describe "with same timezone as user" do
-        it "displays event time normally when event timezone matches user timezone",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Same timezone event",
-            raw:
-              "[event showLocalTime=true timezone=\"America/New_York\" start=\"2025-09-12 08:05\" end=\"2025-09-12 09:05\"]\n[/event]",
-          )
+    describe "when event timezone matches user timezone" do
+      it "displays time without conversion",
+         timezone: "America/New_York",
+         time: Time.utc(2025, 9, 10, 12, 0) do
+        admin.user_option.update!(timezone: "America/New_York")
 
-          upcoming_events.visit
-          upcoming_events.open_year_view
+        create_event(
+          title: "New York office standup meeting",
+          start: "2025-09-12 08:05",
+          end_time: "2025-09-12 09:05",
+          timezone: "America/New_York",
+          show_local_time: true,
+        )
 
-          expect(upcoming_events).to have_event_with_time("Same timezone event", "8:05am - 9:05am")
+        upcoming_events.visit
+        upcoming_events.open_year_view
 
-          find("a", text: "Same timezone event").click
+        expect(upcoming_events).to have_event_with_time(
+          "New York office standup meeting",
+          "8:05am - 9:05am",
+        )
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Fri, Sep 12 8:05 AM → 9:05 AM",
-          )
-        end
+        upcoming_events.click_event("New York office standup meeting")
+
+        expect(upcoming_events).to have_event_dates("Fri, Sep 12 8:05 AM → 9:05 AM")
       end
     end
 
     describe "recurring events" do
-      describe "with local time enabled" do
-        it "displays multiple occurrences with correct local time",
-           timezone: "Australia/Brisbane",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Recurring local event",
-            raw:
-              "[event recurrence=every_week showLocalTime=true timezone=CET start=\"2025-09-11 08:05\" end=\"2025-09-11 10:05\"]\n[/event]",
-          )
+      it "displays multiple occurrences with showLocalTime",
+         timezone: "Australia/Brisbane",
+         time: Time.utc(2025, 9, 10, 12, 0) do
+        admin.user_option.update!(timezone: "Australia/Brisbane")
 
-          upcoming_events.visit
-          upcoming_events.open_year_view
+        create_event(
+          title: "Weekly European team standup",
+          start: "2025-09-11 08:05",
+          end_time: "2025-09-11 10:05",
+          timezone: "CET",
+          recurrence: "every_week",
+          show_local_time: true,
+        )
 
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(2) .fc-list-event-time",
-            text: "8:05am - 10:05am",
-          )
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(4) .fc-list-event-time",
-            text: "8:05am - 10:05am",
-          )
+        upcoming_events.visit
+        upcoming_events.open_year_view
 
-          find("tr.fc-list-event:nth-child(2) .fc-list-event-title a").click
+        expect(upcoming_events).to have_recurring_event_time(
+          occurrence: 1,
+          time: "8:05am - 10:05am",
+        )
+        expect(upcoming_events).to have_recurring_event_time(
+          occurrence: 2,
+          time: "8:05am - 10:05am",
+        )
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Thu, Sep 11 8:05 AM (CET) → 10:05 AM (CET)",
-          )
+        upcoming_events.click_recurring_event(occurrence: 1)
 
-          page.send_keys(:escape)
+        expect(upcoming_events).to have_event_dates("Thu, Sep 11 8:05 AM (CET) → 10:05 AM (CET)")
 
-          find("tr.fc-list-event:nth-child(4) .fc-list-event-title a").click
+        upcoming_events.close_event_modal
+        upcoming_events.click_recurring_event(occurrence: 2)
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Thu, Sep 18 8:05 AM (CET) → 10:05 AM (CET)",
-          )
-        end
+        expect(upcoming_events).to have_event_dates("Thu, Sep 18 8:05 AM (CET) → 10:05 AM (CET)")
       end
 
-      describe "without local time" do
-        it "displays multiple occurrences converted to user timezone",
-           timezone: "Australia/Brisbane",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Recurring CET event",
-            raw:
-              "[event recurrence=every_week timezone=CET start=\"2025-09-11 19:00\" end=\"2025-09-11 20:00\"]\n[/event]",
-          )
-          upcoming_events.visit
-          upcoming_events.open_year_view
+      it "displays multiple occurrences converted to browser timezone",
+         timezone: "Australia/Brisbane",
+         time: Time.utc(2025, 9, 10, 12, 0) do
+        admin.user_option.update!(timezone: "Australia/Brisbane")
 
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(2) .fc-list-event-time",
-            text: "1:00pm - 2:00pm",
-          )
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(4) .fc-list-event-time",
-            text: "1:00pm - 2:00pm",
-          )
+        create_event(
+          title: "Weekly Berlin evening sync",
+          start: "2025-09-11 19:00",
+          end_time: "2025-09-11 20:00",
+          timezone: "CET",
+          recurrence: "every_week",
+        )
 
-          find(
-            "tr.fc-list-event:nth-child(2) .fc-list-event-title a",
-            text: "Recurring CET event",
-          ).click
+        upcoming_events.visit
+        upcoming_events.open_year_view
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Tomorrow 1:00 PM → 2:00 PM (New York)",
-          )
+        # 19:00 CET = 03:00+1 Brisbane
+        expect(upcoming_events).to have_recurring_event_time(occurrence: 1, time: "3:00am - 4:00am")
+        expect(upcoming_events).to have_recurring_event_time(occurrence: 2, time: "3:00am - 4:00am")
 
-          page.send_keys(:escape)
+        upcoming_events.click_recurring_event(occurrence: 1, title: "Weekly Berlin evening sync")
 
-          find(
-            "tr.fc-list-event:nth-child(4) .fc-list-event-title a",
-            text: "Recurring CET event",
-          ).click
+        expect(upcoming_events).to have_event_dates("Friday at 3:00 AM → 4:00 AM (Brisbane)")
 
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Thu, Sep 18 1:00 PM → 2:00 PM",
-          )
-        end
+        upcoming_events.close_event_modal
+        upcoming_events.click_recurring_event(occurrence: 2, title: "Weekly Berlin evening sync")
+
+        expect(upcoming_events).to have_event_dates("Fri, Sep 19 3:00 AM → 4:00 AM (Brisbane)")
       end
 
-      describe "with same timezone as user" do
-        it "displays multiple occurrences without timezone conversion issues",
-           timezone: "Australia/Brisbane",
-           time: Time.utc(2025, 9, 10, 12, 0) do
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "Recurring same TZ event",
-            raw:
-              "[event recurrence=every_week showLocalTime=true timezone=\"America/New_York\" start=\"2025-09-12 08:05\" end=\"2025-09-12 10:05\"]\n[/event]",
-          )
-
-          upcoming_events.visit
-          upcoming_events.open_year_view
-
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(2) .fc-list-event-time",
-            text: "8:05am - 10:05am",
-          )
-          expect(page).to have_css(
-            "tr.fc-list-event:nth-child(4) .fc-list-event-time",
-            text: "8:05am - 10:05am",
-          )
-
-          find("tr.fc-list-event:nth-child(2) .fc-list-event-title a").click
-
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Fri, Sep 12 8:05 AM → 10:05 AM (New York)",
-          )
-
-          page.send_keys(:escape)
-
-          find("tr.fc-list-event:nth-child(4) .fc-list-event-title a").click
-
-          expect(page).to have_css(
-            ".event__section.event-dates",
-            text: "Fri, Sep 19 8:05 AM → 10:05 AM",
-          )
-        end
-      end
-    end
-
-    describe "recurring events" do
-      it "displays recurring events until the specified end date",
-         time: Time.utc(2025, 6, 2, 19, 00) do
-        post =
-          create_post(
-            user: admin,
-            category: Fabricate(:category),
-            title: "A recurring post event",
-            raw:
-              "[event recurrenceUntil=\"#{30.days.from_now.iso8601}\" timezone=\"Australia\/Brisbane\" recurrence=\"every_week\" status=\"public\" start=\"2025-06-11 08:05\"]\n[/event]",
-          )
+      it "respects recurrenceUntil", time: Time.utc(2025, 6, 2, 19, 00) do
+        create_event(
+          title: "Monthly book club with limited occurrences",
+          start: "2025-06-11 08:05",
+          timezone: "Australia/Brisbane",
+          recurrence: "every_week",
+          recurrence_until: 30.days.from_now.iso8601,
+          status: "public",
+        )
 
         upcoming_events.visit
 
-        upcoming_events.expect_event_count(4)
-        upcoming_events.expect_event_at_position(post.topic.title, row: 3, col: 2)
-        upcoming_events.expect_event_at_position(post.topic.title, row: 4, col: 2)
-        upcoming_events.expect_event_at_position(post.topic.title, row: 5, col: 2)
-        upcoming_events.expect_event_at_position(post.topic.title, row: 6, col: 2)
+        expect(upcoming_events).to have_event_count(4)
       end
     end
   end
 
   describe "event filtering" do
-    it "loads the correct range of dates", time: Time.utc(2025, 9, 1, 12, 0) do
-      create_post(
-        user: admin,
-        category: Fabricate(:category),
-        title: "going to the zoo",
-        raw:
-          "[event start=\"2025-09-07 18:30\" status=\"public\" timezone=\"Europe/Prague\" end=\"2025-09-07 21:00\"]\n[/event]",
+    it "loads events for the visible date range", time: Time.utc(2025, 9, 1, 12, 0) do
+      create_event(
+        title: "Company trip to the Prague zoo",
+        start: "2025-09-07 18:30",
+        end_time: "2025-09-07 21:00",
+        timezone: "Europe/Prague",
+        status: "public",
+      )
+      create_event(
+        title: "October team offsite planning retreat",
+        start: "2025-10-15 09:00",
+        end_time: "2025-10-15 17:00",
+        timezone: "Europe/Prague",
+        status: "public",
       )
 
       visit("/upcoming-events/week/2025/9/1")
 
-      upcoming_events.expect_event_visible("zoo")
+      expect(upcoming_events).to have_event("Prague zoo")
+      expect(upcoming_events).to have_no_event("October team offsite")
     end
 
-    it "shows only events the user is attending when filtered",
-       time: Time.utc(2025, 6, 2, 19, 00) do
-      attending_event =
-        create_post(
-          user: admin,
-          category: Fabricate(:category),
-          title: "Attending post event",
-          raw: "[event status=\"public\" start=\"2025-06-11 08:05\"]\n[/event]",
+    it "filters to only attending events", time: Time.utc(2025, 6, 2, 19, 00) do
+      attending =
+        create_event(
+          title: "Conference I am attending this week",
+          start: "2025-06-11 08:05",
+          status: "public",
         )
-      create_post(
-        user: admin,
-        category: Fabricate(:category),
-        title: "Non attending post event",
-        raw: "[event start=\"2025-06-12 08:05\"]\n[/event]",
-      )
-      DiscoursePostEvent::Event.find(attending_event.id).create_invitees(
+      create_event(title: "Workshop I will not attend", start: "2025-06-12 08:05")
+
+      DiscoursePostEvent::Event.find(attending.id).create_invitees(
         [{ user_id: admin.id, status: 0 }],
       )
 
       upcoming_events.visit
 
-      upcoming_events.expect_event_visible("Attending post event")
-      upcoming_events.expect_event_visible("Non attending post event")
+      expect(upcoming_events).to have_event("Conference I am attending")
+      expect(upcoming_events).to have_event("Workshop I will not attend")
 
       upcoming_events.open_mine_events
 
-      upcoming_events.expect_event_visible("Attending post event")
-      upcoming_events.expect_event_not_visible("Non attending post event")
+      expect(upcoming_events).to have_event("Conference I am attending")
+      expect(upcoming_events).to have_no_event("Workshop I will not attend")
     end
   end
 
-  describe "calendar navigation and views" do
-    describe "navigation buttons" do
-      describe "today button" do
-        it "navigates to current date", time: Time.utc(2025, 6, 2, 19, 00) do
-          visit("/upcoming-events/month/2025/8/1")
+  describe "calendar navigation" do
+    describe "today button" do
+      it "navigates to current date", time: Time.utc(2025, 6, 2, 19, 00) do
+        visit("/upcoming-events/month/2025/8/1")
 
-          upcoming_events.today
+        upcoming_events.today
 
-          upcoming_events.expect_to_be_on_path("/upcoming-events/month/2025/6/1")
-        end
-
-        context "in different timezone", timezone: "Europe/London" do
-          it "navigates to current date in day view", time: Time.utc(2025, 6, 2, 19, 00) do
-            visit("/upcoming-events/day/2025/8/1")
-
-            upcoming_events.today
-
-            upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/6/2")
-          end
-        end
+        expect(upcoming_events).to have_current_path("/upcoming-events/month/2025/6/1")
       end
 
-      describe "next button" do
-        it "navigates to next month" do
-          visit("/upcoming-events/month/2025/8/1")
+      it "respects browser timezone for day view",
+         timezone: "Europe/London",
+         time: Time.utc(2025, 6, 2, 19, 00) do
+        visit("/upcoming-events/day/2025/8/1")
 
-          upcoming_events.next
+        upcoming_events.today
 
-          expect(page).to have_content("September 2025")
-          upcoming_events.expect_to_be_on_path("/upcoming-events/month/2025/9/1")
-        end
-
-        it "navigates to next week" do
-          visit("/upcoming-events/week/2025/8/4")
-
-          upcoming_events.next
-
-          expect(page).to have_content("Aug 11 – 17, 2025")
-          upcoming_events.expect_to_be_on_path("/upcoming-events/week/2025/8/11")
-        end
-
-        context "in different timezone", timezone: "Europe/London" do
-          it "navigates to next day" do
-            visit("/upcoming-events/day/2025/8/4")
-
-            upcoming_events.next
-
-            expect(page).to have_content("August 5, 2025")
-            upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/8/5")
-          end
-
-          it "navigates to next week" do
-            visit("/upcoming-events/week/2025/8/4")
-
-            upcoming_events.next
-
-            expect(page).to have_content("Aug 11 – 17, 2025")
-            upcoming_events.expect_to_be_on_path("/upcoming-events/week/2025/8/11")
-          end
-        end
-      end
-
-      describe "prev button" do
-        it "navigates to previous day" do
-          visit("/upcoming-events/day/2025/8/1")
-
-          upcoming_events.prev
-
-          expect(page).to have_content("July 31, 2025")
-          upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/7/31")
-        end
-
-        it "navigates to previous month" do
-          visit("/upcoming-events/month/2025/8/1")
-
-          upcoming_events.prev
-
-          expect(page).to have_content("July 2025")
-          upcoming_events.expect_to_be_on_path("/upcoming-events/month/2025/7/1")
-        end
-
-        it "navigates to previous week" do
-          visit("/upcoming-events/week/2025/8/4")
-
-          upcoming_events.prev
-
-          expect(page).to have_content("Jul 28 – Aug 3, 2025")
-          upcoming_events.expect_to_be_on_path("/upcoming-events/week/2025/7/28")
-        end
-
-        context "in different timezone", timezone: "Europe/London" do
-          it "navigates to previous day" do
-            visit("/upcoming-events/day/2025/8/1")
-
-            upcoming_events.prev
-
-            expect(page).to have_content("July 31, 2025")
-            upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/7/31")
-          end
-
-          it "navigates to previous month" do
-            visit("/upcoming-events/month/2025/8/1")
-
-            upcoming_events.prev
-
-            expect(page).to have_content("July 2025")
-            upcoming_events.expect_to_be_on_path("/upcoming-events/month/2025/7/1")
-          end
-
-          it "navigates to previous week" do
-            visit("/upcoming-events/week/2025/8/4")
-
-            upcoming_events.prev
-
-            expect(page).to have_content("Jul 28 – Aug 3, 2025")
-            upcoming_events.expect_to_be_on_path("/upcoming-events/week/2025/7/28")
-          end
-        end
-      end
-
-      describe "event duration display" do
-        context "with recurring event" do
-          it "displays longer events with appropriate visual height in time grid view",
-             time: Time.utc(2025, 6, 2, 19, 00) do
-            create_post(
-              user: admin,
-              category: Fabricate(:category),
-              title: "This is a short meeting",
-              raw:
-                "[event recurrence=\"every_week\" start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
-            )
-
-            create_post(
-              user: admin,
-              category: Fabricate(:category),
-              title: "This is a long workshop",
-              raw:
-                "[event recurrence=\"every_week\" start=\"2025-06-03 14:00\" end=\"2025-06-03 17:00\"]\n[/event]",
-            )
-
-            upcoming_events.visit
-            visit("/upcoming-events/week/2025/6/2")
-
-            expect(upcoming_events).to have_event_height("This is a short meeting", 47)
-            expect(upcoming_events).to have_event_height("This is a long workshop", 143)
-          end
-        end
-
-        context "with non recurring event" do
-          it "displays longer events with appropriate visual height in time grid view",
-             time: Time.utc(2025, 6, 2, 19, 00) do
-            create_post(
-              user: admin,
-              category: Fabricate(:category),
-              title: "This is a short meeting",
-              raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
-            )
-
-            create_post(
-              user: admin,
-              category: Fabricate(:category),
-              title: "This is a long workshop",
-              raw: "[event start=\"2025-06-03 14:00\" end=\"2025-06-03 17:00\"]\n[/event]",
-            )
-
-            upcoming_events.visit
-            visit("/upcoming-events/week/2025/6/2")
-
-            expect(upcoming_events).to have_event_height("This is a short meeting", 47)
-            expect(upcoming_events).to have_event_height("This is a long workshop", 143)
-          end
-        end
+        expect(upcoming_events).to have_current_path("/upcoming-events/day/2025/6/2")
       end
     end
 
-    describe "configurable view" do
-      before { SiteSetting.calendar_upcoming_events_default_view = "day" }
+    describe "next/prev buttons" do
+      it "navigates between months" do
+        visit("/upcoming-events/month/2025/8/1")
 
-      it "default view is controlled by calendar_upcoming_events_default_view setting",
-         time: Time.utc(2025, 9, 15) do
-        upcoming_events.visit
+        upcoming_events.next
 
-        upcoming_events.expect_content("September 15, 2025")
-        upcoming_events.expect_to_be_on_path("/upcoming-events/day/2025/9/15")
+        expect(upcoming_events).to have_content("September 2025")
+
+        upcoming_events.prev.prev
+
+        expect(upcoming_events).to have_content("July 2025")
       end
-    end
 
-    describe "view switching" do
-      it "switching from month to week view keeps the same day" do
-        visit("/upcoming-events/month/2025/9/16")
+      it "navigates between weeks" do
+        visit("/upcoming-events/week/2025/8/4")
 
-        upcoming_events.open_week_view
+        upcoming_events.next
 
-        upcoming_events.expect_content("Sep 15 – 21, 2025")
-        upcoming_events.expect_to_be_on_path("/upcoming-events/week/2025/9/15")
+        expect(upcoming_events).to have_content("Aug 11 – 17, 2025")
+
+        upcoming_events.prev.prev
+
+        expect(upcoming_events).to have_content("Jul 28 – Aug 3, 2025")
+      end
+
+      it "navigates between days" do
+        visit("/upcoming-events/day/2025/8/1")
+
+        upcoming_events.next
+
+        expect(upcoming_events).to have_content("August 2, 2025")
+
+        upcoming_events.prev.prev
+
+        expect(upcoming_events).to have_content("July 31, 2025")
       end
     end
   end
 
-  describe "with calendar_event_display setting", time: Time.utc(2025, 6, 2, 19, 00) do
+  describe "view configuration" do
+    it "uses calendar_upcoming_events_default_view setting", time: Time.utc(2025, 9, 15) do
+      SiteSetting.calendar_upcoming_events_default_view = "day"
+
+      upcoming_events.visit
+
+      expect(upcoming_events).to have_content("September 15, 2025")
+      expect(upcoming_events).to have_current_path("/upcoming-events/day/2025/9/15")
+    end
+
+    it "preserves date when switching views" do
+      visit("/upcoming-events/month/2025/9/16")
+
+      upcoming_events.open_week_view
+
+      expect(upcoming_events).to have_content("Sep 15 – 21, 2025")
+    end
+  end
+
+  describe "event duration display", time: Time.utc(2025, 6, 2, 19, 00) do
+    it "reflects duration in visual height" do
+      create_event(
+        title: "Quick daily standup meeting",
+        start: "2025-06-03 10:00",
+        end_time: "2025-06-03 11:00",
+      )
+      create_event(
+        title: "Full day architecture workshop",
+        start: "2025-06-03 14:00",
+        end_time: "2025-06-03 17:00",
+      )
+
+      visit("/upcoming-events/week/2025/6/2")
+
+      expect(upcoming_events).to have_event_height("Quick daily standup meeting", 47)
+      expect(upcoming_events).to have_event_height("Full day architecture workshop", 143)
+    end
+  end
+
+  describe "calendar_event_display setting", time: Time.utc(2025, 6, 2, 19, 00) do
     before do
-      create_post(
-        user: admin,
-        category: Fabricate(:category),
-        title: "This is a short meeting",
-        raw:
-          "[event recurrence=\"every_week\" start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
+      create_event(
+        title: "Weekly team planning session",
+        start: "2025-06-03 10:00",
+        end_time: "2025-06-03 11:00",
+        recurrence: "every_week",
       )
     end
 
-    context "with block" do
-      before { SiteSetting.calendar_event_display = "block" }
+    it "renders block style when set to block" do
+      SiteSetting.calendar_event_display = "block"
 
-      it "renders block" do
-        visit("/upcoming-events/month/2025/9/16")
+      visit("/upcoming-events/month/2025/9/16")
 
-        expect(page).to have_selector(".fc-daygrid-block-event")
-      end
+      expect(upcoming_events).to have_block_event_style
     end
 
-    context "with auto" do
-      before { SiteSetting.calendar_event_display = "auto" }
+    it "renders dot style when set to auto" do
+      SiteSetting.calendar_event_display = "auto"
 
-      it "renders dot" do
-        visit("/upcoming-events/month/2025/9/16")
+      visit("/upcoming-events/month/2025/9/16")
 
-        expect(page).to have_selector(".fc-daygrid-dot-event")
-      end
+      expect(upcoming_events).to have_dot_event_style
     end
   end
 
-  context "with tag color", time: Time.utc(2025, 6, 2, 19, 00) do
-    before do
+  describe "event color mapping", time: Time.utc(2025, 6, 2, 19, 00) do
+    it "colors events by tag" do
       SiteSetting.map_events_to_color = [
-        { type: "tag", color: "rgb(231, 76, 60)", slug: "awesome-tag" },
+        { type: "tag", color: "rgb(231, 76, 60)", slug: "red-tag" },
       ].to_json
 
       create_post(
         user: admin,
         category: Fabricate(:category),
-        topic: Fabricate(:topic, tags: [Fabricate(:tag, name: "awesome-tag")]),
-        title: "This is a short meeting",
+        topic: Fabricate(:topic, tags: [Fabricate(:tag, name: "red-tag")]),
+        title: "Important quarterly review meeting",
         raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
       )
-    end
 
-    it "display the event with the correct color" do
       visit("/upcoming-events/month/2025/6/16")
 
-      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(231, 76, 60)")
+      expect(upcoming_events).to have_event_dot_color("rgb(231, 76, 60)")
     end
-  end
 
-  context "with category color", time: Time.utc(2025, 6, 2, 19, 00) do
-    before do
+    it "colors events by category" do
       SiteSetting.map_events_to_color = [
-        { type: "category", color: "rgb(231, 76, 60)", slug: "awesome-category" },
+        { type: "category", color: "rgb(231, 76, 60)", slug: "red-cat" },
       ].to_json
 
       create_post(
         user: admin,
-        category: Fabricate(:category, slug: "awesome-category"),
-        title: "This is a short meeting",
+        category: Fabricate(:category, slug: "red-cat"),
+        title: "Annual company celebration dinner",
         raw: "[event start=\"2025-06-03 10:00\" end=\"2025-06-03 11:00\"]\n[/event]",
       )
-    end
 
-    it "display the event with the correct color" do
       visit("/upcoming-events/month/2025/6/16")
 
-      expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq("rgb(231, 76, 60)")
+      expect(upcoming_events).to have_event_dot_color("rgb(231, 76, 60)")
     end
   end
 end

--- a/plugins/discourse-calendar/test/javascripts/integration/components/dates-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/dates-test.gjs
@@ -1,3 +1,4 @@
+import { set } from "@ember/object";
 import { render, settled, waitFor } from "@ember/test-helpers";
 import { module, skip, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -10,6 +11,14 @@ module("Integration | Component | Dates", function (hooks) {
   hooks.beforeEach(function () {
     moment.tz.guess = () => "UTC";
     this.clock = fakeTime("2025-11-01T00:00:00Z", "UTC", true);
+
+    // Set user's profile timezone to match browser timezone
+    // to avoid timezone mismatch display in tests.
+    // setupRenderingTest sets timezone to Australia/Brisbane by default.
+    set(this.currentUser, "user_option", {
+      ...this.currentUser.user_option,
+      timezone: "UTC",
+    });
   });
 
   hooks.afterEach(function () {
@@ -67,7 +76,7 @@ module("Integration | Component | Dates", function (hooks) {
   }
 
   module("dates without time", function () {
-    test("formats weekdays within range 1 day before and 2 days after the specified day", async function (assert) {
+    test("formats events within calendar range (today/tomorrow)", async function (assert) {
       await render(
         <template>
           <div data-post-id="123">
@@ -80,8 +89,8 @@ module("Integration | Component | Dates", function (hooks) {
       assert
         .dom(".event-dates")
         .hasText(
-          "Sunday → Monday",
-          "`startsAt` should show full weekday names"
+          "Today 2:00 PM → Tomorrow 2:00 PM",
+          "events within calendar range should use relative formatting"
         );
     });
 
@@ -176,8 +185,8 @@ module("Integration | Component | Dates", function (hooks) {
       assert
         .dom(".event-dates")
         .hasText(
-          "Yesterday 6:00 PM → Tomorrow 6:00 PM",
-          "`startsAt` should not show current year and time"
+          "Yesterday 8:00 AM → Tomorrow 8:00 AM",
+          "multi-day events should use relative dates with times"
         );
     });
 
@@ -194,8 +203,8 @@ module("Integration | Component | Dates", function (hooks) {
       assert
         .dom(".event-dates")
         .hasText(
-          "Today 6:00 PM → 7:00 PM (Brisbane)",
-          "`endsAt` should show from today time to time only"
+          "Today 8:00 AM → 9:00 AM (UTC)",
+          "same-day events should show times with timezone suffix"
         );
     });
 

--- a/plugins/discourse-calendar/test/javascripts/integration/components/dates-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/dates-test.gjs
@@ -217,7 +217,7 @@ module("Integration | Component | Dates", function (hooks) {
       assert
         .dom(".event-dates")
         .hasText(
-          "Mon, Oct 6 10:00 AM → 11:00 AM (Brisbane)",
+          "Mon, Oct 6 12:00 AM → 1:00 AM (UTC)",
           "`endsAt` should show time only"
         );
     });

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/modal/local-dates-create.gjs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/modal/local-dates-create.gjs
@@ -90,7 +90,8 @@ export default class LocalDatesCreate extends Component {
       schedule("afterRender", () => {
         applyLocalDates(
           document.querySelectorAll(".preview .discourse-local-date"),
-          this.siteSettings
+          this.siteSettings,
+          this.currentUser?.user_option?.timezone
         );
       });
     }

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -15,12 +15,12 @@ import LocalDateBuilder from "../lib/local-date-builder";
 import richEditorExtension from "../lib/rich-editor-extension";
 
 // Import applyLocalDates from discourse/lib/local-dates instead
-export function applyLocalDates(dates, siteSettings, timezone) {
+export function applyLocalDates(dates, siteSettings, profileTimezone) {
   if (!siteSettings.discourse_local_dates_enabled) {
     return;
   }
 
-  const currentUserTZ = timezone || moment.tz.guess();
+  const browserTimezone = moment.tz.guess();
 
   dates.forEach((element, index, arr) => {
     const opts = buildOptionsFromElement(element, siteSettings);
@@ -36,7 +36,9 @@ export function applyLocalDates(dates, siteSettings, timezone) {
       }
     }
 
-    const localDateBuilder = new LocalDateBuilder(opts, currentUserTZ).build();
+    const localDateBuilder = new LocalDateBuilder(opts, browserTimezone, {
+      profileTimezone,
+    }).build();
 
     element.innerText = "";
     element.insertAdjacentHTML(
@@ -135,8 +137,9 @@ function initializeDiscourseLocalDates(api) {
 
   api.decorateCookedElement((elem, helper) => {
     const dates = elem.querySelectorAll(".discourse-local-date");
+    const currentUser = api.getCurrentUser();
 
-    applyLocalDates(dates, siteSettings);
+    applyLocalDates(dates, siteSettings, currentUser?.user_option?.timezone);
 
     const topicTitle = helper?.getModel()?.topic?.title;
     dates.forEach((date) => {
@@ -161,12 +164,11 @@ function initializeDiscourseLocalDates(api) {
   });
 }
 
-function buildHtmlPreview(element, siteSettings) {
+function buildHtmlPreview(element, siteSettings, profileTimezone) {
   const opts = buildOptionsFromElement(element, siteSettings);
-  const localDateBuilder = new LocalDateBuilder(
-    opts,
-    moment.tz.guess()
-  ).build();
+  const localDateBuilder = new LocalDateBuilder(opts, moment.tz.guess(), {
+    profileTimezone,
+  }).build();
 
   const htmlPreviews = localDateBuilder.previews.map((preview) => {
     const previewNode = document.createElement("div");
@@ -273,6 +275,7 @@ function _calculateDuration(element) {
 }
 
 class LocalDatesInit {
+  @service currentUser;
   @service siteSettings;
   @service tooltip;
 
@@ -331,7 +334,13 @@ class LocalDatesInit {
 
     return this.tooltip.show(event.target, {
       identifier: "local-date",
-      content: trustHTML(buildHtmlPreview(event.target, this.siteSettings)),
+      content: trustHTML(
+        buildHtmlPreview(
+          event.target,
+          this.siteSettings,
+          this.currentUser?.user_option?.timezone
+        )
+      ),
     });
   }
 

--- a/plugins/discourse-local-dates/test/javascripts/unit/local-date-builder-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/unit/local-date-builder-test.js
@@ -603,4 +603,82 @@ module("Unit | Library | local-date-builder", function () {
       );
     });
   });
+
+  test("option[profileTimezone] - shows timezone when browser differs from profile", function (assert) {
+    freezeTime({ date: "2020-03-22", timezone: LOS_ANGELES }, () => {
+      // User's browser is in Los Angeles, but their profile is set to Paris
+      const localDateBuilder = new LocalDateBuilder(
+        {
+          date: "2020-03-22",
+          time: "14:00",
+          timezone: PARIS,
+        },
+        LOS_ANGELES, // browser timezone (localTimezone)
+        { profileTimezone: PARIS } // user's profile timezone
+      );
+
+      const result = localDateBuilder.build();
+      assert.true(
+        result.formatted.includes("Los Angeles"),
+        "shows timezone abbreviation when browser differs from profile"
+      );
+    });
+
+    freezeTime({ date: "2020-03-22", timezone: PARIS }, () => {
+      // User's browser and profile are the same (Paris)
+      const localDateBuilder = new LocalDateBuilder(
+        {
+          date: "2020-03-22",
+          time: "14:00",
+          timezone: PARIS,
+        },
+        PARIS, // browser timezone (localTimezone)
+        { profileTimezone: PARIS } // user's profile timezone - same as browser
+      );
+
+      const result = localDateBuilder.build();
+      assert.false(
+        result.formatted.includes("Paris"),
+        "does not show timezone abbreviation when browser matches profile"
+      );
+    });
+
+    freezeTime({ date: "2020-03-22", timezone: LOS_ANGELES }, () => {
+      // No profile timezone provided (anonymous user)
+      const localDateBuilder = new LocalDateBuilder(
+        {
+          date: "2020-03-22",
+          time: "14:00",
+          timezone: PARIS,
+        },
+        LOS_ANGELES, // browser timezone (localTimezone)
+        { profileTimezone: null } // no profile timezone
+      );
+
+      const result = localDateBuilder.build();
+      assert.false(
+        result.formatted.includes("Los Angeles"),
+        "does not show timezone abbreviation when no profile timezone is set"
+      );
+    });
+
+    freezeTime({ date: "2020-03-22", timezone: LOS_ANGELES }, () => {
+      // Profile timezone is undefined (anonymous user or profile not set)
+      const localDateBuilder = new LocalDateBuilder(
+        {
+          date: "2020-03-22",
+          time: "14:00",
+          timezone: PARIS,
+        },
+        LOS_ANGELES, // browser timezone (localTimezone)
+        {} // no profileTimezone option
+      );
+
+      const result = localDateBuilder.build();
+      assert.false(
+        result.formatted.includes("Los Angeles"),
+        "does not show timezone abbreviation when profileTimezone option is not provided"
+      );
+    });
+  });
 });


### PR DESCRIPTION
When users travel to a different timezone, local dates can be confusing because they see times in their current location's timezone but may not realize it differs from their profile timezone.

This adds a timezone abbreviation when browser timezone differs from profile:

```
Before: "Monday, January 6 • 4pm - 6pm"
After:  "Monday, January 6 • 11:00 AM (Sao Paulo)"
```

Times continue to display in the browser's timezone (not profile), so users see times relevant to their current location, now with clarity about which timezone they're viewing.

### Implementation

- LocalDateBuilder accepts `profileTimezone` option to detect mismatches
- Added `_hasProfileTimezoneMismatch()` method for the comparison
- Modified `_applyFormatting()` to force timezone display on mismatch
- Updated all call sites (posts, chat, modal preview, tooltips)
- Exported `isEqualZones` as shared utility (calendar plugin now imports it instead of duplicating the logic)
- Fixed bug where `_isEqualZones` used `.includes()` which could incorrectly match timezone substrings

### Edge cases

- Anonymous users: no profile timezone exists, so no abbreviation shown
- Users without profile timezone set: treated same as anonymous
- Users at home (timezones match): no abbreviation shown

Ref - t/170851
Replaces #36705

---

**🇧🇪 BRUSSEL**

<img width="2451" height="1753" alt="BRUSSEL" src="https://github.com/user-attachments/assets/c2db9729-8317-4999-85d3-a844d3e4688c" />

**🇯🇵 TOKYO**

<img width="2451" height="1753" alt="TOKYO" src="https://github.com/user-attachments/assets/08bf52d0-8e0a-4c48-b294-00fa78c8164c" />

**🇺🇸 SAN FRANCISCO**

<img width="2451" height="1753" alt="SAN FRANCISCO" src="https://github.com/user-attachments/assets/0ae3f0f8-4a8f-4bb5-9d47-b945ece718cc" />