### PR TITLE
FIX: Latch header topic info visibility to prevent flicker

### DIFF
--- a/frontend/discourse/app/services/header.js
+++ b/frontend/discourse/app/services/header.js
@@ -5,7 +5,7 @@ import { trackedMap } from "@ember/reactive/collections";
 import Service, { service } from "@ember/service";
 import deprecated from "discourse/lib/deprecated";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
-import { SCROLLED_UP } from "./scroll-direction";
+import { SCROLLED_DOWN, SCROLLED_UP } from "./scroll-direction";
 
 const VALID_HEADER_BUTTONS_TO_HIDE = ["search", "login", "signup", "menu"];
 
@@ -26,12 +26,38 @@ export default class Header extends Service {
    */
   @tracked topicInfo = null;
 
-  @tracked mainTopicTitleVisible = false;
-
   @tracked hamburgerVisible = false;
   @tracked userVisible = false;
-
   #hiders = trackedMap();
+  @tracked _mainTopicTitleVisible = false;
+
+  // Latch: when the title scrolls out of view while scrolling down,
+  // hold the "show topic info" decision even if the IntersectionObserver
+  // briefly reports the title as visible again. This prevents a feedback
+  // loop when themes/plugins use a dynamic header height: showing the
+  // topic info grows the sticky header, shifting content, which pushes
+  // the title back into the observer viewport, which hides the topic
+  // info, which shrinks the header — hundreds of times per second.
+  @tracked _topicInfoLatched = false;
+
+  get mainTopicTitleVisible() {
+    return this._mainTopicTitleVisible;
+  }
+
+  set mainTopicTitleVisible(value) {
+    this._mainTopicTitleVisible = value;
+
+    if (!value && this.scrollDirection.lastScrollDirection === SCROLLED_DOWN) {
+      this._topicInfoLatched = true;
+    } else if (value) {
+      // Only unlatch when the title is genuinely visible AND we are not
+      // scrolling down (i.e. the observer isn't just oscillating due to
+      // a layout shift from the header height change).
+      if (this.scrollDirection.lastScrollDirection !== SCROLLED_DOWN) {
+        this._topicInfoLatched = false;
+      }
+    }
+  }
 
   get topic() {
     deprecated(
@@ -52,12 +78,10 @@ export default class Header extends Service {
   @dependentKeyCompat // For legacy `site-header` observer compat
   get topicInfoVisible() {
     if (!this.topicInfo) {
-      // Not on a topic page
       return false;
     }
 
-    if (this.mainTopicTitleVisible) {
-      // Title is already visible on screen, no need to duplicate
+    if (this.mainTopicTitleVisible && !this._topicInfoLatched) {
       return false;
     }
 
@@ -65,7 +89,6 @@ export default class Header extends Service {
       this.site.mobileView &&
       this.scrollDirection.lastScrollDirection === SCROLLED_UP
     ) {
-      // On mobile, we hide the topic info when scrolling up
       return false;
     }
 
@@ -116,11 +139,13 @@ export default class Header extends Service {
    */
   enterTopic(topic, isLoadingFirstPost) {
     this.topicInfo = topic;
+    this._topicInfoLatched = false;
     this.mainTopicTitleVisible = isLoadingFirstPost;
   }
 
   clearTopic() {
     this.topicInfo = null;
+    this._topicInfoLatched = false;
     this.mainTopicTitleVisible = false;
   }
 }

--- a/frontend/discourse/app/services/header.js
+++ b/frontend/discourse/app/services/header.js
@@ -49,6 +49,8 @@ export default class Header extends Service {
 
     if (!value) {
       this._topicInfoLatched = true;
+    } else if (this.scrollDirection.lastScrollDirection === SCROLLED_UP) {
+      this._topicInfoLatched = false;
     }
   }
 

--- a/frontend/discourse/app/services/header.js
+++ b/frontend/discourse/app/services/header.js
@@ -47,15 +47,8 @@ export default class Header extends Service {
   set mainTopicTitleVisible(value) {
     this._mainTopicTitleVisible = value;
 
-    if (!value && this.scrollDirection.lastScrollDirection === SCROLLED_DOWN) {
+    if (!value) {
       this._topicInfoLatched = true;
-    } else if (value) {
-      // Only unlatch when the title is genuinely visible AND we are not
-      // scrolling down (i.e. the observer isn't just oscillating due to
-      // a layout shift from the header height change).
-      if (this.scrollDirection.lastScrollDirection !== SCROLLED_DOWN) {
-        this._topicInfoLatched = false;
-      }
     }
   }
 
@@ -81,7 +74,15 @@ export default class Header extends Service {
       return false;
     }
 
-    if (this.mainTopicTitleVisible && !this._topicInfoLatched) {
+    // The latch is only honored while actively scrolling down — this
+    // prevents the IntersectionObserver feedback loop (header height
+    // change shifting content), but automatically releases when scroll
+    // direction changes so topic info hides normally.
+    const isLatched =
+      this._topicInfoLatched &&
+      this.scrollDirection.lastScrollDirection === SCROLLED_DOWN;
+
+    if (this.mainTopicTitleVisible && !isLatched) {
       return false;
     }
 

--- a/frontend/discourse/app/services/scroll-direction.js
+++ b/frontend/discourse/app/services/scroll-direction.js
@@ -92,8 +92,11 @@ export default class ScrollDirection extends Service {
       return;
     }
 
-    // don't calculate when resetting offset (i.e. going to /latest or to next topic in suggested list)
+    // Reset when scrolled back to top (e.g. scrollTo(0,0), navigating
+    // to /latest, or jumping to next topic in suggested list)
     if (offset === 0) {
+      this.lastScrollDirection = UNSCROLLED;
+      this.#lastScroll = 0;
       return;
     }
 


### PR DESCRIPTION
## Summary

- When themes/plugins use a dynamic header height (e.g. `height: 100%` with `flex-wrap` for multi-row breadcrumb + topic info layouts), the `IntersectionObserver` that toggles `extra-info-wrapper` creates a feedback loop: showing topic info grows the sticky header → content shifts → title re-enters viewport → topic info hidden → header shrinks → repeat (hundreds of times/sec)
- Adds a **latch** via a custom setter on `mainTopicTitleVisible`: once the title scrolls out while going down, `topicInfoVisible` holds stable regardless of observer oscillation. Resets when scroll direction changes or on navigation
- No side effects in getters — latch state is updated in the setter