### PR TITLE
FEATURE: Ignore topics created by ignored users.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -380,15 +380,17 @@ class Topic < ActiveRecord::Base
               condition[1],
             )
 
-          ignored_users_ids =
-            if guardian.nil? || guardian.anonymous?
-              ""
-            else
-              guardian.user.ignored_user_ids.join(",")
-            end
+          if SiteSetting.ignored_users_topics_gets_hidden
+            ignored_users_ids =
+              if guardian.nil? || guardian.anonymous?
+                ""
+              else
+                guardian.user.ignored_user_ids.join(",")
+              end
 
-          if ignored_users_ids.present?
-            scope = scope.where("topics.user_id NOT IN (#{ignored_users_ids})")
+            if ignored_users_ids.present?
+              scope = scope.where("topics.user_id NOT IN (#{ignored_users_ids})")
+            end
           end
 
           scope

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2448,6 +2448,7 @@ en:
     ignored_users_count_message_threshold: "Notify moderators if a particular user is ignored by this many other users."
 
     ignored_users_message_gap_days: "How long to wait before notifying moderators again about a user who has been ignored by many others."
+    ignored_users_topics_gets_hidden: "Topics created by ignored users are automatically hidden in lists. Users can still see the topics if they visit them directly but their content will be hidden."
 
     clean_up_inactive_users_after_days: "Number of days before an inactive user (trust level 0 without any posts) is removed. To disable clean up set to 0."
     clean_up_unused_staged_users_after_days: "Number of days before an unused staged user (without any posts) is removed. To disable clean up set to 0."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1112,6 +1112,10 @@ users:
     min: 1
     max: 36500
     area: "users"
+  ignored_users_topics_gets_hidden:
+    default: false
+    client: true
+    area: "users"
   clean_up_inactive_users_after_days:
     default: 0
     min: 0

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -989,7 +989,9 @@ class TopicQuery
     if options && (options[:include_muted].nil? || options[:include_muted]) &&
          options[:state] != "muted"
       list = remove_muted_topics(list, user)
-      list = remove_topics_from_ignored_users(list, user)
+      if SiteSetting.ignored_users_topics_gets_hidden
+        list = remove_topics_from_ignored_users(list, user)
+      end
     end
 
     list = remove_muted_categories(list, user, exclude: options[:category])

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -989,6 +989,7 @@ class TopicQuery
     if options && (options[:include_muted].nil? || options[:include_muted]) &&
          options[:state] != "muted"
       list = remove_muted_topics(list, user)
+      list = remove_topics_from_ignored_users(list, user)
     end
 
     list = remove_muted_categories(list, user, exclude: options[:category])
@@ -1004,6 +1005,12 @@ class TopicQuery
         )
     end
 
+    list
+  end
+
+  def remove_topics_from_ignored_users(list, user)
+    ignored_users = user.ignored_user_ids.join(",")
+    list = list.where("topics.user_id NOT IN (#{ignored_users})") if ignored_users.present?
     list
   end
 

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -1009,8 +1009,11 @@ class TopicQuery
   end
 
   def remove_topics_from_ignored_users(list, user)
-    ignored_users = user.ignored_user_ids.join(",")
-    list = list.where("topics.user_id NOT IN (#{ignored_users})") if ignored_users.present?
+    if user
+      ignored_users = user.ignored_user_ids.join(",")
+      list = list.where("topics.user_id NOT IN (#{ignored_users})") if ignored_users.present?
+    end
+
     list
   end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -193,6 +193,25 @@ RSpec.describe TopicQuery do
 
       expect(TopicQuery.new(user).list_hot.topics.map(&:id)).not_to include(muted_topic.id)
     end
+
+    context "with ignored users" do
+      fab!(:ignored_user, :user)
+
+      fab!(:ignored_relation) do
+        Fabricate(
+          :ignored_user,
+          user: user,
+          ignored_user: ignored_user,
+          expiring_at: 1.day.from_now,
+        )
+      end
+      it "excludes topics created by ignored users" do
+        ignored_topic = Fabricate(:topic, user: ignored_user)
+        TopicHotScore.create!(topic_id: ignored_topic.id, score: 1.0)
+
+        expect(TopicQuery.new(user).list_hot.topics.map(&:id)).not_to include(ignored_topic.id)
+      end
+    end
   end
 
   describe "#prioritize_pinned_topics" do

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -205,11 +205,24 @@ RSpec.describe TopicQuery do
           expiring_at: 1.day.from_now,
         )
       end
-      it "excludes topics created by ignored users" do
-        ignored_topic = Fabricate(:topic, user: ignored_user)
-        TopicHotScore.create!(topic_id: ignored_topic.id, score: 1.0)
+      describe "when ignored_users_topics_gets_hidden is true" do
+        before { SiteSetting.ignored_users_topics_gets_hidden = true }
+        it "excludes topics created by ignored users" do
+          ignored_topic = Fabricate(:topic, user: ignored_user)
+          TopicHotScore.create!(topic_id: ignored_topic.id, score: 1.0)
 
-        expect(TopicQuery.new(user).list_hot.topics.map(&:id)).not_to include(ignored_topic.id)
+          expect(TopicQuery.new(user).list_hot.topics.map(&:id)).not_to include(ignored_topic.id)
+        end
+      end
+
+      describe "when ignored_users_topics_gets_hidden is false" do
+        before { SiteSetting.ignored_users_topics_gets_hidden = false }
+        it "includes topics created by ignored users" do
+          ignored_topic = Fabricate(:topic, user: ignored_user)
+          TopicHotScore.create!(topic_id: ignored_topic.id, score: 1.0)
+
+          expect(TopicQuery.new(user).list_hot.topics.map(&:id)).to include(ignored_topic.id)
+        end
       end
     end
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2617,6 +2617,28 @@ RSpec.describe Topic do
 
       expect(result.pluck(:id)).to contain_exactly(categorized_topic.id)
     end
