### PR TITLE
UX: various styling improvements for events plugin

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -412,7 +412,6 @@ html:not(.keyboard-visible).mobile-device {
   }
 
   .nav {
-    padding: 10px 30px 10px 15px;
     background-color: var(--secondary);
     border-bottom: 1px solid var(--content-border-color);
 

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -32,6 +32,7 @@
     > a,
     button {
       position: relative;
+      border: 0;
       border-radius: var(--d-nav-pill-border-radius);
       padding: 0.65em 0.75em;
       color: var(--d-nav-color);

--- a/frontend/discourse/admin/components/simple-list.gjs
+++ b/frontend/discourse/admin/components/simple-list.gjs
@@ -144,7 +144,7 @@ export default class SimpleList extends Component {
             @action={{fn this.addValue this.newValue}}
             @disabled={{not this.newValue}}
             @icon="plus"
-            class="add-value-btn btn-small"
+            class="add-value-btn btn-default btn-small"
           />
         {{/if}}
       </div>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -190,19 +190,23 @@ export default class DiscoursePostEvent extends Component {
                   </div>
                 </div>
 
-                <MoreMenu
-                  @event={{event}}
-                  @isStandaloneEvent={{this.isStandaloneEvent}}
-                  @composePrivateMessage={{routeAction "composePrivateMessage"}}
-                />
-
-                {{#if @onClose}}
-                  <DButton
-                    class="btn-default btn-small discourse-post-event-close"
-                    @icon="xmark"
-                    @action={{@onClose}}
+                <div class="event-header__controls">
+                  <MoreMenu
+                    @event={{event}}
+                    @isStandaloneEvent={{this.isStandaloneEvent}}
+                    @composePrivateMessage={{routeAction
+                      "composePrivateMessage"
+                    }}
                   />
-                {{/if}}
+
+                  {{#if @onClose}}
+                    <DButton
+                      class="btn-default btn-small discourse-post-event-close"
+                      @icon="xmark"
+                      @action={{@onClose}}
+                    />
+                  {{/if}}
+                </div>
               </header>
 
               <PluginOutlet

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -295,6 +295,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
       @triggerClass={{concatClass
         "more-dropdown"
         "btn-small"
+        "btn-default"
         (if this.isSavingEvent "--saving")
       }}
       @icon="ellipsis"

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -133,7 +133,7 @@ export default class DiscoursePostEventStatus extends Component {
               }}
             >
               <DButton
-                class="going-button"
+                class="btn-default going-button"
                 @disabled={{and
                   @event.atCapacity
                   (not (eq this.watchingInviteeStatus "going"))
@@ -161,7 +161,7 @@ export default class DiscoursePostEventStatus extends Component {
             }}
           >
             <DButton
-              class="interested-button"
+              class="btn-default interested-button"
               @icon="star"
               @label="discourse_post_event.models.invitee.status.interested"
               @action={{fn this.changeWatchingInviteeStatus "interested"}}
@@ -179,7 +179,7 @@ export default class DiscoursePostEventStatus extends Component {
               }}
             >
               <DButton
-                class="not-going-button"
+                class="btn-default not-going-button"
                 @icon="xmark"
                 @label="discourse_post_event.models.invitee.status.not_going"
                 @action={{fn this.changeWatchingInviteeStatus "not_going"}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -689,7 +689,7 @@ export default class PostEventBuilder extends Component {
                       <DButton
                         @action={{fn @model.event.removeReminder reminder}}
                         @icon="xmark"
-                        class="remove-reminder"
+                        class="btn-default remove-reminder"
                       />
                     </div>
                   {{/each}}
@@ -700,7 +700,7 @@ export default class PostEventBuilder extends Component {
                   @icon="plus"
                   @label="discourse_post_event.builder_modal.add_reminder"
                   @action={{@model.event.addReminder}}
-                  class="add-reminder"
+                  class="btn-default add-reminder"
                 />
               </EventField>
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-invitees/index.gjs
@@ -117,7 +117,7 @@ export default class PostEventInviteesModal extends Component {
 
                   {{#if @model.event.canActOnDiscoursePostEvent}}
                     <DButton
-                      class="remove-invitee"
+                      class="btn-transparent btn-danger remove-invitee"
                       @icon="trash-can"
                       @action={{fn this.removeInvitee invitee}}
                       title={{i18n
@@ -136,7 +136,7 @@ export default class PostEventInviteesModal extends Component {
 
                     {{#if @model.event.canActOnDiscoursePostEvent}}
                       <DButton
-                        class="add-invitee"
+                        class="btn-default add-invitee"
                         @icon="plus"
                         @action={{fn this.addInvitee user}}
                         title={{i18n

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/toggle-invitees.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/toggle-invitees.gjs
@@ -1,37 +1,48 @@
 import { fn } from "@ember/helper";
-import DButton from "discourse/components/d-button";
+import { on } from "@ember/modifier";
 import concatClass from "discourse/helpers/concat-class";
 import { eq } from "discourse/truth-helpers";
+import { i18n } from "discourse-i18n";
 
 const ToggleInvitees = <template>
-  <div class="invitees-type-filter">
-    <DButton
-      @label="discourse_post_event.models.invitee.status.going"
-      class={{concatClass
-        "btn toggle-going"
-        (if (eq @viewType "going") "btn-danger" "btn-default")
-      }}
-      @action={{fn @toggle "going"}}
-    />
-
-    <DButton
-      @label="discourse_post_event.models.invitee.status.interested"
-      class={{concatClass
-        "btn toggle-interested"
-        (if (eq @viewType "interested") "btn-danger" "btn-default")
-      }}
-      @action={{fn @toggle "interested"}}
-    />
-
-    <DButton
-      @label="discourse_post_event.models.invitee.status.not_going"
-      class={{concatClass
-        "btn toggle-not-going"
-        (if (eq @viewType "not_going") "btn-danger" "btn-default")
-      }}
-      @action={{fn @toggle "not_going"}}
-    />
-  </div>
+  <ul class="nav nav-pills invitees-type-filter">
+    <li>
+      <button
+        type="button"
+        class={{concatClass
+          "toggle-going"
+          (if (eq @viewType "going") "active")
+        }}
+        {{on "click" (fn @toggle "going")}}
+      >
+        {{i18n "discourse_post_event.models.invitee.status.going"}}
+      </button>
+    </li>
+    <li>
+      <button
+        type="button"
+        class={{concatClass
+          "toggle-interested"
+          (if (eq @viewType "interested") "active")
+        }}
+        {{on "click" (fn @toggle "interested")}}
+      >
+        {{i18n "discourse_post_event.models.invitee.status.interested"}}
+      </button>
+    </li>
+    <li>
+      <button
+        type="button"
+        class={{concatClass
+          "toggle-not-going"
+          (if (eq @viewType "not_going") "active")
+        }}
+        {{on "click" (fn @toggle "not_going")}}
+      >
+        {{i18n "discourse_post_event.models.invitee.status.not_going"}}
+      </button>
+    </li>
+  </ul>
 </template>;
 
 export default ToggleInvitees;

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-invitees.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-invitees.scss
@@ -1,24 +1,17 @@
 .post-event-invitees-modal {
   .loading-container {
     height: 40vh;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     .no-users {
+      margin-top: var(--space-4);
       text-align: center;
       font-size: var(--font-up-1);
     }
   }
 
   .invitees-type-filter {
-    margin-bottom: 9px;
-    display: flex;
-
-    .btn {
-      width: calc(100% / 3);
-      margin: 0;
-      border-radius: 0;
-      padding: 0.75em 0;
-    }
+    margin: 0 0 -1px 0;
   }
 
   .filter {
@@ -46,7 +39,6 @@
       }
 
       .user {
-        max-width: 175px;
         display: flex;
         align-items: center;
         white-space: nowrap;
@@ -73,10 +65,5 @@
         }
       }
     }
-  }
-
-  .possible-invitees {
-    margin-top: 1em;
-    background-color: var(--primary-very-low);
   }
 }

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -101,7 +101,6 @@ $show-interested: inherit;
 
     .more-dropdown {
       margin-left: auto;
-      align-self: flex-start;
 
       &.has-no-actions {
         display: none;
@@ -125,6 +124,12 @@ $show-interested: inherit;
           }
         }
       }
+    }
+
+    &__controls {
+      display: flex;
+      gap: var(--space-2);
+      margin-left: auto;
     }
   }
 
@@ -341,7 +346,10 @@ $show-interested: inherit;
       .topic-invitee-avatar {
         position: relative;
         display: inline-block;
-        padding-right: 0.5em;
+
+        &:has(.avatar-flair) {
+          padding-right: var(--space-2);
+        }
 
         .avatar {
           width: 1.5rem;

--- a/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
@@ -2,6 +2,11 @@
 
 .fc {
   padding-bottom: 5px;
+
+  .fc-button .fc-icon {
+    font-size: 1.2em;
+    line-height: 0.8;
+  }
 }
 
 .fc-button,
@@ -12,6 +17,10 @@
 .fc-button:focus {
   background: var(--d-button-default-bg-color--hover) !important;
   color: var(--d-button-default-text-color--hover) !important;
+}
+
+.fc-button:not([disabled]):hover {
+  --fc-button-text-color: var(--d-button-default-text-color--hover) !important;
 }
 
 .fc-button-active {

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -100,12 +100,12 @@
     .reminders-list {
       display: flex;
       flex-direction: column;
-      margin-bottom: 1em;
 
       .reminder-item {
         display: flex;
         flex: 1 0 auto;
         padding: 0.25em 0;
+        margin-bottom: var(--space-2);
 
         .select-kit-header {
           height: 100%;


### PR DESCRIPTION
This is a general styling pass of various elements within the events plugin. 

* Adds missing `btn-default` classes where applicable 
* Updates styling of modal toggle to match other core elements 

   Before:
   
   <img width="600"  alt="image" src="https://github.com/user-attachments/assets/33512a0b-2d6d-414e-9bda-422914978e08" />

   
   
   After:
   
     
    <img width="600"  alt="image" src="https://github.com/user-attachments/assets/38f4e1ad-37c8-4c5a-bfa0-ce4e0050d5f5" />

   
* Improves button spacing 

    Before:
    
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/5f51c936-d263-4888-b962-914abdd4ad89" />

    
    After: 
    
    <img width="500"  alt="image" src="https://github.com/user-attachments/assets/902f1a12-cf75-44e0-af90-52a2107cfa37" />

* Minor alignment adjustments