### PR TITLE
FEATURE: Add mode-based access control to data-explorer

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -3,6 +3,7 @@ import { Input } from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { service } from "@ember/service";
 import AceEditor from "discourse/components/ace-editor";
 import BackButton from "discourse/components/back-button";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
@@ -12,6 +13,7 @@ import TextField from "discourse/components/text-field";
 import icon from "discourse/helpers/d-icon";
 import draggable from "discourse/modifiers/draggable";
 import MultiSelect from "discourse/select-kit/components/multi-select";
+import { and, not } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import CodeView from "discourse/plugins/discourse-data-explorer/discourse/components/code-view";
 import ExplorerSchema from "discourse/plugins/discourse-data-explorer/discourse/components/explorer-schema";
@@ -20,6 +22,8 @@ import QueryResultDownloadButtons from "discourse/plugins/discourse-data-explore
 import QueryResultsWrapper from "discourse/plugins/discourse-data-explorer/discourse/components/query-results-wrapper";
 
 export default class QueriesEdit extends Component {
+  @service dataExplorerMode;
+
   get showDestroyQuery() {
     return this.args.controller.model?.id > -1;
   }
@@ -62,13 +66,17 @@ export default class QueriesEdit extends Component {
               <h1 class="query-name-display">
                 <span>{{@controller.model.name}}</span>
               </h1>
-              {{#unless @controller.editDisabled}}
+              {{#if
+                (and
+                  this.dataExplorerMode.isFull (not @controller.editDisabled)
+                )
+              }}
                 <DButton
                   @action={{@controller.editName}}
                   @icon="pencil"
                   class="edit-query-name btn-transparent"
                 />
-              {{/unless}}
+              {{/if}}
             </div>
 
             <div class="desc">
@@ -76,7 +84,9 @@ export default class QueriesEdit extends Component {
             </div>
           {{/if}}
 
-          {{#unless @controller.model.destroyed}}
+          {{#if
+            (and this.dataExplorerMode.isFull (not @controller.model.destroyed))
+          }}
             <div class="groups">
               <span class="label">{{i18n "explorer.allow_groups"}}</span>
               <span>
@@ -88,7 +98,7 @@ export default class QueriesEdit extends Component {
                 />
               </span>
             </div>
-          {{/unless}}
+          {{/if}}
 
           <div class="clear"></div>
 
@@ -167,18 +177,22 @@ export default class QueriesEdit extends Component {
           <div class="query-run-actions">
             <div class="query-run-actions__left">
               {{#if @controller.runDisabled}}
-                {{#if @controller.saveDisabled}}
-                  <DButton
-                    @label="explorer.run"
-                    @disabled="true"
-                    class="btn-primary query-run__submit"
-                  />
-                {{else}}
+                {{#if
+                  (and
+                    this.dataExplorerMode.isFull (not @controller.saveDisabled)
+                  )
+                }}
                   <DButton
                     @action={{@controller.saveAndRun}}
                     @icon="play"
                     @label="explorer.saverun"
                     class="btn-primary query-run__save-and-run"
+                  />
+                {{else}}
+                  <DButton
+                    @label="explorer.run"
+                    @disabled="true"
+                    class="btn-primary query-run__submit"
                   />
                 {{/if}}
               {{else}}
@@ -193,22 +207,24 @@ export default class QueriesEdit extends Component {
                 />
               {{/if}}
 
-              {{#if @controller.editingQuery}}
-                <DButton
-                  class="btn-save-query"
-                  @action={{@controller.save}}
-                  @label="explorer.save"
-                  @disabled={{@controller.saveDisabled}}
-                />
-              {{else}}
-                {{#unless @controller.editDisabled}}
+              {{#if this.dataExplorerMode.isFull}}
+                {{#if @controller.editingQuery}}
                   <DButton
-                    class="btn-edit-query"
-                    @action={{@controller.editQuery}}
-                    @label="explorer.edit"
-                    @icon="pencil"
+                    class="btn-save-query"
+                    @action={{@controller.save}}
+                    @label="explorer.save"
+                    @disabled={{@controller.saveDisabled}}
                   />
-                {{/unless}}
+                {{else}}
+                  {{#unless @controller.editDisabled}}
+                    <DButton
+                      class="btn-edit-query"
+                      @action={{@controller.editQuery}}
+                      @label="explorer.edit"
+                      @icon="pencil"
+                    />
+                  {{/unless}}
+                {{/if}}
               {{/if}}
 
               {{#if @controller.editingQuery}}
@@ -231,11 +247,13 @@ export default class QueriesEdit extends Component {
 
             <div class="query-run-actions__right">
               {{#if @controller.model.destroyed}}
-                <DButton
-                  @action={{@controller.recover}}
-                  @icon="arrow-rotate-left"
-                  @label="explorer.recover"
-                />
+                {{#if this.dataExplorerMode.isFull}}
+                  <DButton
+                    @action={{@controller.recover}}
+                    @icon="arrow-rotate-left"
+                    @label="explorer.recover"
+                  />
+                {{/if}}
               {{else}}
                 {{#if @controller.editingQuery}}
                   <DButton
@@ -261,7 +279,7 @@ export default class QueriesEdit extends Component {
                   />
                 {{/if}}
 
-                {{#if this.showDestroyQuery}}
+                {{#if (and this.dataExplorerMode.isFull this.showDestroyQuery)}}
                   <DButton
                     @action={{@controller.destroyQuery}}
                     @icon="trash-can"

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
@@ -1,232 +1,273 @@
+import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
 import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DPageSubheader from "discourse/components/d-page-subheader";
 import LoadMore from "discourse/components/load-more";
 import PickFilesButton from "discourse/components/pick-files-button";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import TableHeaderToggle from "discourse/components/table-header-toggle";
 import ageWithTooltip from "discourse/helpers/age-with-tooltip";
 import icon from "discourse/helpers/d-icon";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { not } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import ShareReport from "discourse/plugins/discourse-data-explorer/discourse/components/share-report";
 
-export default <template>
-  <div class="admin-detail">
-    {{#if @controller.disallow}}
-      <h1>{{i18n "explorer.admins_only"}}</h1>
-    {{else}}
-      <DPageSubheader @titleLabel={{i18n "explorer.queries"}}>
-        <:actions as |actions|>
-          <actions.Primary
-            @route="adminPlugins.show.explorer.new"
-            @icon="plus"
-            @label="explorer.create"
-          />
-          <actions.Wrapped>
-            <PickFilesButton
-              @label="explorer.import.label"
-              @icon="upload"
-              @acceptedFormatsOverride={{@controller.acceptedImportFileTypes}}
-              @showButton="true"
-              @onFilesPicked={{@controller.import}}
-              class="d-page-action-button btn-small"
-            />
-          </actions.Wrapped>
-        </:actions>
-      </DPageSubheader>
+export default class QueriesIndex extends Component {
+  @service dataExplorerMode;
 
-      <AdminFilterControls
-        @array={{@controller.model.content}}
-        @inputPlaceholder={{i18n "explorer.search_placeholder"}}
-        @noResultsMessage={{i18n "explorer.no_search_results"}}
-        @onTextFilterChange={{@controller.onTextFilterChange}}
-        @onResetFilters={{@controller.onResetFilters}}
-        @loading={{@controller.searchLoading}}
-      >
-        <:aboveFilters>
-          {{#if @controller.othersDirty}}
-            <div class="warning">
-              {{icon "triangle-exclamation"}}
-              {{i18n "explorer.others_dirty"}}
-            </div>
-          {{/if}}
-        </:aboveFilters>
+  <template>
+    <div class="admin-detail">
+      {{#if @controller.disallow}}
+        <h1>{{i18n "explorer.admins_only"}}</h1>
+      {{else}}
+        <DPageSubheader @titleLabel={{i18n "explorer.queries"}}>
+          <:actions as |actions|>
+            {{#if this.dataExplorerMode.isFull}}
+              <actions.Primary
+                @route="adminPlugins.show.explorer.new"
+                @icon="plus"
+                @label="explorer.create"
+              />
+              <actions.Wrapped>
+                <PickFilesButton
+                  @label="explorer.import.label"
+                  @icon="upload"
+                  @acceptedFormatsOverride={{@controller.acceptedImportFileTypes}}
+                  @showButton="true"
+                  @onFilesPicked={{@controller.import}}
+                  class="d-page-action-button btn-small"
+                />
+              </actions.Wrapped>
+            {{/if}}
+          </:actions>
+        </DPageSubheader>
 
-        <:content as |filteredQueries|>
-          {{#if @controller.model.content.length}}
-            <ConditionalLoadingSpinner @condition={{@controller.loading}} />
+        <PluginOutlet
+          @name="data-explorer-index-header"
+          @connectorTagName="div"
+          @outletArgs={{lazyHash dataExplorerMode=this.dataExplorerMode}}
+        />
 
-            <LoadMore @action={{@controller.loadMore}}>
-              <div class="container discourse-data-explorer-query-list">
-                <table class="d-table recent-queries">
-                  <thead class="d-table__header heading-container">
-                    <th class="col heading name">
-                      <div
-                        role="button"
-                        class="heading-toggle"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "name")
-                        }}
-                      >
-                        <TableHeaderToggle
-                          @field="name"
-                          @labelKey="explorer.query_name"
-                          @order={{@controller.order}}
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                        />
-                      </div>
-                    </th>
-                    <th class="col heading created-by">
-                      <div
-                        role="button"
-                        class="heading-toggle"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "username")
-                        }}
-                      >
-                        <TableHeaderToggle
-                          @field="username"
-                          @labelKey="explorer.query_user"
-                          @order={{@controller.order}}
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                        />
-                      </div>
-                    </th>
-                    <th class="col heading group-names">
-                      <div class="group-names-header">
-                        {{i18n "explorer.query_groups"}}
-                      </div>
-                    </th>
-                    <th class="col heading created-at">
-                      <div
-                        role="button"
-                        class="heading-toggle"
-                        {{on
-                          "click"
-                          (fn @controller.updateSortProperty "last_run_at")
-                        }}
-                      >
-                        <TableHeaderToggle
-                          @field="last_run_at"
-                          @labelKey="explorer.query_time"
-                          @order={{@controller.order}}
-                          @asc={{not @controller.sortDescending}}
-                          @automatic="true"
-                        />
-                      </div>
-                    </th>
-                  </thead>
-                  <tbody>
-                    {{#each filteredQueries as |query|}}
-                      <tr class="d-table__row query-row">
-                        <td class="d-table__cell --overview">
-                          <LinkTo
-                            class="d-table__overview-link"
-                            @route="adminPlugins.show.explorer.edit"
-                            @model={{query.id}}
-                          >
-                            <div
-                              class="d-table__overview-name query-name"
-                            >{{query.name}}
-                              {{#if query.is_default}}
-                                <span class="query-badge">{{i18n
-                                    "explorer.default_query"
-                                  }}</span>
-                              {{/if}}
-                            </div>
-                            <div class="query-desc">{{query.description}}</div>
-                          </LinkTo>
-                        </td>
-                        <td class="d-table__cell --detail query-created-by">
-                          <div class="d-table__mobile-label">
-                            {{i18n "explorer.query_user"}}
-                          </div>
-                          {{#if query.username}}
-                            <div>
-                              <LinkTo
-                                @route="user.summary"
-                                @model={{query.username}}
-                              >
-                                {{query.username}}
-                              </LinkTo>
-                            </div>
-                          {{/if}}
-                        </td>
-                        <td class="d-table__cell --detail query-group-names">
-                          <div class="d-table__mobile-label">
+        <AdminFilterControls
+          @array={{@controller.model.content}}
+          @inputPlaceholder={{i18n "explorer.search_placeholder"}}
+          @noResultsMessage={{i18n "explorer.no_search_results"}}
+          @onTextFilterChange={{@controller.onTextFilterChange}}
+          @onResetFilters={{@controller.onResetFilters}}
+          @loading={{@controller.searchLoading}}
+        >
+          <:aboveFilters>
+            {{#if @controller.othersDirty}}
+              <div class="warning">
+                {{icon "triangle-exclamation"}}
+                {{i18n "explorer.others_dirty"}}
+              </div>
+            {{/if}}
+          </:aboveFilters>
+
+          <:content as |filteredQueries|>
+            {{#if @controller.model.content.length}}
+              <ConditionalLoadingSpinner @condition={{@controller.loading}} />
+
+              <LoadMore @action={{@controller.loadMore}}>
+                <div class="container discourse-data-explorer-query-list">
+                  <table class="d-table recent-queries">
+                    <thead class="d-table__header heading-container">
+                      <th class="col heading name">
+                        <div
+                          role="button"
+                          class="heading-toggle"
+                          {{on
+                            "click"
+                            (fn @controller.updateSortProperty "name")
+                          }}
+                        >
+                          <TableHeaderToggle
+                            @field="name"
+                            @labelKey="explorer.query_name"
+                            @order={{@controller.order}}
+                            @asc={{not @controller.sortDescending}}
+                            @automatic="true"
+                          />
+                        </div>
+                      </th>
+                      <th class="col heading created-by">
+                        <div
+                          role="button"
+                          class="heading-toggle"
+                          {{on
+                            "click"
+                            (fn @controller.updateSortProperty "username")
+                          }}
+                        >
+                          <TableHeaderToggle
+                            @field="username"
+                            @labelKey="explorer.query_user"
+                            @order={{@controller.order}}
+                            @asc={{not @controller.sortDescending}}
+                            @automatic="true"
+                          />
+                        </div>
+                      </th>
+                      {{#if this.dataExplorerMode.isFull}}
+                        <th class="col heading group-names">
+                          <div class="group-names-header">
                             {{i18n "explorer.query_groups"}}
                           </div>
-                          <div class="group-names">
-                            {{#each query.group_names as |group|}}
-                              <ShareReport @group={{group}} @query={{query}} />
-                            {{/each}}
-                            {{#unless query.group_names.length}}
-                              -
-                            {{/unless}}
-                          </div>
-                        </td>
-                        <td class="d-table__cell --detail query-created-at">
-                          <div class="d-table__mobile-label">
-                            {{i18n "explorer.query_time"}}
-                          </div>
-                          {{#if query.last_run_at}}
-                            <span>
-                              {{ageWithTooltip
-                                query.last_run_at
-                                format="medium"
-                              }}
-                            </span>
-                          {{else if query.created_at}}
-                            <span>
-                              {{ageWithTooltip
-                                query.created_at
-                                format="medium"
-                              }}
-                            </span>
-                          {{else}}
-                            -
-                          {{/if}}
-                        </td>
-                        <td class="d-table__cell-controls">
-                          <div class="d-table__cell-actions">
-                            <LinkTo
-                              {{on "click" @controller.scrollTop}}
-                              @route="adminPlugins.show.explorer.edit"
-                              @model={{query.id}}
-                              class="btn btn-default btn-small"
+                        </th>
+                      {{/if}}
+                      <th class="col heading created-at">
+                        <div
+                          role="button"
+                          class="heading-toggle"
+                          {{on
+                            "click"
+                            (fn @controller.updateSortProperty "last_run_at")
+                          }}
+                        >
+                          <TableHeaderToggle
+                            @field="last_run_at"
+                            @labelKey="explorer.query_time"
+                            @order={{@controller.order}}
+                            @asc={{not @controller.sortDescending}}
+                            @automatic="true"
+                          />
+                        </div>
+                      </th>
+                    </thead>
+                    <tbody>
+                      {{#each filteredQueries as |query|}}
+                        <tr class="d-table__row query-row">
+                          <td class="d-table__cell --overview">
+                            {{#if this.dataExplorerMode.isDisabled}}
+                              <div class="d-table__overview-name query-name">
+                                {{query.name}}
+                                {{#if query.is_default}}
+                                  <span class="query-badge">{{i18n
+                                      "explorer.default_query"
+                                    }}</span>
+                                {{/if}}
+                              </div>
+                              <div
+                                class="query-desc"
+                              >{{query.description}}</div>
+                            {{else}}
+                              <LinkTo
+                                class="d-table__overview-link"
+                                @route="adminPlugins.show.explorer.edit"
+                                @model={{query.id}}
+                              >
+                                <div class="d-table__overview-name query-name">
+                                  {{query.name}}
+                                  {{#if query.is_default}}
+                                    <span class="query-badge">{{i18n
+                                        "explorer.default_query"
+                                      }}</span>
+                                  {{/if}}
+                                </div>
+                                <div
+                                  class="query-desc"
+                                >{{query.description}}</div>
+                              </LinkTo>
+                            {{/if}}
+                          </td>
+                          <td class="d-table__cell --detail query-created-by">
+                            <div class="d-table__mobile-label">
+                              {{i18n "explorer.query_user"}}
+                            </div>
+                            {{#if query.username}}
+                              <div>
+                                <LinkTo
+                                  @route="user.summary"
+                                  @model={{query.username}}
+                                >
+                                  {{query.username}}
+                                </LinkTo>
+                              </div>
+                            {{/if}}
+                          </td>
+                          {{#if this.dataExplorerMode.isFull}}
+                            <td
+                              class="d-table__cell --detail query-group-names"
                             >
-                              {{i18n "edit"}}
-                            </LinkTo>
-                          </div>
+                              <div class="d-table__mobile-label">
+                                {{i18n "explorer.query_groups"}}
+                              </div>
+                              <div class="group-names">
+                                {{#each query.group_names as |group|}}
+                                  <ShareReport
+                                    @group={{group}}
+                                    @query={{query}}
+                                  />
+                                {{/each}}
+                                {{#unless query.group_names.length}}
+                                  -
+                                {{/unless}}
+                              </div>
+                            </td>
+                          {{/if}}
+                          <td class="d-table__cell --detail query-created-at">
+                            <div class="d-table__mobile-label">
+                              {{i18n "explorer.query_time"}}
+                            </div>
+                            {{#if query.last_run_at}}
+                              <span>
+                                {{ageWithTooltip
+                                  query.last_run_at
+                                  format="medium"
+                                }}
+                              </span>
+                            {{else if query.created_at}}
+                              <span>
+                                {{ageWithTooltip
+                                  query.created_at
+                                  format="medium"
+                                }}
+                              </span>
+                            {{else}}
+                              -
+                            {{/if}}
+                          </td>
+                          {{#if this.dataExplorerMode.isFull}}
+                            <td class="d-table__cell-controls">
+                              <div class="d-table__cell-actions">
+                                <LinkTo
+                                  {{on "click" @controller.scrollTop}}
+                                  @route="adminPlugins.show.explorer.edit"
+                                  @model={{query.id}}
+                                  class="btn btn-default btn-small"
+                                >
+                                  {{i18n "edit"}}
+                                </LinkTo>
+                              </div>
+                            </td>
+                          {{/if}}
+                        </tr>
+                      {{else}}
+                        <br />
+                        <em class="no-search-results">
+                          {{i18n "explorer.no_search_results"}}
+                        </em>
+                      {{/each}}
+                    </tbody>
+                  </table>
+                </div>
+              </LoadMore>
 
-                        </td>
-                      </tr>
-                    {{else}}
-                      <br />
-                      <em class="no-search-results">
-                        {{i18n "explorer.no_search_results"}}
-                      </em>
-                    {{/each}}
-                  </tbody>
-                </table>
-              </div>
-            </LoadMore>
+              <ConditionalLoadingSpinner
+                @condition={{@controller.model.loadingMore}}
+              />
 
-            <ConditionalLoadingSpinner
-              @condition={{@controller.model.loadingMore}}
-            />
-
-            <div class="explorer-pad-bottom"></div>
-          {{/if}}
-        </:content>
-      </AdminFilterControls>
-    {{/if}}
-  </div>
-</template>
+              <div class="explorer-pad-bottom"></div>
+            {{/if}}
+          </:content>
+        </AdminFilterControls>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
+++ b/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
@@ -7,10 +7,24 @@ module DiscourseDataExplorer
     before_action :set_group, only: %i[group_reports_index group_reports_show group_reports_run]
     before_action :set_query, only: %i[group_reports_show group_reports_run show update public_run]
     before_action :ensure_admin
+    before_action :check_mode_access
 
     skip_before_action :check_xhr, only: %i[show group_reports_run run public_run]
     skip_before_action :ensure_admin,
                        only: %i[group_reports_index group_reports_show group_reports_run public_run]
+
+    ACTION_CAPABILITIES = {
+      index: :can_view_query_list,
+      show: :can_view_query_details,
+      create: :can_create_queries,
+      update: :can_modify_queries,
+      destroy: :can_modify_queries,
+      run: :can_run_queries,
+      schema: :can_view_query_details,
+      groups: :can_view_query_details,
+      group_reports_run: :can_run_queries,
+      public_run: :can_run_queries,
+    }.freeze
 
     INDEX_LIMIT = 50
 
@@ -339,6 +353,11 @@ module DiscourseDataExplorer
     def set_query
       @query = Query.find(params[:id])
       raise Discourse::NotFound unless @query
+    end
+
+    def check_mode_access
+      capability = ACTION_CAPABILITIES[action_name.to_sym]
+      Mode.check_access!(capability) if capability
     end
   end
 end

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -1,13 +1,23 @@
+import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
+  @service dataExplorerMode;
+  @service router;
+
   queryParams = {
     autoRun: {
       as: "run",
       refreshModel: false,
     },
   };
+
+  beforeModel() {
+    if (this.dataExplorerMode.isDisabled) {
+      this.router.replaceWith("adminPlugins.show.explorer");
+    }
+  }
 
   model(params, transition) {
     if (!this.currentUser.admin) {

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/index.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/index.js
@@ -4,6 +4,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminPluginsExplorerIndex extends DiscourseRoute {
   @service router;
+  @service dataExplorerMode;
 
   beforeModel(transition) {
     // Redirect old `?id=123` URLs to query details.
@@ -21,21 +22,23 @@ export default class AdminPluginsExplorerIndex extends DiscourseRoute {
       return { model: null, schema: null, disallow: true, groups: null };
     }
 
-    const [groups, model] = await Promise.all([
-      ajax("/admin/plugins/discourse-data-explorer/groups.json"),
-      this.store.findAll("query"),
-    ]);
+    const model = await this.store.findAll("query");
 
-    const groupNames = {};
-    groups.forEach((g) => {
-      groupNames[g.id] = g.name;
-    });
-    model.content.forEach((query) => {
-      query.set(
-        "group_names",
-        (query.group_ids || []).map((id) => groupNames[id])
-      );
-    });
+    let groups;
+    if (this.dataExplorerMode.isFull) {
+      groups = await ajax("/admin/plugins/discourse-data-explorer/groups.json");
+      const groupNames = {};
+      groups.forEach((g) => {
+        groupNames[g.id] = g.name;
+      });
+      model.content.forEach((query) => {
+        query.set(
+          "group_names",
+          (query.group_ids || []).map((id) => groupNames[id])
+        );
+      });
+    }
+
     return { model, groups };
   }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/services/data-explorer-mode.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/services/data-explorer-mode.js
@@ -1,0 +1,13 @@
+import Service, { service } from "@ember/service";
+
+export default class DataExplorerMode extends Service {
+  @service siteSettings;
+
+  get isFull() {
+    return this.siteSettings.data_explorer_mode === "full";
+  }
+
+  get isDisabled() {
+    return this.siteSettings.data_explorer_mode === "disabled";
+  }
+}

--- a/plugins/discourse-data-explorer/config/settings.yml
+++ b/plugins/discourse-data-explorer/config/settings.yml
@@ -15,6 +15,14 @@ plugins:
     depends_on:
       - discourse_ai_enabled
     depends_behavior: hidden
+  data_explorer_mode:
+    default: "full"
+    client: true
+    type: enum
+    choices:
+      - disabled
+      - full
+    hidden: true
   data_explorer_query_result_limit:
     default: 1000
     hidden: true

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/mode.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/mode.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DiscourseDataExplorer
+  class Mode
+    CAPABILITIES = {
+      "disabled" => {
+        can_view_query_list: true,
+        can_view_query_details: false,
+        can_run_queries: false,
+        can_create_queries: false,
+        can_modify_queries: false,
+      },
+      "full" => {
+        can_view_query_list: true,
+        can_view_query_details: true,
+        can_run_queries: true,
+        can_create_queries: true,
+        can_modify_queries: true,
+      },
+    }.freeze
+
+    def self.capabilities
+      CAPABILITIES[SiteSetting.data_explorer_mode]
+    end
+
+    def self.can?(capability)
+      !!capabilities[capability]
+    end
+
+    def self.check_access!(*required_capabilities)
+      required_capabilities.each { |cap| raise Discourse::InvalidAccess unless can?(cap) }
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -706,6 +706,77 @@ describe DiscourseDataExplorer::QueryController do
     end
   end
 
+  describe "mode access" do
+    fab!(:admin)
+    fab!(:user)
+    fab!(:group) { Fabricate(:group, users: [user]) }
+
+    describe "when mode is disabled" do
+      before do
+        SiteSetting.data_explorer_mode = "disabled"
+        sign_in(admin)
+      end
+
+      it "allows index" do
+        get "/admin/plugins/discourse-data-explorer/queries.json"
+        expect(response.status).to eq(200)
+      end
+
+      it "blocks show, create, update, destroy, run, and schema" do
+        query = make_query("SELECT 1 as value")
+
+        get "/admin/plugins/discourse-data-explorer/queries/#{query.id}.json"
+        expect(response.status).to eq(403)
+
+        post "/admin/plugins/discourse-data-explorer/queries.json",
+             params: {
+               query: {
+                 name: "New",
+                 sql: "SELECT 1",
+               },
+             }
+        expect(response.status).to eq(403)
+
+        put "/admin/plugins/discourse-data-explorer/queries/#{query.id}.json",
+            params: {
+              query: {
+                name: "Updated",
+                sql: query.sql,
+              },
+            }
+        expect(response.status).to eq(403)
+
+        delete "/admin/plugins/discourse-data-explorer/queries/#{query.id}.json"
+        expect(response.status).to eq(403)
+
+        post "/admin/plugins/discourse-data-explorer/queries/#{query.id}/run.json",
+             params: {
+               params: {}.to_json,
+             }
+        expect(response.status).to eq(403)
+
+        get "/admin/plugins/discourse-data-explorer/schema.json"
+        expect(response.status).to eq(403)
+      end
+
+      it "blocks group_reports_run" do
+        sign_in(user)
+        query = make_query("SELECT 1 as value", {}, [group.id.to_s])
+
+        post "/g/#{group.name}/reports/#{query.id}/run.json"
+        expect(response.status).to eq(403)
+      end
+
+      it "blocks public_run" do
+        sign_in(user)
+        query = make_query("SELECT 1 as value", {}, [group.id.to_s])
+
+        get "/data-explorer/queries/#{query.id}/run.json"
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
   describe "Non-Admin" do
     fab!(:user)
     fab!(:group) { Fabricate(:group, users: [user]) }

--- a/plugins/discourse-data-explorer/spec/system/data_explorer_mode_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/data_explorer_mode_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "Data explorer mode" do
+  fab!(:admin)
+  fab!(:query) { Fabricate(:query, name: "Test Query", sql: "SELECT 1 AS value", user: admin) }
+
+  let(:index_page) { PageObjects::Pages::DataExplorerIndex.new }
+  let(:query_page) { PageObjects::Pages::DataExplorerQueryRunner.new }
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    sign_in admin
+  end
+
+  context "when mode is disabled" do
+    before { SiteSetting.data_explorer_mode = "disabled" }
+
+    it "shows query list without links or write actions" do
+      index_page.visit
+
+      expect(index_page).to have_query_row(query)
+      expect(index_page).to have_no_query_link(query)
+      expect(index_page).to have_no_create_button
+      expect(index_page).to have_no_import_button
+      expect(index_page).to have_no_groups_column
+      expect(index_page).to have_no_edit_row_button
+    end
+
+    it "redirects to index when visiting query details" do
+      page.visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+
+      expect(page).to have_current_path("/admin/plugins/discourse-data-explorer/queries")
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_index.rb
+++ b/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_index.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class DataExplorerIndex < PageObjects::Pages::Base
+      def visit
+        page.visit("/admin/plugins/discourse-data-explorer/queries")
+        self
+      end
+
+      def has_query_row?(query)
+        page.has_css?(".query-row", text: query.name)
+      end
+
+      def has_query_link?(query)
+        page.has_css?(
+          "a[href='/admin/plugins/discourse-data-explorer/queries/#{query.id}']",
+          text: query.name,
+        )
+      end
+
+      def has_no_query_link?(query)
+        page.has_no_css?(
+          "a[href='/admin/plugins/discourse-data-explorer/queries/#{query.id}']",
+          text: query.name,
+        )
+      end
+
+      def has_create_button?
+        page.has_css?(".d-page-subheader .btn-primary")
+      end
+
+      def has_no_create_button?
+        page.has_no_css?(".d-page-subheader .btn-primary")
+      end
+
+      def has_import_button?
+        page.has_css?(".d-page-subheader .pick-files-button")
+      end
+
+      def has_no_import_button?
+        page.has_no_css?(".d-page-subheader .pick-files-button")
+      end
+
+      def has_groups_column?
+        page.has_css?(".heading.group-names")
+      end
+
+      def has_no_groups_column?
+        page.has_no_css?(".heading.group-names")
+      end
+
+      def has_edit_row_button?
+        page.has_css?(".d-table__cell-controls")
+      end
+
+      def has_no_edit_row_button?
+        page.has_no_css?(".d-table__cell-controls")
+      end
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
+++ b/plugins/discourse-data-explorer/spec/system/page_objects/pages/data_explorer_query_runner.rb
@@ -106,6 +106,46 @@ module PageObjects
       def has_chart?
         page.has_css?(".query-results .chart-canvas-container")
       end
+
+      def has_edit_name_button?
+        page.has_css?(".edit-query-name")
+      end
+
+      def has_no_edit_name_button?
+        page.has_no_css?(".edit-query-name")
+      end
+
+      def has_edit_query_button?
+        page.has_css?(".btn-edit-query")
+      end
+
+      def has_no_edit_query_button?
+        page.has_no_css?(".btn-edit-query")
+      end
+
+      def has_run_button?
+        page.has_css?(".query-run .query-run__submit:not([disabled])")
+      end
+
+      def has_disabled_run_button?
+        page.has_css?(".query-run .query-run__submit[disabled]")
+      end
+
+      def has_delete_button?
+        page.has_css?(".query-run-actions__right .btn-danger")
+      end
+
+      def has_no_delete_button?
+        page.has_no_css?(".query-run-actions__right .btn-danger")
+      end
+
+      def has_groups_section?
+        page.has_css?(".query-edit .groups")
+      end
+
+      def has_no_groups_section?
+        page.has_no_css?(".query-edit .groups")
+      end
     end
   end
 end


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ Just draft, do not merge ⚠️ ⚠️ ⚠️ 

Introduce a `data_explorer_mode` site setting (hidden, enum: full/disabled) that controls which features are available in the Data Explorer plugin.

When mode is "disabled", the UI hides editing, creating, importing, and running queries while still allowing users to view the query list. The edit route redirects back to the index.

Server-side enforcement maps controller actions to capabilities and raises `Discourse::InvalidAccess` when the current mode does not permit the requested operation.