### PR TITLE
FIX: Admin modified setting from old default being clobbered by upcoming change default

### DIFF
--- a/.skills/discourse-upcoming-changes-authoring/SKILL.md
+++ b/.skills/discourse-upcoming-changes-authoring/SKILL.md
@@ -219,8 +219,6 @@ mock_upcoming_change_metadata(
 )
 ```
 
-Always clean up with `clear_mocked_upcoming_change_metadata` in an `after` block (or the helper handles it automatically depending on context). The helper is defined in `spec/support/helpers.rb`.
-
 ### Mocking Default Overrides
 
 Use `mock_upcoming_change_default_overrides` to set up override metadata in tests — never modify `site_settings.yml`:

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -572,11 +572,23 @@ module SiteSettingExtension
         # store site settings. In this case, we should not consider this
         # setting to be modified.
         #
-        # The only exception is for upcoming changes, which have automatic
-        # promotion systems, and admins need to be able to manually opt out
-        # even if the default itself isn't changing.
+        # There are two exceptions, both tied to upcoming changes:
+        #
+        # 1. Upcoming change settings themselves — admins need to be able
+        #    to manually opt out of an auto-promoted change even when the
+        #    DB value matches the YAML default.
+        #
+        # 2. Target settings of an upcoming_change_default_override — the
+        #    "clean" defaults_view here is computed without overrides
+        #    applied, so it still reports the original YAML default.
+        #
+        #    When an override is active, the *effective* default is different,
+        #    and the admin's explicit DB value (even if it equals the
+        #    original default) is a deliberate opt-out that must survive
+        #    refresh!. Without this exception, the override loop below
+        #    would re-clobber the admin's choice.
         new_modified.reject! do |name, val|
-          if UpcomingChanges.exists?(name)
+          if UpcomingChanges.exists?(name) || upcoming_change_default_overrides.key?(name)
             false
           else
             val.to_s == defaults_view[name].to_s

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -2013,6 +2013,26 @@ RSpec.describe SiteSettingExtension do
       end
     end
 
+    context "when admin opts out of the target setting after the override is active" do
+      before do
+        settings.provider.save(
+          :increase_suggested_topics_max_days_old_default,
+          true,
+          SiteSetting.types[:bool],
+        )
+        settings.refresh!
+      end
+
+      it "preserves the admin's explicit value across refresh, even when it equals the original default" do
+        expect(settings.suggested_topics_max_days_old).to eq(1000)
+
+        settings.provider.save(:suggested_topics_max_days_old, 365, SiteSetting.types[:integer])
+        settings.refresh!
+
+        expect(settings.suggested_topics_max_days_old).to eq(365)
+      end
+    end
+
     describe "all_settings effective default" do
       context "when the linked upcoming change is active" do
         before do

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -395,8 +395,6 @@ RSpec.describe UpcomingChanges do
     context "when the setting has no row in the database (admin has not saved it)" do
       before { SiteSetting.remove_override!(setting_name) }
 
-      after { clear_mocked_upcoming_change_metadata }
-
       it "returns the yaml default when the change is below promote_upcoming_changes_on_status" do
         mock_upcoming_change_metadata(
           {
@@ -431,8 +429,6 @@ RSpec.describe UpcomingChanges do
     end
 
     context "when an admin has saved a value to the database" do
-      after { clear_mocked_upcoming_change_metadata }
-
       it "returns the stored value when true" do
         SiteSetting.enable_upload_debug_mode = true
 
@@ -470,8 +466,6 @@ RSpec.describe UpcomingChanges do
           },
         )
       end
-
-      after { clear_mocked_upcoming_change_metadata }
 
       it "returns true even when the database value is false" do
         SiteSetting.enable_upload_debug_mode = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -950,6 +950,7 @@ RSpec.configure do |config|
     Discourse.redis.flushdb
     Scheduler::Defer.do_all_work
     clear_mocked_upcoming_change_metadata
+    clear_mocked_upcoming_change_default_overrides
   end
 
   config.after(:each, type: :system) do |example|

--- a/spec/services/upcoming_changes/list_spec.rb
+++ b/spec/services/upcoming_changes/list_spec.rb
@@ -102,8 +102,6 @@ RSpec.describe UpcomingChanges::List do
             )
           end
 
-          after { clear_mocked_upcoming_change_default_overrides }
-
           it "includes the related setting name" do
             results = result.upcoming_changes
             mock_setting = results.find { |change| change[:setting] == :enable_upload_debug_mode }

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -332,11 +332,6 @@ describe "Admin upcoming changes" do
       SiteSetting.refresh!
     end
 
-    after do
-      clear_mocked_upcoming_change_metadata
-      clear_mocked_upcoming_change_default_overrides
-    end
-
     it "shows information about the default override in the site settings UI" do
       settings_page.visit("suggested_topics_max_days_old")
       expect(settings_page).to have_upcoming_change_default_warning(
@@ -344,6 +339,82 @@ describe "Admin upcoming changes" do
         old_default: 365,
         new_default: 1000,
       )
+    end
+  end
+
+  context "when the upcoming change has a boolean default override and the admin opts out" do
+    let(:settings_page) { PageObjects::Pages::AdminSiteSettings.new }
+
+    before do
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "site_setting_default,all_members",
+            status: :experimental,
+            impact_type: "site_setting_default",
+            impact_role: "all_members",
+          },
+        },
+      )
+      mock_upcoming_change_default_overrides(
+        {
+          limit_suggested_to_category: {
+            upcoming_change: :enable_upload_debug_mode,
+            new_default: true,
+          },
+        },
+      )
+      SiteSetting.enable_upload_debug_mode = true
+      SiteSetting.refresh!
+    end
+
+    after do
+      clear_mocked_upcoming_change_metadata
+      clear_mocked_upcoming_change_default_overrides
+    end
+
+    it "preserves the admin's opt-out across page reload while still showing the override warning" do
+      settings_page.visit("limit_suggested_to_category")
+
+      expect(settings_page).to have_upcoming_change_default_warning(
+        :limit_suggested_to_category,
+        old_default: false,
+        new_default: true,
+      )
+      expect(
+        settings_page.find_setting(:limit_suggested_to_category).find(
+          ".setting-value input[type=checkbox]",
+        ),
+      ).to be_checked
+
+      settings_page.toggle_setting(:limit_suggested_to_category)
+
+      # Wait for the save to land in the DB before forcing the in-process
+      # SiteSetting refresh below — the .overridden class only appears once
+      # the value has been persisted.
+      expect(
+        settings_page.find_setting(:limit_suggested_to_category, overridden: true),
+      ).to be_present
+
+      # Production reproduces the bug because each unicorn worker re-runs
+      # SiteSetting.refresh! via the MessageBus subscriber after another
+      # worker persists a setting change. In a single-process system spec
+      # that subscriber doesn't fire, so we trigger the refresh explicitly
+      # to mirror what happens on the next request in a real deployment.
+      SiteSetting.refresh!
+
+      page.refresh
+
+      expect(settings_page).to have_upcoming_change_default_warning(
+        :limit_suggested_to_category,
+        old_default: false,
+        new_default: true,
+      )
+      expect(
+        settings_page.find_setting(:limit_suggested_to_category).find(
+          ".setting-value input[type=checkbox]",
+        ),
+      ).not_to be_checked
     end
   end
 end


### PR DESCRIPTION
Followup dd8c16cbd615e487bd5635e46d7147583fcdd103

I found this issue when testing https://github.com/discourse/discourse/pull/39250

This is how to reproduce:

* First enable the upcoming change to change discourse_reactions_enabled
  default to true from false
* Go to site settings and find discourse_reactions_enabled
* See that it is enabled by default. Now uncheck it to disable
  and save
* Reload the page. See that it still appears to be enabled and
  doesn't show the overridden dot

This was happening because in SiteSetting.refresh!, we are disregarding
site settings from being considered modified when their value in
the DB is the same as the default value. However this comparison
was made against the _original_ default value, not the upcoming
change overridden one, so the admin's choice ended up being clobbered
by the new default.

This commit fixes the issue, tested against the linked PR for reactions
too
