### PR TITLE
UX: add limitShift to onebox toolbar positioning

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/onebox-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/onebox-toolbar.js
@@ -229,6 +229,14 @@ class OneboxToolbarPluginView {
           crossAxis: -MENU_PADDING,
         };
       },
+      limitShift: {
+        offset: ({ rects }) => ({
+          crossAxis: Math.min(
+            rects.floating.height + 2 * MENU_PADDING,
+            rects.reference.height - MENU_PADDING
+          ),
+        }),
+      },
     });
 
     await this.#menuInstance.show();


### PR DESCRIPTION
On the rich editor, avoids the onebox toolbar to be positioned outside the onebox itself:

<img width="777" height="142" alt="image" src="https://github.com/user-attachments/assets/63c1dd7b-b7b0-4464-a797-397c69d676ee" />
