### PR TITLE
UX: only show topic count on subcategory

### DIFF
--- a/frontend/discourse/app/helpers/category-link.js
+++ b/frontend/discourse/app/helpers/category-link.js
@@ -71,6 +71,7 @@ export function categoryBadgeHTML(category, opts) {
       .map((c) => {
         return categoryBadgeHTML(c, {
           ...newOpts,
+          ...(c !== category ? { topicCount: undefined } : {}),
           ...(readOnly && c === category ? { readOnly } : {}),
         });
       })


### PR DESCRIPTION
We're currently doubling the topic count for subcategories by showing the same count on the parent, this fixes it so it only shows on the subcategory. 

Before (note the issue on software and operating systems):
<img width="450" alt="image" src="https://github.com/user-attachments/assets/4a569a98-6fa8-425c-ad7f-34370cd6c255" />


After: 
<img width="450"  alt="image" src="https://github.com/user-attachments/assets/607cf63d-9317-4cab-a896-e5bec11bc574" />
