### PR TITLE
FEATURE: Bulk convert PMs to public topics (and vice versa)

### DIFF
--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -3,9 +3,10 @@
 class TopicConverter
   attr_reader :topic
 
-  def initialize(topic, user)
+  def initialize(topic, user, silent: false)
     @topic = topic
     @user = user
+    @silent = silent
   end
 
   def convert_to_public_topic(category_id = nil)
@@ -22,55 +23,70 @@ class TopicConverter
 
       PostRevisor.new(@topic.first_post, @topic).revise!(
         @user,
-        category_id: @category.id,
-        archetype: Archetype.default,
+        { category_id: @category.id, archetype: Archetype.default },
+        revise_opts,
       )
 
       raise ActiveRecord::Rollback if !@topic.valid?
 
       update_user_stats
       update_post_uploads_secure_status
-      add_small_action("public_topic")
+      add_small_action("public_topic") unless @silent
       Tag.update_counters(@topic.tags, { public_topic_count: 1 }) if !@category.read_restricted
 
       Jobs.enqueue(:topic_action_converter, topic_id: @topic.id)
       Jobs.enqueue(:delete_inaccessible_notifications, topic_id: @topic.id)
 
-      watch_topic(@topic)
+      watch_topic(@topic) unless @silent
     end
 
     @topic
   end
 
   def convert_to_private_message
+    if exceeds_recipient_cap?
+      @topic.errors.add(
+        :base,
+        I18n.t(
+          "topic_converter.too_many_recipients",
+          max: SiteSetting.max_allowed_message_recipients,
+        ),
+      )
+      return @topic
+    end
+
     Topic.transaction do
       was_public = !@topic.category.read_restricted
       @topic.update_category_topic_count_by(-1) if @topic.visible
 
       PostRevisor.new(@topic.first_post, @topic).revise!(
         @user,
-        category_id: nil,
-        archetype: Archetype.private_message,
+        { category_id: nil, archetype: Archetype.private_message },
+        revise_opts,
       )
 
       raise ActiveRecord::Rollback if !@topic.valid?
 
       add_allowed_users
       update_post_uploads_secure_status
-      add_small_action("private_topic")
+      add_small_action("private_topic") unless @silent
       Tag.update_counters(@topic.tags, { public_topic_count: -1 }) if was_public
       UserProfile.remove_featured_topic_from_all_profiles(@topic)
 
       Jobs.enqueue(:topic_action_converter, topic_id: @topic.id)
       Jobs.enqueue(:delete_inaccessible_notifications, topic_id: @topic.id)
 
-      watch_topic(@topic)
+      watch_topic(@topic) unless @silent
     end
 
     @topic
   end
 
   private
+
+  def revise_opts
+    { bypass_bump: @silent, skip_revision: @silent, silent: @silent }
+  end
 
   def posters
     @posters ||=
@@ -126,15 +142,17 @@ class TopicConverter
     existing_allowed_users = @topic.topic_allowed_users.pluck(:user_id)
     users_to_allow = posters << @user.id
 
-    if (users_to_allow | existing_allowed_users).length > SiteSetting.max_allowed_message_recipients
-      users_to_allow = [@user.id]
-    end
-
     (users_to_allow - existing_allowed_users).uniq.each do |user_id|
       @topic.topic_allowed_users.build(user_id: user_id)
     end
 
     @topic.save!
+  end
+
+  def exceeds_recipient_cap?
+    allowed_users = @topic.topic_allowed_users.pluck(:user_id)
+    total_recipients = (posters | allowed_users | [@user.id]).size
+    total_recipients > SiteSetting.max_allowed_message_recipients
   end
 
   def watch_topic(topic)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3773,6 +3773,8 @@ en:
         archive_topics: "Archive topics"
         move_messages_to_inbox: "Move to Inbox"
         archive_messages: "Move to Archive"
+        convert_to_public_topic: "Make public topics"
+        convert_to_private_message: "Make personal messages"
         notification_level: "Update notifications"
         change_notification_level: "Change Notification Level"
         choose_new_category: "Choose the new category for the topics:"
@@ -3891,6 +3893,12 @@ en:
       update_category:
         name: "Update Category"
         description: "Move all selected topics to the following category:"
