### PR TITLE
PERF: Lazy load full app embed iframe with IntersectionObserver

### DIFF
--- a/frontend/discourse/admin/controllers/admin-embedding/index.js
+++ b/frontend/discourse/admin/controllers/admin-embedding/index.js
@@ -26,7 +26,9 @@ export default class AdminEmbeddingIndexController extends Controller {
     const fullAppLines = this.fullAppMode
       ? `
       fullApp: true,
-      embedHeight: '800px',`
+      embedHeight: '800px',
+      // lazyLoad: false, // disable lazy loading of the iframe
+      // lazyLoadMargin: '1000', // pixels before viewport to start loading`
       : "";
 
     const html = `<div id='discourse-comments'></div>

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -57,7 +57,6 @@
     }
   }
 
-  iframe.src = src;
   iframe.id = "discourse-embed-frame";
   iframe.width = "100%";
   iframe.frameBorder = "0";
@@ -67,7 +66,29 @@
   }
   iframe.referrerPolicy =
     DE.discourseReferrerPolicy || "no-referrer-when-downgrade";
-  comments.appendChild(iframe);
+
+  var lazyLoad = DE.fullApp && DE.lazyLoad !== false;
+
+  if (lazyLoad && "IntersectionObserver" in window) {
+    var margin = parseInt(DE.lazyLoadMargin, 10);
+    if (isNaN(margin)) {
+      margin = 1000;
+    }
+    comments.appendChild(iframe);
+    var observer = new IntersectionObserver(
+      function (entries) {
+        if (entries[0].isIntersecting) {
+          iframe.src = src;
+          observer.disconnect();
+        }
+      },
+      { rootMargin: margin + "px" }
+    );
+    observer.observe(iframe);
+  } else {
+    iframe.src = src;
+    comments.appendChild(iframe);
+  }
 
   // Thanks http://amendsoft-javascript.blogspot.ca/2010/04/find-x-and-y-coordinate-of-html-control.html
   function findPosY(obj) {


### PR DESCRIPTION
## Summary

- Defer loading the Discourse iframe for full app embeds until the user scrolls near it
- Feature detect `IntersectionObserver` — fall back to immediate loading if unavailable
- Default margin of 1000px to give the heavy PWA time to load before the user reaches it
- On by default for `fullApp` embeds, opt out with `lazyLoad: false`
- Configurable margin via `lazyLoadMargin`
- Show options in the admin embedding code snippet

## How it works

The iframe element is appended to the DOM immediately (preserving layout space with `embedHeight`), but its `src` is not set until the `IntersectionObserver` fires. The default 1000px margin gives Discourse a head start on loading before the user actually scrolls to the embed.

```js
DiscourseEmbed = {
  discourseUrl: 'https://forum.example.com/',
  topicId: 123,
  fullApp: true,
  // lazyLoad: false,          // disable lazy loading of the iframe
  // lazyLoadMargin: '1000',   // pixels before viewport to start loading
};
```

## Test plan

- [ ] Full app embed below the fold — verify iframe doesn't load until scrolling near it
- [ ] Full app embed above the fold — verify it loads immediately (IntersectionObserver fires right away)
- [ ] `lazyLoad: false` — verify immediate loading, same as current behavior
- [ ] Custom `lazyLoadMargin` — verify the margin is respected
- [ ] Standard (non-full-app) embed — verify unchanged behavior (always loads immediately)
- [ ] Browser without IntersectionObserver — verify falls back to immediate loading