### PR TITLE
FEAT: add all_day option to calendar events

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -174,6 +174,7 @@ module DiscoursePostEvent
 
     def format_time(event, time)
       return nil unless time
+      return time.utc.strftime("%Y-%m-%d") if event.all_day
 
       if event.show_local_time
         time.in_time_zone(event.timezone).strftime("%Y-%m-%dT%H:%M:%S")

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -139,7 +139,7 @@ module DiscoursePostEvent
     def on_going_event_invitees
       return [] if self.starts_at.nil? # Can't determine ongoing status without start time
       if !self.ends_at && self.starts_at < Time.now &&
-           (!self.all_day || self.starts_at.end_of_day > Time.now)
+           (!self.all_day || self.starts_at.end_of_day <= Time.now)
         return []
       end
 

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -435,7 +435,8 @@ module DiscoursePostEvent
       next_starts_at = calculate_next_recurring_date
       return nil unless next_starts_at
 
-      event_duration = original_ends_at ? original_ends_at - original_starts_at : 3600
+      event_duration =
+        original_ends_at ? original_ends_at - original_starts_at : (all_day ? 86_400 : 3600)
       next_ends_at = next_starts_at + event_duration
       [next_starts_at, next_ends_at]
     end
@@ -449,7 +450,8 @@ module DiscoursePostEvent
       next_starts_at = calculate_next_recurring_date_from(from_time)
       return nil unless next_starts_at
 
-      event_duration = original_ends_at ? original_ends_at - original_starts_at : 3600
+      event_duration =
+        original_ends_at ? original_ends_at - original_starts_at : (all_day ? 86_400 : 3600)
       next_ends_at = next_starts_at + event_duration
       { starts_at: next_starts_at, ends_at: next_ends_at }
     end

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -138,7 +138,10 @@ module DiscoursePostEvent
 
     def on_going_event_invitees
       return [] if self.starts_at.nil? # Can't determine ongoing status without start time
-      return [] if !self.ends_at && !self.all_day && self.starts_at < Time.now
+      if !self.ends_at && self.starts_at < Time.now &&
+           (!self.all_day || self.starts_at.end_of_day > Time.now)
+        return []
+      end
 
       if self.ends_at
         extended_ends_at =

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -133,7 +133,7 @@ module DiscoursePostEvent
 
     def on_going_event_invitees
       return [] if self.starts_at.nil? # Can't determine ongoing status without start time
-      return [] if !self.ends_at && self.starts_at < Time.now
+      return [] if !self.ends_at && !self.all_day && self.starts_at < Time.now
 
       if self.ends_at
         extended_ends_at =
@@ -329,6 +329,19 @@ module DiscoursePostEvent
         parsed_recurrence_until =
           event_params[:"recurrence-until"] ? tz.parse(event_params[:"recurrence-until"]) : nil
 
+        parsed_all_day = event_params[:"all-day"] == "true"
+        if parsed_all_day
+          parsed_starts_at = Time.utc(*event_params[:start].split("-").map(&:to_i))
+          parsed_ends_at =
+            (
+              if event_params[:end]
+                Time.utc(*event_params[:end].split("-").map(&:to_i)).end_of_day
+              else
+                nil
+              end
+            )
+        end
+
         params = {
           name: event_params[:name],
           original_starts_at: parsed_starts_at,
@@ -347,6 +360,7 @@ module DiscoursePostEvent
           closed: event_params[:closed] || false,
           chat_enabled: event_params[:"chat-enabled"]&.downcase == "true",
           max_attendees: event_params[:"max-attendees"]&.to_i,
+          all_day: parsed_all_day,
         }
 
         params[:custom_fields] = {}

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -52,6 +52,11 @@ module DiscoursePostEvent
           topic_id: self.post.topic_id,
           name: TOPIC_POST_EVENT_ENDS_AT,
         ).delete_all
+
+        TopicCustomField.where(
+          topic_id: self.post.topic_id,
+          name: TOPIC_POST_EVENT_ALL_DAY,
+        ).delete_all
       end
     end
 

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -577,4 +577,5 @@ end
 #  recurrence_until   :datetime
 #  show_local_time    :boolean          default(FALSE), not null
 #  max_attendees      :integer
