### PR TITLE
DEV: Replace BPV header piggybacking with fetch('/pageview') beacon

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -16,6 +16,9 @@
 <%= canonical_link_tag %>
 <%= render_sitelinks_search_tag %>
 <%= discourse_track_view_session_tag %>
+<% if SiteSetting.beacon_browser_page_view %>
+<meta name="discourse-enable-beacon-pageview" content="true">
+<% end %>
 <% if SiteSetting.google_site_verification_token.present? %>
   <meta name="google-site-verification" content="<%= SiteSetting.google_site_verification_token %>">
 <% end %>

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -91,7 +91,6 @@ MessageBus.extra_response_headers_lookup do |env|
   headers = env["__mb"][:extra_headers]
   if view_tracking_data = env["discourse.view_tracking_data"]
     headers["X-Discourse-TrackView"] = "1" if view_tracking_data[:track_view]
-    headers["X-Discourse-BrowserPageView"] = "1" if view_tracking_data[:browser_page_view]
   end
   headers
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1897,7 +1897,7 @@ Discourse::Application.routes.draw do
     resources :sidebar_sections, only: %i[index create update destroy]
     put "/sidebar_sections/reset/:id" => "sidebar_sections#reset"
 
-    post "/pageview" => "pageview#index"
+    post "/srv/pv" => "pageview#index"
 
     get "/form-templates/:id" => "form_templates#show"
     get "/form-templates" => "form_templates#index"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -592,6 +592,10 @@ basic:
   trigger_browser_pageview_events:
     default: false
     hidden: true
+  beacon_browser_page_view:
+    default: false
+    hidden: true
+    client: true
   interface_color_selector:
     client: true
     enum: "InterfaceColorSelectorSetting"

--- a/frontend/discourse/app/instance-initializers/message-bus.js
+++ b/frontend/discourse/app/instance-initializers/message-bus.js
@@ -8,6 +8,16 @@ import userPresent, { onPresenceChange } from "discourse/lib/user-presence";
 
 const LONG_POLL_AFTER_UNSEEN_TIME = 1200000; // 20 minutes
 
