### PR TITLE
DEV: Skip caching discobot certificate generation

### DIFF
--- a/plugins/discourse-narrative-bot/app/controllers/discourse_narrative_bot/certificates_controller.rb
+++ b/plugins/discourse-narrative-bot/app/controllers/discourse_narrative_bot/certificates_controller.rb
@@ -8,8 +8,6 @@ module DiscourseNarrativeBot
     requires_login
 
     def generate
-      immutable_for(24.hours)
-
       %i[date user_id].each do |key|
         raise Discourse::InvalidParameters.new("#{key} must be present") if params[key].blank?
       end


### PR DESCRIPTION
This is not strictly necessary and performance-wise it is only a minor protection. The route is behind login and it has rate limits per user (30 max every 10 minutes).

Removing the cache should help some instances where the wrong certificate is shown to users (cert from user A shown to user B).

See https://meta.discourse.org/t/-/394981