### PR TITLE
 UX: Redesign OmniAuth confirmation page with branded styling

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -37,6 +37,16 @@ $github-hover: color.adjust($github, $lightness: 20%) !default;
 $discord: #7289da !default;
 $discord-hover: color.adjust($discord, $lightness: -10%) !default;
 
+// Discourse brand colors (used in wizard, omniauth confirm, etc.)
+$discourse-brand: #7b5fe2 !default;
+$discourse-brand-100: #f4f2fc !default;
+$discourse-brand-300: #b8a4ff !default;
+$discourse-brand-400: #8b6df8 !default;
+$discourse-brand-800: #3a275e !default;
+$discourse-brand-light: #e1d5ff !default;
+$discourse-bg-light: #f9f8fc !default;
+$discourse-bg-dark: #02030a !default;
+
 // Badge color variables
 // --------------------------------------------------
 

--- a/app/assets/stylesheets/common/login/_index.scss
+++ b/app/assets/stylesheets/common/login/_index.scss
@@ -1,1 +1,2 @@
 @import "invite-signup";
+@import "omniauth-confirm";

--- a/app/assets/stylesheets/common/login/omniauth-confirm.scss
+++ b/app/assets/stylesheets/common/login/omniauth-confirm.scss
@@ -1,0 +1,194 @@
+@use "lib/viewport";
+
+// Page-level styles for no_ember layout
+body.no-ember:has(.omniauth-confirm) {
+  --omniauth-bg: light-dark(#{$discourse-bg-light}, #{$discourse-bg-dark});
+  --omniauth-bg-2: light-dark(
+    #{$discourse-brand-light},
+    #{$discourse-brand-800}
+  );
+  background: linear-gradient(
+    180deg,
+    var(--omniauth-bg-2) 0%,
+    var(--omniauth-bg) 100%
+  );
+  min-height: 100vh;
+
+  .d-header {
+    display: none;
+  }
+
+  #main {
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+  }
+
+  #main-outlet {
+    padding: 0;
+    max-width: none;
+    width: 100%;
+  }
+}
+
+.omniauth-confirm {
+  --omniauth-primary: #{$discourse-brand};
+  --omniauth-primary-hover: #{$discourse-brand-400};
+  --omniauth-bg: light-dark(#{$discourse-bg-light}, #{$discourse-bg-dark});
+  --omniauth-bg-2: light-dark(
+    #{$discourse-brand-light},
+    #{$discourse-brand-800}
+  );
+  --omniauth-card-shadow: light-dark(
+    0 10px 30px rgb(123 95 226 / 15%),
+    0 10px 30px rgb(0 0 0 / 30%)
+  );
+  --omniauth-card-radius: 12px;
+  --omniauth-element-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: var(--space-4);
+  box-sizing: border-box;
+
+  // Vertically center in the viewport
+  min-height: calc(100vh - 100px);
+
+  &__logo {
+    margin-bottom: var(--space-4);
+
+    svg {
+      width: 56px;
+      height: 56px;
+    }
+  }
+
+  &__title {
+    font-size: var(--font-up-3);
+    font-weight: 600;
+    color: var(--primary);
+    margin: 0 0 var(--space-2) 0;
+    line-height: var(--line-height-small);
+  }
+
+  &__subtitle {
+    font-size: var(--font-0);
+    color: var(--primary-medium);
+    margin: 0 0 var(--space-5) 0;
+    line-height: var(--line-height-large);
+  }
+
+  &__card {
+    background: var(--secondary);
+    border-radius: var(--omniauth-card-radius);
+    box-shadow: var(--omniauth-card-shadow);
+    padding: var(--space-5);
+    width: 100%;
+    box-sizing: border-box;
+
+    @include viewport.until(sm) {
+      padding: var(--space-4);
+    }
+  }
+
+  &__provider-info {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    background: var(--primary-very-low);
+    border-radius: var(--omniauth-element-radius);
+    margin-bottom: var(--space-4);
+    text-align: left;
+  }
+
+  &__provider-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--omniauth-primary);
+    color: #fff;
+    flex-shrink: 0;
+
+    svg {
+      width: 22px;
+      height: 22px;
+    }
+  }
+
+  &__provider-details {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__provider-name {
+    font-weight: 600;
+    color: var(--primary);
+    font-size: var(--font-0);
+  }
+
+  &__provider-description {
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  &__continue-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: 12px var(--space-4);
+    font-size: var(--font-0);
+    font-weight: 600;
+    border-radius: var(--omniauth-element-radius);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+    box-sizing: border-box;
+
+    &.btn-primary {
+      background: var(--omniauth-primary);
+      color: #fff;
+      border: none;
+
+      &:hover,
+      &:focus {
+        background: var(--omniauth-primary-hover);
+      }
+    }
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  &__footer {
+    margin-top: var(--space-4);
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+
+    strong {
+      color: var(--primary);
+      font-weight: 600;
+    }
+  }
+}

--- a/app/assets/stylesheets/common/login/omniauth-confirm.scss
+++ b/app/assets/stylesheets/common/login/omniauth-confirm.scss
@@ -41,12 +41,13 @@ body.no-ember:has(.omniauth-confirm) {
     #{$discourse-brand-light},
     #{$discourse-brand-800}
   );
-  --omniauth-card-shadow: light-dark(
-    0 10px 30px rgb(123 95 226 / 15%),
-    0 10px 30px rgb(0 0 0 / 30%)
-  );
+  --omniauth-card-shadow: 0 10px 30px
+    light-dark(rgb(123 95 226 / 15%), transparent);
   --omniauth-card-radius: 12px;
   --omniauth-element-radius: 8px;
+  --omniauth-button-radius: 6.25em;
+  --omniauth-text-color: light-dark(var(--primary), #fff);
+  --omniauth-text-muted: light-dark(var(--primary-medium), #a0a0a0);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -73,14 +74,14 @@ body.no-ember:has(.omniauth-confirm) {
   &__title {
     font-size: var(--font-up-3);
     font-weight: 600;
-    color: var(--primary);
+    color: var(--omniauth-text-color);
     margin: 0 0 var(--space-2) 0;
     line-height: var(--line-height-small);
   }
 
   &__subtitle {
     font-size: var(--font-0);
-    color: var(--primary-medium);
+    color: var(--omniauth-text-muted);
     margin: 0 0 var(--space-5) 0;
     line-height: var(--line-height-large);
   }
@@ -159,7 +160,7 @@ body.no-ember:has(.omniauth-confirm) {
     padding: 12px var(--space-4);
     font-size: var(--font-0);
     font-weight: 600;
-    border-radius: var(--omniauth-element-radius);
+    border-radius: var(--omniauth-button-radius);
     cursor: pointer;
     transition: background-color 0.15s ease;
     box-sizing: border-box;
@@ -184,10 +185,10 @@ body.no-ember:has(.omniauth-confirm) {
   &__footer {
     margin-top: var(--space-4);
     font-size: var(--font-down-1);
-    color: var(--primary-medium);
+    color: var(--omniauth-text-muted);
 
     strong {
-      color: var(--primary);
+      color: var(--omniauth-text-color);
       font-weight: 600;
     }
   }

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -1,13 +1,19 @@
 @use "lib/viewport";
 
 :root {
-  --wizard-primary: #7b5fe2;
-  --wizard-primary-100: #f4f2fc;
-  --wizard-primary-300: #b8a4ff;
-  --wizard-primary-400: #8b6df8;
-  --wizard-primary-800: #3a275e;
-  --wizard-bg-color: light-dark(#f9f8fc, var(--background-color));
-  --wizard-bg-color-2: light-dark(#e1d5ff, var(--wizard-primary-800));
+  --wizard-primary: #{$discourse-brand};
+  --wizard-primary-100: #{$discourse-brand-100};
+  --wizard-primary-300: #{$discourse-brand-300};
+  --wizard-primary-400: #{$discourse-brand-400};
+  --wizard-primary-800: #{$discourse-brand-800};
+  --wizard-bg-color: light-dark(
+    #{$discourse-bg-light},
+    var(--background-color)
+  );
+  --wizard-bg-color-2: light-dark(
+    #{$discourse-brand-light},
+    var(--wizard-primary-800)
+  );
   --wizard-input-radius: 8px;
   --wizard-button-radius: 6.25em;
 }

--- a/app/views/users/omniauth_callbacks/confirm_request.html.erb
+++ b/app/views/users/omniauth_callbacks/confirm_request.html.erb
@@ -1,11 +1,47 @@
-<div id='simple-container'>
-  <h2><%= t('login.omniauth_confirm_title', provider:(t "js.login.#{params[:provider]}.name", default: params[:provider])) %></h2>
-  <br/>
+<% provider_name = t("js.login.#{params[:provider]}.name", default: params[:provider].to_s.titleize) %>
 
-  <form method="post">
-    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-    <%= button_tag(type: "submit", class: "btn btn-primary") do %>
-        <%= SvgSprite.raw_svg('plug') %><%= t 'login.omniauth_confirm_button' %>
-    <% end %>
-  </form>
+<div class="omniauth-confirm">
+  <div class="omniauth-confirm__logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 103 104" width="56" height="56">
+      <g fill="none" fill-rule="nonzero">
+        <path fill="currentColor" d="M51.87 0C23.71 0 0 22.83 0 51v52.81l51.86-.05c28.16 0 51-23.71 51-51.87C102.86 23.73 80 0 51.87 0z"/>
+        <path fill="#FFF9AE" d="M52.37 19.74c-11.14.01-21.45 5.87-27.15 15.44-5.65 9.56-5.89 21.42-.59 31.22l-5.72 18.4 20.54-4.64c11.76 5.3 25.56 2.92 34.87-6.01 9.31-8.93 12.25-22.63 7.44-34.6-4.81-11.97-16.41-19.81-29.31-19.82h-.03z"/>
+        <path fill="#00AEEF" d="M77.09 70.91c-8.98 11.33-24.5 15.12-37.69 9.21l-20.54 4.7 20.91-2.47c13.86 8.12 31.61 4.55 41.25-8.3 9.64-12.85 8.1-30.89-3.56-41.93 8.77 11.49 8.62 27.47-.36 38.79z"/>
+        <path fill="#00A94F" d="M75.32 64.91c-7.75 12.2-22.78 17.59-36.52 13.09l-19.94 6.82 20.54-4.65c14.63 6.61 31.89 1.2 40.13-12.58 8.24-13.77 4.84-31.54-7.9-41.3 9.92 10.51 11.44 26.42 3.69 38.62z"/>
+        <path fill="#F15D22" d="M26.47 67.11c-5.72-13.8-1.01-29.72 11.31-38.18 12.32-8.45 28.87-7.13 39.69 3.18-10.02-13.15-28.47-16.36-42.34-7.36-13.87 8.99-18.47 27.15-10.55 41.65l-5.72 18.4 7.61-17.7z"/>
+        <path fill="#D0232B" d="M24.58 66.41c-7.1-13.12-4.07-29.42 7.29-39.1 11.35-9.68 27.93-10.11 39.76-1.01-11.35-11.95-29.98-13.18-42.8-2.81-12.82 10.37-15.52 28.84-6.2 42.44l-3.76 18.9 5.71-18.41z"/>
+      </g>
+    </svg>
+  </div>
+
+  <h1 class="omniauth-confirm__title">
+    <%= t('login.omniauth_confirm_title', provider: provider_name) %>
+  </h1>
+
+  <p class="omniauth-confirm__subtitle">
+    <%= t('login.omniauth_confirm_description', provider: provider_name, site: SiteSetting.title) %>
+  </p>
+
+  <div class="omniauth-confirm__card">
+    <div class="omniauth-confirm__provider-info">
+      <div class="omniauth-confirm__provider-icon">
+        <%= SvgSprite.raw_svg('plug') %>
+      </div>
+      <div class="omniauth-confirm__provider-details">
+        <span class="omniauth-confirm__provider-name"><%= provider_name %></span>
+        <span class="omniauth-confirm__provider-description"><%= t('login.omniauth_confirm_provider_description') %></span>
+      </div>
+    </div>
+
+    <form method="post" class="omniauth-confirm__actions">
+      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+      <%= button_tag(type: "submit", class: "btn btn-primary omniauth-confirm__continue-btn") do %>
+        <%= t('login.omniauth_confirm_button') %>
+      <% end %>
+    </form>
+  </div>
+
+  <p class="omniauth-confirm__footer">
+    <%= t('login.omniauth_confirm_footer_html', site: tag.strong(SiteSetting.title)) %>
+  </p>
 </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3126,8 +3126,11 @@ en:
       unauthorized: "Sorry, the login provider did not authorize your request. Please try again or contact an administrator."
 
     omniauth_error_unknown: "Something went wrong processing your login, please try again."
-    omniauth_confirm_title: "Log in using %{provider}"
+    omniauth_confirm_title: "Log in with %{provider}"
     omniauth_confirm_button: "Continue"
+    omniauth_confirm_description: "You will be redirected to %{provider} to sign in"
+    omniauth_confirm_provider_description: "Secure authentication"
+    omniauth_confirm_footer_html: "You will be signed into %{site}"
     authenticator_error_no_valid_email: "No email addresses associated with %{account} are allowed. You may need to configure your account with a different email address."
     new_registrations_disabled: "New account registrations are not allowed at this time."
     new_registrations_disabled_discourse_connect: "New account registrations are only allowed through Discourse Connect."

--- a/spec/system/omniauth_confirm_styling_spec.rb
+++ b/spec/system/omniauth_confirm_styling_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "OmniAuth Confirm Page" do
+  let(:omniauth_confirm_page) { PageObjects::Pages::OmniauthConfirm.new }
+
+  before { SiteSetting.title = "My Awesome Community" }
+
+  context "with Google OAuth" do
+    before do
+      SiteSetting.enable_google_oauth2_logins = true
+      SiteSetting.google_oauth2_client_id = "fake_client_id"
+      SiteSetting.google_oauth2_client_secret = "fake_secret"
+    end
+
+    it "displays the styled confirmation page with correct content" do
+      omniauth_confirm_page.visit_provider("google_oauth2")
+
+      expect(omniauth_confirm_page).to have_logo
+      expect(omniauth_confirm_page).to have_card
+      expect(omniauth_confirm_page).to have_title_for_provider("Google")
+      expect(omniauth_confirm_page).to have_provider_info("Google")
+      expect(omniauth_confirm_page).to have_continue_button
+      expect(omniauth_confirm_page).to have_site_name_in_footer("My Awesome Community")
+    end
+  end
+
+  context "with Discourse ID" do
+    before do
+      SiteSetting.discourse_id_client_id = SecureRandom.hex
+      SiteSetting.discourse_id_client_secret = SecureRandom.hex
+      SiteSetting.enable_discourse_id = true
+    end
+
+    it "displays the styled confirmation page with correct content" do
+      omniauth_confirm_page.visit_provider("discourse_id")
+
+      expect(omniauth_confirm_page).to have_logo
+      expect(omniauth_confirm_page).to have_card
+      expect(omniauth_confirm_page).to have_title_for_provider("Discourse ID")
+      expect(omniauth_confirm_page).to have_provider_info("Discourse ID")
+      expect(omniauth_confirm_page).to have_continue_button
+      expect(omniauth_confirm_page).to have_site_name_in_footer("My Awesome Community")
+    end
+  end
+end

--- a/spec/system/page_objects/pages/omniauth_confirm.rb
+++ b/spec/system/page_objects/pages/omniauth_confirm.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class OmniauthConfirm < PageObjects::Pages::Base
+      def visit_provider(provider)
+        visit("/auth/#{provider}")
+        self
+      end
+
+      def has_logo?
+        has_css?(".omniauth-confirm__logo")
+      end
+
+      def has_card?
+        has_css?(".omniauth-confirm__card")
+      end
+
+      def has_title_for_provider?(provider_name)
+        has_css?(".omniauth-confirm__title", text: "Log in with #{provider_name}")
+      end
+
+      def has_provider_info?(provider_name)
+        has_css?(".omniauth-confirm__provider-name", text: provider_name)
+      end
+
+      def has_site_name_in_footer?(site_name)
+        has_css?(".omniauth-confirm__footer", text: site_name)
+      end
+
+      def has_continue_button?
+        has_button?("Continue")
+      end
+
+      def click_continue
+        find(".omniauth-confirm__continue-btn").click
+        self
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Previously**, the OmniAuth confirmation page (`/auth/:provider`) was a basic, unstyled page with just a title and button in the corner.

**In this update**, redesigned the page with a centered card layout, purple gradient background matching the wizard branding, Discourse logo, improved copy showing the site name, and proper BEM-structured CSS using shared brand color variables.

**BEFORE:**

| Dark | Light |
| ----- | ----- |
| <img width="1400" height="1400" alt="omniauth_confirm_BEFORE_dark" src="https://github.com/user-attachments/assets/129233a7-be50-4b61-b7dc-412c7562ad07" /> | <img width="1400" height="1400" alt="omniauth_confirm_BEFORE_light" src="https://github.com/user-attachments/assets/d9c1ecd0-ab19-4d31-9ef6-48477bacd132" /> |

**AFTER:**
| Dark | Light |
| ----- | ----- |
| <img width="1400" height="1400" alt="omniauth_final_dark" src="https://github.com/user-attachments/assets/bef7793a-9c02-42a1-8e48-994793b32252" /> | <img width="1400" height="1400" alt="omniauth_final_light" src="https://github.com/user-attachments/assets/e76dfa8c-5ec5-4676-95a5-a1f9f2b9723c" /> |
