### PR TITLE
UX: allow body scrolling when composer is open on iPad

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -15,7 +15,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   padding-bottom: 0.2rem;
 }
 
-html.ios-device:not(.ipados-device).composer-open body {
+html.ios-device:not(.ipados-device:not(.keyboard-visible)).composer-open body {
   overflow: hidden;
 }
 

--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -15,7 +15,7 @@ html.ios-device.keyboard-visible body #main-outlet .full-page-chat {
   padding-bottom: 0.2rem;
 }
 
-html.ios-device.composer-open body {
+html.ios-device:not(.ipados-device).composer-open body {
   overflow: hidden;
 }
 


### PR DESCRIPTION
We prevent scrolling on iOS because the composer is full screen on iPhones, but you can still see content while composing on an iPad with a keyboard attached, so we should allow content to scroll in that case