### PR TITLE
DEV: Tag analytics events with embed_mode in full app embed

### DIFF
--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -5,6 +5,7 @@ import {
   trackNextAjaxAsTopicView,
 } from "discourse/lib/ajax";
 import { sendBeaconPageview } from "discourse/lib/beacon-pageview";
+import EmbedMode from "discourse/lib/embed-mode";
 import {
   googleTagManagerPageChanged,
   resetPageTracking,
@@ -41,11 +42,16 @@ export default {
 
     startPageTracking(router, appEvents, documentTitle);
 
+    const isEmbedded = EmbedMode.enabled;
+
     // Out of the box, Discourse tries to track google analytics
     // if it is present
     if (typeof window._gaq !== "undefined") {
       appEvents.on("page:changed", (data) => {
         if (!data.replacedOnlyQueryParams) {
+          if (isEmbedded) {
+            window._gaq.push(["_setCustomVar", 1, "embed_mode", "true", 3]);
+          }
           window._gaq.push(["_set", "title", data.title]);
           window._gaq.push(["_trackPageview", data.url]);
         }
@@ -60,7 +66,11 @@ export default {
     ) {
       appEvents.on("page:changed", (data) => {
         if (!data.replacedOnlyQueryParams) {
-          window.ga("send", "pageview", { page: data.url, title: data.title });
+          let gaFields = { page: data.url, title: data.title };
+          if (isEmbedded) {
+            gaFields.dimension1 = "embed";
+          }
+          window.ga("send", "pageview", gaFields);
         }
       });
     }
@@ -72,6 +82,7 @@ export default {
           window.gtag("event", "page_view", {
             page_location: data.url,
             page_title: data.title,
+            embed_mode: isEmbedded || undefined,
           });
         }
       });
@@ -81,6 +92,9 @@ export default {
     if (typeof window.dataLayer !== "undefined") {
       appEvents.on("page:changed", (data) => {
         if (!data.replacedOnlyQueryParams) {
+          if (isEmbedded) {
+            data = Object.assign({}, data, { embed_mode: true });
+          }
           googleTagManagerPageChanged(data);
         }
       });

--- a/frontend/discourse/app/lib/page-tracker.js
+++ b/frontend/discourse/app/lib/page-tracker.js
@@ -74,6 +74,10 @@ export function googleTagManagerPageChanged(data) {
     },
   };
 
+  if (data.embed_mode) {
+    gtmData.embed_mode = true;
+  }
+
   _gtmPageChangedCallbacks.forEach((callback) => callback(gtmData));
 
   window.dataLayer.push(gtmData);


### PR DESCRIPTION
## Summary

Tag all analytics pageview events with `embed_mode` when Discourse is rendered in full app embed mode, so admins can segment embedded vs direct traffic in their dashboards.

- **GA v4 (gtag)**: `embed_mode: true` custom event parameter on `page_view` events
- **GA v3 (ga)**: `dimension1: "embed"` on pageview hits
- **GTM (dataLayer)**: `embed_mode: true` added to `virtualPageView` events
- **Legacy `_gaq`**: custom variable `embed_mode = "true"` (page-level scope)

## Context

Full app embed mode loads the complete Discourse app in an iframe on external sites. Without this change, these pageviews are indistinguishable from direct visits in analytics, which can inflate traffic numbers and skew metrics like bounce rate. Rather than suppressing these events entirely, tagging them gives admins full flexibility to filter, segment, or measure embed traffic as they see fit.

## Test plan

- [ ] Enable GA v4 + embed mode — verify `page_view` events include `embed_mode: true` parameter
- [ ] Enable GTM + embed mode — verify `virtualPageView` dataLayer pushes include `embed_mode: true`
- [ ] Load topic normally (no embed mode) — verify no `embed_mode` property on events
- [ ] Verify `embed_mode` is usable as a filter/dimension in GA4 reports