### PR TITLE
DEV: Block MiniRacer use in mold processes

### DIFF
--- a/config/pitchfork.conf.rb
+++ b/config/pitchfork.conf.rb
@@ -52,6 +52,7 @@ end
 
 after_mold_fork do |server, mold|
   if mold.generation.zero?
+    MiniRacerForkSafety.block_initialization!
     Discourse.preload_rails!
 
     supervisor = ENV["UNICORN_SUPERVISOR_PID"].to_i
@@ -74,6 +75,7 @@ after_mold_fork do |server, mold|
 end
 
 after_worker_fork do |server, worker|
+  MiniRacerForkSafety.allow_initialization!
   DiscourseEvent.trigger(:web_fork_started)
   Discourse.after_fork
   SignalTrapLogger.instance.after_fork

--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -266,5 +266,6 @@ class Demon::Base
   end
 
   def after_fork
+    MiniRacerForkSafety.allow_initialization!
   end
 end

--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -105,6 +105,7 @@ class Demon::Sidekiq < ::Demon::Base
   end
 
   def after_fork
+    super
     Demon::Sidekiq.after_fork&.call
     SignalTrapLogger.instance.after_fork
 

--- a/lib/freedom_patches/mini_racer_fork_safety.rb
+++ b/lib/freedom_patches/mini_racer_fork_safety.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MiniRacerForkSafety
+  @@init_blocked = false
+
+  def initialize(*args, **kwargs)
+    if @@init_blocked
+      raise "#{self.class.name} cannot be initialized in a mold process. This would cause catastrophic issues when forking."
+    end
+  end
+
+  def self.block_initialization!
+    @@init_blocked = true
+  end
+
+  def self.allow_initialization!
+    @@init_blocked = false
+  end
+end
+
+MiniRacer::Context.prepend(MiniRacerForkSafety)
+
+MiniRacer::Snapshot.prepend(MiniRacerForkSafety)


### PR DESCRIPTION
MiniRacer is not fork-safe. We know this, and aim to avoid spinning up any mini-racer context in the mold processes. However, we have seen some cases where miniracer is being booted up in long-lived mold processes, and then causing problems when re-forking web/sidekiq workers.

This commit adds a safety net which will absolutely guarantee that MiniRacer cannot be booted in the mold.