+      convert_to_public_topic:
+        name: "Make Public Topic…"
+        description: "Move the selected personal messages into a public topic in the following category:"
+      convert_to_private_message:
+        name: "Make Personal Message"
+        description: "Convert the selected public topics into personal messages."
       reset_bump_dates:
         name: "Reset Bump Dates"
         description: "Do you want to update the bump dates to the last created post date? This may impact their ordering in the topic list."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -463,6 +463,8 @@ en:
   not_logged_in: "You need to be logged in to do that."
   not_found: "The requested URL or resource could not be found."
   invalid_access: "You are not permitted to view the requested resource."
+  topic_converter:
+    too_many_recipients: "Cannot convert: this topic has more participants than the max allowed (%{max})."
   authenticator_not_found: "Authentication method does not exist, or has been disabled."
   authenticator_no_connect: "This authentication provider does not allow connection to an existing forum account."
   invalid_api_credentials: "You are not permitted to view the requested resource. The API username or key is invalid."

--- a/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -125,6 +125,20 @@ export default class BulkSelectTopicsDropdown extends Component {
         visible: ({ topics }) => topics.every((t) => t.isPrivateMessage),
       },
       {
+        id: "convert-to-public-topic",
+        icon: "comments",
+        name: i18n("topic_bulk_actions.convert_to_public_topic.name"),
+        visible: ({ topics, currentUser }) =>
+          currentUser.staff && topics.every((t) => t.isPrivateMessage),
+      },
+      {
+        id: "convert-to-private-message",
+        icon: "envelope",
+        name: i18n("topic_bulk_actions.convert_to_private_message.name"),
+        visible: ({ topics, currentUser }) =>
+          currentUser.staff && topics.every((t) => !t.isPrivateMessage),
+      },
+      {
         id: "unlist-topics",
         icon: "far-eye-slash",
         name: i18n("topic_bulk_actions.unlist_topics.name"),
@@ -295,6 +309,15 @@ export default class BulkSelectTopicsDropdown extends Component {
             confirmButtonTranslationKey: "topics.bulk.confirm_move_to_inbox",
           }
         );
