### PR TITLE
FIX: Restore web crawlers report from legacy reports list

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -76,7 +76,6 @@ class Report
     trust_level_growth
     user_flagging_ratio
     user_to_user_private_messages
-    web_crawlers
     web_hook_events_daily_aggregate
   ]
 


### PR DESCRIPTION
The web crawlers report was added to LEGACY_REPORTS in bc9d3d17 (#38688), which hides it from the /admin/reports page when the reporting_improvements site setting is enabled.

This report provides useful visibility into crawler traffic and should remain accessible to admins.