### PR TITLE
FIX: prevent hashtag autocomplete crash when a type isn't registered

### DIFF
--- a/frontend/discourse/app/lib/hashtag-autocomplete.js
+++ b/frontend/discourse/app/lib/hashtag-autocomplete.js
@@ -113,8 +113,14 @@ function _searchGeneric(term, contextualHashtagConfiguration) {
 }
 
 function _searchRequest(term, contextualHashtagConfiguration, resultFunc) {
+  // Only request types the client can actually render. Plugin-contributed
+  // types may be missing when their JS isn't loaded (e.g. in safe mode).
+  const registeredTypes = getHashtagTypeClassesNew();
+  const order = contextualHashtagConfiguration.filter(
+    (type) => type in registeredTypes
+  );
   currentSearch = ajax("/hashtags/search.json", {
-    data: { term, order: contextualHashtagConfiguration },
+    data: { term, order },
   });
   currentSearch
     .then((response) => {
@@ -142,7 +148,9 @@ function _searchRequest(term, contextualHashtagConfiguration, resultFunc) {
         }
 
         const hashtagType = getHashtagTypeClassesNew()[result.type];
-        result.iconHtml = hashtagType.generateIconHTML(opts);
+        if (hashtagType) {
+          result.iconHtml = hashtagType.generateIconHTML(opts);
+        }
       });
       resultFunc(response.results || CANCELLED_STATUS);
     })

--- a/frontend/discourse/app/lib/hashtag-decorator.js
+++ b/frontend/discourse/app/lib/hashtag-decorator.js
@@ -89,10 +89,9 @@ export function generatePlaceholderHashtagHTML(type, spanEl, data) {
     link.dataset.emoji = data.emoji;
   }
 
-  const hashtagTypeClass = new getHashtagTypeClasses()[type];
-  link.innerHTML = `${hashtagTypeClass.generateIconHTML(
-    data
-  )}<span>${emojiUnescape(data.text)}</span>`;
+  const hashtagTypeClass = getHashtagTypeClasses()[type];
+  const iconHTML = hashtagTypeClass?.generateIconHTML(data) ?? "";
+  link.innerHTML = `${iconHTML}<span>${emojiUnescape(data.text)}</span>`;
   spanEl.replaceWith(link);
 }
 

--- a/frontend/discourse/app/static/prosemirror/extensions/hashtag.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/hashtag.js
@@ -184,7 +184,8 @@ const extension = {
                   getHashtagTypeClasses()[validHashtag.type];
                 const hashtagIconHTML =
                   validHashtag.iconHtml ||
-                  hashtagTypeClass.generateIconHTML(validHashtag).trim();
+                  hashtagTypeClass?.generateIconHTML(validHashtag).trim() ||
+                  "";
 
                 domNode.innerHTML = `${hashtagIconHTML}${tagText}`;
               }

--- a/frontend/discourse/tests/acceptance/hashtag-autocomplete-test.js
+++ b/frontend/discourse/tests/acceptance/hashtag-autocomplete-test.js
@@ -1,5 +1,6 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import pretender from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
   simulateKeys,
@@ -118,3 +119,66 @@ acceptance("#hashtag autocompletion in composer", function (needs) {
       .exists();
   });
 });
+
+acceptance(
+  "#hashtag autocompletion with types unknown to the client",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      server.get("/hashtags", () => helper.response({ category: [], tag: [] }));
+      server.get("/hashtags/search.json", () => {
+        return helper.response({
+          results: [
+            {
+              id: 1,
+              text: "Music Lounge",
+              slug: "music",
+              icon: "comment",
+              relative_url: "/chat/c/music/1",
+              ref: "music",
+              type: "channel",
+              style_type: "icon",
+            },
+            {
+              id: 28,
+              text: "Other Languages",
+              slug: "other-languages",
+              colors: ["FF0000"],
+              icon: "folder",
+              relative_url: "/c/other-languages/28",
+              ref: "other-languages",
+              type: "category",
+              style_type: "square",
+            },
+          ],
+        });
+      });
+    });
+
+    test("only requests types that have a client-side class registered", async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      await click("#topic-footer-buttons .btn.create");
+      await simulateKeys(".d-editor-input", "abc #filter-known");
+
+      const searchRequest = pretender.handledRequests.findLast((r) =>
+        r.url.startsWith("/hashtags/search.json")
+      );
+      const order = new URL(
+        searchRequest.url,
+        "http://dummy"
+      ).searchParams.getAll("order[]");
+      assert.deepEqual(order, ["category", "tag"]);
+    });
+
+    test("does not crash when the server returns a type not registered on the client", async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      await click("#topic-footer-buttons .btn.create");
+      await simulateKeys(".d-editor-input", "abc #unknown-type");
+
+      // The server-side handler above returns a channel result despite the
+      // client not registering a "channel" hashtag type class. The row should
+      // still render (without an icon) and the promise must not reject.
+      assert.dom(".hashtag-autocomplete__option").exists({ count: 2 });
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/hashtag-test.js
@@ -110,5 +110,32 @@ module(
         });
       }
     );
+
+    test("renders without crashing when the server returns a type that isn't registered on the client", async function (assert) {
+      // Can happen in safe mode: plugin Ruby still runs and resolves the
+      // hashtag, but the plugin JS that would register the "channel" type
+      // class isn't loaded.
+      pretender.get("/hashtags", () =>
+        response({
+          channels: [
+            {
+              type: "channel",
+              ref: "unknown-type-channel",
+              icon: "comment",
+              id: 1,
+            },
+          ],
+        })
+      );
+
+      this.siteSettings.rich_editor = true;
+
+      await testMarkdown(
+        assert,
+        "Hello #unknown-type-channel",
+        '<p>Hello <a class="hashtag-cooked" data-name="unknown-type-channel" data-processed="true" contenteditable="false" draggable="true">unknown-type-channel</a></p>',
+        "Hello #unknown-type-channel"
+      );
+    });
   }
 );


### PR DESCRIPTION
When plugins are disabled via safe mode (e.g. ?safe_mode=no_plugins), Discourse skips the plugins' JS assets but the plugins' Ruby code still runs. That means server endpoints like /hashtags/search.json and /hashtags can still return results with plugin-contributed types (e.g. the chat plugin's "channel" type), while the client-side class that knows how to render that type was never registered via api.registerHashtagType.

The autocomplete and hashtag decoration code then did:

    getHashtagTypeClasses()[result.type].generateIconHTML(opts)

which throws "Cannot read properties of undefined (reading 'generateIconHTML')" and aborts the whole autocomplete promise, so the menu never shows any results.

Fix this at three levels:

1. In hashtag-autocomplete.js, filter the `order` sent to /hashtags/search.json down to the types the client can actually render. The client is authoritative about what it can display, so this avoids asking the server for results we'd have to throw away.

2. In hashtag-autocomplete.js and the prosemirror hashtag extension, guard the `generateIconHTML` call so an unregistered type renders without an icon instead of crashing. This protects against stale responses from /hashtags (the cooking lookup endpoint), plugin load races, and any future caller that bypasses the filter.

3. In hashtag-decorator.js, guard `generatePlaceholderHashtagHTML` which cooks hashtags in the markdown preview. The sibling decorateHashtags path already had a similar guard. While there, also drop a stray `new` keyword that was a no-op due to operator precedence (introduced in #25397).

Tests cover the three paths:
- Acceptance: only registered types are requested, and the autocomplete doesn't crash when the server returns an unregistered type.
- Integration: the prosemirror cooking path renders without an icon (and without crashing) for an unregistered type.

https://meta.discourse.org/t/400570