### PR TITLE
DEV: Improve sidekiq parent monitoring

### DIFF
--- a/lib/demon/base.rb
+++ b/lib/demon/base.rb
@@ -225,18 +225,30 @@ class Demon::Base
 
   def monitor_parent
     Thread.new do
-      while true
-        begin
-          unless alive?(@parent_pid)
-            Process.kill "TERM", Process.pid
-            sleep 10
-            Process.kill "KILL", Process.pid
-          end
-        rescue => e
-          log("URGENT monitoring thread had an exception #{e}", level: :error)
-        end
+      loop do
+        monitor_parent_tick
         sleep 1
       end
+    end
+  end
+
+  def monitor_parent_tick
+    if !alive?(@parent_pid)
+      Process.kill "TERM", Process.pid
+      sleep 10
+      Process.kill "KILL", Process.pid
+    end
+  rescue Exception => e
+    log_error(e)
+  end
+
+  def log_error(e)
+    log("URGENT monitoring thread had an exception #{e.class}: #{e.message}", level: :error)
+  rescue Exception
+    # Fall back to STDERR if the logger is broken
+    begin
+      $stderr.puts("[#{self.class}##{Process.pid}] monitor-parent: #{e.class}: #{e.message}")
+    rescue StandardError
     end
   end
 


### PR DESCRIPTION
Fixes (hopefully) the infinite loops of:

```
Failed to report error: can't alloc thread 3 Job exception: can't alloc thread sidekiq-exception
```

…that sometimes were happening after a local rails server restart.