### PR TITLE
UX: `enable_discourse_id` not needed in social logins admin screen

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -646,7 +646,6 @@ login:
   enable_discourse_id:
     default: false
     validator: "EnableDiscourseIdValidator"
-    area: "authenticators"
   discourse_id_client_id:
     default: ""
     hidden: true


### PR DESCRIPTION
It has a dedicated tab in this UI.