### PR TITLE
Remove "prioritize full name in ux" setting

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -384,7 +384,7 @@ class Notification < ActiveRecord::Base
   end
 
   def self.populate_acting_user(notifications)
-    if !(SiteSetting.show_user_menu_avatars || SiteSetting.prioritize_full_name_in_ux)
+    if !(SiteSetting.show_user_menu_avatars || !SiteSetting.prioritize_username_in_ux)
       return notifications
     end
     usernames =

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1033,11 +1033,6 @@ users:
     client: true
     default: true
     area: "users"
-  prioritize_full_name_in_ux:
-    client: true
-    default: false
-    hidden: true
-    area: "users"
   email_token_valid_hours:
     default: 48
     min: 1

--- a/frontend/discourse/app/components/modal/history/revision.gjs
+++ b/frontend/discourse/app/components/modal/history/revision.gjs
@@ -26,10 +26,10 @@ export default class Revision extends Component {
           class="revision-details__user"
         >
           {{boundAvatarTemplate @model.avatar_template "small"}}
-          {{#if this.siteSettings.prioritize_full_name_in_ux}}
-            {{@model.acting_user_name}}
-          {{else}}
+          {{#if this.siteSettings.prioritize_username_in_ux}}
             {{@model.username}}
+          {{else}}
+            {{@model.acting_user_name}}
           {{/if}}
         </LinkTo>
         <PluginOutlet

--- a/frontend/discourse/app/components/user-menu/messages-list.js
+++ b/frontend/discourse/app/components/user-menu/messages-list.js
@@ -79,7 +79,7 @@ export default class UserMenuMessagesList extends UserMenuNotificationsList {
 
     if (
       this.siteSettings.show_user_menu_avatars ||
-      this.siteSettings.prioritize_full_name_in_ux
+      !this.siteSettings.prioritize_username_in_ux
     ) {
       // Populate avatar_template for lastPoster
       const usersById = new Map(data.users.map((u) => [u.id, u]));

--- a/frontend/discourse/app/lib/notification-types/base.js
+++ b/frontend/discourse/app/lib/notification-types/base.js
@@ -73,7 +73,7 @@ export default class NotificationTypeBase {
    * @returns {string} The label is the first part of the text content displayed in the notification. For example, in a like notification, the username of the user who liked the post is the label. If a falsey value is returned, the label is omitted.
    */
   get label() {
-    if (!this.siteSettings.prioritize_full_name_in_ux) {
+    if (this.siteSettings.prioritize_username_in_ux) {
       return this.username;
     }
 

--- a/frontend/discourse/app/lib/notification-types/group-mentioned.js
+++ b/frontend/discourse/app/lib/notification-types/group-mentioned.js
@@ -7,10 +7,10 @@ export default class extends NotificationTypeBase {
   get label() {
     let name;
 
-    if (this.siteSettings.prioritize_full_name_in_ux) {
-      name = this.notification.acting_user_name || this.username;
-    } else {
+    if (this.siteSettings.prioritize_username_in_ux) {
       name = this.username;
+    } else {
+      name = this.notification.acting_user_name || this.username;
     }
 
     return `${name} @${this.notification.data.group_name}`;

--- a/frontend/discourse/app/lib/notification-types/liked.js
+++ b/frontend/discourse/app/lib/notification-types/liked.js
@@ -3,15 +3,15 @@ import { i18n } from "discourse-i18n";
 
 export default class extends NotificationTypeBase {
   get label() {
-    const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
-      ? this.notification.data.display_name ||
-        this.notification.data.display_username
-      : this.notification.data.display_username;
+    const nameOrUsername = this.siteSettings.prioritize_username_in_ux
+      ? this.notification.data.display_username
+      : this.notification.data.display_name ||
+        this.notification.data.display_username;
 
     if (this.count === 2) {
-      const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
-        ? this.notification.data.name2 || this.notification.data.username2
-        : this.notification.data.username2;
+      const nameOrUsername2 = this.siteSettings.prioritize_username_in_ux
+        ? this.notification.data.username2
+        : this.notification.data.name2 || this.notification.data.username2;
 
       return i18n("notifications.liked_by_2_users", {
         username: nameOrUsername,

--- a/frontend/discourse/app/lib/user-menu/bookmark-item.js
+++ b/frontend/discourse/app/lib/user-menu/bookmark-item.js
@@ -25,7 +25,7 @@ export default class UserMenuBookmarkItem extends UserMenuBaseItem {
   }
 
   get label() {
-    if (!this.siteSettings.prioritize_full_name_in_ux) {
+    if (this.siteSettings.prioritize_username_in_ux) {
       return this.bookmark.user?.username;
     }
 

--- a/frontend/discourse/app/lib/user-menu/message-item.js
+++ b/frontend/discourse/app/lib/user-menu/message-item.js
@@ -35,7 +35,7 @@ export default class UserMenuMessageItem extends UserMenuBaseItem {
   }
 
   get label() {
-    if (!this.siteSettings.prioritize_full_name_in_ux) {
+    if (this.siteSettings.prioritize_username_in_ux) {
       return this.message.last_poster_username;
     }
 

--- a/frontend/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
+++ b/frontend/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
@@ -45,7 +45,7 @@ module("Unit | Notification Types | group-mentioned", function (hooks) {
     this.owner.register(
       "service:site-settings",
       class extends Service {
-        prioritize_full_name_in_ux = false;
+        prioritize_username_in_ux = true;
       }
     );
 
@@ -69,7 +69,7 @@ module("Unit | Notification Types | group-mentioned", function (hooks) {
   });
 
   test("label uses the user's name when prioritize_username_in_ux is false", function (assert) {
-    this.siteSettings.prioritize_full_name_in_ux = true;
+    this.siteSettings.prioritize_username_in_ux = false;
 
     const notification = getNotification();
 

--- a/frontend/discourse/tests/unit/lib/notification-types/liked-test.js
+++ b/frontend/discourse/tests/unit/lib/notification-types/liked-test.js
@@ -83,7 +83,7 @@ module(
 
     test("label", function (assert) {
       const siteSettings = this.owner.lookup("service:site-settings");
-      siteSettings.prioritize_full_name_in_ux = true;
+      siteSettings.prioritize_username_in_ux = false;
 
       const notification = getNotification();
       const director = createRenderDirector(

--- a/plugins/discourse-assign/assets/javascripts/discourse/components/assigned-to-first-post.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/assigned-to-first-post.gjs
@@ -61,7 +61,7 @@ export default class AssignedToFirstPost extends Component {
   prioritizedAssigneeName(assignee) {
     // if this code is ever replaced to use `prioritize_username_in_ux`, remove this function and use the helper
     // userPrioritizedName instead
-    return this.siteSettings.prioritize_full_name_in_ux || !assignee.username
+    return !this.siteSettings.prioritize_username_in_ux || !assignee.username
       ? assignee.name || assignee.username
       : assignee.username;
   }

--- a/plugins/discourse-assign/assets/javascripts/discourse/components/assigned-to-post.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/assigned-to-post.gjs
@@ -12,10 +12,10 @@ export default class AssignedToPost extends Component {
   @service siteSettings;
 
   get nameOrUsername() {
-    if (this.siteSettings.prioritize_full_name_in_ux) {
-      return this.args.assignedToUser.name || this.args.assignedToUser.username;
-    } else {
+    if (this.siteSettings.prioritize_username_in_ux) {
       return this.args.assignedToUser.username;
+    } else {
+      return this.args.assignedToUser.name || this.args.assignedToUser.username;
     }
   }
 

--- a/plugins/discourse-assign/assets/javascripts/discourse/components/topic-level-assign-menu.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/topic-level-assign-menu.js
@@ -75,7 +75,7 @@ export default {
       content.push(
         unassignFromTopicButton(
           this.topic,
-          this.siteSettings.prioritize_full_name_in_ux
+          this.siteSettings.prioritize_username_in_ux
         )
       );
     }
@@ -136,11 +136,11 @@ function reassignToSelfButton() {
   };
 }
 
-function unassignFromTopicButton(topic, prioritize_full_name_in_ux) {
+function unassignFromTopicButton(topic, prioritize_username_in_ux) {
   let username =
     topic.assigned_to_user?.username || topic.assigned_to_group?.name;
 
-  if (topic.assigned_to_user && prioritize_full_name_in_ux) {
+  if (topic.assigned_to_user && !prioritize_username_in_ux) {
     username = topic.assigned_to_user?.name || topic.assigned_to_user?.username;
   }
 

--- a/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -406,7 +406,7 @@ function initialize(api) {
       }
 
       const icon = iconHTML(assignee.username ? "user-plus" : "group-plus");
-      const showNameInUx = siteSettings.prioritize_full_name_in_ux;
+      const showNameInUx = !siteSettings.prioritize_username_in_ux;
       const name =
         showNameInUx || !assignee.username
           ? assignee.name || assignee.username

--- a/plugins/discourse-assign/lib/assigner.rb
+++ b/plugins/discourse-assign/lib/assigner.rb
@@ -492,7 +492,7 @@ class ::Assigner
   end
 
   def small_action_username_or_name(assign_to)
-    if (assign_to.is_a?(User) && SiteSetting.prioritize_full_name_in_ux) ||
+    if (assign_to.is_a?(User) && !SiteSetting.prioritize_username_in_ux) ||
          !assign_to.try(:username)
       custom_fields = { "action_code_who" => assign_to.name || assign_to.username }
     else

--- a/plugins/discourse-assign/spec/system/assign_post_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_post_spec.rb
@@ -10,9 +10,10 @@ describe "Assign | Assigning posts" do
   fab!(:post2) { Fabricate(:post, topic: topic) }
 
   before do
+    # FIXME: Test again
     skip "Tests are broken and need to be fixed. See https://github.com/discourse/discourse/actions/runs/13890376408/job/38861216842"
     SiteSetting.assign_enabled = true
-    SiteSetting.prioritize_full_name_in_ux = false
+    SiteSetting.prioritize_username_in_ux = true
     # The system tests in this file are flaky and auth token related so turning this on
     SiteSetting.verbose_auth_token_logging = true
 
@@ -60,8 +61,8 @@ describe "Assign | Assigning posts" do
       expect(topic_page.find_post_assign(post2.post_number)).to have_content(staff_user.username)
     end
 
-    context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_full_name_in_ux = true }
+    context "when prioritize_username_in_ux setting is disabled" do
+      before { SiteSetting.prioritize_username_in_ux = false }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"

--- a/plugins/discourse-assign/spec/system/assign_topic_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_topic_spec.rb
@@ -10,7 +10,7 @@ describe "Assign | Assigning topics" do
 
   before do
     SiteSetting.assign_enabled = true
-    SiteSetting.prioritize_full_name_in_ux = false
+    SiteSetting.prioritize_username_in_ux = true
     SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
     SiteSetting.assign_allowed_on_groups = "#{Group::AUTO_GROUPS[:staff]}"
 
@@ -64,8 +64,8 @@ describe "Assign | Assigning topics" do
       expect(find("#topic .assigned-to")).to have_content(admin2.username)
     end
 
-    context "when prioritize_full_name_in_ux setting is enabled" do
-      before { SiteSetting.prioritize_full_name_in_ux = true }
+    context "when prioritize_username_in_ux setting is disabled" do
+      before { SiteSetting.prioritize_username_in_ux = false }
 
       it "shows the user's name after assign" do
         visit "/t/#{topic.id}"

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
@@ -71,17 +71,10 @@ export default class DiscourseReactionsListEmoji extends Component {
 
   @bind
   displayNameForUser(user) {
-    if (
-      !this.siteSettings.prioritize_username_in_ux &&
-      this.siteSettings.prioritize_full_name_in_ux
-    ) {
+    if (!this.siteSettings.prioritize_username_in_ux) {
       return user.name || user.username;
-    } else if (this.siteSettings.prioritize_username_in_ux) {
-      return user.username;
-    } else if (!user.name) {
-      return user.username;
     } else {
-      return user.name;
+      return user.username;
     }
   }
 

--- a/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/initializers/discourse-reactions.gjs
@@ -107,9 +107,9 @@ function initializeDiscourseReactions(api) {
 
         get label() {
           const count = this.notification.data.count;
-          const nameOrUsername = this.siteSettings.prioritize_full_name_in_ux
-            ? this.notification.data.display_name || this.username
-            : this.username;
+          const nameOrUsername = this.siteSettings.prioritize_username_in_ux
+            ? this.username
+            : this.notification.data.display_name || this.username;
 
           if (!count || count === 1 || !this.notification.data.username2) {
             return nameOrUsername;
@@ -120,10 +120,10 @@ function initializeDiscourseReactions(api) {
               count: count - 1,
             });
           } else {
-            const nameOrUsername2 = this.siteSettings.prioritize_full_name_in_ux
-              ? this.notification.data.name2 ||
-                formatUsername(this.notification.data.username2)
-              : formatUsername(this.notification.data.username2);
+            const nameOrUsername2 = this.siteSettings.prioritize_username_in_ux
+              ? formatUsername(this.notification.data.username2)
+              : this.notification.data.name2 ||
+                formatUsername(this.notification.data.username2);
             return i18n("notifications.reaction_2_users", {
               username: nameOrUsername,
               username2: nameOrUsername2,

--- a/plugins/discourse-reactions/spec/system/reaction_notifications_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reaction_notifications_spec.rb
@@ -76,7 +76,7 @@ describe "Reactions | Notifications" do
       )
     end
 
-    before { SiteSetting.prioritize_full_name_in_ux = true }
+    before { SiteSetting.prioritize_username_in_ux = false }
 
     it "renders reaction notifications with full names" do
       visit("/")

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-notifications-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-notifications-test.js
@@ -253,7 +253,7 @@ acceptance(
       discourse_reactions_enabled_reactions: "otter|open_mouth",
       discourse_reactions_reaction_for_like: "heart",
       discourse_reactions_like_icon: "heart",
-      prioritize_full_name_in_ux: true,
+      prioritize_username_in_ux: false,
     });
 
     needs.pretender((server, helper) => {

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -837,7 +837,7 @@ RSpec.describe Notification do
     end
 
     it "Sets the acting_user correctly for each notification" do
-      SiteSetting.prioritize_full_name_in_ux = true
+      SiteSetting.prioritize_username_in_ux = false
       Notification.populate_acting_user(
         [notification1, notification2, notification3, notification4, notification5],
       )

--- a/spec/system/user_page/user_notifications_spec.rb
+++ b/spec/system/user_page/user_notifications_spec.rb
@@ -85,7 +85,7 @@ describe "User notifications" do
 
     context "when prioritize_username_in_ux is false" do
       before do
-        SiteSetting.prioritize_full_name_in_ux = true
+        SiteSetting.prioritize_username_in_ux = false
         sign_in(user2)
       end
 

--- a/spec/system/viewing_user_menu_spec.rb
+++ b/spec/system/viewing_user_menu_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe "Viewing User Menu" do
       expect(user_menu).to have_group_mentioned_notification(topic, user, mentionable_group)
     end
 
-    context "with SiteSetting.prioritize_full_name_in_ux=true" do
-      before { SiteSetting.prioritize_full_name_in_ux = true }
+    context "with SiteSetting.prioritize_username_in_ux=false" do
+      before { SiteSetting.prioritize_username_in_ux = false }
 
       it "should display user full name in mention notifications" do
         Jobs.run_immediately!
@@ -117,13 +117,11 @@ RSpec.describe "Viewing User Menu" do
       end
     end
 
-    context "with SiteSetting.prioritize_full_name_in_ux=false" do
-      before { SiteSetting.prioritize_full_name_in_ux = false }
+    context "with SiteSetting.prioritize_username_in_ux=true" do
+      before { SiteSetting.prioritize_username_in_ux = true }
 
       it "should display only username in mention notifications" do
         Jobs.run_immediately!
-
-        SiteSetting.prioritize_username_in_ux = true
 
         user = Fabricate(:user)
         user2 = Fabricate(:user, name: "John Doe")


### PR DESCRIPTION
Hello!

This is directly related to [this post](https://meta.discourse.org/t/use-user-names-in-participants-list/390176/17) (and following ones).

I started working on fixing display of name/username depending on the state of the `prioritize_username_in_ux` when I found this internal setting used in a few places but only changed in specs : `prioritize_full_name_in_ux`.

This PR removes it from the codebase, using only `prioritize_username_in_ux` instead.

This PR is separated in 3 commits, for an easier review, and I'll squash them after it, if it makes sense.
