### PR TITLE
UX: Change wording to reflect status

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
@@ -13,14 +13,14 @@ import AiDefaultLlmSelector from "./ai-default-llm-selector";
 import AiFeaturesList from "./ai-features-list";
 
 const ALL = "all";
-const CONFIGURED = "configured";
-const UNCONFIGURED = "unconfigured";
+const ENABLED = "enabled";
+const NOTENABLED = "not enabled";
 
 export default class AiFeatures extends Component {
   @service adminPluginNavManager;
 
   @tracked filterValue = "";
-  @tracked selectedFeatureGroup = CONFIGURED;
+  @tracked selectedFeatureGroup = ENABLED;
 
   constructor() {
     super(...arguments);
@@ -31,7 +31,7 @@ export default class AiFeatures extends Component {
         (f) => f.module_enabled === true
       ).length;
       if (configuredCount === 0) {
-        this.selectedFeatureGroup = UNCONFIGURED;
+        this.selectedFeatureGroup = NOTENABLED;
       }
     }
   }
@@ -40,12 +40,12 @@ export default class AiFeatures extends Component {
     return [
       { value: ALL, label: i18n("discourse_ai.features.filters.all") },
       {
-        value: CONFIGURED,
-        label: i18n("discourse_ai.features.nav.configured"),
+        value: ENABLED,
+        label: i18n("discourse_ai.features.nav.enabled"),
       },
       {
-        value: UNCONFIGURED,
-        label: i18n("discourse_ai.features.nav.unconfigured"),
+        value: NOTENABLED,
+        label: i18n("discourse_ai.features.nav.not_enabled"),
       },
     ];
   }
@@ -57,9 +57,9 @@ export default class AiFeatures extends Component {
 
     let features = this.args.features;
 
-    if (this.selectedFeatureGroup === CONFIGURED) {
+    if (this.selectedFeatureGroup === ENABLED) {
       features = features.filter((feature) => feature.module_enabled === true);
-    } else if (this.selectedFeatureGroup === UNCONFIGURED) {
+    } else if (this.selectedFeatureGroup === NOTENABLED) {
       features = features.filter((feature) => feature.module_enabled === false);
     }
 
@@ -164,7 +164,7 @@ export default class AiFeatures extends Component {
   @action
   resetAndFocus() {
     this.filterValue = "";
-    this.selectedFeatureGroup = CONFIGURED;
+    this.selectedFeatureGroup = ENABLED;
     document.querySelector(".admin-filter__input").focus();
   }
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
@@ -14,7 +14,7 @@ import AiFeaturesList from "./ai-features-list";
 
 const ALL = "all";
 const ENABLED = "enabled";
-const NOTENABLED = "not enabled";
+const NOT_ENABLED = "not enabled";
 
 export default class AiFeatures extends Component {
   @service adminPluginNavManager;

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
@@ -31,7 +31,7 @@ export default class AiFeatures extends Component {
         (f) => f.module_enabled === true
       ).length;
       if (configuredCount === 0) {
-        this.selectedFeatureGroup = NOTENABLED;
+        this.selectedFeatureGroup = NOT_ENABLED;
       }
     }
   }

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
@@ -59,7 +59,7 @@ export default class AiFeatures extends Component {
 
     if (this.selectedFeatureGroup === ENABLED) {
       features = features.filter((feature) => feature.module_enabled === true);
-    } else if (this.selectedFeatureGroup === NOTENABLED) {
+    } else if (this.selectedFeatureGroup === NOT_ENABLED) {
       features = features.filter((feature) => feature.module_enabled === false);
     }
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-features.gjs
@@ -44,7 +44,7 @@ export default class AiFeatures extends Component {
         label: i18n("discourse_ai.features.nav.enabled"),
       },
       {
-        value: NOTENABLED,
+        value: NOT_ENABLED,
         label: i18n("discourse_ai.features.nav.not_enabled"),
       },
     ];

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -265,8 +265,8 @@ en:
             ui_settings: "UI Settings"
             integrations: "Integrations"
         nav:
-          configured: "Configured"
-          unconfigured: "Unconfigured"
+          enabled: "Enabled"
+          not_enabled: "Not Enabled"
         filters:
           all: "All"
           text: "Search features, agents, LLMs, or groups..."

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -266,7 +266,7 @@ en:
             integrations: "Integrations"
         nav:
           enabled: "Enabled"
-          not_enabled: "Not Enabled"
+          not_enabled: "Not enabled"
         filters:
           all: "All"
           text: "Search features, agents, LLMs, or groups..."

--- a/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
@@ -32,16 +32,15 @@ RSpec.describe "Admin AI features configuration" do
     sign_in(admin)
   end
 
-  it "lists all agent backed AI features separated by configured/unconfigured" do
+  it "lists all persona backed AI features separated by enabled/not enabled" do
     all_modules = DiscourseAi::Configuration::Module.all
     configured_count = all_modules.count(&:enabled?)
-
     ai_features_page.visit
-    ai_features_page.toggle_configured
+    ai_features_page.toggle_enabled
 
     expect(ai_features_page).to have_listed_modules(configured_count)
 
-    ai_features_page.toggle_unconfigured
+    ai_features_page.toggle_not_enabled
 
     expect(ai_features_page).to have_listed_modules(all_modules.size - configured_count)
   end
@@ -49,7 +48,7 @@ RSpec.describe "Admin AI features configuration" do
   it "lists the agent used for the corresponding AI feature" do
     ai_features_page.visit
 
-    ai_features_page.toggle_configured
+    ai_features_page.toggle_enabled
 
     expect(ai_features_page).to have_feature_agent("topic_summaries", summarization_agent.name)
   end
@@ -57,7 +56,7 @@ RSpec.describe "Admin AI features configuration" do
   it "lists the groups allowed to use the AI feature" do
     ai_features_page.visit
 
-    ai_features_page.toggle_configured
+    ai_features_page.toggle_enabled
 
     expect(ai_features_page).to have_feature_groups("topic_summaries", [group_1.name, group_2.name])
   end

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_features.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_features.rb
@@ -10,14 +10,14 @@ module PageObjects
         self
       end
 
-      def toggle_configured
+      def toggle_enabled
         select = page.find("#{FEATURES_PAGE} .ai-features__controls .d-select")
-        select.find("option[value='configured']").select_option
+        select.find("option[value='enabled']").select_option
       end
 
-      def toggle_unconfigured
+      def toggle_disabled
         select = page.find("#{FEATURES_PAGE} .ai-features__controls .d-select")
-        select.find("option[value='unconfigured']").select_option
+        select.find("option[value='not enabled']").select_option
       end
 
       def has_listed_modules?(count)

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_features.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_features.rb
@@ -15,7 +15,7 @@ module PageObjects
         select.find("option[value='enabled']").select_option
       end
 
-      def toggle_disabled
+      def toggle_not_enabled
         select = page.find("#{FEATURES_PAGE} .ai-features__controls .d-select")
         select.find("option[value='not enabled']").select_option
       end


### PR DESCRIPTION
This PR changes the names of the AI features page filter dropdown from `configured` and `unconfigured` to `enabled` and `not enabled`.

This more accurately describes the state of the features, as they are already technically configured. They are just not enabled.

<img width="2268" height="1740" alt="CleanShot 2026-02-27 at 17 34 05@2x" src="https://github.com/user-attachments/assets/74070542-1ee9-452d-b299-4a05a8554e97" />
