### PR TITLE
FEATURE: Add primary_upload_id for storage deduplication

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -176,11 +176,26 @@ class UploadsController < ApplicationController
     path_with_ext =
       params[:extension].nil? ? params[:path] : "#{params[:path]}.#{params[:extension]}"
     upload = upload_from_path_and_extension(path_with_ext)
+    permission_upload = upload
+
+    if params[:base62_sha1].present?
+      return render_404 if !params[:base62_sha1].match?(/\A[a-zA-Z0-9]+\z/)
+
+      permission_upload =
+        Upload.find_by(sha1: Upload.sha1_from_base62_encoded(params[:base62_sha1]))
+      storage_upload = permission_upload&.primary_upload || permission_upload
+
+      return render_404 if !secure_upload_path_matches?(storage_upload, path_with_ext)
+
+      upload = storage_upload
+    end
 
     return render_404 if upload.blank?
 
     return render_404 if SiteSetting.prevent_anons_from_downloading_files && current_user.nil?
-    return handle_secure_upload_request(upload, path_with_ext) if SiteSetting.secure_uploads?
+    if SiteSetting.secure_uploads?
+      return handle_secure_upload_request(upload, path_with_ext, permission_upload:)
+    end
 
     # we don't want to 404 here if secure uploads gets disabled
     # because all posts with secure uploads will show broken media
@@ -199,8 +214,8 @@ class UploadsController < ApplicationController
                 allow_other_host: true
   end
 
-  def handle_secure_upload_request(upload, path_with_ext = nil)
-    check_secure_upload_permission(upload)
+  def handle_secure_upload_request(upload, path_with_ext = nil, permission_upload: upload)
+    check_secure_upload_permission(permission_upload)
 
     # defaults to public: false, so only cached by the client browser
     cache_seconds =
@@ -220,10 +235,17 @@ class UploadsController < ApplicationController
                   path_with_ext,
                   expires_in: SiteSetting.s3_presigned_get_url_expires_after_seconds,
                   force_download: force_download?,
-                  filename: upload.original_filename,
+                  filename: permission_upload.original_filename,
                   include_content_disposition: true,
                 ),
                 allow_other_host: true
+  end
+
+  def secure_upload_path_matches?(upload, path_with_ext)
+    return false if upload.blank?
+
+    secure_url = Upload.secure_uploads_url_from_upload_url(upload.url)
+    URI.parse(secure_url).path == "/secure-uploads/#{path_with_ext}"
   end
 
   def metadata

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -172,7 +172,8 @@ module Jobs
       if Discourse.store.has_been_uploaded?(src) || normalize_src(src).start_with?(*local_bases) ||
            src =~ %r{\A/[^/]}i
         if Upload.secure_uploads_url?(src)
-          upload = Upload.fetch_from(sha1: Upload.sha1_from_long_url(src), url: src)
+          sha1 = Upload.sha1_from_secure_uploads_url(src) || Upload.sha1_from_long_url(src)
+          upload = Upload.fetch_from(sha1:, url: src)
           return false if upload.nil?
           return false if !can_see_upload?(upload, guardian: post&.user&.guardian)
         elsif src.match?(%r{/uploads/})

--- a/app/models/concerns/has_post_upload_references.rb
+++ b/app/models/concerns/has_post_upload_references.rb
@@ -76,73 +76,82 @@ module HasPostUploadReferences
         "div/@data-original-video-src",
       )
 
-    links =
-      selectors
-        .map do |media|
-          src = media.value
-          next if src.blank?
+    # Collect (src, sha1) pairs. Use data-base62-sha1 when available for unique
+    # upload identification, even when multiple uploads share the same storage URL.
+    seen_sha1s = Set.new
+    upload_entries = []
 
-          if src.end_with?("/images/transparent.png") &&
-               (parent = media.parent)["data-orig-src"].present?
-            parent["data-orig-src"]
-          else
-            src
-          end
-        end
-        .compact
-        .uniq
+    selectors.each do |media|
+      src = media.value
+      next if src.blank?
 
-    links.each do |src|
+      # Handle lazy-loaded images with data-orig-src
+      if src.end_with?("/images/transparent.png") &&
+           (parent = media.parent)["data-orig-src"].present?
+        src = parent["data-orig-src"]
+      end
+
       src = src.split("?")[0]
+      sha1 = nil
 
-      if src.start_with?("upload://")
-        sha1 = Upload.sha1_from_short_url(src)
-        yield(src, nil, sha1)
-        next
+      # Check for data-base62-sha1 attribute which preserves unique upload identity
+      # even when uploads share storage URLs (deduplication)
+      parent = media.parent
+      if parent && (base62 = parent["data-base62-sha1"]).present?
+        sha1 = Upload.sha1_from_base62(base62)
       end
 
-      if src.include?("/uploads/short-url/")
-        host =
-          begin
-            URI(src).host
-          rescue URI::Error
+      # If no sha1 from attribute, try to extract from URL
+      if sha1.blank?
+        if src.start_with?("upload://")
+          sha1 = Upload.sha1_from_short_url(src)
+        elsif src.include?("/uploads/short-url/")
+          host =
+            begin
+              URI(src).host
+            rescue URI::Error
+            end
+          next if host.present? && host != Discourse.current_hostname
+          sha1 = Upload.sha1_from_short_path(src)
+        else
+          next if upload_patterns.none? { |pattern| src =~ pattern }
+          next if Rails.configuration.multisite && src.exclude?(current_db)
+
+          src = "#{SiteSetting.force_https ? "https" : "http"}:#{src}" if src.start_with?("//")
+
+          if !Discourse.store.has_been_uploaded?(src) && !Upload.secure_uploads_url?(src) &&
+               !(include_local_upload && src =~ %r{\A/[^/]}i)
+            next
           end
 
-        next if host.present? && host != Discourse.current_hostname
+          path =
+            begin
+              URI(
+                UrlHelper.unencode(
+                  GlobalSetting.cdn_url ? src.sub(GlobalSetting.cdn_url, "") : src,
+                ),
+              )&.path
+            rescue URI::Error
+            end
 
-        sha1 = Upload.sha1_from_short_path(src)
-        yield(src, nil, sha1)
-        next
+          next if path.blank?
+
+          sha1 =
+            if path.include? "optimized"
+              OptimizedImage.extract_sha1(path)
+            else
+              Upload.extract_sha1(path) || Upload.sha1_from_short_path(path)
+            end
+        end
       end
 
-      next if upload_patterns.none? { |pattern| src =~ pattern }
-      next if Rails.configuration.multisite && src.exclude?(current_db)
+      # Dedupe by sha1 to avoid duplicate references for the same upload
+      next if sha1.present? && seen_sha1s.include?(sha1)
+      seen_sha1s.add(sha1) if sha1.present?
 
-      src = "#{SiteSetting.force_https ? "https" : "http"}:#{src}" if src.start_with?("//")
-
-      if !Discourse.store.has_been_uploaded?(src) && !Upload.secure_uploads_url?(src) &&
-           !(include_local_upload && src =~ %r{\A/[^/]}i)
-        next
-      end
-
-      path =
-        begin
-          URI(
-            UrlHelper.unencode(GlobalSetting.cdn_url ? src.sub(GlobalSetting.cdn_url, "") : src),
-          )&.path
-        rescue URI::Error
-        end
-
-      next if path.blank?
-
-      sha1 =
-        if path.include? "optimized"
-          OptimizedImage.extract_sha1(path)
-        else
-          Upload.extract_sha1(path) || Upload.sha1_from_short_path(path)
-        end
-
-      yield(src, path, sha1)
+      upload_entries << [src, sha1]
     end
+
+    upload_entries.each { |src, sha1| yield(src, nil, sha1) }
   end
 end

--- a/app/models/concerns/has_post_upload_references.rb
+++ b/app/models/concerns/has_post_upload_references.rb
@@ -76,7 +76,7 @@ module HasPostUploadReferences
         "div/@data-original-video-src",
       )
 
-    # Collect (src, sha1) pairs. Use data-base62-sha1 when available for unique
+    # Collect (src, path, sha1) tuples. Use data-base62-sha1 when available for unique
     # upload identification, even when multiple uploads share the same storage URL.
     seen_sha1s = Set.new
     upload_entries = []
@@ -93,6 +93,7 @@ module HasPostUploadReferences
 
       src = src.split("?")[0]
       sha1 = nil
+      path = nil
 
       # Check for data-base62-sha1 attribute which preserves unique upload identity
       # even when uploads share storage URLs (deduplication)
@@ -149,9 +150,9 @@ module HasPostUploadReferences
       next if sha1.present? && seen_sha1s.include?(sha1)
       seen_sha1s.add(sha1) if sha1.present?
 
-      upload_entries << [src, sha1]
+      upload_entries << [src, path, sha1]
     end
 
-    upload_entries.each { |src, sha1| yield(src, nil, sha1) }
+    upload_entries.each { |src, path, sha1| yield(src, path, sha1) }
   end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -60,7 +60,7 @@ class Upload < ActiveRecord::Base
 
     # If this is a primary upload, transfer primary status to a dependent
     if primary_upload_id.nil? && dependent_uploads.exists?
-      new_primary = dependent_uploads.first
+      new_primary = dependent_uploads.order(:id).first
       remaining = dependent_uploads.where.not(id: new_primary.id)
 
       new_primary.update_columns(primary_upload_id: nil, url: self.url)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -65,6 +65,9 @@ class Upload < ActiveRecord::Base
 
       new_primary.update_columns(primary_upload_id: nil, url: self.url)
       remaining.update_all(primary_upload_id: new_primary.id)
