### PR TITLE
FEATURE: Send localized content in web push notifications

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -29,6 +29,7 @@ class PostAlerter
         post_number: post.post_number,
         topic_title: post.topic.title,
         topic_id: post.topic.id,
+        post_id: post.id,
         excerpt:
           excerpt ||
             post.excerpt(

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -7,6 +7,8 @@ class PushNotificationPusher
   def self.push(user, payload)
     message = nil
     I18n.with_locale(user.effective_locale) do
+      localize_content!(payload) if SiteSetting.content_localization_enabled
+
       notification_icon_name = Notification.types[payload[:notification_type]]
       if !File.exist?(
            File.expand_path(
@@ -182,6 +184,34 @@ class PushNotificationPusher
     end
   end
 
+  def self.localize_content!(payload)
+    locale = I18n.locale.to_s.sub("-", "_")
+
+    if (topic_id = payload[:topic_id])
+      topic_localization =
+        TopicLocalization.find_by(topic_id: topic_id, locale: locale) ||
+          TopicLocalization.matching_locale(locale).find_by(topic_id: topic_id)
+      payload[:topic_title] = topic_localization.title if topic_localization
+    end
+
+    if (post_id = payload[:post_id])
+      post_localization =
+        PostLocalization.find_by(post_id: post_id, locale: locale) ||
+          PostLocalization.matching_locale(locale).find_by(post_id: post_id)
+      if post_localization
+        payload[:excerpt] = Post.excerpt(
+          post_localization.cooked,
+          400,
+          text_entities: true,
+          strip_links: true,
+          remap_emoji: true,
+          plain_hashtags: true,
+        )
+      end
+    end
+  end
+
   private_class_method :send_notification
   private_class_method :handle_generic_error
+  private_class_method :localize_content!
 end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1144,6 +1144,7 @@ RSpec.describe PostAlerter do
         post_number: post.post_number,
         topic_title: post.topic.title,
         topic_id: post.topic.id,
+        post_id: post.id,
         excerpt: post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
         username: post.username,
         post_url: post.url,
@@ -1300,6 +1301,8 @@ RSpec.describe PostAlerter do
       end
 
       set_subfolder "/subpath"
+      post = mention_post
+
       payload = {
         "secret_key" => SiteSetting.push_api_secret_key,
         "url" => Discourse.base_url,
@@ -1311,9 +1314,10 @@ RSpec.describe PostAlerter do
             "post_number" => 1,
             "topic_title" => topic.title,
             "topic_id" => topic.id,
+            "post_id" => post.id,
             "excerpt" => "Hello @eviltrout ❤",
             "username" => user.username,
-            "url" => UrlHelper.absolute(Discourse.base_path + mention_post.url),
+            "url" => UrlHelper.absolute(Discourse.base_path + post.url),
             "client_id" => "xxx0",
           },
           {
@@ -1321,15 +1325,14 @@ RSpec.describe PostAlerter do
             "post_number" => 1,
             "topic_title" => topic.title,
             "topic_id" => topic.id,
+            "post_id" => post.id,
             "excerpt" => "Hello @eviltrout ❤",
             "username" => user.username,
-            "url" => UrlHelper.absolute(Discourse.base_path + mention_post.url),
+            "url" => UrlHelper.absolute(Discourse.base_path + post.url),
             "client_id" => "xxx1",
           },
         ],
       }
-
-      post = mention_post
 
       expect(JSON.parse(body)).to eq(payload)
       expect(headers["Content-Type"]).to eq("application/json")

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1358,6 +1358,7 @@ RSpec.describe PostAlerter do
       changes = {
         "notification_type" => Notification.types[:posted],
         "post_number" => new_post.post_number,
+        "post_id" => new_post.id,
         "username" => new_post.user.username,
         "excerpt" => new_post.raw,
         "url" => UrlHelper.absolute(Discourse.base_path + new_post.url),
@@ -1378,6 +1379,7 @@ RSpec.describe PostAlerter do
 
       changes = {
         "post_number" => new_post.post_number,
+        "post_id" => new_post.id,
         "username" => new_post.user.username,
         "excerpt" => new_post.raw,
         "url" => UrlHelper.absolute(Discourse.base_path + new_post.url),

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -225,6 +225,91 @@ RSpec.describe PushNotificationPusher do
       end
     end
 
+    describe "localized content" do
+      fab!(:topic) { Fabricate(:topic, title: "Original topic title") }
+      fab!(:post) { Fabricate(:post, topic: topic, raw: "Original post content") }
+
+      before do
+        SiteSetting.content_localization_enabled = true
+        SiteSetting.allow_user_locale = true
+        user.update!(locale: "ja")
+      end
+
+      def execute_localized_push
+        PushNotificationPusher.push(
+          user,
+          {
+            topic_title: topic.title,
+            username: "system",
+            excerpt: "Original post content",
+            topic_id: topic.id,
+            post_id: post.id,
+            post_url: "/t/#{topic.id}/#{post.post_number}",
+            notification_type: Notification.types[:mentioned],
+            post_number: post.post_number,
+          },
+        )
+      end
+
+      it "uses localized topic title and post excerpt when localization exists" do
+        Fabricate(
+          :topic_localization,
+          topic: topic,
+          locale: "ja",
+          title: "ローカライズされたトピック",
+          fancy_title: "ローカライズされたトピック",
+        )
+        Fabricate(
+          :post_localization,
+          post: post,
+          locale: "ja",
+          raw: "ローカライズされた投稿",
+          cooked: "<p>ローカライズされた投稿</p>",
+        )
+
+        message = execute_localized_push
+
+        expect(message[:title]).to include("ローカライズされたトピック")
+        expect(message[:body]).to eq("ローカライズされた投稿")
+      end
+
+      it "falls back to original content when no localization exists" do
+        message = execute_localized_push
+
+        expect(message[:title]).to include("Original topic title")
+        expect(message[:body]).to eq("Original post content")
+      end
+
+      it "falls back to original content when content_localization_enabled is false" do
+        SiteSetting.content_localization_enabled = false
+        Fabricate(
+          :topic_localization,
+          topic: topic,
+          locale: "ja",
+          title: "ローカライズされたトピック",
+          fancy_title: "ローカライズされたトピック",
+        )
+
+        message = execute_localized_push
+
+        expect(message[:title]).to include("Original topic title")
+      end
+
+      it "matches regionless locale variants" do
+        Fabricate(
+          :topic_localization,
+          topic: topic,
+          locale: "ja_JP",
+          title: "ローカライズされたトピック",
+          fancy_title: "ローカライズされたトピック",
+        )
+
+        message = execute_localized_push
+
+        expect(message[:title]).to include("ローカライズされたトピック")
+      end
+    end
+
     describe "push_notification_pusher_title_payload modifier" do
       let(:modifier_block) do
         Proc.new do |payload|


### PR DESCRIPTION
## Summary
- When content localization is enabled, web push notifications now include translated topic titles and post excerpts for the recipient's locale
- Adds `post_id` to the push notification payload so `PushNotificationPusher` can look up post localizations
- Locale matching tries exact match first, then falls back to regionless matching (e.g. `ja` matches `ja_JP`)
- No additional DB queries when content localization is disabled
