### PR TITLE
UX: Make dismiss buttons icon use consistent

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3681,6 +3681,10 @@ en:
         dismiss_button_with_selected:
           one: "Dismiss (%{count})…"
           other: "Dismiss (%{count})…"
+        dismiss_unread: "Dismiss Unread"
+        dismiss_unread_with_selected:
+          one: "Dismiss Unread (%{count})"
+          other: "Dismiss Unread (%{count})"
         dismiss_tooltip: "Dismiss just new posts or stop tracking topics"
         also_dismiss_topics: "Stop tracking these topics so they never show up as unread for me again"
         dismiss_new: "Dismiss New"

--- a/frontend/discourse/app/components/topic-dismiss-buttons.gjs
+++ b/frontend/discourse/app/components/topic-dismiss-buttons.gjs
@@ -23,6 +23,16 @@ export default class TopicDismissButtons extends Component {
     });
   }
 
+  get dismissUnreadLabel() {
+    if (this.args.selectedTopics.length === 0) {
+      return i18n("topics.bulk.dismiss_unread");
+    }
+
+    return i18n("topics.bulk.dismiss_unread_with_selected", {
+      count: this.args.selectedTopics.length,
+    });
+  }
+
   get dismissNewLabel() {
     if (this.currentUser?.new_new_view_enabled) {
       return i18n("topics.bulk.dismiss_button");
@@ -56,7 +66,8 @@ export default class TopicDismissButtons extends Component {
         {{~#if @showDismissRead~}}
           <DButton
             @action={{this.dismissReadPosts}}
-            @translatedLabel={{this.dismissLabel}}
+            @icon="check"
+            @translatedLabel={{this.dismissUnreadLabel}}
             @title="topics.bulk.dismiss_tooltip"
             id="dismiss-topics-{{@position}}"
             class="btn-default dismiss-read"
@@ -65,8 +76,9 @@ export default class TopicDismissButtons extends Component {
         {{~#if @showResetNew~}}
           <DButton
             @action={{@resetNew}}
-            @translatedLabel={{this.dismissNewLabel}}
             @icon="check"
+            @translatedLabel={{this.dismissNewLabel}}
+            @title="topics.bulk.dismiss_tooltip"
             id="dismiss-new-{{@position}}"
             class="btn-default dismiss-read"
           />


### PR DESCRIPTION
Currently, the "Dismiss" buttons are different on /unread and /new.

These should be consistent and have an icon similar to other buttons.