+        break;
+      case "convert-to-public-topic":
+      case "convert-to-private-message":
+        const actionName = actionId.replaceAll("-", "_");
+        this.showBulkTopicActionsModal(actionId, actionName, {
+          allowSilent: true,
+          description: i18n(`topic_bulk_actions.${actionName}.description`),
+          confirmButtonTranslationKey: "topics.bulk.confirm_update_topics",
+        });
         break;
       case "unlist-topics":
         this.showBulkTopicActionsModal("unlist", "unlist_topics", {

--- a/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -243,6 +243,15 @@ export default class BulkTopicActions extends Component {
           (t) => t.set("category_id", this.categoryId)
         );
         break;
+      case "convert-to-public-topic":
+        this.performAndRefresh({
+          type: "convert_to_public_topic",
+          category_id: this.categoryId,
+        });
+        break;
+      case "convert-to-private-message":
+        this.performAndRefresh({ type: "convert_to_private_message" });
+        break;
       default:
         // Plugins can register their own custom actions via onRegisterAction
         // when the activeComponent is rendered.
@@ -344,7 +353,10 @@ export default class BulkTopicActions extends Component {
   }
 
   get isCategoryAction() {
-    return this.model.action === "update-category";
+    return (
+      this.model.action === "update-category" ||
+      this.model.action === "convert-to-public-topic"
+    );
   }
 
   get isCloseAction() {

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -32,6 +32,8 @@ class TopicsBulkAction
       reset_bump_dates
       pin
       unpin
+      convert_to_public_topic
+      convert_to_private_message
     ]
   end
 
@@ -166,6 +168,31 @@ class TopicsBulkAction
         else
           t.errors.full_messages.each { |msg| @errors[msg] += 1 }
         end
+      end
+    end
+  end
+
+  def convert_to_public_topic
+    bulk_convert(from_pm: true) { |c| c.convert_to_public_topic(@operation[:category_id]) }
+  end
+
+  def convert_to_private_message
+    bulk_convert(from_pm: false, &:convert_to_private_message)
+  end
+
+  def bulk_convert(from_pm:)
+    silent = @operation.fetch(:silent, true)
+
+    topics.each do |t|
+      next if t.private_message? != from_pm
+      next unless guardian.can_convert_topic?(t)
+
+      yield TopicConverter.new(t, @user, silent: silent)
+
+      if t.errors.any?
+        t.errors.full_messages.each { |msg| @errors[msg] += 1 }
+      elsif t.reload.private_message? != from_pm
+        @changed_ids << t.id
       end
     end
   end

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -833,4 +833,77 @@ RSpec.describe TopicsBulkAction do
       end.to not_change { Notification.where(user: topic_watcher).count }
     end
   end
+
+  describe "convert_to_public_topic" do
+    fab!(:admin)
+    fab!(:category)
+    fab!(:pm, :private_message_topic)
+    fab!(:pm_post) { Fabricate(:post, topic: pm, user: pm.user) }
+
+    it "converts PMs and skips non-PMs" do
+      regular = Fabricate(:post).topic
+
+      changed =
+        TopicsBulkAction.new(
+          admin,
+          [pm.id, regular.id],
+          type: "convert_to_public_topic",
+          category_id: category.id,
+        ).perform!
+
+      expect(changed).to eq([pm.id])
+      expect(pm.reload.archetype).to eq(Archetype.default)
+      expect(pm.category_id).to eq(category.id)
+    end
+
+    it "is silent by default" do
+      Jobs.run_immediately!
+      bumped_at = pm.bumped_at
+
+      expect do
+        TopicsBulkAction.new(
+          admin,
+          [pm.id],
+          type: "convert_to_public_topic",
+          category_id: category.id,
+        ).perform!
+      end.to not_change { PostRevision.count }
+
+      expect(pm.reload.bumped_at).to be_within(1.second).of(bumped_at)
+      expect(pm.posts.where(post_type: Post.types[:small_action])).to be_empty
+    end
+  end
+
+  describe "convert_to_private_message" do
+    fab!(:admin)
+    fab!(:public_topic, :topic)
+    fab!(:public_first_post) { Fabricate(:post, topic: public_topic, user: public_topic.user) }
+
+    it "converts public topics and skips PMs" do
+      pm = Fabricate(:private_message_topic)
+      Fabricate(:post, topic: pm, user: pm.user)
+
+      changed =
+        TopicsBulkAction.new(
+          admin,
+          [public_topic.id, pm.id],
+          type: "convert_to_private_message",
+        ).perform!
+
+      expect(changed).to eq([public_topic.id])
+      expect(public_topic.reload.archetype).to eq(Archetype.private_message)
+    end
+
+    it "surfaces errors and does not mark topic as changed when cap is exceeded" do
+      SiteSetting.max_allowed_message_recipients = 1
+      Fabricate(:post, topic: public_topic)
+
+      operator = TopicsBulkAction.new(admin, [public_topic.id], type: "convert_to_private_message")
+      changed = operator.perform!
+
+      expect(changed).to be_empty
+      expect(public_topic.reload.archetype).to eq(Archetype.default)
+      expect(operator.errors).to be_present
+    end
+  end
 end

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -114,6 +114,37 @@ RSpec.describe TopicConverter do
         end
       end
 
+      it "creates small action and revision when not silent" do
+        Jobs.run_immediately!
+        first_post
+
+        expect do
+          TopicConverter.new(private_message, admin).convert_to_public_topic(category.id)
+        end.to change { PostRevision.count }.by(1)
+
+        expect(
+          private_message.posts.where(
+            post_type: Post.types[:small_action],
+            action_code: "public_topic",
+          ),
+        ).to be_present
+      end
+
+      it "skips small action, revision, and bump when silent" do
+        Jobs.run_immediately!
+        first_post
+        bumped_at = private_message.reload.bumped_at
+
+        expect do
+          TopicConverter.new(private_message, admin, silent: true).convert_to_public_topic(
+            category.id,
+          )
+        end.to not_change { PostRevision.count }
+
+        expect(private_message.posts.where(post_type: Post.types[:small_action])).to be_empty
+        expect(private_message.reload.bumped_at).to be_within(1.second).of(bumped_at)
+      end
+
       it "deletes notifications for users not allowed to see the topic" do
         staff_category = Fabricate(:private_category, group: Group[:staff])
         user_notification =
@@ -216,15 +247,39 @@ RSpec.describe TopicConverter do
         expect(Notification.exists?(admin_notification.id)).to eq(true)
       end
 
-      it "limits PM participants" do
+      it "fails with an error when posters exceed max_allowed_message_recipients" do
         SiteSetting.max_allowed_message_recipients = 2
         Fabricate(:post, topic: topic)
         Fabricate(:post, topic: topic)
 
-        private_message = topic.convert_to_private_message(post.user)
+        result = TopicConverter.new(topic, admin).convert_to_private_message
 
-        # Skips posters and just adds the acting user
-        expect(private_message.topic_allowed_users.count).to eq(1)
+        expect(result.errors[:base]).to be_present
+        expect(topic.reload.archetype).to eq(Archetype.default)
+      end
+
+      it "creates small action and revision when not silent" do
+        Jobs.run_immediately!
+
+        expect do TopicConverter.new(topic, admin).convert_to_private_message end.to change {
+          PostRevision.count
+        }.by(1)
+
+        expect(
+          topic.posts.where(post_type: Post.types[:small_action], action_code: "private_topic"),
+        ).to be_present
+      end
+
+      it "skips small action, revision, and bump when silent" do
+        Jobs.run_immediately!
+        bumped_at = topic.bumped_at
+
+        expect do
+          TopicConverter.new(topic, admin, silent: true).convert_to_private_message
+        end.to not_change { PostRevision.count }
+
+        expect(topic.posts.where(post_type: Post.types[:small_action])).to be_empty
+        expect(topic.reload.bumped_at).to be_within(1.second).of(bumped_at)
       end
 
       it "includes the poster of a single-post topic" do

--- a/spec/system/bulk_convert_topics_spec.rb
+++ b/spec/system/bulk_convert_topics_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "Bulk convert PMs to public topics" do
+  fab!(:admin)
+  fab!(:category)
+  fab!(:pm) { Fabricate(:private_message_topic, recipient: admin) }
+  fab!(:pm_post) { Fabricate(:post, topic: pm, user: pm.user) }
+
+  let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+  let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:modal) { PageObjects::Modals::TopicBulkActions.new }
+  let(:toasts) { PageObjects::Components::Toasts.new }
+
+  before { sign_in(admin) }
+
+  it "silently moves selected PMs into the chosen category" do
+    visit("/u/#{admin.username}/messages")
+
+    topic_list_header.click_bulk_select_button
+    topic_list.click_topic_checkbox(pm)
+    topic_list_header.click_bulk_select_topics_dropdown
+    topic_list_header.click_bulk_button("convert-to-public-topic")
+
+    modal.category_selector.expand
+    modal.category_selector.select_row_by_value(category.id)
+    modal.click_bulk_topics_confirm
+
+    expect(toasts).to have_success(I18n.t("js.topics.bulk.completed"))
+    expect(pm.reload.archetype).to eq(Archetype.default)
+    expect(pm.category_id).to eq(category.id)
+    expect(pm.posts.where(post_type: Post.types[:small_action])).to be_empty
+  end
+end


### PR DESCRIPTION
Adds two new staff-only bulk actions in the topic-list dropdown — "Make Public Topic…" when every selected topic is a PM, and "Make Personal Message" when none of them are. Both are silent by default: no bump, no post revision, no edit notifications to watchers, no small-action post in the topic, and no forced re-watch. Admins who do want to notify participants can tick the existing "Notify" checkbox in the bulk-actions modal.

Today, converting PMs to public topics is a one-at-a-time operation that fans out noisy edit notifications to everyone watching the PM, creates a post revision on the first post, and leaves a small-action post behind. The Support team hits this whenever they move a customer's history out of a group inbox and into an enterprise category — the existing runbook (Ref - t/68360) works around it with a custom console script, and doing it by hand spams participants. A proper bulk action in the UI was the missing piece.

The plumbing starts at TopicConverter, which now takes a `silent:` keyword argument. When true, it passes `bypass_bump`, `skip_revision`, and `silent` through to PostRevisor (suppressing the bump, the revision row, and the edit notifications), skips `add_small_action`, and skips the forced `watch_topic` call at the end. While in there, `convert_to_private_message` now fails loudly with a base error when the final recipient count would exceed
`max_allowed_message_recipients`, rather than silently collapsing to a self-only PM and losing all context — this applies to both the single-topic and bulk paths, since the check lives in the converter itself.

TopicsBulkAction registers two new operations,
`convert_to_public_topic` and `convert_to_private_message`, both driven by a small `bulk_convert(from_pm:)` helper. Per-topic success is detected from the archetype flip rather than from `.valid?`, which would re-run validations and wipe the `errors.add(:base, ...)` added by the cap guard. Validation errors bubble into the modal's failure list through the existing `@errors` channel.

On the frontend, `bulk-select-topics-dropdown` gets two new entries with matching visibility rules, and `bulk-topic-actions` gains a couple of cases that reuse the existing CategoryChooser and `allowSilent`-backed "Notify" checkbox. `isCategoryAction` is extended so the destination-category picker renders for the PM→public flow.

Ref - t/181539