### PR TITLE
FIX: Avoid post_number collisions on topic move/merge with freeze_original

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -79,6 +79,15 @@ class PostMover
   def move_posts_to(topic)
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
+
+    # Serialize concurrent moves/merges on the same source topic. Without this
+    # lock, two transactions can each read `ordered_posts.last.post_number` at
+    # the same value, both compute the same `@first_post_number_moved`, and
+    # then collide on the `(topic_id, post_number)` unique index when each
+    # tries to insert the "split_topic" moderator post. The lock is released
+    # on commit/rollback of the surrounding `Topic.transaction`.
+    @original_topic.lock!
+
     ensure_acting_user_is_allowed_in_destination
 
     # when a topic contains some posts after moving posts to another topic we shouldn't close it
@@ -105,9 +114,18 @@ class PostMover
     if @options[:freeze_original]
       # in this case we need to add the moderator post after the last copied post
       if @full_move
-        @first_post_number_moved = @original_topic.ordered_posts.last.post_number + 1
+        # Use max_post_number (which includes soft-deleted posts) so the number
+        # we force via `add_moderator_post` matches what `Topic.next_post_number`
+        # will atomically assign via raw SQL. Otherwise a deleted post at the
+        # tail leaves a tombstone in `index_posts_on_topic_id_and_post_number`
+        # that collides with our `update!(post_number: ...)`.
+        @first_post_number_moved = @original_topic.max_post_number + 1
       else
-        from_posts = @original_topic.ordered_posts.where("post_number > ?", posts.last.post_number)
+        # Same reason: shift all posts above `posts.last.post_number`, including
+        # soft-deleted ones, so the slot at `posts.last.post_number + 1` is
+        # guaranteed free in the unique index.
+        from_posts =
+          @original_topic.posts.with_deleted.where("post_number > ?", posts.last.post_number)
         shift_post_numbers(from_posts)
         @first_post_number_moved = posts.last.post_number + 1
       end

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -3057,6 +3057,58 @@ RSpec.describe PostMover do
         ).to be_present
       end
 
+      it "does not collide with a soft-deleted post at the tail of the source on full move" do
+        # The unique index on (topic_id, post_number) is not partial, so a
+        # soft-deleted post still occupies its slot. Regression for
+        # `PG::UniqueViolation` when computing the split_topic post number.
+        deleted_tail = Fabricate(:post, topic: original_topic)
+        deleted_tail.trash!
+
+        expect {
+          PostMover.new(
+            original_topic,
+            Discourse.system_user,
+            [op.id, first_post.id, second_post.id, third_post.id],
+            options: {
+              freeze_original: true,
+            },
+          ).to_topic(destination_topic.id)
+        }.not_to raise_error
+
+        expect(
+          original_topic.ordered_posts.where(
+            post_type: Post.types[:small_action],
+            action_code: "split_topic",
+          ),
+        ).to be_present
+      end
+
+      it "does not collide with a soft-deleted post above the shift range on partial move" do
+        deleted_between = Fabricate(:post, topic: original_topic)
+        original_deleted_post_number = deleted_between.post_number
+        deleted_between.trash!
+        tail_post = Fabricate(:post, topic: original_topic)
+        original_tail_post_number = tail_post.post_number
+
+        expect {
+          PostMover.new(
+            original_topic,
+            Discourse.system_user,
+            [first_post.id, second_post.id],
+            options: {
+              freeze_original: true,
+            },
+          ).to_topic(destination_topic.id)
+        }.not_to raise_error
+
+        # The soft-deleted post should have been shifted along with the visible
+        # ones so the slot for the split_topic post is free.
+        expect(Post.with_deleted.find(deleted_between.id).post_number).to eq(
+          original_deleted_post_number + 1,
+        )
+        expect(tail_post.reload.post_number).to eq(original_tail_post_number + 1)
+      end
+
       context "with `post_mover_create_moderator_post` modifier" do
         fab!(:topic_1, :topic)
         fab!(:topic_2, :topic)


### PR DESCRIPTION
## Summary

`POST /t/:id/merge-topic` can fail with:

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation:
  duplicate key value violates unique constraint "index_posts_on_topic_id_and_post_number"
DETAIL:  Key (topic_id, post_number)=(<source_topic>, N) already exists.
```

from `Topic#add_moderator_post`'s trailing `update!(post_number: ...)`. Two independent bugs lead to the same failure:

### 1. Soft-deleted posts on the source (primary cause)

The unique index on `posts(topic_id, post_number)` is **not partial** — soft-deleted rows still occupy their slot:

```
db/migrate/20140715013018_correct_post_number_index.rb:
  add_index :posts, %i[topic_id post_number], unique: true
```

But `ordered_posts` uses `Trashable`'s default scope and skips deleted rows, while `Topic.next_post_number` uses raw SQL that **does** see them:

```ruby
# post_mover.rb:117 (before)
@first_post_number_moved = @original_topic.ordered_posts.last.post_number + 1
# topic.rb:867
DB.query_single("SELECT coalesce(max(post_number),0) FROM posts WHERE topic_id = ?", topic_id)
```

So if the source topic had a soft-deleted post at the tail (or above the shift range on a partial move), `@first_post_number_moved` pointed at the deleted row's slot and `PostCreator` assigned a higher number — then the trailing `update!` collided with the tombstone.

Fix: use `max_post_number` / `posts.with_deleted` so the computed number agrees with what `Topic.next_post_number` will actually return.

### 2. Concurrent moves on the same source (latent race)

Even without deleted posts, two concurrent `PostMover` runs against the same source (e.g. a double-submitted `/merge-topic`) can each read the same `ordered_posts.last.post_number`, both compute the same `@first_post_number_moved`, and collide when each commits its moderator post.

Fix: `@original_topic.lock!` at the top of `move_posts_to` so concurrent moves/merges on the same origin serialize. The lock is held for the surrounding `Topic.transaction`.