+
+    context "with ignored users" do
+      fab!(:ignored_user, :user)
+
+      fab!(:ignored_relation) do
+        Fabricate(
+          :ignored_user,
+          user: user,
+          ignored_user: ignored_user,
+          expiring_at: 1.day.from_now,
+        )
+      end
+      it "excludes topics created by ignored users" do
+        ignored_topic = Fabricate(:topic, user: ignored_user)
+        allowed_topic = Fabricate(:topic, user: user)
+
+        topics = Topic.secured(Guardian.new(user))
+
+        expect(topics).to include(allowed_topic)
+        expect(topics).not_to include(ignored_topic)
+      end
+    end
   end
 
   describe "all_allowed_users" do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2629,14 +2629,31 @@ RSpec.describe Topic do
           expiring_at: 1.day.from_now,
         )
       end
-      it "excludes topics created by ignored users" do
-        ignored_topic = Fabricate(:topic, user: ignored_user)
-        allowed_topic = Fabricate(:topic, user: user)
 
-        topics = Topic.secured(Guardian.new(user))
+      describe "when ignored_users_topics_gets_hidden is true" do
+        before { SiteSetting.ignored_users_topics_gets_hidden = true }
+        it "excludes topics created by ignored users" do
+          ignored_topic = Fabricate(:topic, user: ignored_user)
+          allowed_topic = Fabricate(:topic, user: user)
 
-        expect(topics).to include(allowed_topic)
-        expect(topics).not_to include(ignored_topic)
+          topics = Topic.secured(Guardian.new(user))
+
+          expect(topics).to include(allowed_topic)
+          expect(topics).not_to include(ignored_topic)
+        end
+      end
+
+      describe "when ignored_users_topics_gets_hidden is false" do
+        before { SiteSetting.ignored_users_topics_gets_hidden = false }
+        it "includes topics created by ignored users" do
+          ignored_topic = Fabricate(:topic, user: ignored_user)
+          allowed_topic = Fabricate(:topic, user: user)
+
+          topics = Topic.secured(Guardian.new(user))
+
+          expect(topics).to include(allowed_topic)
+          expect(topics).to include(ignored_topic)
+        end
       end
     end
   end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1956,16 +1956,34 @@ RSpec.describe ListController do
       Fabricate(:ignored_user, user: user, ignored_user: ignored_user, expiring_at: 1.day.from_now)
     end
 
-    it "does not show topics created by ignored users in the topic list" do
-      ignored_topic = Fabricate(:topic, user: ignored_user)
-      sign_in(user)
+    describe "when ignored_users_topics_gets_hidden is true" do
+      before { SiteSetting.ignored_users_topics_gets_hidden = true }
+      it "does not show topics created by ignored users in the topic list" do
+        ignored_topic = Fabricate(:topic, user: ignored_user)
+        sign_in(user)
 
-      get "/latest.json"
+        get "/latest.json"
 
-      expect(response.status).to eq(200)
-      json = response.parsed_body
-      topic_ids = json["topic_list"]["topics"].pluck("id")
-      expect(topic_ids).not_to include(ignored_topic.id)
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        topic_ids = json["topic_list"]["topics"].pluck("id")
+        expect(topic_ids).not_to include(ignored_topic.id)
+      end
+    end
+
+    describe "when ignored_users_topics_gets_hidden is false" do
+      before { SiteSetting.ignored_users_topics_gets_hidden = false }
+      it "shows topics created by ignored users in the topic list" do
+        ignored_topic = Fabricate(:topic, user: ignored_user)
+        sign_in(user)
+
+        get "/latest.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        topic_ids = json["topic_list"]["topics"].pluck("id")
+        expect(topic_ids).to include(ignored_topic.id)
+      end
     end
   end
 end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1948,4 +1948,24 @@ RSpec.describe ListController do
       expect(new_sql_queries).to eq(initial_sql_queries)
     end
   end
+
+  context "with ignored users" do
+    fab!(:ignored_user, :user)
+
+    fab!(:ignored_relation) do
+      Fabricate(:ignored_user, user: user, ignored_user: ignored_user, expiring_at: 1.day.from_now)
+    end
+
+    it "does not show topics created by ignored users in the topic list" do
+      ignored_topic = Fabricate(:topic, user: ignored_user)
+      sign_in(user)
+
+      get "/latest.json"
+
+      expect(response.status).to eq(200)
+      json = response.parsed_body
+      topic_ids = json["topic_list"]["topics"].pluck("id")
+      expect(topic_ids).not_to include(ignored_topic.id)
+    end
+  end
 end


### PR DESCRIPTION
Currently, when a user ignores another user, it only hides the content of the ignored user's posts(also removes from chat and notifications, I think), but topics created by the ignored user still appear in the topic list and other places. This change modifies the topic query logic to exclude topics created by ignored users from appearing in the topic lists for the user who has ignored them.

Relates to these meta requests:
- https://meta.discourse.org/t/topics-created-by-ignored-users-showing-on-homepage/170366/15
- https://meta.discourse.org/t/potential-way-to-hide-ignored-users-from-topic-list/191980

And somewhat related to:
- https://meta.discourse.org/t/hide-ignored-users-topics/276420
