### PR TITLE
FIX: Pass filter category into topic-list-item transformer context

### DIFF
--- a/frontend/discourse/app/components/topic-list/item.gjs
+++ b/frontend/discourse/app/components/topic-list/item.gjs
@@ -67,6 +67,15 @@ export default class Item extends Component {
     });
   }
 
+  get #transformerContext() {
+    return {
+      topic: this.args.topic,
+      index: this.args.index,
+      listContext: this.args.listContext,
+      category: this.args.category,
+    };
+  }
+
   get expandPinned() {
     let expandPinned;
     if (
@@ -84,7 +93,7 @@ export default class Item extends Component {
     return applyValueTransformer(
       "topic-list-item-expand-pinned",
       expandPinned,
-      { topic: this.args.topic, mobileView: this.useMobileLayout }
+      { ...this.#transformerContext, mobileView: this.useMobileLayout }
     );
   }
 
@@ -236,24 +245,24 @@ export default class Item extends Component {
     return applyValueTransformer(
       "topic-list-item-mobile-layout",
       this.site.mobileView,
-      { topic: this.args.topic, listContext: this.args.listContext }
+      this.#transformerContext
     );
   }
 
   get additionalClasses() {
-    return applyValueTransformer("topic-list-item-class", [], {
-      topic: this.args.topic,
-      index: this.args.index,
-      listContext: this.args.listContext,
-    });
+    return applyValueTransformer(
+      "topic-list-item-class",
+      [],
+      this.#transformerContext
+    );
   }
 
   get style() {
-    const parts = applyValueTransformer("topic-list-item-style", [], {
-      topic: this.args.topic,
-      index: this.args.index,
-      listContext: this.args.listContext,
-    });
+    const parts = applyValueTransformer(
+      "topic-list-item-style",
+      [],
+      this.#transformerContext
+    );
 
     const safeParts = parts.filter(Boolean).filter((part) => {
       if (isHTMLSafe(part)) {

--- a/frontend/discourse/app/components/topic-list/list.gjs
+++ b/frontend/discourse/app/components/topic-list/list.gjs
@@ -244,6 +244,7 @@ export default class TopicList extends Component {
             @focusLastVisitedTopic={{@focusLastVisitedTopic}}
             @index={{index}}
             @listContext={{@listContext}}
+            @category={{this.topicTrackingState.filterCategory}}
           />
 
           {{#if (eq topic this.lastVisitedTopic)}}

--- a/frontend/discourse/tests/integration/components/topic-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-list-item-test.gjs
@@ -61,6 +61,27 @@ module("Integration | Component | topic-list-item", function (hooks) {
       .doesNotHaveClass("bar");
   });
 
+  test("topic-list-item-class transformer receives category context", async function (assert) {
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "topic-list-item-class",
+        ({ value, context }) => {
+          value.push(`cat-${context.category?.id ?? "none"}`);
+          return value;
+        }
+      );
+    });
+
+    const store = this.owner.lookup("service:store");
+    this.owner.lookup("service:topic-tracking-state").filterCategory =
+      store.createRecord("category", { id: 42 });
+    const topics = [store.createRecord("topic", { id: 2024 })];
+
+    await render(<template><TopicList @topics={{topics}} /></template>);
+
+    assert.dom(".topic-list-item[data-topic-id='2024']").hasClass("cat-42");
+  });
+
   test("shows unread-by-group-member indicator", async function (assert) {
     const store = this.owner.lookup("service:store");
     const topics = [


### PR DESCRIPTION
The `topic-list-item-class` transformer received `{ topic, index, listContext }` but not the list's filter category, while the sibling `topic-list-columns` transformer received `category` via `topicTrackingState.filterCategory`. Any caller that branches on the category (e.g. Horizon skipping its card layout for doc-categories via `category.doc_index_topic_id`) could correctly opt out of column overrides yet still have per-row classes applied — producing a `tr` with `--high-context` on it but a regular topic list's `td`s inside, breaking the layout.

The list component now forwards `filterCategory` down to each item, and the item exposes a single `#transformerContext` getter shared by the `expand-pinned`, `mobile-layout`, `class`, and `style` transformers so the three (now four) call sites can't drift again.

Regression from #38970

Ref - t/181504