### PR TITLE
PERF: Reduce database queries in reaction operations

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -101,6 +101,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     reaction_users =
       DiscourseReactions::ReactionUser
         .joins(:reaction)
+        .includes(:user, :post, :reaction)
         .where(post_id: post_ids)
         .where.not(discourse_reactions_reactions: { reaction_users_count: nil })
 

--- a/plugins/discourse-reactions/app/services/discourse_reactions/reaction_manager.rb
+++ b/plugins/discourse-reactions/app/services/discourse_reactions/reaction_manager.rb
@@ -96,7 +96,8 @@ module DiscourseReactions
     end
 
     def reaction_user
-      DiscourseReactions::ReactionUser.find_by(user_id: @user.id, post_id: @post.id)
+      @reaction_user_cached ||=
+        DiscourseReactions::ReactionUser.find_by(user_id: @user.id, post_id: @post.id)
     end
 
     def old_reaction_value(reaction_user)
@@ -132,6 +133,7 @@ module DiscourseReactions
 
     def remove_reaction
       @reaction_user.destroy
+      @reaction_user_cached = nil
       remove_shadow_like
       delete_reaction_with_no_users
     end

--- a/plugins/discourse-reactions/app/services/discourse_reactions/reaction_notification.rb
+++ b/plugins/discourse-reactions/app/services/discourse_reactions/reaction_notification.rb
@@ -28,19 +28,19 @@ module DiscourseReactions
     end
 
     def delete
-      return if DiscourseReactions::Reaction.where(post_id: @post.id).by_user(@user).count != 0
-      read = true
-      Notification
-        .where(
+      return if DiscourseReactions::Reaction.where(post_id: @post.id).by_user(@user).exists?
+
+      notifications =
+        Notification.where(
           topic_id: @post.topic_id,
           user_id: @post.user_id,
           post_number: @post.post_number,
           notification_type: Notification.types[:reaction],
         )
-        .each do |notification|
-          read = false unless notification.read
-          notification.destroy
-        end
+
+      read = !notifications.where(read: false).exists?
+      notifications.delete_all
+
       refresh_notification(read)
     end
 


### PR DESCRIPTION
- Memoize reaction_user lookup in ReactionManager to avoid repeated queries during toggle! (called 6+ times per operation)

- Use bulk delete_all instead of iterating with destroy in ReactionNotification#delete (no callbacks on Notification model)

- Change count != 0 to exists? for presence check

- Add includes(:user, :post, :reaction) to reactions_received endpoint to prevent N+1 queries during serialization