+let _sendDeferredPageview = false;
+let _deferredURL = null;
+let _deferredSessionId = null;
+let _deferredReferrer = null;
+let _deferredViewTopicId = null;
+
+export function sendDeferredPageview() {
+  _sendDeferredPageview = true;
+}
+
 function mbAjax(messageBus, opts) {
   opts.headers ||= {};
 
@@ -21,6 +31,28 @@ function mbAjax(messageBus, opts) {
 
   if (userPresent()) {
     opts.headers["Discourse-Present"] = "true";
+  }
+
+  if (_sendDeferredPageview) {
+    opts.headers["Discourse-Track-View-Deferred"] = "true";
+    if (_deferredSessionId) {
+      opts.headers["Discourse-Track-View-Session-Id"] = _deferredSessionId;
+    }
+    if (_deferredURL) {
+      opts.headers["Discourse-Track-View-Url"] = _deferredURL;
+    }
+    if (_deferredReferrer) {
+      opts.headers["Discourse-Track-View-Referrer"] = _deferredReferrer;
+    }
+    if (_deferredViewTopicId) {
+      opts.headers["Discourse-Track-View-Topic-Id"] = _deferredViewTopicId;
+    }
+
+    _sendDeferredPageview = false;
+    _deferredURL = null;
+    _deferredSessionId = null;
+    _deferredReferrer = null;
+    _deferredViewTopicId = null;
   }
 
   const oldComplete = opts.complete;
@@ -43,7 +75,8 @@ export default {
 
     const messageBus = owner.lookup("service:message-bus"),
       user = owner.lookup("service:current-user"),
-      siteSettings = owner.lookup("service:site-settings");
+      siteSettings = owner.lookup("service:site-settings"),
+      router = owner.lookup("service:router");
 
     messageBus.alwaysLongPoll = !isProduction();
     messageBus.shouldLongPollCallback = () =>
@@ -101,6 +134,24 @@ export default {
 
     if (user) {
       messageBus.callbackInterval = siteSettings.polling_interval;
+    }
+
+    if (!siteSettings.beacon_browser_page_view) {
+      if (
+        router.currentRouteName === "topic.fromParams" ||
+        router.currentRouteName === "topic.fromParamsNear"
+      ) {
+        _deferredViewTopicId = router.currentRoute.parent.params.id;
+      }
+
+      _deferredSessionId = document.querySelector(
+        "meta[name=discourse-track-view-session-id]"
+      )?.content;
+
+      if (_deferredSessionId) {
+        _deferredURL = window.location.href;
+        _deferredReferrer = document.referrer;
+      }
     }
   },
 };

--- a/frontend/discourse/app/instance-initializers/message-bus.js
+++ b/frontend/discourse/app/instance-initializers/message-bus.js
@@ -8,16 +8,6 @@ import userPresent, { onPresenceChange } from "discourse/lib/user-presence";
 
 const LONG_POLL_AFTER_UNSEEN_TIME = 1200000; // 20 minutes
 
-let _sendDeferredPageview = false;
-let _deferredURL = null;
-let _deferredSessionId = null;
-let _deferredReferrer = null;
-let _deferredViewTopicId = null;
-
-export function sendDeferredPageview() {
-  _sendDeferredPageview = true;
-}
-
 function mbAjax(messageBus, opts) {
   opts.headers ||= {};
 
@@ -31,28 +21,6 @@ function mbAjax(messageBus, opts) {
 
   if (userPresent()) {
     opts.headers["Discourse-Present"] = "true";
-  }
-
-  if (_sendDeferredPageview) {
-    opts.headers["Discourse-Track-View-Deferred"] = "true";
-    if (_deferredSessionId) {
-      opts.headers["Discourse-Track-View-Session-Id"] = _deferredSessionId;
-    }
-    if (_deferredURL) {
-      opts.headers["Discourse-Track-View-Url"] = _deferredURL;
-    }
-    if (_deferredReferrer) {
-      opts.headers["Discourse-Track-View-Referrer"] = _deferredReferrer;
-    }
-    if (_deferredViewTopicId) {
-      opts.headers["Discourse-Track-View-Topic-Id"] = _deferredViewTopicId;
-    }
-
-    _sendDeferredPageview = false;
-    _deferredURL = null;
-    _deferredSessionId = null;
-    _deferredReferrer = null;
-    _deferredViewTopicId = null;
   }
 
   const oldComplete = opts.complete;
@@ -75,8 +43,7 @@ export default {
 
     const messageBus = owner.lookup("service:message-bus"),
       user = owner.lookup("service:current-user"),
-      siteSettings = owner.lookup("service:site-settings"),
-      router = owner.lookup("service:router");
+      siteSettings = owner.lookup("service:site-settings");
 
     messageBus.alwaysLongPoll = !isProduction();
     messageBus.shouldLongPollCallback = () =>
@@ -109,22 +76,6 @@ export default {
     // pass in a position
     const interval = setInterval(() => {
       if (document.readyState === "complete") {
-        if (
-          router.currentRouteName === "topic.fromParams" ||
-          router.currentRouteName === "topic.fromParamsNear"
-        ) {
-          _deferredViewTopicId = router.currentRoute.parent.params.id;
-        }
-
-        _deferredSessionId = document.querySelector(
-          "meta[name=discourse-track-view-session-id]"
-        )?.content;
-
-        if (_deferredSessionId) {
-          _deferredURL = window.location.href;
-          _deferredReferrer = document.referrer;
-        }
-
         clearInterval(interval);
         messageBus.start();
       }

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -1,15 +1,23 @@
-import { getOwner } from "@ember/owner";
-import {
-  resetAjax,
-  trackNextAjaxAsPageview,
-  trackNextAjaxAsTopicView,
-} from "discourse/lib/ajax";
+import getURL from "discourse/lib/get-url";
 import {
   googleTagManagerPageChanged,
   resetPageTracking,
   startPageTracking,
 } from "discourse/lib/page-tracker";
-import { sendDeferredPageview } from "./message-bus";
+
+function sendPageview({ url, referrer, sessionId, topicId }) {
+  fetch(getURL("/pageview"), {
+    method: "POST",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url,
+      referrer,
+      session_id: sessionId,
+      topic_id: topicId,
+    }),
+  });
+}
 
 export default {
   after: "inject-objects",
@@ -19,14 +27,63 @@ export default {
     const isErrorPage =
       document.querySelector("meta#discourse-error")?.dataset.discourseError ===
       "true";
-    if (!isErrorPage) {
-      sendDeferredPageview();
+    const siteSettings = owner.lookup("service:site-settings");
+    const currentUser = owner.lookup("service:current-user");
+
+    if (!isErrorPage && !(siteSettings.login_required && !currentUser)) {
+      const interval = setInterval(() => {
+        if (document.readyState === "complete") {
+          clearInterval(interval);
+          const sessionId = document.querySelector(
+            "meta[name=discourse-track-view-session-id]"
+          )?.content;
+          sendPageview({
+            url: window.location.href,
+            referrer: document.referrer,
+            sessionId,
+            topicId: null,
+          });
+        }
+      }, 500);
     }
 
-    // Tell our AJAX system to track a page transition
     // eslint-disable-next-line ember/no-private-routing-service
     const router = owner.lookup("router:main");
-    router.on("routeWillChange", this.handleRouteWillChange);
+    let referrer;
+
+    router.on("routeWillChange", (transition) => {
+      // transition.from will be null on initial boot transition, which is already tracked as a pageview via the HTML request
+      if (!transition.from) {
+        return;
+      }
+
+      // Ignore intermediate transitions (e.g. loading substates)
+      if (transition.isIntermediate) {
+        return;
+      }
+
+      referrer = window.location.href;
+    });
+
+    router.on("routeDidChange", (transition) => {
+      if (transition.isAborted || transition.isIntermediate) {
+        return;
+      }
+
+      const sessionId = document.querySelector(
+        "meta[name=discourse-track-view-session-id]"
+      )?.content;
+
+      let topicId = null;
+      if (
+        transition.to.name === "topic.fromParams" ||
+        transition.to.name === "topic.fromParamsNear"
+      ) {
+        topicId = transition.to.parent.params.id;
+      }
+
+      sendPageview({ url: router.currentURL, referrer, sessionId, topicId });
+    });
 
     let appEvents = owner.lookup("service:app-events");
     let documentTitle = owner.lookup("service:document-title");
@@ -79,55 +136,7 @@ export default {
     }
   },
 
-  handleRouteWillChange(transition) {
-    // transition.from will be null on initial boot transition, which is already tracked as a pageview via the HTML request
-    if (!transition.from) {
-      return;
-    }
-
-    // Ignore intermediate transitions (e.g. loading substates)
-    if (transition.isIntermediate) {
-      return;
-    }
-
-    const trackingSessionId = document.querySelector(
-      "meta[name=discourse-track-view-session-id]"
-    )?.content;
-    let trackingUrl, trackingReferrer;
-
-    if (trackingSessionId) {
-      const owner = getOwner(this);
-      const router = owner.lookup("service:router");
-      let path = transition.intent?.url;
-      if (!path) {
-        try {
-          path = router.urlFor(
-            transition.to.name,
-            ...Object.values(transition.to.params)
-          );
-        } catch {}
-      }
-
-      // The path may not be generated when there is a middle transition leading to another path.
-      // That should not be counted as a page view.
-      if (!path) {
-        return;
-      }
-      trackingUrl = new URL(path, window.location.origin).href;
-      trackingReferrer = window.location.href;
-    }
-    trackNextAjaxAsPageview(trackingSessionId, trackingUrl, trackingReferrer);
-
-    if (
-      transition.to.name === "topic.fromParamsNear" ||
-      transition.to.name === "topic.fromParams"
-    ) {
-      trackNextAjaxAsTopicView(transition.to.parent.params.id);
-    }
-  },
-
   teardown() {
     resetPageTracking();
-    resetAjax();
   },
 };

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -1,12 +1,19 @@
+import { getOwner } from "@ember/owner";
+import {
+  resetAjax,
+  trackNextAjaxAsPageview,
+  trackNextAjaxAsTopicView,
+} from "discourse/lib/ajax";
 import getURL from "discourse/lib/get-url";
 import {
   googleTagManagerPageChanged,
   resetPageTracking,
   startPageTracking,
 } from "discourse/lib/page-tracker";
+import { sendDeferredPageview } from "./message-bus";
 
-function sendPageview({ url, referrer, sessionId, topicId }) {
-  fetch(getURL("/pageview"), {
+function sendPageviewBeacon({ url, referrer, sessionId, topicId }) {
+  fetch(getURL("/srv/pv"), {
     method: "POST",
     keepalive: true,
     headers: { "Content-Type": "application/json" },
@@ -30,60 +37,74 @@ export default {
     const siteSettings = owner.lookup("service:site-settings");
     const currentUser = owner.lookup("service:current-user");
 
-    if (!isErrorPage && !(siteSettings.login_required && !currentUser)) {
-      const interval = setInterval(() => {
-        if (document.readyState === "complete") {
-          clearInterval(interval);
-          const sessionId = document.querySelector(
-            "meta[name=discourse-track-view-session-id]"
-          )?.content;
-          sendPageview({
-            url: window.location.href,
-            referrer: document.referrer,
-            sessionId,
-            topicId: null,
-          });
-        }
-      }, 500);
-    }
-
     // eslint-disable-next-line ember/no-private-routing-service
     const router = owner.lookup("router:main");
-    let referrer;
 
-    router.on("routeWillChange", (transition) => {
-      // transition.from will be null on initial boot transition, which is already tracked as a pageview via the HTML request
-      if (!transition.from) {
-        return;
+    if (siteSettings.beacon_browser_page_view) {
+      if (!isErrorPage && !(siteSettings.login_required && !currentUser)) {
+        const interval = setInterval(() => {
+          if (document.readyState === "complete") {
+            clearInterval(interval);
+            const sessionId = document.querySelector(
+              "meta[name=discourse-track-view-session-id]"
+            )?.content;
+            sendPageviewBeacon({
+              url: window.location.href,
+              referrer: document.referrer,
+              sessionId,
+              topicId: null,
+            });
+          }
+        }, 500);
       }
 
-      // Ignore intermediate transitions (e.g. loading substates)
-      if (transition.isIntermediate) {
-        return;
+      let referrer;
+
+      router.on("routeWillChange", (transition) => {
+        // transition.from will be null on initial boot transition, which is already tracked as a pageview via the HTML request
+        if (!transition.from) {
+          return;
+        }
+
+        // Ignore intermediate transitions (e.g. loading substates)
+        if (transition.isIntermediate) {
+          return;
+        }
+
+        referrer = window.location.href;
+      });
+
+      router.on("routeDidChange", (transition) => {
+        if (transition.isAborted || transition.isIntermediate) {
+          return;
+        }
+
+        const sessionId = document.querySelector(
+          "meta[name=discourse-track-view-session-id]"
+        )?.content;
+
+        let topicId = null;
+        if (
+          transition.to.name === "topic.fromParams" ||
+          transition.to.name === "topic.fromParamsNear"
+        ) {
+          topicId = transition.to.parent.params.id;
+        }
+
+        sendPageviewBeacon({
+          url: router.currentURL,
+          referrer,
+          sessionId,
+          topicId,
+        });
+      });
+    } else {
+      if (!isErrorPage) {
+        sendDeferredPageview();
       }
 
-      referrer = window.location.href;
-    });
-
-    router.on("routeDidChange", (transition) => {
-      if (transition.isAborted || transition.isIntermediate) {
-        return;
-      }
-
-      const sessionId = document.querySelector(
-        "meta[name=discourse-track-view-session-id]"
-      )?.content;
-
-      let topicId = null;
-      if (
-        transition.to.name === "topic.fromParams" ||
-        transition.to.name === "topic.fromParamsNear"
-      ) {
-        topicId = transition.to.parent.params.id;
-      }
-
-      sendPageview({ url: router.currentURL, referrer, sessionId, topicId });
-    });
+      router.on("routeWillChange", this.handleRouteWillChange);
+    }
 
     let appEvents = owner.lookup("service:app-events");
     let documentTitle = owner.lookup("service:document-title");
@@ -136,7 +157,56 @@ export default {
     }
   },
 
+  handleRouteWillChange(transition) {
+    // transition.from will be null on initial boot transition, which is already tracked as a pageview via the HTML request
+    if (!transition.from) {
+      return;
+    }
+
+    // Ignore intermediate transitions (e.g. loading substates)
+    if (transition.isIntermediate) {
+      return;
+    }
+
+    const trackingSessionId = document.querySelector(
+      "meta[name=discourse-track-view-session-id]"
+    )?.content;
+    let trackingUrl, trackingReferrer;
+
+    if (trackingSessionId) {
+      const owner = getOwner(this);
+      const router = owner.lookup("service:router");
+      let path = transition.intent?.url;
+      if (!path) {
+        try {
+          path = router.urlFor(
+            transition.to.name,
+            ...Object.values(transition.to.params)
+          );
+        } catch {}
+      }
+
+      // The path may not be generated when there is a middle transition leading to another path.
+      // That should not be counted as a page view.
+      if (!path) {
+        return;
+      }
+      trackingUrl = new URL(path, window.location.origin).href;
+      trackingReferrer = window.location.href;
+    }
+
+    trackNextAjaxAsPageview(trackingSessionId, trackingUrl, trackingReferrer);
+
+    if (
+      transition.to.name === "topic.fromParamsNear" ||
+      transition.to.name === "topic.fromParams"
+    ) {
+      trackNextAjaxAsTopicView(transition.to.parent.params.id);
+    }
+  },
+
   teardown() {
     resetPageTracking();
+    resetAjax();
   },
 };

--- a/frontend/discourse/app/lib/ajax.js
+++ b/frontend/discourse/app/lib/ajax.js
@@ -8,8 +8,35 @@ import Session from "discourse/models/session";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
 
+let _trackView = false;
+let _topicId = null;
+let _trackingSessionId = null;
+let _trackingUrl = null;
+let _trackingReferrer = null;
 let _transientHeader = null;
 let _logoffCallback;
+
+export function trackNextAjaxAsTopicView(topicId) {
+  _topicId = topicId;
+}
+
+export function trackNextAjaxAsPageview(
+  trackingSessionId,
+  trackingUrl,
+  trackingReferrer
+) {
+  _trackView = true;
+  _trackingSessionId = trackingSessionId;
+  _trackingUrl = trackingUrl;
+  _trackingReferrer = trackingReferrer;
+}
+
+export function resetAjax() {
+  _trackView = false;
+  _trackingSessionId = null;
+  _trackingUrl = null;
+  _trackingReferrer = null;
+}
 
 export function setTransientHeader(key, value) {
   _transientHeader = { key, value };
@@ -85,6 +112,31 @@ export function ajax() {
     if (_transientHeader) {
       args.headers[_transientHeader.key] = _transientHeader.value;
       _transientHeader = null;
+    }
+
+    if (_trackView && (!args.type || args.type === "GET")) {
+      _trackView = false;
+      args.headers["Discourse-Track-View"] = "true";
+
+      if (_trackingSessionId) {
+        args.headers["Discourse-Track-View-Session-Id"] = _trackingSessionId;
+        _trackingSessionId = null;
+      }
+
+      if (_trackingUrl) {
+        args.headers["Discourse-Track-View-Url"] = _trackingUrl;
+        _trackingUrl = null;
+      }
+
+      if (_trackingReferrer) {
+        args.headers["Discourse-Track-View-Referrer"] = _trackingReferrer;
+        _trackingReferrer = null;
+      }
+
+      if (_topicId) {
+        args.headers["Discourse-Track-View-Topic-Id"] = _topicId;
+        _topicId = null;
+      }
     }
 
     if (userPresent()) {

--- a/frontend/discourse/app/lib/ajax.js
+++ b/frontend/discourse/app/lib/ajax.js
@@ -8,38 +8,11 @@ import Session from "discourse/models/session";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
 
-let _trackView = false;
-let _topicId = null;
-let _trackingSessionId = null;
-let _trackingUrl = null;
-let _trackingReferrer = null;
 let _transientHeader = null;
 let _logoffCallback;
 
 export function setTransientHeader(key, value) {
   _transientHeader = { key, value };
-}
-
-export function trackNextAjaxAsTopicView(topicId) {
-  _topicId = topicId;
-}
-
-export function trackNextAjaxAsPageview(
-  trackingSessionId,
-  trackingUrl,
-  trackingReferrer
-) {
-  _trackView = true;
-  _trackingSessionId = trackingSessionId;
-  _trackingUrl = trackingUrl;
-  _trackingReferrer = trackingReferrer;
-}
-
-export function resetAjax() {
-  _trackView = false;
-  _trackingSessionId = null;
-  _trackingUrl = null;
-  _trackingReferrer = null;
 }
 
 export function setLogoffCallback(cb) {
@@ -112,31 +85,6 @@ export function ajax() {
     if (_transientHeader) {
       args.headers[_transientHeader.key] = _transientHeader.value;
       _transientHeader = null;
-    }
-
-    if (_trackView && (!args.type || args.type === "GET")) {
-      _trackView = false;
-      args.headers["Discourse-Track-View"] = "true";
-
-      if (_trackingSessionId) {
-        args.headers["Discourse-Track-View-Session-Id"] = _trackingSessionId;
-        _trackingSessionId = null;
-      }
-
-      if (_trackingUrl) {
-        args.headers["Discourse-Track-View-Url"] = _trackingUrl;
-        _trackingUrl = null;
-      }
-
-      if (_trackingReferrer) {
-        args.headers["Discourse-Track-View-Referrer"] = _trackingReferrer;
-        _trackingReferrer = null;
-      }
-
-      if (_topicId) {
-        args.headers["Discourse-Track-View-Topic-Id"] = _topicId;
-        _topicId = null;
-      }
     }
 
     if (userPresent()) {

--- a/frontend/discourse/scripts/pageview.js
+++ b/frontend/discourse/scripts/pageview.js
@@ -1,4 +1,12 @@
 function trackPageView() {
+  const beaconEnabled = !!document.querySelector(
+    "meta[name=discourse-enable-beacon-pageview]"
+  );
+
+  if (!beaconEnabled) {
+    return;
+  }
+
   const isErrorPage =
     document.querySelector("meta#discourse-error")?.dataset.discourseError ===
     "true";
@@ -14,7 +22,7 @@ function trackPageView() {
     "meta[name=discourse-track-view-session-id]"
   )?.content;
 
-  fetch(`${root}/pageview`, {
+  fetch(`${root}/srv/pv`, {
     method: "POST",
     keepalive: true,
     headers: { "Content-Type": "application/json" },

--- a/frontend/discourse/scripts/pageview.js
+++ b/frontend/discourse/scripts/pageview.js
@@ -1,30 +1,30 @@
-document.addEventListener("DOMContentLoaded", function () {
+function trackPageView() {
   const isErrorPage =
     document.querySelector("meta#discourse-error")?.dataset.discourseError ===
     "true";
 
-  if (!isErrorPage) {
-    const root =
-      document.querySelector("meta[name=discourse-base-uri]")?.content || "";
-
-    const trackViewSessionId = document.querySelector(
-      "meta[name=discourse-track-view-session-id]"
-    )?.content;
-
-    let headers = {
-      "Discourse-Track-View-Deferred": "true",
-    };
-
-    if (trackViewSessionId) {
-      headers = Object.assign(headers, {
-        "Discourse-Track-View-Url": window.location.href,
-        "Discourse-Track-View-Referrer": document.referrer,
-        "Discourse-Track-View-Session-Id": trackViewSessionId,
-      });
-    }
-    fetch(`${root}/pageview`, {
-      method: "POST",
-      headers,
-    });
+  if (isErrorPage) {
+    return;
   }
-});
+
+  const root =
+    document.querySelector("meta[name=discourse-base-uri]")?.content || "";
+
+  const sessionId = document.querySelector(
+    "meta[name=discourse-track-view-session-id]"
+  )?.content;
+
+  fetch(`${root}/pageview`, {
+    method: "POST",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url: window.location.href,
+      referrer: document.referrer,
+      session_id: sessionId,
+      topic_id: null,
+    }),
+  });
+}
+
+document.addEventListener("DOMContentLoaded", trackPageView);

--- a/frontend/discourse/tests/acceptance/page-tracking-test.js
+++ b/frontend/discourse/tests/acceptance/page-tracking-test.js
@@ -1,125 +1,49 @@
-import { getOwner } from "@ember/owner";
-import { click, visit } from "@ember/test-helpers";
+import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { ajax } from "discourse/lib/ajax";
-import pretender from "discourse/tests/helpers/create-pretender";
+import sinon from "sinon";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
-const trackViewHeaderName = "Discourse-Track-View";
-
-function setupPretender(server, helper) {
-  server.get("/fake-analytics-endpoint", (request) => {
-    if (request.requestHeaders[trackViewHeaderName]) {
-      throw "Fake analytics endpoint was called with track-view header";
-    }
-    return helper.response({});
-  });
-}
-
-function setupFakeAnalytics(ref) {
-  getOwner(ref)
-    .lookup("service:router")
-    .on("routeDidChange", () => ajax("/fake-analytics-endpoint"));
-}
-
-function assertRequests({ assert, tracked, untracked, message }) {
-  let trackedCount = 0,
-    untrackedCount = 0;
-
-  const requests = pretender.handledRequests;
-  requests.forEach((request) => {
-    if (request.requestHeaders[trackViewHeaderName]) {
-      trackedCount++;
-    } else {
-      untrackedCount++;
-    }
-  });
-
-  assert.strictEqual(trackedCount, tracked, `${message} (tracked)`);
-  assert.strictEqual(untrackedCount, untracked, `${message} (untracked)`);
-
-  pretender.handledRequests = [];
-}
-
-acceptance("Page tracking - loading slider", function (needs) {
+acceptance("Page tracking - initial load", function (needs) {
   needs.user();
-  needs.pretender(setupPretender);
 
-  test("sets the discourse-track-view header correctly", async function (assert) {
-    setupFakeAnalytics(this);
-
-    assertRequests({
-      assert,
-      tracked: 0,
-      untracked: 1,
-      message: "no tracked requests before app boot",
+  needs.hooks.beforeEach(function () {
+    this.fetchRequests = [];
+    sinon.stub(window, "fetch").callsFake((url, opts) => {
+      this.fetchRequests.push({ url, opts });
+      return Promise.resolve(new Response("{}", { status: 200 }));
     });
-
-    await visit("/");
-    assertRequests({
-      assert,
-      tracked: 0,
-      untracked: 2,
-      message: "no ajax tracked for initial page load",
-    });
-
-    await click("#site-logo");
-    assertRequests({
-      assert,
-      tracked: 1,
-      untracked: 1,
-      message: "tracked one pageview for reloading latest",
-    });
-
-    await visit("/t/-/280");
-    assertRequests({
-      assert,
-      tracked: 1,
-      untracked: 1,
-      message: "tracked one pageview for navigating to topic",
-    });
-  });
-});
-
-acceptance("Page tracking - loading spinner", function (needs) {
-  needs.user();
-  needs.pretender(setupPretender);
-  needs.settings({
-    page_loading_indicator: "spinner",
+    const meta = document.createElement("meta");
+    meta.name = "discourse-track-view-session-id";
+    meta.content = "test-session-id";
+    document.head.appendChild(meta);
   });
 
-  test("sets the discourse-track-view header correctly", async function (assert) {
-    setupFakeAnalytics(this);
+  needs.hooks.afterEach(function () {
+    document
+      .querySelector("meta[name='discourse-track-view-session-id']")
+      ?.remove();
+  });
 
-    assertRequests({
-      assert,
-      tracked: 0,
-      untracked: 1,
-      message: "no tracked requests before app boot",
-    });
-
+  test("sends pageview on initial load with session_id", async function (assert) {
     await visit("/");
-    assertRequests({
-      assert,
-      tracked: 0,
-      untracked: 2,
-      message: "no ajax tracked for initial page load",
-    });
+    const pageviewCall = this.fetchRequests.find((r) =>
+      r.url.includes("/pageview")
+    );
+    assert.notStrictEqual(
+      pageviewCall,
+      undefined,
+      "fetch called for /pageview"
+    );
+    assert.true(pageviewCall.opts.keepalive);
+    const body = JSON.parse(pageviewCall.opts.body);
+    assert.strictEqual(body.session_id, "test-session-id");
+  });
 
-    await click("#site-logo");
-    assertRequests({
-      assert,
-      tracked: 1,
-      untracked: 1,
-      message: "tracked one pageview for reloading latest",
-    });
-
-    await visit("/t/-/280");
-    assertRequests({
-      assert,
-      tracked: 1,
-      untracked: 1,
-      message: "tracked one pageview for navigating to topic",
-    });
+  test("sends pageview with topic_id on topic route", async function (assert) {
+    await visit("/t/some-topic/280");
+    const calls = this.fetchRequests.filter((r) => r.url.includes("/pageview"));
+    const topicCall = calls.find((c) => JSON.parse(c.opts.body).topic_id);
+    assert.notStrictEqual(topicCall, undefined, "pageview sent with topic_id");
+    assert.strictEqual(JSON.parse(topicCall.opts.body).topic_id, "280");
   });
 });

--- a/frontend/discourse/tests/acceptance/page-tracking-test.js
+++ b/frontend/discourse/tests/acceptance/page-tracking-test.js
@@ -5,6 +5,7 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Page tracking - initial load", function (needs) {
   needs.user();
+  needs.settings({ beacon_browser_page_view: true });
 
   needs.hooks.beforeEach(function () {
     this.fetchRequests = [];
@@ -27,13 +28,9 @@ acceptance("Page tracking - initial load", function (needs) {
   test("sends pageview on initial load with session_id", async function (assert) {
     await visit("/");
     const pageviewCall = this.fetchRequests.find((r) =>
-      r.url.includes("/pageview")
+      r.url.includes("/srv/pv")
     );
-    assert.notStrictEqual(
-      pageviewCall,
-      undefined,
-      "fetch called for /pageview"
-    );
+    assert.notStrictEqual(pageviewCall, undefined, "fetch called for /srv/pv");
     assert.true(pageviewCall.opts.keepalive);
     const body = JSON.parse(pageviewCall.opts.body);
     assert.strictEqual(body.session_id, "test-session-id");
@@ -41,7 +38,7 @@ acceptance("Page tracking - initial load", function (needs) {
 
   test("sends pageview with topic_id on topic route", async function (assert) {
     await visit("/t/some-topic/280");
-    const calls = this.fetchRequests.filter((r) => r.url.includes("/pageview"));
+    const calls = this.fetchRequests.filter((r) => r.url.includes("/srv/pv"));
     const topicCall = calls.find((c) => JSON.parse(c.opts.body).topic_id);
     assert.notStrictEqual(topicCall, undefined, "pageview sent with topic_id");
     assert.strictEqual(JSON.parse(topicCall.opts.body).topic_id, "280");

--- a/frontend/discourse/tests/helpers/create-pretender.js
+++ b/frontend/discourse/tests/helpers/create-pretender.js
@@ -433,6 +433,7 @@ export function applyDefaultHandlers(pretender) {
   });
 
   pretender.post("/clicks/track", success);
+  pretender.post("/srv/pv", success);
 
   pretender.get("/search", (request) => {
     if (

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -178,7 +178,7 @@ class Middleware::RequestTracker
     is_topic_timings = request.path.start_with?("#{Discourse.base_path}/topics/timings")
 
     current_user_id =
-      if view_tracking_data[:deferred_track_view] || view_tracking_data[:explicit_track_view]
+      if view_tracking_data[:browser_page_view]
         begin
           (auth_cookie&.[](:user_id) || CurrentUser.lookup_from_env(env)&.id)
         rescue Discourse::InvalidAccess => err
@@ -249,7 +249,6 @@ class Middleware::RequestTracker
     if data
       if result && (headers = result[1])
         headers["X-Discourse-TrackView"] = "1" if data[:track_view]
-        headers["X-Discourse-BrowserPageView"] = "1" if data[:browser_page_view]
       end
 
       if @@detailed_request_loggers
@@ -521,54 +520,26 @@ class Middleware::RequestTracker
     is_html_request = headers["Content-Type"]&.include?("text/html")
     is_ajax_request = request.xhr?
 
-    # This Discourse-Track-View request header is set in `lib/ajax.js`,
-    # whenever the user navigates between Ember routes, to indicate a
-    # browser page view.
-    env_track_view = env["HTTP_DISCOURSE_TRACK_VIEW"]
-    explicit_track_view = status == 200 && %w[1 true].include?(env_track_view)
+    # An HTML response to a GET request is tracked as a legacy page view.
+    # The X-Discourse-TrackView header is included in the response when this is true.
+    track_view = !!(status == 200 && request.get? && !is_ajax_request && is_html_request)
 
-    # An HTML response to a GET request is tracked implicitly, these do
-    # not count as browser page views but they do count as legacy page views.
-    implicit_track_view =
-      status == 200 && !%w[0 false].include?(env_track_view) && request.get? && !is_ajax_request &&
-        is_html_request
-
-    # This Discourse-Deferred-Track-View header is piggybacked on a
-    # follow-up MessageBus request after a real browser loads up a page
-    # to avoid bots influencing browser page views when loading HTML
-    # versions of a page.
+    # A POST to /pageview is a dedicated browser page view beacon sent via
+    # fetch(..., { keepalive: true }). The view data is passed in the JSON body.
     #
     # See `scripts/pageview.js` and `instance-initializers/page-tracking.js`
-    env_deferred_track_view = env["HTTP_DISCOURSE_TRACK_VIEW_DEFERRED"]
-    deferred_track_view = %w[1 true].include?(env_deferred_track_view)
+    is_pageview_request = request.post? && request.path_info == "/pageview"
+    body_data = is_pageview_request ? read_pageview_body(env) : nil
+    browser_page_view = is_pageview_request
 
-    # This only indicates that we are tracking a page view of some kind, not
-    # using an API key. In #log_request is where we are determining which
-    # of these count as browser page views.
-    #
-    # TL;DR -- Explicit and Deferred page views count as browser page views (BPVs),
-    # explicit and implicit page views count as legacy page views.
-    #
-    # If this is true, then the X-Discourse-TrackView header is included in
-    # the response.
-    #
-    # If the page view is explicit or deferred, then the X-Discourse-BrowserPageView header
-    # is included in the response.
-    track_view = !!(explicit_track_view || implicit_track_view)
-    browser_page_view = !!(explicit_track_view || deferred_track_view)
-
-    topic_id = env["HTTP_DISCOURSE_TRACK_VIEW_TOPIC_ID"]&.to_i
-    tracking_url = env["HTTP_DISCOURSE_TRACK_VIEW_URL"]&.slice(0, MAX_URL_LENGTH)
-    tracking_referrer = env["HTTP_DISCOURSE_TRACK_VIEW_REFERRER"]&.slice(0, MAX_URL_LENGTH)
-    tracking_session_id =
-      env["HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID"]&.slice(0, MAX_SESSION_ID_LENGTH)
+    topic_id = body_data&.[]("topic_id").to_i.nonzero?
+    tracking_url = body_data&.[]("url")&.slice(0, MAX_URL_LENGTH)
+    tracking_referrer = body_data&.[]("referrer")&.slice(0, MAX_URL_LENGTH)
+    tracking_session_id = body_data&.[]("session_id")&.slice(0, MAX_SESSION_ID_LENGTH)
     user_agent = env["HTTP_USER_AGENT"]&.slice(0, MAX_USER_AGENT_LENGTH)
 
     {
       track_view: track_view,
-      explicit_track_view: explicit_track_view,
-      deferred_track_view: deferred_track_view,
-      implicit_track_view: implicit_track_view,
       browser_page_view: browser_page_view,
       topic_id: topic_id,
       tracking_url: tracking_url,
@@ -577,6 +548,16 @@ class Middleware::RequestTracker
       user_agent: user_agent,
     }
   end
+
+  def self.read_pageview_body(env)
+    raw_body = env["rack.input"].read
+    JSON.parse(raw_body)
+  rescue JSON::ParserError
+    nil
+  ensure
+    env["rack.input"].rewind
+  end
+  private_class_method :read_pageview_body
 
   def self.trigger_browser_pageview_event(data)
     if SiteSetting.trigger_browser_pageview_events

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -522,20 +522,53 @@ class Middleware::RequestTracker
 
     # An HTML response to a GET request is tracked as a legacy page view.
     # The X-Discourse-TrackView header is included in the response when this is true.
-    track_view = !!(status == 200 && request.get? && !is_ajax_request && is_html_request)
+    implicit_track_view = status == 200 && request.get? && !is_ajax_request && is_html_request
 
-    # A POST to /pageview is a dedicated browser page view beacon sent via
+    # A POST to /srv/pv is a dedicated browser page view beacon sent via
     # fetch(..., { keepalive: true }). The view data is passed in the JSON body.
     #
     # See `scripts/pageview.js` and `instance-initializers/page-tracking.js`
-    is_pageview_request = request.post? && request.path_info == "/pageview"
-    body_data = is_pageview_request ? read_pageview_body(env) : nil
-    browser_page_view = is_pageview_request
+    is_pageview_request = request.post? && request.path_info == "/srv/pv"
 
-    topic_id = body_data&.[]("topic_id").to_i.nonzero?
-    tracking_url = body_data&.[]("url")&.slice(0, MAX_URL_LENGTH)
-    tracking_referrer = body_data&.[]("referrer")&.slice(0, MAX_URL_LENGTH)
-    tracking_session_id = body_data&.[]("session_id")&.slice(0, MAX_SESSION_ID_LENGTH)
+    topic_id = nil
+    tracking_url = nil
+    tracking_referrer = nil
+    tracking_session_id = nil
+    track_view = nil
+    browser_page_view = nil
+
+    if is_pageview_request
+      body_data = read_pageview_body(env)
+      topic_id = body_data&.[]("topic_id").to_i.nonzero?
+      tracking_url = body_data&.[]("url")&.slice(0, MAX_URL_LENGTH)
+      tracking_referrer = body_data&.[]("referrer")&.slice(0, MAX_URL_LENGTH)
+      tracking_session_id = body_data&.[]("session_id")&.slice(0, MAX_SESSION_ID_LENGTH)
+      track_view = !!implicit_track_view
+      browser_page_view = true
+    else
+      # When the beacon is not in use, browser page views are tracked via headers
+      # piggybacked on AJAX and MessageBus requests.
+
+      # This Discourse-Track-View request header is set in `lib/ajax.js` whenever
+      # the user navigates between Ember routes to indicate a browser page view.
+      env_track_view = env["HTTP_DISCOURSE_TRACK_VIEW"]
+      explicit_track_view = status == 200 && %w[1 true].include?(env_track_view)
+
+      # This Discourse-Track-View-Deferred header is piggybacked on a follow-up
+      # MessageBus request after a real browser loads a page to avoid bots
+      # influencing browser page views when loading HTML versions of a page.
+      env_deferred_track_view = env["HTTP_DISCOURSE_TRACK_VIEW_DEFERRED"]
+      deferred_track_view = %w[1 true].include?(env_deferred_track_view)
+
+      topic_id = env["HTTP_DISCOURSE_TRACK_VIEW_TOPIC_ID"]&.to_i&.nonzero?
+      tracking_url = env["HTTP_DISCOURSE_TRACK_VIEW_URL"]&.slice(0, MAX_URL_LENGTH)
+      tracking_referrer = env["HTTP_DISCOURSE_TRACK_VIEW_REFERRER"]&.slice(0, MAX_URL_LENGTH)
+      tracking_session_id =
+        env["HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID"]&.slice(0, MAX_SESSION_ID_LENGTH)
+      track_view = !!(implicit_track_view || explicit_track_view)
+      browser_page_view = !!(explicit_track_view || deferred_track_view)
+    end
+
     user_agent = env["HTTP_USER_AGENT"]&.slice(0, MAX_USER_AGENT_LENGTH)
 
     {

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -86,38 +86,6 @@ RSpec.describe Middleware::RequestTracker do
       ApplicationRequest.clear_cache!
     end
 
-    def log_tracked_view(val)
-      data =
-        Middleware::RequestTracker.get_data(
-          env("HTTP_DISCOURSE_TRACK_VIEW" => val),
-          ["200", { "Content-Type" => "text/html" }],
-          0.2,
-        )
-
-      Middleware::RequestTracker.log_request(data)
-    end
-
-    it "can exclude/include based on custom header" do
-      log_tracked_view("true")
-      log_tracked_view("1")
-      log_tracked_view("false")
-      log_tracked_view("0")
-
-      CachedCounting.flush
-
-      expect(ApplicationRequest.page_view_anon.first.count).to eq(2)
-      expect(ApplicationRequest.page_view_anon_browser.first.count).to eq(2)
-    end
-
-    it "adds the appropriate response header based on explicit tracking (AJAX requests, BPVs)" do
-      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
-      status, headers = middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW" => "1"))
-
-      expect(status).to eq(200)
-      expect(headers["X-Discourse-TrackView"]).to eq("1")
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
-    end
-
     it "adds the appropriate response header based on implicit tracking (HTML requests)" do
       middleware =
         Middleware::RequestTracker.new(
@@ -136,7 +104,7 @@ RSpec.describe Middleware::RequestTracker do
 
       expect(status).to eq(200)
       expect(headers["X-Discourse-TrackView"]).to eq(nil)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
+      expect(headers["X-Discourse-BrowserPageView"]).to eq(nil)
     end
 
     it "adds the appropriate response headers for MessageBus requests with deferred tracking" do
@@ -154,7 +122,7 @@ RSpec.describe Middleware::RequestTracker do
         )
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
+      expect(headers["X-Discourse-BrowserPageView"]).to eq(nil)
     end
 
     it "adds the appropriate response headers for MessageBus requests with regular tracking" do
@@ -170,8 +138,8 @@ RSpec.describe Middleware::RequestTracker do
         middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW" => "1", :path => "/message-bus/abcde/poll"))
 
       expect(status).to eq(200)
-      expect(headers["X-Discourse-BrowserPageView"]).to eq("1")
-      expect(headers["X-Discourse-TrackView"]).to eq("1")
+      expect(headers["X-Discourse-BrowserPageView"]).to eq(nil)
+      expect(headers["X-Discourse-TrackView"]).to eq(nil)
     end
 
     it "does not add these response headers when skipping the request tracker" do
@@ -249,19 +217,23 @@ RSpec.describe Middleware::RequestTracker do
 
       expect(ApplicationRequest.page_view_crawler.first.count).to eq(1)
 
-      expect(ApplicationRequest.page_view_anon_browser.first.count).to eq(1)
+      expect(ApplicationRequest.page_view_anon_browser.first).to eq(nil)
     end
 
     it "logs deferred pageviews correctly" do
       data =
         Middleware::RequestTracker.get_data(
-          env(:path => "/message-bus/abcde/poll", "HTTP_DISCOURSE_TRACK_VIEW_DEFERRED" => "1"),
-          ["200", { "Content-Type" => "text/html" }],
+          env(
+            :path => "/pageview",
+            "REQUEST_METHOD" => "POST",
+            "rack.input" => StringIO.new({ url: "https://example.com/" }.to_json),
+          ),
+          ["200", {}],
           0.1,
         )
       Middleware::RequestTracker.log_request(data)
 
-      expect(data[:deferred_track_view]).to eq(true)
+      expect(data[:browser_page_view]).to eq(true)
       CachedCounting.flush
 
       expect(ApplicationRequest.page_view_anon_browser.first.count).to eq(1)
@@ -331,6 +303,66 @@ RSpec.describe Middleware::RequestTracker do
       expect(ApplicationRequest.page_view_anon.first.count).to eq(1)
     end
 
+    describe "POST /pageview JSON body parsing" do
+      it "sets browser_page_view and populates tracking fields from JSON body" do
+        json_body = {
+          url: "https://example.com/t/slug/123",
+          referrer: "https://example.com/",
+          session_id: "abc123",
+          topic_id: 456,
+        }.to_json
+
+        pageview_env =
+          env(
+            :path => "/pageview",
+            "REQUEST_METHOD" => "POST",
+            "rack.input" => StringIO.new(json_body),
+          )
+
+        data = described_class.extract_view_tracking_data(pageview_env, nil, nil)
+        expect(data[:browser_page_view]).to eq(true)
+        expect(data[:track_view]).to eq(false)
+        expect(data[:tracking_url]).to eq("https://example.com/t/slug/123")
+        expect(data[:tracking_referrer]).to eq("https://example.com/")
+        expect(data[:tracking_session_id]).to eq("abc123")
+        expect(data[:topic_id]).to eq(456)
+      end
+
+      it "gracefully returns nil tracking fields for malformed JSON body" do
+        pageview_env =
+          env(
+            :path => "/pageview",
+            "REQUEST_METHOD" => "POST",
+            "rack.input" => StringIO.new("not valid json{{{"),
+          )
+
+        data = nil
+        expect {
+          data = described_class.extract_view_tracking_data(pageview_env, nil, nil)
+        }.not_to raise_error
+        expect(data[:browser_page_view]).to eq(true)
+        expect(data[:tracking_url]).to be_nil
+        expect(data[:tracking_referrer]).to be_nil
+        expect(data[:tracking_session_id]).to be_nil
+      end
+
+      it "rewinds rack.input after reading the body" do
+        json_body = {
+          url: "https://example.com/",
+          referrer: "",
+          session_id: "s1",
+          topic_id: nil,
+        }.to_json
+        input = StringIO.new(json_body)
+
+        pageview_env = env(:path => "/pageview", "REQUEST_METHOD" => "POST", "rack.input" => input)
+
+        data = described_class.extract_view_tracking_data(pageview_env, nil, nil)
+        expect(data[:browser_page_view]).to eq(true)
+        expect(pageview_env["rack.input"].pos).to eq(0)
+      end
+    end
+
     describe "topic views" do
       fab!(:topic)
       fab!(:post) { Fabricate(:post, topic: topic) }
@@ -348,24 +380,24 @@ RSpec.describe Middleware::RequestTracker do
 
       def log_topic_view(authenticated: false, deferred: false)
         headers = { "action_dispatch.remote_ip" => "127.0.0.1" }
-
         headers["HTTP_COOKIE"] = "_t=#{auth_cookie};" if authenticated
 
-        if deferred
-          headers["HTTP_DISCOURSE_TRACK_VIEW"] = "1"
-          headers["HTTP_DISCOURSE_TRACK_VIEW_DEFERRED"] = "1"
-          headers["HTTP_DISCOURSE_TRACK_VIEW_TOPIC_ID"] = topic.id
-          path = "/message-bus/abcde/poll"
-        else
-          headers["HTTP_DISCOURSE_TRACK_VIEW"] = "1"
-          headers["HTTP_DISCOURSE_TRACK_VIEW_TOPIC_ID"] = topic.id
-          path = URI.parse(topic.url).path
-        end
+        json_body = {
+          topic_id: topic.id,
+          url: topic.url,
+          referrer: "",
+          session_id: "abc123",
+        }.to_json
 
         data =
           Middleware::RequestTracker.get_data(
-            env(path: path, **headers),
-            ["200", { "Content-Type" => "text/html" }],
+            env(
+              :path => "/pageview",
+              "REQUEST_METHOD" => "POST",
+              "rack.input" => StringIO.new(json_body),
+              **headers,
+            ),
+            ["200", {}],
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
@@ -595,18 +627,26 @@ RSpec.describe Middleware::RequestTracker do
     describe "browser_pageview event" do
       context "when SiteSetting.trigger_browser_pageview_events is true" do
         before { SiteSetting.trigger_browser_pageview_events = true }
+
         it "triggers event for anonymous user page views when `login_required` site setting is false" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
 
           data =
             Middleware::RequestTracker.get_data(
               env(
-                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
-                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
-                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
-                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
+                :path => "/pageview",
+                "REQUEST_METHOD" => "POST",
+                "rack.input" =>
+                  StringIO.new(
+                    {
+                      url: "https://discourse.org",
+                      referrer: "https://example.com",
+                      session_id: session_id,
+                      topic_id: nil,
+                    }.to_json,
+                  ),
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", {}],
               0.2,
             )
 
@@ -632,12 +672,19 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env(
-                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
-                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
-                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
-                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
+                :path => "/pageview",
+                "REQUEST_METHOD" => "POST",
+                "rack.input" =>
+                  StringIO.new(
+                    {
+                      url: "https://discourse.org",
+                      referrer: "https://example.com",
+                      session_id: session_id,
+                      topic_id: nil,
+                    }.to_json,
+                  ),
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", {}],
               0.2,
             )
 
@@ -654,14 +701,21 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env(
-                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
-                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => "A" * 50,
-                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "A" * 5000,
-                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "A" * 5000,
+                :path => "/pageview",
+                "REQUEST_METHOD" => "POST",
+                "rack.input" =>
+                  StringIO.new(
+                    {
+                      url: "A" * 5000,
+                      referrer: "A" * 5000,
+                      session_id: "A" * 50,
+                      topic_id: nil,
+                    }.to_json,
+                  ),
                 "HTTP_USER_AGENT" => "A" * 5000,
                 "action_dispatch.remote_ip" => "1" * 50,
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", {}],
               0.2,
             )
 
@@ -693,12 +747,20 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env(
-                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                :path => "/pageview",
+                "REQUEST_METHOD" => "POST",
                 "HTTP_COOKIE" => "_t=#{cookie};",
-                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
-                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
+                "rack.input" =>
+                  StringIO.new(
+                    {
+                      url: "https://discourse.org",
+                      referrer: "https://example.com",
+                      session_id: nil,
+                      topic_id: nil,
+                    }.to_json,
+                  ),
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", {}],
               0.2,
             )
 
@@ -740,12 +802,19 @@ RSpec.describe Middleware::RequestTracker do
           data =
             Middleware::RequestTracker.get_data(
               env(
-                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
-                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
-                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
-                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
+                :path => "/pageview",
+                "REQUEST_METHOD" => "POST",
+                "rack.input" =>
+                  StringIO.new(
+                    {
+                      url: "https://discourse.org",
+                      referrer: "https://example.com",
+                      session_id: session_id,
+                      topic_id: nil,
+                    }.to_json,
+                  ),
               ),
-              ["200", { "Content-Type" => "text/html" }],
+              ["200", {}],
               0.2,
             )
 

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -14,392 +14,406 @@ describe "Request tracking", type: :system do
     CachedCounting.disable
   end
 
-  describe "pageviews" do
-    it "tracks an anonymous visit correctly" do
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/"
-          try_until_success do
-            CachedCounting.flush
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 1,
-              "page_view_anon_browser_total" => 1,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 0,
-            )
+  shared_examples "tracks pageviews and topic views" do
+    describe "pageviews" do
+      it "tracks an anonymous visit correctly" do
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/"
+            try_until_success do
+              CachedCounting.flush
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 1,
+                "page_view_anon_browser_total" => 1,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 0,
+              )
+            end
           end
+
+        event = events[0][:params].last
+
+        expect(event[:user_id]).to be_nil
+        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
+        expect(event[:ip_address]).to eq("::1")
+        expect(event[:referrer]).to be_blank
+        expect(event[:session_id]).to be_present
+
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            find(".nav-item_categories a").click
+
+            try_until_success do
+              CachedCounting.flush
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 2,
+                "page_view_anon_browser_total" => 2,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 0,
+              )
+            end
+          end
+
+        event_2 = events[0][:params].last
+
+        expect(event_2[:user_id]).to be_nil
+        expect(event_2[:url]).to eq("#{Discourse.base_url_no_prefix}/categories")
+        expect(event_2[:ip_address]).to eq("::1")
+        expect(event_2[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
+        expect(event_2[:session_id]).to eq(event[:session_id])
+      end
+
+      it "tracks a crawler visit correctly" do
+        # Can't change playwright user agent for now... so change site settings to make Discourse detect chrome as a crawler
+        SiteSetting.crawler_user_agents += "|chrome"
+
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/"
+
+            try_until_success do
+              CachedCounting.flush
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 0,
+                "page_view_anon_browser_total" => 0,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 1,
+              )
+            end
+          end
+
+        expect(events).to be_blank
+      end
+
+      it "tracks a logged-in session correctly" do
+        user = Fabricate(:user)
+        sign_in user
+
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/"
+
+            try_until_success do
+              CachedCounting.flush
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 0,
+                "page_view_anon_browser_total" => 0,
+                "page_view_logged_in_total" => 1,
+                "page_view_crawler_total" => 0,
+                "page_view_logged_in_browser_total" => 1,
+              )
+            end
+          end
+
+        event = events[0][:params].last
+
+        expect(event[:user_id]).to eq(user.id)
+        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
+        expect(event[:ip_address]).to eq("::1")
+        expect(event[:referrer]).to be_blank
+        expect(event[:session_id]).to be_present
+        expect(event[:topic_id]).to be_blank
+
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            find(".nav-item_categories a").click
+            try_until_success do
+              CachedCounting.flush
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 0,
+                "page_view_anon_browser_total" => 0,
+                "page_view_logged_in_total" => 2,
+                "page_view_crawler_total" => 0,
+                "page_view_logged_in_browser_total" => 2,
+              )
+            end
+          end
+
+        event_2 = events[0][:params].last
+
+        expect(event_2[:user_id]).to eq(user.id)
+        expect(event_2[:url]).to eq("#{Discourse.base_url_no_prefix}/categories")
+        expect(event_2[:ip_address]).to eq("::1")
+        expect(event_2[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
+        expect(event_2[:session_id]).to eq(event[:session_id])
+      end
+
+      it "tracks normal error pages correctly" do
+        SiteSetting.bootstrap_error_pages = false
+
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/foobar"
+
+            try_until_success do
+              CachedCounting.flush
+
+              # Does not count error as a pageview
+              expect(ApplicationRequest.stats).to include(
+                "http_4xx_total" => 1,
+                "page_view_anon_total" => 0,
+                "page_view_anon_browser_total" => 0,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 0,
+              )
+            end
+          end
+
+        expect(events).to be_blank
+
+        click_logo
+
+        try_until_success do
+          CachedCounting.flush
+          expect(ApplicationRequest.stats).to include(
+            "http_4xx_total" => 1,
+            "page_view_anon_total" => 1,
+            "page_view_anon_browser_total" => 1,
+            "page_view_logged_in_total" => 0,
+            "page_view_crawler_total" => 0,
+          )
+        end
+      end
+
+      it "tracks non-ember pages correctly" do
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/safe-mode"
+
+            try_until_success do
+              CachedCounting.flush
+
+              # Does not count error as a pageview
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 1,
+                "page_view_anon_browser_total" => 1,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 0,
+              )
+            end
+          end
+
+        event = events[0][:params].last
+
+        expect(event[:user_id]).to be_nil
+        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/safe-mode")
+        expect(event[:ip_address]).to eq("::1")
+        expect(event[:referrer]).to be_blank
+        expect(event[:session_id]).to be_present
+      end
+
+      it "tracks bootstrapped error pages correctly" do
+        SiteSetting.bootstrap_error_pages = true
+
+        visit "/foobar"
+
+        try_until_success do
+          CachedCounting.flush
+
+          # Does not count error as a pageview
+          expect(ApplicationRequest.stats).to include(
+            "http_4xx_total" => 1,
+            "page_view_anon_total" => 0,
+            "page_view_anon_browser_total" => 0,
+            "page_view_logged_in_total" => 0,
+            "page_view_crawler_total" => 0,
+          )
         end
 
-      event = events[0][:params].last
+        click_logo
 
-      expect(event[:user_id]).to be_nil
-      expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
-      expect(event[:ip_address]).to eq("::1")
-      expect(event[:referrer]).to be_blank
-      expect(event[:session_id]).to be_present
-
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          find(".nav-item_categories a").click
-
-          try_until_success do
-            CachedCounting.flush
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 2,
-              "page_view_anon_browser_total" => 2,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 0,
-            )
-          end
+        try_until_success do
+          CachedCounting.flush
+          expect(ApplicationRequest.stats).to include(
+            "http_4xx_total" => 1,
+            "page_view_anon_total" => 1,
+            "page_view_anon_browser_total" => 1,
+            "page_view_logged_in_total" => 0,
+            "page_view_crawler_total" => 0,
+          )
         end
+      end
 
-      event_2 = events[0][:params].last
+      it "tracks published pages correctly" do
+        SiteSetting.enable_page_publishing = true
+        Fabricate(:published_page, public: true, slug: "some-page", topic: Fabricate(:post).topic)
 
-      expect(event_2[:user_id]).to be_nil
-      expect(event_2[:url]).to eq("#{Discourse.base_url_no_prefix}/categories")
-      expect(event_2[:ip_address]).to eq("::1")
-      expect(event_2[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
-      expect(event_2[:session_id]).to eq(event[:session_id])
-    end
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do
+            visit "/pub/some-page"
 
-    it "tracks a crawler visit correctly" do
-      # Can't change playwright user agent for now... so change site settings to make Discourse detect chrome as a crawler
-      SiteSetting.crawler_user_agents += "|chrome"
+            try_until_success do
+              CachedCounting.flush
 
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/"
-
-          try_until_success do
-            CachedCounting.flush
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 0,
-              "page_view_anon_browser_total" => 0,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 1,
-            )
+              # Does not count error as a pageview
+              expect(ApplicationRequest.stats).to include(
+                "page_view_anon_total" => 1,
+                "page_view_anon_browser_total" => 1,
+                "page_view_logged_in_total" => 0,
+                "page_view_crawler_total" => 0,
+              )
+            end
           end
-        end
 
-      expect(events).to be_blank
-    end
+        event = events[0][:params].last
 
-    it "tracks a logged-in session correctly" do
-      user = Fabricate(:user)
-      sign_in user
-
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/"
-
-          try_until_success do
-            CachedCounting.flush
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 0,
-              "page_view_anon_browser_total" => 0,
-              "page_view_logged_in_total" => 1,
-              "page_view_crawler_total" => 0,
-              "page_view_logged_in_browser_total" => 1,
-            )
-          end
-        end
-
-      event = events[0][:params].last
-
-      expect(event[:user_id]).to eq(user.id)
-      expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
-      expect(event[:ip_address]).to eq("::1")
-      expect(event[:referrer]).to be_blank
-      expect(event[:session_id]).to be_present
-      expect(event[:topic_id]).to be_blank
-
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          find(".nav-item_categories a").click
-          try_until_success do
-            CachedCounting.flush
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 0,
-              "page_view_anon_browser_total" => 0,
-              "page_view_logged_in_total" => 2,
-              "page_view_crawler_total" => 0,
-              "page_view_logged_in_browser_total" => 2,
-            )
-          end
-        end
-
-      event_2 = events[0][:params].last
-
-      expect(event_2[:user_id]).to eq(user.id)
-      expect(event_2[:url]).to eq("#{Discourse.base_url_no_prefix}/categories")
-      expect(event_2[:ip_address]).to eq("::1")
-      expect(event_2[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
-      expect(event_2[:session_id]).to eq(event[:session_id])
-    end
-
-    it "tracks normal error pages correctly" do
-      SiteSetting.bootstrap_error_pages = false
-
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/foobar"
-
-          try_until_success do
-            CachedCounting.flush
-
-            # Does not count error as a pageview
-            expect(ApplicationRequest.stats).to include(
-              "http_4xx_total" => 1,
-              "page_view_anon_total" => 0,
-              "page_view_anon_browser_total" => 0,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 0,
-            )
-          end
-        end
-
-      expect(events).to be_blank
-
-      click_logo
-
-      try_until_success do
-        CachedCounting.flush
-        expect(ApplicationRequest.stats).to include(
-          "http_4xx_total" => 1,
-          "page_view_anon_total" => 1,
-          "page_view_anon_browser_total" => 1,
-          "page_view_logged_in_total" => 0,
-          "page_view_crawler_total" => 0,
-        )
+        expect(event[:user_id]).to be_nil
+        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/pub/some-page")
+        expect(event[:ip_address]).to eq("::1")
+        expect(event[:referrer]).to be_blank
+        expect(event[:session_id]).to be_present
       end
     end
 
-    it "tracks non-ember pages correctly" do
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/safe-mode"
+    describe "topic views" do
+      fab!(:current_user, :user)
+      fab!(:topic)
+      fab!(:post) { Fabricate(:post, topic: topic) }
 
-          try_until_success do
-            CachedCounting.flush
+      context "when logged in" do
+        before { sign_in(current_user) }
 
-            # Does not count error as a pageview
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 1,
-              "page_view_anon_browser_total" => 1,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 0,
-            )
-          end
+        it "tracks user viewing a topic correctly with deferred tracking" do
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              visit topic.url
+
+              try_until_success do
+                CachedCounting.flush
+                expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
+                  true,
+                )
+                expect(
+                  TopicViewStat.exists?(
+                    topic_id: topic.id,
+                    viewed_at: Time.zone.now.to_date,
+                    anonymous_views: 0,
+                    logged_in_views: 1,
+                  ),
+                ).to eq(true)
+              end
+            end
+
+          event = events[0][:params].last
+
+          expect(event[:user_id]).to eq(current_user.id)
+          expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
+          expect(event[:ip_address]).to eq("::1")
+          expect(event[:referrer]).to be_blank
+          expect(event[:session_id]).to be_present
+          expect(event[:topic_id]).to eq(topic.id)
         end
 
-      event = events[0][:params].last
+        it "tracks user viewing a topic correctly with explicit tracking" do
+          visit "/"
 
-      expect(event[:user_id]).to be_nil
-      expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/safe-mode")
-      expect(event[:ip_address]).to eq("::1")
-      expect(event[:referrer]).to be_blank
-      expect(event[:session_id]).to be_present
-    end
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              find(".topic-list-item .raw-topic-link[data-topic-id='#{topic.id}']").click
 
-    it "tracks bootstrapped error pages correctly" do
-      SiteSetting.bootstrap_error_pages = true
+              try_until_success do
+                CachedCounting.flush
+                expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
+                  true,
+                )
+                expect(
+                  TopicViewStat.exists?(
+                    topic_id: topic.id,
+                    viewed_at: Time.zone.now.to_date,
+                    anonymous_views: 0,
+                    logged_in_views: 1,
+                  ),
+                ).to eq(true)
+              end
+            end
 
-      visit "/foobar"
+          # Find the event for the topic we navigated to (by topic_id) to avoid flakiness
+          # from potential timing issues with multiple events
+          event = events.find { |e| e[:params].last[:topic_id] == topic.id }&.dig(:params)&.last
+          expect(event).to be_present
 
-      try_until_success do
-        CachedCounting.flush
-
-        # Does not count error as a pageview
-        expect(ApplicationRequest.stats).to include(
-          "http_4xx_total" => 1,
-          "page_view_anon_total" => 0,
-          "page_view_anon_browser_total" => 0,
-          "page_view_logged_in_total" => 0,
-          "page_view_crawler_total" => 0,
-        )
+          expect(event[:user_id]).to eq(current_user.id)
+          expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
+          expect(event[:ip_address]).to eq("::1")
+          expect(event[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
+          expect(event[:session_id]).to be_present
+        end
       end
 
-      click_logo
+      context "when anonymous" do
+        it "tracks an anonymous user viewing a topic correctly with deferred tracking" do
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              visit topic.url
 
-      try_until_success do
-        CachedCounting.flush
-        expect(ApplicationRequest.stats).to include(
-          "http_4xx_total" => 1,
-          "page_view_anon_total" => 1,
-          "page_view_anon_browser_total" => 1,
-          "page_view_logged_in_total" => 0,
-          "page_view_crawler_total" => 0,
-        )
-      end
-    end
+              try_until_success do
+                CachedCounting.flush
+                expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
+                expect(
+                  TopicViewStat.exists?(
+                    topic_id: topic.id,
+                    viewed_at: Time.zone.now.to_date,
+                    anonymous_views: 1,
+                    logged_in_views: 0,
+                  ),
+                ).to eq(true)
+              end
+            end
 
-    it "tracks published pages correctly" do
-      SiteSetting.enable_page_publishing = true
-      Fabricate(:published_page, public: true, slug: "some-page", topic: Fabricate(:post).topic)
+          event = events[0][:params].last
 
-      events =
-        DiscourseEvent.track_events(:browser_pageview) do
-          visit "/pub/some-page"
-
-          try_until_success do
-            CachedCounting.flush
-
-            # Does not count error as a pageview
-            expect(ApplicationRequest.stats).to include(
-              "page_view_anon_total" => 1,
-              "page_view_anon_browser_total" => 1,
-              "page_view_logged_in_total" => 0,
-              "page_view_crawler_total" => 0,
-            )
-          end
+          expect(event[:user_id]).to be_blank
+          expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
+          expect(event[:ip_address]).to eq("::1")
+          expect(event[:referrer]).to be_blank
+          expect(event[:session_id]).to be_present
         end
 
-      event = events[0][:params].last
+        it "tracks an anonymous user viewing a topic correctly with explicit tracking" do
+          visit "/"
 
-      expect(event[:user_id]).to be_nil
-      expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/pub/some-page")
-      expect(event[:ip_address]).to eq("::1")
-      expect(event[:referrer]).to be_blank
-      expect(event[:session_id]).to be_present
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              find(".topic-list-item .raw-topic-link[data-topic-id='#{topic.id}']").click
+
+              try_until_success do
+                CachedCounting.flush
+                expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
+                expect(
+                  TopicViewStat.exists?(
+                    topic_id: topic.id,
+                    viewed_at: Time.zone.now.to_date,
+                    anonymous_views: 1,
+                    logged_in_views: 0,
+                  ),
+                ).to eq(true)
+              end
+            end
+
+          # Find the event for the topic we navigated to (by topic_id) to avoid flakiness
+          # from potential timing issues with multiple events
+          event = events.find { |e| e[:params].last[:topic_id] == topic.id }&.dig(:params)&.last
+          expect(event).to be_present
+
+          expect(event[:user_id]).to be_blank
+          expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
+          expect(event[:ip_address]).to eq("::1")
+          expect(event[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
+          expect(event[:session_id]).to be_present
+        end
+      end
     end
   end
 
-  describe "topic views" do
-    fab!(:current_user, :user)
-    fab!(:topic)
-    fab!(:post) { Fabricate(:post, topic: topic) }
+  context "with beacon_browser_page_view disabled (header-based tracking)" do
+    before { SiteSetting.beacon_browser_page_view = false }
 
-    context "when logged in" do
-      before { sign_in(current_user) }
+    include_examples "tracks pageviews and topic views"
+  end
 
-      it "tracks user viewing a topic correctly with deferred tracking" do
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            visit topic.url
+  context "with beacon_browser_page_view enabled (fetch beacon)" do
+    before { SiteSetting.beacon_browser_page_view = true }
 
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
-                true,
-              )
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 0,
-                  logged_in_views: 1,
-                ),
-              ).to eq(true)
-            end
-          end
-
-        event = events[0][:params].last
-
-        expect(event[:user_id]).to eq(current_user.id)
-        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
-        expect(event[:ip_address]).to eq("::1")
-        expect(event[:referrer]).to be_blank
-        expect(event[:session_id]).to be_present
-        expect(event[:topic_id]).to eq(topic.id)
-      end
-
-      it "tracks user viewing a topic correctly with explicit tracking" do
-        visit "/"
-
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            find(".topic-list-item .raw-topic-link[data-topic-id='#{topic.id}']").click
-
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
-                true,
-              )
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 0,
-                  logged_in_views: 1,
-                ),
-              ).to eq(true)
-            end
-          end
-
-        # Find the event for the topic we navigated to (by topic_id) to avoid flakiness
-        # from potential timing issues with multiple events
-        event = events.find { |e| e[:params].last[:topic_id] == topic.id }&.dig(:params)&.last
-        expect(event).to be_present
-
-        expect(event[:user_id]).to eq(current_user.id)
-        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
-        expect(event[:ip_address]).to eq("::1")
-        expect(event[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
-        expect(event[:session_id]).to be_present
-      end
-    end
-
-    context "when anonymous" do
-      it "tracks an anonymous user viewing a topic correctly with deferred tracking" do
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            visit topic.url
-
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 1,
-                  logged_in_views: 0,
-                ),
-              ).to eq(true)
-            end
-          end
-
-        event = events[0][:params].last
-
-        expect(event[:user_id]).to be_blank
-        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
-        expect(event[:ip_address]).to eq("::1")
-        expect(event[:referrer]).to be_blank
-        expect(event[:session_id]).to be_present
-      end
-
-      it "tracks an anonymous user viewing a topic correctly with explicit tracking" do
-        visit "/"
-
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            find(".topic-list-item .raw-topic-link[data-topic-id='#{topic.id}']").click
-
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 1,
-                  logged_in_views: 0,
-                ),
-              ).to eq(true)
-            end
-          end
-
-        # Find the event for the topic we navigated to (by topic_id) to avoid flakiness
-        # from potential timing issues with multiple events
-        event = events.find { |e| e[:params].last[:topic_id] == topic.id }&.dig(:params)&.last
-        expect(event).to be_present
-
-        expect(event[:user_id]).to be_blank
-        expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/t/#{topic.slug}/#{topic.id}")
-        expect(event[:ip_address]).to eq("::1")
-        expect(event[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
-        expect(event[:session_id]).to be_present
-      end
-    end
+    include_examples "tracks pageviews and topic views"
   end
 end


### PR DESCRIPTION
Previously, browser page views were tracked by injecting `Discourse-Track-View*` headers onto unrelated AJAX and MessageBus requests. This spread tracking logic across `ajax.js` and `message-bus.js`, and meant pageview data was invisible in request logs.

This replaces that with a dedicated `POST /pageview` fetch call using `keepalive: true`.