### PR TITLE
UX: avoid spacing between gallery mode

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -184,7 +184,7 @@
     padding: var(--space-half) var(--space-2) 0 var(--space-2);
     margin-block: var(--space-4);
 
-    > div {
+    > div:not(.composer-image-gallery__mode-buttons) {
       display: flex;
       flex-wrap: wrap;
       gap: var(--space-2);


### PR DESCRIPTION
Small tweak needed to avoid the image gallery mode buttons to be spaced apart:

<img width="1454" height="514" alt="CleanShot 2026-04-16 at 14 52 47@2x" src="https://github.com/user-attachments/assets/8f892d40-92c2-49f8-b50a-ca03b16fa484" />
