### PR TITLE
UX: Improved loading experience when jumping on topic timeline

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -2377,3 +2377,17 @@ span.post-count {
     }
   }
 }
+
+.container.posts.posts--loading {
+  box-sizing: border-box;
+  min-height: calc(100dvh - var(--main-outlet-offset));
+  margin-bottom: 0;
+}
+
+#main-outlet:has(.container.posts.posts--loading):not(:has(#topic-title)) {
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  border-radius: 0;
+}

--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-jquery, ember/no-private-routing-service */
+/* eslint-disable ember/no-private-routing-service */
 import EmberObject from "@ember/object";
 import { setOwner } from "@ember/owner";
 import { next, schedule } from "@ember/runloop";
@@ -391,6 +391,16 @@ class DiscourseURL extends EmberObject {
 
         if (!routeOpts.keepFilter) {
           opts.cancelFilter = true;
+        }
+
+        // If the post is not currently in the post stream, scroll to the top
+        // so the loading spinner will be visible while loading new posts,
+        // regardless of the previous post number.
+        const nearPostNumber = parseInt(opts.nearPost, 10);
+        if (
+          !postStream.posts.some((post) => post.post_number === nearPostNumber)
+        ) {
+          window.scrollTo(0, 0);
         }
 
         postStream.refresh(opts).then(() => {

--- a/frontend/discourse/app/templates/topic.gjs
+++ b/frontend/discourse/app/templates/topic.gjs
@@ -38,12 +38,13 @@ import TopicTitle from "discourse/components/topic-title";
 import TopicTitleEditor from "discourse/components/topic-title-editor";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import bodyClass from "discourse/helpers/body-class";
+import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import hideApplicationFooter from "discourse/helpers/hide-application-footer";
 import hideScrollableContent from "discourse/helpers/hide-scrollable-content";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
-import { and, eq } from "discourse/truth-helpers";
+import { and, eq, not, or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import booleanString from "../helpers/boolean-string";
 
@@ -99,7 +100,12 @@ export default <template>
     {{/unless}}
 
     {{#if @controller.model.postStream.loaded}}
-      {{#if @controller.model.postStream.firstPostPresent}}
+      {{#if
+        (and
+          @controller.model.postStream.firstPostPresent
+          (not @controller.model.postStream.loadingFilter)
+        )
+      }}
         <TopicTitle
           @cancelled={{@controller.cancelEditingTopic}}
           @save={{@controller.finishedEditingTopic}}
@@ -231,7 +237,12 @@ export default <template>
 
       {{/if}}
 
-      <div class="container posts">
+      <div
+        class={{concatClass
+          "container posts"
+          (if @controller.model.postStream.loadingFilter "posts--loading")
+        }}
+      >
         <div class="selected-posts {{unless @controller.multiSelect 'hidden'}}">
           <SelectedPosts
             @selectedPostsCount={{@controller.selectedPostsCount}}
@@ -249,7 +260,13 @@ export default <template>
           />
         </div>
 
-        {{#if (and @controller.showBottomTopicMap @controller.loadedAllPosts)}}
+        {{#if
+          (and
+            @controller.showBottomTopicMap
+            @controller.loadedAllPosts
+            (not @controller.model.postStream.loadingFilter)
+          )
+        }}
           <div class="topic-map --bottom">
             <TopicMap
               @model={{@controller.model}}
@@ -434,7 +451,12 @@ export default <template>
                 />
               {{/unless}}
 
-              {{#if @controller.model.postStream.lastPostNotLoaded}}
+              {{#if
+                (or
+                  @controller.model.postStream.lastPostNotLoaded
+                  @controller.model.postStream.loadingFilter
+                )
+              }}
                 {{hideScrollableContent "below"}}
               {{/if}}
             </div>
@@ -570,7 +592,12 @@ export default <template>
         </div>
 
       </div>
-      {{#if @controller.loadedAllPosts}}
+      {{#if
+        (and
+          @controller.loadedAllPosts
+          (not @controller.model.postStream.loadingFilter)
+        )
+      }}
         {{#if @controller.session.showSignupCta}}
           {{! replace "Log In to Reply" with the infobox }}
           <SignupCta />


### PR DESCRIPTION
This is a first draft at improving the UX when jumping to a post not already loaded in the post stream using the topic timeline.

Before:
- When starting in the middle of the topic and jumping to a post using the timeline, the posts container shows a loading spinner but the size of the post container is a bit off. It doesn't extend below the reply/notification level buttons and the styling might appear different from when there are posts visible.
- When starting at the bottom of the topic (last post) and jumping to a post using the timeline, the page stays scrolled at the bottom. On chrome it stays anchored to the topic-footer-buttons-outlet, but on firefox/safari it scrolls to the very bottom of the page. Either way, the user can't see the loading spinner.
- When starting at the top of the topic (above the first post) so that the header is visible above the post stream, keep the header visible while loading posts.

After:
- Regardless of starting post, scroll to the top of the page so the loading spinner will be visible if the target post is not already loaded in the post stream.
- Extend the height of the posts container to fill the page, as it would if the user were in the middle of a long topic.
- Still keep the header visible if it was visible when initiating the jump to a post outside the post stream.

I'll add some screenshots/video here as well.

Dev Topic: /t/179451 