### PR TITLE
FEATURE: Show event description in calendar popup

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
@@ -1,11 +1,70 @@
-import CookText from "discourse/components/cook-text";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { modifier } from "ember-modifier";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 
-const DiscoursePostEventDescription = <template>
-  {{#if @description}}
-    <section class="event__section event-description">
-      <CookText @rawText={{@description}} />
-    </section>
-  {{/if}}
-</template>;
+export default class DiscoursePostEventDescription extends Component {
+  @tracked expanded = false;
+  @tracked overflowing = false;
 
-export default DiscoursePostEventDescription;
+  detectOverflow = modifier((element) => {
+    const check = () => {
+      const textEl = element.querySelector(".event-description__text");
+      if (textEl) {
+        this.overflowing = textEl.scrollHeight > textEl.clientHeight;
+      }
+    };
+
+    const observer = new ResizeObserver(check);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  });
+
+  toggle = (event) => {
+    event.preventDefault();
+    this.expanded = !this.expanded;
+  };
+
+  get showToggle() {
+    return this.clamp && (this.overflowing || this.expanded);
+  }
+
+  get clamp() {
+    return this.args.clamp ?? false;
+  }
+
+  get toggleLabel() {
+    return this.expanded
+      ? i18n("discourse_post_event.event_description.show_less")
+      : i18n("discourse_post_event.event_description.show_more");
+  }
+
+  <template>
+    {{#if @description}}
+      <section
+        class="event__section event-description
+          {{if this.clamp 'is-clamped'}}
+          {{if this.expanded 'is-expanded'}}"
+      >
+        {{icon "file-lines"}}
+
+        <div
+          class="event-description__content"
+          {{(if this.clamp this.detectOverflow)}}
+        >
+          <p class="event-description__text">{{@description}}</p>
+          {{#if this.showToggle}}
+            <a
+              href
+              class="event-description__toggle"
+              {{on "click" this.toggle}}
+            >{{this.toggleLabel}}</a>
+          {{/if}}
+        </div>
+      </section>
+    {{/if}}
+  </template>
+}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -66,6 +66,10 @@ export default class DiscoursePostEvent extends Component {
     }
   }
 
+  get clampDescription() {
+    return this.args.clampDescription ?? false;
+  }
+
   get withDescription() {
     return this.args.withDescription ?? true;
   }
@@ -203,7 +207,9 @@ export default class DiscoursePostEvent extends Component {
                   Section=(component InfoSection event=event)
                   Url=(component Url url=event.url)
                   Description=(component
-                    Description description=event.description
+                    Description
+                    description=event.description
+                    clamp=this.clampDescription
                   )
                   Location=(component Location location=event.location)
                   Dates=(component
@@ -235,7 +241,10 @@ export default class DiscoursePostEvent extends Component {
                 <Invitees @event={{event}} />
 
                 {{#if this.withDescription}}
-                  <Description @description={{event.description}} />
+                  <Description
+                    @description={{event.description}}
+                    @clamp={{this.clampDescription}}
+                  />
                 {{/if}}
 
                 {{#if @event.canUpdateAttendance}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -21,7 +21,8 @@ const PostEventMenu = <template>
     @linkToPost={{true}}
     @event={{@data.event}}
     @onClose={{@data.onClose}}
-    @withDescription={{false}}
+    @withDescription={{true}}
+    @clampDescription={{true}}
   />
 </template>;
 

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-calendar.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-calendar.scss
@@ -283,8 +283,8 @@ a.holiday {
 }
 
 .discourse-post-event-loader {
-  width: 200px;
-  height: 100px;
+  width: 100%;
+  min-height: 200px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -358,10 +358,7 @@ $show-interested: inherit;
     margin: 0;
   }
 
-  .event-description {
-    display: flex;
-  }
-
+  .event-description,
   .event-location,
   .event-url,
   .event-dates,
@@ -382,6 +379,33 @@ $show-interested: inherit;
 
     .chat-channel-link {
       @include ellipsis;
+    }
+  }
+
+  .event-description {
+    align-items: start;
+    padding-right: 2em;
+
+    > .d-icon {
+      margin-top: 0.25em;
+    }
+
+    .event-description__text {
+      text-align: justify;
+    }
+
+    &.is-clamped .event-description__text {
+      @include line-clamp(3);
+    }
+
+    &.is-clamped.is-expanded .event-description__text {
+      -webkit-line-clamp: unset;
+    }
+
+    .event-description__toggle {
+      font-size: var(--font-down-1);
+      margin-top: 0.25em;
+      cursor: pointer;
     }
   }
 

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -334,6 +334,9 @@ en:
         invite_user_notification: "%{username} %{description}"
         invite_user_predefined_attendance_notification: "%{username} has automatically set your attendance and invited you to %{eventName}"
         an_event: "an event"
+      event_description:
+        show_more: "Show more"
+        show_less: "Show less"
       edit_reason: "Event updated"
       edit_reason_closed: "Event closed"
       edit_reason_opened: "Event opened"

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
@@ -30,6 +30,31 @@ module PageObjects
           has_css?(".event-description", text:)
         end
 
+        def has_no_description?
+          has_no_css?(".event-description")
+        end
+
+        def has_description_toggle?
+          has_css?(".event-description__toggle")
+        end
+
+        def has_no_description_toggle?
+          has_no_css?(".event-description__toggle")
+        end
+
+        def click_description_toggle
+          find(".event-description__toggle").click
+          self
+        end
+
+        def has_description_clamped?
+          has_css?(".event-description.is-clamped:not(.is-expanded)")
+        end
+
+        def has_description_expanded?
+          has_css?(".event-description.is-clamped.is-expanded")
+        end
+
         def close
           has_css?(".discourse-post-event .status-and-creators .status:not(.closed)")
           open_more_menu

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -51,7 +51,18 @@ describe "Post event" do
       expect(post_event_page).to have_description(
         %r{this is a test description\s+and a link http://example.com},
       )
-      expect(page).to have_css(".event-description a[href='http://example.com']")
+    end
+
+    it "shows the full description without a toggle in the topic view" do
+      title = "Event with full description"
+      description = "A short event description"
+      raw = "[event start='2222-02-22 14:22']\n#{description}\n[/event]"
+      post = PostCreator.create(admin, title:, raw:)
+
+      visit(post.topic.url)
+
+      expect(post_event_page).to have_description(description)
+      expect(post_event_page).to have_no_description_toggle
     end
 
     it "correctly builds a multiline description" do

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -36,7 +36,8 @@ describe "Upcoming Events" do
     let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }
 
     it "shows clamped description with expand toggle", time: Time.utc(2025, 9, 10, 12, 0) do
-      long_description = "This is a long event description. " * 20
+      long_description =
+        "Join us for a <b>great</b> event :tada: with **bold text** and more details! " * 10
       create_post(
         user: admin,
         category: Fabricate(:category),
@@ -51,6 +52,9 @@ describe "Upcoming Events" do
       find("a", text: "Event with long description").click
 
       expect(post_event_page).to have_description_clamped
+      expect(post_event_page).to have_description(
+        "Join us for a great event with bold text and more details!",
+      )
       expect(post_event_page).to have_description_toggle
 
       post_event_page.click_description_toggle

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -32,6 +32,50 @@ describe "Upcoming Events" do
     end
   end
 
+  describe "event description in popup" do
+    let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }
+
+    it "shows clamped description with expand toggle", time: Time.utc(2025, 9, 10, 12, 0) do
+      long_description = "This is a long event description. " * 20
+      create_post(
+        user: admin,
+        category: Fabricate(:category),
+        title: "Event with long description",
+        raw:
+          "[event start=\"2025-09-11 08:05\" end=\"2025-09-11 10:05\"]\n#{long_description}\n[/event]",
+      )
+
+      upcoming_events.visit
+      upcoming_events.open_year_view
+
+      find("a", text: "Event with long description").click
+
+      expect(post_event_page).to have_description_clamped
+      expect(post_event_page).to have_description_toggle
+
+      post_event_page.click_description_toggle
+
+      expect(post_event_page).to have_description_expanded
+    end
+
+    it "shows description without toggle for short text", time: Time.utc(2025, 9, 10, 12, 0) do
+      create_post(
+        user: admin,
+        category: Fabricate(:category),
+        title: "Event with short description",
+        raw: "[event start=\"2025-09-11 08:05\" end=\"2025-09-11 10:05\"]\nBrief sync.\n[/event]",
+      )
+
+      upcoming_events.visit
+      upcoming_events.open_year_view
+
+      find("a", text: "Event with short description").click
+
+      expect(post_event_page).to have_description("Brief sync.")
+      expect(post_event_page).to have_no_description_toggle
+    end
+  end
+
   describe "event display and formatting" do
     before { admin.user_option.update!(timezone: "America/New_York") }
 


### PR DESCRIPTION
When clicking an event in the calendar (upcoming events or category calendar), the popup showed event details like dates, recurrence, and invitees — but not the description. Users had to click through to the topic to see it, which was a common customer complaint.

This enables the description in the calendar popup by flipping `@withDescription` to `true` in the `PostEventMenu` component and introducing a `@clampDescription` arg that controls whether the description is truncated.

In the popup, descriptions are clamped to 3 lines using the existing `line-clamp` mixin with a "Show more"/"Show less" toggle. A `ResizeObserver` detects whether the text actually overflows, so the toggle only appears when needed. In the topic view, the full description is shown without clamping.

The description is stored as plain text (the event parser extracts it via `doc.text.strip` from the cooked HTML), so it's rendered as a plain `<p>` element rather than through `CookText`. This also makes overflow detection straightforward since there's no async rendering.

Other changes:
- Added a `file-lines` icon and grid layout to the description section to match the visual pattern of other event sections (dates, location, recurrence)
- Increased the event loader `min-height` from 100px to 200px to reduce layout shift while the event widget loads
- Removed the pre-existing assertion that descriptions auto-link URLs, since descriptions are plain text

**Calendar popup**
<img width="543" height="383" alt="2026-04-02 @ 14 40 48" src="https://github.com/user-attachments/assets/b73e01b5-ab67-455d-a4d6-d74a66373c31" />
<img width="540" height="535" alt="2026-04-02 @ 14 40 53" src="https://github.com/user-attachments/assets/d63ad3ad-acf1-4aa0-b14d-00149243de51" />

**Topic**
<img width="712" height="466" alt="2026-04-02 @ 14 41 01" src="https://github.com/user-attachments/assets/164591fe-6684-4632-938d-d17d32357675" />

Ref - t/180829