### PR TITLE
FIX: Translate the overrides instead of just the en.yml file

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_theme_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_theme_translations_controller.rb
@@ -9,7 +9,10 @@ module DiscourseAi
         theme = Theme.find_by(id: params[:theme_id])
         raise Discourse::NotFound if theme.blank?
 
-        Jobs.enqueue(:localize_theme_translations, theme_id: theme.id)
+        locale = params[:locale].to_s
+        source_locale = (locale.present? && LocaleSiteSetting.valid_value?(locale)) ? locale : "en"
+
+        Jobs.enqueue(:localize_theme_translations, theme_id: theme.id, source_locale:)
 
         head :no_content
       end

--- a/plugins/discourse-ai/app/jobs/regular/localize_theme_translations.rb
+++ b/plugins/discourse-ai/app/jobs/regular/localize_theme_translations.rb
@@ -11,47 +11,75 @@ module Jobs
       theme = Theme.find_by(id: theme_id)
       return if theme.blank?
 
-      en_field = theme.theme_fields.find_by(target_id: Theme.targets[:translations], name: "en")
-      return if en_field.blank?
+      target_locales = SiteSetting.content_localization_supported_locales.to_s.split("|")
+      return if target_locales.empty?
 
-      en_data = en_field.raw_translation_data[:en] || {}
-      translations =
-        ThemeTranslationManager.list_from_hash(locale: "en", hash: en_data, theme: theme)
-      return if translations.blank?
+      source_locale = args[:source_locale].presence || "en"
+      non_en_source = source_locale != "en"
 
-      locales = SiteSetting.content_localization_supported_locales.to_s.split("|") - ["en"]
-      return if locales.empty?
+      source_overrides = non_en_source ? load_overrides(theme, source_locale) : {}
+      source_yaml = non_en_source ? load_yaml(theme, source_locale) : {}
+      en_overrides = load_overrides(theme, "en")
+      en_yaml = load_yaml(theme, "en")
 
-      locales.each do |locale|
-        translations.each do |tm|
-          begin
-            value =
-              DiscourseAi::Translation::ShortTextTranslator.new(
-                text: tm.default,
-                target_locale: locale,
-              ).translate
-            next if value.blank?
+      en_yaml.each_key do |key|
+        if (text = source_overrides[key].presence || source_yaml[key].presence)
+          effective_locale = source_locale
+        elsif (text = en_overrides[key].presence || en_yaml[key].presence)
+          effective_locale = "en"
+        else
+          next
+        end
 
-            ThemeTranslationOverride.upsert(
-              {
-                theme_id: theme.id,
-                locale: locale,
-                translation_key: tm.key,
-                value: value,
-                created_at: Time.now,
-                updated_at: Time.now,
-              },
-              unique_by: %i[theme_id locale translation_key],
-            )
-          rescue FinalDestination::SSRFDetector::LookupFailedError
-            # transient lookup failures
-          rescue => e
-            DiscourseAi::Translation::VerboseLogger.log(
-              "Failed to translate theme #{theme.id} key #{tm.key} to #{locale}: #{e.message}",
-            )
-          end
+        (target_locales - [effective_locale]).each do |locale|
+          translate_and_upsert(theme, key, text, locale)
         end
       end
+    end
+
+    private
+
+    def load_overrides(theme, locale)
+      ThemeTranslationOverride
+        .where(theme_id: theme.id, locale: locale)
+        .pluck(:translation_key, :value)
+        .to_h
+    end
+
+    def load_yaml(theme, locale)
+      field = theme.theme_fields.find_by(target_id: Theme.targets[:translations], name: locale)
+      return {} if field.blank?
+      data = field.raw_translation_data[locale.to_sym] || {}
+      ThemeTranslationManager
+        .list_from_hash(locale: locale, hash: data, theme: theme)
+        .each_with_object({}) { |tm, h| h[tm.key] = tm.default }
+    end
+
+    def translate_and_upsert(theme, key, text, locale)
+      value =
+        DiscourseAi::Translation::ShortTextTranslator.new(
+          text: text,
+          target_locale: locale,
+        ).translate
+      return if value.blank?
+
+      ThemeTranslationOverride.upsert(
+        {
+          theme_id: theme.id,
+          locale: locale,
+          translation_key: key,
+          value: value,
+          created_at: Time.now,
+          updated_at: Time.now,
+        },
+        unique_by: %i[theme_id locale translation_key],
+      )
+    rescue FinalDestination::SSRFDetector::LookupFailedError
+      # transient lookup failures
+    rescue => e
+      DiscourseAi::Translation::VerboseLogger.log(
+        "Failed to translate theme #{theme.id} key #{key} to #{locale}: #{e.message}",
+      )
     end
   end
 end

