### PR TITLE
FIX: Make edit history viewable for category moderators in the certain catergory

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1785,7 +1785,7 @@ en:
     staff_edit_locks_post: "Posts will be locked from editing if they are edited by staff members"
     post_edit_time_limit: "A tl0 or tl1 author can edit their post for (n) minutes after posting. Set to 0 for forever."
     tl2_post_edit_time_limit: "A tl2+ author can edit their post for (n) minutes after posting. Set to 0 for forever."
-    edit_history_visible_to_public: "Allow everyone to see previous versions of an edited post. When disabled, only staff members can view."
+    edit_history_visible_to_public: "Allow everyone to see previous versions of an edited post. When disabled, only staff members and category group moderators (for posts in their moderated categories) can view."
     delete_removed_posts_after: "Posts removed by the author will be automatically deleted after (n) hours. If set to 0, posts will be deleted immediately."
     notify_users_after_responses_deleted_on_flagged_post: "When a post is flagged and then removed, all users that responded to the post and had their responses removed will be notified."
     max_image_width: "Maximum thumbnail width of images in a post. Images with a larger width will be resized and lightboxed."

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -352,7 +352,7 @@ module PostGuardian
     return false if !authenticated?
     return false if !can_see_post?(post)
 
-    is_staff? || is_my_own?(post)
+    is_staff? || is_my_own?(post) || is_category_group_moderator?(post.topic&.category)
   end
 
   def can_change_post_owner?


### PR DESCRIPTION
When category moderators use review panel and encounters an edited topic/post, the clicking on the edit-history button will result in a dialog showing invalid_access.

<img width="690" height="143" alt="image" src="https://github.com/user-attachments/assets/4dda617b-6672-4b0c-a4fa-121a66a05308" />

<img width="694" height="247" alt="image" src="https://github.com/user-attachments/assets/4478b9c5-3766-4745-974a-73934e23b0dc" />

This commit allows category moderators to view the edit-history in the certain category they moderate, so as to solve this problem, as well as changing the description for the setting `edit_history_visible_to_public` to match this change.