+#  all_day            :boolean          default(FALSE), not null
 #

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
@@ -20,7 +20,7 @@ module DiscoursePostEvent
       SQL
     end
 
-    after_commit :upsert_topic_custom_field, on: %i[create]
+    after_commit :upsert_topic_custom_field, on: %i[create update]
     def upsert_topic_custom_field
       if self.event.post && self.event.post.is_first_post?
         TopicCustomField.upsert(

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
@@ -44,6 +44,17 @@ module DiscoursePostEvent
           },
           unique_by: "idx_topic_custom_fields_topic_post_event_ends_at",
         )
+
+        TopicCustomField.upsert(
+          {
+            topic_id: self.event.post.topic_id,
+            name: TOPIC_POST_EVENT_ALL_DAY,
+            value: self.event.all_day || false,
+            created_at: Time.now,
+            updated_at: Time.now,
+          },
+          unique_by: "idx_topic_custom_fields_topic_post_event_all_day",
+        )
       end
     end
 

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -14,7 +14,8 @@ module DiscoursePostEvent
                :timezone,
                :post,
                :duration,
-               :occurrences
+               :occurrences,
+               :all_day
 
     def category_id
       object.post.topic.category_id
@@ -62,6 +63,8 @@ module DiscoursePostEvent
     end
 
     def starts_at
+      return object.starts_at&.utc&.strftime("%Y-%m-%d") if object.all_day
+
       if object.recurring? && object.recurrence_until.present? &&
            object.recurrence_until < Time.current
         return nil
@@ -77,6 +80,8 @@ module DiscoursePostEvent
     end
 
     def ends_at
+      return object.ends_at&.utc&.strftime("%Y-%m-%d") if object.all_day
+
       if object.recurring? && object.recurrence_until.present? &&
            object.recurrence_until < Time.current
         return nil

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -167,6 +167,26 @@ export default class DiscoursePostEventDates extends Component {
       return;
     }
 
+    if (this.args.event.allDay) {
+      const start = moment(this.args.event.startsAt, "YYYY-MM-DD");
+      const includeStartYear = !start.isSame(moment(), "year");
+      const startFormat = includeStartYear ? "ddd, MMM D, YYYY" : "ddd, MMM D";
+      let dates = start.format(startFormat);
+
+      if (this.args.event.endsAt) {
+        const end = moment(this.args.event.endsAt, "YYYY-MM-DD");
+        if (!end.isSame(start, "day")) {
+          const includeEndYear =
+            !end.isSame(moment(), "year") || !end.isSame(start, "year");
+          const endFormat = includeEndYear ? "ddd, MMM D, YYYY" : "ddd, MMM D";
+          dates += ` → ${end.format(endFormat)}`;
+        }
+      }
+
+      this.htmlDates = htmlSafe(dates);
+      return;
+    }
+
     if (this.siteSettings.discourse_local_dates_enabled) {
       const bbcode = this.datesBBCode.join("<span> → </span>");
       const result = await cook(bbcode);

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/dates.gjs
@@ -183,7 +183,7 @@ export default class DiscoursePostEventDates extends Component {
         }
       }
 
