### PR TITLE
DEV: Add reusable DockedComposer component

### DIFF
--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -19,6 +19,7 @@
 @import "composer-toggle-switch";
 @import "convert-to-public-topic-modal";
 @import "d-autocomplete";
+@import "docked-composer";
 @import "d-toggle-switch";
 @import "date-input";
 @import "date-picker";

--- a/app/assets/stylesheets/common/components/docked-composer.scss
+++ b/app/assets/stylesheets/common/components/docked-composer.scss
@@ -1,0 +1,204 @@
+.docked-composer {
+  --docked-composer-input-min-height: 2.5em;
+  --docked-composer-max-width: 100%;
+  --docked-composer-content-offset: 0;
+  --docked-composer-drag-offset: 0px;
+  position: sticky;
+  bottom: 0;
+  z-index: 50;
+  background: var(--secondary);
+  padding: 0.75em 0 max(env(safe-area-inset-bottom), 0.75em);
+  margin-top: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+
+  // fade scrolling content into the sticky composer's solid background
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -2.5em;
+    height: 2.5em;
+    background: linear-gradient(to bottom, transparent, var(--secondary));
+    pointer-events: none;
+  }
+
+  html.keyboard-visible & {
+    padding-bottom: 0.5em;
+  }
+
+  &__resize-handle {
+    width: 100%;
+    max-width: var(--docked-composer-max-width);
+    padding-left: var(--docked-composer-content-offset);
+    margin: 0 auto;
+    box-sizing: border-box;
+    height: 0.5em;
+    cursor: ns-resize;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: none;
+    user-select: none;
+
+    &::after {
+      content: "";
+      width: 2em;
+      height: 3px;
+      background: var(--primary-low);
+      border-radius: 3px;
+      transition: background 0.15s ease-in-out;
+    }
+
+    &:hover::after,
+    &:active::after,
+    &:focus-visible::after {
+      background: var(--primary-medium);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--tertiary);
+      outline-offset: 2px;
+    }
+  }
+
+  &__inner {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5em;
+    width: 100%;
+    max-width: var(--docked-composer-max-width);
+    padding-left: var(--docked-composer-content-offset);
+    margin: 0 auto;
+    box-sizing: border-box;
+  }
+
+  &__editor {
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+
+    .d-editor-container {
+      background: transparent;
+    }
+
+    .d-editor-textarea-column {
+      position: relative;
+      border: 1px solid var(--primary-low);
+      border-radius: var(--d-input-border-radius);
+      background: var(--d-input-bg-color);
+      transition: border-color 0.15s ease-in-out;
+
+      &:focus-within {
+        border-color: var(--tertiary);
+      }
+
+      &:has(.d-editor-input[disabled]) {
+        background: var(--d-input-bg-color--disabled);
+      }
+    }
+
+    // we deliberately don't show the preview in the docked composer — users
+    // can toggle to the rich editor via the toolbar's RTE switch for a
+    // live preview. `@processPreview={{false}}` on DEditor skips cooking,
+    // but DEditor still renders a wrapper element that we hide here.
+    .d-editor-preview-wrapper {
+      display: none;
+    }
+
+    .d-editor-textarea-wrapper {
+      border: none;
+      background: transparent;
+      box-shadow: none;
+    }
+
+    .d-editor-input {
+      border: none;
+      background: transparent;
+      max-height: 70vh;
+      min-height: calc(
+        var(--docked-composer-input-min-height) +
+          var(--docked-composer-drag-offset, 0px)
+      );
+      resize: none;
+
+      // reserve room for the absolutely-positioned send button
+      padding-right: 3.5em;
+
+      &:focus-visible {
+        outline: none;
+      }
+    }
+  }
+
+  // submit button yielded into DEditor's textarea column, positioned in
+  // the bottom-right corner of the input box (ChatGPT-style) — icon only.
+  // Consumers overriding the `<:submit>` block should reuse this class so
+  // their buttons inherit positioning + chrome.
+  &__submit-btn.btn {
+    position: absolute;
+    right: 0.5em;
+    bottom: 0.5em;
+    z-index: 2;
+    min-width: auto;
+    min-height: auto;
+    padding: 0.35em 0.5em;
+    border-radius: var(--d-button-border-radius);
+    background: transparent !important;
+
+    .d-icon {
+      color: var(--tertiary) !important;
+      font-size: var(--font-up-1);
+    }
+
+    &:hover:not(:disabled),
+    &:focus-visible {
+      background: var(--primary-very-low) !important;
+
+      .d-icon {
+        color: var(--tertiary-hover, var(--tertiary)) !important;
+      }
+    }
+
+    &:disabled,
+    &[disabled] {
+      cursor: not-allowed;
+
+      .d-icon {
+        color: var(--primary-low-mid) !important;
+      }
+    }
+  }
+
+  &__uploads {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    width: 100%;
+    max-width: var(--docked-composer-max-width);
+    padding-left: var(--docked-composer-content-offset);
+    margin: 0 auto;
+    box-sizing: border-box;
+  }
+
+  &__upload {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--primary-low);
+    border-radius: 10em;
+    padding-left: 0.75em;
+    color: var(--primary-high);
+    font-size: var(--font-down-2);
+
+    &-progress {
+      margin-left: 0.5em;
+    }
+
+    &-remove:hover .d-icon,
+    &-cancel:hover .d-icon {
+      color: var(--danger);
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3210,6 +3210,7 @@ en:
       uploading: "Uploading…"
       show_preview: "show preview"
       hide_preview: "hide preview"
+      resize: "Resize composer"
 
       switch_to_markdown: "Switch to standard Markdown editor (%{keyboardShortcut})"
       switch_to_rich_text: "Switch to new rich text editor (%{keyboardShortcut})"

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { guidFor } from "@ember/object/internals";
 import { getOwner } from "@ember/owner";
 import { trackedArray } from "@ember/reactive/collections";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -34,13 +35,13 @@ export default class DockedComposer extends Component {
   @service mediaOptimizationWorker;
   @service siteSettings;
 
+  @tracked dragOffset = 0;
   @tracked reply = "";
   @tracked uploads = trackedArray();
 
   textarea = null;
   uppyUpload = null;
   fileInputEl = null;
-  dragOffset = 0;
   #dragStart = null;
   #rootElement = null;
 
@@ -86,7 +87,9 @@ export default class DockedComposer extends Component {
   }
 
   get uploaderId() {
-    return this.args.uploaderId ?? "docked-composer-file-uploader";
+    return (
+      this.args.uploaderId ?? `docked-composer-file-uploader-${guidFor(this)}`
+    );
   }
 
   get uploadType() {
@@ -112,9 +115,11 @@ export default class DockedComposer extends Component {
     if (this.args.isSubmitting || this.args.disabled) {
       return false;
     }
+    if (this.inProgressUploads.length > 0) {
+      return false;
+    }
     return (
-      this.reply.trim().length >= this.minLength &&
-      this.inProgressUploads.length === 0
+      this.reply.trim().length >= this.minLength || this.uploads.length > 0
     );
   }
 
@@ -310,10 +315,10 @@ export default class DockedComposer extends Component {
         next = Math.max(0, this.dragOffset - STEP);
         break;
       case "Home":
-        next = MAX_OFFSET;
+        next = 0;
         break;
       case "End":
-        next = 0;
+        next = MAX_OFFSET;
         break;
       default:
         return;

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -1,0 +1,453 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn, hash } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
+import { trackedArray } from "@ember/reactive/collections";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
+import { schedule } from "@ember/runloop";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import DEditor from "discourse/components/d-editor";
+import bodyClass from "discourse/helpers/body-class";
+import concatClass from "discourse/helpers/concat-class";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import UppyUpload from "discourse/lib/uppy/uppy-upload";
+import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
+import { clipboardHelpers } from "discourse/lib/utilities";
+import { i18n } from "discourse-i18n";
+
+// Reusable chat-style "docked" composer. There is deliberately no
+// markdown-preview toggle — users who want to see rendered output
+// switch to the rich editor via the toolbar's RTE toggle, which is
+// effectively a live preview. Skipping preview also avoids the
+// cook-on-change CPU cost on every keystroke.
+//
+// @onSubmit is required; all other args are optional. See the
+// styleguide entry (/styleguide → Organisms → Docked Composer) for
+// the live API surface.
+export default class DockedComposer extends Component {
+  @service capabilities;
+  @service keyValueStore;
+  @service mediaOptimizationWorker;
+  @service siteSettings;
+
+  @tracked reply = "";
+  @tracked uploads = trackedArray();
+
+  textarea = null;
+  uppyUpload = null;
+  fileInputEl = null;
+  dragOffset = 0;
+  #dragStart = null;
+  #rootElement = null;
+
+  #handlePaste = (event) => {
+    if (!this.textarea || document.activeElement !== this.textarea) {
+      return;
+    }
+    const { canUpload, canPasteHtml, types } = clipboardHelpers(event, {
+      siteSettings: this.siteSettings,
+      canUpload: true,
+    });
+    if (!canUpload || canPasteHtml || types.includes("text/plain")) {
+      return;
+    }
+    if (event?.clipboardData?.files?.length) {
+      this.uppyUpload?.addFiles([...event.clipboardData.files], {
+        pasted: true,
+      });
+    }
+  };
+
+  #handleKeyDown = (event) => {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.isComposing &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.submit();
+    }
+  };
+
+  get show() {
+    return this.args.show ?? true;
+  }
+
+  get draftKey() {
+    return this.args.draftKey ?? "docked-composer-draft";
+  }
+
+  get uploaderId() {
+    return this.args.uploaderId ?? "docked-composer-file-uploader";
+  }
+
+  get uploadType() {
+    return this.args.uploadType ?? "composer";
+  }
+
+  get minLength() {
+    return this.args.minLength ?? 1;
+  }
+
+  // DEditor's composer-event bus (quote-reply insert, toolbar replace,
+  // etc.). Defaults on for real app use; tests can pass false to avoid
+  // app-event listener churn in rendering harnesses.
+  get composerEvents() {
+    return this.args.composerEvents ?? true;
+  }
+
+  get inProgressUploads() {
+    return this.uppyUpload?.inProgressUploads || [];
+  }
+
+  get canSubmit() {
+    if (this.args.isSubmitting || this.args.disabled) {
+      return false;
+    }
+    return (
+      this.reply.trim().length >= this.minLength &&
+      this.inProgressUploads.length === 0
+    );
+  }
+
+  get submitDisabled() {
+    return !this.canSubmit;
+  }
+
+  get showUploadsContainer() {
+    return this.uploads?.length > 0 || this.inProgressUploads?.length > 0;
+  }
+
+  @action
+  setupEditor(textManipulation) {
+    this.textarea =
+      textManipulation?.textarea ??
+      // Scope the fallback to this instance's root so multiple docked
+      // composers on the same page can't cross-wire.
+      this.#rootElement?.querySelector(".d-editor-input") ??
+      null;
+    if (this.textarea) {
+      // capture phase so Enter-to-send wins over ItsATrap / smart-list handlers
+      this.textarea.addEventListener("keydown", this.#handleKeyDown, true);
+      this.textarea.addEventListener("paste", this.#handlePaste);
+    }
+  }
+
+  @action
+  loadDraft() {
+    const saved = this.keyValueStore.get(this.draftKey);
+    if (saved) {
+      this.reply = saved;
+    }
+  }
+
+  @action
+  persistDraft(value) {
+    if (value?.length) {
+      this.keyValueStore.set({ key: this.draftKey, value });
+    } else {
+      this.keyValueStore.remove(this.draftKey);
+    }
+  }
+
+  @action
+  onReplyChange(event) {
+    const value = event?.target?.value ?? "";
+    this.reply = value;
+    this.persistDraft(value);
+  }
+
+  @action
+  setupContainer(element) {
+    this.#rootElement = element;
+    this.loadDraft();
+
+    this.uppyUpload = new UppyUpload(getOwner(this), {
+      id: this.uploaderId,
+      type: this.uploadType,
+      useMultipartUploadsIfAvailable: true,
+      uppyReady: () => {
+        if (this.siteSettings.composer_media_optimization_image_enabled) {
+          this.uppyUpload.uppyWrapper.useUploadPlugin(UppyMediaOptimization, {
+            optimizeFn: (data, opts) =>
+              this.mediaOptimizationWorker.optimizeImage(data, opts),
+            runParallel: !this.capabilities.isMobileDevice,
+          });
+        }
+      },
+      uploadDone: (upload) => {
+        this.uploads.push(upload);
+      },
+    });
+  }
+
+  @action
+  teardown() {
+    this.textarea?.removeEventListener("keydown", this.#handleKeyDown, true);
+    this.textarea?.removeEventListener("paste", this.#handlePaste);
+    this.uppyUpload?.teardown();
+    this.#rootElement = null;
+  }
+
+  @action
+  registerFileInput(element) {
+    if (!element) {
+      return;
+    }
+    this.fileInputEl = element;
+    this.uppyUpload?.setup(element);
+  }
+
+  @action
+  openFileUpload() {
+    this.fileInputEl?.click();
+  }
+
+  @action
+  addToolbarButtons(toolbar) {
+    toolbar.addButton({
+      id: "docked-composer-upload",
+      group: "insertions",
+      icon: "upload",
+      title: this.args.uploadTitle ?? "composer.upload_title",
+      sendAction: () => this.openFileUpload(),
+    });
+
+    this.args.extraToolbarButtons?.(toolbar);
+  }
+
+  @action
+  removeUpload(upload) {
+    this.uploads = trackedArray(this.uploads.filter((u) => u !== upload));
+  }
+
+  @action
+  cancelUpload(upload) {
+    this.uppyUpload?.cancelSingleUpload({ fileId: upload.id });
+  }
+
+  @action
+  async submit() {
+    if (!this.canSubmit || !this.args.onSubmit) {
+      return;
+    }
+    try {
+      const result = await this.args.onSubmit({
+        raw: this.reply,
+        uploads: this.uploads,
+        inProgressUploadsCount: this.inProgressUploads.length,
+      });
+      // Falsy return → don't clear; consumer can short-circuit on
+      // validation failure without losing the user's input.
+      if (!result) {
+        return;
+      }
+      this.reply = "";
+      this.uploads = trackedArray();
+      this.persistDraft("");
+      schedule("afterRender", () => this.textarea?.focus());
+    } catch (error) {
+      // Consumers can opt into custom error handling; otherwise we
+      // fall back to the generic ajax-error popup for network failures.
+      if (this.args.onError) {
+        this.args.onError(error);
+      } else {
+        popupAjaxError(error);
+      }
+    }
+  }
+
+  @action
+  focus() {
+    this.textarea?.focus();
+  }
+
+  @action
+  onResizeStart(event) {
+    event.preventDefault();
+    this.#dragStart = {
+      clientY: event.clientY,
+      offset: this.dragOffset,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }
+
+  @action
+  onResizeMove(event) {
+    if (!this.#dragStart || !this.#rootElement?.isConnected) {
+      return;
+    }
+    // dragging UP should grow the composer, so invert
+    const delta = this.#dragStart.clientY - event.clientY;
+    this.dragOffset = Math.max(0, this.#dragStart.offset + delta);
+    this.#rootElement.style.setProperty(
+      "--docked-composer-drag-offset",
+      `${this.dragOffset}px`
+    );
+  }
+
+  @action
+  onResizeKeyDown(event) {
+    // Arrow keys nudge height; Home/End snap to bounds. We mirror the
+    // dragOffset state so the keyboard interaction stays in sync with
+    // pointer drags.
+    const STEP = 16;
+    const MAX_OFFSET = 400;
+    let next = this.dragOffset;
+    switch (event.key) {
+      case "ArrowUp":
+        next = Math.min(MAX_OFFSET, this.dragOffset + STEP);
+        break;
+      case "ArrowDown":
+        next = Math.max(0, this.dragOffset - STEP);
+        break;
+      case "Home":
+        next = MAX_OFFSET;
+        break;
+      case "End":
+        next = 0;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    this.dragOffset = next;
+    this.#rootElement?.style.setProperty(
+      "--docked-composer-drag-offset",
+      `${next}px`
+    );
+  }
+
+  @action
+  onResizeEnd(event) {
+    if (!this.#dragStart) {
+      return;
+    }
+    this.#dragStart = null;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+  }
+
+  <template>
+    {{#if this.show}}
+      {{#if @bodyClassName}}
+        {{bodyClass @bodyClassName}}
+      {{/if}}
+      <div
+        class={{concatClass
+          "docked-composer"
+          (if @resizable "docked-composer--resizable")
+          @class
+        }}
+        ...attributes
+        {{didInsert this.setupContainer}}
+        {{willDestroy this.teardown}}
+      >
+        {{#if @resizable}}
+          <div
+            class="docked-composer__resize-handle"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label={{i18n "composer.resize"}}
+            aria-valuenow={{this.dragOffset}}
+            aria-valuemin="0"
+            aria-valuemax="400"
+            tabindex="0"
+            {{! template-lint-disable no-pointer-down-event-binding }}
+            {{on "pointerdown" this.onResizeStart}}
+            {{on "pointermove" this.onResizeMove}}
+            {{on "pointerup" this.onResizeEnd}}
+            {{on "pointercancel" this.onResizeEnd}}
+            {{on "keydown" this.onResizeKeyDown}}
+          ></div>
+        {{/if}}
+        <div class="docked-composer__inner">
+          <div class="docked-composer__editor">
+            <DEditor
+              @value={{this.reply}}
+              @change={{this.onReplyChange}}
+              @onSetup={{this.setupEditor}}
+              @extraButtons={{this.addToolbarButtons}}
+              @composerEvents={{this.composerEvents}}
+              @topicId={{@topicId}}
+              @categoryId={{@categoryId}}
+              @processPreview={{false}}
+              @placeholder={{@placeholder}}
+            >
+              {{#if (has-block "submit")}}
+                {{yield
+                  (hash
+                    submit=this.submit
+                    disabled=this.submitDisabled
+                    isSubmitting=@isSubmitting
+                  )
+                  to="submit"
+                }}
+              {{else}}
+                <DButton
+                  @icon="reply"
+                  @action={{this.submit}}
+                  @disabled={{this.submitDisabled}}
+                  @isLoading={{@isSubmitting}}
+                  @title={{@submitTitle}}
+                  class="docked-composer__submit-btn"
+                />
+              {{/if}}
+            </DEditor>
+          </div>
+
+          <input
+            type="file"
+            id={{this.uploaderId}}
+            class="hidden-upload-field"
+            multiple="multiple"
+            {{didInsert this.registerFileInput}}
+          />
+        </div>
+
+        {{#if this.showUploadsContainer}}
+          <div class="docked-composer__uploads">
+            {{#each this.uploads as |upload|}}
+              <div class="docked-composer__upload">
+                <span class="docked-composer__upload-filename">
+                  {{upload.original_filename}}
+                </span>
+                <DButton
+                  @icon="xmark"
+                  @action={{fn this.removeUpload upload}}
+                  class="btn-transparent docked-composer__upload-remove"
+                />
+              </div>
+            {{/each}}
+            {{#each this.inProgressUploads as |upload|}}
+              <div
+                class="docked-composer__upload docked-composer__upload--in-progress"
+              >
+                <span class="docked-composer__upload-filename">
+                  {{upload.fileName}}
+                </span>
+                <span class="docked-composer__upload-progress">
+                  {{upload.progress}}%
+                </span>
+                <DButton
+                  @icon="xmark"
+                  @action={{fn this.cancelUpload upload}}
+                  class="btn-flat docked-composer__upload-cancel"
+                />
+              </div>
+            {{/each}}
+          </div>
+        {{/if}}
+
+        {{yield}}
+      </div>
+    {{/if}}
+  </template>
+}

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/docked-composer.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/docked-composer.gjs
@@ -1,0 +1,80 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import DToggleSwitch from "discourse/components/d-toggle-switch";
+import DockedComposer from "discourse/components/docked-composer";
+import withEventValue from "discourse/helpers/with-event-value";
+import { i18n } from "discourse-i18n";
+import StyleguideComponent from "discourse/plugins/styleguide/discourse/components/styleguide/component";
+import Controls from "discourse/plugins/styleguide/discourse/components/styleguide/controls";
+import Row from "discourse/plugins/styleguide/discourse/components/styleguide/controls/row";
+import StyleguideExample from "discourse/plugins/styleguide/discourse/components/styleguide-example";
+
+export default class DockedComposerSection extends Component {
+  @tracked resizable = true;
+  @tracked disabled = false;
+  @tracked placeholder = i18n("composer.reply_placeholder");
+  submitTitle = "composer.title";
+
+  @action
+  toggleResizable() {
+    this.resizable = !this.resizable;
+  }
+
+  @action
+  toggleDisabled() {
+    this.disabled = !this.disabled;
+  }
+
+  @action
+  async handleSubmit({ raw }) {
+    // no-op: pretend the submission succeeded so the composer clears itself
+    // eslint-disable-next-line no-console
+    console.log("[styleguide] DockedComposer submit:", raw);
+    return { ok: true };
+  }
+
+  <template>
+    {{! template-lint-disable no-potential-path-strings}}
+    <StyleguideExample @title="<DockedComposer>">
+      <StyleguideComponent>
+        <div class="docked-composer-styleguide">
+          <DockedComposer
+            @resizable={{this.resizable}}
+            @disabled={{this.disabled}}
+            @placeholder={{this.placeholder}}
+            @submitTitle={{this.submitTitle}}
+            @uploadTitle="composer.upload_title"
+            @draftKey="styleguide-docked-composer"
+            @uploaderId="styleguide-docked-composer-uploader"
+            @onSubmit={{this.handleSubmit}}
+          />
+        </div>
+      </StyleguideComponent>
+
+      <Controls>
+        <Row @name="@resizable">
+          <DToggleSwitch
+            @state={{this.resizable}}
+            {{on "click" this.toggleResizable}}
+          />
+        </Row>
+        <Row @name="@disabled">
+          <DToggleSwitch
+            @state={{this.disabled}}
+            {{on "click" this.toggleDisabled}}
+          />
+        </Row>
+        <Row @name="@placeholder">
+          <input
+            {{on "input" (withEventValue (fn (mut this.placeholder)))}}
+            type="text"
+            value={{this.placeholder}}
+          />
+        </Row>
+      </Controls>
+    </StyleguideExample>
+  </template>
+}

--- a/plugins/styleguide/assets/javascripts/discourse/lib/styleguide.js
+++ b/plugins/styleguide/assets/javascripts/discourse/lib/styleguide.js
@@ -34,6 +34,7 @@ import topicFooterButtons from "../components/sections/organisms/04-topic-footer
 import topicList from "../components/sections/organisms/05-topic-list";
 import basicTopicList from "../components/sections/organisms/basic-topic-list";
 import categoriesList from "../components/sections/organisms/categories-list";
+import dockedComposer from "../components/sections/organisms/docked-composer";
 import modal from "../components/sections/organisms/modal";
 import moreTopics from "../components/sections/organisms/more-topics";
 import navigation from "../components/sections/organisms/navigation";
@@ -115,6 +116,7 @@ const SECTIONS = [
   },
   { component: basicTopicList, category: "organisms", id: "basic-topic-list" },
   { component: categoriesList, category: "organisms", id: "categories-list" },
+  { component: dockedComposer, category: "organisms", id: "docked-composer" },
   { component: modal, category: "organisms", id: "modal" },
   { component: navigation, category: "organisms", id: "navigation" },
   { component: siteHeader, category: "organisms", id: "site-header" },

--- a/plugins/styleguide/config/locales/client.en.yml
+++ b/plugins/styleguide/config/locales/client.en.yml
@@ -91,6 +91,8 @@ en:
           title: "More Topics"
         post_menu:
           title: "Post Menu"
+        docked_composer:
+          title: "Docked Composer"
         modal:
           title: "Modal"
           header: "Modal Title"

--- a/plugins/styleguide/spec/system/smoke_test_spec.rb
+++ b/plugins/styleguide/spec/system/smoke_test_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Styleguide Smoke Test" do
       { href: "/organisms/basic-topic-list", title: "Basic Topic List" },
       { href: "/organisms/categories-list", title: "Categories List" },
       { href: "/organisms/chat", title: "Chat" },
+      { href: "/organisms/docked-composer", title: "Docked Composer" },
       { href: "/organisms/modal", title: "Modal" },
       { href: "/organisms/navigation", title: "Navigation" },
       { href: "/organisms/site-header", title: "Site Header" },


### PR DESCRIPTION
**Previously**, there was no shared primitive for chat-style composers that stick to the viewport, so consumers had to reimplement editor, upload, and draft plumbing themselves.

**In this update**, introduces a `DockedComposer` component wrapping `DEditor` with Uppy uploads, draft persistence, optional resize/preview plus a styleguide entry showcasing it.

This comonent will allow us to use have an inline composer in the AI bot conversations page (https://github.com/discourse/discourse/pull/39336) as well as in `embed_mode` (https://github.com/discourse/discourse/pull/39352)

<img width="906" height="744" alt="Screenshot 2026-04-16 at 15 57 55" src="https://github.com/user-attachments/assets/2219e523-0cbd-4626-8ff2-9d5de238e923" />
