### PR TITLE
UX: Find groups also by their full_name when mentioning

### DIFF
--- a/frontend/discourse/app/lib/user-search.js
+++ b/frontend/discourse/app/lib/user-search.js
@@ -172,6 +172,7 @@ function organizeResults(r, options) {
       if (!exclude.includes(user.username)) {
         user.isUser = true;
         user.isMetadataMatch =
+          term &&
           !lowerCaseIncludes(user.username, term) &&
           !lowerCaseIncludes(user.name, term);
         users.push(user);
@@ -193,85 +194,123 @@ function organizeResults(r, options) {
   }
 
   // Build prioritized list
-  const exactUsernameSet = new Set();
-  const partialUsernameSet = new Set();
-  const exactGroupSet = new Set();
-  const exactNameSet = new Set();
+  // These Sets are used to prevent duplicate entries in the autocomplete suggestions
+  const userUsernameSet = new Set();
+  const groupNameSet = new Set();
 
   // 1. Exact username matches
-  const exactUsernameMatches = users.filter((u) => {
+  const exactUserUsernameMatches = users.filter((u) => {
     if (u.username.toLowerCase() !== term?.toLowerCase()) {
       return false;
     }
-    exactUsernameSet.add(u.username);
+    userUsernameSet.add(u.username);
     return true;
   });
 
   // 2. Exact group name matches
-  const exactGroupMatches = groups.filter((g) => {
+  const exactGroupNameMatches = groups.filter((g) => {
     if (g.name.toLowerCase() !== term?.toLowerCase()) {
       return false;
     }
-    exactGroupSet.add(g.name);
+    groupNameSet.add(g.name);
     return true;
   });
 
   // 3. Partial username matches (not already in exact matches)
-  const partialUsernameMatches = users.filter((u) => {
+  const partialUserUsernameMatches = users.filter((u) => {
     if (
-      exactUsernameSet.has(u.username) ||
+      userUsernameSet.has(u.username) ||
       u.isMetadataMatch ||
-      !lowerCaseIncludes(u.username, term)
+      (term && !lowerCaseIncludes(u.username, term))
     ) {
       return false;
     }
-    partialUsernameSet.add(u.username);
+    userUsernameSet.add(u.username);
     return true;
   });
 
   // 4. Partial group name matches (not already in exact matches)
-  const partialGroupMatches = groups.filter(
-    (g) =>
-      !term || (!exactGroupSet.has(g.name) && lowerCaseIncludes(g.name, term))
-  );
+  const partialGroupNameMatches = groups.filter((g) => {
+    if (
+      groupNameSet.has(g.name) ||
+      (term && !lowerCaseIncludes(g.name, term))
+    ) {
+      return false;
+    }
+
+    groupNameSet.add(g.name);
+    return true;
+  });
 
   // 5. Exact name matches (not already included via username)
-  const exactNameMatches = users.filter((u) => {
+  const exactUserNameMatches = users.filter((u) => {
     if (
-      exactUsernameSet.has(u.username) ||
-      partialUsernameSet.has(u.username) ||
+      userUsernameSet.has(u.username) ||
       u.name?.toLowerCase() !== term?.toLowerCase() ||
       u.isMetadataMatch
     ) {
       return false;
     }
-    exactNameSet.add(u.username);
+    userUsernameSet.add(u.username);
     return true;
   });
 
   // 6. Partial name matches (not already included)
-  const partialNameMatches = users.filter(
-    (u) =>
-      !exactUsernameSet.has(u.username) &&
-      !partialUsernameSet.has(u.username) &&
-      !exactNameSet.has(u.username) &&
-      lowerCaseIncludes(u.name, term) &&
-      !u.isMetadataMatch
-  );
+  const partialUserNameMatches = users.filter((u) => {
+    if (
+      userUsernameSet.has(u.username) ||
+      !lowerCaseIncludes(u.name, term) ||
+      u.isMetadataMatch
+    ) {
+      return false;
+    }
 
-  // 7. Users with metadata match
-  const metadataMatchUsers = users.filter((u) => u.isMetadataMatch);
+    userUsernameSet.add(u.username);
+    return true;
+  });
+
+  // 7. Exact group full_name matches
+  const exactGroupFullNameMatches = groups.filter((g) => {
+    if (
+      groupNameSet.has(g.name) ||
+      !g.full_name ||
+      g.full_name?.toLowerCase() !== term?.toLowerCase()
+    ) {
+      return false;
+    }
+    groupNameSet.add(g.name);
+    return true;
+  });
+
+  // 8. Partial group full_name matches (not already in exact matches)
+  const partialGroupFullNameMatches = groups.filter((g) => {
+    if (
+      groupNameSet.has(g.name) ||
+      !g.full_name ||
+      !lowerCaseIncludes(g.full_name, term)
+    ) {
+      return false;
+    }
+
+    groupNameSet.add(g.name);
+    return true;
+  });
+
+  // 9. Users with metadata match
+  const metadataUserMatches = users.filter((u) => u.isMetadataMatch);
 
   // Build the prioritized results in the new order
   const prioritizedResults = [
-    ...exactUsernameMatches,
-    ...exactGroupMatches,
+    ...exactUserUsernameMatches,
+    ...exactGroupNameMatches,
     ...emails,
-    ...partialUsernameMatches,
-    ...partialGroupMatches,
-    ...exactNameMatches,
-    ...partialNameMatches,
-    ...metadataMatchUsers,
+    ...partialUserUsernameMatches,
+    ...partialGroupNameMatches,
+    ...exactUserNameMatches,
+    ...partialUserNameMatches,
+    ...exactGroupFullNameMatches,
+    ...partialGroupFullNameMatches,
+    ...metadataUserMatches,
   ];
 
   // Truncate to limit

--- a/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -143,7 +143,7 @@ acceptance("Composer - editor mentions", function (needs) {
     );
   });
 
-  test("shows users immediately when @ is typed in a reply", async function (assert) {
+  test("shows users and groups immediately when @ is typed in a reply", async function (assert) {
     await visit("/");
     await click(".topic-list-item .title");
     await click(".btn-primary.create");
@@ -154,7 +154,7 @@ acceptance("Composer - editor mentions", function (needs) {
       [...document.querySelectorAll(".ac-user .username")].map(
         (e) => e.innerText
       ),
-      ["user_group", "user", "user2", "johndoe", "foo"]
+      ["user", "user2", "johndoe", "foo", "user_group"]
     );
   });
 

--- a/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -144,7 +144,7 @@ acceptance("Composer - editor mentions", function (needs) {
     );
   });
 
-  test("shows users immediately when @ is typed in a reply", async function (assert) {
+  test("shows users and groups immediately when @ is typed in a reply", async function (assert) {
     await visit("/");
     await click(".topic-list-item .title");
     await click(".btn-primary.create");
@@ -155,7 +155,7 @@ acceptance("Composer - editor mentions", function (needs) {
       [...document.querySelectorAll(".ac-user .username")].map(
         (e) => e.innerText
       ),
-      ["user_group", "user", "user2", "johndoe", "foo"]
+      ["user", "user2", "johndoe", "foo", "user_group"]
     );
   });
 

--- a/frontend/discourse/tests/unit/lib/user-search-test.js
+++ b/frontend/discourse/tests/unit/lib/user-search-test.js
@@ -198,6 +198,8 @@ module("Unit | Utility | user-search", function (hooks) {
           groups: [
             { name: "testers", usernames: [] }, // partial group match
             { name: "test", usernames: [] }, // exact group match
+            { name: "group_2", full_name: "Testers", usernames: [] }, // partial group match
+            { name: "group_4", full_name: "Test", usernames: [] }, // exact group match
           ],
         });
       }
@@ -210,30 +212,56 @@ module("Unit | Utility | user-search", function (hooks) {
       limit: 10,
     });
 
-    // Expected order: exact username, exact group, partial username, partial group, exact name, partial name
+    // Expected order:
+    // exact user username, exact group name,
+    // partial user username, partial group name,
+    // exact user name, partial user name
+    // exact group full_name, partial group full_name
     assert.strictEqual(
       results[0].username,
       "test",
-      "Exact username match first"
+      "First: Exact user username match"
     );
-    assert.strictEqual(results[1].name, "test", "Exact group match second");
+    assert.strictEqual(
+      results[1].name,
+      "test",
+      "Second: Exact group name match"
+    );
     assert.strictEqual(
       results[2].username,
       "testing",
-      "Partial username match third"
+      "Third: Partial user username match"
     );
     assert.strictEqual(
       results[3].name,
       "testers",
-      "Partial group match fourth"
+      "Fourth: Partial group name match"
     );
-    assert.strictEqual(results[4].username, "player", "Exact name match fifth");
+    assert.strictEqual(
+      results[4].username,
+      "player",
+      "Fifth: Exact user name match"
+    );
     assert.strictEqual(
       results[5].username,
       "gamer",
-      "Partial name match sixth"
+      "Sixth: Partial user name match"
     );
-    assert.strictEqual(results[6].username, "user123", "Metadata match last");
+    assert.strictEqual(
+      results[6].full_name,
+      "Test",
+      "Seventh: Exact group full name match"
+    );
+    assert.strictEqual(
+      results[7].full_name,
+      "Testers",
+      "Eighth: Partial group full name match"
+    );
+    assert.strictEqual(
+      results[8].username,
+      "user123",
+      "Ninth/Last: Metadata match"
+    );
   });
 
   test("it includes all matching groups when limit allows", async function (assert) {


### PR DESCRIPTION
Previously, when replying to a post and using the mention feature (typing "@" followed by a string), it would suggest users by their `username` and `name` as well as groups by their `name`. However, even though the GET call to `/u/search/users` returns groups that include the string in their `full_name`, these groups would not have been displayed by the frontend.

---

In this example I have a group with `name: "foo"` and `full_name: "bar"`:  
<img width="250" height="215" alt="group_details" src="https://github.com/user-attachments/assets/9b5b88e4-f705-4ac9-b3d0-1cb8a178f315" />

Searching for "foo" suggests that group in the UI:  
<img width="250" height="81" alt="group_search_by_name" src="https://github.com/user-attachments/assets/324e38f7-de22-42da-93df-894a71e2cc3b" />

Searching for "bar" does not suggest that group in the UI, even though the GET request to /u/search/users returns it:  
<img width="250" height="81" alt="group_search_by_full_name-missing" src="https://github.com/user-attachments/assets/c213ff6b-8dfd-4028-91d2-e1be7a7110db" />

After my changes:  
<img width="250" height="81" alt="group_search_by_full_name-fixed" src="https://github.com/user-attachments/assets/528dfa3d-bccf-49a3-a284-cedc910cd1eb" />

---

Last time I know this has worked was in Discourse v3.4.2. The feature probably got broken since then or deliberately removed. This could probably be seen as a bugfix or a UX improvement.
