### PR TITLE
FIX: allow category group moderators to view edit history

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1932,7 +1932,7 @@ en:
     staff_edit_locks_post: "Posts will be locked from editing if they are edited by staff members"
     post_edit_time_limit: "A tl0 or tl1 author can edit their post for (n) minutes after posting. Set to 0 for forever."
     tl2_post_edit_time_limit: "A tl2+ author can edit their post for (n) minutes after posting. Set to 0 for forever."
-    edit_history_visible_to_public: "Allow everyone to see previous versions of an edited post. When disabled, only staff members can view."
+    edit_history_visible_to_public: "Allow everyone to see previous versions of an edited post. When disabled, only staff members and category group moderators (for posts in their moderated categories) can view."
     delete_removed_posts_after: "Posts removed by the author will be automatically deleted after (n) hours. If set to 0, posts will be deleted immediately."
     notify_users_after_responses_deleted_on_flagged_post: "When a post is flagged and then removed, all users that responded to the post and had their responses removed will be notified."
     max_image_width: "Maximum thumbnail width of images in a post. Images with a larger width will be resized and lightboxed."

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -368,7 +368,7 @@ module PostGuardian
     return false if !authenticated?
     return false if !can_see_post?(post)
 
-    is_staff? || is_my_own?(post)
+    is_staff? || is_my_own?(post) || is_category_group_moderator?(post.topic.category)
   end
 
   def can_change_post_owner?

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -1381,6 +1381,15 @@ RSpec.describe PostGuardian do
       expect(Guardian.new(post.user).can_view_edit_history?(post)).to be_truthy
     end
 
+    it "returns true for a category group moderator viewing a hidden post" do
+      SiteSetting.edit_history_visible_to_public = true
+      SiteSetting.enable_category_group_moderation = true
+      Fabricate(:category_moderation_group, category: category, group:)
+      post.update!(hidden: true)
+
+      expect(Guardian.new(user).can_view_edit_history?(post)).to be_truthy
+    end
+
     it "returns false when user can not see post" do
       post.update!(hidden: true)
 
@@ -1389,6 +1398,36 @@ RSpec.describe PostGuardian do
       guardian.stubs(:can_see_post?).returns(false)
 
       expect(guardian.can_view_edit_history?(post)).to be_falsey
+    end
+
+    context "when edit_history_visible_to_public is false" do
+      before { SiteSetting.edit_history_visible_to_public = false }
+
+      it "returns false for a regular user" do
+        expect(Guardian.new(user).can_view_edit_history?(post)).to be_falsey
+      end
+
+      it "returns true for a category group moderator" do
+        SiteSetting.enable_category_group_moderation = true
+        Fabricate(:category_moderation_group, category: category, group:)
+
+        expect(Guardian.new(user).can_view_edit_history?(post)).to be_truthy
+      end
+
+      it "returns false for a category group moderator in a different category" do
+        SiteSetting.enable_category_group_moderation = true
+        other_category = Fabricate(:category)
+        Fabricate(:category_moderation_group, category: other_category, group:)
+
+        expect(Guardian.new(user).can_view_edit_history?(post)).to be_falsey
+      end
+
+      it "returns false for a category group moderator when feature is disabled" do
+        SiteSetting.enable_category_group_moderation = false
+        Fabricate(:category_moderation_group, category: category, group:)
+
+        expect(Guardian.new(user).can_view_edit_history?(post)).to be_falsey
+      end
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -139,6 +139,21 @@ RSpec.describe PostsController do
           expect(response).to be_forbidden
         end
 
+        it "rejects access for a category group moderator" do
+          SiteSetting.enable_category_group_moderation = true
+          group = Fabricate(:group)
+          category_moderator = Fabricate(:user, groups: [group])
+          Fabricate(
+            :category_moderation_group,
+            category: post_with_revisions.topic.category,
+            group:,
+          )
+
+          sign_in(category_moderator)
+          get "/posts/#{post_with_revisions.id}.json?version=1"
+          expect(response).to be_forbidden
+        end
+
         it "allows access for staff" do
           sign_in(admin)
           get "/posts/#{post_with_revisions.id}.json?version=1"
@@ -2967,6 +2982,38 @@ RSpec.describe PostsController do
         sign_in(Fabricate(:user, trust_level: 4))
         get "/posts/#{post_revision.post_id}/revisions/#{post_revision.number}.json"
         expect(response.status).to eq(403)
+      end
+
+      context "with a category group moderator" do
+        fab!(:group)
+        fab!(:category_moderator) { Fabricate(:user, groups: [group]) }
+
+        before do
+          SiteSetting.enable_category_group_moderation = true
+          sign_in(category_moderator)
+        end
+
+        it "ensures they can see the revisions in their moderated category" do
+          Fabricate(:category_moderation_group, category: post.topic.category, group:)
+
+          get "/posts/#{post.id}/revisions/#{post_revision.number}.json"
+          expect(response.status).to eq(200)
+        end
+
+        it "ensures they cannot see the revisions in other categories" do
+          Fabricate(:category_moderation_group, category: Fabricate(:category), group:)
+
+          get "/posts/#{post.id}/revisions/#{post_revision.number}.json"
+          expect(response).to be_forbidden
+        end
+
+        it "ensures they cannot see hidden revisions in their moderated category" do
+          Fabricate(:category_moderation_group, category: post.topic.category, group:)
+          post_revision.update!(hidden: true)
+
+          get "/posts/#{post.id}/revisions/#{post_revision.number}.json"
+          expect(response).to be_forbidden
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- When `edit_history_visible_to_public` is disabled, category group moderators using the review panel get an `invalid_access` error when viewing edit history for posts in their moderated categories
- Allows category group moderators to view edit history for posts in categories they moderate
- Updates the `edit_history_visible_to_public` setting description to reflect this change
- Adds guardian specs plus request specs verifying category group moderators can only view revisions in their moderated categories, and that hidden revisions remain staff-only (both on the revisions endpoints and the `?version=` post endpoint)

Based on #37025 by @small-lovely-cat.