### PR TITLE
FIX: don't mislabel allowed tags as disabled in composer tag search

### DIFF
--- a/app/services/tags/search.rb
+++ b/app/services/tags/search.rb
@@ -114,11 +114,11 @@ class Tags::Search
     context[:forbidden_message] = nil
   end
 
-  def append_disabled_tags(params:, tags:, guardian:)
+  def append_disabled_tags(params:, category:, tags:, guardian:)
     selected_ids = params.resolved_selected_tag_ids
     skip_ids = tags.map { |t| t[:id] } | selected_ids
 
-    excluded_tags =
+    candidate_tags =
       DiscourseTagging
         .filter_visible(
           Tag.where("position(LOWER(?) IN LOWER(tags.name)) <> 0", params.term),
@@ -126,6 +126,11 @@ class Tags::Search
         )
         .where.not(id: skip_ids)
         .limit(SiteSetting.max_tag_search_results)
+        .to_a
+
+    return if candidate_tags.empty?
+
+    excluded_tags = reject_allowed_tags(candidate_tags, params:, category:, tags:, guardian:)
 
     disabled =
       excluded_tags.map do |tag|
@@ -136,11 +141,12 @@ class Tags::Search
     context[:tags] = tags.concat(disabled) if disabled.present?
   end
 
-  def detect_forbidden_tag(params:, tags:, guardian:)
+  def detect_forbidden_tag(params:, category:, tags:, guardian:)
     return if tags.any? { |h| h[:name].downcase == params.term.downcase }
 
     tag = Tag.where_name(params.term).first
     return unless tag && guardian.can_see_tag?(tag)
+    return if reject_allowed_tags([tag], params:, category:, tags:, guardian:).empty?
 
     context[:forbidden] = params.q
     context[:forbidden_message] = explain_exclusion(
@@ -149,6 +155,23 @@ class Tags::Search
       params.resolved_selected_tag_ids,
       guardian,
     )
+  end
+
+  def reject_allowed_tags(candidates, params:, category:, tags:, guardian:)
+    return candidates unless params.capped_limit && tags.size >= params.capped_limit
+
+    only_tag_names = candidates.map(&:name)
+
+    allowed_names =
+      DiscourseTagging
+        .filter_allowed_tags(
+          guardian,
+          **params.filter_options.merge(category:, only_tag_names:, limit: nil),
+        )
+        .map(&:name)
+        .to_set
+
+    candidates.reject { |tag| allowed_names.include?(tag.name) }
   end
 
   def explain_exclusion(tag, params, selected_ids, guardian)

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe(Tags::Search) do
       fab!(:parent_tag) { Fabricate(:tag, name: "parent") }
       fab!(:child_tag) { Fabricate(:tag, name: "childtag") }
       fab!(:tag_group) do
-        Fabricate(:tag_group, name: "Child Group", parent_tag: parent_tag, tags: [child_tag])
+        Fabricate(:tag_group, name: "Child Group", parent_tag:, tags: [child_tag])
       end
 
       let(:params) { { q: "childtag", filterForInput: true } }
@@ -139,7 +139,7 @@ RSpec.describe(Tags::Search) do
       fab!(:category)
       fab!(:restricted_tag) { Fabricate(:tag, name: "restricted") }
 
-      before { CategoryTag.create!(category: category, tag: restricted_tag) }
+      before { CategoryTag.create!(category:, tag: restricted_tag) }
 
       let(:params) { { q: "restricted", filterForInput: true } }
 
@@ -156,9 +156,34 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "when allowed tags are cut off by the limit" do
+      fab!(:tag_foo1) { Fabricate(:tag, name: "foomatch1") }
+      fab!(:tag_foo2) { Fabricate(:tag, name: "foomatch2") }
+
+      let(:params) { { q: "foomatch", filterForInput: true, limit: 1 } }
+
+      it "does not mislabel allowed tags as disabled" do
+        disabled = result[:tags].select { |t| t[:disabled] }
+        expect(disabled).to be_empty
+      end
+    end
+
+    context "when an exact-match allowed tag is cut off by the limit" do
+      fab!(:tag_exact) { Fabricate(:tag, name: "exacthit") }
+      fab!(:tag_noise1) { Fabricate(:tag, name: "aexacthit") }
+      fab!(:tag_noise2) { Fabricate(:tag, name: "bexacthit") }
+
+      let(:params) { { q: "exacthit", filterForInput: true, limit: 1 } }
+
+      it "does not mark an allowed tag as forbidden" do
+        expect(result[:forbidden]).to be_nil
+        expect(result[:forbidden_message]).to be_nil
+      end
+    end
+
     context "when a forbidden tag is detected" do
       fab!(:target_tag) { Fabricate(:tag, name: "maintag") }
-      fab!(:synonym_tag) { Fabricate(:tag, name: "syntag", target_tag: target_tag) }
+      fab!(:synonym_tag) { Fabricate(:tag, name: "syntag", target_tag:) }
 
       let(:params) { { q: "syntag", excludeSynonyms: true } }
 


### PR DESCRIPTION
When searching tags in the composer, `filter_allowed_tags` applies a LIMIT (`max_tag_search_results`, default 5). If more allowed tags match the query than fit under the limit, the overflow is silently dropped.

`append_disabled_tags` then ran a naive substring query for visible tags matching the term, assumed any tag not in the allowed list must be excluded by filter rules, and asked `explain_exclusion` to fabricate a reason. Allowed-but-cut-off tags leaked into the disabled list and showed the vague fallback "\"X\" cannot be used in this category".

Because `filter_allowed_tags` orders by term (`DISTINCT ON (lower(name) = lower(term), ...)`), the same tag could appear allowed under one search term (prefix match, ranks high, fits in the limit) and disabled under another (mid-string match, ranks lower, gets cut off) — producing inconsistent verdicts for the same tag in the same category.

Before labeling any tag as disabled or forbidden, re-run `filter_allowed_tags` scoped to the candidate names (no limit) and drop any that come back allowed. Extracted to `reject_allowed_tags` so both `append_disabled_tags` and `detect_forbidden_tag` go through the same verification. The probe is skipped when the allowed result didn't saturate its limit, since no cutoff is possible in that case.

https://meta.discourse.org/t/400696