### PR TITLE
FIX: External IDs, and hidden groups to admins only. Allow moderators to see SSO when the moderators_view_sso_details site setting is enabled

### DIFF
--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -152,6 +152,10 @@ class AdminDetailedUserSerializer < AdminUserSerializer
     object.api_keys.active.count
   end
 
+  def include_external_ids?
+    scope.can_check_sso_details?(object)
+  end
+
   def external_ids
     external_ids = {}
 
@@ -195,5 +199,9 @@ class AdminDetailedUserSerializer < AdminUserSerializer
 
   def include_upcoming_changes_stats?
     scope.is_staff?
+  end
+
+  def groups
+    object.groups.visible_groups(scope.user)
   end
 end

--- a/app/serializers/admin_user_serializer.rb
+++ b/app/serializers/admin_user_serializer.rb
@@ -14,6 +14,11 @@ class AdminUserSerializer < AdminUserListSerializer
 
   has_one :single_sign_on_record, serializer: SingleSignOnRecordSerializer, embed: :objects
 
+  def include_single_sign_on_record?
+    scope.can_check_sso_details?(object) ||
+      (scope.is_staff? && SiteSetting.moderators_view_sso_details)
+  end
+
   def can_approve
     scope.can_approve?(object)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1960,6 +1960,7 @@ en:
     top_page_default_timeframe: "Default top page time period for anonymous users (automatically adjusts for logged in users based on their last visit)."
     moderators_view_emails: "Allow moderators to view user email addresses."
     moderators_view_ips: "Allow moderators to view user ip addresses."
+    moderators_view_sso_details: "Allow moderators to view SSO records and external authentication provider IDs."
     moderators_change_trust_levels: "Allow moderators to change user trust levels."
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
     enable_rich_text_paste: "Enable automatic HTML to Markdown conversion when pasting text into the composer."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2690,6 +2690,9 @@ security:
   moderators_view_ips:
     default: true
     client: true
+  moderators_view_sso_details:
+    default: false
+    client: true
   moderators_change_trust_levels:
     default: true
   non_crawler_user_agents:

--- a/spec/serializers/admin_detailed_user_serializer_spec.rb
+++ b/spec/serializers/admin_detailed_user_serializer_spec.rb
@@ -26,4 +26,77 @@ RSpec.describe AdminDetailedUserSerializer do
       expect(serializer.as_json[:latest_export]).to be_nil
     end
   end
+
+  describe "#single_sign_on_record" do
+    fab!(:sso_record) do
+      Fabricate(:single_sign_on_record, user: user, external_id: "external_user_id")
+    end
+
+    it "is always included for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      expect(serializer.as_json[:single_sign_on_record][:external_id]).to eq("external_user_id")
+    end
+
+    it "is not included for moderators by default" do
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:single_sign_on_record)
+    end
+
+    it "is included for moderators when site setting is enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json[:single_sign_on_record][:external_id]).to eq("external_user_id")
+    end
+  end
+
+  describe "#external_ids" do
+    fab!(:associated_account) do
+      Fabricate(:user_associated_account, user: user, provider_name: "google_oauth2")
+    end
+
+    it "is only included for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      expect(serializer.as_json[:external_ids]["google_oauth2"]).to eq(
+        associated_account.provider_uid,
+      )
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:external_ids)
+    end
+
+    it "is not included for moderators even with site setting enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:external_ids)
+    end
+  end
+
+  describe "#groups" do
+    fab!(:public_group) { Fabricate(:group, visibility_level: Group.visibility_levels[:public]) }
+    fab!(:owner_only_group) do
+      Fabricate(:group, visibility_level: Group.visibility_levels[:owners])
+    end
+
+    before do
+      public_group.add(user)
+      owner_only_group.add_owner(user)
+    end
+
+    it "filters groups based on visibility for moderators" do
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      group_names = serializer.as_json[:groups].map { |g| g[:name] }
+
+      expect(group_names).to include(public_group.name)
+      expect(group_names).not_to include(owner_only_group.name)
+    end
+
+    it "shows all groups for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      group_names = serializer.as_json[:groups].map { |g| g[:name] }
+
+      expect(group_names).to include(public_group.name, owner_only_group.name)
+    end
+  end
 end


### PR DESCRIPTION
### Description

Moderators could access admin-only SSO, external identity and hidden groups data via GET /admin/users/:id.json — the single_sign_on_record field, external_ids field and hidden groups were serialized unconditionally for all staff members instead of being restricted to admins. This PR restricts External IDs, and hidden group to admins only but allows moderators to see SSO information when the moderators_view_sso_details SiteSetting is enabled