### PR TITLE
DEV: Fix job serialization deprecation in d-automation

### DIFF
--- a/plugins/automation/app/jobs/scheduled/discourse_automation/tracker.rb
+++ b/plugins/automation/app/jobs/scheduled/discourse_automation/tracker.rb
@@ -67,7 +67,7 @@ module Jobs
 
           pending_automation.automation.trigger!(
             "kind" => pending_automation.automation.trigger,
-            "execute_at" => pending_automation.execute_at.iso8601,
+            "execute_at" => pending_automation.execute_at,
           )
 
           pending_automation.destroy!

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -130,6 +130,8 @@ module DiscourseAutomation
           new_context["_serialized_#{k}"] = { "class" => "Symbol", "value" => v.to_s }
         elsif v.is_a?(ActiveRecord::Base)
           new_context["_serialized_#{k}"] = { "class" => v.class.name, "id" => v.id }
+        elsif v.is_a?(Date) || v.is_a?(Time)
+          new_context[k] = v.iso8601
         else
           new_context[k] = v
         end

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -72,7 +72,7 @@ describe DiscourseAutomation::Automation do
     end
   end
 
-  context "when automation’s script has a field with validor" do
+  context "when automation’s script has a field with validator" do
     before do
       DiscourseAutomation::Scriptable.add("required_dogs") do
         field :dog, component: :text, validator: ->(input) { "must have dog" if input != "dog" }
@@ -161,6 +161,28 @@ describe DiscourseAutomation::Automation do
           }.to raise_error(ActiveRecord::RecordInvalid, /dog/)
         end
       end
+    end
+  end
+
+  describe ".serialize_context" do
+    it "serializes date and time as iso8601" do
+      expect(
+        described_class.serialize_context(
+          {
+            "time" => Time.utc(2026, 4, 15, 12, 0, 0),
+            "time_with_zone" => Time.utc(2026, 4, 15, 12, 0, 0).in_time_zone("Europe/Warsaw"),
+            "date_time" => DateTime.new(2026, 4, 15, 12, 0, 0),
+            "date" => Date.new(2026, 4, 15),
+          },
+        ),
+      ).to eq(
+        {
+          "time" => "2026-04-15T12:00:00Z",
+          "time_with_zone" => "2026-04-15T14:00:00+02:00",
+          "date_time" => "2026-04-15T12:00:00+00:00",
+          "date" => "2026-04-15",
+        },
+      )
     end
   end
 


### PR DESCRIPTION
🎶

```
DEPRECATION NOTICE: Jobs::DiscourseAutomation::Trigger was enqueued with argument values which do not cleanly serialize to/from JSON. This means that the job will be run with slightly different values than the ones supplied to `enqueue`. Argument values should be strings, booleans, numbers, or nil (or arrays/hashes of those value types). (deprecated since Discourse 2.9) (removal in Discourse 3.0)
At /__w/discourse/discourse/plugins/automation/app/models/discourse_automation/automation.rb:141:in `DiscourseAutomation::Automation#trigger_in_background!`
```