### PR TITLE
UX: improve share modal on small screens

### DIFF
--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -16,10 +16,6 @@
   .invite-link {
     flex: 1 0;
   }
-
-  .mobile-view & {
-    flex-direction: column;
-  }
 }
 
 .link-share-actions {
@@ -34,6 +30,7 @@
 
   .sources {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .new-topic {

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -290,6 +290,7 @@
   .d-modal {
     &__title {
       display: flex;
+      flex-wrap: wrap;
       align-items: center;
       gap: 0.5rem;
     }


### PR DESCRIPTION
Fixes some styles for sharing on small screens


Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/61425f3b-e220-46e4-9390-5e66b16d83b1" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/188e90d2-f075-49bf-8a1b-fa98b919e831" />


After:
<img width="325" alt="image" src="https://github.com/user-attachments/assets/7680fbb4-3aba-4254-ae91-54073ce7dcec" />

<img width="332" alt="image" src="https://github.com/user-attachments/assets/16499f7e-35f4-4d8b-b778-52ce4e76a6ac" />
