### PR TITLE
DEV: Fix typo "overriden" -> "overridden" in site_setting_extension comment

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -166,7 +166,7 @@ module SiteSettingExtension
   end
 
   # Has a pointer from a site setting name to the upcoming change name
-  # and overriden default value. Looks like this in site_settings.yml:
+  # and overridden default value. Looks like this in site_settings.yml:
   #
   # setting_name:
   #   upcoming_change_default_override:


### PR DESCRIPTION
Fix a typo in a comment in `lib/site_setting_extension.rb`:

`overriden` → `overridden`

The comment describes the structure of `upcoming_change_default_override` in `site_settings.yml`.