### PR TITLE
FIX: Call Discourse.before_fork before forking in multisite:migrate

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -130,6 +130,8 @@ task "multisite:migrate" => %w[
 
     puts "Running migrations and seeds for #{databases.join(", ")} database(s)"
 
+    Discourse.before_fork
+
     results =
       Parallel.map(
         databases,


### PR DESCRIPTION
Follow-up to 790dc4a5ed16a7ef146bfe2cd1d218239d007c58

Ensure that we dispose of mini_racer context before forking. Getting
reports of seg faults pointing to mini_racer.

Context: https://meta.discourse.org/t/running-multisite-migrate-concurrently-fails/397755