### PR TITLE
UX: floating action buttons

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -96,19 +96,55 @@ body.embed-mode {
     border-bottom: 1px solid var(--content-border-color);
   }
 
-  // Floating reply button above the topic-progress widget (bottom-right)
-  // Visible while scrolling, hides when the footer reply area is in view
-  // On wide viewports (>=925px) the timeline already has its own reply button
-  .embed-floating-reply-button {
+  // Hide default topic-progress bar and docked timeline in embed mode
+  // We replace them with floating action buttons
+  #topic-progress-wrapper {
+    opacity: 0;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  .container.posts .topic-navigation {
+    display: contents;
+  }
+
+  .timeline-container:not(.timeline-fullscreen) {
+    display: none !important;
+  }
+
+  // Floating action buttons (timeline + reply) in the bottom-right
+  .embed-floating-buttons {
     position: fixed;
     bottom: calc(
-      env(safe-area-inset-bottom) + var(--composer-height, 0px) + 3.5em
+      env(safe-area-inset-bottom) + var(--composer-height, 0px) + 1em
     );
     right: var(--space-4);
     z-index: z("timeline");
+    display: flex;
+    flex-direction: column;
+    gap: 0.65em;
+    align-items: center;
 
-    @media screen and (width >= 925px) {
-      display: none;
+    .embed-floating-timeline-button,
+    .embed-floating-reply-button {
+      width: 2.75em;
+      height: 2.75em;
+      border-radius: 50%;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: var(--shadow-dropdown);
+
+      .d-button-label {
+        display: none;
+      }
+
+      .d-icon {
+        margin: 0;
+      }
     }
   }
 

--- a/frontend/discourse/app/components/embed-topic-footer.gjs
+++ b/frontend/discourse/app/components/embed-topic-footer.gjs
@@ -12,6 +12,7 @@ import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
 
 export default class EmbedTopicFooter extends Component {
+  @service appEvents;
   @service composer;
   @service currentUser;
   @service siteSettings;
@@ -66,6 +67,19 @@ export default class EmbedTopicFooter extends Component {
     );
   }
 
+  get showFloatingTimelineButton() {
+    return this.args.topic?.replyCount > 0 && !this.footerButtonsVisible;
+  }
+
+  get showFloatingButtons() {
+    return this.showFloatingReplyButton || this.showFloatingTimelineButton;
+  }
+
+  @action
+  handleTimelineToggle() {
+    this.appEvents.trigger("topic:toggle-progress-expansion");
+  }
+
   @action
   async handleReply() {
     if (!this.currentUser) {
@@ -106,13 +120,25 @@ export default class EmbedTopicFooter extends Component {
           </div>
         {{/if}}
       </div>
-      {{#if this.showFloatingReplyButton}}
-        <DButton
-          @action={{this.handleReply}}
-          @icon="reply"
-          @label={{this.replyButtonLabel}}
-          class="btn-primary embed-floating-reply-button"
-        />
+      {{#if this.showFloatingButtons}}
+        <div class="embed-floating-buttons">
+          {{#if this.showFloatingTimelineButton}}
+            <DButton
+              @action={{this.handleTimelineToggle}}
+              @icon="bars-staggered"
+              @title="topic.progress.title"
+              class="btn-default embed-floating-timeline-button"
+            />
+          {{/if}}
+          {{#if this.showFloatingReplyButton}}
+            <DButton
+              @action={{this.handleReply}}
+              @icon="reply"
+              @title={{this.replyButtonLabel}}
+              class="btn-primary embed-floating-reply-button"
+            />
+          {{/if}}
+        </div>
       {{/if}}
     {{/if}}
   </template>

--- a/frontend/discourse/app/components/topic-navigation.gjs
+++ b/frontend/discourse/app/components/topic-navigation.gjs
@@ -8,6 +8,7 @@ import { observes } from "@ember-decorators/object";
 import $ from "jquery";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
+import EmbedMode from "discourse/lib/embed-mode";
 import discourseLater from "discourse/lib/later";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import SwipeEvents from "discourse/lib/swipe-events";
@@ -52,7 +53,7 @@ export default class TopicNavigation extends Component {
 
     if (this.info.topicProgressExpanded) {
       this.info.set("renderTimeline", true);
-    } else if (this.site.mobileView) {
+    } else if (this.site.mobileView || EmbedMode.enabled) {
       this.info.set("renderTimeline", false);
     } else {
       const composerHeight =
@@ -119,6 +120,11 @@ export default class TopicNavigation extends Component {
   composerClosed() {
     this.set("composerOpen", false);
     this._checkSize();
+  }
+
+  @bind
+  _toggleExpansion() {
+    this.info.toggleProperty("topicProgressExpanded");
   }
 
   _collapseFullscreen(postId, delay = 500) {
@@ -231,7 +237,8 @@ export default class TopicNavigation extends Component {
     this.appEvents
       .on("topic:current-post-scrolled", this, this._topicScrolled)
       .on("topic:jump-to-post", this, this._collapseFullscreen)
-      .on("topic:keyboard-trigger", this, this.keyboardTrigger);
+      .on("topic:keyboard-trigger", this, this.keyboardTrigger)
+      .on("topic:toggle-progress-expansion", this, this._toggleExpansion);
 
     if (this.site.desktopView) {
       this._desktopListenersActive = true;
@@ -262,7 +269,8 @@ export default class TopicNavigation extends Component {
     this.appEvents
       .off("topic:current-post-scrolled", this, this._topicScrolled)
       .off("topic:jump-to-post", this, this._collapseFullscreen)
-      .off("topic:keyboard-trigger", this, this.keyboardTrigger);
+      .off("topic:keyboard-trigger", this, this.keyboardTrigger)
+      .off("topic:toggle-progress-expansion", this, this._toggleExpansion);
 
     $(window).off("click.hide-fullscreen");
 

--- a/spec/system/embed_mode_spec.rb
+++ b/spec/system/embed_mode_spec.rb
@@ -101,6 +101,12 @@ describe "Embed mode" do
         expect(page).to have_no_css("#reply-control.open")
         expect(page).to have_no_css("#reply-control.fullscreen")
       end
+
+      it "does not show floating timeline button" do
+        visit("/t/#{no_reply_topic.slug}/#{no_reply_topic.id}?embed_mode=true")
+
+        expect(topic_page).to have_no_floating_timeline_button
+      end
     end
 
     context "with a topic that has replies" do
@@ -123,23 +129,35 @@ describe "Embed mode" do
       context "with many replies" do
         before { 15.times { Fabricate(:post, topic: topic) } }
 
-        it "shows a floating reply button when footer is not visible" do
-          resize_window(width: 900) do
-            visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
-            expect(topic_page).to have_post_number(2)
+        it "shows floating action buttons when footer is not visible" do
+          visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+          expect(topic_page).to have_post_number(2)
 
-            expect(topic_page).to have_floating_reply_button
-          end
+          expect(topic_page).to have_floating_reply_button
+          expect(topic_page).to have_floating_timeline_button
         end
 
         it "opens the composer when clicking the floating reply button" do
-          resize_window(width: 900) do
-            visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
-            expect(topic_page).to have_post_number(2)
+          visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+          expect(topic_page).to have_post_number(2)
 
-            topic_page.click_floating_reply_button
-            expect(page).to have_css("#reply-control.open")
-          end
+          topic_page.click_floating_reply_button
+          expect(page).to have_css("#reply-control.open")
+        end
+
+        it "opens the timeline when clicking the floating timeline button" do
+          visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+          expect(topic_page).to have_post_number(2)
+
+          topic_page.click_floating_timeline_button
+          expect(page).to have_css(".timeline-fullscreen.show")
+        end
+
+        it "hides the default topic progress bar" do
+          visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+          expect(topic_page).to have_post_number(2)
+
+          expect(page).to have_no_css("#topic-progress-wrapper", visible: :visible)
         end
       end
 

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -250,6 +250,18 @@ module PageObjects
         has_no_css?(".embed-floating-reply-button")
       end
 
+      def click_floating_timeline_button
+        find(".embed-floating-timeline-button").click
+      end
+
+      def has_floating_timeline_button?
+        has_css?(".embed-floating-timeline-button")
+      end
+
+      def has_no_floating_timeline_button?
+        has_no_css?(".embed-floating-timeline-button")
+      end
+
       def has_expanded_composer?
         has_css?("#reply-control.open")
       end


### PR DESCRIPTION
Continuing from the changes in: https://github.com/discourse/discourse/pull/39185

Here we experiment with making timeline and reply button floating and stacked.

<img width="733" height="817" alt="Screenshot 2026-04-10 at 08 20 31" src="https://github.com/user-attachments/assets/e73cb2d1-276d-4ec9-98ad-6ad2a19535c0" />
