### PR TITLE
UX: Truncate category list in disabled tag reasons

### DIFF
--- a/app/services/tags/search.rb
+++ b/app/services/tags/search.rb
@@ -221,12 +221,23 @@ class Tags::Search
 
     if category_names.present?
       category_names.uniq!
-      I18n.t(
-        "tags.forbidden.restricted_to",
-        count: category_names.count,
-        tag_name: tag.name,
-        category_names: category_names.join(", "),
-      )
+      category_names.sort!
+
+      if category_names.size > 3
+        I18n.t(
+          "tags.forbidden.restricted_to_truncated",
+          tag_name: tag.name,
+          category_names: category_names.first(3).join(", "),
+          more_count: category_names.size - 3,
+        )
+      else
+        I18n.t(
+          "tags.forbidden.restricted_to",
+          count: category_names.count,
+          tag_name: tag.name,
+          category_names: category_names.join(", "),
+        )
+      end
     else
       I18n.t("tags.forbidden.in_this_category", tag_name: tag.name)
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5554,6 +5554,7 @@ en:
       restricted_to:
         one: '"%{tag_name}" is restricted to the "%{category_names}" category'
         other: '"%{tag_name}" is restricted to the following categories: %{category_names}'
+      restricted_to_truncated: '"%{tag_name}" is restricted to the following categories: %{category_names}, and %{more_count} more'
       synonym: 'This is a synonym for "%{tag_name}". Use "%{tag_name}" instead.'
       has_synonyms: '"%{tag_name}" cannot be used because it has synonyms.'
       one_tag_per_topic_group: 'Only one tag from the "%{tag_group_name}" group is allowed per topic'

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1455,6 +1455,52 @@ RSpec.describe TagsController do
           expect(result["disabled"]).to eq(true)
         end
 
+        it "truncates category names when tag is restricted to many categories" do
+          categories = [category] + (1..4).map { |i| Fabricate(:category, tags: [yup]) }
+
+          get "/tags/filter/search.json",
+              params: {
+                q: yup.name,
+                filterForInput: true,
+                categoryId: Fabricate(:category).id,
+              }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body["results"].find { |t| t["name"] == yup.name }
+          expect(result).to be_present
+          expect(result["disabled"]).to eq(true)
+
+          sorted_names = categories.map(&:name).sort
+          expect(result["title"]).to eq(
+            I18n.t(
+              "tags.forbidden.restricted_to_truncated",
+              tag_name: yup.name,
+              category_names: sorted_names.first(3).join(", "),
+              more_count: 2,
+            ),
+          )
+        end
+
+        it "truncates category names in forbidden_message when restricted to many categories" do
+          categories = [category] + (1..4).map { |i| Fabricate(:category, tags: [yup]) }
+
+          get "/tags/filter/search.json",
+              params: {
+                q: yup.name,
+                categoryId: Fabricate(:category).id,
+              }
+
+          sorted_names = categories.map(&:name).sort
+          expect(response.parsed_body["forbidden_message"]).to eq(
+            I18n.t(
+              "tags.forbidden.restricted_to_truncated",
+              tag_name: yup.name,
+              category_names: sorted_names.first(3).join(", "),
+              more_count: 2,
+            ),
+          )
+        end
+
         it "can filter on category without q param" do
           Fabricate(:tag, name: "nope")
           get "/tags/filter/search.json", params: { categoryId: category.id }


### PR DESCRIPTION
When a tag is restricted to many categories, the disabled reason text in the composer tag search lists every single category name, creating a wall of text that overwhelms the dropdown.

Truncate to 3 category names with a "+ N more" suffix when the count exceeds 3. Also sort category names alphabetically for consistency.

Ref - t/181010