### PR TITLE
 FIX: Use dynamic first emoji group instead of hardcoded "smileys_&_emotion"

### DIFF
--- a/frontend/discourse/app/components/emoji-picker/content.gjs
+++ b/frontend/discourse/app/components/emoji-picker/content.gjs
@@ -33,7 +33,6 @@ import { eq, gt, includes, notEq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import DiversityMenu from "./diversity-menu";
 
-const DEFAULT_VISIBLE_SECTIONS = ["favorites", "smileys_&_emotion"];
 const DEFAULT_LAST_SECTION = "favorites";
 
 const tonableEmojiTitle = (emoji, diversity) => {
@@ -61,7 +60,7 @@ export default class EmojiPicker extends Component {
   @tracked filteredEmojis = null;
   @tracked scrollObserverEnabled = true;
   @tracked scrollDirection = "up";
-  @tracked visibleSections = DEFAULT_VISIBLE_SECTIONS;
+  @tracked visibleSections = ["favorites"];
   @tracked lastVisibleSection = DEFAULT_LAST_SECTION;
   @tracked term = this.args.term;
 
@@ -368,6 +367,14 @@ export default class EmojiPicker extends Component {
 
     try {
       this.emojiStore.list = await ajax("/emojis.json");
+
+      // Dynamically set visible sections to favorites + first actual group
+      // instead of hardcoding "smileys_&_emotion"
+      const sections = Object.keys(this.emojiStore.list);
+      const firstGroup = sections.find((g) => g !== "favorites");
+      this.visibleSections = firstGroup
+        ? ["favorites", firstGroup]
+        : ["favorites"];
 
       // we cant filter an empty list so have to wait for it
       this.didInputFilter(this.term);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                   

When a plugin (such as `discourse-custom-emoji-priority`) reorders emojis so custom emojis appear at the top of the favorites section, the hardcoded second section `"smileys_&_emotion"` no longer reflects the actual first emoji group. This causes the emoji picker to display only the favorites section's first emoji instead of showing the full intended picker state.                                            

### Problem                                                                                                                                                                                                  

The original code hardcoded the default visible sections:

```javascript
const DEFAULT_VISIBLE_SECTIONS = ["favorites", "smileys_&_emotion"];
```

This hardcoded group name assumes the emoji store always has "smileys_&_emotion" as the first non-favorites group. However, when plugins modify the emoji loading order or add custom emoji groupings, this assumption breaks, resulting in an empty or incorrect second section in the picker UI.                                                                                                                       

### Solution                                                                                                                   

Instead of hardcoding "smileys_&_emotion", dynamically determine the first actual emoji group from the loaded emoji store:                                                                                   

```javascript
const sections = Object.keys(this.emojiStore.list);                                                                                                                                                          
const firstGroup = sections.find((g) => g !== "favorites");                                                                
this.visibleSections = firstGroup ? ["favorites", firstGroup] : ["favorites"];                                                                                                                                                                                           
```

This ensures the emoji picker always displays favorites plus the first available emoji group, regardless of how plugins may have altered the emoji ordering or groupings.                                    

### Test Plan                                                                                                                                                                                                    

1. Install a plugin that reorders emojis (e.g., discourse-custom-emoji-priority)                                                                                                                             
2. Add custom emojis to your Discourse instance
3. Open the emoji picker in a new post/composer                                                                                                                                                              
4. Verify that both favorites and the first emoji group are visible with correct content                                                                                                                     

### Related Plugin                                                                                                                                                                                               

- https://github.com/InternationalRiversiders/discourse-custom-emoji-priority - Plugin that motivated this fix