### PR TITLE
FIX: Restore "All Patrons" pseudo-tier in admin UI

### DIFF
--- a/plugins/discourse-patreon/lib/campaign.rb
+++ b/plugins/discourse-patreon/lib/campaign.rb
@@ -30,6 +30,7 @@ module Patreon
 
       # Special catch all patrons virtual reward
       rewards["0"] ||= {}
+      rewards["0"]["id"] = "0"
       rewards["0"]["title"] = "All Patrons"
       rewards["0"]["amount_cents"] = 0
 

--- a/plugins/discourse-patreon/spec/lib/campaign_spec.rb
+++ b/plugins/discourse-patreon/spec/lib/campaign_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Patreon::Campaign do
       expect(Patreon.get("pledges").count).to eq(3)
       expect(Patreon::Pledge::Decline.all.count).to eq(2)
       expect(Patreon.get("rewards").count).to eq(expected_rewards_count)
+      expect(Patreon.get("rewards")["0"]).to include(
+        "id" => "0",
+        "title" => "All Patrons",
+        "amount_cents" => 0,
+      )
       expect(Patreon.get("users").count).to eq(3)
       expect(Patreon.get("reward-users")["0"].count).to eq(3)
       expect(Patreon.get("filters").count).to eq(1)


### PR DESCRIPTION
## Summary

The Patreon plugin maintains a synthetic `rewards[\"0\"]` tier ("All Patrons") that catches every patron, including paying patrons whose pledge doesn't map to any predefined tier. It's supposed to appear as `\$0 - All Patrons` in the admin dropdown where group filters are configured.

In affected campaigns, this option silently disappeared and was replaced by `\$0 - Free` (Patreon's real default free tier, with its own numeric id). Admins lost the ability to filter on "any patron".

### Root cause

`rewards[\"0\"] ||= {}` in `lib/campaign.rb` relied on Patreon's payload having already populated `rewards[\"0\"][\"id\"] = \"0\"` via the adapter's `parse_campaigns`. For campaigns where Patreon no longer returns a reward keyed on `\"0\"` (e.g. when the campaign has a real "Free" tier), the pseudo-tier ended up stored with only `title` and `amount_cents` — no `id`.

The admin dropdown filters rewards client-side with `r.id >= 0` (in `assets/javascripts/discourse/controllers/admin-plugins/patreon.js`). Since `undefined >= 0` evaluates to `false`, "All Patrons" was dropped from the options. Existing filter rules keyed on `\"0\"` continued to work on the backend, but admins could no longer create or edit them.

### Fix

Assign `rewards[\"0\"][\"id\"] = \"0\"` explicitly so the pseudo-tier is always selectable. Confirmed against a live v1 site: `reward-users[\"0\"]` still tracked all 946 patrons, the backend state was healthy, only the UI was broken. Applies equally to v1 and v2 since the assignment runs adapter-agnostic.

Existing filter rules keyed on `\"0\"` keep working and start matching again on the next sync — no data migration needed.

## Test plan

- [x] `bin/rspec plugins/discourse-patreon/spec/lib/campaign_spec.rb` passes under both v1 and v2 shared examples, asserting `rewards[\"0\"]` includes `id: \"0\"`
- [x] `bin/lint` clean
- [ ] On the affected site, run \`Patreon::Campaign.update!\` (or click *Update Data*) and verify \`\$0 - All Patrons\` reappears in the admin dropdown and can be assigned to a group