### PR TITLE
FIX: Trigger reactions re-render with a new array reference

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
@@ -474,8 +474,9 @@ export default class DiscourseReactionsActions extends Component {
     }
     // Trigger re-render for anything autotracking reactions.
     // In future, we should make reactions a deeply-trackable structure.
-    // eslint-disable-next-line no-self-assign
-    this.data.reactions = this.data.reactions;
+    // A new array reference is required because Ember's native trackedObject
+    // skips dirtying when Object.is(oldValue, newValue) is true.
+    this.data.reactions = [...this.data.reactions];
   }
 
   @action


### PR DESCRIPTION
After the migration to native `@ember/reactive/collections` in #38221,                                                                                                                                 
  the reactions counter stopped updating when consumers wrap the post data
  in `trackedObject`. `toggleReaction` mutates `reactions` in place via                                                                                                                                  
  `splice`, then does `this.data.reactions = this.data.reactions` to nudge                                                                                                                               
  autotracking. Legacy `TrackedObject` always dirtied on `set`; native                                                                                                                                   
  `trackedObject` short-circuits with `Object.is`, so the self-assignment                                                                                                                                
  is now a no-op and downstream consumers never re-render.                                                                                                                                               
                                                                                                                                                                                                         
  Reassigning to a fresh array (`[...this.data.reactions]`) gives the                                                                                                                                    
  proxy a new reference and the `set` trap dirties storage as intended.