+
+      # Mark that we transferred ownership so destroy skips S3 removal
+      @transferred_to_new_primary = true
     end
   end
 
@@ -222,7 +225,11 @@ class Upload < ActiveRecord::Base
 
   def destroy
     Upload.transaction do
-      Discourse.store.remove_upload(self)
+      # Skip S3 removal if:
+      # - This is a dependent upload (file belongs to the primary)
+      # - This primary just transferred ownership to a new primary
+      should_remove_file = primary_upload_id.nil? && !@transferred_to_new_primary
+      Discourse.store.remove_upload(self) if should_remove_file
       super
     end
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -227,8 +227,9 @@ class Upload < ActiveRecord::Base
     Upload.transaction do
       # Skip S3 removal if:
       # - This is a dependent upload (file belongs to the primary)
-      # - This primary just transferred ownership to a new primary
-      should_remove_file = primary_upload_id.nil? && !@transferred_to_new_primary
+      # - This primary will transfer ownership to a dependent (before_destroy sets the flag)
+      will_transfer = primary_upload_id.nil? && dependent_uploads.exists?
+      should_remove_file = primary_upload_id.nil? && !will_transfer
       Discourse.store.remove_upload(self) if should_remove_file
       super
     end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -16,6 +16,8 @@ class Upload < ActiveRecord::Base
 
   belongs_to :user
   belongs_to :access_control_post, class_name: "Post"
+  belongs_to :primary_upload, class_name: "Upload", optional: true
+  has_many :dependent_uploads, class_name: "Upload", foreign_key: :primary_upload_id
 
   # when we access this post we don't care if the post
   # is deleted
@@ -55,6 +57,15 @@ class Upload < ActiveRecord::Base
     UserProfile.where(profile_background_upload_id: id).update_all(
       profile_background_upload_id: nil,
     )
+
+    # If this is a primary upload, transfer primary status to a dependent
+    if primary_upload_id.nil? && dependent_uploads.exists?
+      new_primary = dependent_uploads.first
+      remaining = dependent_uploads.where.not(id: new_primary.id)
+
+      new_primary.update_columns(primary_upload_id: nil, url: self.url)
+      remaining.update_all(primary_upload_id: new_primary.id)
+    end
   end
 
   after_destroy do
@@ -243,6 +254,29 @@ class Upload < ActiveRecord::Base
       return nil
     end
     upload
