### PR TITLE
UX: reset review queue tab, don't look up insights every toggle

### DIFF
--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -101,6 +101,7 @@ export default class ReviewableItem extends Component {
 
   @tracked disabled = false;
   @tracked activeTab = "timeline";
+  @tracked insightsOpened = false;
 
   updating = null;
   editing = false;
@@ -116,6 +117,12 @@ export default class ReviewableItem extends Component {
     super.willDestroy(...arguments);
     this.messageBus.unsubscribe("/reviewable_claimed", this._updateClaimedBy);
     this.messageBus.unsubscribe("/reviewable_action", this._updateStatus);
+  }
+
+  didUpdateAttrs() {
+    super.didUpdateAttrs(...arguments);
+    this.activeTab = "timeline";
+    this.insightsOpened = false;
   }
 
   @computed("reviewable.claimed_by.automatic")
@@ -610,6 +617,9 @@ export default class ReviewableItem extends Component {
   switchTab(tabName, event) {
     event.preventDefault();
     this.activeTab = tabName;
+    if (tabName === "insights") {
+      this.insightsOpened = true;
+    }
   }
 
   @action
@@ -832,9 +842,12 @@ export default class ReviewableItem extends Component {
               </HorizontalOverflowNav>
             </div>
 
-            {{#if (eq this.activeTab "insights")}}
-              <ReviewableInsights @reviewable={{this.reviewable}} />
-            {{else if (eq this.activeTab "timeline")}}
+            {{#if this.insightsOpened}}
+              <div hidden={{if (eq this.activeTab "insights") false true}}>
+                <ReviewableInsights @reviewable={{this.reviewable}} />
+              </div>
+            {{/if}}
+            {{#if (eq this.activeTab "timeline")}}
               <ReviewableTimeline
                 @reviewable={{this.reviewable}}
                 @historyEvents={{this.reviewable.reviewable_histories}}

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -38,7 +38,7 @@ import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
 import { PENDING } from "discourse/models/reviewable";
 import Topic from "discourse/models/topic";
-import { eq } from "discourse/truth-helpers";
+import { eq, not } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 let _components = {};
@@ -106,9 +106,11 @@ export default class ReviewableItem extends Component {
   updating = null;
   editing = false;
   _updates = null;
+  _previousReviewableId = null;
 
   constructor() {
     super(...arguments);
+    this._previousReviewableId = this.reviewable?.id;
     this.messageBus.subscribe("/reviewable_claimed", this._updateClaimedBy);
     this.messageBus.subscribe("/reviewable_action", this._updateStatus);
   }
@@ -121,8 +123,11 @@ export default class ReviewableItem extends Component {
 
   didUpdateAttrs() {
     super.didUpdateAttrs(...arguments);
-    this.activeTab = "timeline";
-    this.insightsOpened = false;
+    if (this.reviewable?.id !== this._previousReviewableId) {
+      this._previousReviewableId = this.reviewable?.id;
+      this.activeTab = "timeline";
+      this.insightsOpened = false;
+    }
   }
 
   @computed("reviewable.claimed_by.automatic")
@@ -843,7 +848,7 @@ export default class ReviewableItem extends Component {
             </div>
 
             {{#if this.insightsOpened}}
-              <div hidden={{if (eq this.activeTab "insights") false true}}>
+              <div hidden={{not (eq this.activeTab "insights")}}>
                 <ReviewableInsights @reviewable={{this.reviewable}} />
               </div>
             {{/if}}

--- a/spec/system/viewing_reviewable_spec.rb
+++ b/spec/system/viewing_reviewable_spec.rb
@@ -252,6 +252,30 @@ describe "Viewing reviewable item" do
         expect(review_page).to have_account_in_modal(other_user.username)
       end
 
+      it "shows correct IP when navigating between reviewables" do
+        other_reviewable =
+          Fabricate(
+            :reviewable_flagged_post,
+            target_created_by: Fabricate(:user, ip_address: "2.125.160.216"),
+          )
+
+        Resolv::DNS
+          .any_instance
+          .stubs(:getname)
+          .with("2.125.160.216")
+          .returns("ip-2-125-160-216.example.com")
+
+        review_page.visit_reviewable(reviewable_flagged_post)
+        review_page.click_insights_tab
+
+        expect(review_page).to have_ip_hostname("ip-81-2-69-142.example.com")
+
+        review_page.visit_reviewable(other_reviewable)
+        review_page.click_insights_tab
+
+        expect(review_page).to have_ip_hostname("ip-2-125-160-216.example.com")
+      end
+
       context "when category moderator" do
         fab!(:category)
         fab!(:trust_level_1_user, :trust_level_1)


### PR DESCRIPTION
Fixes a couple issues reported here: https://meta.discourse.org/t/ip-info-is-not-updated-when-you-switch-to-a-different-reviewable/391230

1. When you navigated from one review item directly to another, from notifications for example, we weren't resetting the state so if you had opened the insights tab it would remain open with stale IP data. Now didUpdateAttrs will reset the state so the data will be fetched for the new reviewable. 

2. Every switch to the insights tab fetches data all over again — this will check if it's been opened and shows/hides it with `hidden` to avoid fetching the data every time 