### PR TITLE
DEV: Allow forceEditorMode to be passed through to FKComposer

### DIFF
--- a/frontend/discourse/app/form-kit/components/fk/control/composer.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/composer.gjs
@@ -26,6 +26,7 @@ export default class FKControlComposer extends FKBaseControl {
       @value={{readonly @field.value}}
       @change={{this.handleInput}}
       @disabled={{@field.disabled}}
+      @forceEditorMode={{@forceEditorMode}}
       class={{concatClass
         "form-kit__control-composer"
         (if @preview "--preview")


### PR DESCRIPTION
This allows us in forms to make it so the composer _only_
uses rich text/markdown as appropriate.
