### PR TITLE
UX: in header dropdown nav mode, keep AI bot header functionality the same

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-header-icon.gjs
@@ -11,7 +11,6 @@ import { AI_CONVERSATIONS_PANEL } from "../services/ai-conversations-sidebar-man
 export default class AiBotHeaderIcon extends Component {
   @service appEvents;
   @service currentUser;
-  @service navigationMenu;
   @service sidebarState;
   @service siteSettings;
   @service aiConversationsSidebarManager;
@@ -44,10 +43,7 @@ export default class AiBotHeaderIcon extends Component {
   }
 
   get clickShouldRouteOutOfConversations() {
-    return (
-      !this.navigationMenu.isHeaderDropdownMode &&
-      this.sidebarState.currentPanel?.key === AI_CONVERSATIONS_PANEL
-    );
+    return this.sidebarState.currentPanel?.key === AI_CONVERSATIONS_PANEL;
   }
 
   get href() {

--- a/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
@@ -412,12 +412,12 @@ RSpec.describe "AI Bot - Homepage" do
         SiteSetting.ai_bot_add_to_header = true
       end
 
-      it "keeps robot icon in the header and doesn't display sidebar back link" do
+      it "shows shuffle icon in the header and doesn't display sidebar back link" do
         visit "/"
         expect(header).to have_icon_in_bot_button(icon: "robot")
         header.click_bot_button
         expect(ai_pm_homepage).to have_homepage
-        expect(header).to have_icon_in_bot_button(icon: "robot")
+        expect(header).to have_icon_in_bot_button(icon: "shuffle")
         expect(ai_pm_homepage).to have_no_sidebar_back_link
       end
 


### PR DESCRIPTION
When the site setting for navigation menu is set to header dropdown, we prevent the AI bot button from navigating users back to their last forum page (this is the behavior when the sidebar is enabled). 


The behavior of the bot icon here always navigates you to the AI conversation interface, even when you're already in it:  

<img width="370" height="108" alt="image" src="https://github.com/user-attachments/assets/43cf0e85-b97f-45da-b7c1-7e61e21d7192" />


I can't see any reason for this divergence in behavior, and the lack of a "back to forum" button feels missed in header dropdown mode. 

This removes the navigation mode check so the button always behaves the same. So now when in AI conversations, you can get back to where you left off in the forum:

<img width="378" height="106" alt="image" src="https://github.com/user-attachments/assets/be48b54d-5b30-4501-8b06-642ddcdf0f84" />