### PR TITLE
FIX: clean up onebox loading decorations on fetch failure

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/onebox.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/onebox.js
@@ -319,6 +319,7 @@ const extension = {
                       );
                     } else {
                       failedUrls.full.add(oneboxUrl);
+                      removeLoadingDecorations(view, oneboxUrl, "full");
                       if (forceRetry) {
                         showPreviewFailedToast();
                       }
@@ -327,6 +328,7 @@ const extension = {
                   .catch(() => {
                     pendingUrls.full.delete(oneboxUrl);
                     failedUrls.full.add(oneboxUrl);
+                    removeLoadingDecorations(view, oneboxUrl, "full");
                     if (forceRetry) {
                       showPreviewFailedToast();
                     }
@@ -337,8 +339,8 @@ const extension = {
             // Inline oneboxes, batched
             if (pendingUrls.inline.size) {
               const inlineUrls = pendingUrls.inline;
-              loadInlineOneboxes(inlineUrls, getContext()).then(
-                (inlineOneboxes) => {
+              loadInlineOneboxes(inlineUrls, getContext())
+                .then((inlineOneboxes) => {
                   for (const url of inlineUrls) {
                     pendingUrls.inline.delete(url);
                   }
@@ -348,8 +350,14 @@ const extension = {
                       view.state.tr.setMeta(plugin, { inlineOneboxes })
                     );
                   }
-                }
-              );
+                })
+                .catch(() => {
+                  for (const url of inlineUrls) {
+                    pendingUrls.inline.delete(url);
+                    failedUrls.inline.add(url);
+                  }
+                  removeLoadingDecorations(view, inlineUrls, "inline");
+                });
             }
           },
 
@@ -508,6 +516,21 @@ const extension = {
         return tr.steps.length ? tr.setMeta("addToHistory", false) : null;
       },
     });
+
+    function removeLoadingDecorations(view, urls, type) {
+      const urlSet = typeof urls === "string" ? new Set([urls]) : new Set(urls);
+      const decoState = plugin.getState(view.state);
+      const toRemove = decoState.find(
+        undefined,
+        undefined,
+        (spec) => spec.oneboxType === type && urlSet.has(spec.oneboxUrl)
+      );
+      if (toRemove.length) {
+        view.dispatch(
+          view.state.tr.setMeta(plugin, { removeDecorations: toRemove })
+        );
+      }
+    }
 
     function showPreviewFailedToast() {
       getContext().toasts.default({

--- a/frontend/discourse/app/static/prosemirror/extensions/onebox.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/onebox.js
@@ -306,6 +306,7 @@ const extension = {
                       );
                     } else {
                       failedUrls.full.add(oneboxUrl);
+                      removeLoadingDecorations(view, oneboxUrl, "full");
                       if (forceRetry) {
                         showPreviewFailedToast();
                       }
@@ -314,6 +315,7 @@ const extension = {
                   .catch(() => {
                     pendingUrls.full.delete(oneboxUrl);
                     failedUrls.full.add(oneboxUrl);
+                    removeLoadingDecorations(view, oneboxUrl, "full");
                     if (forceRetry) {
                       showPreviewFailedToast();
                     }
@@ -324,8 +326,8 @@ const extension = {
             // Inline oneboxes, batched
             if (pendingUrls.inline.size) {
               const inlineUrls = pendingUrls.inline;
-              loadInlineOneboxes(inlineUrls, getContext()).then(
-                (inlineOneboxes) => {
+              loadInlineOneboxes(inlineUrls, getContext())
+                .then((inlineOneboxes) => {
                   for (const url of inlineUrls) {
                     pendingUrls.inline.delete(url);
                   }
@@ -335,8 +337,14 @@ const extension = {
                       view.state.tr.setMeta(plugin, { inlineOneboxes })
                     );
                   }
-                }
-              );
+                })
+                .catch(() => {
+                  for (const url of inlineUrls) {
+                    pendingUrls.inline.delete(url);
+                    failedUrls.inline.add(url);
+                  }
+                  removeLoadingDecorations(view, inlineUrls, "inline");
+                });
             }
           },
 
@@ -414,6 +422,21 @@ const extension = {
         };
       },
     });
+
+    function removeLoadingDecorations(view, urls, type) {
+      const urlSet = typeof urls === "string" ? new Set([urls]) : new Set(urls);
+      const decoState = plugin.getState(view.state);
+      const toRemove = decoState.find(
+        undefined,
+        undefined,
+        (spec) => spec.oneboxType === type && urlSet.has(spec.oneboxUrl)
+      );
+      if (toRemove.length) {
+        view.dispatch(
+          view.state.tr.setMeta(plugin, { removeDecorations: toRemove })
+        );
+      }
+    }
 
     function showPreviewFailedToast() {
       getContext().toasts.default({

--- a/frontend/pretty-text/addon/oneboxer.js
+++ b/frontend/pretty-text/addon/oneboxer.js
@@ -87,9 +87,17 @@ function loadNext(ajax) {
         if (result?.jqXHR?.status === 429) {
           timeoutMs = 2000;
           removeLoading = false;
-          loadingQueue.unshift({ url, refresh, elem, categoryId, topicId });
+          loadingQueue.unshift({
+            url,
+            refresh,
+            elem,
+            categoryId,
+            topicId,
+            onResolve,
+          });
         } else {
           setFailedCache(normalize(url), true);
+          onResolve?.(null);
         }
       }
     )

--- a/spec/system/composer/prosemirror_onebox_spec.rb
+++ b/spec/system/composer/prosemirror_onebox_spec.rb
@@ -181,6 +181,22 @@ describe "Composer - ProseMirror - Oneboxing" do
     expect(composer).to have_value("Hey https://example.com/x and https://example.com/x")
   end
 
+  it "removes loading decoration when onebox fetch fails" do
+    # A blank preview makes /onebox respond 404, so the request rejects instead
+    # of resolving to an error card.
+    Oneboxer.stubs(:preview).returns("")
+
+    cdp.allow_clipboard
+    open_composer
+    cdp.copy_paste("https://example.com/fail")
+    page.send_keys(:enter)
+
+    expect(rich).to have_css(".onebox-loading")
+    expect(rich).to have_no_css(".onebox-loading")
+    expect(rich).to have_css("a[href='https://example.com/fail']")
+    expect(rich).to have_no_css(".onebox-wrapper")
+  end
+
   context "with watched word links" do
     fab!(:topic) { Fabricate(:topic, user: current_user) }
     fab!(:post) do

--- a/spec/system/composer/prosemirror_onebox_spec.rb
+++ b/spec/system/composer/prosemirror_onebox_spec.rb
@@ -181,6 +181,18 @@ describe "Composer - ProseMirror - Oneboxing" do
     expect(composer).to have_value("Hey https://example.com/x and https://example.com/x")
   end
 
+  it "removes loading decoration when onebox fetch fails" do
+    stub_request(:get, "https://example.com/fail").to_return(status: 404)
+
+    cdp.allow_clipboard
+    open_composer
+    cdp.copy_paste("https://example.com/fail")
+    page.send_keys(:enter)
+
+    expect(rich).to have_no_css(".onebox-loading")
+    expect(rich).to have_css("a[href='https://example.com/fail']")
+  end
+
   context "with watched word links" do
     fab!(:topic) { Fabricate(:topic, user: current_user) }
     fab!(:post) do


### PR DESCRIPTION
When a onebox fetch fails (e.g. 404), the oneboxer never calls `onResolve`, so the ProseMirror plugin's promise hangs forever and the `onebox-loading` decoration is never cleaned up — leaving a permanently pulsing animation on the link.

Calls `onResolve(null)` in the oneboxer failure path so the promise resolves

Preserves `onResolve` in the 429 rate-limit re-queue (was silently dropped)

Removes stale loading decorations when full onebox fetch fails

Adds missing `.catch()` for inline onebox batch requests