+  end
+
+  # Find a primary upload for the given content hash and security context.
+  # Primary uploads have primary_upload_id = nil and are the canonical storage
+  # location for deduplicated uploads.
+  def self.find_primary_for(original_sha1:, secure:)
+    return nil if original_sha1.blank?
+    where(original_sha1: original_sha1, secure: secure, primary_upload_id: nil).first
+  end
+
+  # Check if this upload is a primary (has dependents or could have dependents)
+  def primary?
+    primary_upload_id.nil? && original_sha1.present?
+  end
+
+  # Check if this upload is a dependent (references a primary)
+  def dependent?
+    primary_upload_id.present?
+  end
+
+  # Get the actual storage URL (from primary if dependent)
+  def storage_url
+    primary_upload&.url || url
   end
 
   def self.secure_uploads_url?(url)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -502,6 +502,10 @@ class Upload < ActiveRecord::Base
     sha1_from_base62_encoded($2) if url =~ %r{(upload://)?([a-zA-Z0-9]+)(\..*)?}
   end
 
+  def self.sha1_from_base62(base62)
+    self.sha1_from_base62_encoded(base62)
+  end
+
   def self.sha1_from_long_url(url)
     $2 if url =~ URL_REGEX || url =~ OptimizedImage::URL_REGEX
   end
@@ -557,7 +561,6 @@ class Upload < ActiveRecord::Base
 
   def handle_dedup_context_transition(new_secure_status)
     return if primary_upload_id.nil?
-    return if !Discourse.store.external?
 
     # Try to find a primary with matching secure status
     new_primary = Upload.find_primary_for(original_sha1: original_sha1, secure: new_secure_status)
@@ -565,9 +568,12 @@ class Upload < ActiveRecord::Base
     if new_primary
       # Switch to the new primary
       update_columns(primary_upload_id: new_primary.id, url: new_primary.url)
-    else
-      # No matching primary exists - copy file and become a primary
+    elsif Discourse.store.external?
+      # No matching primary exists and using S3 - copy file and become a primary
       copy_from_primary_and_become_primary(new_secure_status)
+    else
+      # Local store - just break the relationship, file will be handled by store
+      update_columns(primary_upload_id: nil)
     end
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -538,14 +538,56 @@ class Upload < ActiveRecord::Base
     end
 
     secure_status_did_change = secure? != mark_secure
+
+    # Handle deduplication context transitions before changing secure status
+    if secure_status_did_change && primary_upload_id.present?
+      handle_dedup_context_transition(mark_secure)
+    end
+
     update(secure_params(mark_secure, reason, source))
 
     if secure_status_did_change && Discourse.store.external?
-      Discourse.store.update_upload_access_control(self)
+      # Skip ACL update if we're still a dependent (we switched to a new primary)
+      Discourse.store.update_upload_access_control(self) if primary_upload_id.nil?
       sync_optimized_videos_secure_status(mark_secure)
     end
 
     secure_status_did_change
+  end
+
+  def handle_dedup_context_transition(new_secure_status)
+    return if primary_upload_id.nil?
+    return if !Discourse.store.external?
+
+    # Try to find a primary with matching secure status
+    new_primary = Upload.find_primary_for(original_sha1: original_sha1, secure: new_secure_status)
+
+    if new_primary
+      # Switch to the new primary
+      update_columns(primary_upload_id: new_primary.id, url: new_primary.url)
+    else
+      # No matching primary exists - copy file and become a primary
+      copy_from_primary_and_become_primary(new_secure_status)
+    end
+  end
+
+  def copy_from_primary_and_become_primary(new_secure_status)
+    return if primary_upload_id.nil?
+
+    store = Discourse.store
+    source_path = store.get_path_for_upload(self)
+
+    # Generate our own destination path using our sha1
+    extension = self.extension.present? ? ".#{self.extension}" : File.extname(original_filename)
+    dest_path = store.get_path_for("original", id, sha1, extension)
+    dest_path = File.join(store.upload_path, dest_path) if Rails.configuration.multisite
+
+    # Copy the file to our own path
+    store.copy_file(source: source_path, destination: dest_path, secure: new_secure_status)
+
+    # Update URL to our own path and clear primary relationship
+    new_url = File.join(store.absolute_base_url, dest_path)
+    update_columns(primary_upload_id: nil, url: new_url)
   end
 
   def sync_optimized_videos_secure_status(mark_secure)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -753,6 +753,7 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  access_control_post_id       :bigint
+#  primary_upload_id            :bigint
 #  user_id                      :integer          not null
 #
 # Indexes
@@ -764,6 +765,8 @@ end
 #  index_uploads_on_id                      (id) WHERE (dominant_color IS NULL)
 #  index_uploads_on_id_and_url              (id,url)
 #  index_uploads_on_original_sha1           (original_sha1)
+#  index_uploads_on_primary_lookup          (original_sha1,secure) WHERE ((primary_upload_id IS NULL) AND (original_sha1 IS NOT NULL))
+#  index_uploads_on_primary_upload_id       (primary_upload_id)
 #  index_uploads_on_sha1                    (sha1) UNIQUE
 #  index_uploads_on_url                     (url)
 #  index_uploads_on_user_id                 (user_id)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -771,3 +771,7 @@ end
 #  index_uploads_on_url                     (url)
 #  index_uploads_on_user_id                 (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (primary_upload_id => uploads.id) ON DELETE => nullify
+#

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -511,6 +511,18 @@ class Upload < ActiveRecord::Base
     sha1_from_base62_encoded(base62)
   end
 
+  def self.sha1_from_secure_uploads_url(url)
+    query = URI.parse(url).query
+    return if query.blank?
+
+    base62_sha1 = Rack::Utils.parse_query(query)["base62_sha1"]
+    return if !base62_sha1.is_a?(String) || !base62_sha1.match?(/\A[a-zA-Z0-9]+\z/)
+
+    sha1_from_base62_encoded(base62_sha1)
+  rescue URI::InvalidURIError, ArgumentError
+    nil
+  end
+
   def self.sha1_from_long_url(url)
     $2 if url =~ URL_REGEX || url =~ OptimizedImage::URL_REGEX
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -63,7 +63,7 @@ class Upload < ActiveRecord::Base
       new_primary = dependent_uploads.order(:id).first
       remaining = dependent_uploads.where.not(id: new_primary.id)
 
-      new_primary.update_columns(primary_upload_id: nil, url: self.url)
+      new_primary.update_columns(primary_upload_id: nil, url: url)
       remaining.update_all(primary_upload_id: new_primary.id)
 
       # Mark that we transferred ownership so destroy skips S3 removal
@@ -504,7 +504,7 @@ class Upload < ActiveRecord::Base
   end
 
   def self.sha1_from_base62(base62)
-    self.sha1_from_base62_encoded(base62)
+    sha1_from_base62_encoded(base62)
   end
 
   def self.sha1_from_long_url(url)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -59,16 +59,7 @@ class Upload < ActiveRecord::Base
     )
 
     # If this is a primary upload, transfer primary status to a dependent
-    if primary_upload_id.nil? && dependent_uploads.exists?
-      new_primary = dependent_uploads.order(:id).first
-      remaining = dependent_uploads.where.not(id: new_primary.id)
-
-      new_primary.update_columns(primary_upload_id: nil, url: url)
-      remaining.update_all(primary_upload_id: new_primary.id)
-
-      # Mark that we transferred ownership so destroy skips S3 removal
-      @transferred_to_new_primary = true
-    end
+    promote_dependent_to_primary! if primary_upload_id.nil?
   end
 
   after_destroy do
@@ -225,9 +216,8 @@ class Upload < ActiveRecord::Base
 
   def destroy
     Upload.transaction do
-      # Skip S3 removal if:
-      # - This is a dependent upload (file belongs to the primary)
-      # - This primary will transfer ownership to a dependent (before_destroy sets the flag)
+      # Skip file removal if this upload depends on another primary or if a dependent
+      # is about to take over this primary's storage in the before_destroy callback.
       will_transfer = primary_upload_id.nil? && dependent_uploads.exists?
       should_remove_file = primary_upload_id.nil? && !will_transfer
       Discourse.store.remove_upload(self) if should_remove_file
@@ -285,6 +275,23 @@ class Upload < ActiveRecord::Base
   # Get the actual storage URL (from primary if dependent)
   def storage_url
     primary_upload&.url || url
+  end
+
+  def promote_dependent_to_primary!(copy_storage: false, secure: secure?)
+    new_primary = dependent_uploads.order(:id).first
+    return if new_primary.blank?
+
+    if copy_storage
+      new_primary.copy_from_upload_and_become_primary(self, secure)
+    else
+      new_primary.update_columns(primary_upload_id: nil, url: url)
+    end
+
+    dependent_uploads
+      .where.not(id: new_primary.id)
+      .update_all(primary_upload_id: new_primary.id, url: new_primary.url)
+
+    new_primary
   end
 
   def self.secure_uploads_url?(url)
@@ -545,9 +552,7 @@ class Upload < ActiveRecord::Base
     secure_status_did_change = secure? != mark_secure
 
     # Handle deduplication context transitions before changing secure status
-    if secure_status_did_change && primary_upload_id.present?
-      handle_dedup_context_transition(mark_secure)
-    end
+    handle_dedup_context_transition(mark_secure) if secure_status_did_change
 
     update(secure_params(mark_secure, reason, source))
 
@@ -561,39 +566,62 @@ class Upload < ActiveRecord::Base
   end
 
   def handle_dedup_context_transition(new_secure_status)
-    return if primary_upload_id.nil?
+    return if original_sha1.blank?
 
-    # Try to find a primary with matching secure status
     new_primary = Upload.find_primary_for(original_sha1: original_sha1, secure: new_secure_status)
 
+    if primary_upload_id.present?
+      if new_primary
+        update_columns(primary_upload_id: new_primary.id, url: new_primary.url)
+      else
+        copy_from_primary_and_become_primary(new_secure_status)
+      end
+      return
+    end
+
+    return if new_primary.blank? && !dependent_uploads.exists?
+
+    promoted_upload =
+      if dependent_uploads.exists?
+        promote_dependent_to_primary!(copy_storage: new_primary.blank?, secure: secure?)
+      end
+
     if new_primary
-      # Switch to the new primary
+      Discourse.store.remove_upload(self) if promoted_upload.blank?
       update_columns(primary_upload_id: new_primary.id, url: new_primary.url)
-    elsif Discourse.store.external?
-      # No matching primary exists and using S3 - copy file and become a primary
-      copy_from_primary_and_become_primary(new_secure_status)
-    else
-      # Local store - just break the relationship, file will be handled by store
-      update_columns(primary_upload_id: nil)
     end
   end
 
   def copy_from_primary_and_become_primary(new_secure_status)
     return if primary_upload_id.nil?
 
+    copy_from_upload_and_become_primary(primary_upload, new_secure_status)
+  end
+
+  def copy_from_upload_and_become_primary(source_upload, new_secure_status)
     store = Discourse.store
-    source_path = store.get_path_for_upload(self)
-
-    # Generate our own destination path using our sha1
     extension = self.extension.present? ? ".#{self.extension}" : File.extname(original_filename)
-    dest_path = store.get_path_for("original", id, sha1, extension)
-    dest_path = File.join(store.upload_path, dest_path) if Rails.configuration.multisite
+    destination_path = store.get_path_for("original", id, sha1, extension)
 
-    # Copy the file to our own path
-    store.copy_file(source: source_path, destination: dest_path, secure: new_secure_status)
+    if store.external?
+      source_path = store.get_path_for_upload(source_upload)
+      if Rails.configuration.multisite
+        if source_path.exclude?(store.upload_path)
+          source_path = File.join(store.upload_path, source_path)
+        end
+        destination_path = File.join(store.upload_path, destination_path)
+      end
 
-    # Update URL to our own path and clear primary relationship
-    new_url = File.join(store.absolute_base_url, dest_path)
+      store.copy_file(source: source_path, destination: destination_path, secure: new_secure_status)
+      new_url = File.join(store.absolute_base_url, destination_path)
+    else
+      source_path = store.path_for(source_upload)
+      File.open(source_path, "rb") do |file|
+        store.copy_file(file, "#{store.public_dir}#{destination_path}")
+      end
+      new_url = destination_path
+    end
+
     update_columns(primary_upload_id: nil, url: new_url)
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -300,27 +300,24 @@ class Upload < ActiveRecord::Base
     route = UrlHelper.rails_route_from_url(url)
     return false if route.blank?
     route[:action] == "show_secure" && route[:controller] == "uploads" &&
-      FileHelper.is_supported_media?(url)
+      FileHelper.is_supported_media?(url.split("?", 2).first)
   rescue ActionController::RoutingError
     false
   end
 
   def self.signed_url_from_secure_uploads_url(url, include_content_disposition:)
     route = UrlHelper.rails_route_from_url(url)
-    url = Rails.application.routes.url_for(route.merge(only_path: true))
+    url = Rails.application.routes.url_for(route.merge(only_path: true)).split("?", 2).first
     secure_upload_s3_path = url[url.index(route[:path])..-1]
     Discourse.store.signed_url_for_path(secure_upload_s3_path, include_content_disposition:)
   end
 
-  def self.secure_uploads_url_from_upload_url(url)
+  def self.secure_uploads_url_from_upload_url(url, base62_sha1: nil)
     return url if !url.include?(SiteSetting.Upload.absolute_base_url)
     uri = URI.parse(url)
-    Rails.application.routes.url_for(
-      controller: "uploads",
-      action: "show_secure",
-      path: uri.path[1..-1],
-      only_path: true,
-    )
+    route = { controller: "uploads", action: "show_secure", path: uri.path[1..-1], only_path: true }
+    route[:base62_sha1] = base62_sha1 if base62_sha1.present?
+    Rails.application.routes.url_for(route)
   end
 
   def self.short_path(sha1:, extension:)

--- a/db/migrate/20260130220000_add_primary_upload_id_to_uploads.rb
+++ b/db/migrate/20260130220000_add_primary_upload_id_to_uploads.rb
@@ -11,5 +11,8 @@ class AddPrimaryUploadIdToUploads < ActiveRecord::Migration[7.2]
               %i[original_sha1 secure],
               where: "primary_upload_id IS NULL AND original_sha1 IS NOT NULL",
               name: "index_uploads_on_primary_lookup"
+
+    # FK ensures DB-level integrity; SET NULL handles edge cases like raw SQL deletes
+    add_foreign_key :uploads, :uploads, column: :primary_upload_id, on_delete: :nullify
   end
 end

--- a/db/migrate/20260130220000_add_primary_upload_id_to_uploads.rb
+++ b/db/migrate/20260130220000_add_primary_upload_id_to_uploads.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPrimaryUploadIdToUploads < ActiveRecord::Migration[7.2]
+  def change
+    add_column :uploads, :primary_upload_id, :bigint, null: true
+
+    add_index :uploads, :primary_upload_id
+
+    # Partial index for fast primary lookups by original_sha1 and secure status
+    add_index :uploads,
+              %i[original_sha1 secure],
+              where: "primary_upload_id IS NULL AND original_sha1 IS NOT NULL",
+              name: "index_uploads_on_primary_lookup"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10817,7 +10817,8 @@ CREATE TABLE public.uploads (
     verification_status integer DEFAULT 1 NOT NULL,
     security_last_changed_at timestamp without time zone,
     security_last_changed_reason character varying,
-    dominant_color text
+    dominant_color text,
+    primary_upload_id bigint
 );
 
 
@@ -22045,6 +22046,20 @@ CREATE INDEX index_uploads_on_original_sha1 ON public.uploads USING btree (origi
 
 
 --
+-- Name: index_uploads_on_primary_lookup; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_uploads_on_primary_lookup ON public.uploads USING btree (original_sha1, secure) WHERE ((primary_upload_id IS NULL) AND (original_sha1 IS NOT NULL));
+
+
+--
+-- Name: index_uploads_on_primary_upload_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_uploads_on_primary_upload_id ON public.uploads USING btree (primary_upload_id);
+
+
+--
 -- Name: index_uploads_on_sha1; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -23069,6 +23084,14 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 
 
 --
+-- Name: uploads fk_rails_fce8fca60c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.uploads
+    ADD CONSTRAINT fk_rails_fce8fca60c FOREIGN KEY (primary_upload_id) REFERENCES public.uploads(id) ON DELETE SET NULL;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -23253,6 +23276,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260206000937'),
 ('20260206000936'),
 ('20260205065417'),
+('20260130220000'),
 ('20260126204830'),
 ('20260122214226'),
 ('20260122134202'),

--- a/frontend/discourse-markdown-it/src/engine.js
+++ b/frontend/discourse-markdown-it/src/engine.js
@@ -156,19 +156,39 @@ export function extractDataAttribute(str) {
 // as oneboxer.rb when dealing with these formats
 function videoHTML(token) {
   const src = token.attrGet("src");
+  const attrs = [`data-video-src="${src}"`];
   const origSrc = token.attrGet("data-orig-src");
-  const dataOrigSrcAttr = origSrc !== null ? `data-orig-src="${origSrc}"` : "";
-  return `<div class="video-placeholder-container" data-video-src="${src}" ${dataOrigSrcAttr}>
+  const base62Sha1 = token.attrGet("data-base62-sha1");
+
+  if (origSrc !== null) {
+    attrs.push(`data-orig-src="${origSrc}"`);
+  }
+  if (base62Sha1 !== null) {
+    attrs.push(`data-base62-sha1="${base62Sha1}"`);
+  }
+
+  return `<div class="video-placeholder-container" ${attrs.join(" ")}>
   </div>`;
 }
 
 function audioHTML(token) {
   const src = token.attrGet("src");
+  const sourceAttrs = [`src="${src}"`];
+  const linkAttrs = [`href="${src}"`];
   const origSrc = token.attrGet("data-orig-src");
-  const dataOrigSrcAttr = origSrc !== null ? `data-orig-src="${origSrc}"` : "";
+  const base62Sha1 = token.attrGet("data-base62-sha1");
+
+  if (origSrc !== null) {
+    sourceAttrs.push(`data-orig-src="${origSrc}"`);
+  }
+  if (base62Sha1 !== null) {
+    sourceAttrs.push(`data-base62-sha1="${base62Sha1}"`);
+    linkAttrs.push(`data-base62-sha1="${base62Sha1}"`);
+  }
+
   return `<audio preload="metadata" controls>
-    <source src="${src}" ${dataOrigSrcAttr}>
-    <a href="${src}">${src}</a>
+    <source ${sourceAttrs.join(" ")}>
+    <a ${linkAttrs.join(" ")}>${src}</a>
   </audio>`;
 }
 

--- a/frontend/discourse-markdown-it/src/features/upload-protocol.js
+++ b/frontend/discourse-markdown-it/src/features/upload-protocol.js
@@ -102,10 +102,10 @@ function rule(state) {
         let attrs = [];
 
         if (mapped) {
-          attrs.push(
-            attr("src", mapped.url),
-            attr("data-base62-sha1", mapped.base62_sha1)
-          );
+          attrs.push(attr("src", mapped.url));
+          if (mapped.base62_sha1) {
+            attrs.push(attr("data-base62-sha1", mapped.base62_sha1));
+          }
         } else {
           attrs.push(
             attr(
@@ -120,7 +120,9 @@ function rule(state) {
       } else if (token.tag === "img") {
         if (mapped) {
           token.attrs[srcIndex][1] = mapped.url;
-          token.attrs.push(["data-base62-sha1", mapped.base62_sha1]);
+          if (mapped.base62_sha1) {
+            token.attrs.push(["data-base62-sha1", mapped.base62_sha1]);
+          }
         } else {
           // no point putting a transparent .png for audio/video
           if (token.content.match(/\|video|\|audio/)) {
@@ -147,6 +149,10 @@ function rule(state) {
           } else {
             token.attrs[srcIndex][1] = mapped.short_path;
           }
+
+          if (mapped.base62_sha1) {
+            token.attrs.push(["data-base62-sha1", mapped.base62_sha1]);
+          }
         } else {
           token.attrs[srcIndex][1] = state.md.options.discourse.getURL("/404");
 
@@ -167,6 +173,9 @@ export function setup(helper) {
     "img[data-orig-src]",
     "img[data-base62-sha1]",
     "a[data-orig-href]",
+    "a[data-base62-sha1]",
+    "div[data-base62-sha1]",
+    "source[data-base62-sha1]",
   ]);
 
   helper.registerPlugin((md) => {

--- a/frontend/discourse/tests/unit/lib/pretty-text-test.js
+++ b/frontend/discourse/tests/unit/lib/pretty-text-test.js
@@ -1026,6 +1026,7 @@ eviltrout</p>
         short_url: "upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf",
         url: "/secure-uploads/original/3X/c/b/o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf",
         short_path: "/uploads/short-url/blah",
+        base62_sha1: "o8iobpLcW3WSFvVH7YQmyGlKmGM",
       };
       return cache;
     }
@@ -1035,7 +1036,7 @@ eviltrout</p>
         siteSettings: { secure_uploads: false },
         lookupUploadUrls,
       },
-      `<p><a class="attachment" href="/uploads/short-url/blah">test.pdf</a></p>`,
+      `<p><a class="attachment" href="/uploads/short-url/blah" data-base62-sha1="o8iobpLcW3WSFvVH7YQmyGlKmGM">test.pdf</a></p>`,
       "returns the correct attachment link HTML when the URL is mapped without secure uploads"
     );
   });
@@ -1047,6 +1048,7 @@ eviltrout</p>
         short_url: "upload://o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf",
         url: "/secure-uploads/original/3X/c/b/o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf",
         short_path: "/uploads/short-url/blah",
+        base62_sha1: "o8iobpLcW3WSFvVH7YQmyGlKmGM",
       };
       return cache;
     }
@@ -1056,7 +1058,7 @@ eviltrout</p>
         siteSettings: { secure_uploads: true },
         lookupUploadUrls,
       },
-      `<p><a class="attachment" href="/secure-uploads/original/3X/c/b/o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf">test.pdf</a></p>`,
+      `<p><a class="attachment" href="/secure-uploads/original/3X/c/b/o8iobpLcW3WSFvVH7YQmyGlKmGM.pdf" data-base62-sha1="o8iobpLcW3WSFvVH7YQmyGlKmGM">test.pdf</a></p>`,
       "returns the correct attachment link HTML when the URL is mapped with secure uploads"
     );
   });
@@ -1077,6 +1079,7 @@ eviltrout</p>
         short_url: "upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4",
         url: "/secure-uploads/original/3X/c/b/test.mp4",
         short_path: "/uploads/short-url/blah",
+        base62_sha1: "eyPnj7UzkU0AkGkx2dx8G4YM1Jx",
       };
       return cache;
     }
@@ -1086,7 +1089,7 @@ eviltrout</p>
         siteSettings: { secure_uploads: true },
         lookupUploadUrls,
       },
-      `<p><div class="video-placeholder-container" data-video-src="/secure-uploads/original/3X/c/b/test.mp4">
+      `<p><div class="video-placeholder-container" data-video-src="/secure-uploads/original/3X/c/b/test.mp4" data-base62-sha1="eyPnj7UzkU0AkGkx2dx8G4YM1Jx">
   </div></p>`,
       "returns the correct video HTML when the URL is mapped with secure uploads, removing data-orig-src"
     );
@@ -1110,6 +1113,7 @@ eviltrout</p>
         short_url: "upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp3",
         url: "/secure-uploads/original/3X/c/b/test.mp3",
         short_path: "/uploads/short-url/blah",
+        base62_sha1: "eyPnj7UzkU0AkGkx2dx8G4YM1Jx",
       };
       return cache;
     }
@@ -1120,8 +1124,8 @@ eviltrout</p>
         lookupUploadUrls,
       },
       `<p><audio preload="metadata" controls>
-    <source src="/secure-uploads/original/3X/c/b/test.mp3">
-    <a href="/secure-uploads/original/3X/c/b/test.mp3">/secure-uploads/original/3X/c/b/test.mp3</a>
+    <source src="/secure-uploads/original/3X/c/b/test.mp3" data-base62-sha1="eyPnj7UzkU0AkGkx2dx8G4YM1Jx">
+    <a href="/secure-uploads/original/3X/c/b/test.mp3" data-base62-sha1="eyPnj7UzkU0AkGkx2dx8G4YM1Jx">/secure-uploads/original/3X/c/b/test.mp3</a>
   </audio></p>`,
       "returns the correct audio HTML when the URL is mapped with secure uploads, removing data-orig-src"
     );

