### PR TITLE
Zulip: Update terminology and add per-thread topic mapping

### DIFF
--- a/plugins/discourse-chat-integration/admin/assets/javascripts/admin/components/modal/edit-channel.gjs
+++ b/plugins/discourse-chat-integration/admin/assets/javascripts/admin/components/modal/edit-channel.gjs
@@ -15,7 +15,7 @@ export default class EditChannel extends Component {
       const value = this.args.model.channel.get(`data.${param.key}`);
 
       if (!value?.trim()) {
-        return false;
+        return param.required === false;
       }
 
       if (!param.regex) {

--- a/plugins/discourse-chat-integration/app/models/channel.rb
+++ b/plugins/discourse-chat-integration/app/models/channel.rb
@@ -43,7 +43,10 @@ class DiscourseChatIntegration::Channel < DiscourseChatIntegration::PluginModel
 
     params = DiscourseChatIntegration::Provider.get_by_name(provider)::CHANNEL_PARAMETERS
 
-    unless params.map { |p| p[:key] }.sort == data.keys.sort
+    required_params = params.reject { |p| p[:required] == false }
+    optional_params = params.select { |p| p[:required] == false }
+    unless required_params.map { |p| p[:key] }.sort ==
+             (data.keys - optional_params.map { |p| p[:key] }).sort
       errors.add(:data, "data does not match the required structure for provider #{provider}")
       return
     end
@@ -52,7 +55,10 @@ class DiscourseChatIntegration::Channel < DiscourseChatIntegration::PluginModel
     matching_channels = DiscourseChatIntegration::Channel.with_provider(provider).where.not(id: id)
 
     data.each do |key, value|
-      regex_string = params.find { |p| p[:key] == key }[:regex]
+      param = params.find { |p| p[:key] == key }
+      next if param.nil?
+      next if param[:required] == false && value.blank?
+      regex_string = param[:regex]
       if regex_string.present? && !Regexp.new(regex_string).match?(value)
         errors.add(:data, "data.#{key} is invalid")
       end

--- a/plugins/discourse-chat-integration/config/locales/client.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/client.en.yml
@@ -160,14 +160,14 @@ en:
         zulip:
           title: "Zulip"
           param:
-            stream:
-              title: "Stream"
-              help: "The name of the Zulip stream the message should be sent to. e.g. 'general'"
-            subject:
-              title: "Subject"
-              help: "The subject that these messages sent by the bot should be given"
+            channel:
+              title: "Channel"
+              help: "The name of the Zulip channel the message should be sent to. e.g. 'general'"
+            topic:
+              title: "Topic"
+              help: "The topic that these messages sent by the bot should be given. If left blank, the Discourse thread title will be used."
           errors:
-            does_not_exist: "That stream does not exist on Zulip"
+            does_not_exist: "That channel does not exist on Zulip"
 
         #######################################
         ######## ROCKET CHAT STRINGS ##########

--- a/plugins/discourse-chat-integration/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/plugins/discourse-chat-integration/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -63,7 +63,7 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
           "mattermost" => "identifier",
           "matrix" => "name",
           "teams" => "name",
-          "zulip" => "stream",
+          "zulip" => "channel",
           "powerautomate" => "name",
           "rocketchat" => "identifier",
           "gitter" => "name",

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -5,10 +5,10 @@ module DiscourseChatIntegration
     module ZulipProvider
       PROVIDER_NAME = "zulip"
       PROVIDER_ENABLED_SETTING = :chat_integration_zulip_enabled
-      CHANNEL_IDENTIFIER_KEY = "stream"
+      CHANNEL_IDENTIFIER_KEY = "channel"
       CHANNEL_PARAMETERS = [
-        { key: "stream", unique: true, regex: '^\S+' },
-        { key: "subject", unique: true, regex: '^\S+' },
+        { key: "channel", unique: true, regex: '^\S+' },
+        { key: "topic", unique: false, regex: '^\S+', required: false },
       ]
 
       def self.send_message(message)
@@ -29,7 +29,7 @@ module DiscourseChatIntegration
         response
       end
 
-      def self.generate_zulip_message(post, stream, subject)
+      def self.generate_zulip_message(post, channel, topic)
         display_name = DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         message =
@@ -47,14 +47,14 @@ module DiscourseChatIntegration
               ),
           )
 
