### PR TITLE
PERF: Use native iframe lazy loading for full app embeds

### DIFF
--- a/frontend/discourse/admin/controllers/admin-embedding/index.js
+++ b/frontend/discourse/admin/controllers/admin-embedding/index.js
@@ -27,8 +27,7 @@ export default class AdminEmbeddingIndexController extends Controller {
       ? `
       fullApp: true,
       embedHeight: '800px',
-      // lazyLoad: false, // disable lazy loading of the iframe
-      // lazyLoadMargin: '1000', // pixels before viewport to start loading
+      // lazyLoad: false, // disable native lazy loading of the iframe
       // dynamicHeight: true,
       // embedMinHeight: '400',
       // embedMaxHeight: '900',`

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -57,38 +57,18 @@
     }
   }
 
+  iframe.src = src;
   iframe.id = "discourse-embed-frame";
   iframe.width = "100%";
   iframe.frameBorder = "0";
   iframe.scrolling = DE.fullApp ? "yes" : "no";
   if (DE.fullApp) {
     iframe.style.height = DE.embedHeight || "600px";
+    iframe.loading = DE.lazyLoad === false ? "eager" : "lazy";
   }
   iframe.referrerPolicy =
     DE.discourseReferrerPolicy || "no-referrer-when-downgrade";
-
-  var lazyLoad = DE.fullApp && DE.lazyLoad !== false;
-
-  if (lazyLoad && "IntersectionObserver" in window) {
-    var margin = parseInt(DE.lazyLoadMargin, 10);
-    if (isNaN(margin)) {
-      margin = 1000;
-    }
-    comments.appendChild(iframe);
-    var observer = new IntersectionObserver(
-      function (entries) {
-        if (entries[0].isIntersecting) {
-          iframe.src = src;
-          observer.disconnect();
-        }
-      },
-      { rootMargin: margin + "px" }
-    );
-    observer.observe(iframe);
-  } else {
-    iframe.src = src;
-    comments.appendChild(iframe);
-  }
+  comments.appendChild(iframe);
 
   // Thanks http://amendsoft-javascript.blogspot.ca/2010/04/find-x-and-y-coordinate-of-html-control.html
   function findPosY(obj) {


### PR DESCRIPTION
## Summary

Replaces the `IntersectionObserver` implementation from #39299 with the native `loading="lazy"` attribute on the iframe. All supported browsers (Chrome 77+, Safari 16.4+, Firefox 121+) handle this, and the browser-determined threshold adapts to connection speed — generally smarter than a fixed pixel margin.

- Drops ~20 lines of JS and the feature-detection fallback
- Removes the `lazyLoadMargin` option (no longer configurable — browser decides)
- `lazyLoad: false` still opts out by setting `loading="eager"`
- Admin embedding snippet updated to drop the `lazyLoadMargin` line

Shipped two days ago in #39299, so no external consumers should depend on `lazyLoadMargin` yet.

## Test plan

- [ ] Full app embed below the fold — verify iframe defers loading until scrolling near it
- [ ] Full app embed above the fold — verify it loads immediately
- [ ] `lazyLoad: false` — verify immediate loading, same as pre-#39299 behavior
- [ ] Standard (non-full-app) embed — verify unchanged behavior