### PR TITLE
FIX: Add rate limiting to Ad impression

### DIFF
--- a/plugins/discourse-adplugin/app/controllers/ad_plugin/ad_impressions_controller.rb
+++ b/plugins/discourse-adplugin/app/controllers/ad_plugin/ad_impressions_controller.rb
@@ -3,9 +3,29 @@ module AdPlugin
   class AdImpressionsController < ::ApplicationController
     requires_plugin PLUGIN_NAME
 
+    CREATE_RATE_LIMIT_KEY = "ad-impressions-create"
+    CREATE_RATE_LIMIT_PER_MINUTE = 30
+    CREATE_RATE_LIMIT_SECONDS = 1.minute
+
     skip_before_action :check_xhr, :preload_json, only: [:update]
 
     def create
+      raise Discourse::InvalidAccess unless SiteSetting.ad_plugin_enable_tracking
+
+      rate_limit_key =
+        if current_user
+          CREATE_RATE_LIMIT_KEY
+        else
+          "#{CREATE_RATE_LIMIT_KEY}-#{request.ip}"
+        end
+
+      RateLimiter.new(
+        current_user,
+        rate_limit_key,
+        CREATE_RATE_LIMIT_PER_MINUTE,
+        CREATE_RATE_LIMIT_SECONDS,
+      ).performed!
+
       impression =
         AdPlugin::AdImpression.create!(impression_params.merge(user_id: current_user&.id))
 

--- a/plugins/discourse-adplugin/spec/requests/ad_impressions_controller_spec.rb
+++ b/plugins/discourse-adplugin/spec/requests/ad_impressions_controller_spec.rb
@@ -7,6 +7,88 @@ describe AdPlugin::AdImpressionsController do
   before { enable_current_plugin }
 
   describe "#create" do
+    before { SiteSetting.ad_plugin_enable_tracking = true }
+
+    context "when ad_plugin_enable_tracking is disabled" do
+      before { SiteSetting.ad_plugin_enable_tracking = false }
+
+      it "rejects impression creation with 403" do
+        expect {
+          post "/ad_plugin/ad_impressions.json",
+               params: {
+                 ad_plugin_impression: {
+                   ad_type: AdPlugin::AdType.types[:house],
+                   placement: "topic_list_top",
+                   ad_plugin_house_ad_id: house_ad.id,
+                 },
+               }
+        }.not_to change { AdPlugin::AdImpression.count }
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when rate limited" do
+      before { RateLimiter.enable }
+
+      it "rate limits anonymous impression creation by IP" do
+        stub_const(described_class, "CREATE_RATE_LIMIT_PER_MINUTE", 1) do
+          post "/ad_plugin/ad_impressions.json",
+               params: {
+                 ad_plugin_impression: {
+                   ad_type: AdPlugin::AdType.types[:house],
+                   placement: "topic_list_top",
+                   ad_plugin_house_ad_id: house_ad.id,
+                 },
+               }
+
+          expect(response.status).to eq(200)
+
+          post "/ad_plugin/ad_impressions.json",
+               params: {
+                 ad_plugin_impression: {
+                   ad_type: AdPlugin::AdType.types[:house],
+                   placement: "topic_list_top",
+                   ad_plugin_house_ad_id: house_ad.id,
+                 },
+               }
+        end
+
+        expect(response.status).to eq(429)
+      end
+
+      it "does not rate limit logged in users based on anonymous traffic from the same IP" do
+        ip_address = "1.2.3.4"
+
+        stub_const(described_class, "CREATE_RATE_LIMIT_PER_MINUTE", 1) do
+          RateLimiter.new(
+            nil,
+            "#{described_class::CREATE_RATE_LIMIT_KEY}-#{ip_address}",
+            described_class::CREATE_RATE_LIMIT_PER_MINUTE,
+            described_class::CREATE_RATE_LIMIT_SECONDS,
+          ).performed!
+
+          sign_in(user)
+
+          expect {
+            post "/ad_plugin/ad_impressions.json",
+                 params: {
+                   ad_plugin_impression: {
+                     ad_type: AdPlugin::AdType.types[:house],
+                     placement: "topic_list_top",
+                     ad_plugin_house_ad_id: house_ad.id,
+                   },
+                 },
+                 env: {
+                   "REMOTE_ADDR" => ip_address,
+                 }
+          }.to change { AdPlugin::AdImpression.count }.by(1)
+
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+
     context "when creating house ad impression" do
       it "creates impression for logged in user" do
         sign_in(user)


### PR DESCRIPTION
Users should be rate-limited on ad impression tracking so that the reports can better reflect the true  performance of the ad