### PR TITLE
UX: Composer reply icon

### DIFF
--- a/frontend/discourse/select-kit/components/composer-actions.js
+++ b/frontend/discourse/select-kit/components/composer-actions.js
@@ -70,7 +70,7 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
     } else if (this.isEditing) {
       return "pencil";
     } else {
-      return "share";
+      return "reply";
     }
   }
 
@@ -169,7 +169,7 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
           postUsername: _postSnapshot.username,
         }),
         description: i18n("composer.composer_actions.reply_to_post.desc"),
-        icon: "share",
+        icon: "reply",
         id: "reply_to_post",
       });
     }

--- a/frontend/discourse/select-kit/components/composer-actions.js
+++ b/frontend/discourse/select-kit/components/composer-actions.js
@@ -186,7 +186,7 @@ export default class ComposerActions extends DropdownSelectBoxComponent {
       items.push({
         name: i18n("composer.composer_actions.reply_to_topic.label"),
         description: i18n("composer.composer_actions.reply_to_topic.desc"),
-        icon: "share",
+        icon: "reply",
         id: "reply_to_topic",
       });
     }

--- a/frontend/discourse/tests/acceptance/composer-actions-test.js
+++ b/frontend/discourse/tests/acceptance/composer-actions-test.js
@@ -88,7 +88,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".composer-actions svg.d-icon-far-eye-slash")
       .doesNotExist("whisper icon is not visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .exists("reply icon is visible");
 
     await composerActions.expand();
@@ -98,7 +98,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".composer-actions svg.d-icon-far-eye-slash")
       .exists("whisper icon is visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .doesNotExist("reply icon is not visible");
   });
 
@@ -246,7 +246,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".composer-actions svg.d-icon-anchor")
       .doesNotExist("no-bump icon is not visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .exists("reply icon is visible");
 
     await composerActions.expand();
@@ -256,7 +256,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".composer-actions svg.d-icon-anchor")
       .exists("no-bump icon is visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .doesNotExist("reply icon is not visible");
 
     await composerActions.expand();
@@ -266,7 +266,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".composer-actions svg.d-icon-anchor")
       .doesNotExist("no-bump icon is not visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .exists("reply icon is visible");
   });
 
@@ -283,7 +283,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".reply-details .whisper .d-icon-anchor")
       .doesNotExist("no-bump icon is not visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .exists("reply icon is visible");
 
     await composerActions.expand();
@@ -298,7 +298,7 @@ acceptance(`Composer Actions`, function (needs) {
       .dom(".reply-details .no-bump .d-icon-anchor")
       .exists("no-bump icon is visible");
     assert
-      .dom(".composer-actions svg.d-icon-share")
+      .dom(".composer-actions svg.d-icon-reply")
       .doesNotExist("reply icon is not visible");
   });
 


### PR DESCRIPTION
This PR uses the reply icon instead of share on the composer actions dropdown.

## Before
Composer action icon is pointing right, which previously used [FontAwesome's share icon](https://fontawesome.com/icons/share?f=classic&s=solid).
<img width="266" height="234" alt="Screenshot 2026-04-16 at 5 06 28 PM" src="https://github.com/user-attachments/assets/a455f8d6-b701-44ae-856c-1e32e2bb80ee" />
<img width="388" height="98" alt="Screenshot 2026-04-16 at 5 29 31 PM" src="https://github.com/user-attachments/assets/9b10055e-753c-4b0b-874a-b21211a535bb" />

## After
<img width="105" height="237" alt="Screenshot 2026-04-16 at 5 11 22 PM" src="https://github.com/user-attachments/assets/59196b42-eeea-4bf2-8730-bb101061ce7e" />
<img width="384" height="96" alt="Screenshot 2026-04-16 at 5 27 52 PM" src="https://github.com/user-attachments/assets/d5e40005-b6f4-4b47-8080-63a062f307b8" />
