### PR TITLE
DEV: Don't use `fab!` for non-ActiveRecord model objects

### DIFF
--- a/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
+++ b/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
@@ -4,14 +4,14 @@ describe "Automatic user removal from channels" do
   fab!(:user_1) { Fabricate(:user, trust_level: 1) }
   fab!(:user_2) { Fabricate(:user, trust_level: 3) }
 
-  fab!(:user_1_guardian) { Guardian.new(user_1) }
-
   fab!(:secret_group, :group)
   fab!(:private_category) { Fabricate(:private_category, group: secret_group) }
 
   fab!(:public_channel, :chat_channel)
   fab!(:private_channel) { Fabricate(:chat_channel, chatable: private_category) }
   fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user_1, user_2]) }
+
+  let(:user_1_guardian) { Guardian.new(user_1) }
 
   before do
     SiteSetting.chat_enabled = true

--- a/plugins/chat/spec/lib/chat/message_bookmarkable_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_bookmarkable_spec.rb
@@ -5,13 +5,14 @@ describe Chat::MessageBookmarkable do
 
   fab!(:chatters, :group)
   fab!(:user) { Fabricate(:user, group_ids: [chatters.id]) }
-  fab!(:guardian) { Guardian.new(user) }
   fab!(:other_category) { Fabricate(:private_category, group: Fabricate(:group)) }
   fab!(:category_channel) { Fabricate(:category_channel, chatable: other_category) }
   fab!(:private_category) { Fabricate(:private_category, group: Fabricate(:group)) }
   fab!(:channel, :category_channel)
   fab!(:direct_message)
   fab!(:direct_message_channel) { Fabricate(:direct_message_channel, chatable: direct_message) }
+
+  let(:guardian) { Guardian.new(user) }
 
   before do
     register_test_bookmarkable(described_class)

--- a/plugins/chat/spec/serializer/chat/structured_channel_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/structured_channel_serializer_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe Chat::StructuredChannelSerializer do
   fab!(:user1, :user)
-  fab!(:guardian) { Guardian.new(user1) }
   fab!(:user2, :user)
   fab!(:user3, :user)
   fab!(:channel1, :category_channel)
@@ -31,6 +30,8 @@ RSpec.describe Chat::StructuredChannelSerializer do
   fab!(:membership6) do
     Fabricate(:user_chat_channel_membership_for_dm, user: user3, chat_channel: channel4)
   end
+
+  let(:guardian) { Guardian.new(user1) }
 
   def fetch_data
     Chat::ChannelFetcher.structured(guardian)

--- a/plugins/discourse-assign/spec/serializers/suggested_topic_serializer_spec.rb
+++ b/plugins/discourse-assign/spec/serializers/suggested_topic_serializer_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe SuggestedTopicSerializer do
   fab!(:post) { Fabricate(:post, topic: topic) }
   fab!(:topic2, :topic)
   fab!(:post2) { Fabricate(:post, topic: topic2) }
-  fab!(:guardian) { Guardian.new(user) }
-  fab!(:serializer) { described_class.new(topic, scope: guardian) }
-  fab!(:serializer2) { described_class.new(topic2, scope: guardian) }
+
+  let(:guardian) { Guardian.new(user) }
+  let(:serializer) { described_class.new(topic, scope: guardian) }
+  let(:serializer2) { described_class.new(topic2, scope: guardian) }
 
   before do
     SiteSetting.assign_enabled = true

--- a/plugins/discourse-calendar/spec/serializers/user_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/user_serializer_spec.rb
@@ -11,7 +11,7 @@ describe UserSerializer do
   end
 
   context "as another user" do
-    fab!(:guardian) { Fabricate(:user).guardian }
+    let(:guardian) { Fabricate(:user).guardian }
 
     it "does not return user region" do
       expect(json[:user][:custom_fields]).to be_blank
@@ -19,7 +19,7 @@ describe UserSerializer do
   end
 
   context "as current user" do
