### PR TITLE
DEV: update solved schema for non text posts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -774,8 +774,9 @@ module ApplicationHelper
   end
 
   def crawler_post_schema_overridden?(post, topic)
-    itemprop = crawler_post_schema_hash(post, topic)[:itemprop]
-    itemprop.present? && itemprop != "comment"
+    hash = crawler_post_schema_hash(post, topic)
+    itemprop = hash[:itemprop]
+    (itemprop.present? && itemprop != "comment") || hash[:data].present?
   end
 
   # If there is plugin HTML return that, otherwise yield to the template

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -779,6 +779,10 @@ module ApplicationHelper
     (itemprop.present? && itemprop != "comment") || hash[:data].present?
   end
 
+  def crawler_post_schema_skip?(post, topic)
+    DiscoursePluginRegistry.apply_modifier(:topic_crawler_skip_post, false, post, topic)
+  end
+
   # If there is plugin HTML return that, otherwise yield to the template
   def replace_plugin_html(name)
     if (html = build_plugin_html(name)).present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -757,20 +757,25 @@ module ApplicationHelper
     ).presence
   end
 
+  def crawler_post_schema_hash(post, topic)
+    @crawler_post_schema_hash ||= {}
+    @crawler_post_schema_hash[post.id] ||= begin
+      default = {
+        itemprop: "comment",
+        itemscope: true,
+        itemtype: "http://schema.org/Comment",
+      } unless post.is_first_post?
+      DiscoursePluginRegistry.apply_modifier(:topic_crawler_post_schema, default || {}, post, topic)
+    end
+  end
+
   def crawler_post_schema(post, topic)
-    default = {
-      itemprop: "comment",
-      itemscope: true,
-      itemtype: "http://schema.org/Comment",
-    } unless post.is_first_post?
-    tag.attributes(
-      DiscoursePluginRegistry.apply_modifier(
-        :topic_crawler_post_schema,
-        default || {},
-        post,
-        topic,
-      ),
-    )
+    tag.attributes(crawler_post_schema_hash(post, topic))
+  end
+
+  def crawler_post_schema_overridden?(post, topic)
+    itemprop = crawler_post_schema_hash(post, topic)[:itemprop]
+    itemprop.present? && itemprop != "comment"
   end
 
   # If there is plugin HTML return that, otherwise yield to the template

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -74,7 +74,8 @@
           <div id='post_<%= post.post_number %>' <%= crawler_post_schema(post, @topic_view.topic) %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>
               <span class="creator" itemprop="author" itemscope itemtype="http://schema.org/Person">
-                <a itemprop="url" rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
+                <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
+                <meta itemprop='url' content='<%= Discourse.base_url %>/u/<%= u.username %>'>
                 <%= "(#{u.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names? && !u.name.blank?) %>
                 <%
                   post_custom_fields = @topic_view.post_custom_fields[post.id] || {}

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -70,6 +70,7 @@
       <% end %>
 
       <% @topic_view.crawler_posts.each do |post| %>
+        <% next if crawler_post_schema_skip?(post, @topic_view.topic) %>
         <% if (u = post.user) && !post.hidden && post.cooked && !post.cooked.strip.empty? %>
           <div id='post_<%= post.post_number %>' <%= crawler_post_schema(post, @topic_view.topic) %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -110,11 +110,13 @@
               <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
             </div>
 
-            <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-              <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
-              <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />
-              <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
-            </div>
+            <% unless crawler_post_schema_overridden?(post, @topic_view.topic) %>
+              <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
+                <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+                <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />
+                <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
+              </div>
+            <% end %>
 
               <% if (linkbacks = @topic_view.linkbacks_for(post)).present? %>
                 <div class='crawler-linkback-list'>

--- a/plugins/discourse-solved/app/serializers/discourse_solved/answer_schema_serializer.rb
+++ b/plugins/discourse-solved/app/serializers/discourse_solved/answer_schema_serializer.rb
@@ -2,7 +2,7 @@
 
 class DiscourseSolved::AnswerSchemaSerializer < ApplicationSerializer
   # attributes are camelCase as the Q&A schema spec requires it
