### PR TITLE
UX: fix composer overflow when tagging is disabled

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -318,7 +318,7 @@ html.composer-open:not(.has-full-page-chat) {
     width: 100%;
     align-items: center;
     position: relative;
-    gap: 0 0.5em;
+    gap: 0 var(--space-2);
   }
 
   .user-selector {
@@ -365,9 +365,10 @@ html.composer-open:not(.has-full-page-chat) {
   .category-input {
     position: relative;
     display: flex;
-    flex: 1 0 40%;
+    flex: 1 1 auto;
     max-width: 40%;
-    margin: 0 0 8px 8px;
+    margin: 0 0 8px 0;
+    min-width: 0;
 
     .category-chooser {
       display: flex;
@@ -665,7 +666,7 @@ html.composer-open:not(.has-full-page-chat) {
       .with-tags {
         .title-and-category {
           flex-wrap: nowrap;
-          gap: 0.5em;
+          gap: var(--space-2);
 
           .tags-input {
             max-width: 50%;


### PR DESCRIPTION
When tagging is disabled we put the category input on the same line as the topic title in the composer. Currently when a category is selected this can overflow. This fixes it by forcing the category input to shrink. 


Before: 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/24d7af6a-6001-4990-a333-8e803a726ae6" />


After: 
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/2f044a18-44c5-4c6a-b124-a60902e2cc40" />