-        data = { type: "stream", to: stream, subject: subject, content: message }
+        data = { type: "stream", to: channel, topic: topic, content: message }
       end
 
       def self.trigger_notification(post, channel, rule)
-        stream = channel.data["stream"]
-        subject = channel.data["subject"]
+        channel_name = channel.data["channel"]
+        topic = channel.data["topic"].presence || post.topic.title
 
-        message = self.generate_zulip_message(post, stream, subject)
+        message = self.generate_zulip_message(post, channel_name, topic)
 
         response = send_message(message)
 

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/zulip/zulip_provider_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/zulip/zulip_provider_spec.rb
@@ -15,15 +15,37 @@ RSpec.describe DiscourseChatIntegration::Provider::ZulipProvider do
       DiscourseChatIntegration::Channel.create!(
         provider: "zulip",
         data: {
-          stream: "general",
-          subject: "Discourse Notifications",
+          channel: "general",
+          topic: "Discourse Notifications",
         },
       )
+    end
+
+    let(:chan_no_topic) do
+      DiscourseChatIntegration::Channel.create!(provider: "zulip", data: { channel: "general" })
     end
 
     it "sends a webhook request" do
       stub1 = stub_request(:post, "https://hello.world/api/v1/messages").to_return(status: 200)
       described_class.trigger_notification(post, chan1, nil)
+      expect(stub1).to have_been_requested.once
+    end
+
+    it "uses the fixed topic when configured" do
+      stub1 =
+        stub_request(:post, "https://hello.world/api/v1/messages").with(
+          body: hash_including("topic" => "Discourse Notifications"),
+        ).to_return(status: 200)
+      described_class.trigger_notification(post, chan1, nil)
+      expect(stub1).to have_been_requested.once
+    end
+
+    it "uses the Discourse thread title as topic when no topic is configured" do
+      stub1 =
+        stub_request(:post, "https://hello.world/api/v1/messages").with(
+          body: hash_including("topic" => post.topic.title),
+        ).to_return(status: 200)
+      described_class.trigger_notification(post, chan_no_topic, nil)
       expect(stub1).to have_been_requested.once
     end
 
@@ -47,8 +69,8 @@ RSpec.describe DiscourseChatIntegration::Provider::ZulipProvider do
         DiscourseChatIntegration::Channel.create!(
           provider: "zulip",
           data: {
-            stream: "foo",
-            subject: "Discourse Notifications",
+            channel: "foo",
+            topic: "Discourse Notifications",
           },
         )
       channel = described_class.get_channel_by_name("foo")


### PR DESCRIPTION
## Zulip: Update terminology and add per-thread topic mapping

### Terminology update
- Replaces all occurrences of `stream` and `subject` with `channel` and `topic` respectively in user-facing parts
  of the Zulip integration, to match current Zulip terminology.

### Per-thread topic mapping
- Makes the `topic` field optional in channel settings.
- When a fixed topic is configured, it is used as before.
- When the topic field is left blank, the Discourse thread title is
  automatically used as the Zulip topic, mapping each Discourse thread to its own Zulip topic.

### Optional parameter support in Channel model
- Updates `channel.rb` to support `required: false` on channel parameters,
  skipping validation for optional parameters when left blank.
- Updates `edit-channel.gjs` frontend validation to allow saving a channel
  when optional parameters are left blank.

## Motivation
Zulip has updated its terminology: `streams` are now called `channels` and `subjects` are now called `topics`. This PR updates the integration to reflect that.

The per-thread topic mapping was requested in this [comment](https://meta.discourse.org/t/discourse-chat-integration/66522/309).

This PR is part of the work tracked in: [#33769](https://github.com/zulip/zulip/issues/33769#issuecomment-4020150075)

## Testing
- Syntax verified via `ruby -c` on all changed files.
- Spec file updated to reflect new keys (`channel`, `topic`) and includes
  tests for both fixed topic and thread-title fallback behavior,
  with request body assertions to verify the correct topic is sent.
- Full test suite requires a Discourse development environment to run.
