### PR TITLE
FIX: Avoid reloading post in post events so that the revisor doesn't reset

### DIFF
--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -243,7 +243,7 @@ after_initialize do
 
   on(:post_created) do |post|
     DiscoursePostEvent::Event.update_from_raw(post)
-    post.reload
+    post.association(:event).reload
     if SiteSetting.discourse_post_event_enabled && post.event
       WebHook.enqueue_calendar_event_hooks(:calendar_event_created, post.event)
     end
@@ -253,7 +253,7 @@ after_initialize do
     event_before = post.event
     had_event_before = event_before.present?
     DiscoursePostEvent::Event.update_from_raw(post)
-    post.reload
+    post.association(:event).reload
 
     if SiteSetting.discourse_post_event_enabled
       if post.event && had_event_before


### PR DESCRIPTION
Invoking `post.reload` within the `post_created` or `post_edited` events may cause data within `revisor.post_changes` to reset.