--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -576,8 +576,17 @@ module CookedProcessorMixin
     lightbox.add_child(img)
 
     # then, the link to our larger image
-    src_url = Upload.secure_uploads_url?(img["src"]) ? upload&.url || img["src"] : img["src"]
-    src = UrlHelper.cook_url(src_url, secure: @should_secure_uploads)
+    src =
+      if Upload.secure_uploads_url?(img["src"])
+        secure_url =
+          Upload.secure_uploads_url_from_upload_url(
+            upload&.url || img["src"],
+            base62_sha1: img["data-base62-sha1"],
+          )
+        UrlHelper.schemaless(UrlHelper.absolute_without_cdn(secure_url))
+      else
+        UrlHelper.cook_url(img["src"], secure: @should_secure_uploads)
+      end
 
     a = create_link_node("lightbox", src)
     img.add_next_sibling(a)

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -371,7 +371,11 @@ module Email
           if FileHelper.is_supported_image?(original_upload.original_filename)
             next if !should_attach_image?(original_upload, optimized_1X)
             # Don't attach images that aren't rendered in the e-mail.
-            next if is_digest && !@message.html_part.body.include?(original_upload.sha1)
+            # Check for both raw sha1 and base62-encoded sha1 (used in data-base62-sha1 attributes)
+            body = @message.html_part.body.to_s
+            has_sha1 = body.include?(original_upload.sha1)
+            has_base62 = body.include?(Upload.base62_sha1(original_upload.sha1))
+            next if is_digest && !has_sha1 && !has_base62
           else
             # Only attach images in digests.
             next if is_digest

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -372,7 +372,7 @@ module Email
             next if !should_attach_image?(original_upload, optimized_1X)
             # Don't attach images that aren't rendered in the e-mail.
             # Check for both raw sha1 and base62-encoded sha1 (used in data-base62-sha1 attributes)
