### PR TITLE
FIX: only clear current device push subscription on logout

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -178,6 +178,7 @@ class Admin::UsersController < Admin::StaffController
   def log_out
     if @user
       @user.user_auth_tokens.destroy_all
+      PushNotificationPusher.clear_subscriptions(@user)
       @user.logged_out
       render json: success_json
     else

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -700,19 +700,17 @@ class SessionController < ApplicationController
     # `redirect_url` might have been updated by a `before_session_destroy` listener
     redirect_url = data[:redirect_url]
 
-    begin
-      if params[:push_subscription].is_a?(ActionController::Parameters)
-        request.env["discourse.push_subscription"] = params.require(:push_subscription).permit(
-          :endpoint,
-          keys: %i[p256dh auth],
-        )
+    push_subscription =
+      begin
+        if params[:push_subscription].is_a?(ActionController::Parameters)
+          params.require(:push_subscription).permit(:endpoint, keys: %i[p256dh auth])
+        end
+      rescue StandardError
+        nil # best-effort: malformed push_subscription should never block logout
       end
-    rescue StandardError
-      # best-effort: malformed push_subscription should never block logout
-    end
 
     reset_session
-    log_off_user
+    log_off_user(push_subscription:)
 
     if request.xhr?
       render json: { redirect_url: }

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -700,6 +700,17 @@ class SessionController < ApplicationController
     # `redirect_url` might have been updated by a `before_session_destroy` listener
     redirect_url = data[:redirect_url]
 
+    begin
+      if params[:push_subscription].is_a?(ActionController::Parameters)
+        request.env["discourse.push_subscription"] = params.require(:push_subscription).permit(
+          :endpoint,
+          keys: %i[p256dh auth],
+        )
+      end
+    rescue StandardError
+      # best-effort: malformed push_subscription should never block logout
+    end
+
     reset_session
     log_off_user
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -97,7 +97,7 @@ class PushNotificationPusher
   end
 
   def self.unsubscribe(user, subscription)
-    PushSubscription.find_by(user: user, data: subscription.to_json)&.destroy!
+    PushSubscription.where(user: user, data: subscription.to_json).delete_all
   end
 
   def self.get_badge

--- a/app/services/user_suspender.rb
+++ b/app/services/user_suspender.rb
@@ -29,6 +29,7 @@ class UserSuspender
           post_id: @post_id,
         )
     end
+    PushNotificationPusher.clear_subscriptions(@user)
     @user.logged_out
 
     if @message.present?

--- a/config/initializers/100-push-notifications.rb
+++ b/config/initializers/100-push-notifications.rb
@@ -23,6 +23,4 @@ Rails.application.config.to_prepare do
 
     PushSubscription.delete_all if ActiveRecord::Base.connection.table_exists?(:push_subscriptions)
   end
-
-  DiscourseEvent.on(:user_logged_out) { |user| PushNotificationPusher.clear_subscriptions(user) }
 end

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -105,6 +105,25 @@ export function subscribe(callback, applicationServerKey) {
   });
 }
 
