### PR TITLE
FEATURE: linkify URLs in calendar event descriptions

### DIFF
--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -25,6 +25,7 @@ module DiscoursePostEvent
     attributes :status
     attributes :url
     attributes :description
+    attributes :description_html
     attributes :location
     attributes :watching_invitee
     attributes :chat_enabled
@@ -123,6 +124,11 @@ module DiscoursePostEvent
 
     def include_url?
       object.url.present?
+    end
+
+    def description_html
+      return if object.description.blank?
+      EventParser.linkify_description(object.description, post: object.post)
     end
   end
 end

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
+import { trustHTML } from "@ember/template";
 import { modifier } from "ember-modifier";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -43,7 +44,7 @@ export default class DiscoursePostEventDescription extends Component {
   }
 
   <template>
-    {{#if @description}}
+    {{#if @descriptionHtml}}
       <section
         class="event__section event-description
           {{if this.clamp 'is-clamped'}}
@@ -55,7 +56,7 @@ export default class DiscoursePostEventDescription extends Component {
           class="event-description__content"
           {{(if this.clamp this.detectOverflow)}}
         >
-          <p class="event-description__text">{{@description}}</p>
+          <p class="event-description__text">{{trustHTML @descriptionHtml}}</p>
           {{#if this.showToggle}}
             <a
               href

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -250,7 +250,7 @@ export default class DiscoursePostEvent extends Component {
 
                 {{#if this.withDescription}}
                   <Description
-                    @description={{event.description}}
+                    @descriptionHtml={{event.descriptionHtml}}
                     @clamp={{this.clampDescription}}
                   />
                 {{/if}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event.js
@@ -35,6 +35,7 @@ export default class DiscoursePostEventEvent {
   @tracked location;
   @tracked url;
   @tracked description;
+  @tracked descriptionHtml;
   @tracked timezone;
   @tracked showLocalTime;
   @tracked status;
@@ -75,6 +76,7 @@ export default class DiscoursePostEventEvent {
     this.location = args.location;
     this.url = args.url;
     this.description = args.description;
+    this.descriptionHtml = args.description_html;
     this.timezone = args.timezone;
     this.showLocalTime = args.show_local_time;
     this.status = args.status;
@@ -169,6 +171,7 @@ export default class DiscoursePostEventEvent {
     this.timezone = event.timezone;
     this.showLocalTime = event.showLocalTime;
     this.description = event.description;
+    this.descriptionHtml = event.descriptionHtml;
     this.status = event.status;
     this.creator = event.creator;
     this.isClosed = event.isClosed;

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -406,10 +406,6 @@ $show-interested: inherit;
       margin-top: 0.25em;
     }
 
-    .event-description__text {
-      text-align: justify;
-    }
-
     &.is-clamped .event-description__text {
       @include line-clamp(3);
     }

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
@@ -70,5 +70,19 @@ module DiscoursePostEvent
         end
         .compact
     end
+
+    def self.linkify_description(text, post: nil)
+      escaped = ERB::Util.html_escape(text)
+      html =
+        escaped.gsub(URI::DEFAULT_PARSER.make_regexp(%w[http https])) do |url|
+          "<a href=\"#{url}\">#{url}</a>"
+        end
+
+      doc = Nokogiri::HTML5.fragment(html)
+      add_nofollow = post.nil? || post.add_nofollow?
+      PrettyText.add_rel_attributes_to_user_content(doc, add_nofollow)
+
+      doc.to_html
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_parser_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_parser_spec.rb
@@ -123,6 +123,50 @@ describe DiscoursePostEvent::EventParser do
     expect(events[0][:image]).to eq("upload://6c4fsAgNM6Npo7raNCPqVm2whzz.jpeg")
   end
 
+  it "extracts description as plain text" do
+    post_event = build_post user, <<~TXT
+      [event start="2020"]
+      Check out https://example.com for details
+      [/event]
+    TXT
+
+    events = parser.extract_events(post_event)
+    expect(events[0][:description]).to eq("Check out https://example.com for details")
+  end
+
+  describe ".linkify_description" do
+    it "wraps URLs in anchor tags" do
+      expect(parser.linkify_description("Visit https://example.com for info")).to eq(
+        'Visit <a href="https://example.com" rel="noopener nofollow ugc">https://example.com</a> for info',
+      )
+    end
+
+    it "handles multiple URLs" do
+      expect(parser.linkify_description("See https://a.com and https://b.com")).to eq(
+        'See <a href="https://a.com" rel="noopener nofollow ugc">https://a.com</a> and <a href="https://b.com" rel="noopener nofollow ugc">https://b.com</a>',
+      )
+    end
+
+    it "leaves text without URLs unchanged" do
+      expect(parser.linkify_description("No links here")).to eq("No links here")
+    end
+
+    it "escapes HTML in description text" do
+      expect(parser.linkify_description("Use <b>bold</b> & more at https://example.com")).to eq(
+        'Use &lt;b&gt;bold&lt;/b&gt; &amp; more at <a href="https://example.com" rel="noopener nofollow ugc">https://example.com</a>',
+      )
+    end
+
+    it "omits nofollow for staff posts" do
+      staff_user = Fabricate(:admin)
+      post = Fabricate(:post, user: staff_user)
+
+      expect(parser.linkify_description("See https://example.com", post: post)).to eq(
+        'See <a href="https://example.com">https://example.com</a>',
+      )
+    end
+  end
+
   context "with custom fields" do
     before { SiteSetting.discourse_post_event_allowed_custom_fields = "foo-bar|bar" }
 

--- a/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_detailed_response.json
+++ b/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_detailed_response.json
@@ -205,6 +205,12 @@
               "null"
             ]
           },
+          "description_html": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "location": {
             "type": [
               "string",

--- a/plugins/discourse-calendar/test/javascripts/integration/components/description-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/description-test.gjs
@@ -1,0 +1,33 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import Description from "../../discourse/components/discourse-post-event/description";
+
+module("Integration | Component | Description", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders plain text description", async function (assert) {
+    await render(
+      <template>
+        <Description @descriptionHtml="Just some plain text" />
+      </template>
+    );
+
+    assert.dom(".event-description__text").hasText("Just some plain text");
+    assert.dom(".event-description__text a").doesNotExist();
+  });
+
+  test("renders linkified description HTML", async function (assert) {
+    const html =
+      'Check out <a href="https://example.com">https://example.com</a> for details';
+
+    await render(
+      <template><Description @descriptionHtml={{html}} /></template>
+    );
+
+    assert
+      .dom(".event-description__text a")
+      .hasAttribute("href", "https://example.com")
+      .hasText("https://example.com");
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/unit/models/discourse-post-event-event-test.js
+++ b/plugins/discourse-calendar/test/javascripts/unit/models/discourse-post-event-event-test.js
@@ -1,0 +1,37 @@
+import { module, test } from "qunit";
+import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
+
+module("Unit | Model | DiscoursePostEventEvent", function () {
+  test("maps description fields from API response", function (assert) {
+    const event = DiscoursePostEventEvent.create({
+      id: 1,
+      description: "Visit https://example.com",
+      description_html:
+        'Visit <a href="https://example.com">https://example.com</a>',
+    });
+
+    assert.strictEqual(event.description, "Visit https://example.com");
+    assert.strictEqual(
+      event.descriptionHtml,
+      'Visit <a href="https://example.com">https://example.com</a>'
+    );
+  });
+
+  test("updateFromEvent copies description fields", function (assert) {
+    const event = DiscoursePostEventEvent.create({ id: 1 });
+    const updated = DiscoursePostEventEvent.create({
+      id: 1,
+      description: "Visit https://example.com",
+      description_html:
+        'Visit <a href="https://example.com">https://example.com</a>',
+    });
+
+    event.updateFromEvent(updated);
+
+    assert.strictEqual(event.description, "Visit https://example.com");
+    assert.strictEqual(
+      event.descriptionHtml,
+      'Visit <a href="https://example.com">https://example.com</a>'
+    );
+  });
+});


### PR DESCRIPTION
Event descriptions are stored as plain text (extracted via `doc.text.strip` from cooked HTML), so any URLs typed by the user were rendered as non-clickable text in the event popup.

This adds a `description_html` attribute to the event serializer that linkifies URLs at serialization time via `EventParser.linkify_description`. The method wraps URL matches in `<a>` tags and delegates `rel` attribute handling to `PrettyText.add_rel_attributes_to_user_content`, which respects trust levels, staff status, domain allowlists, and the `add_rel_nofollow_to_user_content` site setting.

The raw `description` attribute remains unchanged (plain text) so the edit form continues to show editable text without HTML markup.

On the client side, the Description component now receives `@descriptionHtml` and renders it via `trustHTML`. The JS model maps the new `description_html` field from the API response.

Also removes `text-align: justify` from the description text style.

Ref - t/180829