-  attributes :text, :upvoteCount, :datePublished, :url, :author
+  attributes :author, :dateModified, :datePublished, :text, :upvoteCount, :url
 
   def serializable_hash
     { "@type" => "Answer" }.merge(super)
@@ -19,6 +19,10 @@ class DiscourseSolved::AnswerSchemaSerializer < ApplicationSerializer
 
   def datePublished
     object.created_at
+  end
+
+  def dateModified
+    object.last_version_at || object.created_at
   end
 
   def url

--- a/plugins/discourse-solved/app/serializers/discourse_solved/question_schema_serializer.rb
+++ b/plugins/discourse-solved/app/serializers/discourse_solved/question_schema_serializer.rb
@@ -2,7 +2,7 @@
 
 class DiscourseSolved::QuestionSchemaSerializer < ApplicationSerializer
   # attributes are camelCase as the Q&A schema spec requires it
-  attributes :name, :text, :upvoteCount, :answerCount, :datePublished, :author
+  attributes :answerCount, :author, :dateModified, :datePublished, :name, :text, :upvoteCount
 
   def serializable_hash
     hash = { "@type" => "Question" }.merge(super)
@@ -40,6 +40,10 @@ class DiscourseSolved::QuestionSchemaSerializer < ApplicationSerializer
 
   def datePublished
     object.created_at
+  end
+
+  def dateModified
+    object.first_post&.last_version_at || object.created_at
   end
 
   def author

--- a/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
@@ -45,7 +45,11 @@ class DiscourseSolved::BuildSchemaMarkup
     excluded_ids << accepted_answer.id if accepted_answer.present?
     scope = topic.posts.where.not(id: excluded_ids)
     scope = scope.where(id: params.post_ids) if params.post_ids.present?
-    scope.where(post_type: Post.types[:regular], hidden: false).order(:post_number).to_a
+    scope
+      .where(post_type: Post.types[:regular], hidden: false)
+      .order(:post_number)
+      .to_a
+      .select { |p| p.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present? }
   end
 
   def fetch_html(topic:, accepted_answer:, suggested_answers:)

--- a/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
@@ -68,6 +68,7 @@ class DiscourseSolved::BuildSchemaMarkup
           "@context" => "http://schema.org",
           "@type" => "QAPage",
           "name" => topic.title,
+          "datePublished" => topic.created_at,
           "mainEntity" => question_json,
         )
         .gsub("</", "<\\/")

--- a/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
@@ -37,7 +37,8 @@ class DiscourseSolved::BuildSchemaMarkup
 
   def fetch_accepted_answer(topic:)
     post = topic.solved&.answer_post
-    post if post.present? && Guardian.new.can_see_post?(post)
+    return unless post.present? && Guardian.new.can_see_post?(post)
+    post if post.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present?
   end
 
   def fetch_suggested_answers(params:, topic:, accepted_answer:)

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -49,6 +49,7 @@ module DiscourseSolved
       return nil unless qa_page_schema?(topic)
       return {} if post.is_first_post?
       return { itemscope: true } if post.post_type == Post.types[:small_action]
+      return {} unless eligible_answer?(post)
       if accepted_answer_visible?(topic) && topic.solved.answer_post_id == post.id
         { itemprop: "acceptedAnswer", itemscope: true, itemtype: "https://schema.org/Answer" }
       else
@@ -56,10 +57,11 @@ module DiscourseSolved
       end
     end
 
-    def self.main_entity_meta(topic)
+    def self.main_entity_meta(topic, crawler_posts)
       return unless qa_page_schema?(topic)
       "<meta itemprop='name' content='#{ERB::Util.html_escape(topic.title)}'>" \
-        "<meta itemprop='answerCount' content='#{eligible_answers(topic).count}'>"
+        "<meta itemprop='datePublished' content='#{topic.created_at.iso8601}'>" \
+        "<meta itemprop='answerCount' content='#{Array(crawler_posts).count { |p| eligible_answer?(p) }}'>"
     end
 
     private_class_method def self.accepted_answer_visible?(topic)
