### PR TITLE
FEATURE: Generate AI topic summaries in the user's locale

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/summarization/summary_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/summarization/summary_controller.rb
@@ -22,6 +22,9 @@ module DiscourseAi
         opts = params.permit(:skip_age_check)
         skip_age_check = opts[:skip_age_check] == "true"
 
+        locale = current_user&.effective_locale || SiteSetting.default_locale
+        summarization_service = DiscourseAi::TopicSummarization.for(topic, current_user, locale:)
+        cached_summary = summarization_service.cached_summary
         if params[:stream] && current_user
           if cached_summary && !skip_age_check
             render_serialized(cached_summary, AiTopicSummarySerializer)
@@ -33,6 +36,7 @@ module DiscourseAi
             topic_id: topic.id,
             user_id: current_user.id,
             skip_age_check: skip_age_check,
+            locale:,
           )
 
           render json: success_json

--- a/plugins/discourse-ai/app/jobs/regular/stream_topic_ai_summary.rb
+++ b/plugins/discourse-ai/app/jobs/regular/stream_topic_ai_summary.rb
@@ -8,7 +8,8 @@ module Jobs
       return unless topic = Topic.find_by(id: args[:topic_id])
       return unless user = User.find_by(id: args[:user_id])
 
-      strategy = DiscourseAi::Summarization.topic_summary(topic)
+      locale = args[:locale].presence || SiteSetting.default_locale
+      strategy = DiscourseAi::Summarization.topic_summary(topic, locale:)
       return if strategy.nil?
 
       summarization_service = DiscourseAi::TopicSummarization.new(strategy, user)

--- a/plugins/discourse-ai/app/models/ai_summary.rb
+++ b/plugins/discourse-ai/app/models/ai_summary.rb
@@ -6,7 +6,7 @@ class AiSummary < ActiveRecord::Base
   enum :summary_type, { complete: 0, gist: 1 }
   enum :origin, { human: 0, system: 1 }
 
-  def self.store!(strategy, llm_model, summary, og_content, human:)
+  def self.store!(strategy, llm_model, summary, og_content, human:, locale: "")
     content_ids = og_content.map { |c| c[:id] }
 
     AiSummary
@@ -20,8 +20,9 @@ class AiSummary < ActiveRecord::Base
           original_content_sha: build_sha(content_ids.join),
           summary_type: strategy.type,
           origin: !!human ? origins[:human] : origins[:system],
+          locale: locale.to_s,
         },
