### PR TITLE
FIX: Narrative bot plugin.rb unnecessary setting change

### DIFF
--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -38,7 +38,7 @@ after_initialize do
   RailsMultisite::ConnectionManagement.safe_each_connection do
     if SiteSetting.discourse_narrative_bot_enabled
       # Disable welcome message because that is what the bot is supposed to replace.
-      SiteSetting.send_welcome_message = false
+      SiteSetting.send_welcome_message = false if SiteSetting.send_welcome_message
 
       certificate_path = "#{Discourse.base_url}/discobot/certificate.svg"
       if !SiteSetting.allowed_iframes.include?(certificate_path)


### PR DESCRIPTION
In the initializer for this plugin we were always
setting `SiteSetting.send_welcome_message = false`
if SiteSetting.discourse_narrative_bot_enabled is true.

However we were not already checking if the setting was
false, which caused site setting churn for no reason,
which isn't good on boot.