-    fab!(:guardian) { user.guardian }
+    let(:guardian) { user.guardian }
 
     it "returns user region" do
       expect(json[:user][:custom_fields]).to eq(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")
@@ -27,7 +27,7 @@ describe UserSerializer do
   end
 
   context "as staff" do
-    fab!(:guardian) { Fabricate(:admin).guardian }
+    let(:guardian) { Fabricate(:admin).guardian }
 
     it "returns user region" do
       expect(json[:user][:custom_fields]).to eq(DiscourseCalendar::REGION_CUSTOM_FIELD => "uk")

--- a/plugins/discourse-data-explorer/spec/lib/data_explorer/query_group_bookmarkable_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/data_explorer/query_group_bookmarkable_spec.rb
@@ -7,7 +7,6 @@ describe DiscourseDataExplorer::QueryGroupBookmarkable do
 
   fab!(:admin_user, :admin)
   fab!(:user)
-  fab!(:guardian) { Guardian.new(user) }
   fab!(:group0, :group)
   fab!(:group1, :group)
   fab!(:group2, :group)
@@ -30,6 +29,8 @@ describe DiscourseDataExplorer::QueryGroupBookmarkable do
       user: admin_user,
     )
   end
+
+  let(:guardian) { Guardian.new(user) }
 
   before do
     SiteSetting.data_explorer_enabled = true

--- a/plugins/discourse-post-voting/spec/serializers/post_voting/topic_view_serializer_spec.rb
+++ b/plugins/discourse-post-voting/spec/serializers/post_voting/topic_view_serializer_spec.rb
@@ -6,7 +6,8 @@ describe PostVoting::TopicViewSerializerExtension do
   fab!(:answer) { Fabricate(:post, topic: topic, reply_to_post_number: nil) }
   fab!(:comment) { Fabricate(:post_voting_comment, post: answer) }
   fab!(:user)
-  fab!(:guardian) { Guardian.new(user) }
+
+  let(:guardian) { Guardian.new(user) }
   let(:topic_view) { TopicView.new(topic, user) }
 
   before { SiteSetting.post_voting_enabled = true }

--- a/plugins/discourse-topic-voting/spec/serializers/current_user_serializer_spec.rb
+++ b/plugins/discourse-topic-voting/spec/serializers/current_user_serializer_spec.rb
@@ -3,12 +3,13 @@
 RSpec.describe CurrentUserSerializer do
   fab!(:user1) { Fabricate(:user, trust_level: 3) }
   let(:user2) { Fabricate(:user) }
-  fab!(:guardian) { Guardian.new(user1) }
   fab!(:category)
   fab!(:topic1) { Fabricate(:topic, category_id: category.id) }
   let(:topic2) { Fabricate(:topic, category_id: category.id) }
   let(:topic3) { Fabricate(:topic, category_id: category.id) }
   let(:topic4) { Fabricate(:topic, category_id: category.id) }
+
+  let(:guardian) { Guardian.new(user1) }
 
   it "does not return attributes related to voting if disabled" do
     SiteSetting.topic_voting_enabled = false

--- a/spec/models/concerns/reviewable_action_builder_spec.rb
+++ b/spec/models/concerns/reviewable_action_builder_spec.rb
@@ -2,8 +2,9 @@
 
 RSpec.describe ReviewableActionBuilder do
   fab!(:admin)
-  fab!(:guardian) { Guardian.new(admin) }
   fab!(:user)
+
+  let(:guardian) { Guardian.new(admin) }
 
   describe "#build_action" do
     fab!(:reviewable_user) { ReviewableUser.create_for(user) }

--- a/spec/services/themes/create_spec.rb
+++ b/spec/services/themes/create_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Themes::Create do
 
     fab!(:user)
     fab!(:admin)
-    fab!(:guardian) { admin.guardian }
     fab!(:color_scheme)
 
+    let(:guardian) { admin.guardian }
     let(:dependencies) { { guardian: } }
 
     let(:theme_params) do


### PR DESCRIPTION
should fix a flake or two (`fab!` was making guardian state leak between specs)