### PR TITLE
FEATURE: Upcoming change to modify trust level 3 requirement defaults

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2799,7 +2799,7 @@ en:
     nested_replies_backfill_batch_size: "Number of topics to backfill nested reply stats for per scheduled run."
     nested_replies_cap_nesting_depth: "Cap reply nesting at the maximum visual depth. When enabled, replies to the deepest level are re-parented as siblings instead of children."
     fake_upcoming_change: "This is a fake upcoming change for testing purposes. No need to translate this string."
-    enable_new_defaults_for_trust_level_3_requirements: "We have updated the TL3 default requirements so they’re more reasonable for members of large, active communities. If you have previously overridden these settings, you must first reset them before the new default values will take effect."
+    enable_new_defaults_for_trust_level_3_requirements: "We have updated the TL3 default requirements so they’re more reasonable for members of large, active communities. If you have previously overridden these settings, this upcoming change will have no effect."
     floating_dismiss_topics_on_mobile: "Shows a floating 'Dismiss...' button on mobile for the topic list for easier access and to free up space in the top of the topic list"
     rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The 'faq url' setting works as before."
     enable_simplified_category_creation: "Enables a simplified category creation flow with fewer options and a cleaner interface."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2799,6 +2799,7 @@ en:
     nested_replies_backfill_batch_size: "Number of topics to backfill nested reply stats for per scheduled run."
     nested_replies_cap_nesting_depth: "Cap reply nesting at the maximum visual depth. When enabled, replies to the deepest level are re-parented as siblings instead of children."
     fake_upcoming_change: "This is a fake upcoming change for testing purposes. No need to translate this string."
+    enable_new_defaults_for_trust_level_3_requirements: "We have updated the TL3 default requirements so they’re more reasonable for members of large, active communities. If you have previously overridden these settings, you must first reset them before the new default values will take effect."
     floating_dismiss_topics_on_mobile: "Shows a floating 'Dismiss...' button on mobile for the topic list for easier access and to free up space in the top of the topic list"
     rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The 'faq url' setting works as before."
     enable_simplified_category_creation: "Enables a simplified category creation flow with fewer options and a cleaner interface."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2683,6 +2683,9 @@ trust:
   tl3_requires_topics_viewed_cap:
     default: 500
     area: "trust_levels"
+    upcoming_change_default_override:
+      upcoming_change: "enable_new_defaults_for_trust_level_3_requirements"
+      new_default: 250
   tl3_requires_posts_read:
     default: 25
     max: 100
@@ -2691,6 +2694,9 @@ trust:
     default: 20000
     max: 99000
     area: "trust_levels"
+    upcoming_change_default_override:
+      upcoming_change: "enable_new_defaults_for_trust_level_3_requirements"
+      new_default: 2000
   tl3_requires_topics_viewed_all_time:
     default: 200
     area: "trust_levels"
@@ -2704,6 +2710,9 @@ trust:
     default: 14
     max: 10000
     area: "trust_levels"
+    upcoming_change_default_override:
+      upcoming_change: "enable_new_defaults_for_trust_level_3_requirements"
+      new_default: 100
   tl3_requires_likes_given:
     default: 30
     area: "trust_levels"
@@ -4409,6 +4418,15 @@ experimental:
       status: "stable"
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/394971"
+  enable_new_defaults_for_trust_level_3_requirements:
+    default: false
+    hidden: true
+    client: true
+    upcoming_change:
+      status: "experimental"
+      impact: "site_setting_default,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/397098"
+      disallow_enabled_for_groups: true
   experimental_topic_category_change_notification:
     default: false
     hidden: true


### PR DESCRIPTION
Uses the upcoming change system to modify the defaults for the following
site settings:

- The default of `tl3_requires_topics_viewed_cap` is set to 250
- The default for `tl3_requires_posts_read_cap` is set to 2000
- The default for `tl3_promotion_min_duration` is set to 100 days

If admins have already modified these settings, this upcoming change
will not have any effect.

<img width="1112" height="211" alt="image" src="https://github.com/user-attachments/assets/57c7bb10-7dce-469f-88e7-bc15a7f5271c" />


<img width="1154" height="795" alt="image" src="https://github.com/user-attachments/assets/37bb21ea-f92c-4b97-a96d-67479b268b9e" />
