### PR TITLE
FIX: update post voting for new JSON encoding

### DIFF
--- a/plugins/discourse-post-voting/plugin.rb
+++ b/plugins/discourse-post-voting/plugin.rb
@@ -184,7 +184,7 @@ after_initialize do
   TopicSubtype.register(Topic::POST_VOTING_SUBTYPE)
 
   NewPostManager.add_handler do |manager|
-    if !manager.args[:topic_id] && manager.args[:create_as_post_voting] == "true" &&
+    if !manager.args[:topic_id] && manager.args[:create_as_post_voting].to_s == "true" &&
          (manager.args[:archetype].blank? || manager.args[:archetype] == Archetype.default)
       manager.args[:subtype] = Topic::POST_VOTING_SUBTYPE
     end

--- a/plugins/discourse-post-voting/spec/requests/posts_controller_spec.rb
+++ b/plugins/discourse-post-voting/spec/requests/posts_controller_spec.rb
@@ -15,6 +15,9 @@ describe PostsController do
              raw: "this is some raw",
              title: "this is some title",
              create_as_post_voting: true,
+           }.to_json,
+           headers: {
+             "CONTENT_TYPE" => "application/json",
            }
 
       expect(response.status).to eq(200)
@@ -33,6 +36,9 @@ describe PostsController do
              create_as_post_voting: true,
              archetype: Archetype.private_message,
              target_recipients: user.username,
+           }.to_json,
+           headers: {
+             "CONTENT_TYPE" => "application/json",
            }
 
       expect(response.status).to eq(200)


### PR DESCRIPTION
In https://github.com/discourse/discourse/commit/5080cebb0a86b4a546711c5156cb487b85f5b297 the post adapter was changed to JSON which resulted in a `true == "true"` comparison, which is false and broke new post voting topics. The test used the old encoding which is why it didn't fail. 

This adds `.to_s` to convert to a string and updates the test to reflect the JSON encoding. 