### PR TITLE
FIX: Use correct field name for Gemini embedding dimensions

### DIFF
--- a/plugins/discourse-ai/lib/inference/gemini_embeddings.rb
+++ b/plugins/discourse-ai/lib/inference/gemini_embeddings.rb
@@ -16,9 +16,7 @@ module DiscourseAi
         headers = { "Referer" => referer, "Content-Type" => "application/json" }
         url = "#{embedding_url}\?key\=#{api_key}"
         body = { content: { parts: [{ text: content }] } }
-        if !@dimensions.nil?
-          body.merge!(outputDimensionality: @dimensions)
-        end
+        body.merge!(outputDimensionality: @dimensions) unless @dimensions.nil?
 
         conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }
         response = conn.post(url, body.to_json, headers)

--- a/plugins/discourse-ai/lib/inference/gemini_embeddings.rb
+++ b/plugins/discourse-ai/lib/inference/gemini_embeddings.rb
@@ -17,7 +17,7 @@ module DiscourseAi
         url = "#{embedding_url}\?key\=#{api_key}"
         body = { content: { parts: [{ text: content }] } }
         if !@dimensions.nil?
-          body.merge!({ embedding_config: { output_dimensionality: @dimensions } })
+          body.merge!(outputDimensionality: @dimensions)
         end
 
         conn = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }

--- a/plugins/discourse-ai/spec/lib/inference/gemini_embeddings_spec.rb
+++ b/plugins/discourse-ai/spec/lib/inference/gemini_embeddings_spec.rb
@@ -54,14 +54,7 @@ RSpec.describe DiscourseAi::Inference::GeminiEmbeddings do
     context "when dimensions are provided" do
       let(:dimensions) { 512 }
       let(:payload) do
-        {
-          content: {
-            parts: [{ text: content }],
-          },
-          embedding_config: {
-            output_dimensionality: dimensions,
-          },
-        }.to_json
+        { content: { parts: [{ text: content }] }, outputDimensionality: dimensions }.to_json
       end
 
       before do
@@ -75,7 +68,7 @@ RSpec.describe DiscourseAi::Inference::GeminiEmbeddings do
         let(:response_status) { 200 }
         let(:response_body) { { embedding: { values: [0.1, 0.2, 0.3] } }.to_json }
 
-        it "includes embedding_config with output_dimensionality in the request" do
+        it "includes outputDimensionality in the request" do
           result = gemini_embeddings.perform!(content)
           expect(result).to eq([0.1, 0.2, 0.3])
         end
@@ -98,7 +91,7 @@ RSpec.describe DiscourseAi::Inference::GeminiEmbeddings do
         )
       end
 
-      it "does not include embedding_config in the request" do
+      it "does not include outputDimensionality in the request" do
         gemini_embeddings.perform!(content)
         expect(WebMock).to have_requested(:post, url).with(body: payload)
       end


### PR DESCRIPTION
## Summary

- Fix Gemini embeddings API request to use `outputDimensionality` as a top-level camelCase field instead of `embedding_config: { output_dimensionality: ... }` as a nested object
- The Google Gemini `embedContent` API expects `outputDimensionality` at the top level per [API docs](https://ai.google.dev/api/embeddings#v1beta.models.embedContent), not wrapped in `embedding_config`
- Update specs to match the corrected request format

## Root Cause

When Matryoshka dimensions were enabled for the `gemini-embedding-001` model, the plugin sent:
```json
{
  "content": { "parts": [{ "text": "..." }] },
  "embedding_config": { "output_dimensionality": 768 }
}
```

The Google API returned a 400 error: `Unknown name "embedding_config": Cannot find field.`

The correct format per the API spec is:
```json
{
  "content": { "parts": [{ "text": "..." }] },
  "outputDimensionality": 768
}
```

## Test plan

- [x] Updated `gemini_embeddings_spec.rb` to verify the corrected payload format
- [ ] Verify "Run test" button works with Matryoshka dimensions enabled for `gemini-embedding-001`
- [ ] Verify embeddings still work correctly without Matryoshka dimensions (no `outputDimensionality` sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)