### PR TITLE
DEV: Fix typo in password_unique_characters string

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8617,7 +8617,7 @@ en:
           min_admin_password_length:
             prompt: "You're about to change your password policy. This will affect all admins changing their passwords from now on. Are you sure you want to proceed?"
             confirm: "Yes, update password policy"
-          password_unique_charactes:
+          password_unique_characters:
             prompt: "You're about to change your password policy. This will affect all users changing their passwords from now on. Are you sure you want to proceed?"
             confirm: "Yes, update password policy"
           block_common_passwords:


### PR DESCRIPTION
When changing the site setting, we were previously showing a generic message vs this specific one. 