+export async function getCurrentPushSubscription() {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+    return null;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (!registration) {
+      return null;
+    }
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription ? subscription.toJSON() : null;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    return null;
+  }
+}
+
 export function unsubscribe(user, callback) {
   if (!isPushNotificationsSupported()) {
     return;

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -401,8 +401,12 @@ export default class User extends RestModel.extend(Evented) {
     return this.staff && this.get("has_new_upcoming_changes");
   }
 
-  destroySession() {
-    return ajax(`/session/${this.username}`, { type: "DELETE" });
+  destroySession(pushSubscription) {
+    const data = {};
+    if (pushSubscription) {
+      data.push_subscription = pushSubscription;
+    }
+    return ajax(`/session/${this.username}`, { type: "DELETE", data });
   }
 
   @computed("username_lower")

--- a/frontend/discourse/app/routes/application.js
+++ b/frontend/discourse/app/routes/application.js
@@ -8,6 +8,7 @@ import EmbedMode from "discourse/lib/embed-mode";
 import getURL from "discourse/lib/get-url";
 import logout from "discourse/lib/logout";
 import mobile from "discourse/lib/mobile";
+import { getCurrentPushSubscription } from "discourse/lib/push-notifications";
 import identifySource, { consolePrefix } from "discourse/lib/source-identifier";
 import DiscourseURL from "discourse/lib/url";
 import Category from "discourse/models/category";
@@ -82,15 +83,15 @@ export default class ApplicationRoute extends DiscourseRoute {
   }
 
   @action
-  logout() {
+  async logout() {
     const { isReadOnly, isStaffWritesOnly } = this.site;
 
     if (isReadOnly && !isStaffWritesOnly) {
       this.dialog.alert(i18n("read_only_mode.logout_disabled"));
     } else if (this.currentUser) {
-      this.currentUser
-        .destroySession()
-        .then((response) => logout({ redirect: response["redirect_url"] }));
+      const pushSubscription = await getCurrentPushSubscription();
+      const response = await this.currentUser.destroySession(pushSubscription);
+      logout({ redirect: response["redirect_url"] });
     }
   }
 

--- a/lib/auth/current_user_provider.rb
+++ b/lib/auth/current_user_provider.rb
@@ -50,7 +50,7 @@ class Auth::CurrentUserProvider
     raise NotImplementedError
   end
 
-  def log_off_user(session, cookie_jar)
+  def log_off_user(session, cookie_jar, push_subscription: nil)
     raise NotImplementedError
   end
 end

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -335,7 +335,7 @@ class Auth::DefaultCurrentUserProvider
     end
   end
 
-  def log_off_user(session, cookie_jar)
+  def log_off_user(session, cookie_jar, push_subscription: nil)
     user = current_user
 
     if SiteSetting.log_out_strict && user
@@ -350,9 +350,7 @@ class Auth::DefaultCurrentUserProvider
       user.logged_out
     elsif user && @user_token
       @user_token.destroy
-      if (push_subscription = @env["discourse.push_subscription"])
-        PushNotificationPusher.unsubscribe(user, push_subscription)
-      end
+      PushNotificationPusher.unsubscribe(user, push_subscription) if push_subscription
       DiscourseEvent.trigger(:user_logged_out, user)
     end
 

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -346,9 +346,13 @@ class Auth::DefaultCurrentUserProvider
         cookie_jar.delete("__profilin")
       end
 
+      PushNotificationPusher.clear_subscriptions(user)
       user.logged_out
     elsif user && @user_token
       @user_token.destroy
+      if (push_subscription = @env["discourse.push_subscription"])
+        PushNotificationPusher.unsubscribe(user, push_subscription)
+      end
       DiscourseEvent.trigger(:user_logged_out, user)
     end
 

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -19,8 +19,8 @@ module CurrentUser
     user.logged_in
   end
 
-  def log_off_user
-    current_user_provider.log_off_user(session, cookies)
+  def log_off_user(push_subscription: nil)
+    current_user_provider.log_off_user(session, cookies, push_subscription:)
   end
 
   def start_impersonating_user(user)

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -765,6 +765,48 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
 
       DiscourseEvent.off(:user_logged_out, &event_handler)
     end
+
+    context "with push subscriptions" do
+      let(:device_a_data) do
+        { endpoint: "https://push.example.com/device-a", keys: { p256dh: "key_a", auth: "auth_a" } }
+      end
+      let(:device_b_data) do
+        { endpoint: "https://push.example.com/device-b", keys: { p256dh: "key_b", auth: "auth_b" } }
+      end
+
+      before do
+        PushSubscription.create!(user: user, data: device_a_data.to_json)
+        PushSubscription.create!(user: user, data: device_b_data.to_json)
+      end
+
+      it "only removes the current device push subscription on normal logout" do
+        env_with_push =
+          env.merge("discourse.push_subscription" => device_a_data.with_indifferent_access)
+
+        user_provider = TestProvider.new(env_with_push)
+        user_provider.log_off_user({}, user_provider.cookie_jar)
+
+        remaining = user.push_subscriptions.reload
+        expect(remaining.size).to eq(1)
+        expect(remaining.first.parsed_data["endpoint"]).to eq("https://push.example.com/device-b")
+      end
+
+      it "preserves all push subscriptions when no push subscription data is provided" do
+        user_provider = TestProvider.new(env)
+        user_provider.log_off_user({}, user_provider.cookie_jar)
+
+        expect(user.push_subscriptions.reload.size).to eq(2)
+      end
+
+      it "clears all push subscriptions on strict logout" do
+        SiteSetting.log_out_strict = true
+
+        user_provider = TestProvider.new(env)
+        user_provider.log_off_user({}, user_provider.cookie_jar)
+
+        expect(user.push_subscriptions.reload.size).to eq(0)
+      end
+    end
   end
 
   describe "first admin user" do

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -780,11 +780,12 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
       end
 
       it "only removes the current device push subscription on normal logout" do
-        env_with_push =
-          env.merge("discourse.push_subscription" => device_a_data.with_indifferent_access)
-
-        user_provider = TestProvider.new(env_with_push)
-        user_provider.log_off_user({}, user_provider.cookie_jar)
+        user_provider = TestProvider.new(env)
+        user_provider.log_off_user(
+          {},
+          user_provider.cookie_jar,
+          push_subscription: device_a_data.with_indifferent_access,
+        )
 
         remaining = user.push_subscriptions.reload
         expect(remaining.size).to eq(1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1064,7 +1064,7 @@ RSpec.configure do |config|
       super
     end
 
-    def log_off_user(session, cookies)
+    def log_off_user(session, cookies, push_subscription: nil)
       # Try using the main session as `session` sometimes is a server session
       (cookies.try(:request).try(:session) || session).delete(:current_user_id)
       super


### PR DESCRIPTION
## Summary
- Previously, logging out of any device cleared push notification subscriptions for **all** devices via a blanket `user_logged_out` event handler
- Now the frontend sends the current browser's push subscription as part of the session destroy request, and only that subscription is removed server-side
- "Log out everywhere" paths (admin log out, user suspension, `log_out_strict`) still correctly clear all subscriptions