-            body = @message.html_part.body.to_s
+            body = @message.html_part.body
             has_sha1 = body.include?(original_upload.sha1)
             has_base62 = body.include?(Upload.base62_sha1(original_upload.sha1))
             next if is_digest && !has_sha1 && !has_base62

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -366,7 +366,17 @@ module Email
           upload_shas = {}
           stripped_media.each do |div|
             url = div["data-stripped-secure-media"] || div["data-stripped-secure-upload"]
-            upload_shas[url] = Upload.sha1_from_long_url(url)
+            # Prefer data-base62-sha1 for unique upload identification with deduplication
+            # When uploads share storage URLs, data-base62-sha1 preserves unique identity
+            sha1 =
+              if (base62 = div["data-base62-sha1"]).present?
+                Upload.sha1_from_base62(base62)
+              else
+                Upload.sha1_from_long_url(url)
+              end
+            # Use base62_sha1 as key when present to handle deduped uploads with same URL
+            key = div["data-base62-sha1"].presence || url
+            upload_shas[key] = sha1
           end
           upload_shas
         end
@@ -381,11 +391,11 @@ module Email
       uploads = stripped_secure_image_uploads
       upload_shas = stripped_upload_sha_map
       stripped_media.each do |div|
-        upload =
-          uploads.find do |upl|
-            upl.sha1 ==
-              upload_shas[div["data-stripped-secure-media"] || div["data-stripped-secure-upload"]]
-          end
+        # Use same key logic as stripped_upload_sha_map: prefer base62_sha1 for deduped uploads
+        key =
+          div["data-base62-sha1"].presence ||
+            (div["data-stripped-secure-media"] || div["data-stripped-secure-upload"])
+        upload = uploads.find { |upl| upl.sha1 == upload_shas[key] }
         next if !upload
 
         if attachments[attachments_index[upload.sha1]]

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -657,16 +657,19 @@ module PrettyText
                                url,
                                width: img["width"],
                                height: img["height"],
+                               base62_sha1: img["data-base62-sha1"],
                              )
           a.remove
         else
-          width = non_image_media ? nil : a.at_css("img").attr("width")
-          height = non_image_media ? nil : a.at_css("img").attr("height")
+          img = non_image_media ? nil : a.at_css("img")
+          width = img&.attr("width")
+          height = img&.attr("height")
           target.add_next_sibling secure_uploads_placeholder(
                                     doc,
                                     a["href"],
                                     width: width,
                                     height: height,
+                                    base62_sha1: img&.[]("data-base62-sha1"),
                                   )
           target.remove
         end
@@ -713,17 +716,26 @@ module PrettyText
                                  onebox_type: onebox_type,
                                  width: width,
                                  height: height,
+                                 base62_sha1: img["data-base62-sha1"],
                                )
           img.remove
         end
       end
   end
 
-  def self.secure_uploads_placeholder(doc, url, onebox_type: false, width: nil, height: nil)
+  def self.secure_uploads_placeholder(
+    doc,
+    url,
+    onebox_type: false,
+    width: nil,
+    height: nil,
+    base62_sha1: nil
+  )
     notice = doc.document.create_element("div")
     notice["class"] = "secure-upload-notice"
     notice["data-stripped-secure-upload"] = url.to_s
     notice["data-onebox-type"] = onebox_type.to_s if onebox_type
+    notice["data-base62-sha1"] = base62_sha1 if base62_sha1
 
     width = numeric_dimension(width)
     height = numeric_dimension(height)

--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -76,7 +76,10 @@ module PrettyText
                   url:
                     (
                       if secure_uploads
-                        Upload.secure_uploads_url_from_upload_url(url)
+                        Upload.secure_uploads_url_from_upload_url(
+                          url,
+                          base62_sha1: Upload.base62_sha1(sha1),
+                        )
                       else
                         Discourse.store.cdn_url(url)
                       end

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -234,7 +234,6 @@ class UploadCreator
           primary = Upload.find_primary_for(original_sha1: sha1, secure: @upload.secure)
           if primary && primary.url.present?
             @upload.primary_upload_id = primary.id
-            @upload.url = primary.url
             @dedup_from_primary = true
           end
         end
@@ -258,9 +257,12 @@ class UploadCreator
           Upload.generate_digest(@file) != sha1_before_changes
         end
 
-      # Skip storage if deduplicating from an existing primary upload
+      # Storage deduplication: share the primary's URL instead of re-uploading
+      # The dependent upload keeps its own unique sha1 (used for short_url and data-base62-sha1)
+      # but points to the same storage object as the primary
       if @dedup_from_primary
-        # URL already set from primary, just save
+        primary = Upload.find(@upload.primary_upload_id)
+        @upload.url = primary.url
         @upload.save!(validate: @opts[:validate])
       else
         store = Discourse.store

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -261,10 +261,18 @@ class UploadCreator
       # The dependent upload keeps its own unique sha1 (used for short_url and data-base62-sha1)
       # but points to the same storage object as the primary
       if @dedup_from_primary
-        primary = Upload.find(@upload.primary_upload_id)
-        @upload.url = primary.url
-        @upload.save!(validate: @opts[:validate])
-      else
+        primary = Upload.find_by(id: @upload.primary_upload_id)
+        if primary&.url.present?
+          @upload.url = primary.url
+          @upload.save!(validate: @opts[:validate])
+        else
+          # Primary was deleted between dedup check and now - clear the reference and upload normally
+          @upload.update_columns(primary_upload_id: nil)
+          @dedup_from_primary = false
+        end
+      end
+
+      if !@dedup_from_primary
         store = Discourse.store
 
         if @opts[:existing_external_upload_key] && store.external?

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -227,6 +227,17 @@ class UploadCreator
           UploadSecurity.new(@upload, @opts.merge(creating: true)).should_be_secure_with_reason
         attrs = @upload.secure_params(secure, reason, "upload creator")
         @upload.assign_attributes(attrs)
+
+        # Check for existing primary with same content and security context
+        # This enables storage deduplication while maintaining separate upload records
+        if sha1.present? && !is_thumbnail
+          primary = Upload.find_primary_for(original_sha1: sha1, secure: @upload.secure)
+          if primary && primary.url.present?
+            @upload.primary_upload_id = primary.id
+            @upload.url = primary.url
+            @dedup_from_primary = true
+          end
+        end
       end
 
       # Callbacks using this event to validate the upload or the file must add errors to the
@@ -247,35 +258,41 @@ class UploadCreator
           Upload.generate_digest(@file) != sha1_before_changes
         end
 
-      store = Discourse.store
-
-      if @opts[:existing_external_upload_key] && store.external?
-        should_move = external_upload_too_big || !upload_changed
-      end
-
-      if should_move
-        # move the file in the store instead of reuploading
-        url =
-          store.move_existing_stored_upload(
-            existing_external_upload_key: @opts[:existing_external_upload_key],
-            upload: @upload,
-          )
-      else
-        # store the file and update its url
-        File.open(@file.path) { |f| url = store.store_upload(f, @upload) }
-        if @opts[:existing_external_upload_key]
-          store.delete_file(@opts[:existing_external_upload_key])
-        end
-      end
-
-      if url.present?
-        @upload.url = url
+      # Skip storage if deduplicating from an existing primary upload
+      if @dedup_from_primary
+        # URL already set from primary, just save
         @upload.save!(validate: @opts[:validate])
       else
-        @upload.errors.add(
-          :url,
-          I18n.t("upload.store_failure", upload_id: @upload.id, user_id: user_id),
-        )
+        store = Discourse.store
+
+        if @opts[:existing_external_upload_key] && store.external?
+          should_move = external_upload_too_big || !upload_changed
+        end
+
+        if should_move
+          # move the file in the store instead of reuploading
+          url =
+            store.move_existing_stored_upload(
+              existing_external_upload_key: @opts[:existing_external_upload_key],
+              upload: @upload,
+            )
+        else
+          # store the file and update its url
+          File.open(@file.path) { |f| url = store.store_upload(f, @upload) }
+          if @opts[:existing_external_upload_key]
+            store.delete_file(@opts[:existing_external_upload_key])
+          end
+        end
+
+        if url.present?
+          @upload.url = url
+          @upload.save!(validate: @opts[:validate])
+        else
+          @upload.errors.add(
+            :url,
+            I18n.t("upload.store_failure", upload_id: @upload.id, user_id: user_id),
+          )
+        end
       end
 
       if @upload.errors.empty? && is_image && @opts[:type] == "avatar" && @upload.extension != "svg"

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -181,7 +181,7 @@ class UploadCreator
             sha1
           end
         )
