### PR TITLE
UX: append theme added date to theme-grid-card

### DIFF
--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -165,6 +165,12 @@
     margin: 0 0 10px 0;
   }
 
+  &__meta {
+    margin: 10px 0 0 0;
+    font-size: var(--font-down-3);
+    opacity: 0.3;
+  }
+
   &__components {
     display: -webkit-box;
     font-size: var(--font-down-1);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7142,6 +7142,7 @@ en:
           themes:
             title: "Themes"
             description: "Site-wide themes that change the overall look and feel of your site for all users."
+            added_date: "Date added: %{date}"
             themes_intro: "Install a new theme to get started, or create your own from scratch using these resources."
             new_theme: "New theme"
             back: "Back to themes"

--- a/frontend/discourse/admin/components/themes-grid-card.gjs
+++ b/frontend/discourse/admin/components/themes-grid-card.gjs
@@ -11,7 +11,7 @@ import icon from "discourse/helpers/d-icon";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
 import getURL from "discourse/lib/get-url";
-import { i18n } from "discourse-i18n";
+import I18n, { i18n } from "discourse-i18n";
 import ThemesGridPlaceholder from "./themes-grid-placeholder";
 
 // NOTE (martin): We will need to revisit and improve this component
@@ -82,6 +82,26 @@ export default class ThemeCard extends Component {
       "themes",
       this.args.theme.id
     );
+  }
+
+  get themeAddedDate() {
+    const date = new Date(this.args.theme.created_at);
+
+    if (!date) {
+      return "N/A";
+    }
+
+    const locale = I18n.locale?.replace(/_/g, "-") || "en-GB";
+    const formattedDate = new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date);
+
+    return formattedDate;
   }
 
   @action
@@ -354,6 +374,14 @@ export default class ThemeCard extends Component {
               </DMenu>
             </div>
           </div>
+          {{#if @theme.created_at}}
+            <p class="theme-card__meta">
+              {{i18n
+                "admin.config_areas.themes_and_components.themes.added_date"
+                date=this.themeAddedDate
+              }}
+            </p>
+          {{/if}}
         </div>
       </:content>
     </AdminConfigAreaCard>


### PR DESCRIPTION
UX change to adds the date from the theme 'created_at' argument to the bottom of a theme grid card. 

Particularly useful for when editing theme locally and re-uploading to know exactly when theme was added. Uses the `Intl.DateTimeFormat` and the user's current locale as the argument.

<img width="1469" height="725" alt="image" src="https://github.com/user-attachments/assets/88717f8e-cb06-414c-b582-03a9b9aaa597" />