@@ -69,6 +71,11 @@ module DiscourseSolved
 
     private_class_method def self.eligible_answers(topic)
       topic.posts.where.not(post_number: 1).where(post_type: Post.types[:regular], hidden: false)
+    end
+
+    private_class_method def self.eligible_answer?(post)
+      !post.is_first_post? && post.post_type == Post.types[:regular] && !post.hidden &&
+        post.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present?
     end
   end
 end

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -48,7 +48,6 @@ module DiscourseSolved
     def self.post_schema(post, topic)
       return nil unless qa_page_schema?(topic)
       return { data: { qa_question: true } } if post.is_first_post?
-      return { itemscope: true } if post.post_type == Post.types[:small_action]
       return {} unless eligible_answer?(post)
       if accepted_answer_visible?(topic) && topic.solved.answer_post_id == post.id
         { itemprop: "acceptedAnswer", itemscope: true, itemtype: "https://schema.org/Answer" }

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -47,7 +47,7 @@ module DiscourseSolved
 
     def self.post_schema(post, topic)
       return nil unless qa_page_schema?(topic)
-      return {} if post.is_first_post?
+      return { data: { qa_question: true } } if post.is_first_post?
       return { itemscope: true } if post.post_type == Post.types[:small_action]
       return {} unless eligible_answer?(post)
       if accepted_answer_visible?(topic) && topic.solved.answer_post_id == post.id
@@ -57,16 +57,19 @@ module DiscourseSolved
       end
     end
 
-    def self.post_upvote_count_meta(post, topic)
+    def self.post_answer_meta(post, topic)
       return unless post_schema(post, topic)&.[](:itemprop)
-      "<meta itemprop='upvoteCount' content='#{post.like_count}'>"
+      "<meta itemprop='upvoteCount' content='#{post.like_count}'>" \
+        "<meta itemprop='url' content='#{post.full_url}'>"
     end
 
     def self.main_entity_meta(topic, crawler_posts)
       return unless qa_page_schema?(topic)
-      "<meta itemprop='name' content='#{ERB::Util.html_escape(topic.title)}'>" \
+      first_post = topic.first_post
+      "<meta itemprop='answerCount' content='#{Array(crawler_posts).count { |p| eligible_answer?(p) }}'>" \
         "<meta itemprop='datePublished' content='#{topic.created_at.iso8601}'>" \
-        "<meta itemprop='answerCount' content='#{Array(crawler_posts).count { |p| eligible_answer?(p) }}'>"
+        "<meta itemprop='name' content='#{ERB::Util.html_escape(topic.title)}'>" \
+        "<meta itemprop='upvoteCount' content='#{first_post&.like_count || 0}'>"
     end
 
     private_class_method def self.accepted_answer_visible?(topic)

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -57,6 +57,11 @@ module DiscourseSolved
       end
     end
 
+    def self.post_upvote_count_meta(post, topic)
+      return unless post_schema(post, topic)&.[](:itemprop)
+      "<meta itemprop='upvoteCount' content='#{post.like_count}'>"
+    end
+
     def self.main_entity_meta(topic, crawler_posts)
       return unless qa_page_schema?(topic)
       "<meta itemprop='name' content='#{ERB::Util.html_escape(topic.title)}'>" \

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -91,6 +91,11 @@ after_initialize do
     DiscourseSolved::SchemaUtils.post_schema(post, topic) || schema
   end
 
+  register_modifier(:topic_crawler_skip_post) do |default, post, topic|
+    DiscourseSolved::SchemaUtils.qa_page_schema?(topic) &&
+      post.post_type == Post.types[:small_action]
+  end
+
   register_html_builder("server:topic-main-entity-meta-crawler") do |controller|
     topic_view = controller.instance_variable_get(:@topic_view)
     DiscourseSolved::SchemaUtils.main_entity_meta(topic_view&.topic, topic_view&.crawler_posts)

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -98,7 +98,7 @@ after_initialize do
 
   register_html_builder("server:topic-show-crawler-post-end") do |controller, post:|
     topic = controller.instance_variable_get(:@topic_view)&.topic
