### PR TITLE
FEAT: Add optional email field to DiscourseConnect Provider response

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2012,6 +2012,7 @@ en:
     discourse_connect_url: "URL of DiscourseConnect endpoint (must include http:// or https://, and must not include a trailing slash)"
     discourse_connect_secret: "Secret string used to cryptographically authenticate DiscourseConnect information, be sure it is 10 characters or longer"
     discourse_connect_provider_secrets: "A list of domain-secret pairs that are using DiscourseConnect. Make sure DiscourseConnect secret is 10 characters or longer. Wildcard symbol * can be used to match any domain or only a part of it (e.g. *.example.com)."
+    discourse_connect_provider_provides_email: "Include user email in DiscourseConnect Provider response"
     discourse_connect_overrides_bio: "Overrides user bio in user profile and prevents user from changing it"
     discourse_connect_overrides_groups: "Synchronize all manual group membership with groups specified in the groups attribute (WARNING: if you do not specify groups all manual group membership will be cleared for user)"
     auth_overrides_email: "Overrides local email with external site email on every login, and prevent local changes. Applies to all authentication providers. (WARNING: discrepancies can occur due to normalization of local emails)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -865,6 +865,9 @@ login:
       key: "sso_provider.key_placeholder"
       value: "sso_provider.value_placeholder"
     area: "discourseconnect"
+  discourse_connect_provider_provides_email:
+    default: true
+    area: "discourseconnect"
   blocked_email_domains:
     default: "mailinator.com"
     type: host_list

--- a/lib/second_factor/actions/discourse_connect_provider.rb
+++ b/lib/second_factor/actions/discourse_connect_provider.rb
@@ -74,7 +74,7 @@ module SecondFactor::Actions
     def populate_user_data(sso)
       sso.name = current_user.name
       sso.username = current_user.username
-      sso.email = current_user.email
+      sso.email = current_user.email if SiteSetting.discourse_connect_provider_provides_email
       sso.external_id = current_user.id.to_s
       sso.admin = current_user.admin?
       sso.moderator = current_user.moderator?


### PR DESCRIPTION
Adds a new site setting `discourse_connect_provider_provides_email` (default: true) to control whether user email is included in the SSO redirect URL. This maintains backward compatibility while allowing admins to disable email exposure for privacy reasons.

See: https://meta.discourse.org/t/security-privacy-concern-email-exposed-in-discourseconnect-provider-redirect-url/397980