### PR TITLE
DEV: Fix a content localization spec flake

### DIFF
--- a/frontend/discourse/app/components/topic-localized-content-toggle.gjs
+++ b/frontend/discourse/app/components/topic-localized-content-toggle.gjs
@@ -34,7 +34,7 @@ export default class TopicLocalizedContentToggle extends Component {
 
     if (this.currentUser) {
       this.currentUser.set("user_option.show_original_content", newValue);
-      ajax(`/u/${this.currentUser.username}.json`, {
+      await ajax(`/u/${this.currentUser.username}.json`, {
         type: "PUT",
         data: { show_original_content: newValue },
       });


### PR DESCRIPTION
it was a timing issue, we didn't wait for save request to finish before updating the page

the failing spec:

```
  1) Content Localization when the feature is enabled for English and Japanese for html title shows localized fancy_title in HTML title when user locale differs
     Failure/Error: expect(page).to have_title(shady_topic.title)
       expected "a fancy これはローカライズされたトピックです。7 - 未分類 - Discourse" to include "Topic with — <script>alert('xss')</script> …"
```