### PR TITLE
FEATURE: Inform of deprecated columns in Data Explorer schema

### DIFF
--- a/app/models/concerns/has_deprecated_columns.rb
+++ b/app/models/concerns/has_deprecated_columns.rb
@@ -3,9 +3,25 @@
 module HasDeprecatedColumns
   extend ActiveSupport::Concern
 
+  DeprecatedColumn =
+    Data.define(:table_name, :column_name, :message) do
+      def ==(other)
+        case other
+        when String
+          [table_name, column_name] == other.split(".")
+        when DeprecatedColumn
+          [table_name, column_name] == [other.table_name, other.column_name]
+        else
+          false
+        end
+      end
+    end
+
   class_methods do
     def deprecate_column(column_name, drop_from:, raise_error: false, message: nil)
       message = message.presence || "column `#{column_name}` is deprecated."
+
+      Discourse.deprecated_columns << DeprecatedColumn.new(table_name, column_name.to_s, message)
 
       define_method(column_name) do
         Discourse.deprecate(message, drop_from: drop_from, raise_error: raise_error)

--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -7,7 +7,7 @@ class UserField < ActiveRecord::Base
 
   FLAG_ATTRIBUTES = %w[editable show_on_profile show_on_signup show_on_user_card searchable].freeze
 
-  deprecate_column :required, drop_from: "3.3"
+  deprecate_column :required, drop_from: "3.3", message: "See UserField.requirement"
   self.ignored_columns += %i[field_type]
 
   validates :description, presence: true

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -184,7 +184,22 @@ module Discourse
   end
 
   def self.deprecated_columns
-    DEPRECATED_COLUMNS
+    DEPRECATED_COLUMNS.concat(ignored_columns)
+  end
+
+  def self.ignored_columns
+    ActiveRecord::Base.descendants.filter_map do |model|
+      model
+        .ignored_columns
+        .map do |column_name|
+          HasDeprecatedColumns::DeprecatedColumn.new(
+            model.table_name,
+            column_name,
+            "column `#{column_name}` is deprecated.",
+          )
+        end
+        .presence
+    end
   end
 
   def self.job_exception_stats

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -11,6 +11,7 @@ module Discourse
   DB_POST_MIGRATE_PATH = "db/post_migrate"
   MAX_METADATA_FILE_SIZE = 64.kilobytes
   LOCALE_PARAM = "tl"
+  DEPRECATED_COLUMNS = []
 
   class Utils
     URI_REGEXP = URI.regexp(%w[http https])
@@ -180,6 +181,10 @@ module Discourse
         stdout
       end
     end
+  end
+
+  def self.deprecated_columns
+    DEPRECATED_COLUMNS
   end
 
   def self.job_exception_stats

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/explorer-schema/one-table.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/explorer-schema/one-table.gjs
@@ -1,7 +1,9 @@
 /* eslint-disable ember/no-tracked-properties-from-args */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { concat } from "@ember/helper";
 import { on } from "@ember/modifier";
+import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
@@ -41,13 +43,27 @@ export default class OneTable extends Component {
             {{#each @table.columns as |col|}}
               <div>
                 <dt
-                  class={{if col.sensitive "sensitive"}}
-                  title={{if col.sensitive (i18n "explorer.schema.sensitive")}}
+                  class={{concatClass
+                    (if col.sensitive "sensitive")
+                    (if col.is_deprecated "deprecated")
+                  }}
+                  title={{concat
+                    (if col.sensitive (i18n "explorer.schema.sensitive"))
+                    (if col.is_deprecated col.deprecation_message)
+                  }}
                 >
                   {{#if col.sensitive}}
                     {{icon "triangle-exclamation"}}
                   {{/if}}
-                  {{col.column_name}}
+                  {{#if col.is_deprecated}}
+                    {{icon "triangle-exclamation"}}
+                  {{/if}}
+                  <span class="column-name">{{col.column_name}}</span>
+                  {{#if col.is_deprecated}}
+                    <span class="extra-info">{{i18n
+                        "explorer.schema.deprecated"
+                      }}</span>
+                  {{/if}}
                 </dt>
                 <dd>
                   {{col.data_type}}

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -137,6 +137,17 @@ table.group-reports {
         &.sensitive {
           color: var(--danger);
         }
+
+        &.deprecated {
+          .column-name {
+            text-decoration: line-through;
+          }
+
+          .extra-info {
+            color: var(--primary-medium);
+            font-style: italic;
+          }
+        }
       }
 
       dd {

--- a/plugins/discourse-data-explorer/config/locales/client.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/client.en.yml
@@ -70,6 +70,7 @@ en:
         title: "Database Schema"
         filter: "Search..."
         sensitive: "The contents of this column may contain particularly sensitive or private information. Please exercise caution when using the contents of this column."
+        deprecated: "Deprecated"
       types:
         bool:
           yes: "Yes"

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -272,6 +272,10 @@ module DiscourseDataExplorer
           results.each do |hash|
             full_col_name = "#{hash["table_name"]}.#{hash["column_name"]}"
 
+            if deprecated = Discourse.deprecated_columns.find { |c| c == full_col_name }
+              hash["is_deprecated"] = true
+              hash["deprecation_message"] = deprecated.message
+            end
             if hash["is_nullable"] == "YES"
               hash["is_nullable"] = true
             else


### PR DESCRIPTION
### Background

DataExplorer queries interface with the database directly, and so is unaware of deprecated columns. This results in people's queries sometimes breaking when upgrading, and a column has been dropped or renamed.

### What is this change?

This PR makes it so we display a deprecation warning in the DataExplorer schema. This is a small improvement, but likely the most we can do without introducing a SQL parser as a dependency. In other words: it is something.

**Screenshot:**

<img width="752" height="409" alt="Screenshot 2026-04-09 at 11 31 36 AM" src="https://github.com/user-attachments/assets/e1592198-cd62-4b84-a9d9-70bb4a72f753" />
