### PR TITLE
DEV: include subcategories in category search threshold

### DIFF
--- a/frontend/discourse/select-kit/components/category-drop.js
+++ b/frontend/discourse/select-kit/components/category-drop.js
@@ -89,12 +89,34 @@ export default class CategoryDrop extends ComboBoxComponent {
     return this.options.subCategory || false;
   }
 
-  @computed("content.length", "site.lazy_load_categories")
+  @computed(
+    "content.length",
+    "site.lazy_load_categories",
+    "site.categoriesList.[]"
+  )
   get autoFilterable() {
-    return (
-      this.site.lazy_load_categories ||
-      this.content.length >= FILTER_VISIBILITY_THRESHOLD
-    );
+    if (this.site.lazy_load_categories) {
+      return true;
+    }
+
+    if (this.content.length >= FILTER_VISIBILITY_THRESHOLD) {
+      return true;
+    }
+
+    // When there's no parent category context, searching also returns
+    // subcategories and sub-subcategories. Count all categories
+    // (including all descendants) to determine if the search field is useful.
+    if (!this.options?.parentCategory?.id) {
+      const allCategories = this._filterUncategorized(
+        this.site.categoriesList || []
+      );
+      return (
+        this.shortcuts.length + allCategories.length >=
+        FILTER_VISIBILITY_THRESHOLD
+      );
+    }
+
+    return false;
   }
 
   @computed("value", "selectKit.options.{subCategory,noSubcategories}")

--- a/frontend/discourse/select-kit/components/category-drop.js
+++ b/frontend/discourse/select-kit/components/category-drop.js
@@ -91,8 +91,12 @@ export default class CategoryDrop extends ComboBoxComponent {
 
   @computed(
     "content.length",
+    "options.parentCategory.id",
+    "shortcuts.length",
     "site.lazy_load_categories",
-    "site.categoriesList.[]"
+    "site.categoriesList.[]",
+    "site.uncategorized_category_id",
+    "siteSettings.allow_uncategorized_topics"
   )
   get autoFilterable() {
     if (this.site.lazy_load_categories) {

--- a/frontend/discourse/tests/integration/components/select-kit/category-drop-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-drop-test.gjs
@@ -382,16 +382,56 @@ module("Integration | Component | select-kit/category-drop", function (hooks) {
   });
 });
 
-// Helper that produces fewer top-level categories than the search threshold,
-// while the site's full categoriesList still contains subcategories and
-// sub-subcategories that push the searchable total above the threshold.
-function initFewTopLevelCategories(context) {
-  const topLevelCategories = context.site.categoriesList.filter(
-    (c) => !c.parent_category_id
+function createSearchVisibilityCategory(context, attrs) {
+  const store = context.owner.lookup("service:store");
+  const name = attrs.name || `Category ${attrs.id}`;
+
+  return store.createRecord("category", {
+    color: "0088CC",
+    text_color: "FFFFFF",
+    style_type: "square",
+    slug: name.toLowerCase().replaceAll(" ", "-"),
+    topic_count: 1,
+    post_count: 1,
+    description: name,
+    description_text: name,
+    topic_url: `/c/${attrs.id}`,
+    read_restricted: false,
+    permission: 1,
+    notification_level: null,
+    ...attrs,
+  });
+}
+
+function initCategoriesWithSubSubcategoryThreshold(context) {
+  const topLevelCategories = Array.from(
+    { length: FILTER_VISIBILITY_THRESHOLD - 2 },
+    (_, index) =>
+      createSearchVisibilityCategory(context, {
+        id: 2000 + index,
+        name: `Parent ${index}`,
+      })
   );
+  const subcategory = createSearchVisibilityCategory(context, {
+    id: 3000,
+    name: "Sub category",
+    parent_category_id: topLevelCategories[0].id,
+  });
+  const subSubcategory = createSearchVisibilityCategory(context, {
+    id: 3001,
+    name: "Sub sub category",
+    parent_category_id: subcategory.id,
+  });
+
+  context.site.set("categories", [
+    ...topLevelCategories,
+    subcategory,
+    subSubcategory,
+  ]);
   context.setProperties({
     category: null,
-    categories: topLevelCategories.slice(0, FILTER_VISIBILITY_THRESHOLD - 1),
+    categories: topLevelCategories,
+    parentCategory: null,
   });
 }
 
@@ -402,10 +442,10 @@ module(
 
     hooks.beforeEach(function () {
       this.set("subject", selectKit());
-      initFewTopLevelCategories(this);
+      initCategoriesWithSubSubcategoryThreshold(this);
     });
 
-    test("[TL0] shows search filter when all descendants bring total above threshold", async function (assert) {
+    test("[TL0] shows search filter when sub-subcategories bring total up to threshold", async function (assert) {
       set(this.currentUser, "trust_level", 0);
       set(this.currentUser, "staff", false);
       set(this.currentUser, "admin", false);
@@ -424,11 +464,11 @@ module(
       assert
         .dom(".filter-input")
         .exists(
-          "search is visible for TL0 user when all descendants bring total above threshold"
+          "search is visible for TL0 user when sub-subcategories bring total up to threshold"
         );
     });
 
-    test("[admin] shows search filter when all descendants bring total above threshold", async function (assert) {
+    test("[admin] shows search filter when sub-subcategories bring total up to threshold", async function (assert) {
       set(this.currentUser, "admin", true);
 
       await render(
@@ -445,7 +485,35 @@ module(
       assert
         .dom(".filter-input")
         .exists(
-          "search is visible for admin when all descendants bring total above threshold"
+          "search is visible for admin when sub-subcategories bring total up to threshold"
+        );
+    });
+
+    test("hides search filter when rerendered into a below-threshold parent scope", async function (assert) {
+      await render(
+        <template>
+          <CategoryDrop
+            @category={{this.category}}
+            @categories={{this.categories}}
+            @options={{hash parentCategory=this.parentCategory}}
+          />
+        </template>
+      );
+
+      await this.subject.expand();
+
+      assert
+        .dom(".filter-input")
+        .exists("search is visible before scoping to a parent category");
+
+      await this.subject.collapse();
+      this.set("parentCategory", this.categories[0]);
+      await this.subject.expand();
+
+      assert
+        .dom(".filter-input")
+        .doesNotExist(
+          "search is hidden when parent-scoped content remains below threshold"
         );
     });
   }
@@ -458,10 +526,10 @@ module(
 
     hooks.beforeEach(function () {
       this.set("subject", selectKit());
-      initFewTopLevelCategories(this);
+      initCategoriesWithSubSubcategoryThreshold(this);
     });
 
-    test("[anon] shows search filter when all descendants bring total above threshold", async function (assert) {
+    test("[anon] shows search filter when sub-subcategories bring total up to threshold", async function (assert) {
       await render(
         <template>
           <CategoryDrop
@@ -476,7 +544,7 @@ module(
       assert
         .dom(".filter-input")
         .exists(
-          "search is visible for anonymous user when all descendants bring total above threshold"
+          "search is visible for anonymous user when sub-subcategories bring total up to threshold"
         );
     });
   }


### PR DESCRIPTION
Context: https://meta.discourse.org/t/finding-subcategories-via-the-category-dropdown-in-the-topic-list/397016?u=isaac

we only allow searching the category dropdown when 10 or more results are available. This PR introduces sub + sub sub categories in the calculation of results.  

# Preview 

https://github.com/user-attachments/assets/48885bcf-a730-4196-a9c4-b8d5be033fdf
