### PR TITLE
UX: increase contrast of topic voting count

### DIFF
--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -61,7 +61,7 @@
 }
 
 .voting-wrapper__count-text {
-  color: var(--primary-medium);
+  color: var(--primary-high);
 }
 
 .voting-wrapper__count {
@@ -109,7 +109,7 @@
 .header-title-voting {
   --secondary: var(--header_background);
   --primary-high: var(--header_primary-high);
-  --primary-medium: var(--header_primary-medium);
+  --primary-medium: var(--header_primary-high);
   --primary-low: var(--header_primary-low);
   margin-top: 0.15em; // vertical alignment tweak
   margin-right: var(--space-2);

--- a/themes/horizon/scss/topic-voting.scss
+++ b/themes/horizon/scss/topic-voting.scss
@@ -26,7 +26,7 @@
 }
 
 .voting.header-title-voting .voting-wrapper {
-  --primary-high: var(--header_primary-medium);
+  --primary-high: var(--header_primary-high);
 
   @include viewport.from(lg) {
     --secondary: var(--background-color);


### PR DESCRIPTION
Went a little too light here, this darkens a shade 

Before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/6a2d0ea9-a216-4c1b-8107-bcdcff79c9ee" />



After: 
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/2ff0649b-4c18-4c3c-8439-db29f3d8126f" />
