### PR TITLE
FIX: Sync category description when post content changes outside PostRevisor

### DIFF
--- a/app/jobs/regular/change_display_name.rb
+++ b/app/jobs/regular/change_display_name.rb
@@ -55,6 +55,7 @@ module Jobs
       post.cooked = update_cooked(post.cooked)
 
       post.update_columns(raw: post.raw, cooked: post.cooked)
+      post.sync_first_post_caches
 
       SearchIndexer.index(post, force: true) if post.topic
     rescue => e

--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -38,7 +38,7 @@ module Jobs
             )
           else
             post.update_column(:cooked, cp.html)
-            post.topic.update_excerpt(post.excerpt_for_topic) if post.is_first_post?
+            post.sync_first_post_caches
             extract_links(post)
             post.publish_change_to_clients! :revised
           end

--- a/app/jobs/regular/update_username.rb
+++ b/app/jobs/regular/update_username.rb
@@ -66,16 +66,31 @@ module Jobs
         .with_deleted
         .where("raw ILIKE ?", "%@#{@old_username}%")
         .where("posts.user_id = :user_id", user_id: @user_id)
+        .where.not(id: updated_post_ids)
         .find_each do |post|
           update_post(post)
           updated_post_ids << post.id
         end
 
+      # Posts quoting this user
       Post
         .with_deleted
         .joins(quoted("posts.id"))
         .where("p.user_id = :user_id", user_id: @user_id)
-        .find_each { |post| update_post(post) if updated_post_ids.exclude?(post.id) }
+        .where.not(id: updated_post_ids)
+        .find_each do |post|
+          update_post(post)
+          updated_post_ids << post.id
+        end
+
+      # Category description posts may be authored by the system user and have no user_actions
+      Post
+        .with_deleted
+        .joins("INNER JOIN categories ON categories.topic_id = posts.topic_id")
+        .where(post_number: 1)
+        .where("raw ILIKE ?", "%@#{@old_username}%")
+        .where.not(id: updated_post_ids)
+        .find_each { |post| update_post(post) }
     end
 
     def update_revisions
@@ -138,6 +153,7 @@ module Jobs
       post.cooked = update_cooked(post.cooked)
 
       post.update_columns(raw: post.raw, cooked: post.cooked)
+      post.sync_first_post_caches
 
       SearchIndexer.index(post, force: true) if post.topic
     rescue => e

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -566,6 +566,29 @@ class Post < ActiveRecord::Base
     topic.present? && topic.is_category_topic? && is_first_post?
   end
 
+  def sync_first_post_caches
+    return if post_number > 1
+    topic&.update_excerpt(excerpt_for_topic)
+    sync_category_description
+  end
+
+  def sync_category_description(category = nil)
+    category ||= Category.find_by(topic_id:)
+    return unless category
+
+    doc = Nokogiri::HTML5.fragment(cooked)
+    doc.css("img").remove
+
+    if (html = doc.css("p").first&.inner_html&.strip)
+      new_description = html unless html.starts_with?(Category.post_template[..50])
+      return category if category.description == new_description
+      category.update_column(:description, new_description)
+      category.publish_category
+      Site.clear_cache
+      category
+    end
+  end
+
   def is_reply_by_email?
     via_email && post_number.present? && post_number > 1
   end
@@ -847,7 +870,7 @@ class Post < ActiveRecord::Base
 
     update_columns(cooked: new_cooked, baked_at: Time.zone.now, baked_version: BAKED_VERSION)
 
-    topic&.update_excerpt(excerpt_for_topic) if is_first_post?
+    sync_first_post_caches
 
     if invalidate_broken_images
       post_hotlinked_media.download_failed.destroy_all

