### PR TITLE
DEV: Stop prometheus/ai spam in plugin backend specs

### DIFF
--- a/plugins/discourse-ai/lib/ai_moderation/spam_metric.rb
+++ b/plugins/discourse-ai/lib/ai_moderation/spam_metric.rb
@@ -23,7 +23,7 @@ module DiscourseAi
         metric.description = "AI spam scanning statistics"
         metric.labels = { db: RailsMultisite::ConnectionManagement.current_db, type: }
         metric.value = value
-        $prometheus_client.send_json(metric.to_h) # rubocop:disable Style/GlobalVars
+        $prometheus_client.send_json(metric.to_h) unless Rails.env.test? # rubocop:disable Style/GlobalVars
       end
     end
   end

--- a/plugins/discourse-ai/lib/completions/llm_metric.rb
+++ b/plugins/discourse-ai/lib/completions/llm_metric.rb
@@ -70,7 +70,7 @@ module DiscourseAi
           metric.description = description
           metric.labels = labels
           metric.value = value
-          $prometheus_client.send_json(metric.to_h) # rubocop:disable Style/GlobalVars
+          $prometheus_client.send_json(metric.to_h) unless Rails.env.test? # rubocop:disable Style/GlobalVars
         end
 
         def observe_histogram(name, description, labels, value)
@@ -80,7 +80,7 @@ module DiscourseAi
           metric.description = description
           metric.labels = labels
           metric.value = value
-          $prometheus_client.send_json(metric.to_h) # rubocop:disable Style/GlobalVars
+          $prometheus_client.send_json(metric.to_h) unless Rails.env.test? # rubocop:disable Style/GlobalVars
         end
       end
     end


### PR DESCRIPTION
No more of these

```
E, [2026-04-13T13:40:33.862133 #2069] ERROR -- : Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9405
```