### PR TITLE
UX: Persist data explorer graph/table toggle state per query

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -6,6 +6,7 @@ import { capitalize } from "@ember/string";
 import moment from "moment";
 import DButton from "discourse/components/d-button";
 import icon from "discourse/helpers/d-icon";
+import KeyValueStore from "discourse/lib/key-value-store";
 import Badge from "discourse/models/badge";
 import Category from "discourse/models/category";
 import I18n, { i18n } from "discourse-i18n";
@@ -26,6 +27,8 @@ import TopicViewComponent from "./result-types/topic";
 import UrlViewComponent from "./result-types/url";
 import UserViewComponent from "./result-types/user";
 
+const store = new KeyValueStore("discourse_data_explorer_");
+
 const VIEW_COMPONENTS = {
   topic: TopicViewComponent,
   text: TextViewComponent,
@@ -44,17 +47,37 @@ const VIEW_COMPONENTS = {
 export default class QueryResult extends Component {
   @service site;
 
-  @tracked showChart = true;
-  @tracked showTable = true;
+  @tracked showChart;
+  @tracked showTable;
+
+  constructor() {
+    super(...arguments);
+    const queryId = this.args.query?.id;
+    if (queryId) {
+      this.showChart = store.get(`showChart_${queryId}`) !== "false";
+      this.showTable = store.get(`showTable_${queryId}`) !== "false";
+    } else {
+      this.showChart = true;
+      this.showTable = true;
+    }
+  }
 
   @action
   toggleChart() {
     this.showChart = !this.showChart;
+    const queryId = this.args.query?.id;
+    if (queryId) {
+      store.set({ key: `showChart_${queryId}`, value: this.showChart });
+    }
   }
 
   @action
   toggleTable() {
     this.showTable = !this.showTable;
+    const queryId = this.args.query?.id;
+    if (queryId) {
+      store.set({ key: `showTable_${queryId}`, value: this.showTable });
+    }
   }
 
   get chartVisible() {
@@ -343,13 +366,15 @@ export default class QueryResult extends Component {
               @action={{this.toggleChart}}
               @icon="signal"
               @translatedTitle={{i18n "explorer.show_graph"}}
-              class={{if this.showChart "btn-primary" "btn-default"}}
+              class="btn-toggle-chart
+                {{if this.showChart 'btn-primary' 'btn-default'}}"
             />
             <DButton
               @action={{this.toggleTable}}
               @icon="table"
               @translatedTitle={{i18n "explorer.show_table"}}
-              class={{if this.showTable "btn-primary" "btn-default"}}
+              class="btn-toggle-table
+                {{if this.showTable 'btn-primary' 'btn-default'}}"
             />
           </div>
         {{/if}}

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -324,6 +324,46 @@ module(
       assert.dom("table").doesNotExist("table stays hidden");
     });
 
+    test("persists toggle state per query in localStorage", async function (assert) {
+      const query = { id: 42 };
+      const content = {
+        colrender: [],
+        result_count: 2,
+        columns: ["user_name", "like_count"],
+        rows: [
+          ["user1", 10],
+          ["user2", 20],
+        ],
+      };
+
+      await render(
+        <template>
+          <QueryResult @content={{content}} @query={{query}} />
+        </template>
+      );
+
+      assert.dom(".query-results-chart").exists("chart is visible by default");
+      assert.dom(".query-results-table").exists("table is visible by default");
+
+      await click(".btn-toggle-chart");
+      assert
+        .dom(".query-results-chart")
+        .doesNotExist("chart is hidden after toggle");
+
+      await render(
+        <template>
+          <QueryResult @content={{content}} @query={{query}} />
+        </template>
+      );
+
+      assert
+        .dom(".query-results-chart")
+        .doesNotExist("chart state is restored from localStorage");
+      assert
+        .dom(".query-results-table")
+        .exists("table state is restored from localStorage");
+    });
+
     test("toggle buttons are not shown for non-chartable data", async function (assert) {
       const content = {
         colrender: [],


### PR DESCRIPTION
Previously, the chart and table toggle buttons in the data explorer reset to both-visible every time a query was run. This persists the user's toggle preference per query in localStorage so it is remembered across runs and page navigations.