### PR TITLE
UX: replace old slide-in admin menu behavior with DMenu

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -95,14 +95,6 @@ $mobile-breakpoint: 700px;
   .row::after {
     clear: both;
   }
-
-  &.admin-site-settings-category {
-    overflow: hidden;
-
-    @media (width <= 500px) {
-      background-color: var(--primary-very-low);
-    }
-  }
 }
 
 .admin-contents table {
@@ -702,6 +694,7 @@ $mobile-breakpoint: 700px;
 .admin-controls {
   display: flex;
   align-items: center;
+  border-bottom: 1px solid var(--content-border-color);
 
   .admin-actions {
     margin-left: auto;
@@ -790,10 +783,6 @@ $mobile-breakpoint: 700px;
       }
     }
 
-    @include viewport.until(sm) {
-      margin: 0 -10px;
-    }
-
     input {
       @include viewport.until(md) {
         max-width: 150px;
@@ -813,21 +802,6 @@ $mobile-breakpoint: 700px;
           margin-right: 0.5em;
         }
       }
-    }
-  }
-
-  .menu-toggle {
-    border-color: var(--primary-medium);
-    border-radius: 3px;
-    background: transparent;
-    color: var(--primary);
-
-    &:hover {
-      background-color: var(--primary-low-mid);
-    }
-
-    .not-mobile-device & {
-      display: none;
     }
   }
 
