### PR TITLE
DEV: Optionally raise error on DiscourseHub calls

### DIFF
--- a/lib/discourse_hub.rb
+++ b/lib/discourse_hub.rb
@@ -3,6 +3,16 @@
 module DiscourseHub
   STATS_FETCHED_AT_KEY = "stats_fetched_at"
 
+  class Error < StandardError
+    attr_reader :status, :body
+
+    def initialize(rel_url, status, body)
+      @status = status
+      @body = body
+      super("Discourse Hub (#{rel_url}) returned status #{status}")
+    end
+  end
+
   def self.version_check_payload
     default_payload = { installed_version: Discourse::VERSION::STRING }.merge!(
       Discourse.git_branch == "unknown" && !Rails.env.test? ? {} : { branch: Discourse.git_branch },
@@ -39,37 +49,42 @@ module DiscourseHub
     end
   end
 
-  def self.get(rel_url, params = {})
-    singular_action :get, rel_url, params
+  def self.get(rel_url, params = {}, raise_on_error: false)
+    singular_action :get, rel_url, params, raise_on_error: raise_on_error
   end
 
-  def self.post(rel_url, params = {})
-    collection_action :post, rel_url, params
+  def self.post(rel_url, params = {}, raise_on_error: false)
+    collection_action :post, rel_url, params, raise_on_error: raise_on_error
   end
 
-  def self.put(rel_url, params = {})
-    collection_action :put, rel_url, params
+  def self.put(rel_url, params = {}, raise_on_error: false)
+    collection_action :put, rel_url, params, raise_on_error: raise_on_error
   end
 
-  def self.delete(rel_url, params = {})
-    singular_action :delete, rel_url, params
+  def self.delete(rel_url, params = {}, raise_on_error: false)
+    singular_action :delete, rel_url, params, raise_on_error: raise_on_error
   end
 
-  def self.singular_action(action, rel_url, params = {})
+  def self.singular_action(action, rel_url, params = {}, raise_on_error: false)
     connect_opts = connect_opts(params)
 
-    JSON.parse(
+    response =
       Excon.public_send(
         action,
         "#{hub_base_url}#{rel_url}",
         { headers: { "Referer" => referer, "Accept" => accepts.join(", ") }, query: params }.merge(
           connect_opts,
         ),
-      ).body,
-    )
+      )
+
+    if raise_on_error && response.status != 200
+      raise Error.new(rel_url, response.status, parse_body(response.body))
+    end
+
+    JSON.parse(response.body)
   end
 
-  def self.collection_action(action, rel_url, params = {})
+  def self.collection_action(action, rel_url, params = {}, raise_on_error: false)
     connect_opts = connect_opts(params)
 
     response =
@@ -90,11 +105,18 @@ module DiscourseHub
       Rails.logger.warn(response_status_log_message(rel_url, status))
     end
 
-    begin
-      JSON.parse(response.body)
-    rescue JSON::ParserError
-      Rails.logger.error(response_body_log_message(response.body))
-    end
+    body = parse_body(response.body)
+
+    raise Error.new(rel_url, status, body) if raise_on_error && status != 200
+
+    body
+  end
+
+  def self.parse_body(raw)
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    Rails.logger.error(response_body_log_message(raw))
+    nil
   end
 
   def self.response_status_log_message(rel_url, status)

--- a/spec/lib/discourse_hub_spec.rb
+++ b/spec/lib/discourse_hub_spec.rb
@@ -126,5 +126,30 @@ RSpec.describe DiscourseHub do
 
       expect(fake_logger.errors).to eq([DiscourseHub.response_body_log_message("")])
     end
+
+    context "when raise_on_error is true" do
+      it "raises DiscourseHub::Error with the parsed body on non-200 responses" do
+        stub_request(
+          :put,
+          (ENV["HUB_BASE_URL"] || "http://local.hub:3000/api") + "/test",
+        ).to_return(status: 422, body: { "error" => "Nope" }.to_json)
+
+        expect { DiscourseHub.put("/test", {}, raise_on_error: true) }.to raise_error(
+          DiscourseHub::Error,
+        ) do |error|
+          expect(error.status).to eq(422)
+          expect(error.body).to eq("error" => "Nope")
+        end
+      end
+
+      it "returns the parsed body on 200 responses" do
+        stub_request(
+          :put,
+          (ENV["HUB_BASE_URL"] || "http://local.hub:3000/api") + "/test",
+        ).to_return(status: 200, body: { "success" => true }.to_json)
+
+        expect(DiscourseHub.put("/test", {}, raise_on_error: true)).to eq("success" => true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This change won't affect functionality in core. It is only for plugins which are calling these DiscourseHub APIs.