### PR TITLE
FIX: Include banner topics in translation backfill

### DIFF
--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -59,6 +59,20 @@ module DiscourseAi
           posts = posts.where.not(topics: { archetype: Archetype.private_message })
         end
 
+        # Always include posts from banner topics regardless of age or category filters
+        banner_posts =
+          Post
+            .where(deleted_at: nil)
+            .where.not(raw: [nil, ""])
+            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
+            .joins(:topic)
+            .where(topics: { archetype: Archetype.banner, deleted_at: nil })
+        banner_posts =
+          banner_posts.where(
+            "posts.user_id > 0",
+          ) unless SiteSetting.ai_translation_include_bot_content
+        posts = posts.or(banner_posts)
+
         posts
       end
 

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -45,6 +45,10 @@ module DiscourseAi
           topics = topics.where.not(archetype: Archetype.private_message)
         end
 
+        # Always include banner topics regardless of age or category filters
+        banner_topics = Topic.where(archetype: Archetype.banner, deleted_at: nil)
+        topics = topics.or(banner_topics)
+
         topics
       end
 

--- a/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
@@ -35,6 +35,32 @@ describe DiscourseAi::Translation::TopicCandidates do
       expect(DiscourseAi::Translation::TopicCandidates.get).not_to include(topic)
     end
 
+    it "returns banner topics even when older than max_age_days" do
+      banner_topic =
+        Fabricate(
+          :topic,
+          archetype: Archetype.banner,
+          created_at: SiteSetting.ai_translation_backfill_max_age_days.days.ago - 30.days,
+        )
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).to include(banner_topic)
+    end
+
+    it "returns banner topics even when no target categories are set" do
+      SiteSetting.ai_translation_target_categories = ""
+      SiteSetting.ai_translation_personal_messages = "none"
+
+      banner_topic = Fabricate(:topic, archetype: Archetype.banner)
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).to include(banner_topic)
+    end
+
+    it "does not return deleted banner topics" do
+      banner_topic = Fabricate(:topic, archetype: Archetype.banner, deleted_at: Time.now)
+
+      expect(DiscourseAi::Translation::TopicCandidates.get).not_to include(banner_topic)
+    end
+
     it "does not return deleted topics" do
       topic = Fabricate(:topic, deleted_at: Time.now)
       SiteSetting.ai_translation_target_categories = Category.pluck(:id).join("|")


### PR DESCRIPTION
Regardless of date, if there is a banner topic, we should translate as soon as possible, it is shown to users on the homepage. 