### PR TITLE
FIX: Render group_list settings in AI feature editor

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-features/edit.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/templates/admin-plugins/show/discourse-ai-features/edit.gjs
@@ -2,7 +2,7 @@ import { concat } from "@ember/helper";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
 import BackButton from "discourse/components/back-button";
 import Form from "discourse/components/form";
-import { eq } from "discourse/truth-helpers";
+import { eq, or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import AiFeatureSettingField from "discourse/plugins/discourse-ai/discourse/components/ai-feature-setting-field";
 
@@ -55,11 +55,13 @@ export default <template>
                                   (eq setting.type "enum")
                                   "select"
                                   (if
-                                    (eq setting.type "category_list")
-                                    "custom"
-                                    (if
-                                      (eq setting.type "list") "custom" "input"
+                                    (or
+                                      (eq setting.type "category_list")
+                                      (eq setting.type "group_list")
+                                      (eq setting.type "list")
                                     )
+                                    "custom"
+                                    "input"
                                   )
                                 )
                               )
@@ -97,7 +99,15 @@ export default <template>
                         (if
                           (eq setting.type "enum")
                           "select"
-                          (if (eq setting.type "list") "custom" "input")
+                          (if
+                            (or
+                              (eq setting.type "category_list")
+                              (eq setting.type "group_list")
+                              (eq setting.type "list")
+                            )
+                            "custom"
+                            "input"
+                          )
                         )
                       )
                     }}

--- a/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe "Admin AI features configuration" do
     expect(page).to have_css(".form-kit__field")
   end
 
+  it "renders group_list settings as group selectors" do
+    SiteSetting.ai_bot_enabled = true
+    SiteSetting.ai_bot_allowed_groups = "#{group_1.id}|#{group_2.id}"
+
+    page.visit(
+      "/admin/plugins/discourse-ai/ai-features/#{DiscourseAi::Configuration::Module::BOT_ID}/edit",
+    )
+
+    expect(page).to have_css(".ai-feature-editor")
+
+    field = form.field("ai_bot_allowed_groups")
+    expect(field.component).to have_css(".list-setting")
+    expect(field.component).to have_content(group_1.name)
+    expect(field.component).to have_content(group_2.name)
+  end
+
   it "displays LLM names in compact_list settings" do
     llm1 = Fabricate(:llm_model, display_name: "Test LLM Alpha")
     llm2 = Fabricate(:llm_model, display_name: "Test LLM Beta")


### PR DESCRIPTION
The AI plugin has a custom feature settings editor that uses FormKit to render site settings. When commit e8d63c94488 (#38552) moved the `@type` attribute onto `form.Field`, it added type mappings for `bool`, `integer`, `enum`, and `list` but missed `group_list` (and `category_list` in the fallback branch). Since `group_list` didn't match any condition, it fell through to `"input"`, causing the field to render as a plain text input displaying raw pipe-separated IDs like "1|4" instead of a group selector.

Before:
<img width="701" height="1284" alt="Screenshot 2026-04-10 at 2 29 21 pm" src="https://github.com/user-attachments/assets/f4d286a3-7c60-4bc7-bf02-b1c38d0b2010" />
After:
<img width="739" height="1300" alt="Screenshot 2026-04-10 at 2 18 28 pm" src="https://github.com/user-attachments/assets/d6bd4438-3b7e-4378-a6f8-f72ffb1626f5" />

