### PR TITLE
FIX: preserve site dir for neutral text

### DIFF
--- a/frontend/discourse/app/components/text-field.js
+++ b/frontend/discourse/app/components/text-field.js
@@ -2,6 +2,7 @@ import { computed } from "@ember/object";
 import { cancel, next } from "@ember/runloop";
 import { attributeBindings } from "@ember-decorators/component";
 import discourseDebounce from "discourse/lib/debounce";
+import { isLTR, isRTL, siteDir } from "discourse/lib/text-direction";
 import { i18n } from "discourse-i18n";
 import TextField from "./ember-text-field";
 
@@ -49,8 +50,15 @@ export default class DiscourseTextField extends TextField {
     next(() => this.onChange(this.value));
   }
 
+  @computed("siteSettings.support_mixed_text_direction", "value")
   get dir() {
     if (this.siteSettings.support_mixed_text_direction) {
+      const value = this.value?.toString() || "";
+
+      if (!isLTR(value) && !isRTL(value)) {
+        return siteDir();
+      }
+
       return "auto";
     }
   }

--- a/frontend/discourse/app/components/text-field.js
+++ b/frontend/discourse/app/components/text-field.js
@@ -2,7 +2,7 @@ import { computed } from "@ember/object";
 import { cancel, next } from "@ember/runloop";
 import { attributeBindings } from "@ember-decorators/component";
 import discourseDebounce from "discourse/lib/debounce";
-import { isLTR, isRTL, siteDir } from "discourse/lib/text-direction";
+import { siteDir } from "discourse/lib/text-direction";
 import { i18n } from "discourse-i18n";
 import TextField from "./ember-text-field";
 
@@ -55,11 +55,11 @@ export default class DiscourseTextField extends TextField {
     if (this.siteSettings.support_mixed_text_direction) {
       const value = this.value?.toString() || "";
 
-      if (!isLTR(value) && !isRTL(value)) {
-        return siteDir();
+      if (value) {
+        return "auto";
       }
 
-      return "auto";
+      return siteDir();
     }
   }
 

--- a/frontend/discourse/app/lib/text-direction.js
+++ b/frontend/discourse/app/lib/text-direction.js
@@ -34,6 +34,10 @@ export function siteDir() {
   return _siteDir;
 }
 
+export function resetSiteDirForTesting() {
+  _siteDir = null;
+}
+
 export function isDocumentRTL() {
   return siteDir() === "rtl";
 }

--- a/frontend/discourse/tests/integration/components/text-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/text-field-test.gjs
@@ -53,7 +53,7 @@ module("Integration | Component | text-field", function (hooks) {
     assert.dom("input").hasAttribute("dir", "auto");
   });
 
-  test("uses site direction until mixed text direction has a strong character", async function (assert) {
+  test("uses site direction if the input is empty and `auto` if the input isn't empty", async function (assert) {
     this.siteSettings.support_mixed_text_direction = true;
     document.documentElement.removeAttribute("dir");
     document.documentElement.classList.add("rtl");
@@ -64,7 +64,7 @@ module("Integration | Component | text-field", function (hooks) {
     assert.dom("input").hasAttribute("dir", "rtl");
 
     await fillIn("input", "123");
-    assert.dom("input").hasAttribute("dir", "rtl");
+    assert.dom("input").hasAttribute("dir", "auto");
 
     await fillIn("input", "hello");
     assert.dom("input").hasAttribute("dir", "auto");

--- a/frontend/discourse/tests/integration/components/text-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/text-field-test.gjs
@@ -1,10 +1,30 @@
 import { fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import TextField from "discourse/components/text-field";
+import { resetSiteDirForTesting } from "discourse/lib/text-direction";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module("Integration | Component | text-field", function (hooks) {
   setupRenderingTest(hooks);
+
+  let originalHtmlDir;
+  let originalHtmlIsRtl;
+
+  hooks.beforeEach(function () {
+    originalHtmlDir = document.documentElement.getAttribute("dir");
+    originalHtmlIsRtl = document.documentElement.classList.contains("rtl");
+  });
+
+  hooks.afterEach(function () {
+    if (originalHtmlDir === null) {
+      document.documentElement.removeAttribute("dir");
+    } else {
+      document.documentElement.setAttribute("dir", originalHtmlDir);
+    }
+
+    document.documentElement.classList.toggle("rtl", originalHtmlIsRtl);
+    resetSiteDirForTesting();
+  });
 
   test("renders correctly with no properties set", async function (assert) {
     await render(<template><TextField /></template>);
@@ -31,6 +51,26 @@ module("Integration | Component | text-field", function (hooks) {
     );
 
     assert.dom("input").hasAttribute("dir", "auto");
+  });
+
+  test("uses site direction until mixed text direction has a strong character", async function (assert) {
+    this.siteSettings.support_mixed_text_direction = true;
+    document.documentElement.removeAttribute("dir");
+    document.documentElement.classList.add("rtl");
+    resetSiteDirForTesting();
+
+    await render(<template><TextField /></template>);
+
+    assert.dom("input").hasAttribute("dir", "rtl");
+
+    await fillIn("input", "123");
+    assert.dom("input").hasAttribute("dir", "rtl");
+
+    await fillIn("input", "hello");
+    assert.dom("input").hasAttribute("dir", "auto");
+
+    await fillIn("input", "");
+    assert.dom("input").hasAttribute("dir", "rtl");
   });
 
   test("supports onChange", async function (assert) {


### PR DESCRIPTION
Use the site's direction as the fallback `dir` value for mixed-direction
text fields until the user enters a strong LTR or RTL character.

This keeps empty and neutral input aligned with the current locale while
still switching to `auto` when the field content provides directionality.
