### PR TITLE
FIX: Restore chat link on post event widget

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/chat-channel.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/chat-channel.gjs
@@ -1,24 +1,27 @@
+import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { optionalRequire } from "discourse/lib/utilities";
 import { and } from "discourse/truth-helpers";
 
-const ChannelTitle = optionalRequire(
-  "discourse/plugins/chat/discourse/components/channel-title"
-);
+export default class DiscoursePostEventChatChannel extends Component {
+  get channelTitle() {
+    return optionalRequire(
+      "discourse/plugins/chat/discourse/components/channel-title"
+    );
+  }
 
-const DiscoursePostEventChatChannel = <template>
-  {{#if (and @event.channel ChannelTitle)}}
-    <section class="event__section event-chat-channel">
-      <span></span>
-      <LinkTo
-        @route="chat.channel"
-        @models={{@event.channel.routeModels}}
-        class="chat-channel-link"
-      >
-        <ChannelTitle @channel={{@event.channel}} />
-      </LinkTo>
-    </section>
-  {{/if}}
-</template>;
-
-export default DiscoursePostEventChatChannel;
+  <template>
+    {{#if (and @event.channel this.channelTitle)}}
+      <section class="event__section event-chat-channel">
+        <span></span>
+        <LinkTo
+          @route="chat.channel"
+          @models={{@event.channel.routeModels}}
+          class="chat-channel-link"
+        >
+          <this.channelTitle @channel={{@event.channel}} />
+        </LinkTo>
+      </section>
+    {{/if}}
+  </template>
+}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -7,10 +7,6 @@ import User from "discourse/models/user";
 import DiscoursePostEventEventStats from "./discourse-post-event-event-stats";
 import DiscoursePostEventInvitee from "./discourse-post-event-invitee";
 
-const ChatChannel = optionalRequire(
-  "discourse/plugins/chat/discourse/models/chat-channel"
-);
-
 const DEFAULT_REMINDER = {
   type: "notification",
   value: 15,
@@ -62,6 +58,10 @@ export default class DiscoursePostEventEvent {
   @tracked _reminders;
 
   constructor(args = {}) {
+    const ChatChannel = optionalRequire(
+      "discourse/plugins/chat/discourse/models/chat-channel"
+    );
+
     this.id = args.id;
     this.rrule = args.rrule;
     this.name = args.name;


### PR DESCRIPTION
This fixes a regression introduced (most likely) by the switch to
Rollup: the post event widget would no longer display a link to the
associated chat channel, even though the channel was present a chat
enabled for the event.

The reason is, that `optionalRequire` would always evaluate to `false`,
as if the chat plugin wasn't available. This is due how Rollup evaluates
the modules and their dependencies when bundling.

The lazy requiring can be fixed by moving it into the constructor of the
respective component, so that it actually happens lazily.

See the bug topic in meta for more background: https://meta.discourse.org/t/chat-link-missing-in-post-event-widget-after-to-rollup/400691
