### PR TITLE
FIX: cache field controls by type

### DIFF
--- a/frontend/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/field-data.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { cached } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import curryComponent from "ember-curry-component";
@@ -23,6 +22,8 @@ export default class FKFieldData extends Component {
    * @type {string}
    */
   errorId = uniqueId();
+
+  #controlCache = new Map();
 
   // Set by legacy controls in their constructor (during render),
   // read by the applyControlType modifier (post-render)
@@ -102,15 +103,28 @@ export default class FKFieldData extends Component {
     this._legacyControlType = value;
   }
 
-  /**
-   * Contextual component for the control set by `@type`.
-   * @type {Component}
-   */
-  @cached
-  get Control() {
-    const { component, args } = resolveFieldControl(this.type);
+  // Rerenders can revisit <field.Control> even when the resolved type is unchanged.
+  // Cache the curried component by type so the control DOM is preserved, while
+  // still allowing real type changes to swap to a different control component.
+  controlFor(type) {
+    let curried = this.#controlCache.get(type);
 
-    return curryComponent(component, { field: this, ...args }, getOwner(this));
+    if (!curried) {
+      const { component, args } = resolveFieldControl(type);
+
+      curried = curryComponent(
+        component,
+        { field: this, ...args },
+        getOwner(this)
+      );
+      this.#controlCache.set(type, curried);
+    }
+
+    return curried;
+  }
+
+  get Control() {
+    return this.controlFor(this.type);
   }
 
   /**

--- a/frontend/discourse/tests/integration/components/form-kit/object-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/object-test.gjs
@@ -1,9 +1,24 @@
-import { array, concat, fn, hash } from "@ember/helper";
-import { click, render } from "@ember/test-helpers";
+import { array, concat, fn, get, hash } from "@ember/helper";
+import { click, focus, render, typeIn } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+
+function getFieldMeta() {
+  return {
+    qux: { type: "text" },
+    quux: { type: "text" },
+  };
+}
+
+function fieldType(type) {
+  return type === "checkbox" ? "checkbox" : "input";
+}
+
+function fieldKeys(obj) {
+  return obj ? Object.keys(obj) : [];
+}
 
 module("Integration | Component | FormKit | Object", function (hooks) {
   setupRenderingTest(hooks);
@@ -104,5 +119,37 @@ module("Integration | Component | FormKit | Object", function (hooks) {
     await formKit().field("one.two.0.foo").fillIn("2");
 
     assert.form().field("one.two.0.foo").hasValue("2");
+  });
+
+  test("retains focus when @type depends on yielded data inside form.Object", async function (assert) {
+    await render(
+      <template>
+        <Form
+          @data={{hash foo="bar" baz=(hash qux="" quux="test")}}
+          as |form data|
+        >
+          <form.Object @name="baz" as |object objectData|>
+            {{#each (fieldKeys objectData) as |key|}}
+              {{#let (get (getFieldMeta data.foo) key) as |params|}}
+                <object.Field
+                  @type={{fieldType params.type}}
+                  @name={{key}}
+                  @title={{key}}
+                  as |field|
+                >
+                  <field.Control />
+                </object.Field>
+              {{/let}}
+            {{/each}}
+          </form.Object>
+        </Form>
+      </template>
+    );
+
+    const input = document.querySelector("[data-name='baz.qux'] input");
+    await focus(input);
+    await typeIn(input, "u", { delay: 0 });
+
+    assert.strictEqual(document.activeElement, input, "focus retained");
   });
 });


### PR DESCRIPTION
Rerenders can re create `<field.Control>` even when the resolved type is unchanged, this would cause the whole component to be re-rendered and lose focus while typing in a text input for example.

This commit caches the curried component by type so the control DOM is preserved, while still allowing real type changes to swap to a different control component.