### PR TITLE
DEV: Update prompts for translations

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
@@ -170,7 +170,7 @@ export const AI_FEATURE_SETTING_GROUPS = {
         "ai_translation_include_bot_content",
         "ai_translation_max_post_length",
         "ai_translation_backfill_max_age_days",
-        "ai_translation_max_tokens_multiplier",
+
         "ai_translation_verbose_logs",
       ],
     },

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -146,7 +146,6 @@ en:
     ai_translation_max_post_length: "The maximum number of characters for a post to be translated. Posts longer than this will not be translated."
     ai_translation_backfill_max_age_days: "The maximum age of a post and topic to be translated. Posts and topics older than this will not be translated. 0 disables backfilling, but will not disable translation of new posts."
     ai_translation_backfill_hourly_rate: "The number of posts and topics to translate per hour during backfill operations. Set to 0 to disable automatic backfilling of translations for existing content."
-    ai_translation_max_tokens_multiplier: "Multiplier to determine the maximum number of tokens to use for translation. By default, we set the max tokens to approximately two to five times the number of characters in the post. This multiplier can be adjusted to allow for thinking or reasoning models which will use more tokens."
     ai_usage_rollup_after_days: "Number of days to keep per-request AI usage stats before rolling them into daily aggregates. Set to 0 to disable rollups."
     ai_audit_logs_purge_after_days: "Delete AI API audit logs older than this many days. Defaults to about 6 months. Set to 0 to keep indefinitely."
 

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -472,12 +472,7 @@ discourse_ai:
     max: 20000
     client: false
     area: "ai-features/translation"
-  ai_translation_max_tokens_multiplier:
-    default: 1.0
-    type: float
-    min: 1.0
-    max: 10.0
-    area: "ai-features/translation"
+
   ai_translation_verbose_logs:
     default: false
     client: false

--- a/plugins/discourse-ai/lib/agents/post_raw_translator.rb
+++ b/plugins/discourse-ai/lib/agents/post_raw_translator.rb
@@ -36,10 +36,19 @@ module DiscourseAi
             output:
               "アップデートでエラーが発生しました\n\n```ruby\napi_key = \"a quick brown fox\"\nfetch(\"https://api.example.com/data\", headers: { 'Authorization' => api_key })\n```\n\n修正にご協力ください。\"",
           },
+          {
+            input: {
+              content:
+                "We're so glad you're here! Want to run your own community site? It's easy to get started.",
+              target_locale: "de",
+            }.to_json,
+            output:
+              "Wir freuen uns sehr, dass du hier bist! Möchtest du deine eigene Community-Seite betreiben? Der Einstieg ist ganz einfach.",
+          },
         ]
 
         <<~PROMPT.strip
-          You are a highly skilled translator tasked with translating content from one language to another. Your goal is to provide accurate and contextually appropriate translations while preserving the original structure and formatting of the content. Follow these instructions strictly:
+          You are a friendly and very skilled human linguist and translator. Your goal is to produce translations that read naturally to native speakers, as if originally written in the target language — indistinguishable from content written by a human. Follow these instructions strictly:
 
           1. Preserve Markdown elements, HTML elements, or newlines. Text must be translated without altering the original formatting.
           2. Maintain the original document structure including headings, lists, tables, code blocks, etc.
@@ -47,15 +56,16 @@ module DiscourseAi
           4. For technical and brand terminology:
             - Provide the accepted target language term if it exists.
             - If no equivalent exists, transliterate the term and include the original term in parentheses.
-          5. For ambiguous terms or phrases, choose the most contextually appropriate translation.
+          5. For ambiguous terms or phrases, do not translate word-for-word in isolation. Derive the intended meaning from the full context of the document before choosing a translation.
           6. Ensure the translation only contains the original language and the target language.
+          7. Match the tone and register of the source text. If the source is informal and conversational, use informal address forms and a casual tone in the target language. Do not default to formal address (e.g. German Sie, French vous) unless the source text is itself formal.
 
           Follow these instructions on what NOT to do:
-          7. Do not translate code snippets or programming language names, but ensure that any comments within the code are translated. Code can be represented in ``` or in single ` backticks or in <code> HTML tags.
-          8. Do not add any content besides the translation.
-          9. Do not add unnecessary newlines.
+          8. Do not translate code snippets or programming language names, but ensure that any comments within the code are translated. Code can be represented in ``` or in single ` backticks or in <code> HTML tags.
+          9. Do not add any content besides the translation.
+          10. Do not add unnecessary newlines.
 
-          Here are three examples of correct translations:
+          Here are four examples of correct translations:
 
           Input: #{examples[0][:input]}
           Output: #{examples[0][:output]}
@@ -65,6 +75,9 @@ module DiscourseAi
 
           Input: #{examples[2][:input]}
           Output: #{examples[2][:output]}
+
+          Input: #{examples[3][:input]}
+          Output: #{examples[3][:output]}
 
           The text to translate will be provided in JSON format with the following structure:
           {"content": "Text to translate", "target_locale": "Target language code"}

--- a/plugins/discourse-ai/lib/agents/topic_title_translator.rb
+++ b/plugins/discourse-ai/lib/agents/topic_title_translator.rb
@@ -35,20 +35,13 @@ module DiscourseAi
         ]
 
         <<~PROMPT.strip
-          You are a translation service specializing in translating forum post titles from English to the asked target_locale. Your task is to provide accurate and contextually appropriate translations while adhering to the following guidelines:
+          You are a friendly human linguist and translator specializing in translating forum post titles. Your goal is to produce translations that read naturally to native speakers, as if originally written in the target language — indistinguishable from content written by a human. Follow these guidelines:
 