-      this.htmlDates = htmlSafe(dates);
+      this.htmlDates = trustHTML(dates);
       return;
     }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -54,7 +54,9 @@ export default class DiscoursePostEvent extends Component {
   });
 
   getDisplayTime(time) {
-    if (this.event.showLocalTime) {
+    if (this.event.allDay) {
+      return moment(time, "YYYY-MM-DD");
+    } else if (this.event.showLocalTime) {
       return moment.tz(time, this.event.timezone || "UTC");
     } else {
       return moment

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/event-date.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/event-date.gjs
@@ -99,6 +99,9 @@ export default class EventDate extends Component {
   }
 
   _parsedDate(date) {
+    if (this.args.topic.event_all_day) {
+      return moment(date, "YYYY-MM-DD");
+    }
     const timezone = this.args.topic.event_show_local_time
       ? this.args.topic.event_timezone
       : moment.tz.guess();

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -32,14 +32,30 @@ export default class PostEventBuilder extends Component {
   @tracked isSaving = false;
   @tracked maxAttendeesInput = this.args.model.event.maxAttendees;
 
-  @tracked startsAt = moment(this.event.startsAt).tz(
-    this.event.timezone || "UTC"
-  );
+  @tracked allDay = this.event.allDay || false;
+  @tracked startsAt = this.#initStartsAt();
+  @tracked endsAt = this.#initEndsAt();
 
-  @tracked
-  endsAt =
-    this.event.endsAt &&
-    moment(this.event.endsAt).tz(this.event.timezone || "UTC");
+  #initStartsAt() {
+    if (this.event.allDay) {
+      return moment(this.event.startsAt, "YYYY-MM-DD");
+    }
+    return moment(this.event.startsAt).tz(this.event.timezone || "UTC");
+  }
+
+  #initEndsAt() {
+    if (!this.event.endsAt) {
+      return null;
+    }
+    if (this.event.allDay) {
+      return moment(this.event.endsAt, "YYYY-MM-DD");
+    }
+    return moment(this.event.endsAt).tz(this.event.timezone || "UTC");
+  }
+
+  get showTime() {
+    return !this.allDay;
+  }
 
   get isEditing() {
     return this.args.model.event.id || this.args.model.onUpdate;
@@ -195,6 +211,21 @@ export default class PostEventBuilder extends Component {
     this.event.endsAt = dates.to;
     this.startsAt = dates.from;
     this.endsAt = dates.to;
+  }
+
+  @action
+  setAllDay(e) {
+    this.allDay = e.target.checked;
+    this.event.allDay = e.target.checked;
+    if (e.target.checked) {
+      // snap times to start/end of day in the event's timezone
+      if (this.startsAt) {
+        this.startsAt = this.startsAt.clone().startOf("day");
+      }
+      if (this.endsAt) {
+        this.endsAt = this.endsAt.clone().endOf("day");
+      }
+    }
   }
 
   @action
@@ -385,7 +416,27 @@ export default class PostEventBuilder extends Component {
                   @to={{this.endsAt}}
                   @timezone={{@model.event.timezone}}
                   @onChange={{this.onChangeDates}}
+                  @showFromTime={{this.showTime}}
+                  @showToTime={{this.showTime}}
                 />
+              </EventField>
+
+              <EventField
+                @label="discourse_post_event.builder_modal.all_day.label"
+                class="all-day"
+              >
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={{this.allDay}}
+                    {{on "input" this.setAllDay}}
+                  />
+                  <span class="message">
+                    {{i18n
+                      "discourse_post_event.builder_modal.all_day.description"
+                    }}
+                  </span>
+                </label>
               </EventField>
 
               <EventField

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -88,12 +88,22 @@ export default class UpcomingEventsCalendar extends Component {
         backgroundColor = `#${categoryColor}`;
       }
 
+      const isAllDay =
+        event.allDay || !isNotFullDayEvent(moment(startsAt), moment(endsAt));
+
+      // FullCalendar treats end as exclusive for allDay events,
+      // so add one day to make the end date inclusive
+      let calendarEnd = endsAt || startsAt;
+      if (isAllDay && calendarEnd) {
+        calendarEnd = moment(calendarEnd).add(1, "day").format("YYYY-MM-DD");
+      }
+
       return {
         extendedProps: { postEvent: event },
         title: formatEventName(event, this.currentUser?.user_option?.timezone),
         start: startsAt,
-        end: endsAt || startsAt,
-        allDay: !isNotFullDayEvent(moment(startsAt), moment(endsAt)),
+        end: calendarEnd,
+        allDay: isAllDay,
         url: getURL(`/t/-/${post?.topic?.id}/${post?.post_number}`),
         backgroundColor,
       };

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -163,8 +163,14 @@ export default class UpcomingEventsList extends Component {
   }
 
   formatDateRange(event) {
-    const start = new Date(event.starts_at);
-    const end = new Date(event.ends_at);
+    // Date-only strings (all-day events) must be parsed as local dates;
+    // new Date("YYYY-MM-DD") treats them as UTC, shifting the day in western timezones
+    const start = event.all_day
+      ? new Date(event.starts_at + "T00:00:00")
+      : new Date(event.starts_at);
+    const end = event.all_day
+      ? new Date(event.ends_at + "T00:00:00")
+      : new Date(event.ends_at);
     return new Intl.DateTimeFormat(moment.locale(), {
       month: "long",
       day: "numeric",

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -3,7 +3,9 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
 
   const eventTz = event.timezone || "UTC";
 
-  params.start = moment(startsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
+  params.start = event.allDay
+    ? moment(startsAt).format("YYYY-MM-DD")
+    : moment(startsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
 
   if (event.isClosed) {
     params.closed = "true";
@@ -59,8 +61,14 @@ export function buildParams(startsAt, endsAt, event, siteSettings) {
     params.maxAttendees = `${event.maxAttendees}`;
   }
 
+  if (event.allDay) {
+    params.allDay = "true";
+  }
+
   if (endsAt) {
-    params.end = moment(endsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
+    params.end = event.allDay
+      ? moment(endsAt).format("YYYY-MM-DD")
+      : moment(endsAt).tz(eventTz).format("YYYY-MM-DD HH:mm");
   }
 
   if (event.status === "private") {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -29,6 +29,7 @@ export default class DiscoursePostEventEvent {
   @tracked categoryId;
   @tracked startsAt;
   @tracked endsAt;
+  @tracked allDay;
   @tracked duration;
   @tracked rawInvitees;
   @tracked location;
@@ -66,6 +67,7 @@ export default class DiscoursePostEventEvent {
     this.categoryId = args.category_id;
     this.startsAt = args.starts_at;
     this.endsAt = args.ends_at;
+    this.allDay = args.all_day || false;
     this.duration = args.duration;
     this.rawInvitees = args.raw_invitees;
     this.sampleInvitees = args.sample_invitees || [];
@@ -154,6 +156,7 @@ export default class DiscoursePostEventEvent {
     this.name = event.name;
     this.startsAt = event.startsAt;
     this.endsAt = event.endsAt;
+    this.allDay = event.allDay;
     this.duration = event.duration;
     this.location = event.location;
     this.url = event.url;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -20,6 +20,7 @@ export const EVENT_ATTRIBUTES = {
   recurrence: { default: null },
   recurrenceUntil: { default: null },
   chatEnabled: { default: null },
+  allDay: { default: null },
 };
 
 /** @type {RichEditorExtension} */

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -455,6 +455,9 @@ en:
         timezone:
           label: Timezone
           remove_timezone: No timezone (UTC)
+        all_day:
+          label: "All day event"
+          description: "An all-day event will not have specific times, just a date. The event will run from the start of the day to the end of the day."
         reminders:
           label: "Reminders"
           types:

--- a/plugins/discourse-calendar/db/migrate/20260311021412_add_all_day_to_discourse_post_event_events.rb
+++ b/plugins/discourse-calendar/db/migrate/20260311021412_add_all_day_to_discourse_post_event_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllDayToDiscoursePostEventEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :discourse_post_event_events, :all_day, :boolean, default: false, null: false
+  end
+end

--- a/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
+++ b/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
@@ -6,6 +6,6 @@ class AddTopicCustomFieldAllDayIndex < ActiveRecord::Migration[8.0]
               %i[name topic_id],
               name: :idx_topic_custom_fields_topic_post_event_all_day,
               unique: true,
-              where: "name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY}'"
+              where: "name = 'TopicEventAllDay'"
   end
 end

--- a/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
+++ b/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddTopicCustomFieldAllDayIndex < ActiveRecord::Migration[7.2]
+class AddTopicCustomFieldAllDayIndex < ActiveRecord::Migration[8.0]
   def change
     add_index :topic_custom_fields,
               %i[name topic_id],

--- a/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
+++ b/plugins/discourse-calendar/db/migrate/20260311161955_add_topic_custom_field_all_day_index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddTopicCustomFieldAllDayIndex < ActiveRecord::Migration[7.2]
+  def change
+    add_index :topic_custom_fields,
+              %i[name topic_id],
+              name: :idx_topic_custom_fields_topic_post_event_all_day,
+              unique: true,
+              where: "name = '#{DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY}'"
+  end
+end

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
@@ -19,6 +19,7 @@ module DiscoursePostEvent
       :closed,
       :"chat-enabled",
       :"max-attendees",
+      :"all-day",
     ]
 
     def self.extract_events(post)

--- a/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
@@ -27,7 +27,7 @@ module DiscoursePostEvent
         parsed_starts_at =
           (
             if calendar_event.all_day
-              calendar_event.starts_at.strftime("%Y-%m-%d")
+              calendar_event.starts_at&.utc&.strftime("%Y-%m-%d")
             else
               calendar_event.starts_at
             end
@@ -35,7 +35,7 @@ module DiscoursePostEvent
         parsed_ends_at =
           (
             if calendar_event.all_day
-              calendar_event.ends_at&.strftime("%Y-%m-%d")
+              calendar_event.ends_at&.utc&.strftime("%Y-%m-%d")
             else
               calendar_event.ends_at
             end

--- a/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
@@ -24,6 +24,23 @@ module DiscoursePostEvent
         post = calendar_event.post
         topic = post&.topic
 
+        parsed_starts_at =
+          (
+            if calendar_event.all_day
+              calendar_event.starts_at.strftime("%Y-%m-%d")
+            else
+              calendar_event.starts_at
+            end
+          )
+        parsed_ends_at =
+          (
+            if calendar_event.all_day
+              calendar_event.ends_at.strftime("%Y-%m-%d")
+            else
+              calendar_event.ends_at
+            end
+          )
+
         {
           event: {
             id: calendar_event.id,
@@ -32,8 +49,9 @@ module DiscoursePostEvent
             location: calendar_event.location,
             url: calendar_event.url,
             status: DiscoursePostEvent::Event.statuses[calendar_event.status]&.to_s,
-            starts_at: calendar_event.starts_at,
-            ends_at: calendar_event.ends_at,
+            starts_at: parsed_starts_at,
+            ends_at: parsed_ends_at,
+            all_day: calendar_event.all_day,
             recurrence: calendar_event.recurrence,
             recurrence_until: calendar_event.recurrence_until,
             timezone: calendar_event.timezone,

--- a/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/web_hook_extension.rb
@@ -35,7 +35,7 @@ module DiscoursePostEvent
         parsed_ends_at =
           (
             if calendar_event.all_day
-              calendar_event.ends_at.strftime("%Y-%m-%d")
+              calendar_event.ends_at&.strftime("%Y-%m-%d")
             else
               calendar_event.ends_at
             end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -73,6 +73,7 @@ module ::DiscoursePostEvent
   # Topic where op has a post event custom field
   TOPIC_POST_EVENT_STARTS_AT = "TopicEventStartsAt"
   TOPIC_POST_EVENT_ENDS_AT = "TopicEventEndsAt"
+  TOPIC_POST_EVENT_ALL_DAY = "TopicEventAllDay"
 end
 
 require_relative "lib/discourse_calendar/engine"
@@ -315,6 +316,35 @@ after_initialize do
         SiteSetting.display_post_event_date_on_topic_title && object.event_ends_at
     end,
   ) { object.event_ends_at }
+
+  add_preloaded_topic_list_custom_field DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY
+
+  add_to_serializer(
+    :topic_view,
+    :event_all_day,
+    include_condition: -> do
+      SiteSetting.discourse_post_event_enabled &&
+        SiteSetting.display_post_event_date_on_topic_title &&
+        object.topic.custom_fields.keys.include?(DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY)
+    end,
+  ) { object.topic.event_all_day }
+
+  add_to_class(:topic, :event_all_day) do
+    @event_all_day ||=
+      begin
+        value = custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY].to_s
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+  end
+
+  add_to_serializer(
+    :topic_list_item,
+    :event_all_day,
+    include_condition: -> do
+      SiteSetting.discourse_post_event_enabled &&
+        SiteSetting.display_post_event_date_on_topic_title && object.event_all_day
+    end,
+  ) { object.event_all_day }
 
   add_to_serializer(
     :topic_view,

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -324,13 +324,13 @@ after_initialize do
     :event_all_day,
     include_condition: -> do
       SiteSetting.discourse_post_event_enabled &&
-        SiteSetting.display_post_event_date_on_topic_title &&
-        object.topic.custom_fields.keys.include?(DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY)
+        SiteSetting.display_post_event_date_on_topic_title && object.topic.event_all_day
     end,
   ) { object.topic.event_all_day }
 
   add_to_class(:topic, :event_all_day) do
-    @event_all_day ||=
+    return @event_all_day if defined?(@event_all_day)
+    @event_all_day =
       begin
         value = custom_fields[DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY].to_s
         ActiveModel::Type::Boolean.new.cast(value)

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_date_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_date_spec.rb
@@ -34,4 +34,38 @@ describe DiscoursePostEvent::EventDate do
       end
     end
   end
+
+  describe "Topic custom fields" do
+    it "writes TopicEventAllDay custom field for all-day events" do
+      all_day_post = Fabricate(:post, topic: Fabricate(:topic, user: user))
+      event =
+        Fabricate(
+          :event,
+          post: all_day_post,
+          original_starts_at: "2020-04-25 00:00:00 UTC",
+          original_ends_at: "2020-04-27 00:00:00 UTC",
+          all_day: true,
+        )
+
+      custom_field =
+        TopicCustomField.find_by(
+          topic_id: all_day_post.topic_id,
+          name: DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY,
+        )
+
+      expect(custom_field).to be_present
+      expect(custom_field.value).to eq("t")
+    end
+
+    it "writes false for non-all-day events" do
+      custom_field =
+        TopicCustomField.find_by(
+          topic_id: first_post.topic_id,
+          name: DiscoursePostEvent::TOPIC_POST_EVENT_ALL_DAY,
+        )
+
+      expect(custom_field).to be_present
+      expect(custom_field.value).to eq("f")
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_detailed_response.json
+++ b/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_detailed_response.json
@@ -66,6 +66,9 @@
             "type": "string",
             "pattern": "^\\d{2}:\\d{2}:\\d{2}$"
           },
+          "all_day": {
+            "type": "boolean"
+          },
           "can_act_on_discourse_post_event": {
             "type": [
               "boolean",

--- a/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_response.json
+++ b/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_response.json
@@ -45,6 +45,9 @@
             "type": "string",
             "pattern": "^\\d{2}:\\d{2}:\\d{2}$"
           },
+          "all_day": {
+            "type": "boolean"
+          },
           "post": {
             "type": "object",
             "additionalProperties": false,

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -120,6 +120,25 @@ module DiscoursePostEvent
       end
     end
 
+    context "with an all-day event" do
+      it "returns date-only strings for starts_at and ends_at" do
+        Fabricate(
+          :event,
+          original_starts_at: Time.utc(2026, 3, 12),
+          original_ends_at: Time.utc(2026, 3, 14),
+          all_day: true,
+        )
+
+        get "/discourse-post-event/events.json"
+
+        expect(response.status).to eq(200)
+        event = response.parsed_body["events"].first
+        expect(event["starts_at"]).to eq("2026-03-12")
+        expect(event["ends_at"]).to eq("2026-03-14")
+        expect(event["all_day"]).to eq(true)
+      end
+    end
+
     context "with an existing post" do
       let(:user) { Fabricate(:user, admin: true) }
       let(:topic) { Fabricate(:topic, user: user, category: Fabricate(:category)) }

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -89,5 +89,33 @@ describe DiscoursePostEvent::EventSerializer do
         expect(json[:event][:duration]).to eq("01:00:00")
       end
     end
+
+    context "when event is all-day" do
+      fab!(:post_all_day) { Fabricate(:post, topic: topic) }
+      fab!(:all_day_event) do
+        Fabricate(
+          :event,
+          post: post_all_day,
+          original_starts_at: "2026-03-12 00:00:00 UTC",
+          original_ends_at: "2026-03-14 00:00:00 UTC",
+          all_day: true,
+        )
+      end
+
+      it "serializes starts_at as date-only string" do
+        json = DiscoursePostEvent::EventSerializer.new(all_day_event, scope: Guardian.new).as_json
+        expect(json[:event][:starts_at]).to eq("2026-03-12")
+      end
+
+      it "serializes ends_at as date-only string" do
+        json = DiscoursePostEvent::EventSerializer.new(all_day_event, scope: Guardian.new).as_json
+        expect(json[:event][:ends_at]).to eq("2026-03-14")
+      end
+
+      it "serializes all_day as true" do
+        json = DiscoursePostEvent::EventSerializer.new(all_day_event, scope: Guardian.new).as_json
+        expect(json[:event][:all_day]).to eq(true)
+      end
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/serializers/topic_list_item_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_list_item_serializer_spec.rb
@@ -46,4 +46,28 @@ RSpec.describe TopicListItemSerializer do
       expect(parsed_json["event_ends_at"]).to eq("2020-04-24T16:10:00.000Z")
     end
   end
+
+  describe "#event_all_day" do
+    it "returns true when the event is all-day" do
+      SiteSetting.display_post_event_date_on_topic_title = true
+
+      all_day_topic = Fabricate(:topic)
+      all_day_post = Fabricate(:post, topic: all_day_topic)
+      DiscoursePostEvent::Event.create!(
+        id: all_day_post.id,
+        original_starts_at: Time.utc(2020, 4, 25),
+        original_ends_at: Time.utc(2020, 4, 27),
+        all_day: true,
+      )
+
+      all_day_serializer = described_class.new(all_day_topic, scope: Guardian.new, root: false)
+      all_day_json = JSON.parse(all_day_serializer.to_json)
+
+      expect(all_day_json["event_all_day"]).to eq(true)
+    end
+
+    it "is not included when the event is not all-day" do
+      expect(parsed_json).not_to have_key("event_all_day")
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe TopicViewSerializer do
     end
 
     describe "#event_all_day" do
-      it "returns false" do
-        expect(parsed_json["event_all_day"]).to eq(false)
+      it "is not included" do
+        expect(parsed_json).not_to have_key("event_all_day")
       end
     end
   end

--- a/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
@@ -97,4 +97,38 @@ RSpec.describe TopicViewSerializer do
       end
     end
   end
+
+  context "with all-day event" do
+    before do
+      SiteSetting.display_post_event_date_on_topic_title = true
+      DiscoursePostEvent::Event.create!(
+        id: first_post.id,
+        original_starts_at: Time.utc(2020, 4, 25),
+        original_ends_at: Time.utc(2020, 4, 27),
+        all_day: true,
+      )
+    end
+
+    describe "#event_all_day" do
+      it "returns true" do
+        expect(parsed_json["event_all_day"]).to eq(true)
+      end
+    end
+  end
+
+  context "without all-day event" do
+    before do
+      DiscoursePostEvent::Event.create!(
+        id: first_post.id,
+        original_starts_at: 1.hour.from_now,
+        original_ends_at: 2.hours.from_now,
+      )
+    end
+
+    describe "#event_all_day" do
+      it "returns false" do
+        expect(parsed_json["event_all_day"]).to eq(false)
+      end
+    end
+  end
 end

--- a/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
@@ -94,8 +94,8 @@ module("Integration | Component | EventDate", function (hooks) {
     this.clock = fakeTime("2026-03-11T12:00:00Z", "America/Chicago", true);
 
     const topic = {
-      event_starts_at: "2026-03-12T00:00:00.000Z",
-      event_ends_at: "2026-03-14T00:00:00.000Z",
+      event_starts_at: "2026-03-12",
+      event_ends_at: "2026-03-14",
       event_all_day: true,
     };
 

--- a/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
@@ -85,4 +85,26 @@ module("Integration | Component | EventDate", function (hooks) {
         "displays date in browser timezone (Harare) when no event timezone"
       );
   });
+
+  test("all-day event does not shift date across timezones", async function (assert) {
+    // Use a western timezone where UTC midnight would shift to the previous day
+    moment.tz.guess = () => "America/Chicago";
+    this.clock = fakeTime("2026-03-11T12:00:00Z", "America/Chicago", true);
+
+    const topic = {
+      event_starts_at: "2026-03-12T00:00:00.000Z",
+      event_ends_at: "2026-03-14T00:00:00.000Z",
+      event_all_day: true,
+    };
+
+    await render(<template><EventDate @topic={{topic}} /></template>);
+
+    assert
+      .dom(".event-date")
+      .hasAttribute(
+        "title",
+        /March 12, 2026/,
+        "displays March 12 (correct date) not March 11 (timezone-shifted)"
+      );
+  });
 });

--- a/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/event-date-test.gjs
@@ -10,9 +10,11 @@ module("Integration | Component | EventDate", function (hooks) {
   hooks.beforeEach(function () {
     this.siteSettings.discourse_post_event_enabled = true;
     this.siteSettings.use_local_event_date = true;
+    this.originalGuess = moment.tz.guess;
   });
 
   hooks.afterEach(function () {
+    moment.tz.guess = this.originalGuess;
     this.clock?.restore();
   });
 

--- a/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -542,6 +542,53 @@ module("Integration | Component | upcoming-events-list", function (hooks) {
       .dom(".upcoming-events-list__event-name")
       .hasText("Awesome Event", "displays the event name");
   });
+
+  test("with all-day multi-day event shows correct date range", async function (assert) {
+    pretender.get("/discourse-post-event/events", () => {
+      return response({
+        events: [
+          {
+            id: 67510,
+            starts_at: "2100-02-05",
+            ends_at: "2100-02-08",
+            timezone: "America/Chicago",
+            post: {
+              id: 67510,
+              post_number: 1,
+              url: "/t/all-day-event/18460/1",
+              topic: { id: 18460, title: "All day conference" },
+            },
+            name: "All Day Conference",
+            category_id: 1,
+            all_day: true,
+          },
+        ],
+      });
+    });
+
+    await render(<template><UpcomingEventsList /></template>);
+
+    this.appEvents.trigger("page:changed", { url: "/" });
+
+    await waitFor(".loading-container .spinner", { count: 0 });
+
+    assert
+      .dom(".upcoming-events-list__event")
+      .exists({ count: 1 }, "all-day event is displayed");
+
+    assert
+      .dom(".upcoming-events-list__event-name")
+      .hasText("All Day Conference", "displays the event name");
+
+    const eventTime = document.querySelector(
+      ".upcoming-events-list__event-time"
+    ).innerText;
+
+    assert.true(eventTime.includes("February"), "contains month name");
+    assert.true(eventTime.includes("5"), "contains start day");
+    assert.true(eventTime.includes("8"), "contains end day");
+    assert.true(eventTime.includes("2100"), "contains year");
+  });
 });
 
 function twoEventsResponseHandler({ queryParams }) {


### PR DESCRIPTION
This feature adds all day functionality to discourse-calendar post event events, and fixes the display across different timezones.

There are many smaller changes in here to get the date to display correctly across timezones, including on the event topic itself, the upcoming events block in right-sidebar-blocks, the upcoming events page (calendar), and the badge on topics in list view. 

####  A bit more detailed:
- Adds new column `all_day` to `discourse_post_event_events` and wires that up through the model, serializer, and controller
- Modifies existing methods for formatting time to account for `all_day` flag
- Modifies the frontend components to check for the `all_day` flag and, if present, display the dates without times and ignoring timezones
- The post event builder form will now snap the times to 00:00 and 23:59 if all day is checked, and then hide the time entry input boxes
- Adds the all day flag to the webhook payload and parses start/end times based on that flag
- Tests for all of the new functionality

#### Demo video

https://github.com/user-attachments/assets/b4067764-d2e6-48df-b95e-5b8c717f8716


