### PR TITLE
FIX: check user id from model in user-invite route

### DIFF
--- a/frontend/discourse/app/routes/user-invited.js
+++ b/frontend/discourse/app/routes/user-invited.js
@@ -5,7 +5,7 @@ export default class UserInvited extends DiscourseRoute {
   setupController(controller) {
     const can_see_invite_details =
       this.currentUser.staff ||
-      this.controllerFor("user").id === this.currentUser?.id;
+      this.modelFor("user").id === this.currentUser?.id;
 
     controller.setProperties({
       can_see_invite_details,

--- a/frontend/discourse/tests/acceptance/user-test.js
+++ b/frontend/discourse/tests/acceptance/user-test.js
@@ -67,6 +67,14 @@ acceptance("User Routes", function (needs) {
       .hasClass("user-invites-page", "has the body class");
   });
 
+  test("Invites - non-staff user viewing own page sees invite tabs", async function (assert) {
+    updateCurrentUser({ admin: false, moderator: false });
+    await visit("/u/eviltrout/invited/pending");
+    assert
+      .dom(".user-navigation.user-navigation-secondary")
+      .exists("renders the invite tabs navigation");
+  });
+
   test("Notifications", async function (assert) {
     await visit("/u/eviltrout/notifications");
 


### PR DESCRIPTION
`this.controllerFor("user").id` doesn't exist so this fails and users can't see their invite details unless they're staff. This switches to `modelFor` to correct it, and adds an acceptance test to avoid future regressions. 