-      @upload.original_sha1 = SiteSetting.secure_uploads? ? sha1 : nil
+      @upload.original_sha1 = SiteSetting.secure_uploads? && !is_thumbnail ? sha1 : nil
       @upload.url = ""
       @upload.origin = @opts[:origin][0...2000] if @opts[:origin]
       @upload.extension = image_type || File.extname(@filename)[1..10]

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -567,6 +567,31 @@ RSpec.describe Jobs::PullHotlinkedImages do
           url = Upload.secure_uploads_url_from_upload_url(upload.url)
           expect(job.should_download_image?(url)).to eq(false)
         end
+
+        it "uses the logical upload identity for deduplicated secure-upload urls" do
+          setup_s3
+          SiteSetting.secure_uploads = true
+
+          other_post = Fabricate(:post)
+          post = Fabricate(:post)
+          primary = Fabricate(:upload_s3, secure: true, access_control_post: other_post)
+          dependent =
+            Fabricate(
+              :upload_s3,
+              secure: true,
+              access_control_post: post,
+              original_sha1: SecureRandom.hex(20),
+              primary_upload: primary,
+              url: primary.url,
+            )
+          url =
+            Upload.secure_uploads_url_from_upload_url(
+              primary.url,
+              base62_sha1: dependent.base62_sha1,
+            )
+
+          expect(job.should_download_image?(url, post)).to eq(false)
+        end
       end
 
       it "should return true for optimized" do

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -591,7 +591,7 @@ RSpec.describe CookedPostProcessor do
           end
 
           let(:secure_uploads_url) do
-            "//test.localhost/secure-uploads/original/1X/#{upload.sha1}.png"
+            "//test.localhost/secure-uploads/original/1X/#{upload.sha1}.png?base62_sha1=#{upload.base62_sha1}"
           end
 
           let(:cooked_html) { <<~HTML }
@@ -1770,7 +1770,7 @@ RSpec.describe CookedPostProcessor do
 
           expect(cpp.html).to match_html <<~HTML
             <p>This post has a local emoji <img src="https://local.cdn.com/images/emoji/twitter/+1.png?v=#{Emoji::EMOJI_VERSION}" title=":+1:" class="emoji" alt=":+1:" loading="lazy" width="20" height="20"> and an external upload</p>
-            <p><img src="/secure-uploads/#{stored_path}" alt="smallest.png" data-base62-sha1="#{upload.base62_sha1}" width="10" height="20"></p>
+            <p><img src="/secure-uploads/#{stored_path}?base62_sha1=#{upload.base62_sha1}" alt="smallest.png" data-base62-sha1="#{upload.base62_sha1}" width="10" height="20"></p>
           HTML
         end
 

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -656,6 +656,9 @@ RSpec.describe Email::Sender do
         end
 
         it "attaches only allowed images from multiple posts in the activity summary" do
+          # Stub S3 downloads to return the fixture file
+          FileHelper.stubs(:download).returns(file_from_fixtures("logo.png", "images"))
+
           digest_post = Fabricate(:post)
           other_digest_post = Fabricate(:post)
 

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2788,9 +2788,9 @@ HTML
         <div>
           Block img <img src="#{cdn_url}" data-base62-sha1="#{upload.base62_sha1}">
         </div>
-        <p><a href="#{upload.short_path}">some attachment</a></p>
-        <p><a class="attachment" href="#{upload.short_path}">some attachment</a></p>
-        <p><a href="#{upload.short_path}">some attachment|random</a></p>
+        <p><a href="#{upload.short_path}" data-base62-sha1="#{upload.base62_sha1}">some attachment</a></p>
+        <p><a class="attachment" href="#{upload.short_path}" data-base62-sha1="#{upload.base62_sha1}">some attachment</a></p>
+        <p><a href="#{upload.short_path}" data-base62-sha1="#{upload.base62_sha1}">some attachment|random</a></p>
       HTML
 
       expect(PrettyText.cook(raw)).to eq(cooked.strip)

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2266,8 +2266,12 @@ HTML
 
       # Due to a bug in node 18.16 and lower this takes about 11s.
       # On node 18.19 and newer it takes about 250ms
+      # Keep PrettyText startup outside the timed assertion. The 5s timeout still
+      # catches the ~11s Node 18.16 regression while allowing randomized suite overhead.
+      PrettyText.v8
+
       expect do
-        Timeout.timeout(3) do
+        Timeout.timeout(5) do
           expect(PrettyText.cook("abc nope def")).to match_html("<p>abc yep def</p>")
         end
       end.not_to raise_error

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -784,6 +784,58 @@ RSpec.describe UploadCreator do
             expect(result.original_sha1).not_to eq(nil)
           end
         end
+
+        context "with primary upload deduplication" do
+          let(:opts) { { for_private_message: true } }
+
+          it "deduplicates when a primary exists with same original_sha1 and secure status" do
+            # Create first upload which becomes the primary
+            first_upload = UploadCreator.new(file, filename, opts).create_for(user.id)
+            expect(first_upload.primary_upload_id).to be_nil
+            expect(first_upload.original_sha1).to be_present
+            primary_url = first_upload.url
+
+            # Create second upload with same file - should reference the primary
+            second_upload =
+              UploadCreator.new(file_from_fixtures(filename), filename, opts).create_for(user.id)
+
+            expect(second_upload.id).not_to eq(first_upload.id)
+            expect(second_upload.primary_upload_id).to eq(first_upload.id)
+            expect(second_upload.url).to eq(primary_url)
+            expect(second_upload.original_sha1).to eq(first_upload.original_sha1)
+          end
+
+          it "creates separate primaries for different security contexts" do
+            # Create secure upload
+            secure_upload = UploadCreator.new(file, filename, opts).create_for(user.id)
+            expect(secure_upload.secure).to eq(true)
+            expect(secure_upload.primary_upload_id).to be_nil
+
+            # Create public upload with same file
+            public_opts = { for_site_setting: true }
+            public_upload =
+              UploadCreator.new(file_from_fixtures(filename), filename, public_opts).create_for(
+                admin.id,
+              )
+
+            expect(public_upload.secure).to eq(false)
+            expect(public_upload.primary_upload_id).to be_nil
+            expect(public_upload.original_sha1).to eq(secure_upload.original_sha1)
+            expect(public_upload.url).not_to eq(secure_upload.url)
+          end
+
+          it "does not deduplicate thumbnails" do
+            thumb_opts = opts.merge(type: "thumbnail")
+
+            first_thumb = UploadCreator.new(file, filename, thumb_opts).create_for(user.id)
+            second_thumb =
+              UploadCreator.new(file_from_fixtures(filename), filename, thumb_opts).create_for(
+                user.id,
+              )
+
+            expect(second_thumb.primary_upload_id).to be_nil
+          end
+        end
       end
     end
 

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -833,7 +833,20 @@ RSpec.describe UploadCreator do
                 user.id,
               )
 
+            expect(first_thumb.primary_upload_id).to be_nil
             expect(second_thumb.primary_upload_id).to be_nil
+          end
+
+          it "does not use a thumbnail as the primary for a regular upload" do
+            thumb_opts = opts.merge(type: "thumbnail")
+            thumbnail = UploadCreator.new(file, filename, thumb_opts).create_for(user.id)
+            regular_upload =
+              UploadCreator.new(file_from_fixtures(filename), filename, opts).create_for(user.id)
+
+            expect(thumbnail.primary_upload_id).to be_nil
+            expect(thumbnail.original_sha1).to be_nil
+            expect(regular_upload.primary_upload_id).to be_nil
+            expect(regular_upload.url).not_to eq(thumbnail.url)
           end
         end
       end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -871,6 +871,48 @@ RSpec.describe Upload do
       expect(user.user_profile.card_background_upload_id).to eq(nil)
       expect(user.user_profile.profile_background_upload_id).to eq(nil)
     end
+
+    context "with deduplication" do
+      it "removes S3 file when standalone upload is destroyed" do
+        upload = Fabricate(:upload)
+        store = Discourse.store
+        store.expects(:remove_upload).with(upload).once
+
+        upload.destroy
+      end
+
+      it "does not remove S3 file when dependent upload is destroyed" do
+        primary = Fabricate(:secure_upload, original_sha1: "abc123")
+        dependent = Fabricate(:secure_upload, original_sha1: "abc123", primary_upload: primary)
+        store = Discourse.store
+        store.expects(:remove_upload).with(dependent).never
+
+        dependent.destroy
+      end
+
+      it "does not remove S3 file when primary transfers to dependent" do
+        primary = Fabricate(:secure_upload, url: "/uploads/primary.png", original_sha1: "abc123")
+        _dependent =
+          Fabricate(
+            :secure_upload,
+            url: "/uploads/dep.png",
+            original_sha1: "abc123",
+            primary_upload: primary,
+          )
+        store = Discourse.store
+        store.expects(:remove_upload).with(primary).never
+
+        primary.destroy
+      end
+
+      it "removes S3 file when primary has no dependents" do
+        primary = Fabricate(:secure_upload, original_sha1: "abc123")
+        store = Discourse.store
+        store.expects(:remove_upload).with(primary).once
+
+        primary.destroy
+      end
+    end
   end
 
   describe ".secure_uploads_url_from_upload_url" do

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -875,7 +875,11 @@ RSpec.describe Upload do
     context "with deduplication" do
       let(:mock_store) { mock("store") }
 
