### PR TITLE
DEV: move value transformer to be behavior in homepage model

### DIFF
--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -11,6 +11,7 @@
 export const BEHAVIOR_TRANSFORMERS = Object.freeze([
   "composer-position:correct-scroll-position",
   "composer-position:editor-touch-move",
+  "custom-homepage-model",
   "discovery-topic-list-load-more",
   "full-page-search-load-more",
   "post-menu-toggle-like-action",
@@ -52,7 +53,6 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "composer-toggles-class",
   "create-topic-button-class",
   "create-topic-label",
-  "custom-homepage-model",
   "flag-button-disabled-state",
   "flag-button-dynamic-class",
   "flag-button-render-decision",

--- a/frontend/discourse/app/routes/discovery/custom.js
+++ b/frontend/discourse/app/routes/discovery/custom.js
@@ -1,4 +1,4 @@
-import { applyValueTransformer } from "discourse/lib/transformer";
+import { applyBehaviorTransformer } from "discourse/lib/transformer";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class DiscoveryCustomRoute extends DiscourseRoute {
@@ -7,7 +7,7 @@ export default class DiscoveryCustomRoute extends DiscourseRoute {
   };
 
   model(data) {
-    return applyValueTransformer("custom-homepage-model", null, {
+    return applyBehaviorTransformer("custom-homepage-model", () => null, {
       queryParams: data,
     });
   }

--- a/frontend/discourse/tests/unit/routes/discovery-custom-test.js
+++ b/frontend/discourse/tests/unit/routes/discovery-custom-test.js
@@ -11,12 +11,12 @@ module("Unit | Route | discovery-custom", function (hooks) {
     assert.strictEqual(await route.model({}), null);
   });
 
-  test("custom-homepage-model value transformer can provide the model", async function (assert) {
+  test("custom-homepage-model behavior transformer can provide the model", async function (assert) {
     const route = this.owner.lookup("route:discovery.custom");
     const homepageModel = { latest: [{ id: 1 }], hot: [{ id: 2 }] };
 
     withPluginApi((api) => {
-      api.registerValueTransformer(
+      api.registerBehaviorTransformer(
         "custom-homepage-model",
         () => homepageModel
       );
@@ -25,12 +25,12 @@ module("Unit | Route | discovery-custom", function (hooks) {
     assert.strictEqual(await route.model({}), homepageModel);
   });
 
-  test("custom-homepage-model value transformer can be async", async function (assert) {
+  test("custom-homepage-model behavior transformer can be async", async function (assert) {
     const route = this.owner.lookup("route:discovery.custom");
     const homepageModel = { leaderboard: { users: [] } };
 
     withPluginApi((api) => {
-      api.registerValueTransformer(
+      api.registerBehaviorTransformer(
         "custom-homepage-model",
         async () => homepageModel
       );
@@ -39,15 +39,18 @@ module("Unit | Route | discovery-custom", function (hooks) {
     assert.strictEqual(await route.model({}), homepageModel);
   });
 
-  test("custom-homepage-model value transformer receives queryParams in context", async function (assert) {
+  test("custom-homepage-model behavior transformer receives queryParams in context", async function (assert) {
     const route = this.owner.lookup("route:discovery.custom");
     let receivedContext;
 
     withPluginApi((api) => {
-      api.registerValueTransformer("custom-homepage-model", ({ context }) => {
-        receivedContext = context;
-        return null;
-      });
+      api.registerBehaviorTransformer(
+        "custom-homepage-model",
+        ({ context }) => {
+          receivedContext = context;
+          return null;
+        }
+      );
     });
 
     await route.model({ q: "search term" });
@@ -55,17 +58,22 @@ module("Unit | Route | discovery-custom", function (hooks) {
     assert.deepEqual(receivedContext.queryParams, { q: "search term" });
   });
 
-  test("multiple value transformers compose, each receiving the previous value", async function (assert) {
+  test("custom-homepage-model behavior transformer can delegate via next()", async function (assert) {
     const route = this.owner.lookup("route:discovery.custom");
 
     withPluginApi((api) => {
-      api.registerValueTransformer("custom-homepage-model", () => ({ a: 1 }));
-      api.registerValueTransformer("custom-homepage-model", ({ value }) => ({
-        ...value,
-        b: 2,
+      api.registerBehaviorTransformer(
+        "custom-homepage-model",
+        async ({ next }) => {
+          const value = await next();
+          return { ...value, wrapped: true };
+        }
+      );
+      api.registerBehaviorTransformer("custom-homepage-model", () => ({
+        a: 1,
       }));
     });
 
-    assert.deepEqual(await route.model({}), { a: 1, b: 2 });
+    assert.deepEqual(await route.model({}), { a: 1, wrapped: true });
   });
 });


### PR DESCRIPTION
Moving `custom-homepage-model` from using a value transformer to using a behavior one because consumers _might_ do async calls, breaking one of the rules stated in `registerValueTransformer`:

https://github.com/discourse/discourse/blob/86046da198d1db11903dfb06a5437847d044843d/frontend/discourse/app/lib/plugin-api.gjs#L470-L474