### PR TITLE
DEV: update event plugin category settings to be compatible with formkit

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/category-custom-settings/show-event-category-sorting-settings.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/category-custom-settings/show-event-category-sorting-settings.gjs
@@ -1,49 +1,115 @@
-/* eslint-disable ember/no-classic-components */
-import Component, { Input } from "@ember/component";
-import { tagName } from "@ember-decorators/component";
-import { or } from "discourse/truth-helpers";
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { i18n } from "discourse-i18n";
 
-@tagName("")
 export default class ShowEventCategorySortingSettings extends Component {
+  @service siteSettings;
+
+  get showSection() {
+    return (
+      this.siteSettings.sort_categories_by_event_start_date_enabled ||
+      this.siteSettings.disable_resorting_on_categories_enabled
+    );
+  }
+
+  @action
+  onChangeSortByEventStartDate(event) {
+    this.args.outletArgs.category.set(
+      "custom_fields.sort_topics_by_event_start_date",
+      event.target.checked
+    );
+  }
+
+  @action
+  onChangeDisableTopicResorting(event) {
+    this.args.outletArgs.category.set(
+      "custom_fields.disable_topic_resorting",
+      event.target.checked
+    );
+  }
+
   <template>
-    {{#if
-      (or
-        this.siteSettings.sort_categories_by_event_start_date_enabled
-        this.siteSettings.disable_resorting_on_categories_enabled
-      )
-    }}
-      <section>
-        <h3>{{i18n
+    {{#if this.showSection}}
+      {{#if this.siteSettings.enable_simplified_category_creation}}
+        <@outletArgs.form.Section
+          @title={{i18n
             "discourse_post_event.category.settings_sections.event_sorting"
-          }}</h3>
-
-        {{#if this.siteSettings.sort_categories_by_event_start_date_enabled}}
-          <section class="field show-subcategory-list-field">
-            <label>
-              <Input
+          }}
+          class="category-custom-settings-outlet show-event-category-sorting-settings"
+        >
+          <@outletArgs.form.Object @name="custom_fields" as |object|>
+            {{#if
+              this.siteSettings.sort_categories_by_event_start_date_enabled
+            }}
+              <object.Field
+                @name="sort_topics_by_event_start_date"
+                @title={{i18n
+                  "discourse_post_event.category.sort_topics_by_event_start_date"
+                }}
+                @format="max"
                 @type="checkbox"
-                @checked={{this.category.custom_fields.sort_topics_by_event_start_date}}
-              />
-              {{i18n
-                "discourse_post_event.category.sort_topics_by_event_start_date"
-              }}
-            </label>
-          </section>
-        {{/if}}
+                as |field|
+              >
+                <field.Control />
+              </object.Field>
+            {{/if}}
 
-        {{#if this.siteSettings.disable_resorting_on_categories_enabled}}
-          <section class="field show-subcategory-list-field">
-            <label>
-              <Input
+            {{#if this.siteSettings.disable_resorting_on_categories_enabled}}
+              <object.Field
+                @name="disable_topic_resorting"
+                @title={{i18n
+                  "discourse_post_event.category.disable_topic_resorting"
+                }}
+                @format="max"
                 @type="checkbox"
-                @checked={{this.category.custom_fields.disable_topic_resorting}}
-              />
-              {{i18n "discourse_post_event.category.disable_topic_resorting"}}
-            </label>
-          </section>
-        {{/if}}
-      </section>
+                as |field|
+              >
+                <field.Control />
+              </object.Field>
+            {{/if}}
+          </@outletArgs.form.Object>
+        </@outletArgs.form.Section>
+      {{else}}
+        <div
+          class="category-custom-settings-outlet show-event-category-sorting-settings"
+        >
+          <h3>{{i18n
+              "discourse_post_event.category.settings_sections.event_sorting"
+            }}</h3>
+
+          {{#if this.siteSettings.sort_categories_by_event_start_date_enabled}}
+            <section class="field">
+              <label class="checkbox-label">
+                <input
+                  id="sort-topics-by-event-start-date"
+                  type="checkbox"
+                  checked={{@outletArgs.category.custom_fields.sort_topics_by_event_start_date}}
+                  {{on "change" this.onChangeSortByEventStartDate}}
+                />
+                {{i18n
+                  "discourse_post_event.category.sort_topics_by_event_start_date"
+                }}
+              </label>
+            </section>
+          {{/if}}
+
+          {{#if this.siteSettings.disable_resorting_on_categories_enabled}}
+            <section class="field">
+              <label class="checkbox-label">
+                <input
+                  id="disable-topic-resorting"
+                  type="checkbox"
+                  checked={{@outletArgs.category.custom_fields.disable_topic_resorting}}
+                  {{on "change" this.onChangeDisableTopicResorting}}
+                />
+                {{i18n "discourse_post_event.category.disable_topic_resorting"}}
+              </label>
+            </section>
+          {{/if}}
+        </div>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/plugins/discourse-calendar/spec/system/category_event_sorting_settings_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_event_sorting_settings_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "Event Sorting Category Settings" do
+  fab!(:admin)
+  fab!(:category)
+
+  let(:category_page) { PageObjects::Pages::Category.new }
+  let(:form) { PageObjects::Components::FormKit.new(".form-kit") }
+  let(:banner) { PageObjects::Components::AdminChangesBanner.new }
+  let(:toasts) { PageObjects::Components::Toasts.new }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.sort_categories_by_event_start_date_enabled = true
+    SiteSetting.disable_resorting_on_categories_enabled = true
+    sign_in(admin)
+  end
+
+  context "when simplified category creation is enabled" do
+    before { SiteSetting.enable_simplified_category_creation = true }
+
+    it "can toggle event sorting custom fields via FormKit" do
+      category_page.visit_settings(category)
+
+      form.field("custom_fields.sort_topics_by_event_start_date").toggle
+      form.field("custom_fields.disable_topic_resorting").toggle
+      banner.click_save
+
+      expect(toasts).to have_success(I18n.t("js.saved"))
+      category.reload
+      expect(category.custom_fields["sort_topics_by_event_start_date"]).to eq(true)
+      expect(category.custom_fields["disable_topic_resorting"]).to eq(true)
+    end
+  end
+
+  context "when simplified category creation is disabled" do
+    before { SiteSetting.enable_simplified_category_creation = false }
+
+    it "can toggle event sorting custom fields via legacy form" do
+      category_page.visit_settings(category)
+
+      find("#sort-topics-by-event-start-date").click
+      find("#disable-topic-resorting").click
+      category_page.save_settings
+
+      expect(toasts).to have_success(I18n.t("js.saved"))
+      category.reload
+      expect(category.custom_fields["sort_topics_by_event_start_date"]).to eq(true)
+      expect(category.custom_fields["disable_topic_resorting"]).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This updates the category settings for the Events plugin, `sort_topics_by_event_start_date` and `disable_topic_resorting`, to a glimmer component and formkit, so they're compatible with the setting `enable_simplified_category_creation` — the legacy settings are still available when that change is disabled. 