### PR TITLE
FIX: render 0 in post-voting count when upvotes and downvotes cancel out

### DIFF
--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-vote-controls.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-vote-controls.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { concat } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
@@ -120,7 +121,7 @@ export default class PostVotingVoteControls extends Component {
         <DButton
           class="post-voting-post-toggle-voters btn-flat"
           @action={{this.toggleWhoVoted}}
-          @translatedLabel={{@post.post_voting_vote_count}}
+          @translatedLabel={{concat @post.post_voting_vote_count}}
         />
         {{#if this.showWhoVoted}}
           <PostVotingWhoVotedList

--- a/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
+++ b/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
@@ -737,6 +737,25 @@ acceptance(`Discourse Post Voting - logged in user`, function (needs) {
       .hasText("0", "does not render a button to show post voters");
   });
 
+  test("receiving user post voted message where upvotes and downvotes cancel out", async function (assert) {
+    await visit("/t/280");
+
+    publishToMessageBus("/topic/280", {
+      type: "post_voting_post_voted",
+      id: topicResponse.post_stream.posts[1].id,
+      post_voting_vote_count: 0,
+      post_voting_has_votes: true,
+      post_voting_user_voted_id: 123456,
+      post_voting_user_voted_direction: "up",
+    });
+
+    await settled();
+
+    assert
+      .dom("#post_2 .post-voting-post-toggle-voters")
+      .hasText("0", "displays 0 when upvotes and downvotes cancel out");
+  });
+
   test("receiving user post voted message where current user is not the one that voted", async function (assert) {
     await visit("/t/280");
 


### PR DESCRIPTION
When a post-voting answer had an equal number of upvotes and downvotes (net score 0) the count between the arrows rendered blank instead of "0".

The `DButton` component used to render the count wraps its label in `{{#if this.computedLabel}}`. Because `0` is falsy in JavaScript, the `<span class="d-button-label">` was never rendered for a zeroed-out score. Posts with no votes at all took a different `<span>` branch and correctly showed "0", which hid the bug from existing tests.

Coerce the numeric count to a string via `{{concat ...}}` so the label is truthy and the span always renders. Also adds an acceptance test covering the cancel-out case, which was not exercised before.

**BEFORE**

<img width="221" height="252" alt="2026-04-15 @ 19 36 34" src="https://github.com/user-attachments/assets/3e261189-8acf-4e68-bc35-46e004c72762" />


**AFTER**

<img width="296" height="353" alt="2026-04-15 @ 19 36 18" src="https://github.com/user-attachments/assets/64e32c31-e037-4705-a04c-884c277c682c" />


Ref - t/181827