-      before { Discourse.stubs(:store).returns(mock_store) }
+      before do
+        Discourse.stubs(:store).returns(mock_store)
+        # Allow fabricator to call get_path_for for URL generation
+        mock_store.stubs(:get_path_for).returns("/uploads/default/original/1X/test.png")
+      end
 
       it "removes S3 file when standalone upload is destroyed" do
         upload = Fabricate(:upload)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -873,10 +873,13 @@ RSpec.describe Upload do
     end
 
     context "with deduplication" do
+      let(:mock_store) { mock("store") }
+
+      before { Discourse.stubs(:store).returns(mock_store) }
+
       it "removes S3 file when standalone upload is destroyed" do
         upload = Fabricate(:upload)
-        store = Discourse.store
-        store.expects(:remove_upload).with(upload).once
+        mock_store.expects(:remove_upload).with(upload).once
 
         upload.destroy
       end
@@ -884,8 +887,7 @@ RSpec.describe Upload do
       it "does not remove S3 file when dependent upload is destroyed" do
         primary = Fabricate(:secure_upload, original_sha1: "abc123")
         dependent = Fabricate(:secure_upload, original_sha1: "abc123", primary_upload: primary)
-        store = Discourse.store
-        store.expects(:remove_upload).with(dependent).never
+        mock_store.expects(:remove_upload).with(dependent).never
 
         dependent.destroy
       end
@@ -899,16 +901,14 @@ RSpec.describe Upload do
             original_sha1: "abc123",
             primary_upload: primary,
           )
-        store = Discourse.store
-        store.expects(:remove_upload).with(primary).never
+        mock_store.expects(:remove_upload).with(primary).never
 
         primary.destroy
       end
 
       it "removes S3 file when primary has no dependents" do
         primary = Fabricate(:secure_upload, original_sha1: "abc123")
-        store = Discourse.store
-        store.expects(:remove_upload).with(primary).once
+        mock_store.expects(:remove_upload).with(primary).once
 
         primary.destroy
       end
@@ -1281,58 +1281,37 @@ RSpec.describe Upload do
     end
 
     describe "context transition handling" do
+      let(:sha1_hash) { "a" * 40 }
+
       it "switches to existing primary when secure status changes" do
-        secure_primary =
-          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
-        public_primary =
-          Fabricate(
-            :upload,
-            original_sha1: "abc123",
-            secure: false,
-            url: "/public/url.png",
-            primary_upload_id: nil,
-          )
+        secure_primary = Fabricate(:upload, original_sha1: sha1_hash, secure: true)
+        public_primary = Fabricate(:upload, original_sha1: sha1_hash, secure: false)
         dependent =
-          Fabricate(
-            :secure_upload,
-            original_sha1: "abc123",
-            secure: true,
-            url: "/secure/url.png",
-            primary_upload: secure_primary,
-          )
+          Fabricate(:upload, original_sha1: sha1_hash, secure: true, primary_upload: secure_primary)
 
         dependent.handle_dedup_context_transition(false)
+        dependent.reload
 
         expect(dependent.primary_upload_id).to eq(public_primary.id)
-        expect(dependent.url).to eq("/public/url.png")
+        expect(dependent.url).to eq(public_primary.url)
       end
 
       it "breaks relationship when no matching primary exists" do
-        secure_primary =
-          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
+        secure_primary = Fabricate(:upload, original_sha1: sha1_hash, secure: true)
         dependent =
-          Fabricate(
-            :secure_upload,
-            original_sha1: "abc123",
-            secure: true,
-            url: "/secure/url.png",
-            primary_upload: secure_primary,
-          )
-
-        # Stub external store check to skip S3 operations
-        Discourse.stubs(:store).returns(stub(external?: false))
+          Fabricate(:upload, original_sha1: sha1_hash, secure: true, primary_upload: secure_primary)
 
         dependent.handle_dedup_context_transition(false)
+        dependent.reload
 
         expect(dependent.primary_upload_id).to be_nil
       end
 
       it "does nothing for non-dependents" do
-        primary =
-          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
+        primary = Fabricate(:upload, original_sha1: sha1_hash, secure: true)
 
         expect { primary.handle_dedup_context_transition(false) }.not_to change {
-          primary.primary_upload_id
+          primary.reload.primary_upload_id
         }
       end
     end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1300,15 +1300,57 @@ RSpec.describe Upload do
         expect(dependent.url).to eq(public_primary.url)
       end
 
-      it "breaks relationship when no matching primary exists" do
+      it "promotes a dependent before a primary switches to an existing primary" do
+        secure_primary =
+          Fabricate(:upload, original_sha1: sha1_hash, secure: true, url: "/uploads/secure.png")
+        public_primary =
+          Fabricate(:upload, original_sha1: sha1_hash, secure: false, url: "/uploads/public.png")
+        dependent =
+          Fabricate(
+            :upload,
+            original_sha1: sha1_hash,
+            secure: true,
+            primary_upload: secure_primary,
+            url: secure_primary.url,
+          )
+
+        secure_primary.update_secure_status(override: false, source: "spec")
+
+        expect(secure_primary.reload.primary_upload_id).to eq(public_primary.id)
+        expect(secure_primary.url).to eq(public_primary.url)
+        expect(secure_primary.secure).to eq(false)
+        expect(dependent.reload.primary_upload_id).to be_nil
+        expect(dependent.url).to eq("/uploads/secure.png")
+      end
+
+      it "copies a local dependent upload to its own path when no matching primary exists" do
         secure_primary = Fabricate(:upload, original_sha1: sha1_hash, secure: true)
         dependent =
-          Fabricate(:upload, original_sha1: sha1_hash, secure: true, primary_upload: secure_primary)
+          Fabricate(
+            :upload,
+            original_sha1: sha1_hash,
+            secure: true,
+            primary_upload: secure_primary,
+            url: secure_primary.url,
+          )
+
+        source_path = Discourse.store.path_for(secure_primary)
+        FileUtils.mkdir_p(File.dirname(source_path))
+        File.write(source_path, "upload contents")
+        expected_url =
+          Discourse.store.get_path_for(
+            "original",
+            dependent.id,
+            dependent.sha1,
+            ".#{dependent.extension}",
+          )
 
         dependent.handle_dedup_context_transition(false)
         dependent.reload
 
         expect(dependent.primary_upload_id).to be_nil
+        expect(dependent.url).to eq(expected_url)
+        expect(File.read(Discourse.store.path_for(dependent))).to eq("upload contents")
       end
 
       it "does nothing for non-dependents" do

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -931,6 +931,30 @@ RSpec.describe Upload do
       secure_url = Upload.secure_uploads_url_from_upload_url(url)
       expect(secure_url).not_to include(SiteSetting.Upload.absolute_base_url)
     end
+
+    it "includes the logical upload identity when provided" do
+      upload = Fabricate(:upload_s3, secure: true)
+      secure_url =
+        Upload.secure_uploads_url_from_upload_url(upload.url, base62_sha1: upload.base62_sha1)
+
+      expect(secure_url).to end_with("?base62_sha1=#{upload.base62_sha1}")
+    end
+  end
+
+  describe ".signed_url_from_secure_uploads_url" do
+    before { enable_secure_uploads }
+
+    it "does not include the logical upload identity in the storage path" do
+      url =
+        "/secure-uploads/original/2X/f/f62055931bb702c7fd8f552fb901f977e0289a18.png?base62_sha1=1Eg9p8rrCURq4T3a6iJUk0ri6"
+      signed_url =
+        Upload.signed_url_from_secure_uploads_url(url, include_content_disposition: false)
+
+      expect(URI.parse(signed_url).path).to end_with(
+        "/original/2X/f/f62055931bb702c7fd8f552fb901f977e0289a18.png",
+      )
+      expect(signed_url).not_to include("base62_sha1")
+    end
   end
 
   describe ".secure_uploads_url?" do
@@ -942,6 +966,13 @@ RSpec.describe Upload do
       expect(Upload.secure_uploads_url?(url)).to eq(true)
       url =
         "http://localhost:3000/secure-uploads/original/2X/f/f62055931bb702c7fd8f552fb901f977e0289a18.png"
+      expect(Upload.secure_uploads_url?(url)).to eq(true)
+    end
+
+    it "works when the secure uploads url includes a logical upload identity" do
+      url =
+        "/secure-uploads/original/2X/f/f62055931bb702c7fd8f552fb901f977e0289a18.png?base62_sha1=1Eg9p8rrCURq4T3a6iJUk0ri6"
+
       expect(Upload.secure_uploads_url?(url)).to eq(true)
     end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -848,6 +848,20 @@ RSpec.describe Upload do
     end
   end
 
+  describe ".sha1_from_secure_uploads_url" do
+    it "extracts the logical upload sha1 from the query string" do
+      url = "/secure-uploads/original/1X/storage.png?base62_sha1=#{upload.base62_sha1}"
+
+      expect(Upload.sha1_from_secure_uploads_url(url)).to eq(upload.sha1)
+    end
+
+    it "returns nil for an invalid logical upload identity" do
+      url = "/secure-uploads/original/1X/storage.png?base62_sha1=not%20base62"
+
+      expect(Upload.sha1_from_secure_uploads_url(url)).to be_nil
+    end
+  end
+
   def enable_secure_uploads
     setup_s3
     SiteSetting.secure_uploads = true

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1279,5 +1279,62 @@ RSpec.describe Upload do
         expect(Upload.find_by(id: primary.id)).to be_nil
       end
     end