-    DiscourseSolved::SchemaUtils.post_upvote_count_meta(post, topic) if topic
+    DiscourseSolved::SchemaUtils.post_answer_meta(post, topic) if topic
   end
 
   register_html_builder("server:before-head-close-crawler") do |controller|

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -96,6 +96,11 @@ after_initialize do
     DiscourseSolved::SchemaUtils.main_entity_meta(topic_view&.topic, topic_view&.crawler_posts)
   end
 
+  register_html_builder("server:topic-show-crawler-post-end") do |controller, post:|
+    topic = controller.instance_variable_get(:@topic_view)&.topic
+    DiscourseSolved::SchemaUtils.post_upvote_count_meta(post, topic) if topic
+  end
+
   register_html_builder("server:before-head-close-crawler") do |controller|
     topic_view = controller.instance_variable_get(:@topic_view)
     result =

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -93,7 +93,7 @@ after_initialize do
 
   register_html_builder("server:topic-main-entity-meta-crawler") do |controller|
     topic_view = controller.instance_variable_get(:@topic_view)
-    DiscourseSolved::SchemaUtils.main_entity_meta(topic_view&.topic)
+    DiscourseSolved::SchemaUtils.main_entity_meta(topic_view&.topic, topic_view&.crawler_posts)
   end
 
   register_html_builder("server:before-head-close-crawler") do |controller|

--- a/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe TopicsController do
       expect(accepted.at_css('[itemprop="text"]')).to be_present
       expect(accepted.at_css('[itemprop="datePublished"]')).to be_present
       expect(accepted.at_css('[itemprop="author"] [itemprop="name"]')).to be_present
+      expect(accepted.at_css('[itemprop="upvoteCount"]')["content"]).to eq(p2.like_count.to_s)
 
       suggested = doc.at_css("#post_#{p3.post_number}")
       expect(suggested["itemprop"]).to eq("suggestedAnswer")
@@ -175,6 +176,7 @@ RSpec.describe TopicsController do
       expect(suggested.at_css('[itemprop="text"]')).to be_present
       expect(suggested.at_css('[itemprop="datePublished"]')).to be_present
       expect(suggested.at_css('[itemprop="author"] [itemprop="name"]')).to be_present
+      expect(suggested.at_css('[itemprop="upvoteCount"]')["content"]).to eq(p3.like_count.to_s)
     end
 
     it "does not modify schema for topics without solved enabled" do

--- a/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
@@ -7,23 +7,25 @@ RSpec.describe TopicsController do
 
   def expected_schema_json
     answer_json =
-      ',"acceptedAnswer":{"@type":"Answer","text":"%{answer_text}","upvoteCount":%{answer_likes},"datePublished":"%{answered_at}","url":"%{answer_url}","author":{"@type":"Person","name":"%{username2}","url":"%{user2_url}"}}' %
+      ',"acceptedAnswer":{"@type":"Answer","author":{"@type":"Person","name":"%{username2}","url":"%{user2_url}"},"dateModified":"%{answer_modified}","datePublished":"%{answered_at}","text":"%{answer_text}","upvoteCount":%{answer_likes},"url":"%{answer_url}"}' %
         {
           answer_text: p2.excerpt,
           answer_likes: p2.like_count,
           answered_at: p2.created_at.as_json,
+          answer_modified: (p2.last_version_at || p2.created_at).as_json,
           answer_url: p2.full_url,
           username2: p2.user&.username,
           user2_url: p2.user&.full_url,
         }
 