@@ -881,16 +855,9 @@ $mobile-breakpoint: 700px;
 .admin-nav {
   width: 18%;
   box-sizing: border-box;
-  position: relative; // The admin-nav becomes a slide-out menu at the mobile-nav breakpoint
 
-  @media (max-width: $mobile-breakpoint) {
-    position: absolute;
-    z-index: z("base") - 1;
-    width: 250px;
-  }
-
-  @media (width <= 500px) {
-    width: 50%;
+  @include viewport.until(sm) {
+    display: none;
   }
 
   .nav-stacked {
@@ -914,29 +881,55 @@ $mobile-breakpoint: 700px;
   width: 82%;
   box-sizing: border-box;
 
-  @media (max-width: $mobile-breakpoint) {
+  @include viewport.until(sm) {
     width: 100%;
     border: none;
-  }
-}
-
-.admin-detail.mobile-open {
-  @media (max-width: $mobile-breakpoint) {
-    transition: transform 0.3s ease;
-    transform: translateX(250px);
-  }
-
-  @media (width <= 500px) {
-    transition: transform 0.3s ease;
-    transform: translateX(50%);
-  }
-}
-
-.admin-detail.mobile-closed {
-  @media (max-width: $mobile-breakpoint) {
-    transition: transform 0.3s ease;
-    transform: translateX(0);
     padding: 30px 20px;
+  }
+}
+
+.fk-d-menu-modal.admin-site-settings-category-nav-content,
+.fk-d-menu-modal.admin-watched-words-action-nav-content {
+  justify-content: flex-start;
+
+  .d-modal__container {
+    width: 80vw;
+    max-width: 300px;
+    height: 100%;
+    max-height: 100%;
+    border-radius: 0;
+
+    &.is-entering {
+      animation: admin-nav-slide-in 250ms ease;
+    }
+
+    &.is-exiting {
+      animation: admin-nav-slide-out 250ms ease;
+    }
+  }
+
+  .fk-d-menu-modal__grip {
+    display: none;
+  }
+}
+
+@keyframes admin-nav-slide-in {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes admin-nav-slide-out {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-100%);
   }
 }
 

--- a/app/assets/stylesheets/admin/site-settings.scss
+++ b/app/assets/stylesheets/admin/site-settings.scss
@@ -6,8 +6,10 @@
   max-width: 300px;
 }
 
-.admin-controls.admin-site-settings-filter-controls .menu-toggle {
-  margin-left: 0.5em;
+.fk-d-menu-modal.admin-site-settings-category-nav-content {
+  .admin-site-settings-category-nav__list a.active {
+    background: var(--d-selected);
+  }
 }
 
 .admin-filtered-site-settings {

--- a/frontend/discourse/admin/components/admin-site-settings-category-nav.gjs
+++ b/frontend/discourse/admin/components/admin-site-settings-category-nav.gjs
@@ -1,0 +1,61 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { LinkTo } from "@ember/routing";
+import { next } from "@ember/runloop";
+import concatClass from "discourse/helpers/concat-class";
+import { waitForAnimationEnd } from "discourse/lib/animation-utils";
+
+export default class AdminSiteSettingsCategoryNav extends Component {
+  get categories() {
+    return this.args.categories ?? this.args.data?.categories ?? [];
+  }
+
+  get filtersApplied() {
+    return this.args.filtersApplied ?? this.args.data?.filtersApplied ?? false;
+  }
+
+  @action
+  onLinkClick() {
+    next(() => this.args.close?.());
+  }
+
+  @action
+  async scrollToActive(element) {
+    const modalContainer = element.closest(".d-modal__container");
+    if (modalContainer) {
+      await waitForAnimationEnd(modalContainer);
+    }
+    element.querySelector("a.active")?.scrollIntoView({ block: "center" });
+  }
+
+  <template>
+    <ul
+      class="nav nav-stacked admin-site-settings-category-nav__list"
+      {{didInsert this.scrollToActive}}
+    >
+      {{#each this.categories as |category|}}
+        <li
+          class={{concatClass
+            "admin-site-settings-category-nav__item"
+            category.nameKey
+          }}
+        >
+          <LinkTo
+            @route="adminSiteSettingsCategory"
+            @model={{category.nameKey}}
+            class={{category.nameKey}}
+            title={{category.name}}
+            {{on "click" this.onLinkClick}}
+          >
+            {{category.name}}
+            {{#if this.filtersApplied}}
+              <span class="count">({{category.count}})</span>
+            {{/if}}
+          </LinkTo>
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}

--- a/frontend/discourse/admin/components/admin-site-settings-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-site-settings-filter-controls.gjs
@@ -5,13 +5,23 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
+import { and, not } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 export default class AdminSiteSettingsFilterControls extends Component {
+  @service capabilities;
+
   @tracked filter = this.args.initialFilter || "";
   @tracked onlyOverridden = false;
-  @tracked isMenuOpen = false;
+
+  menuTrigger = null;
+
+  @action
+  registerMenuTrigger(element) {
+    this.menuTrigger = element;
+  }
 
   @action
   clearFilter() {
@@ -50,8 +60,7 @@ export default class AdminSiteSettingsFilterControls extends Component {
 
   @action
   toggleMenu() {
-    this.isMenuOpen = !this.isMenuOpen;
-    this.args.onToggleMenu();
+    this.args.onToggleMenu(this.menuTrigger);
   }
 
   <template>
@@ -62,11 +71,12 @@ export default class AdminSiteSettingsFilterControls extends Component {
     >
       <div class="controls">
         <div class="inline-form">
-          {{#if @showMenu}}
+          {{#if (and @showMenu (not this.capabilities.viewport.sm))}}
             <DButton
               @action={{this.toggleMenu}}
-              @icon={{if this.isMenuOpen "xmark" "bars"}}
-              class="menu-toggle"
+              @icon="bars"
+              class="btn-default menu-toggle"
+              {{didInsert this.registerMenuTrigger}}
             />
           {{/if}}
           <input

--- a/frontend/discourse/admin/components/admin-watched-words-action-nav.gjs
+++ b/frontend/discourse/admin/components/admin-watched-words-action-nav.gjs
@@ -1,0 +1,46 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { LinkTo } from "@ember/routing";
+import { next } from "@ember/runloop";
+import { waitForAnimationEnd } from "discourse/lib/animation-utils";
+
+export default class AdminWatchedWordsActionNav extends Component {
+  get items() {
+    return this.args.items ?? this.args.data?.items ?? [];
+  }
+
+  @action
+  onLinkClick() {
+    next(() => this.args.close?.());
+  }
+
+  @action
+  async scrollToActive(element) {
+    const modalContainer = element.closest(".d-modal__container");
+    if (modalContainer) {
+      await waitForAnimationEnd(modalContainer);
+    }
+    element.querySelector("a.active")?.scrollIntoView({ block: "center" });
+  }
+
+  <template>
+    <ul class="nav nav-stacked" {{didInsert this.scrollToActive}}>
+      {{#each this.items as |watchedWordAction|}}
+        <li class={{watchedWordAction.nameKey}}>
+          <LinkTo
+            @route="adminWatchedWords.action"
+            @model={{watchedWordAction.nameKey}}
+            {{on "click" this.onLinkClick}}
+          >
+            {{watchedWordAction.name}}
+            {{#if watchedWordAction.words}}
+              <span class="count">({{watchedWordAction.words.length}})</span>
+            {{/if}}
+          </LinkTo>
+        </li>
+      {{/each}}
+    </ul>
+  </template>
+}

--- a/frontend/discourse/admin/controllers/admin-site-settings.js
+++ b/frontend/discourse/admin/controllers/admin-site-settings.js
@@ -1,11 +1,13 @@
 import Controller from "@ember/controller";
 import { action, computed, set } from "@ember/object";
 import { service } from "@ember/service";
+import AdminSiteSettingsCategoryNav from "discourse/admin/components/admin-site-settings-category-nav";
 import { debounce } from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
 
 export default class AdminSiteSettingsController extends Controller {
   @service router;
+  @service menu;
 
   @computed("model.filteredSettings")
   get visibleSiteSettings() {
@@ -53,10 +55,15 @@ export default class AdminSiteSettingsController extends Controller {
   }
 
   @action
-  toggleMenu() {
-    const adminDetail = document.querySelector(".admin-detail");
-    ["mobile-closed", "mobile-open"].forEach((state) => {
-      adminDetail.classList.toggle(state);
+  toggleMenu(triggerEl) {
+    this.menu.show(triggerEl, {
+      identifier: "admin-site-settings-category-nav",
+      component: AdminSiteSettingsCategoryNav,
+      modalForMobile: true,
+      data: {
+        categories: this.visibleSiteSettings,
+        filtersApplied: this.filtersApplied,
+      },
     });
   }
 }

--- a/frontend/discourse/admin/controllers/admin-watched-words.js
+++ b/frontend/discourse/admin/controllers/admin-watched-words.js
@@ -6,6 +6,7 @@ import { trackedArray } from "@ember/reactive/collections";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { observes } from "@ember-decorators/object";
+import AdminWatchedWordsActionNav from "discourse/admin/components/admin-watched-words-action-nav";
 import WatchedWord from "discourse/admin/models/watched-word";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
@@ -16,13 +17,22 @@ import { autoTrackedArray } from "discourse/lib/tracked-tools";
 const MESSAGE_BUS_UPLOAD_PATH = "/watched_words/upload";
 
 export default class AdminWatchedWordsController extends Controller {
+  @service capabilities;
   @service messageBus;
+  @service menu;
 
   @tracked filter = null;
+  menuTrigger = null;
+
   @autoTrackedArray allWatchedWords;
+
   @autoTrackedArray filteredWatchedWords;
 
   showWords = false;
+
+  get showMenuToggle() {
+    return !this.capabilities.viewport.sm;
+  }
 
   @observes("allWatchedWords", "filter")
   filterContent() {
@@ -93,10 +103,19 @@ export default class AdminWatchedWordsController extends Controller {
   }
 
   @action
+  registerMenuTrigger(element) {
+    this.menuTrigger = element;
+  }
+
+  @action
   toggleMenu() {
-    const adminDetail = document.querySelector(".admin-detail");
-    ["mobile-closed", "mobile-open"].forEach((state) => {
-      adminDetail.classList.toggle(state);
+    this.menu.show(this.menuTrigger, {
+      identifier: "admin-watched-words-action-nav",
+      component: AdminWatchedWordsActionNav,
+      modalForMobile: true,
+      data: {
+        items: this.filteredWatchedWords,
+      },
     });
   }
 }

--- a/frontend/discourse/admin/templates/admin-site-settings.gjs
+++ b/frontend/discourse/admin/templates/admin-site-settings.gjs
@@ -1,9 +1,8 @@
-import { LinkTo } from "@ember/routing";
+import AdminSiteSettingsCategoryNav from "discourse/admin/components/admin-site-settings-category-nav";
 import AdminSiteSettingsChangesBanner from "discourse/admin/components/admin-site-settings-changes-banner";
 import AdminSiteSettingsFilterControls from "discourse/admin/components/admin-site-settings-filter-controls";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DPageHeader from "discourse/components/d-page-header";
-import concatClass from "discourse/helpers/concat-class";
 import { i18n } from "discourse-i18n";
 
 export default <template>
@@ -29,31 +28,13 @@ export default <template>
   />
 
   <div class="admin-nav admin-site-settings-category-nav pull-left">
-    <ul class="nav nav-stacked">
-      {{#each @controller.visibleSiteSettings as |category|}}
-        <li
-          class={{concatClass
-            "admin-site-settings-category-nav__item"
-            category.nameKey
-          }}
-        >
-          <LinkTo
-            @route="adminSiteSettingsCategory"
-            @model={{category.nameKey}}
-            class={{category.nameKey}}
-            title={{category.name}}
-          >
-            {{category.name}}
-            {{#if @controller.filtersApplied}}
-              <span class="count">({{category.count}})</span>
-            {{/if}}
-          </LinkTo>
-        </li>
-      {{/each}}
-    </ul>
+    <AdminSiteSettingsCategoryNav
+      @categories={{@controller.visibleSiteSettings}}
+      @filtersApplied={{@controller.filtersApplied}}
+    />
   </div>
 
-  <div class="admin-detail pull-left mobile-closed">
+  <div class="admin-detail pull-left">
     {{outlet}}
   </div>
 

--- a/frontend/discourse/admin/templates/admin-watched-words.gjs
+++ b/frontend/discourse/admin/templates/admin-watched-words.gjs
@@ -1,6 +1,6 @@
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
-import { LinkTo } from "@ember/routing";
+import AdminWatchedWordsActionNav from "discourse/admin/components/admin-watched-words-action-nav";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DButton from "discourse/components/d-button";
 import DPageHeader from "discourse/components/d-page-header";
@@ -27,11 +27,14 @@ export default <template>
     <div class="admin-controls">
       <div class="controls">
         <div class="inline-form">
-          <DButton
-            @action={{@controller.toggleMenu}}
-            @icon="bars"
-            class="menu-toggle"
-          />
+          {{#if @controller.showMenuToggle}}
+            <DButton
+              @action={{@controller.toggleMenu}}
+              @icon="bars"
+              class="btn-default menu-toggle"
+              {{didInsert @controller.registerMenuTrigger}}
+            />
+          {{/if}}
           <TextField
             @value={{@controller.filter}}
             @placeholderKey="admin.watched_words.search"
@@ -40,6 +43,7 @@ export default <template>
           <DButton
             @action={{@controller.clearFilter}}
             @label="admin.watched_words.clear_filter"
+            class="btn-default"
           />
         </div>
       </div>
@@ -50,24 +54,10 @@ export default <template>
       {{didInsert @controller.subscribe}}
       {{willDestroy @controller.unsubscribe}}
     >
-      <ul class="nav nav-stacked">
-        {{#each @controller.filteredWatchedWords as |watchedWordAction|}}
-          <li class={{watchedWordAction.nameKey}}>
-            <LinkTo
-              @route="adminWatchedWords.action"
-              @model={{watchedWordAction.nameKey}}
-            >
-              {{watchedWordAction.name}}
-              {{#if watchedWordAction.words}}<span
-                  class="count"
-                >({{watchedWordAction.words.length}})</span>{{/if}}
-            </LinkTo>
-          </li>
-        {{/each}}
-      </ul>
+      <AdminWatchedWordsActionNav @items={{@controller.filteredWatchedWords}} />
     </div>
 
-    <div class="admin-detail pull-left mobile-closed watched-words-detail">
+    <div class="admin-detail pull-left watched-words-detail">
       {{outlet}}
     </div>
 

--- a/frontend/discourse/app/components/d-page-header.gjs
+++ b/frontend/discourse/app/components/d-page-header.gjs
@@ -97,7 +97,7 @@ export default class DPageHeader extends Component {
                     @identifier="d-page-header-mobile-actions"
                     @title={{i18n "more_options"}}
                     @icon="ellipsis-vertical"
-                    class="btn-small"
+                    class="btn-small btn-default"
                   >
                     <:content>
                       <DropdownMenu class="d-page-header__mobile-actions">


### PR DESCRIPTION
This replaces our old and slightly janky slide-in menu for admin site settings and watched words with DMenu. This makes the implementation more reliable and avoids a couple issues (including https://meta.discourse.org/t/site-setting-menu-limited-by-results-page-size/372904)

Before: 

https://github.com/user-attachments/assets/d17c7a35-2cba-4e6f-bdd9-a3697145d0d4



After: 

https://github.com/user-attachments/assets/3bf84e5e-a338-42a9-ad40-eac551243205

