### PR TITLE
FIX: add missing 'expand' icon to SVG sprite

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -110,6 +110,7 @@ module SvgSprite
         ellipsis
         ellipsis-vertical
         envelope
+        expand
         eye
         eye-dropper
         eye-slash


### PR DESCRIPTION
It's used since https://github.com/discourse/discourse/commit/af0f428164ba481d80f15cea4056db11cdbc434f, but is not explicitly in the `svg_sprite.rb` file.