### PR TITLE
FIX: Do not rerender FormKit controls when data changes

### DIFF
--- a/frontend/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/field-data.gjs
@@ -24,6 +24,8 @@ export default class FKFieldData extends Component {
    */
   errorId = uniqueId();
 
+  #controlArgs = { field: this };
+
   // Set by legacy controls in their constructor (during render),
   // read by the applyControlType modifier (post-render)
   _legacyControlType;
@@ -108,9 +110,11 @@ export default class FKFieldData extends Component {
    */
   @cached
   get Control() {
-    const { component, args } = resolveFieldControl(this.type);
-
-    return curryComponent(component, { field: this, ...args }, getOwner(this));
+    return curryComponent(
+      resolveFieldControl(this.type, getOwner(this)),
+      this.#controlArgs,
+      getOwner(this)
+    );
   }
 
   /**

--- a/frontend/discourse/app/form-kit/lib/field-control.js
+++ b/frontend/discourse/app/form-kit/lib/field-control.js
@@ -1,3 +1,4 @@
+import curryComponent from "ember-curry-component";
 import FKControlCalendar from "discourse/form-kit/components/fk/control/calendar";
 import FKControlCheckbox from "discourse/form-kit/components/fk/control/checkbox";
 import FKControlCode from "discourse/form-kit/components/fk/control/code";
@@ -38,18 +39,36 @@ const CONTROL_COMPONENTS = {
   toggle: FKControlToggle,
 };
 
-export function resolveFieldControl(type) {
+const _INPUT_CONTROL_COMPONENTS = new WeakMap();
+function getInputControlComponent(inputType, owner) {
+  let mapForOwner = _INPUT_CONTROL_COMPONENTS.get(owner);
+  if (!mapForOwner) {
+    mapForOwner = new Map();
+    _INPUT_CONTROL_COMPONENTS.set(owner, mapForOwner);
+  }
+  if (mapForOwner.has(inputType)) {
+    return mapForOwner.get(inputType);
+  }
+
+  const curried = curryComponent(
+    FKControlInput,
+    {
+      type: inputType,
+    },
+    owner
+  );
+  mapForOwner.set(inputType, curried);
+
+  return curried;
+}
+
+export function resolveFieldControl(type, owner) {
   if (!type) {
     throw new Error("@type is required on `<form.Field />`.");
   }
 
   if (type.startsWith("input-")) {
-    return {
-      component: FKControlInput,
-      args: {
-        type: type.slice("input-".length),
-      },
-    };
+    return getInputControlComponent(type.slice("input-".length), owner);
   }
 
   const component = CONTROL_COMPONENTS[type];
@@ -58,5 +77,5 @@ export function resolveFieldControl(type) {
     throw new Error(`Unsupported \`<form.Field @type>\` value: "${type}".`);
   }
 
-  return { component, args: {} };
+  return component;
 }

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -45,7 +45,7 @@
     "chartjs-plugin-datalabels": "2.2.0",
     "decorator-transforms": "^2.3.1",
     "diff": "^8.0.4",
-    "ember-curry-component": "^0.3.1",
+    "ember-curry-component": "^0.4.0",
     "ember-resolver": "^13.2.0",
     "ember-route-template": "^1.0.3",
     "ember-source": "~6.10.0",

--- a/frontend/discourse/tests/integration/components/form-kit/object-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/object-test.gjs
@@ -1,9 +1,24 @@
-import { array, concat, fn, hash } from "@ember/helper";
-import { click, render } from "@ember/test-helpers";
+import { array, concat, fn, get, hash } from "@ember/helper";
+import { click, focus, render, typeIn } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
+
+function getFieldMeta() {
+  return {
+    qux: { type: "text" },
+    quux: { type: "text" },
+  };
+}
+
+function fieldType(type) {
+  return type === "checkbox" ? "checkbox" : "input";
+}
+
+function fieldKeys(obj) {
+  return obj ? Object.keys(obj) : [];
+}
 
 module("Integration | Component | FormKit | Object", function (hooks) {
   setupRenderingTest(hooks);
@@ -104,5 +119,37 @@ module("Integration | Component | FormKit | Object", function (hooks) {
     await formKit().field("one.two.0.foo").fillIn("2");
 
     assert.form().field("one.two.0.foo").hasValue("2");
+  });
+
+  test("retains focus when @type depends on yielded data inside form.Object", async function (assert) {
+    await render(
+      <template>
+        <Form
+          @data={{hash foo="bar" baz=(hash qux="" quux="test")}}
+          as |form data|
+        >
+          <form.Object @name="baz" as |object objectData|>
+            {{#each (fieldKeys objectData) as |key|}}
+              {{#let (get (getFieldMeta data.foo) key) as |params|}}
+                <object.Field
+                  @type={{fieldType params.type}}
+                  @name={{key}}
+                  @title={{key}}
+                  as |field|
+                >
+                  <field.Control />
+                </object.Field>
+              {{/let}}
+            {{/each}}
+          </form.Object>
+        </Form>
+      </template>
+    );
+
+    const input = document.querySelector("[data-name='baz.qux'] input");
+    await focus(input);
+    await typeIn(input, "u", { delay: 0 });
+
+    assert.strictEqual(document.activeElement, input, "focus retained");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       ember-curry-component:
-        specifier: ^0.3.1
-        version: 0.3.1(@babel/core@7.29.0)
+        specifier: ^0.4.0
+        version: 0.4.0(@babel/core@7.29.0)
       ember-resolver:
         specifier: ^13.2.0
         version: 13.2.0
@@ -4941,8 +4941,8 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-curry-component@0.3.1:
-    resolution: {integrity: sha512-cIfGQ4p2oP8AHPWsf6KGciMJJW4BeaaFKOn+PF+6W8Gk5/BDj/JbalR0Txuko0Zr9OXUfUH6ZWfMsvdZaPoViw==}
+  ember-curry-component@0.4.0:
+    resolution: {integrity: sha512-mXtlgCA0eW5B4ZdIP4qqMeatFCxKni7uuLbo06UK1a9y/itL5nKQosHwbyx5N7TfXXQt8oQl0oXAliIvw2sdmA==}
 
   ember-decorators@6.1.1:
     resolution: {integrity: sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==}
@@ -14446,7 +14446,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-curry-component@0.3.1(@babel/core@7.29.0):
+  ember-curry-component@0.4.0(@babel/core@7.29.0):
     dependencies:
       '@embroider/addon-shim': 1.10.2
       decorator-transforms: 2.3.1(@babel/core@7.29.0)


### PR DESCRIPTION
Possible alternative to #39218

- Uses & caches `curryComponent` directly in `lib/field-control.js`, so the return type is always a component-ish object

- Updates `field-control.gjs` to have a consistent argument object

- Updates ember-curry-component to latest version, which supports nested curries & prevents rerendering if component & args are unchanged