### PR TITLE
UX: Support dynamic iframe height for full app embed mode

### DIFF
--- a/frontend/discourse/admin/controllers/admin-embedding/index.js
+++ b/frontend/discourse/admin/controllers/admin-embedding/index.js
@@ -28,7 +28,10 @@ export default class AdminEmbeddingIndexController extends Controller {
       fullApp: true,
       embedHeight: '800px',
       // lazyLoad: false, // disable lazy loading of the iframe
-      // lazyLoadMargin: '1000', // pixels before viewport to start loading`
+      // lazyLoadMargin: '1000', // pixels before viewport to start loading
+      // dynamicHeight: true,
+      // embedMinHeight: '400',
+      // embedMaxHeight: '900',`
       : "";
 
     const html = `<div id='discourse-comments'></div>

--- a/frontend/discourse/app/instance-initializers/embed-mode-resize.js
+++ b/frontend/discourse/app/instance-initializers/embed-mode-resize.js
@@ -1,0 +1,29 @@
+import EmbedMode from "discourse/lib/embed-mode";
+
+let resizeObserver;
+
+function postHeight() {
+  if (parent === window) {
+    return;
+  }
+  parent.postMessage(
+    { type: "discourse-resize", height: document.body.scrollHeight },
+    "*"
+  );
+}
+
+export default {
+  initialize() {
+    if (!EmbedMode.enabled) {
+      return;
+    }
+
+    resizeObserver = new ResizeObserver(postHeight);
+    resizeObserver.observe(document.body);
+  },
+
+  teardown() {
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+  },
+};

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -118,8 +118,19 @@
     }
 
     if (e.data) {
-      if (e.data.type === "discourse-resize" && e.data.height && !DE.fullApp) {
-        iframe.height = e.data.height + "px";
+      if (e.data.type === "discourse-resize" && e.data.height) {
+        if (DE.fullApp && !DE.dynamicHeight) {
+          return;
+        }
+
+        var height = e.data.height;
+        if (DE.embedMinHeight) {
+          height = Math.max(height, parseInt(DE.embedMinHeight, 10));
+        }
+        if (DE.embedMaxHeight) {
+          height = Math.min(height, parseInt(DE.embedMaxHeight, 10));
+        }
+        iframe.height = height + "px";
       }
 
       if (e.data.type === "discourse-scroll" && e.data.top) {


### PR DESCRIPTION
## Summary

- Add opt-in `dynamicHeight` option for full app embeds that resizes the iframe based on content
- Add `embedMinHeight` / `embedMaxHeight` options to clamp the dynamic sizing
- Inside the embedded app, a `ResizeObserver` posts `discourse-resize` messages to the parent window
- Scrolling stays enabled inside the iframe — Discourse's virtual DOM only renders ~20 posts at a time and relies on internal scroll position
- Show the new options (commented out) in the admin embedding code snippet

## Usage

```html
<script type="text/javascript">
  window.DiscourseEmbed = {
    discourseUrl: 'https://forum.example.com/',
    topicId: 123,
    fullApp: true,
    dynamicHeight: true,        // opt-in to iframe resizing
    embedMinHeight: '400',      // optional, pixels
    embedMaxHeight: '900',      // optional, pixels
    embedHeight: '600px',       // initial height before first resize
  };
</script>
```

## How it works

- **Default (no `dynamicHeight`)**: Full app embed uses fixed height (`embedHeight` or `600px`) with internal scrolling. No change from current behavior.
- **With `dynamicHeight: true`**: The iframe resizes to match content height, clamped by `embedMinHeight` / `embedMaxHeight` if set. Short topics shrink the iframe (no wasted whitespace), long topics grow to max and scroll internally.

## Test plan

- [ ] Full app embed without `dynamicHeight` — verify unchanged behavior (fixed height, scrolling)
- [ ] Full app embed with `dynamicHeight: true` — verify iframe resizes as content loads
- [ ] Verify `embedMinHeight` / `embedMaxHeight` clamp the height correctly
- [ ] Verify standard (non-full-app) embed still resizes as before
- [ ] Open the composer in embed mode — verify height updates propagate
- [ ] Load a long topic — verify virtual DOM post loading works with scrolling
- [ ] Admin > Embedding page shows the new options commented out in the code snippet