-          1. Translate the given title from English to target_locale asked.
+          1. Translate the given title to the target_locale.
           2. Keep proper nouns and technical terms in their original language.
           3. Attempt to keep the translated title length close to the original when possible.
-          4. Ensure the translation maintains the original meaning and tone.
-
-          To complete this task:
-
-          1. Read and understand the title carefully.
-          2. Identify any proper nouns or technical terms that should remain untranslated.
-          3. Translate the remaining words and phrases into the target_locale, ensuring the meaning is preserved.
-          4. Adjust the translation if necessary to keep the length similar to the original title.
-          5. Review your translation for accuracy and naturalness in the target_locale.
+          4. Match the tone and register of the source text. Do not default to formal address unless the source is itself formal.
+          5. For ambiguous terms or phrases, do not translate word-for-word in isolation. Derive the intended meaning from the full context of the title before choosing a translation.
 
           Here are three examples of correct translations:
 
@@ -64,7 +57,7 @@ module DiscourseAi
           The text to translate will be provided in JSON format with the following structure:
           {"content": "Title to translate", "target_locale": "Target language code"}
 
-          Remember to keep proper nouns like "Minecraft" and "Toyota" in their original form. You are being consumed via an API that expects only the translated title. Only return the translated title in the correct language. Do not add questions or explanations.
+          You are being consumed via an API that expects only the translated title. Only return the translated title in the correct language. Do not add questions or explanations.
         PROMPT
       end
 

--- a/plugins/discourse-ai/lib/translation/base_translator.rb
+++ b/plugins/discourse-ai/lib/translation/base_translator.rb
@@ -28,7 +28,7 @@ module DiscourseAi
 
         ContentSplitter
           .split(content: @text, chunk_size: model.max_output_tokens)
-          .map { |text| get_translation(text:, bot:, translation_user:) }
+          .map { |text| get_translation(text:, bot:, translation_user:, model:) }
           .join("")
       end
 
@@ -38,7 +38,7 @@ module DiscourseAi
         { content:, target_locale: @target_locale }.to_json
       end
 
-      def get_translation(text:, bot:, translation_user:)
+      def get_translation(text:, bot:, translation_user:, model:)
         context =
           DiscourseAi::Agents::BotContext.new(
             user: translation_user,
@@ -48,30 +48,11 @@ module DiscourseAi
             topic: @topic,
             post: @post,
           )
-        max_tokens = get_max_tokens(text)
-        llm_args = { max_tokens: }
+        llm_args = { max_tokens: model.max_output_tokens }
 
         result = +""
         bot.reply(context, llm_args:) { |partial| result << partial }
         result
-      end
-
-      def get_max_tokens(text)
-        base_tokens =
-          if text.length < 100
-            500
-          elsif text.length < 500
-            1000
-          else
-            text.length * 2
-          end
-
-        (base_tokens * max_token_multiplier).to_i
-      end
-
-      def max_token_multiplier
-        multiplier = SiteSetting.ai_translation_max_tokens_multiplier
-        multiplier > 0 ? multiplier : 1.0
       end
 
       def agent_setting

--- a/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
@@ -33,7 +33,7 @@ describe DiscourseAi::Translation::BaseTranslator do
       end
     end
 
-    it "creates BotContext with the correct parameters and calls bot.reply with correct args" do
+    it "creates BotContext with the correct parameters and calls bot.reply with model max_output_tokens" do
       post_translator =
         DiscourseAi::Translation::PostRawTranslator.new(text:, target_locale:, post:, topic:)
 
@@ -58,37 +58,12 @@ describe DiscourseAi::Translation::BaseTranslator do
       )
 
       expect(DiscourseAi::Agents::Bot).to have_received(:as)
-      expect(mock_bot).to have_received(:reply).with(bot_context, llm_args: { max_tokens: 500 })
-    end
-
-    it "sets max_tokens correctly based on text length and ai_translation_max_tokens_multiplier setting" do
-      multiplier = 1.5
-      SiteSetting.ai_translation_max_tokens_multiplier = multiplier
-      test_cases = [
-        ["Short text", 500 * multiplier], # Short text (< 100 chars)
-        ["a" * 200, 1000 * multiplier], # Medium text (100-500 chars)
-        ["a" * 600, 1200 * multiplier], # Long text (> 500 chars, 600*2=1200)
-      ]
-
-      test_cases.each do |text, expected_max_tokens|
-        translator = DiscourseAi::Translation::PostRawTranslator.new(text: text, target_locale:)
-
-        bot_context = instance_double(DiscourseAi::Agents::BotContext)
-        allow(DiscourseAi::Agents::BotContext).to receive(:new).and_return(bot_context)
-
-        mock_bot = instance_double(DiscourseAi::Agents::Bot)
-        allow(DiscourseAi::Agents::Bot).to receive(:as).and_return(mock_bot)
-        allow(mock_bot).to receive(:reply).and_yield("translated #{text[0..10]}")
-
-        translator.translate
-
-        expect(mock_bot).to have_received(:reply).with(
-          bot_context,
-          llm_args: {
-            max_tokens: expected_max_tokens,
-          },
-        )
-      end
+      expect(mock_bot).to have_received(:reply).with(
+        bot_context,
+        llm_args: {
+          max_tokens: LlmModel.last.max_output_tokens,
+        },
+      )
     end
 
     it "returns the translation from the llm's response" do


### PR DESCRIPTION
This PR updates the system prompts for the post and topic title translators to produce more natural, idiomatic output.

The previous prompts optimised for accuracy, which led to translations that were technically correct but read like machine translation being overly literal, sometimes the wrong register, and occasionally picking the wrong sense of an ambiguous word.

