### PR TITLE
FIX: negative voter count in post voting who-voted popup

### DIFF
--- a/plugins/discourse-post-voting/app/controllers/post_voting/votes_controller.rb
+++ b/plugins/discourse-post-voting/app/controllers/post_voting/votes_controller.rb
@@ -86,15 +86,20 @@ module PostVoting
 
     def voters
       # TODO: Probably a site setting to hide/show voters
+      vote_scope = PostVotingVote.where(votable_id: @post.id, votable_type: "Post")
+
       voters =
         User
           .joins(:post_voting_votes)
-          .where(post_voting_votes: { votable_id: @post.id, votable_type: "Post" })
+          .merge(vote_scope)
           .order("post_voting_votes.created_at DESC")
           .select("users.*", "post_voting_votes.direction")
           .limit(VOTERS_LIMIT)
 
-      render_json_dump(voters: serialize_data(voters, BasicVoterSerializer))
+      render_json_dump(
+        voters: serialize_data(voters, BasicVoterSerializer),
+        total_voters_count: vote_scope.count,
+      )
     end
 
     private

--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-who-voted-list.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-who-voted-list.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action, get } from "@ember/object";
 import AsyncContent from "discourse/components/async-content";
@@ -13,9 +14,11 @@ import { i18n } from "discourse-i18n";
 import { whoVoted } from "../lib/post-voting-utilities";
 
 export default class PostVotingWhoVotedList extends Component {
+  @tracked totalVotersCount = 0;
+
   @bind
   calcRemainingCount(voters) {
-    return this.args.post.post_voting_vote_count - voters.length;
+    return Math.max(0, this.totalVotersCount - voters.length);
   }
 
   @bind
@@ -37,6 +40,7 @@ export default class PostVotingWhoVotedList extends Component {
   @action
   async loadWhoVoted() {
     const result = await whoVoted({ post_id: this.args.post.id });
+    this.totalVotersCount = result.total_voters_count ?? 0;
 
     return result.voters?.map((voter) => {
       const userAttrs = smallUserAttrs(voter);
@@ -61,28 +65,26 @@ export default class PostVotingWhoVotedList extends Component {
           {{i18n "loading"}}
         </:loading>
         <:content as |voters|>
-          {{#if whoVoted}}
-            {{#let (this.splitUpAndDownLists voters) as |splitVoters|}}
-              <PostVotingSmallUserList
-                @list={{get splitVoters "up"}}
-                @direction="up"
-              />
-              <PostVotingSmallUserList
-                @list={{get splitVoters "down"}}
-                @direction="down"
-              />
-            {{/let}}
-            {{#let (this.calcRemainingCount voters) as |remainingCount|}}
-              {{#if remainingCount}}
-                <span>
-                  {{i18n
-                    "post_voting.topic.voters_count_diff"
-                    count=remainingCount
-                  }}
-                </span>
-              {{/if}}
-            {{/let}}
-          {{/if}}
+          {{#let (this.splitUpAndDownLists voters) as |splitVoters|}}
+            <PostVotingSmallUserList
+              @list={{get splitVoters "up"}}
+              @direction="up"
+            />
+            <PostVotingSmallUserList
+              @list={{get splitVoters "down"}}
+              @direction="down"
+            />
+          {{/let}}
+          {{#let (this.calcRemainingCount voters) as |remainingCount|}}
+            {{#if remainingCount}}
+              <span>
+                {{i18n
+                  "post_voting.topic.voters_count_diff"
+                  count=remainingCount
+                }}
+              </span>
+            {{/if}}
+          {{/let}}
         </:content>
       </AsyncContent>
     </div>

--- a/plugins/discourse-post-voting/assets/stylesheets/common/post-voting.scss
+++ b/plugins/discourse-post-voting/assets/stylesheets/common/post-voting.scss
@@ -236,6 +236,11 @@
   }
 }
 
+.topic-post:has(.post-voting-post-list) {
+  position: relative;
+  z-index: 3;
+}
+
 .post-voting-post {
   position: relative;
   display: flex;

--- a/plugins/discourse-post-voting/spec/requests/post_voting/votes_controller_spec.rb
+++ b/plugins/discourse-post-voting/spec/requests/post_voting/votes_controller_spec.rb
@@ -191,6 +191,41 @@ RSpec.describe PostVoting::VotesController do
 
       expect(voters[1]["id"]).to eq(user_2.id)
       expect(voters[1]["direction"]).to eq(PostVotingVote.directions[:down])
+
+      expect(parsed["total_voters_count"]).to eq(2)
+    end
+
+    it "should return total_voters_count so the client can compute remaining voters correctly" do
+      sign_in(user)
+
+      user_2 = Fabricate(:user)
+      user_3 = Fabricate(:user)
+      user_4 = Fabricate(:user)
+
+      Fabricate(:post_voting_vote, votable: answer, user: user)
+      Fabricate(:post_voting_vote, votable: answer, user: user_2)
+      Fabricate(
+        :post_voting_vote,
+        votable: answer,
+        user: user_3,
+        direction: PostVotingVote.directions[:down],
+      )
+      Fabricate(
+        :post_voting_vote,
+        votable: answer,
+        user: user_4,
+        direction: PostVotingVote.directions[:down],
+      )
+
+      stub_const(PostVoting::VotesController, "VOTERS_LIMIT", 2) do
+        get "/post_voting/voters.json", params: { post_id: answer.id }
+      end
+
+      expect(response.status).to eq(200)
+
+      parsed = JSON.parse(response.body)
+
+      expect(parsed["total_voters_count"]).to eq(4)
     end
   end
 

--- a/plugins/discourse-post-voting/spec/system/page_objects/pages/post_voting_topic.rb
+++ b/plugins/discourse-post-voting/spec/system/page_objects/pages/post_voting_topic.rb
@@ -10,6 +10,15 @@ module PageObjects
       def has_no_comment_menu?
         has_no_css?(".post-voting-comments-menu")
       end
+
+      def click_vote_count(post)
+        find("#post_#{post.post_number} .post-voting-post-toggle-voters").click
+        self
+      end
+
+      def has_no_remaining_voters_label?
+        has_no_text?("more user")
+      end
     end
   end
 end

--- a/plugins/discourse-post-voting/spec/system/post_voting_spec.rb
+++ b/plugins/discourse-post-voting/spec/system/post_voting_spec.rb
@@ -22,6 +22,37 @@ RSpec.describe "Post voting" do
     expect(topic_page).to have_no_comment_menu
   end
 
+  it "does not show a negative remaining voters label when downvotes outnumber upvotes" do
+    SiteSetting.post_voting_enabled = true
+
+    topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: admin)
+    post_1 = Fabricate(:post, topic: topic, user: admin)
+    answer = Fabricate(:post, topic: topic, user: admin)
+
+    user3 = Fabricate(:user, refresh_auto_groups: true)
+
+    Fabricate(:post_voting_vote, votable: answer, user: user1)
+    Fabricate(
+      :post_voting_vote,
+      votable: answer,
+      user: user2,
+      direction: PostVotingVote.directions[:down],
+    )
+    Fabricate(
+      :post_voting_vote,
+      votable: answer,
+      user: user3,
+      direction: PostVotingVote.directions[:down],
+    )
+
+    sign_in(admin)
+
+    topic_page.visit_topic(topic)
+    topic_page.click_vote_count(answer)
+
+    expect(topic_page).to have_no_remaining_voters_label
+  end
+
   it "disallows voting on archived or closed topics" do
     SiteSetting.post_voting_enabled = true
     topic = Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: user2, archived: true)


### PR DESCRIPTION
When a post in a post-voting topic had both upvotes and downvotes, clicking the vote count to view the voter list could display a "and -N more users..." label with a negative number.

The root cause was that `calcRemainingCount` used the post's `post_voting_vote_count` (the net score, i.e. upvotes − downvotes) instead of the actual total number of voters. With 2 upvotes and 3 downvotes, net score is −1, minus 5 displayed voters = −6. Since −6 is truthy in JS, the label would render.

The fix adds `total_voters_count` to the `/post_voting/voters` JSON response so the client has a reliable total to subtract from. The component now stores this value and uses it in `calcRemainingCount` with a `Math.max(0, ...)` guard.

Also removes a no-op `{{#if whoVoted}}` template guard that referenced the imported function (always truthy) instead of a result, and fixes the voter popup z-index so it renders above subsequent posts.

Ref - t/181822