--- a/app/services/group_mentions_updater.rb
+++ b/app/services/group_mentions_updater.rb
@@ -11,6 +11,7 @@ class GroupMentionsUpdater
         posts.each do |post|
           post.raw.gsub!(/(^|\s)(@#{previous_name})(\s|$)/, "\\1@#{current_name}\\3")
           post.save!(validate: false)
+          post.sync_first_post_caches
         end
       end
   end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -800,14 +800,9 @@ class PostRevisor
   end
 
   def update_category_description
-    return unless category = Category.find_by(topic_id: @topic.id)
+    return unless (category = Category.find_by(topic_id: @topic.id))
 
-    doc = Nokogiri::HTML5.fragment(@post.cooked)
-    doc.css("img").remove
-
-    if html = doc.css("p").first&.inner_html&.strip
-      new_description = html unless html.starts_with?(Category.post_template[0..50])
-      category.update_column(:description, new_description)
+    if @post.sync_category_description(category)
       @category_changed = category
     else
       @post.errors.add(:base, I18n.t("category.errors.description_incomplete"))

--- a/spec/jobs/process_post_spec.rb
+++ b/spec/jobs/process_post_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Jobs::ProcessPost do
       expect(post.cooked).to eq(cooked)
     end
 
-    it "updates the topic excerpt when first post" do
+    it "updates first post caches only for the OP" do
       post = Fabricate(:post, raw: "Some OP content", cooked: "")
       post.topic.update_excerpt("Incorrect")
 

--- a/spec/jobs/update_username_spec.rb
+++ b/spec/jobs/update_username_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe Jobs::UpdateUsername do
       <p><a class="mention" href="/u/newname">@newname</a> <a class="mention" href="/u/foo-bar">@foo-bar</a></p>
     HTML
   end
+
+  it "updates the category description when a category description topic mentions the user" do
+    category = Fabricate(:category_with_definition, user: Discourse.system_user)
+    first_post = category.topic.first_post
+    first_post.revise(first_post.user, { raw: "This category is managed by @#{user.username}" })
+    category.reload
+
+    expect(category.description).to include(user.username)
+
+    old_username = user.username
+    new_username = "new_username_123"
+
+    described_class.new.execute(
+      user_id: user.id,
+      old_username:,
+      new_username:,
+      avatar_template: user.avatar_template,
+    )
+    category.reload
+
+    expect(category.description).to include(new_username)
+    expect(category.description).not_to include(old_username)
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1367,6 +1367,18 @@ RSpec.describe Post do
       expect(post.topic.excerpt).to eq("test")
     end
 
+    it "updates the category description when rebaking a category description topic" do
+      category = Fabricate(:category_with_definition)
+      first_post = category.topic.first_post
+      first_post.revise(first_post.user, { raw: "Original description" })
+      expect(category.reload.description).to include("Original description")
+
+      first_post.update_column(:raw, "Updated description")
+      first_post.rebake!
+
+      expect(category.reload.description).to include("Updated description")
+    end
+
     it "works with posts in deleted topics" do
       post = create_post
       post.topic.trash!

--- a/spec/services/group_mentions_updater_spec.rb
+++ b/spec/services/group_mentions_updater_spec.rb
@@ -41,6 +41,23 @@ RSpec.describe GroupMentionsUpdater do
       expect(post.reload.raw_mentions).to eq([])
     end
 
+    it "should update the category description when a category description topic mentions the group" do
+      group = Fabricate(:group, name: "old_team", mentionable_level: Group::ALIAS_LEVELS[:everyone])
+
+      category = Fabricate(:category_with_definition)
+      first_post = category.topic.first_post
+      first_post.revise(first_post.user, { raw: "This category is managed by @old_team" })
+      category.reload
+
+      expect(category.description).to include("old_team")
+
+      GroupMentionsUpdater.update("new_team", "old_team")
+      category.reload
+
+      expect(category.description).to include("new_team")
+      expect(category.description).not_to include("old_team")
+    end
+
     it "should ignore validations" do
       everyone_mention_level = Group::ALIAS_LEVELS[:everyone]
 


### PR DESCRIPTION
When a group or user is renamed, `GroupMentionsUpdater` and `Jobs::UpdateUsername` update the post's raw/cooked content but skip `PostRevisor`, so `categories.description` (a denormalized copy of the first paragraph) is never refreshed. The Edit Category page and category banner keep showing the old name, while the actual topic shows the new one. Same issue with `Post#rebake!` (Rebuild HTML) and `ProcessPost`.

Extract `Post#sync_category_description` as the single source of truth for deriving `categories.description` from a post's cooked HTML — both `PostRevisor` and the new `Post#sync_first_post_caches` now delegate to it. `sync_first_post_caches` also updates `topics.excerpt`, centralizing all first-post denormalized field updates.

Call `sync_first_post_caches` from every code path that modifies post content outside PostRevisor: `GroupMentionsUpdater`, `UpdateUsername`, `ChangeDisplayName`, `ProcessPost`, and `Post#rebake!`.

Skip the update when the description hasn't changed to avoid unnecessary writes. When it has changed, call `publish_category` and `Site.clear_cache` so connected clients see the update immediately (fixes a pre-existing flicker where the old description would briefly appear then get overwritten by stale cached site data).

Also add a targeted query in `UpdateUsername` for category description posts authored by the system user, which were missed by the existing `user_actions`-based and self-mention queries.

Ref - t/181445