### PR TITLE
UX: when changes are requested on queued post, link draft to edit

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -168,15 +168,21 @@ class ReviewableQueuedPost < Reviewable
         "system_messages.reviewable_queued_post_revise_and_reject_edit_post_no_reply"
       end
 
+    create_revise_and_reject_draft(is_new_topic)
+
     pm_translation_args = {
       topic_title: self.topic&.title || self.payload["title"],
       topic_url: self.topic&.url,
       reason: args[:revise_custom_reason].presence || args[:revise_reason],
       feedback: args[:revise_feedback],
-      original_post: self.payload["raw"],
+      original_post: self.payload["raw"].lines.map { |line| "> #{line}" }.join,
       site_name: SiteSetting.title,
       edit_instructions:
-        I18n.t(edit_instructions_key, locale: self.target_created_by.effective_locale),
+        I18n.t(
+          edit_instructions_key,
+          base_url: Discourse.base_url,
+          locale: self.target_created_by.effective_locale,
+        ),
     }
 
     SystemMessage.create(
@@ -213,6 +219,23 @@ class ReviewableQueuedPost < Reviewable
   end
 
   private
+
+  def create_revise_and_reject_draft(is_new_topic)
+    draft_data = { reply: self.payload["raw"] }
+
+    if is_new_topic
+      draft_key = Draft::NEW_TOPIC
+      draft_data[:action] = "createTopic"
+      draft_data[:title] = self.payload["title"]
+      draft_data[:categoryId] = self.category_id
+      draft_data[:tags] = self.payload["tags"] if self.payload["tags"].present?
+    else
+      draft_key = "#{Draft::EXISTING_TOPIC}#{self.topic_id}"
+      draft_data[:action] = "reply"
+    end
+
+    Draft.set(self.target_created_by, draft_key, 0, draft_data.to_json, nil, force_save: true)
+  end
 
   def delete_opts
     {

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -228,13 +228,22 @@ class ReviewableQueuedPost < Reviewable
       draft_data[:action] = "createTopic"
       draft_data[:title] = self.payload["title"]
       draft_data[:categoryId] = self.category_id
-      draft_data[:tags] = self.payload["tags"] if self.payload["tags"].present?
+      if self.payload["tags"].is_a?(Array)
+        draft_data[:tags] = self.payload["tags"].map { |t| t.is_a?(Hash) ? t["name"] : t }
+      end
     else
       draft_key = "#{Draft::EXISTING_TOPIC}#{self.topic_id}"
       draft_data[:action] = "reply"
     end
 
-    Draft.set(self.target_created_by, draft_key, 0, draft_data.to_json, nil, force_save: true)
+    Draft.set(
+      self.target_created_by,
+      draft_key,
+      DraftSequence.next(self.target_created_by, draft_key),
+      draft_data.to_json,
+      nil,
+      force_save: true,
+    )
   end
 
   def delete_opts

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -239,7 +239,7 @@ class ReviewableQueuedPost < Reviewable
     Draft.set(
       self.target_created_by,
       draft_key,
-      DraftSequence.next(self.target_created_by, draft_key),
+      DraftSequence.next!(self.target_created_by, draft_key),
       draft_data.to_json,
       nil,
       force_save: true,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3445,10 +3445,10 @@ en:
 
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
 
-    reviewable_queued_post_revise_and_reject_edit_post: "You can edit your original post below and re-submit to make the suggested changes, or reply to this message if you have any questions."
-    reviewable_queued_post_revise_and_reject_edit_post_no_reply: "You can edit your original post below and re-submit to make the suggested changes."
-    reviewable_queued_post_revise_and_reject_edit_topic: "You can edit your topic's original post below and re-submit to make the suggested changes, or reply to this message if you have any questions."
-    reviewable_queued_post_revise_and_reject_edit_topic_no_reply: "You can edit your topic's original post below and re-submit to make the suggested changes."
+    reviewable_queued_post_revise_and_reject_edit_post: "A draft has been saved with your original content. You can find it in your [drafts](%{base_url}/my/activity/drafts), make the suggested changes, and resubmit, or reply to this message if you have any questions."
+    reviewable_queued_post_revise_and_reject_edit_post_no_reply: "A draft has been saved with your original content. You can find it in your [drafts](%{base_url}/my/activity/drafts), make the suggested changes, and resubmit."
+    reviewable_queued_post_revise_and_reject_edit_topic: "A draft has been saved with your original content. You can find it in your [drafts](%{base_url}/my/activity/drafts), make the suggested changes, and resubmit, or reply to this message if you have any questions."
+    reviewable_queued_post_revise_and_reject_edit_topic_no_reply: "A draft has been saved with your original content. You can find it in your [drafts](%{base_url}/my/activity/drafts), make the suggested changes, and resubmit."
     reviewable_queued_post_revise_and_reject:
       title: "Feedback on your post"
       subject_template: "Feedback on your post in %{topic_title}"
@@ -3463,11 +3463,7 @@ en:
 
         %{edit_instructions}
 
-        --------
-
         %{original_post}
-
-        --------
 
         Thanks,
         %{site_name} Moderators
@@ -3486,11 +3482,7 @@ en:
 
         %{edit_instructions}
 
-        --------
-
         %{original_post}
-
-        --------
 
         Thanks,
         %{site_name} Moderators

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -162,10 +162,13 @@ RSpec.describe ReviewableQueuedPost, type: :model do
             topic_url: reviewable.topic.url,
             reason: args[:revise_reason],
             feedback: args[:revise_feedback],
-            original_post: reviewable.payload["raw"],
+            original_post: reviewable.payload["raw"].lines.map { |line| "> #{line}" }.join,
             site_name: SiteSetting.title,
             edit_instructions:
-              I18n.t("system_messages.reviewable_queued_post_revise_and_reject_edit_post"),
+              I18n.t(
+                "system_messages.reviewable_queued_post_revise_and_reject_edit_post",
+                base_url: Discourse.base_url,
+              ),
           }
           expect(topic.topic_allowed_users.pluck(:user_id)).to include(contact_user.id)
           expect(topic.topic_allowed_groups.pluck(:group_id)).to include(contact_group.id)
@@ -176,6 +179,18 @@ RSpec.describe ReviewableQueuedPost, type: :model do
             ).chomp,
           )
           expect(topic.first_post.raw).to include("reply to this message")