-    '<script type="application/ld+json">{"@context":"http://schema.org","@type":"QAPage","name":"%{title}","mainEntity":{"@type":"Question","name":"%{title}","text":"%{question_text}","upvoteCount":%{question_likes},"answerCount":1,"datePublished":"%{created_at}","author":{"@type":"Person","name":"%{username1}","url":"%{user1_url}"}%{answer_json}}}</script>' %
+    '<script type="application/ld+json">{"@context":"http://schema.org","@type":"QAPage","name":"%{title}","datePublished":"%{created_at}","mainEntity":{"@type":"Question","answerCount":1,"author":{"@type":"Person","name":"%{username1}","url":"%{user1_url}"},"dateModified":"%{question_modified}","datePublished":"%{created_at}","name":"%{title}","text":"%{question_text}","upvoteCount":%{question_likes}%{answer_json}}}</script>' %
       # rubocop:enable Layout/LineLength
       {
         title: topic.title,
         question_text: p1.excerpt,
         question_likes: p1.like_count,
         created_at: topic.created_at.as_json,
+        question_modified: (p1.last_version_at || p1.created_at).as_json,
         username1: topic.user&.username,
         user1_url: topic.user&.full_url,
         answer_json:,
@@ -159,6 +161,7 @@ RSpec.describe TopicsController do
       expect(question.at_css('[itemprop="name"]')["content"]).to eq(topic.title)
       expect(question.at_css('[itemprop="datePublished"]')["content"]).to be_present
       expect(question.at_css('[itemprop="answerCount"]')["content"]).to eq("2")
+      expect(question.at_css('[itemprop="upvoteCount"]')["content"]).to eq(p1.like_count.to_s)
       expect(question.at_css('[itemprop="text"]')).to be_present
       expect(question.at_css('[itemprop="author"] [itemprop="name"]')).to be_present
 
@@ -168,7 +171,12 @@ RSpec.describe TopicsController do
       expect(accepted.at_css('[itemprop="text"]')).to be_present
       expect(accepted.at_css('[itemprop="datePublished"]')).to be_present
       expect(accepted.at_css('[itemprop="author"] [itemprop="name"]')).to be_present
+      expect(accepted.at_css('[itemprop="author"] [itemprop="url"]')["content"]).to include(
+        p2.user.username,
+      )
       expect(accepted.at_css('[itemprop="upvoteCount"]')["content"]).to eq(p2.like_count.to_s)
+      accepted_urls = accepted.css('meta[itemprop="url"]').map { |el| el["content"] }
+      expect(accepted_urls).to include(p2.full_url)
 
       suggested = doc.at_css("#post_#{p3.post_number}")
       expect(suggested["itemprop"]).to eq("suggestedAnswer")
@@ -176,7 +184,12 @@ RSpec.describe TopicsController do
       expect(suggested.at_css('[itemprop="text"]')).to be_present
       expect(suggested.at_css('[itemprop="datePublished"]')).to be_present
       expect(suggested.at_css('[itemprop="author"] [itemprop="name"]')).to be_present
+      expect(suggested.at_css('[itemprop="author"] [itemprop="url"]')["content"]).to include(
+        p3.user.username,
+      )
       expect(suggested.at_css('[itemprop="upvoteCount"]')["content"]).to eq(p3.like_count.to_s)
+      suggested_urls = suggested.css('meta[itemprop="url"]').map { |el| el["content"] }
+      expect(suggested_urls).to include(p3.full_url)
     end
 
     it "does not modify schema for topics without solved enabled" do

--- a/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
@@ -153,11 +153,11 @@ RSpec.describe TopicsController do
       qa_page = doc.at_css('[itemtype*="QAPage"]')
       expect(qa_page).to be_present
       expect(qa_page.at_css('> [itemprop="name"]')["content"]).to eq(topic.title)
-      expect(qa_page.at_css('> [itemprop="datePublished"]')["content"]).to be_present
 
       question = doc.at_css('[itemtype*="Question"]')
       expect(question).to be_present
       expect(question.at_css('[itemprop="name"]')["content"]).to eq(topic.title)
+      expect(question.at_css('[itemprop="datePublished"]')["content"]).to be_present
       expect(question.at_css('[itemprop="answerCount"]')["content"]).to eq("2")
       expect(question.at_css('[itemprop="text"]')).to be_present
       expect(question.at_css('[itemprop="author"] [itemprop="name"]')).to be_present

--- a/plugins/discourse-solved/spec/serializers/discourse_solved/question_schema_serializer_spec.rb
+++ b/plugins/discourse-solved/spec/serializers/discourse_solved/question_schema_serializer_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe DiscourseSolved::QuestionSchemaSerializer do
     it "includes the accepted answer" do
       accepted = json["acceptedAnswer"]
       expect(accepted["@type"]).to eq("Answer")
+      expect(accepted["text"]).to be_present
+      expect(accepted["datePublished"]).to be_present
       expect(accepted["upvoteCount"]).to eq(7)
       expect(accepted["author"]).to eq(
         { "@type" => "Person", "name" => answer_user.username, "url" => answer_user.full_url },
@@ -73,7 +75,11 @@ RSpec.describe DiscourseSolved::QuestionSchemaSerializer do
     end
 
     it "includes suggestedAnswer as an array of Answer objects" do
-      expect(json["suggestedAnswer"].sole["@type"]).to eq("Answer")
+      suggested = json["suggestedAnswer"].sole
+      expect(suggested["@type"]).to eq("Answer")
+      expect(suggested["text"]).to be_present
+      expect(suggested["datePublished"]).to be_present
+      expect(suggested["upvoteCount"]).to eq(0)
     end
   end
 end

--- a/plugins/discourse-solved/spec/serializers/discourse_solved/question_schema_serializer_spec.rb
+++ b/plugins/discourse-solved/spec/serializers/discourse_solved/question_schema_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe DiscourseSolved::QuestionSchemaSerializer do
       expect(json["upvoteCount"]).to eq(2)
       expect(json["answerCount"]).to eq(0)
       expect(json["datePublished"]).to eq(topic.created_at)
+      expect(json["dateModified"]).to be_present
     end
 
     it "serializes the author" do
@@ -52,6 +53,7 @@ RSpec.describe DiscourseSolved::QuestionSchemaSerializer do
       expect(accepted["@type"]).to eq("Answer")
       expect(accepted["text"]).to be_present
       expect(accepted["datePublished"]).to be_present
+      expect(accepted["dateModified"]).to be_present
       expect(accepted["upvoteCount"]).to eq(7)
       expect(accepted["author"]).to eq(
         { "@type" => "Person", "name" => answer_user.username, "url" => answer_user.full_url },
@@ -79,6 +81,7 @@ RSpec.describe DiscourseSolved::QuestionSchemaSerializer do
       expect(suggested["@type"]).to eq("Answer")
       expect(suggested["text"]).to be_present
       expect(suggested["datePublished"]).to be_present
+      expect(suggested["dateModified"]).to be_present
       expect(suggested["upvoteCount"]).to eq(0)
     end
   end

--- a/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
@@ -108,6 +108,38 @@ RSpec.describe DiscourseSolved::BuildSchemaMarkup do
       end
     end
 
+    context "when the accepted answer has no text content" do
+      fab!(:answer_post) do
+        Fabricate(
+          :post,
+          topic:,
+          raw: "https://www.youtube.com/watch?v=test",
+          cooked:
+            '<div class="onebox video-onebox"><iframe src="https://youtube.com/embed/test"></iframe></div>',
+        )
+      end
+
+      before do
+        SiteSetting.solved_add_schema_markup = "always"
+        Fabricate(:solved_topic, topic:, answer_post:)
+      end
+
+      context "when there are other visible replies" do
+        fab!(:visible_reply) { Fabricate(:post, topic:) }
+
+        it "excludes the text-less accepted answer but includes suggested answers" do
+          html = result[:html]
+          expect(html).not_to include('"acceptedAnswer"')
+          expect(html).to include('"suggestedAnswer"')
+          expect(html).to include('"answerCount":1')
+        end
+      end
+
+      context "when there are no other replies" do
+        it { is_expected.to fail_a_policy(:has_answers) }
+      end
+    end
+
     context "when the accepted answer is hidden but there are other visible replies" do
       fab!(:answer_user, :user)
       fab!(:answer_post) { Fabricate(:post, topic:, user: answer_user, like_count: 3) }


### PR DESCRIPTION
This change fixes missing schema fields for solved topics. Since introducing the `suggestedAnswer` schema entry as part of the Solved plugin, we are seeing issues with some emoji-only and image-only posts.

These non text posts lead to either `acceptedAnswer` or `suggestedAnswer` items in the JSON-LD with "text": null, which Google reports as "Missing field 'text'".

This change filters out posts that have no excerpt value and still preserves written posts.