### PR TITLE
FIX: prevent silence_reason from leaking private email body

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -341,7 +341,8 @@ class Admin::UsersController < Admin::StaffController
         render_json_dump(
           silence: {
             silenced: true,
-            silence_reason: full_reason,
+            silence_reason: user.silence_reason,
+            full_silence_reason: full_reason,
             silenced_till: user.silenced_till,
             silenced_at: user.silenced_at,
             silenced_by:
@@ -372,6 +373,7 @@ class Admin::UsersController < Admin::StaffController
       unsilence: {
         silenced: false,
         silence_reason: nil,
+        full_silence_reason: nil,
         silenced_till: nil,
         silenced_at: nil,
       },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1341,8 +1341,18 @@ class User < ActiveRecord::Base
     user_histories.where(action: UserHistory.actions[:silence_user]).order("id DESC").first
   end
 
+  def full_silence_reason
+    text = silenced_record.try(:details) if silenced?
+    return text if text.blank?
+    PrettyText.cleanup(text.gsub("\n", "<br>"))
+  end
+
   def silence_reason
-    PrettyText.cleanup(silenced_record.try(:details)) if silenced?
+    if details = full_silence_reason
+      return details.split("<br>")[0]
+    end
+
+    nil
   end
 
   def silenced_at

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -21,6 +21,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
              :can_be_merged,
              :full_suspend_reason,
              :suspended_till,
+             :full_silence_reason,
              :silence_reason,
              :penalty_counts,
              :next_penalty,

--- a/frontend/discourse/admin/models/admin-user.js
+++ b/frontend/discourse/admin/models/admin-user.js
@@ -306,6 +306,7 @@ export default class AdminUser extends User {
       .then((result) => {
         this.setProperties({
           silence_reason: result.unsilence.silence_reason,
+          full_silence_reason: result.unsilence.full_silence_reason,
           silenced_at: result.unsilence.silence_at,
           silenced_till: result.unsilence.silence_till,
         });
@@ -323,6 +324,7 @@ export default class AdminUser extends User {
       .then((result) => {
         this.setProperties({
           silence_reason: result.silence.silence_reason,
+          full_silence_reason: result.silence.full_silence_reason,
           silenced_at: result.silence.silenced_at,
           silenced_by: result.silence.silenced_by,
           silenced_till: result.silence.silenced_till,

--- a/frontend/discourse/admin/templates/admin-user/index.gjs
+++ b/frontend/discourse/admin/templates/admin-user/index.gjs
@@ -639,7 +639,7 @@ export default <template>
         <div class="controls">
           <b>{{i18n "admin.user.silence_reason"}}</b>:
           <div class="full-reason">{{trustHTML
-              @controller.model.silence_reason
+              @controller.model.full_silence_reason
             }}</div>
         </div>
       </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3756,6 +3756,17 @@ RSpec.describe User do
   describe "#silence_reason" do
     before { user.update!(silenced_till: 1.day.from_now) }
 
+    it "returns only the first line when details contain a message body" do
+      Fabricate(
+        :user_history,
+        action: UserHistory.actions[:silence_user],
+        target_user: user,
+        details: "short reason\n\nprivate email body",
+      )
+
+      expect(user.silence_reason).to eq("short reason")
+    end
+
     it "returns sanitized silence reason" do
       Fabricate(
         :user_history,
@@ -3778,6 +3789,37 @@ RSpec.describe User do
       expect(user.silence_reason).to eq(
         "foo <a href=\"https://example.com\" rel=\"noopener nofollow ugc\">link</a> bar",
       )
+    end
+  end
+
+  describe "#full_silence_reason" do
+    before { user.update!(silenced_till: 1.day.from_now) }
+
+    it "returns the full silence reason including message body" do
+      Fabricate(
+        :user_history,
+        action: UserHistory.actions[:silence_user],
+        target_user: user,
+        details: "short reason\n\nprivate email body",
+      )
+
+      expect(user.full_silence_reason).to eq("short reason<br><br>private email body")
+    end
+
+    it "returns sanitized content" do
+      Fabricate(
+        :user_history,
+        action: UserHistory.actions[:silence_user],
+        target_user: user,
+        details: "foo <script>alert('XSS Test')</script> bar",
+      )
+
+      expect(user.full_silence_reason).to eq("foo  bar")
+    end
+
+    it "returns nil when user is not silenced" do
+      user.update!(silenced_till: nil)
+      expect(user.full_silence_reason).to be_nil
     end
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -124,6 +124,28 @@ RSpec.describe Admin::UsersController do
         expect(response.parsed_body["silence_reason"]).to eq("because I said so")
       end
 
+      it "does not leak the message body in the public silence_reason" do
+        put "/admin/users/#{user.id}/silence.json",
+            params: {
+              reason: "because I said so",
+              message: "private email body",
+              post_action: "delete",
+              silenced_till: 2.days.from_now,
+            }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["silence"]["silence_reason"]).to eq("because I said so")
+        expect(response.parsed_body["silence"]["full_silence_reason"]).to eq(
+          "because I said so\n\nprivate email body",
+        )
+
+        get "/admin/users/#{user.id}.json"
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["silence_reason"]).to eq("because I said so")
+        expect(response.parsed_body["full_silence_reason"]).to eq(
+          "because I said so<br><br>private email body",
+        )
+      end
+
       context "with a non-existing user" do
         it "returns 404 error" do
           get "/admin/users/0.json"

--- a/spec/requests/api/schemas/json/admin_user_response.json
+++ b/spec/requests/api/schemas/json/admin_user_response.json
@@ -140,6 +140,9 @@
     "latest_export": {
       "type": ["object", "null"]
     },
+    "full_silence_reason": {
+      "type": ["string", "null"]
+    },
     "silence_reason": {
       "type": ["string", "null"]
     },

--- a/spec/requests/api/schemas/json/user_silence_response.json
+++ b/spec/requests/api/schemas/json/user_silence_response.json
@@ -11,6 +11,9 @@
         "silence_reason": {
           "type": "string"
         },
+        "full_silence_reason": {
+          "type": "string"
+        },
         "silenced_till": {
           "type": "string"
         },
@@ -40,6 +43,7 @@
       "required": [
         "silenced",
         "silence_reason",
+        "full_silence_reason",
         "silenced_till",
         "silenced_at",
         "silenced_by"

--- a/spec/system/page_objects/components/user_card.rb
+++ b/spec/system/page_objects/components/user_card.rb
@@ -37,6 +37,10 @@ module PageObjects
       def has_inactive_user?
         has_css?("#{USER_CARD_SELECTOR} .inactive-user", visible: true)
       end
+
+      def silence_reason_description
+        find("#{USER_CARD_SELECTOR} .silence-reason .silence-reason-description").text
+      end
     end
   end
 end

--- a/spec/system/user_card_spec.rb
+++ b/spec/system/user_card_spec.rb
@@ -32,6 +32,25 @@ describe "User Card" do
     end
   end
 
+  context "when the mentioned user is silenced" do
+    before do
+      UserSilencer.new(
+        user,
+        current_user,
+        reason: "public reason",
+        message_body: "private email body",
+      ).silence
+    end
+
+    it "does not show the private email body on the user card" do
+      topic_page.visit_topic(topic)
+      mention_post.find("a.mention").click
+
+      expect(user_card).to be_visible
+      expect(user_card.silence_reason_description).to eq("public reason")
+    end
+  end
+
   context "when filtering posts by user" do
     fab!(:another_user, :user)
     let!(:first_post_by_another_user) do


### PR DESCRIPTION
When an admin silences a user with both a reason and an email message, the private email body was visible publicly on user profile cards.

This applies the same fix previously used (commit 4ae1bba) for suspension reasons: only the short reason is shown publicly, while the full text including the email body is reserved for admin views.