### PR TITLE
FIX: Ensure consistent admin bypasses for tag restrictions in bulk actions

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -289,7 +289,7 @@ module DiscourseTagging
   end
 
   def self.validate_min_required_tags_for_category(guardian, model, category, tags = [])
-    if !guardian.is_staff? && category && category.minimum_required_tags > 0 &&
+    if !guardian.is_admin? && category && category.minimum_required_tags > 0 &&
          tags.length < category.minimum_required_tags
       model.errors.add(
         :base,
@@ -302,7 +302,7 @@ module DiscourseTagging
   end
 
   def self.validate_required_tags_from_group(guardian, model, category, tags = [])
-    return true if guardian.is_staff? || category.nil?
+    return true if guardian.is_admin? || category.nil?
 
     success = true
     category.category_required_tag_groups.each do |crtg|
@@ -332,10 +332,12 @@ module DiscourseTagging
     tags_restricted_to_categories = Hash.new { |h, k| h[k] = Set.new }
 
     query = Tag.where(name: tags)
+
     query
       .joins(tag_groups: :categories)
       .pluck(:name, "categories.id")
       .each { |(tag, cat_id)| tags_restricted_to_categories[tag] << cat_id }
+
     query
       .joins(:categories)
       .pluck(:name, "categories.id")
@@ -347,6 +349,8 @@ module DiscourseTagging
       end
 
     if unallowed_tags.present?
+      return true if guardian.is_admin?
+
       msg =
         I18n.t(
           "tags.forbidden.restricted_tags_cannot_be_used_in_category",
@@ -361,6 +365,8 @@ module DiscourseTagging
     if !category.allow_global_tags && category.has_restricted_tags?
       unrestricted_tags = tags - tags_restricted_to_categories.keys
       if unrestricted_tags.present?
+        return true if guardian.is_admin?
+
         msg =
           I18n.t(
             "tags.forbidden.category_does_not_allow_tags",
@@ -372,6 +378,7 @@ module DiscourseTagging
         return false
       end
     end
+
     true
   end
 
@@ -379,6 +386,7 @@ module DiscourseTagging
     tags_cant_be_used = filter_tags_violating_one_tag_from_group_per_topic(guardian, category, tags)
 
     return true if tags_cant_be_used.blank?
+    return true if guardian&.is_admin?
 
     tags_cant_be_used.each do |_, incompatible_tags|
       model.errors.add(

--- a/spec/integration/category_tag_spec.rb
+++ b/spec/integration/category_tag_spec.rb
@@ -110,10 +110,11 @@ RSpec.describe "category tag restrictions" do
       expect {
         create_post(category: category_with_tags, tags: [tag1.name, "newtag"])
       }.to raise_error(StandardError, msg)
+    end
 
-      expect {
-        create_post(category: category_with_tags, tags: [tag1.name, "newtag"], user: admin)
-      }.to raise_error(StandardError, msg)
+    it "lets admins post in a restricted category without raising on disallowed tags" do
+      post = create_post(category: category_with_tags, tags: [tag1.name, "newtag"], user: admin)
+      expect_same_tag_names(post.topic.tags, [tag1.name])
     end
 
     it "can create new tags in a non-restricted category" do

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -280,14 +280,13 @@ RSpec.describe TopicsBulkAction do
       fab!(:restricted_tag) { Fabricate(:tag, name: "restricted-tag") }
       fab!(:source_category) { Fabricate(:category, tags: [restricted_tag]) }
       fab!(:admin)
+      fab!(:moderator)
       fab!(:topic_with_tag) { Fabricate(:topic, category: source_category, tags: [restricted_tag]) }
       fab!(:first_post_for_tagged_topic) { Fabricate(:post, topic: topic_with_tag) }
 
       before { destination_category.update!(tags: [other_tag]) }
 
-      it "does not change category" do
-        original_category = topic_with_tag.category
-
+      it "allows admins to change category" do
         topic_ids =
           TopicsBulkAction.new(
             admin,
@@ -296,33 +295,35 @@ RSpec.describe TopicsBulkAction do
             category_id: destination_category.id,
           ).perform!
 
-        expect(topic_ids).to eq([])
-        expect(topic_with_tag.reload.category).to eq(original_category)
+        expect(topic_ids).to eq([topic_with_tag.id])
+        expect(topic_with_tag.reload.category).to eq(destination_category)
+        expect(topic_with_tag.tags).to contain_exactly(restricted_tag)
       end
 
-      it "logs a warning with error details" do
-        Rails.logger.expects(:warn).with(includes("restricted-tag"))
-
-        TopicsBulkAction.new(
-          admin,
-          [topic_with_tag.id],
-          type: "change_category",
-          category_id: destination_category.id,
-        ).perform!
-      end
-
-      it "exposes errors via attr_reader" do
-        operator =
+      it "does not change category for moderators" do
+        topic_ids =
           TopicsBulkAction.new(
-            admin,
+            moderator,
             [topic_with_tag.id],
             type: "change_category",
             category_id: destination_category.id,
-          )
-        operator.perform!
+          ).perform!
 
-        expect(operator.errors).to be_present
-        expect(operator.errors.values.sum).to eq(1)
+        expect(topic_ids).to eq([])
+        expect(topic_with_tag.reload.category).to eq(source_category)
+      end
+
+      it "does not change category for regular users" do
+        topic_ids =
+          TopicsBulkAction.new(
+            topic_with_tag.user,
+            [topic_with_tag.id],
+            type: "change_category",
+            category_id: destination_category.id,
+          ).perform!
+
+        expect(topic_ids).to eq([])
+        expect(topic_with_tag.reload.category).to eq(source_category)
       end
     end
 
@@ -368,6 +369,88 @@ RSpec.describe TopicsBulkAction do
 
         expect(topic_ids).to eq([topic_with_tag.id])
         expect(topic_with_tag.reload.category).to eq(destination_category)
+      end
+    end
+
+    context "when destination category disallows global tags" do
+      fab!(:global_tag) { Fabricate(:tag, name: "global-tag") }
+      fab!(:restricted_tag) { Fabricate(:tag, name: "restricted-tag") }
+      fab!(:tag_group) { Fabricate(:tag_group, tags: [restricted_tag]) }
+      fab!(:source_category, :category)
+      fab!(:destination_category) do
+        Fabricate(:category, tag_groups: [tag_group], allow_global_tags: false)
+      end
+      fab!(:admin)
+      fab!(:moderator)
+      fab!(:topic_with_global_tag) do
+        Fabricate(:topic, category: source_category, tags: [global_tag])
+      end
+      fab!(:first_post) { Fabricate(:post, topic: topic_with_global_tag) }
+
+      it "allows admin to move topic with global tags" do
+        topic_ids =
+          TopicsBulkAction.new(
+            admin,
+            [topic_with_global_tag.id],
+            type: "change_category",
+            category_id: destination_category.id,
+          ).perform!
+
+        expect(topic_ids).to eq([topic_with_global_tag.id])
+        expect(topic_with_global_tag.reload.category).to eq(destination_category)
+      end
+
+      it "prevents moderator from moving topic with global tags" do
+        topic_ids =
+          TopicsBulkAction.new(
+            moderator,
+            [topic_with_global_tag.id],
+            type: "change_category",
+            category_id: destination_category.id,
+          ).perform!
+
+        expect(topic_ids).to eq([])
+        expect(topic_with_global_tag.reload.category).to eq(source_category)
+      end
+    end
+
+    context "when tags violate one-per-topic tag group rule" do
+      fab!(:tag1) { Fabricate(:tag, name: "priority-high") }
+      fab!(:tag2) { Fabricate(:tag, name: "priority-low") }
+      fab!(:tag_group) { Fabricate(:tag_group, tags: [tag1, tag2], one_per_topic: true) }
+      fab!(:source_category, :category)
+      fab!(:destination_category) { Fabricate(:category, tag_groups: [tag_group]) }
+      fab!(:admin)
+      fab!(:moderator)
+      fab!(:topic_with_conflicting_tags) do
+        Fabricate(:topic, category: source_category, tags: [tag1, tag2])
+      end
+      fab!(:first_post) { Fabricate(:post, topic: topic_with_conflicting_tags) }
+
+      it "allows admin to move topic with conflicting tags" do
+        topic_ids =
+          TopicsBulkAction.new(
+            admin,
+            [topic_with_conflicting_tags.id],
+            type: "change_category",
+            category_id: destination_category.id,
+          ).perform!
+
+        expect(topic_ids).to eq([topic_with_conflicting_tags.id])
+        expect(topic_with_conflicting_tags.reload.category).to eq(destination_category)
+      end
+
+      it "prevents moderator from moving topic with conflicting tags" do
+        topic_ids =
+          TopicsBulkAction.new(
+            moderator,
+            [topic_with_conflicting_tags.id],
+            type: "change_category",
+            category_id: destination_category.id,
+          ).perform!
+
+        expect(topic_ids).to eq([])
+        expect(topic_with_conflicting_tags.reload.category).to eq(source_category)
       end
     end
   end
@@ -595,7 +678,7 @@ RSpec.describe TopicsBulkAction do
   end
 
   describe "change_tags" do
-    fab!(:first_post) { Fabricate(:post, topic:) }
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
     fab!(:tag1, :tag)
     fab!(:tag2, :tag)
 
@@ -692,7 +775,7 @@ RSpec.describe TopicsBulkAction do
   end
 
   describe "append_tags" do
-    fab!(:first_post) { Fabricate(:post, topic:) }
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
     fab!(:tag1, :tag)
     fab!(:tag2, :tag)
     fab!(:tag3, :tag)
@@ -786,7 +869,7 @@ RSpec.describe TopicsBulkAction do
   end
 
   describe "remove_tags" do
-    fab!(:first_post) { Fabricate(:post, topic:) }
+    fab!(:first_post) { Fabricate(:post, topic: topic) }
     fab!(:tag1, :tag)
     fab!(:tag2, :tag)
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4682,7 +4682,7 @@ RSpec.describe TopicsController do
       end
 
       it "includes errors in the response when operations partially fail" do
-        sign_in(Fabricate(:admin))
+        sign_in(Fabricate(:moderator))
 
         restricted_tag = Fabricate(:tag, name: "restricted-tag")
         source_category = Fabricate(:category, tags: [restricted_tag])

--- a/spec/system/topic_bulk_select_spec.rb
+++ b/spec/system/topic_bulk_select_spec.rb
@@ -541,7 +541,7 @@ describe "Topic bulk select" do
 
     it "shows errors in the modal when some topics cannot be moved due to tag restrictions" do
       original_category = topics.first.category
-      sign_in(admin)
+      sign_in(Fabricate(:moderator))
       visit("/latest")
 
       open_bulk_actions_modal([topics.first], "update-category")


### PR DESCRIPTION
Following up on #37570 and #37807, this commit addresses remaining inconsistencies in how tag restrictions are enforced during bulk operations.

1. **remove_tags bypassed all validation**: The `remove_tags` operation directly deleted `TopicTag` records without any validation, allowing any user to remove tags even when categories required minimum tags or specific tag groups. This was inconsistent with `change_tags` and `append_tags` which properly validated tag restrictions.

2. **Incomplete admin bypasses**: While #37570 added admin bypasses for restricted tags between categories, two validation methods still blocked admins:
   - `validate_one_tag_from_group_per_topic` - prevented moving topics with multiple tags from one-per-topic tag groups
   - Unrestricted/global tags validation - prevented moving topics with global tags to categories that disallow them

3. **Inconsistent permissions**: Some validations used `is_staff?` while the new admin bypasses used `is_admin?`, creating an inconsistent permission model where moderators had different capabilities across different validation paths.

**lib/topics_bulk_action.rb**
- Updated `remove_tags` to use `DiscourseTagging.tag_topic_by_names()` with an empty array instead of directly deleting records
- This ensures proper validation through the standard pipeline and respects category requirements while allowing admin bypasses
- Added error collection for failed removals (consistent with other tag operations)

**lib/discourse_tagging.rb**
- Changed `is_staff?` to `is_admin?` in `validate_min_required_tags_for_category` and `validate_required_tags_from_group` for consistency
- Added admin bypass to `validate_one_tag_from_group_per_topic` (uses safe navigation since guardian can be nil)
- Added admin bypass to unrestricted/global tags validation section

All bulk tag operations now have consistent behavior:
- Admins can bypass all tag restrictions when performing bulk operations
- Moderators and regular users are properly constrained by tag rules
- `remove_tags` validates category requirements like other operations
- Error handling is consistent across all tag operations

This resolves the issue reported in meta.discourse.org/t/395269 where admins couldn't force-move topics between categories due to tag restrictions.