+        end
+
+        it "creates a draft for the user with the original post content" do
+          args = { revise_reason: "Duplicate", revise_feedback: "This is old news" }
+          reviewable.perform(moderator, :revise_and_reject_post, args)
+
+          draft_key = "#{Draft::EXISTING_TOPIC}#{reviewable.topic_id}"
+          draft = Draft.find_by(user_id: reviewable.target_created_by.id, draft_key: draft_key)
+          expect(draft).to be_present
+          draft_data = JSON.parse(draft.data)
+          expect(draft_data["reply"]).to eq(reviewable.payload["raw"])
+          expect(draft_data["action"]).to eq("reply")
         end
 
         it "supports sending a custom revise reason" do
@@ -232,10 +247,13 @@ RSpec.describe ReviewableQueuedPost, type: :model do
               topic_url: nil,
               reason: args[:revise_reason],
               feedback: args[:revise_feedback],
-              original_post: reviewable.payload["raw"],
+              original_post: reviewable.payload["raw"].lines.map { |line| "> #{line}" }.join,
               site_name: SiteSetting.title,
               edit_instructions:
-                I18n.t("system_messages.reviewable_queued_post_revise_and_reject_edit_topic"),
+                I18n.t(
+                  "system_messages.reviewable_queued_post_revise_and_reject_edit_topic",
+                  base_url: Discourse.base_url,
+                ),
             }
             expect(topic.first_post.raw.chomp).to eq(
               I18n.t(
@@ -243,6 +261,19 @@ RSpec.describe ReviewableQueuedPost, type: :model do
                 translation_params,
               ).chomp,
             )
+          end
+
+          it "creates a draft for the user with the original topic content" do
+            args = { revise_reason: "Duplicate", revise_feedback: "This is old news" }
+            reviewable.perform(moderator, :revise_and_reject_post, args)
+
+            draft =
+              Draft.find_by(user_id: reviewable.target_created_by.id, draft_key: Draft::NEW_TOPIC)
+            expect(draft).to be_present
+            draft_data = JSON.parse(draft.data)
+            expect(draft_data["reply"]).to eq(reviewable.payload["raw"])
+            expect(draft_data["action"]).to eq("createTopic")
+            expect(draft_data["title"]).to eq(reviewable.payload["title"])
           end
         end
       end

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe ReviewableQueuedPost, type: :model do
           draft_key = "#{Draft::EXISTING_TOPIC}#{reviewable.topic_id}"
           draft = Draft.find_by(user_id: reviewable.target_created_by.id, draft_key: draft_key)
           expect(draft).to be_present
+          expect(draft.sequence).to be > 0
           draft_data = JSON.parse(draft.data)
           expect(draft_data["reply"]).to eq(reviewable.payload["raw"])
           expect(draft_data["action"]).to eq("reply")
@@ -270,6 +271,7 @@ RSpec.describe ReviewableQueuedPost, type: :model do
             draft =
               Draft.find_by(user_id: reviewable.target_created_by.id, draft_key: Draft::NEW_TOPIC)
             expect(draft).to be_present
+            expect(draft.sequence).to be > 0
             draft_data = JSON.parse(draft.data)
             expect(draft_data["reply"]).to eq(reviewable.payload["raw"])
             expect(draft_data["action"]).to eq("createTopic")
@@ -439,8 +441,8 @@ RSpec.describe ReviewableQueuedPost, type: :model do
         end
       end
 
-      context "when status doesn’t change" do
-        it "doesn’t update user stats" do
+      context "when status doesn���t change" do
+        it "doesn���t update user stats" do
           user_stats.expects(:update_pending_posts).never
           reviewable.update!(score: 10)
         end

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -441,8 +441,8 @@ RSpec.describe ReviewableQueuedPost, type: :model do
         end
       end
 
-      context "when status doesn���t change" do
-        it "doesn���t update user stats" do
+      context "when status doesn’t change" do
+        it "doesn’t update user stats" do
           user_stats.expects(:update_pending_posts).never
           reviewable.update!(score: 10)
         end


### PR DESCRIPTION
Currently when a post is queued for review, and the reviewer requests edits — we send a message to the poster that looks like this...

> 
> Hi username,
> 
> We’ve reviewed your post in [example topic](#) and have some feedback for you.
> 
> Reason: Does not meet posting guidelines
> 
> Feedback: Moderator feedback goes here
> 
> You can edit your original post below and re-submit to make the suggested changes.
> ___
> this is the original post content
> ___
> Thanks,
> Sitename Moderators


The problem with this is that "you can edit your original post below" isn't actually true — it's just the content of the post so you can copy and paste it into the composer and try again. 

This change creates a new draft of the rejected content and links to the posting user's drafts, so they can more easily edit it and resubmit. This is a clearer flow than the current message. 

The new message looks like this

> Hi username,
> 
> We’ve reviewed your post in [example topic](#) and have some feedback for you.
> 
> Reason: Does not meet posting guidelines
> 
> Feedback: Moderator feedback goes here
> 
> A draft has been saved with your original content. You can find it in your [drafts](/my/activity/drafts), make the suggested changes, and resubmit.
> 
> > this is the original post content
> 
> Thanks,
> Sitename Moderators


