### PR TITLE
 UX: update formkit validation summary error styles, improve danger-low contrast

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_errors-summary.scss
+++ b/app/assets/stylesheets/common/form-kit/_errors-summary.scss
@@ -1,10 +1,16 @@
+@use "lib/viewport";
+
 .form-kit__errors-summary {
+  box-sizing: border-box;
   padding: var(--space-4);
   border: 1px solid var(--danger);
   background-color: var(--danger-low);
-  width: var(--form-kit-large-input);
   border-radius: var(--d-border-radius);
-  box-sizing: border-box;
+  width: var(--form-kit-large-input);
+
+  @include viewport.until(sm) {
+    width: 100%;
+  }
 
   h2 {
     font-size: var(--font-0);

--- a/app/assets/stylesheets/common/form-kit/_errors-summary.scss
+++ b/app/assets/stylesheets/common/form-kit/_errors-summary.scss
@@ -7,18 +7,15 @@
   box-sizing: border-box;
 
   h2 {
-    font-size: var(--font-up-1);
-
-    .d-icon {
-      font-size: var(--font-down-1);
-    }
-  }
-
-  .d-icon-triangle-exclamation {
-    color: var(--danger);
+    font-size: var(--font-0);
   }
 
   ul {
     margin-block: 0;
+    font-size: var(--font-down-1-rem);
+
+    a {
+      font-weight: bold;
+    }
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_errors-summary.scss
+++ b/app/assets/stylesheets/common/form-kit/_errors-summary.scss
@@ -1,10 +1,18 @@
 .form-kit__errors-summary {
-  padding: 1em;
+  padding: var(--space-4);
   border: 1px solid var(--danger);
   background-color: var(--danger-low);
-  width: 100%;
+  width: var(--form-kit-large-input);
   border-radius: var(--d-border-radius);
   box-sizing: border-box;
+
+  h2 {
+    font-size: var(--font-up-1);
+
+    .d-icon {
+      font-size: var(--font-down-1);
+    }
+  }
 
   .d-icon-triangle-exclamation {
     color: var(--danger);

--- a/app/assets/stylesheets/common/form-kit/_errors-summary.scss
+++ b/app/assets/stylesheets/common/form-kit/_errors-summary.scss
@@ -16,12 +16,19 @@
     font-size: var(--font-0);
   }
 
+  .d-icon {
+    color: var(--danger);
+    width: var(--space-5);
+  }
+
   ul {
     margin-block: 0;
+    margin-inline: var(--space-5) 0;
     font-size: var(--font-down-1-rem);
 
     a {
       font-weight: bold;
+      padding-left: var(--space-1);
     }
   }
 }

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -83,7 +83,7 @@ $highlight-high: dark-light-diff(
 ) !default; // TO BE REMOVED IF POSS
 
 // danger
-$danger-low: dark-light-diff($danger, $secondary, 85%, -64%) !default;
+$danger-low: dark-light-diff($danger, $secondary, 90%, -68%) !default;
 $danger-low-mid: dark-light-diff(
   rgba($danger, 0.7),
   $secondary,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2507,8 +2507,8 @@ en:
       reset: Reset
       optional: optional
       errors_summary_title:
-        one: "Fix this error to continue:"
-        other: "Fix these errors to continue:"
+        one: "Fix this error to continue"
+        other: "Fix these errors to continue"
       dirty_form: "You didn't submit your changes! Are you sure you want to leave?"
       errors:
         starts_with: "Must start with %{prefix}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2506,7 +2506,9 @@ en:
     form_kit:
       reset: Reset
       optional: optional
-      errors_summary_title: "This form contains errors:"
+      errors_summary_title:
+        one: "Fix this error to continue:"
+        other: "Fix these errors to continue:"
       dirty_form: "You didn't submit your changes! Are you sure you want to leave?"
       errors:
         starts_with: "Must start with %{prefix}"
@@ -4568,7 +4570,7 @@ en:
       errors:
         self_lockout: "You are about to change category permissions in a way that will remove your own access. Are you sure you want to proceed?"
       validations:
-        emoji_required: "Select an emoji to continue."
+        emoji_required: "Select an emoji."
       name: "Category name"
       untitled: "Untitled category"
       description: "Description"

--- a/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
-import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class FKErrorsSummary extends Component {
@@ -42,7 +41,6 @@ export default class FKErrorsSummary extends Component {
     {{#if this.hasErrors}}
       <div class="form-kit__errors-summary" aria-live="assertive" ...attributes>
         <h2 class="form-kit__errors-summary-title">
-          {{icon "triangle-exclamation"}}
           {{i18n "form_kit.errors_summary_title" count=this.errorCount}}
         </h2>
 

--- a/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class FKErrorsSummary extends Component {
@@ -41,6 +42,7 @@ export default class FKErrorsSummary extends Component {
     {{#if this.hasErrors}}
       <div class="form-kit__errors-summary" aria-live="assertive" ...attributes>
         <h2 class="form-kit__errors-summary-title">
+          {{icon "triangle-exclamation"}}
           {{i18n "form_kit.errors_summary_title" count=this.errorCount}}
         </h2>
 

--- a/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/errors-summary.gjs
@@ -1,15 +1,37 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
+import { on } from "@ember/modifier";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class FKErrorsSummary extends Component {
+  focusField = (event) => {
+    const href = event.currentTarget.getAttribute("href");
+    if (!href?.startsWith("#control-")) {
+      return;
+    }
+
+    const container = document.getElementById(href.slice(1));
+    const focusable = container?.querySelector(
+      "input, select, textarea, button, [tabindex]:not([tabindex='-1'])"
+    );
+
+    if (focusable) {
+      event.preventDefault();
+      focusable.focus({ preventScroll: true, focusVisible: true });
+      focusable.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  };
+
   concatErrors(errors) {
     return errors.join(", ");
   }
 
+  get errorCount() {
+    return Object.keys(this.args.errors).length;
+  }
+
   get hasErrors() {
-    return Object.keys(this.args.errors).length > 0;
+    return this.errorCount > 0;
   }
 
   normalizeName(name) {
@@ -21,7 +43,7 @@ export default class FKErrorsSummary extends Component {
       <div class="form-kit__errors-summary" aria-live="assertive" ...attributes>
         <h2 class="form-kit__errors-summary-title">
           {{icon "triangle-exclamation"}}
-          {{i18n "form_kit.errors_summary_title"}}
+          {{i18n "form_kit.errors_summary_title" count=this.errorCount}}
         </h2>
 
         <ul class="form-kit__errors-summary-list">
@@ -29,7 +51,8 @@ export default class FKErrorsSummary extends Component {
             <li>
               <a
                 rel="noopener noreferrer"
-                href={{concat "#control-" (this.normalizeName name)}}
+                href="#control-{{this.normalizeName name}}"
+                {{on "click" this.focusField}}
               >{{error.title}}</a>:
               {{this.concatErrors error.messages}}
             </li>

--- a/frontend/discourse/tests/integration/components/form-kit/form-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/form-test.gjs
@@ -371,4 +371,53 @@ module("Integration | Component | FormKit | Form", function (hooks) {
       0
     );
   });
+
+  test("clicking error link focuses the field input", async function (assert) {
+    await render(
+      <template>
+        <Form as |form|>
+          <form.Field
+            @name="foo"
+            @title="Foo"
+            @validation="required"
+            as |field|
+          >
+            <field.Input />
+          </form.Field>
+          <form.Submit />
+        </Form>
+      </template>
+    );
+
+    await formKit().submit();
+
+    await click(".form-kit__errors-summary-list a");
+
+    assert.dom(document.activeElement).hasClass("form-kit__control-input");
+  });
+
+  test("error link has anchor href for fields without focusable elements", async function (assert) {
+    const validate = async (data, { addError }) => {
+      addError("foo", { title: "Foo", message: "error" });
+    };
+
+    await render(
+      <template>
+        <Form @validate={{validate}} as |form|>
+          <form.Field @name="foo" @title="Foo" as |field|>
+            <field.Custom>
+              <div class="not-focusable">Custom content</div>
+            </field.Custom>
+          </form.Field>
+          <form.Submit />
+        </Form>
+      </template>
+    );
+
+    await formKit().submit();
+
+    assert
+      .dom(".form-kit__errors-summary-list a")
+      .hasAttribute("href", "#control-foo");
+  });
 });


### PR DESCRIPTION
Generally styling our formkit validation error summary to be smaller and simpler — removing the icon, smaller text to match the form labels, width to match inputs. Also included a singular version in addition to the plural error text. 

I've adjusted our danger-low color globally to be *slightly* lighter, which helps with improving the contrast of links against it. 

Before: 

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/bf46268d-fbe1-4fec-8a9d-f4645baf8648" />



After: 

<img width="380" alt="image" src="https://github.com/user-attachments/assets/cf276ebc-65d5-4221-a98c-54e453168e69" />