+
+    describe "context transition handling" do
+      it "switches to existing primary when secure status changes" do
+        secure_primary =
+          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
+        public_primary =
+          Fabricate(
+            :upload,
+            original_sha1: "abc123",
+            secure: false,
+            url: "/public/url.png",
+            primary_upload_id: nil,
+          )
+        dependent =
+          Fabricate(
+            :secure_upload,
+            original_sha1: "abc123",
+            secure: true,
+            url: "/secure/url.png",
+            primary_upload: secure_primary,
+          )
+
+        dependent.handle_dedup_context_transition(false)
+
+        expect(dependent.primary_upload_id).to eq(public_primary.id)
+        expect(dependent.url).to eq("/public/url.png")
+      end
+
+      it "breaks relationship when no matching primary exists" do
+        secure_primary =
+          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
+        dependent =
+          Fabricate(
+            :secure_upload,
+            original_sha1: "abc123",
+            secure: true,
+            url: "/secure/url.png",
+            primary_upload: secure_primary,
+          )
+
+        # Stub external store check to skip S3 operations
+        Discourse.stubs(:store).returns(stub(external?: false))
+
+        dependent.handle_dedup_context_transition(false)
+
+        expect(dependent.primary_upload_id).to be_nil
+      end
+
+      it "does nothing for non-dependents" do
+        primary =
+          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, url: "/secure/url.png")
+
+        expect { primary.handle_dedup_context_transition(false) }.not_to change {
+          primary.primary_upload_id
+        }
+      end
+    end
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1118,4 +1118,124 @@ RSpec.describe Upload do
       expect(upload_3.reload.verification_status).to eq(Upload.verification_statuses[:verified])
     end
   end
+
+  describe "primary upload deduplication" do
+    fab!(:user)
+
+    describe ".find_primary_for" do
+      it "returns nil when original_sha1 is blank" do
+        expect(Upload.find_primary_for(original_sha1: nil, secure: false)).to be_nil
+        expect(Upload.find_primary_for(original_sha1: "", secure: false)).to be_nil
+      end
+
+      it "finds a primary upload matching original_sha1 and secure status" do
+        primary = Fabricate(:secure_upload, original_sha1: "abc123", secure: true)
+
+        found = Upload.find_primary_for(original_sha1: "abc123", secure: true)
+        expect(found).to eq(primary)
+      end
+
+      it "does not find a primary with different secure status" do
+        Fabricate(:secure_upload, original_sha1: "abc123", secure: true)
+
+        found = Upload.find_primary_for(original_sha1: "abc123", secure: false)
+        expect(found).to be_nil
+      end
+
+      it "does not find an upload that is itself a dependent" do
+        primary = Fabricate(:secure_upload, original_sha1: "abc123", secure: true)
+        dependent =
+          Fabricate(:secure_upload, original_sha1: "abc123", secure: true, primary_upload: primary)
+
+        found = Upload.find_primary_for(original_sha1: "abc123", secure: true)
+        expect(found).to eq(primary)
+        expect(found).not_to eq(dependent)
+      end
+    end
+
+    describe "#primary? and #dependent?" do
+      it "returns true for primary when primary_upload_id is nil and original_sha1 present" do
+        upload = Fabricate(:secure_upload, original_sha1: "abc123", primary_upload_id: nil)
+        expect(upload.primary?).to be true
+        expect(upload.dependent?).to be false
+      end
+
+      it "returns true for dependent when primary_upload_id is set" do
+        primary = Fabricate(:secure_upload, original_sha1: "abc123")
+        dependent = Fabricate(:secure_upload, original_sha1: "abc123", primary_upload: primary)
+
+        expect(dependent.primary?).to be false
+        expect(dependent.dependent?).to be true
+      end
+
+      it "returns false for primary when original_sha1 is blank" do
+        upload = Fabricate(:upload, original_sha1: nil, primary_upload_id: nil)
+        expect(upload.primary?).to be false
+      end
+    end
+
+    describe "#storage_url" do
+      it "returns own url when no primary" do
+        upload = Fabricate(:upload, url: "/uploads/test.png")
+        expect(upload.storage_url).to eq("/uploads/test.png")
+      end
+
+      it "returns primary url when dependent" do
+        primary = Fabricate(:secure_upload, url: "/uploads/primary.png", original_sha1: "abc123")
+        dependent =
+          Fabricate(
+            :secure_upload,
+            url: "/uploads/dependent.png",
+            original_sha1: "abc123",
+            primary_upload: primary,
+          )
+
+        expect(dependent.storage_url).to eq("/uploads/primary.png")
+      end
+    end
+
+    describe "before_destroy primary transfer" do
+      it "transfers primary status to a dependent when destroyed" do
+        primary =
+          Fabricate(
+            :secure_upload,
+            url: "/uploads/primary.png",
+            original_sha1: "abc123",
+            secure: true,
+          )
+        dependent1 =
+          Fabricate(
+            :secure_upload,
+            url: "/uploads/dep1.png",
+            original_sha1: "abc123",
+            secure: true,
+            primary_upload: primary,
+          )
+        dependent2 =
+          Fabricate(
+            :secure_upload,
+            url: "/uploads/dep2.png",
+            original_sha1: "abc123",
+            secure: true,
+            primary_upload: primary,
+          )
+
+        primary.destroy!
+
+        dependent1.reload
+        dependent2.reload
+
+        expect(dependent1.primary_upload_id).to be_nil
+        expect(dependent1.url).to eq("/uploads/primary.png")
+        expect(dependent2.primary_upload_id).to eq(dependent1.id)
+      end
+
+      it "does nothing when no dependents exist" do
+        primary = Fabricate(:secure_upload, url: "/uploads/primary.png", original_sha1: "abc123")
+
+        expect { primary.destroy! }.not_to raise_error
+        expect(Upload.find_by(id: primary.id)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -668,6 +668,72 @@ RSpec.describe UploadsController do
 
         result = response.parsed_body
         expect(result[0]["url"]).to match("secure-uploads")
+        expect(result[0]["url"]).to end_with("?base62_sha1=#{upload.base62_sha1}")
+      end
+
+      context "with a storage-deduplicated upload" do
+        fab!(:allowed_group, :group)
+        fab!(:allowed_category) { Fabricate(:private_category, group: allowed_group) }
+        fab!(:allowed_post) do
+          Fabricate(:post, topic: Fabricate(:topic, category: allowed_category))
+        end
+        fab!(:blocked_post) do
+          Fabricate(
+            :post,
+            topic:
+              Fabricate(:topic, category: Fabricate(:private_category, group: Fabricate(:group))),
+          )
+        end
+        let!(:dependent_upload) do
+          Fabricate(
+            :secure_upload_s3,
+            original_sha1: "a" * 40,
+            primary_upload: upload,
+            url: upload.url,
+            access_control_post: allowed_post,
+          )
+        end
+
+        before do
+          allowed_group.add(user)
+          upload.update!(secure: true, original_sha1: "a" * 40, access_control_post: blocked_post)
+          sign_in(user)
+        end
+
+        it "authorizes against the logical upload while serving the primary storage path" do
+          get Upload.secure_uploads_url_from_upload_url(
+                upload.url,
+                base62_sha1: dependent_upload.base62_sha1,
+              )
+
+          expect(response.status).to eq(302)
+          expect(response.redirect_url).to match("Amz-Expires")
+        end
+
+        it "does not allow an upload identity to authorize a different storage path" do
+          other_upload =
+            Fabricate(:secure_upload_s3, secure: true, access_control_post: allowed_post)
+
+          get Upload.secure_uploads_url_from_upload_url(
+                upload.url,
+                base62_sha1: other_upload.base62_sha1,
+              )
+
+          expect(response.status).to eq(404)
+        end
+
+        it "continues serving the storage path after the original primary is deleted" do
+          secure_url =
+            Upload.secure_uploads_url_from_upload_url(
+              upload.url,
+              base62_sha1: dependent_upload.base62_sha1,
+            )
+          upload.destroy!
+
+          get secure_url
+
+          expect(response.status).to eq(302)
+        end
       end
 
       context "when the upload cannot be found from the URL" do


### PR DESCRIPTION
## Summary

When secure_uploads is enabled, uploads with the same content now share S3 storage via a `primary_upload_id` reference. This addresses storage explosion where identical files create separate S3 objects for each upload.

Example impact: 246k copies of the same GIF now share 2 S3 objects (one secure, one public) instead of 246k.

## How it works

1. When creating an upload, check if a primary with matching `original_sha1` and security context exists. If so, set `primary_upload_id` and copy the URL instead of uploading to S3.

2. Each Upload keeps its own unique `sha1` (used for short URLs and `data-base62-sha1` attributes). Only the storage is shared.

3. When deleting a primary upload, ownership transfers to a dependent before the S3 object is removed.

4. When an upload's security status changes (e.g., moved from PM to public topic), `handle_dedup_context_transition` either finds a new primary in the target context or creates a new S3 object.

## Database changes

- Add `primary_upload_id` column to uploads table (FK to uploads.id)
- Add partial index on `(original_sha1, secure)` for fast primary lookups

## Key files

- `app/models/upload.rb` - `find_primary_for`, `primary?`, `dependent?`, destroy logic
- `lib/upload_creator.rb` - Dedup check before S3 upload
- `app/models/concerns/has_post_upload_references.rb` - Use `data-base62-sha1` to track unique uploads even when URLs are shared
- `lib/email/sender.rb` - Check both raw and base62-encoded sha1 for digest attachments
- `lib/email/styles.rb` - Handle `data-base62-sha1` for stripped secure images
- `app/services/topic_upload_security_manager.rb` - Context transition handling