--- a/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-customize-theme-translation-selector/ai-theme-translate.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-customize-theme-translation-selector/ai-theme-translate.gjs
@@ -17,11 +17,11 @@ export default class AiThemeTranslate extends Component {
 
   @action
   async translate() {
-    const { theme } = this.args.outletArgs;
+    const { theme, locale } = this.args.outletArgs;
     try {
       await ajax("/admin/plugins/discourse-ai/ai-theme-translations", {
         type: "POST",
-        data: { theme_id: theme.id },
+        data: { theme_id: theme.id, locale },
       });
       this.toasts.success({
         duration: "short",

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -408,7 +408,7 @@ en:
         theme_translations:
           translate:
             label: "Translate"
-            title: "Translate to all supported languages"
+            title: "Translate to all supported languages using the selected language as the source"
             queued: "Translation queued"
             failed: "Failed to queue translation"
         translations_menu:

--- a/plugins/discourse-ai/spec/jobs/regular/localize_theme_translations_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/localize_theme_translations_spec.rb
@@ -26,12 +26,12 @@ describe Jobs::LocalizeThemeTranslations do
   end
 
   it "does nothing when no target locales are configured" do
-    SiteSetting.content_localization_supported_locales = "en"
+    SiteSetting.content_localization_supported_locales = ""
     DiscourseAi::Translation::ShortTextTranslator.expects(:new).never
     job.execute(theme_id: theme.id)
   end
 
-  it "translates each key into every non-en locale and upserts overrides" do
+  it "translates each key into every non-source locale and upserts overrides" do
     translator = mock
     translator.stubs(:translate).returns("translated")
     DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
@@ -45,7 +45,7 @@ describe Jobs::LocalizeThemeTranslations do
   end
 
   it "only translates to locales in content_localization_supported_locales" do
-    SiteSetting.content_localization_supported_locales = "en|fr"
+    SiteSetting.content_localization_supported_locales = "fr"
     translator = mock
     translator.stubs(:translate).returns("translated")
     DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
@@ -65,5 +65,125 @@ describe Jobs::LocalizeThemeTranslations do
     job.execute(theme_id: theme.id)
 
     expect(ThemeTranslationOverride.where(theme_id: theme.id)).to be_empty
+  end
+
+  it "uses the en override value when present instead of the yaml default" do
+    ThemeTranslationOverride.create!(
+      theme_id: theme.id,
+      locale: "en",
+      translation_key: "greeting",
+      value: "Howdy",
+    )
+
+    translator = mock
+    translator.stubs(:translate).returns("translated")
+    DiscourseAi::Translation::ShortTextTranslator
+      .expects(:new)
+      .with(has_entries(text: "Howdy"))
+      .at_least_once
+      .returns(translator)
+
+    job.execute(theme_id: theme.id)
+  end
+
+  describe "with a non-en source locale" do
+    before do
+      theme.set_field(target: :translations, name: "fr", value: <<~YAML)
+        fr:
+          greeting: "Bonjour"
+      YAML
+      theme.save!
+    end
+
+    it "uses the source locale override when present" do
+      ThemeTranslationOverride.create!(
+        theme_id: theme.id,
+        locale: "fr",
+        translation_key: "greeting",
+        value: "Salut",
+      )
+
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
+      DiscourseAi::Translation::ShortTextTranslator
+        .expects(:new)
+        .with(has_entries(text: "Salut", target_locale: "es"))
+        .returns(translator)
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+
+      expect(
+        ThemeTranslationOverride.where(theme_id: theme.id, value: "translated").pluck(:locale),
+      ).to contain_exactly("en", "es")
+    end
+
+    it "falls back to the source locale yaml when no source override exists" do
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
+      DiscourseAi::Translation::ShortTextTranslator
+        .expects(:new)
+        .with(has_entries(text: "Bonjour", target_locale: "es"))
+        .returns(translator)
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+    end
+
+    it "falls back to en override, then en yaml, when source locale has neither and translates into the source locale too" do
+      theme.theme_fields.find_by(target_id: Theme.targets[:translations], name: "fr").destroy!
+      ThemeTranslationOverride.create!(
+        theme_id: theme.id,
+        locale: "en",
+        translation_key: "greeting",
+        value: "Howdy",
+      )
+
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator
+        .expects(:new)
+        .with(has_entries(text: "Howdy", target_locale: "fr"))
+        .returns(translator)
+      DiscourseAi::Translation::ShortTextTranslator
+        .expects(:new)
+        .with(has_entries(text: "Howdy", target_locale: "es"))
+        .returns(translator)
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+    end
+
+    it "excludes only the effective source locale from target locales per key" do
+      theme.set_field(target: :translations, name: "en", value: <<~YAML)
+        en:
+          greeting: "Hello"
+          farewell: "Goodbye"
+      YAML
+      theme.save!
+
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+
+      greeting_locales =
+        ThemeTranslationOverride.where(
+          theme_id: theme.id,
+          translation_key: "greeting",
+          value: "translated",
+        ).pluck(:locale)
+      farewell_locales =
+        ThemeTranslationOverride.where(
+          theme_id: theme.id,
+          translation_key: "farewell",
+          value: "translated",
+        ).pluck(:locale)
+
+      # greeting has a fr yaml → effective source fr → targets en and es
+      expect(greeting_locales).to contain_exactly("en", "es")
+      # farewell has no fr anywhere → effective source en → targets fr and es
+      expect(farewell_locales).to contain_exactly("fr", "es")
+    end
   end
 end

--- a/plugins/discourse-ai/spec/requests/admin/ai_theme_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_theme_translations_controller_spec.rb
@@ -11,8 +11,14 @@ describe DiscourseAi::Admin::AiThemeTranslationsController do
     context "when logged in as admin" do
       before { sign_in(admin) }
 
-      it "enqueues the localize job with the theme id" do
-        expect_enqueued_with(job: :localize_theme_translations, args: { theme_id: theme.id }) do
+      it "enqueues the localize job with the theme id and defaults source_locale to en" do
+        expect_enqueued_with(
+          job: :localize_theme_translations,
+          args: {
+            theme_id: theme.id,
+            source_locale: "en",
+          },
+        ) do
           post "/admin/plugins/discourse-ai/ai-theme-translations.json",
                params: {
                  theme_id: theme.id,
@@ -20,6 +26,38 @@ describe DiscourseAi::Admin::AiThemeTranslationsController do
         end
 
         expect(response.status).to eq(204)
+      end
+
+      it "passes a valid locale through as source_locale" do
+        expect_enqueued_with(
+          job: :localize_theme_translations,
+          args: {
+            theme_id: theme.id,
+            source_locale: "fr",
+          },
+        ) do
+          post "/admin/plugins/discourse-ai/ai-theme-translations.json",
+               params: {
+                 theme_id: theme.id,
+                 locale: "fr",
+               }
+        end
+      end
+
+      it "defaults to en when locale is invalid" do
+        expect_enqueued_with(
+          job: :localize_theme_translations,
+          args: {
+            theme_id: theme.id,
+            source_locale: "en",
+          },
+        ) do
+          post "/admin/plugins/discourse-ai/ai-theme-translations.json",
+               params: {
+                 theme_id: theme.id,
+                 locale: "not-a-locale",
+               }
+        end
       end
 
       it "returns 404 when the theme does not exist" do


### PR DESCRIPTION
Follow up from https://github.com/discourse/discourse/pull/39282, when the (example) English value is overridden, we want to translate that instead of the value in the yml file.

We now pass a source_locale depending on which language in the dropdown is selected. If "de" is selected, we will (load and) translate using this priority:
- "de" translation overrides
- "de" yml file
- "en" translation overrides
- "en" yml file
