### PR TITLE
DEV: Remove duplicate "optional"

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7664,7 +7664,7 @@ en:
             button: "Change source"
             title: "Change Theme Source"
             repository_url: "Repository URL"
-            branch: "Branch (optional)"
+            branch: "Branch"
             updating: "Updating theme source…"
             update: "Update Source"
             has_existing_key: "This theme has an existing SSH key configured."


### PR DESCRIPTION
As you can see in the [PR](https://github.com/discourse/discourse/pull/38169), the word “(optional)” is already displayed after the title. That's why I suggest removing it from the text.

<img width="1242" height="636" alt="image" src="https://github.com/user-attachments/assets/64b388d4-8f85-4573-b1fc-61a8de555337" />
