### PR TITLE
UX: Update styles of event badge on topic list, topic header

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -26,12 +26,19 @@
     display: inline-flex;
     align-items: center;
     font-size: var(--font-down-2);
-    border: 1px solid var(--primary-medium);
-    background: none;
-    padding: 0 0.25em;
+    border: 1px solid var(--tertiary-very-low);
+    background: var(--tertiary-very-low);
+    color: var(--tertiary);
+    padding: 0 0.35em;
     border-radius: 3px;
     pointer-events: auto; // needed to show title attribute on hover
-    vertical-align: text-bottom;
+    vertical-align: middle;
+
+    &.past {
+      border: 1px solid var(--primary-very-low);
+      background: var(--primary-very-low);
+      color: var(--primary-medium);
+    }
 
     .indicator {
       display: flex;

--- a/themes/horizon/scss/topic-cards.scss
+++ b/themes/horizon/scss/topic-cards.scss
@@ -403,7 +403,7 @@
   }
 
   .link-top-line .event-date-container {
-    top: -0.25rem;
+    top: -0.15rem;
     line-height: normal;
   }
 

--- a/themes/horizon/scss/topic.scss
+++ b/themes/horizon/scss/topic.scss
@@ -120,3 +120,16 @@ nav.post-controls .actions button {
 .archetype-private_message {
   --pm-border-radius: var(--d-border-radius);
 }
+
+.header-title {
+  .event-date {
+    font-size: var(--font-down-3);
+    border: 1px solid var(--tertiary-low);
+    background: var(--tertiary-low);
+
+    &.past {
+      border-color: transparent;
+      background-color: transparent;
+    }
+  }
+}


### PR DESCRIPTION
/t/181662

Before / After
<img width="2194" height="1248" alt="CleanShot 2026-04-13 at 11 52 14@2x" src="https://github.com/user-attachments/assets/7b04c93a-52ef-4aea-b155-5b4221a1950b" />

<img width="2132" height="1238" alt="CleanShot 2026-04-13 at 11 51 56@2x" src="https://github.com/user-attachments/assets/a43def7a-3d6c-4e3f-abd6-25a203e80e7f" />
