### PR TITLE
DEV: Add category-boxes-url value transformer

### DIFF
--- a/frontend/discourse/app/components/categories-boxes.gjs
+++ b/frontend/discourse/app/components/categories-boxes.gjs
@@ -17,7 +17,6 @@ import concatClass from "discourse/helpers/concat-class";
 import dirSpan from "discourse/helpers/dir-span";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { applyValueTransformer } from "discourse/lib/transformer";
-import { notEq } from "discourse/truth-helpers";
 
 @tagName("")
 export default class CategoriesBoxes extends Component {
@@ -82,15 +81,7 @@ export default class CategoriesBoxes extends Component {
 
               <div class="category-details">
                 <div class="category-box-heading">
-                  <a
-                    class="parent-box-link"
-                    href={{this.categoryUrl c}}
-                    target={{if (notEq (this.categoryUrl c) c.url) "_blank"}}
-                    rel={{if
-                      (notEq (this.categoryUrl c) c.url)
-                      "noopener noreferrer"
-                    }}
-                  >
+                  <a class="parent-box-link" href={{this.categoryUrl c}}>
                     <h3>
                       <CategoryTitleBefore @category={{c}} />
                       {{this.categoryName c}}
@@ -149,18 +140,7 @@ export default class CategoriesBoxes extends Component {
                   {{else if c.subcategories}}
                     <div class="subcategories">
                       {{#each c.subcategories as |sc|}}
-                        <a
-                          class="subcategory"
-                          href={{this.categoryUrl sc}}
-                          target={{if
-                            (notEq (this.categoryUrl sc) sc.url)
-                            "_blank"
-                          }}
-                          rel={{if
-                            (notEq (this.categoryUrl sc) sc.url)
-                            "noopener noreferrer"
-                          }}
-                        >
+                        <a class="subcategory" href={{this.categoryUrl sc}}>
                           {{#if sc.uploaded_logo.url}}
                             <span class="subcategory-image-placeholder">
                               <CategoryLogo @category={{sc}} />

--- a/frontend/discourse/app/components/categories-boxes.gjs
+++ b/frontend/discourse/app/components/categories-boxes.gjs
@@ -16,6 +16,8 @@ import categoryLink, {
 import concatClass from "discourse/helpers/concat-class";
 import dirSpan from "discourse/helpers/dir-span";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { applyValueTransformer } from "discourse/lib/transformer";
+import { notEq } from "discourse/truth-helpers";
 
 @tagName("")
 export default class CategoriesBoxes extends Component {
@@ -34,6 +36,12 @@ export default class CategoriesBoxes extends Component {
         link: false,
       })
     );
+  }
+
+  categoryUrl(category) {
+    return applyValueTransformer("category-boxes-url", category.url, {
+      category,
+    });
   }
 
   <template>
@@ -59,7 +67,7 @@ export default class CategoriesBoxes extends Component {
             style={{categoryColorVariable c.color}}
             data-category-id={{c.id}}
             data-notification-level={{c.notificationLevelString}}
-            data-url={{c.url}}
+            data-url={{this.categoryUrl c}}
             class="category category-box category-box-{{c.slug}}
               {{if c.isMuted 'muted'}}"
           >
@@ -74,7 +82,15 @@ export default class CategoriesBoxes extends Component {
 
               <div class="category-details">
                 <div class="category-box-heading">
-                  <a class="parent-box-link" href={{c.url}}>
+                  <a
+                    class="parent-box-link"
+                    href={{this.categoryUrl c}}
+                    target={{if (notEq (this.categoryUrl c) c.url) "_blank"}}
+                    rel={{if
+                      (notEq (this.categoryUrl c) c.url)
+                      "noopener noreferrer"
+                    }}
+                  >
                     <h3>
                       <CategoryTitleBefore @category={{c}} />
                       {{this.categoryName c}}
@@ -133,7 +149,18 @@ export default class CategoriesBoxes extends Component {
                   {{else if c.subcategories}}
                     <div class="subcategories">
                       {{#each c.subcategories as |sc|}}
-                        <a class="subcategory" href={{sc.url}}>
+                        <a
+                          class="subcategory"
+                          href={{this.categoryUrl sc}}
+                          target={{if
+                            (notEq (this.categoryUrl sc) sc.url)
+                            "_blank"
+                          }}
+                          rel={{if
+                            (notEq (this.categoryUrl sc) sc.url)
+                            "noopener noreferrer"
+                          }}
+                        >
                           {{#if sc.uploaded_logo.url}}
                             <span class="subcategory-image-placeholder">
                               <CategoryLogo @category={{sc}} />

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -36,6 +36,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "admin-reports-show-query-params",
   "bulk-select-in-nav-controls",
   "category-available-views",
+  "category-boxes-url",
   "category-default-colors",
   "category-description-text",
   "category-display-name",

--- a/frontend/discourse/tests/acceptance/transformers/category-boxes-url-test.js
+++ b/frontend/discourse/tests/acceptance/transformers/category-boxes-url-test.js
@@ -1,0 +1,58 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("category-boxes-url transformer", function (needs) {
+  needs.settings({
+    desktop_category_page_style: "categories_boxes",
+  });
+
+  test("transforms the category box URL", async function (assert) {
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "category-boxes-url",
+        ({ value, context }) => {
+          if (context.category.slug === "bug") {
+            return "https://example.com/bug-tracker";
+          }
+          return value;
+        }
+      );
+    });
+
+    await visit("/categories");
+
+    assert
+      .dom(
+        ".category-box[data-category-id='1'] a.parent-box-link[href='https://example.com/bug-tracker']"
+      )
+      .exists("it transforms the category URL for matched slug");
+
+    assert
+      .dom(
+        ".category-box[data-category-id='1'] a.parent-box-link[target='_blank']"
+      )
+      .exists("it adds target=_blank for transformed URLs");
+
+    assert
+      .dom(
+        ".category-box[data-category-id='1'] a.parent-box-link[rel='noopener noreferrer']"
+      )
+      .exists("it adds rel=noopener noreferrer for transformed URLs");
+
+    assert
+      .dom(".category-box[data-category-id='2'] a.parent-box-link")
+      .doesNotHaveAttribute(
+        "target",
+        "it does not add target for non-transformed URLs"
+      );
+
+    assert
+      .dom(".category-box[data-category-id='2'] a.parent-box-link")
+      .doesNotHaveAttribute(
+        "rel",
+        "it does not add rel for non-transformed URLs"
+      );
+  });
+});

--- a/frontend/discourse/tests/acceptance/transformers/category-boxes-url-test.js
+++ b/frontend/discourse/tests/acceptance/transformers/category-boxes-url-test.js
@@ -28,31 +28,5 @@ acceptance("category-boxes-url transformer", function (needs) {
         ".category-box[data-category-id='1'] a.parent-box-link[href='https://example.com/bug-tracker']"
       )
       .exists("it transforms the category URL for matched slug");
-
-    assert
-      .dom(
-        ".category-box[data-category-id='1'] a.parent-box-link[target='_blank']"
-      )
-      .exists("it adds target=_blank for transformed URLs");
-
-    assert
-      .dom(
-        ".category-box[data-category-id='1'] a.parent-box-link[rel='noopener noreferrer']"
-      )
-      .exists("it adds rel=noopener noreferrer for transformed URLs");
-
-    assert
-      .dom(".category-box[data-category-id='2'] a.parent-box-link")
-      .doesNotHaveAttribute(
-        "target",
-        "it does not add target for non-transformed URLs"
-      );
-
-    assert
-      .dom(".category-box[data-category-id='2'] a.parent-box-link")
-      .doesNotHaveAttribute(
-        "rel",
-        "it does not add rel for non-transformed URLs"
-      );
   });
 });


### PR DESCRIPTION
This PR adds a `category-boxes-url` transformer to `components/categories-boxes.gjs`, with it, you can change the category URL cleanly.