### PR TITLE
dev: add `custom-homepage-model` transformer

### DIFF
--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -52,6 +52,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "composer-toggles-class",
   "create-topic-button-class",
   "create-topic-label",
+  "custom-homepage-model",
   "flag-button-disabled-state",
   "flag-button-dynamic-class",
   "flag-button-render-decision",

--- a/frontend/discourse/app/routes/discovery/custom.js
+++ b/frontend/discourse/app/routes/discovery/custom.js
@@ -1,0 +1,14 @@
+import { applyValueTransformer } from "discourse/lib/transformer";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default class DiscoveryCustomRoute extends DiscourseRoute {
+  queryParams = {
+    q: { refreshModel: true },
+  };
+
+  model(data) {
+    return applyValueTransformer("custom-homepage-model", null, {
+      queryParams: data,
+    });
+  }
+}

--- a/frontend/discourse/app/templates/discovery/custom.gjs
+++ b/frontend/discourse/app/templates/discovery/custom.gjs
@@ -1,11 +1,15 @@
 import BlockOutlet from "discourse/blocks/block-outlet";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  <BlockOutlet @name="homepage-blocks">
+  <BlockOutlet @name="homepage-blocks" @outletArgs={{lazyHash model=@model}}>
     <:after as |hasBlocks|>
-      <PluginOutlet @name="custom-homepage">
+      <PluginOutlet
+        @name="custom-homepage"
+        @outletArgs={{lazyHash model=@model}}
+      >
         {{#if @controller.currentUser.admin}}
           {{#unless hasBlocks}}
             <p class="alert alert-info">

--- a/frontend/discourse/tests/unit/routes/discovery-custom-test.js
+++ b/frontend/discourse/tests/unit/routes/discovery-custom-test.js
@@ -1,0 +1,71 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+module("Unit | Route | discovery-custom", function (hooks) {
+  setupTest(hooks);
+
+  test("model returns null by default when no transformer is registered", async function (assert) {
+    const route = this.owner.lookup("route:discovery.custom");
+
+    assert.strictEqual(await route.model({}), null);
+  });
+
+  test("custom-homepage-model value transformer can provide the model", async function (assert) {
+    const route = this.owner.lookup("route:discovery.custom");
+    const homepageModel = { latest: [{ id: 1 }], hot: [{ id: 2 }] };
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "custom-homepage-model",
+        () => homepageModel
+      );
+    });
+
+    assert.strictEqual(await route.model({}), homepageModel);
+  });
+
+  test("custom-homepage-model value transformer can be async", async function (assert) {
+    const route = this.owner.lookup("route:discovery.custom");
+    const homepageModel = { leaderboard: { users: [] } };
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "custom-homepage-model",
+        async () => homepageModel
+      );
+    });
+
+    assert.strictEqual(await route.model({}), homepageModel);
+  });
+
+  test("custom-homepage-model value transformer receives queryParams in context", async function (assert) {
+    const route = this.owner.lookup("route:discovery.custom");
+    let receivedContext;
+
+    withPluginApi((api) => {
+      api.registerValueTransformer("custom-homepage-model", ({ context }) => {
+        receivedContext = context;
+        return null;
+      });
+    });
+
+    await route.model({ q: "search term" });
+
+    assert.deepEqual(receivedContext.queryParams, { q: "search term" });
+  });
+
+  test("multiple value transformers compose, each receiving the previous value", async function (assert) {
+    const route = this.owner.lookup("route:discovery.custom");
+
+    withPluginApi((api) => {
+      api.registerValueTransformer("custom-homepage-model", () => ({ a: 1 }));
+      api.registerValueTransformer("custom-homepage-model", ({ value }) => ({
+        ...value,
+        b: 2,
+      }));
+    });
+
+    assert.deepEqual(await route.model({}), { a: 1, b: 2 });
+  });
+});


### PR DESCRIPTION
Previously, themes/plugins customizing the custom homepage had to fetch data from inside components using AsyncContent or via fetch, which produced per-component loading spinners after the outlet rendered.

  This adds a custom-homepage-model value transformer so themes and
  plugins can provide the model (sync or async) at route-load time. The
  page renders completely instead of flashing per-block spinners.

Consumers who still want to fetch data after the homepage is loaded will not be affected by this; the model returning null should not make the page loading slower