### PR TITLE
DEV: Add automatically closed topics event trigger and adapt the automation plugin's auto tag_topic_script accordingly

### DIFF
--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -45,7 +45,8 @@ TopicStatusUpdater =
         result = false if rc == 0
       end
 
-      DiscourseEvent.trigger(:topic_closed, topic) if status.manually_closing_topic?
+      DiscourseEvent.trigger(:topic_closed, topic, :manually) if status.manually_closing_topic?
+      DiscourseEvent.trigger(:topic_closed, topic, :automatically) if status.auto_closing_topic?
 
       if status.visible? && status.disabled?
         UserProfile.remove_featured_topic_from_all_profiles(topic)
@@ -201,6 +202,10 @@ TopicStatusUpdater =
 
         def closing_topic?
           (closed? || autoclosed?) && enabled?
+        end
+
+        def auto_closing_topic?
+          autoclosed? && enabled?
         end
 
         def manually_closing_topic?

--- a/plugins/automation/config/locales/client.en.yml
+++ b/plugins/automation/config/locales/client.en.yml
@@ -314,6 +314,12 @@ en:
             tags:
               label: Tags
               description: List of tags to add to the topic.
+            closed_automatically:
+              label: Automatically closed topics 
+              description: Add tags to automatically closed topics.
+            closed_manually:
+              label: Manually closed topics
+              description: Add tags to manually closed topics.
         post:
           fields:
             creator:

--- a/plugins/automation/lib/discourse_automation/event_handlers.rb
+++ b/plugins/automation/lib/discourse_automation/event_handlers.rb
@@ -309,7 +309,7 @@ module DiscourseAutomation
         end
     end
 
-    def self.handle_topic_closed(topic)
+    def self.handle_topic_closed(topic, status)
       name = DiscourseAutomation::Triggers::TOPIC_CLOSED
 
       DiscourseAutomation::Automation
