### PR TITLE
FIX: add "in reply to #x" when the queued post is a reply to other

### DIFF
--- a/frontend/discourse/app/components/reviewable/queued-post.gjs
+++ b/frontend/discourse/app/components/reviewable/queued-post.gjs
@@ -1,11 +1,12 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
+import { concat, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import CookText from "discourse/components/cook-text";
 import RawEmailModal from "discourse/components/modal/raw-email";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import PostQuotedContent from "discourse/components/post/quoted-content";
 import ReviewableCreatedBy from "discourse/components/reviewable/created-by";
 import ReviewableTopicLink from "discourse/components/reviewable/topic-link";
 import ReviewableTags from "discourse/components/reviewable-tags";
@@ -18,8 +19,25 @@ import { i18n } from "discourse-i18n";
 export default class ReviewableQueuedPost extends Component {
   @service modal;
 
-  get replyToPostUrl() {
-    return `${this.args.reviewable.topic_url}/${this.args.reviewable.reply_to_post_number}`;
+  get quotedTopicId() {
+    return this.args.reviewable.topic_id ?? this.args.reviewable.topic?.id;
+  }
+
+  get quoteTitle() {
+    return `${i18n("review.in_reply_to")} #${this.args.reviewable.reply_to_post_number}`;
+  }
+
+  get quotedPostContext() {
+    const { reply_to_post_number, topic } = this.args.reviewable;
+    return {
+      firstPost: false,
+      post_number: reply_to_post_number,
+      username: null,
+      topic: {
+        id: this.quotedTopicId,
+        slug: topic?.slug,
+      },
+    };
   }
 
   @action
@@ -61,13 +79,13 @@ export default class ReviewableQueuedPost extends Component {
     <div class="review-item__post">
       <div class="review-item__post-content">
         {{#if @reviewable.reply_to_post_number}}
-          <div>
-            <a href={{this.replyToPostUrl}}>
-              {{icon "share"}}
-              {{i18n "review.in_reply_to"}}
-              #{{@reviewable.reply_to_post_number}}
-            </a>
-          </div>
+          <PostQuotedContent
+            @id={{concat "quoted-" @reviewable.reply_to_post_number}}
+            @post={{this.quotedPostContext}}
+            @quotedTopicId={{this.quotedTopicId}}
+            @quotedPostNumber={{@reviewable.reply_to_post_number}}
+            @title={{this.quoteTitle}}
+          />
         {{/if}}
         <CookText
           class="post-body"

--- a/frontend/discourse/app/components/reviewable/queued-post.gjs
+++ b/frontend/discourse/app/components/reviewable/queued-post.gjs
@@ -18,6 +18,10 @@ import { i18n } from "discourse-i18n";
 export default class ReviewableQueuedPost extends Component {
   @service modal;
 
+  get replyToPostUrl() {
+    return `${this.args.reviewable.topic_url}/${this.args.reviewable.reply_to_post_number}`;
+  }
+
   @action
   showRawEmail(event) {
     event?.preventDefault();
@@ -56,6 +60,15 @@ export default class ReviewableQueuedPost extends Component {
 
     <div class="review-item__post">
       <div class="review-item__post-content">
+        {{#if @reviewable.reply_to_post_number}}
+          <div>
+            <a href={{this.replyToPostUrl}}>
+              {{icon "share"}}
+              {{i18n "review.in_reply_to"}}
+              #{{@reviewable.reply_to_post_number}}
+            </a>
+          </div>
+        {{/if}}
         <CookText
           class="post-body"
           @rawText={{highlightWatchedWords @reviewable.payload.raw @reviewable}}

--- a/frontend/discourse/app/components/reviewable/queued-post.gjs
+++ b/frontend/discourse/app/components/reviewable/queued-post.gjs
@@ -20,11 +20,11 @@ export default class ReviewableQueuedPost extends Component {
   @service modal;
 
   get quotedTopicId() {
-    return this.args.reviewable.topic_id ?? this.args.reviewable.topic?.id;
+    return this.args.reviewable.topic_id;
   }
 
   get quoteTitle() {
-    return `${i18n("review.in_reply_to")} #${this.args.reviewable.reply_to_post_number}`;
+    return `#${this.args.reviewable.reply_to_post_number}`;
   }
 
   get quotedPostContext() {


### PR DESCRIPTION
The reviewable api has a key "reply_to_post_number", but it is not rendered on the page for queued posts, making reviewing sometimes difficult.

This commit adds a "in reply to #x" link to the header of a queued reply, so that admins can quickly locate the context of a queued post.

<img width="663" height="719" alt="image" src="https://github.com/user-attachments/assets/cb4ba93f-0ef2-45e5-a7f4-39f7eeb6a7c3" />