-        unique_by: %i[target_id target_type summary_type],
+        unique_by: %i[target_id target_type summary_type locale],
         update_only: %i[
           summarized_text
           original_content_sha
@@ -62,9 +63,10 @@ end
 #  summary_type          :integer          default("complete"), not null
 #  origin                :integer
 #  highest_target_number :integer          default(1), not null
+#  locale                :string           default(""), not null
 #
 # Indexes
 #
-#  idx_on_target_id_target_type_summary_type_3355609fbb  (target_id,target_type,summary_type) UNIQUE
-#  index_ai_summaries_on_target_type_and_target_id       (target_type,target_id)
+#  idx_ai_summaries_on_target_type_id_summary_type_locale  (target_id,target_type,summary_type,locale) UNIQUE
+#  index_ai_summaries_on_target_type_and_target_id         (target_type,target_id)
 #

--- a/plugins/discourse-ai/app/services/discourse_ai/topic_summarization.rb
+++ b/plugins/discourse-ai/app/services/discourse_ai/topic_summarization.rb
@@ -3,8 +3,8 @@
 module DiscourseAi
   # A cache layer on top of our topic summarization engine. Also handle permissions.
   class TopicSummarization
-    def self.for(topic, user)
-      new(DiscourseAi::Summarization.topic_summary(topic), user)
+    def self.for(topic, user, locale: nil)
+      new(DiscourseAi::Summarization.topic_summary(topic, locale:), user)
     end
 
     def initialize(summarizer, user)

--- a/plugins/discourse-ai/db/migrate/20260303000000_add_locale_to_ai_summaries.rb
+++ b/plugins/discourse-ai/db/migrate/20260303000000_add_locale_to_ai_summaries.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddLocaleToAiSummaries < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ai_summaries, :locale, :string, null: false, default: ""
+
+    remove_index :ai_summaries, name: "idx_on_target_id_target_type_summary_type_3355609fbb"
+    add_index :ai_summaries,
+              %i[target_id target_type summary_type locale],
+              unique: true,
+              name: "idx_ai_summaries_on_target_type_id_summary_type_locale"
+  end
+end

--- a/plugins/discourse-ai/lib/agents/summarizer.rb
+++ b/plugins/discourse-ai/lib/agents/summarizer.rb
@@ -14,7 +14,7 @@ module DiscourseAi
 
           - Only include the summary, without any additional commentary.
           - You understand and generate Discourse forum Markdown; including links, _italics_, **bold**.
-          - Maintain the original language of the text being summarized.
+          - Generate the summary in {user_language}.
           - Aim for summaries to be 400 words or less.
           - Each post is formatted as "<POST_NUMBER>) <USERNAME> <MESSAGE>"
           - Cite specific noteworthy posts using the format [DESCRIPTION]({resource_url}/POST_NUMBER)
@@ -39,7 +39,7 @@ module DiscourseAi
       def examples
         [
           [
-            "Here are the posts inside <input></input> XML tags:\n\n<input>1) user1 said: I love Mondays 2) user2 said: I hate Mondays</input>\n\nGenerate a concise, coherent summary of the text above maintaining the original language.",
+            "Here are the posts inside <input></input> XML tags:\n\n<input>1) user1 said: I love Mondays 2) user2 said: I hate Mondays</input>\n\nGenerate a concise, coherent summary of the text above.",
             {
               summary:
                 "Two users are sharing their feelings toward Mondays. [user1]({resource_url}/1) hates them, while [user2]({resource_url}/2) loves them.",

--- a/plugins/discourse-ai/lib/summarization.rb
+++ b/plugins/discourse-ai/lib/summarization.rb
@@ -3,7 +3,7 @@
 module DiscourseAi
   module Summarization
     class << self
-      def topic_summary(topic, llm_model: nil)
+      def topic_summary(topic, locale: nil, llm_model: nil)
         return nil if !SiteSetting.ai_summarization_enabled
         if (ai_agent = AiAgent.find_by_id_from_cache(SiteSetting.ai_summarization_agent)).blank?
           return nil
@@ -16,6 +16,7 @@ module DiscourseAi
         DiscourseAi::Summarization::FoldContent.new(
           build_bot(agent_klass, llm_model),
           DiscourseAi::Summarization::Strategies::TopicSummary.new(topic),
+          locale:,
         )
       end
 

--- a/plugins/discourse-ai/lib/summarization/fold_content.rb
+++ b/plugins/discourse-ai/lib/summarization/fold_content.rb
@@ -9,10 +9,11 @@ module DiscourseAi
     # into a final version.
     #
     class FoldContent
-      def initialize(bot, strategy, persist_summaries: true)
+      def initialize(bot, strategy, persist_summaries: true, locale: nil)
         @bot = bot
         @strategy = strategy
         @persist_summaries = persist_summaries
+        @locale = locale.to_s
       end
 
       attr_reader :bot, :strategy
@@ -30,7 +31,14 @@ module DiscourseAi
         summary = fold(truncated_content, user, &on_partial_blk)
 
         if persist_summaries
-          AiSummary.store!(strategy, llm_model, summary, truncated_content, human: user&.human?)
+          AiSummary.store!(
+            strategy,
+            llm_model,
+            summary,
+            truncated_content,
+            human: user&.human?,
+            locale: @locale,
+          )
         else
           AiSummary.new(summarized_text: summary)
         end
@@ -38,10 +46,14 @@ module DiscourseAi
 
       # @returns { AiSummary } - Resulting summary.
       #
-      # Finds a summary matching the target and strategy. Marks it as outdated if the strategy found newer content
+      # Finds a summary matching the target and strategy. Marks it as outdated if the strategy found newer content.
+      # Looks up by exact locale first, then falls back to legacy entries with no locale.
       def existing_summary
         if !defined?(@existing_summary)
-          summary = AiSummary.find_by(target: strategy.target, summary_type: strategy.type)
+          summary =
+            AiSummary.find_by(target: strategy.target, summary_type: strategy.type, locale: @locale)
+          summary ||=
+            AiSummary.find_by(target: strategy.target, summary_type: strategy.type, locale: "")
 
           if summary
             @existing_summary = summary
@@ -150,6 +162,14 @@ module DiscourseAi
           end
         end
 
+        locale_name =
+          if @locale.present?
+            locale_hash =
+              LocaleSiteSetting.language_names[@locale] ||
+                LocaleSiteSetting.language_names[@locale.split("_").first]
+            locale_hash&.dig("name")
+          end
+
         context =
           DiscourseAi::Agents::BotContext.new(
             user: user,
@@ -158,6 +178,7 @@ module DiscourseAi
             resource_url: "#{Discourse.base_path}/t/-/#{strategy.target.id}",
             messages: strategy.as_llm_messages(content_in_window),
           )
+        context.user_language = locale_name if locale_name
 
         summary = +""
 

--- a/plugins/discourse-ai/lib/summarization/strategies/topic_summary.rb
+++ b/plugins/discourse-ai/lib/summarization/strategies/topic_summary.rb
@@ -67,7 +67,7 @@ module DiscourseAi
               #{input}
             </input>
 
-            Generate a concise, coherent summary of the text above maintaining the original language.
+            Generate a concise, coherent summary of the text above.
           TEXT
         end
 

--- a/plugins/discourse-ai/spec/fabricators/ai_summary_fabricator.rb
+++ b/plugins/discourse-ai/spec/fabricators/ai_summary_fabricator.rb
@@ -8,6 +8,7 @@ Fabricator(:ai_summary) do
   summary_type AiSummary.summary_types[:complete]
   origin AiSummary.origins[:human]
   highest_target_number 1
+  locale ""
 end
 
 Fabricator(:topic_ai_gist, from: :ai_summary) do

--- a/plugins/discourse-ai/spec/services/discourse_ai/topic_summarization_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/topic_summarization_spec.rb
@@ -25,20 +25,22 @@ describe DiscourseAi::TopicSummarization do
   end
 
   let(:strategy) { DiscourseAi::Summarization.topic_summary(topic) }
-
   let(:summary) { "This is the final summary" }
 
   describe "#summarize" do
     subject(:summarization) { described_class.new(strategy, user) }
 
-    def assert_summary_is_cached(topic, summary_response)
+    let(:strategy) { DiscourseAi::Summarization.topic_summary(topic) }
+
+    def assert_summary_is_cached(topic, summary_response, locale: "")
       cached_summary =
-        AiSummary.find_by(target: topic, summary_type: AiSummary.summary_types[:complete])
+        AiSummary.find_by(target: topic, summary_type: AiSummary.summary_types[:complete], locale:)
 
       expect(cached_summary.highest_target_number).to eq(topic.highest_post_number)
       expect(cached_summary.summarized_text).to eq(summary)
       expect(cached_summary.original_content_sha).to be_present
       expect(cached_summary.algorithm).to eq("fake")
+      expect(cached_summary.locale).to eq(locale)
     end
 
     context "when the content was summarized in a single chunk" do
@@ -61,6 +63,86 @@ describe DiscourseAi::TopicSummarization do
         summarization = described_class.new(strategy, user)
         section = summarization.summarize
         expect(section.summarized_text).to eq(cached_summary_text)
+      end
+    end
+
+    describe "locale-specific caching" do
+      let(:zh_strategy) { DiscourseAi::Summarization.topic_summary(topic, locale: "zh_CN") }
+      let(:en_strategy) { DiscourseAi::Summarization.topic_summary(topic, locale: "en") }
+
+      it "caches summary with the given locale" do
+        DiscourseAi::Completions::Llm.with_prepared_responses([summary]) do
+          described_class.new(zh_strategy, user).summarize
+        end
+
+        assert_summary_is_cached(topic, summary, locale: "zh_CN")
+        expect(
+          AiSummary.find_by(
+            target: topic,
+            summary_type: AiSummary.summary_types[:complete],
+            locale: "en",
+          ),
+        ).to be_nil
+      end
+
+      it "generates separate cached summaries per locale" do
+        zh_summary = "Chinese summary"
+        en_summary = "English summary"
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([zh_summary]) do
+          described_class.new(zh_strategy, user).summarize
+        end
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([en_summary]) do
+          described_class.new(en_strategy, user).summarize
+        end
+
+        zh_cached =
+          AiSummary.find_by(
+            target: topic,
+            summary_type: AiSummary.summary_types[:complete],
+            locale: "zh_CN",
+          )
+        en_cached =
+          AiSummary.find_by(
+            target: topic,
+            summary_type: AiSummary.summary_types[:complete],
+            locale: "en",
+          )
+
+        expect(zh_cached.summarized_text).to eq(zh_summary)
+        expect(en_cached.summarized_text).to eq(en_summary)
+      end
+
+      it "falls back to locale='' summary when no locale-specific summary exists" do
+        legacy_text = "Legacy summary"
+        Fabricate(:ai_summary, target: topic, summarized_text: legacy_text, locale: "")
+
+        section = described_class.new(zh_strategy, user).cached_summary
+        expect(section.summarized_text).to eq(legacy_text)
+      end
+
+      it "prefers locale-specific summary over legacy summary" do
+        Fabricate(:ai_summary, target: topic, summarized_text: "Legacy summary", locale: "")
+        Fabricate(:ai_summary, target: topic, summarized_text: "Chinese summary", locale: "zh_CN")
+
+        section = described_class.new(zh_strategy, user).cached_summary
+        expect(section.summarized_text).to eq("Chinese summary")
+      end
+
+      it "sets user_language on BotContext when locale resolves to a known language name" do
+        captured_context = nil
+
+        allow_any_instance_of(DiscourseAi::Personas::Bot).to receive(:reply) do |_, context, &_blk|
+          captured_context = context
+          ""
+        end
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([summary]) do
+          described_class.new(zh_strategy, user).summarize
+        end
+
+        expect(captured_context&.user_language).to be_present
       end
     end
 


### PR DESCRIPTION
This PR involves a prompt update, a migration, and some updates down the stack to supply the user's locale to the prompt.

The Summarizer persona previously said "Maintain the original language of the text being summarized." That instruction is replaced with "Generate the summary in {user_language}." The {user_language} template param is already supported by BotContext — we just resolve the locale code to a human-readable language name (e.g. "zh_CN" → "Chinese Simplified") via LocaleSiteSetting.language_names and set it on the context before calling the LLM.

Per-locale caching introduced as well, and summaries are cached in ai_summaries. Without per-locale caching it's first-requester-wins — whoever hits the topic first sets the language for everyone. This adds a locale string column and includes it in the unique index so each locale gets its own cached entry.

Existing rows get locale: "" — this is intentional. "" is a sentinel meaning "generated without locale tracking", not "English" or "site default". The fallback to "" means no existing summaries need to be regenerated: every user, regardless of locale, will continue to be served the old summary until it becomes outdated.

Related: https://meta.discourse.org/t/how-do-i-translate-ai-summaries/397395