@@ -318,6 +318,7 @@ module DiscourseAutomation
           automation.trigger!(
             "kind" => name,
             "topic" => topic,
+            "status" => status,
             "placeholders" => {
               "topic_url" => topic.relative_url,
               "topic_title" => topic.title,

--- a/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
@@ -23,7 +23,8 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::AUTO_TAG_TOPIC
 
     tags = fields.dig("tags", "value")
     if (context["status"] == :manually && fields.dig("closed_manually", "value")) ||
-         (context["status"] == :automatically && fields.dig("closed_automatically", "value"))
+         (context["status"] == :automatically && fields.dig("closed_automatically", "value")) ||
+         context["post"]
       DiscourseTagging.tag_topic_by_names(
         topic,
         Guardian.new(Discourse.system_user),

--- a/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/auto_tag_topic.rb
@@ -2,6 +2,8 @@
 
 DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::AUTO_TAG_TOPIC) do
   field :tags, component: :tags, required: true
+  field :closed_automatically, component: :boolean
+  field :closed_manually, component: :boolean
 
   version 1
 
@@ -20,12 +22,14 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::AUTO_TAG_TOPIC
     end
 
     tags = fields.dig("tags", "value")
-
-    DiscourseTagging.tag_topic_by_names(
-      topic,
-      Guardian.new(Discourse.system_user),
-      tags,
-      append: true,
-    )
+    if (context["status"] == :manually && fields.dig("closed_manually", "value")) ||
+         (context["status"] == :automatically && fields.dig("closed_automatically", "value"))
+      DiscourseTagging.tag_topic_by_names(
+        topic,
+        Guardian.new(Discourse.system_user),
+        tags,
+        append: true,
+      )
+    end
   end
 end

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -161,7 +161,9 @@ after_initialize do
     )
   end
 
-  on(:topic_closed) { |topic| ::DiscourseAutomation::EventHandlers.handle_topic_closed(topic) }
+  on(:topic_closed) do |topic, status|
+    ::DiscourseAutomation::EventHandlers.handle_topic_closed(topic, status)
+  end
 
   on(:post_created) do |post|
     DiscourseAutomation::EventHandlers.handle_post_created_edited(post, :create)

--- a/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
+++ b/plugins/automation/spec/lib/discourse_automation/event_handlers_spec.rb
@@ -30,7 +30,7 @@ describe DiscourseAutomation::EventHandlers do
     end
     fab!(:topic) { Fabricate(:post).topic }
 
-    it "triggers automation when a topic is closed" do
+    it "triggers automation when a topic is closed manually" do
       list =
         capture_contexts do
           TopicStatusUpdater.new(topic, Fabricate(:admin)).update!("closed", true)
@@ -39,6 +39,23 @@ describe DiscourseAutomation::EventHandlers do
       expect(list.size).to eq(1)
       expect(list.first["kind"]).to eq("topic_closed")
       expect(list.first["topic"].id).to eq(topic.id)
+      expect(list.first["status"]).to eq(:manually)
+      expect(list.first["placeholders"]["topic_url"]).to eq(topic.relative_url)
+      expect(list.first["placeholders"]["topic_title"]).to eq(topic.title)
+    end
+
+    it "triggers automation when a topic is closed automatically" do
+      topic.set_or_create_timer(TopicTimer.types[:close], "10")
+
+      list =
+        capture_contexts do
+          TopicStatusUpdater.new(topic, Fabricate(:admin)).update!("autoclosed", true)
+        end
+
+      expect(list.size).to eq(1)
+      expect(list.first["kind"]).to eq("topic_closed")
+      expect(list.first["topic"].id).to eq(topic.id)
+      expect(list.first["status"]).to eq(:automatically)
       expect(list.first["placeholders"]["topic_url"]).to eq(topic.relative_url)
       expect(list.first["placeholders"]["topic_title"]).to eq(topic.title)
     end

--- a/plugins/automation/spec/scripts/auto_tag_topic_spec.rb
+++ b/plugins/automation/spec/scripts/auto_tag_topic_spec.rb
@@ -84,12 +84,67 @@ describe "AutoTagTopic" do
     end
 
     context "when there are tags" do
-      before { automation.upsert_field!("tags", "tags", { value: %w[tag1 tag2] }) }
+      context "when closed_automatically is set" do
+        before do
+          automation.upsert_field!("tags", "tags", { value: %w[tag1 tag2] })
+          automation.upsert_field!(
+            "closed_automatically",
+            "boolean",
+            { value: true },
+            target: "script",
+          )
+        end
+        it "works" do
+          automation.trigger!("topic" => topic, "status" => :automatically)
 
-      it "works" do
-        automation.trigger!("topic" => topic)
+          expect(topic.reload.tags.pluck(:name)).to match_array(%w[tag1 tag2])
+        end
 
-        expect(topic.reload.tags.pluck(:name)).to match_array(%w[tag1 tag2])
+        it "does not apply tags for manual closures" do
+          automation.trigger!("topic" => topic, "status" => :manually)
+
+          expect(topic.reload.tags.pluck(:name)).to be_empty
+        end
+      end
+      context "when closed_manually is set" do
+        before do
+          automation.upsert_field!("tags", "tags", { value: %w[tag1 tag2] })
+          automation.upsert_field!("closed_manually", "boolean", { value: true }, target: "script")
+        end
+
+        it "applies tags for manual closures" do
+          automation.trigger!("topic" => topic, "status" => :manually)
+
+          expect(topic.reload.tags.pluck(:name)).to match_array(%w[tag1 tag2])
+        end
+
+        it "does not apply tags for automatic closures" do
+          automation.trigger!("topic" => topic, "status" => :automatically)
+
+          expect(topic.reload.tags.pluck(:name)).to be_empty
+        end
+      end
+
+      context "when both fields are set" do
+        before do
+          automation.upsert_field!("tags", "tags", { value: %w[tag1 tag2] })
+          automation.upsert_field!(
+            "closed_automatically",
+            "boolean",
+            { value: true },
+            target: "script",
+          )
+          automation.upsert_field!("closed_manually", "boolean", { value: true }, target: "script")
+        end
+
+        it "applies tags for both closure types" do
+          automation.trigger!("topic" => topic, "status" => :manually)
+          expect(topic.reload.tags.pluck(:name)).to match_array(%w[tag1 tag2])
+
+          topic.tags = []
+          automation.trigger!("topic" => topic, "status" => :automatically)
+          expect(topic.reload.tags.pluck(:name)).to match_array(%w[tag1 tag2])
+        end
       end
     end
   end

--- a/spec/services/topic_status_updater_spec.rb
+++ b/spec/services/topic_status_updater_spec.rb
@@ -75,18 +75,42 @@ RSpec.describe TopicStatusUpdater do
     expect(last_post.raw).to eq(I18n.t("topic_statuses.autoclosed_enabled_minutes", count: 0))
   end
 
-  it "triggers a DiscourseEvent on close" do
+  it "triggers a DiscourseEvent with :manually when manually closing a topic" do
     topic = create_topic
 
-    called = false
-    updater = ->(_) { called = true }
+    closure_type = nil
+    captured_topic = nil
+    updater = ->(t, type) do
+      captured_topic = t
+      closure_type = type
+    end
 
     DiscourseEvent.on(:topic_closed, &updater)
     TopicStatusUpdater.new(topic, admin).update!("closed", true)
     DiscourseEvent.off(:topic_closed, &updater)
 
     expect(topic).to be_closed
-    expect(called).to eq(true)
+    expect(captured_topic).to eq(topic)
+    expect(closure_type).to eq(:manually)
+  end
+
+  it "triggers a DiscourseEvent with :automatically when auto-closing a topic" do
+    topic = create_topic
+
+    closure_type = nil
+    captured_topic = nil
+    updater = ->(t, type) do
+      captured_topic = t
+      closure_type = type
+    end
+
+    DiscourseEvent.on(:topic_closed, &updater)
+    TopicStatusUpdater.new(topic, admin).update!("autoclosed", true)
+    DiscourseEvent.off(:topic_closed, &updater)
+
+    expect(topic).to be_closed
+    expect(captured_topic).to eq(topic)
+    expect(closure_type).to eq(:automatically)
   end
 
   it "adds an autoclosed message based on last post" do


### PR DESCRIPTION
### Description

This PR fixes an issue where the :topic_closed DiscourseEvent only fired when topics were closed manually, preventing automations from responding to automatically closed topics. The event now fires for both manual and automatic closures.

The auto_tag_topic automation script has been enhanced to take advantage of this change by adding two new optional boolean fields (closed_automatically and closed_manually) that allow users to configure whether tags should be applied based on how the topic was closed. 