### PR TITLE
FIX: Use iframe style.height for embed resize messages

### DIFF
--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -130,7 +130,7 @@
         if (DE.embedMaxHeight) {
           height = Math.min(height, parseInt(DE.embedMaxHeight, 10));
         }
-        iframe.height = height + "px";
+        iframe.style.height = height + "px";
       }
 
       if (e.data.type === "discourse-scroll" && e.data.top) {


### PR DESCRIPTION
## Summary

When Discourse is loaded in full app embed mode with `dynamicHeight: true`, the iframe was not resizing in production despite `discourse-resize` messages arriving correctly. 

The full app path sets `iframe.style.height` as an inline style for the initial height. Inline styles always win over the `height` HTML attribute, so our resize handler — which set `iframe.height = ...` — had no visible effect.

This changes the resize handler to set `iframe.style.height` so it actually overrides the inline style. This also works for the standard (non-full-app) embed path since no inline style is set there initially.

## Test plan

- [ ] Full app embed with `dynamicHeight: true` — verify iframe height updates as content loads
- [ ] Standard (non-full-app) embed — verify iframe still resizes correctly
- [ ] CSS `max-height` on the iframe still wins (inline `height` doesn't override `max-height`)