### PR TITLE
FIX: clear push subscriptions on DiscourseConnect single-logout

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -57,6 +57,7 @@ class SessionController < ApplicationController
       data = result.data
       if data[:logout]
         params[:return_url] = data[:return_sso_url]
+        PushNotificationPusher.clear_subscriptions(current_user) if current_user
         destroy
         return
       end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1664,6 +1664,18 @@ RSpec.describe SessionController do
         expect(response.cookies["_t"]).to be_blank
       end
 
+      it "clears all push subscriptions on SSO single-logout" do
+        sign_in(@user)
+        Fabricate(:push_subscription, user: @user)
+        Fabricate(:push_subscription, user: @user)
+
+        @sso.logout = true
+        get "/session/sso_provider",
+            params: Rack::Utils.parse_query(@sso.payload("secretForOverRainbow"))
+
+        expect(@user.push_subscriptions.reload).to be_empty
+      end
+
       it "successfully logs out and redirects user to return_sso_url when the user is not logged in" do
         @sso.logout = true
         get "/session/sso_provider",


### PR DESCRIPTION
## Summary
- Follow-up to #39266 which removed the blanket `clear_subscriptions` from the `:user_logged_out` event handler
- The SSO single-logout flow (`session#sso_provider` → `destroy`) is server-initiated with no frontend context, so the current browser's push subscription can't be identified individually
- Clear all push subscriptions for the user in this flow, matching the pre-#39266 behavior and consistent with other server-initiated logout paths (admin log out, suspension, `log_out_strict`)

## Test plan
- [ ] `bin/rspec spec/requests/session_controller_spec.rb` — includes new spec asserting SSO single-logout clears all push subscriptions
- [ ] Manual: configure DiscourseConnect provider, subscribe to push on two browsers, trigger SSO logout, verify all subscriptions are removed