### PR TITLE
DEV: Add modifier for default_navigation_menu_categories

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2217,6 +2217,12 @@ class User < ActiveRecord::Base
 
     if SiteSetting.default_navigation_menu_categories.present?
       categories_to_update = SiteSetting.default_navigation_menu_categories.split("|")
+      categories_to_update =
+        DiscoursePluginRegistry.apply_modifier(
+          :default_navigation_categories,
+          categories_to_update,
+          user: self,
+        )
 
       SidebarSectionLinksUpdater.update_category_section_links(
         self,

--- a/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
@@ -1,3 +1,4 @@
+import { applyValueTransformer } from "discourse/lib/transformer";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
 import AllCategoriesSectionLink from "../common/all-categories-section-link";
@@ -6,19 +7,26 @@ import Section from "../section";
 import SectionLink from "../section-link";
 
 export default class SidebarAnonymousCategoriesSection extends SidebarCommonCategoriesSection {
-  shouldSortCategoriesByDefault =
-    !!this.siteSettings.default_navigation_menu_categories;
+  get #defaultCategoryIds() {
+    const raw = this.siteSettings.default_navigation_menu_categories;
+    const initial = raw ? raw.split("|").map((id) => parseInt(id, 10)) : [];
+
+    return applyValueTransformer(
+      "sidebar-anonymous-default-categories",
+      initial
+    );
+  }
+
+  get shouldSortCategoriesByDefault() {
+    return this.#defaultCategoryIds.length > 0;
+  }
 
   get categories() {
-    if (this.siteSettings.default_navigation_menu_categories) {
-      return Category.findByIds(
-        this.siteSettings.default_navigation_menu_categories
-          .split("|")
-          .map((categoryId) => parseInt(categoryId, 10))
-      );
-    } else {
-      return this.topSiteCategories;
+    const ids = this.#defaultCategoryIds;
+    if (ids.length) {
+      return Category.findByIds(ids);
     }
+    return this.topSiteCategories;
   }
 
   <template>

--- a/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/categories-section.gjs
@@ -7,7 +7,17 @@ import Section from "../section";
 import SectionLink from "../section-link";
 
 export default class SidebarAnonymousCategoriesSection extends SidebarCommonCategoriesSection {
-  get #defaultCategoryIds() {
+  shouldSortCategoriesByDefault = this.#defaultCategoryIds().length > 0;
+
+  get categories() {
+    const ids = this.#defaultCategoryIds();
+    if (ids.length) {
+      return Category.findByIds(ids);
+    }
+    return this.topSiteCategories;
+  }
+
+  #defaultCategoryIds() {
     const raw = this.siteSettings.default_navigation_menu_categories;
     const initial = raw ? raw.split("|").map((id) => parseInt(id, 10)) : [];
 
@@ -15,18 +25,6 @@ export default class SidebarAnonymousCategoriesSection extends SidebarCommonCate
       "sidebar-anonymous-default-categories",
       initial
     );
-  }
-
-  get shouldSortCategoriesByDefault() {
-    return this.#defaultCategoryIds.length > 0;
-  }
-
-  get categories() {
-    const ids = this.#defaultCategoryIds;
-    if (ids.length) {
-      return Category.findByIds(ids);
-    }
-    return this.topSiteCategories;
   }
 
   <template>

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -102,6 +102,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "poster-name-user-title",
   "preferences-save-attributes",
   "quote-params",
+  "sidebar-anonymous-default-categories",
   "small-user-attrs",
   "tag-separator",
   "topic-list-class",

--- a/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -129,6 +129,40 @@ acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
     assert.deepEqual(received, [1, 3]);
   });
 
+  test("sidebar-anonymous-default-categories value transformer appends a category to the ids received from default_navigation_menu_categories", async function (assert) {
+    this.siteSettings.default_navigation_menu_categories = "1";
+
+    let received;
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "sidebar-anonymous-default-categories",
+        ({ value }) => {
+          received = value;
+          return [...value, 3];
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert.deepEqual(
+      received,
+      [1],
+      "transformer receives the ids parsed from the site setting"
+    );
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id='1']"
+      )
+      .exists("category 1 (from the original setting) is in the sidebar");
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id='3']"
+      )
+      .exists("category 3 (appended by the transformer) is in the sidebar");
+  });
+
   test("sidebar-anonymous-default-categories value transformer can fall back to top site categories by returning an empty array", async function (assert) {
     this.siteSettings.default_navigation_menu_categories = "1|3";
 

--- a/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -1,5 +1,6 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import Site from "discourse/models/site";
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 
@@ -71,6 +72,78 @@ acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
     assert.dom(categories[1]).hasText("blog");
     assert.dom(categories[2]).hasText("bug");
 
+    assert
+      .dom("a.sidebar-section-link[data-link-name='all-categories']")
+      .exists("all categories link is visible");
+  });
+
+  test("sidebar-anonymous-default-categories value transformer overrides the category IDs used in the sidebar", async function (assert) {
+    this.siteSettings.fixed_category_positions = true;
+    this.siteSettings.default_navigation_menu_categories = "1";
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "sidebar-anonymous-default-categories",
+        () => [3, 13]
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id='3']"
+      )
+      .exists("category 3 (from the override) is in the sidebar");
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id='13']"
+      )
+      .exists("category 13 (from the override) is in the sidebar");
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id='1']"
+      )
+      .doesNotExist(
+        "category 1 (from the original setting) is replaced by the override"
+      );
+  });
+
+  test("sidebar-anonymous-default-categories value transformer receives the ids parsed from default_navigation_menu_categories", async function (assert) {
+    this.siteSettings.default_navigation_menu_categories = "1|3";
+
+    let received;
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "sidebar-anonymous-default-categories",
+        ({ value }) => {
+          received = value;
+          return value;
+        }
+      );
+    });
+
+    await visit("/");
+
+    assert.deepEqual(received, [1, 3]);
+  });
+
+  test("sidebar-anonymous-default-categories value transformer can fall back to top site categories by returning an empty array", async function (assert) {
+    this.siteSettings.default_navigation_menu_categories = "1|3";
+
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "sidebar-anonymous-default-categories",
+        () => []
+      );
+    });
+
+    await visit("/");
+
+    assert
+      .dom(".sidebar-section[data-section-name='categories']")
+      .exists("categories section is still rendered");
     assert
       .dom("a.sidebar-section-link[data-link-name='all-categories']")
       .exists("all categories link is visible");

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,6 +121,50 @@ RSpec.describe User do
         expect(SidebarSectionLink.exists?(linkable_type: "Category", user_id: user.id)).to eq(true)
         expect(SidebarSectionLink.exists?(linkable_type: "Tag", user_id: user.id)).to eq(false)
       end
+
+      describe "the :default_navigation_categories modifier" do
+        fab!(:alternate_category, :category)
+
+        let!(:plugin) { Plugin::Instance.new }
+        let!(:modifier) { :default_navigation_categories }
+
+        it "lets plugins override the category ids used to seed the sidebar" do
+          block =
+            Proc.new do |_default_categories, opts|
+              expect(opts[:user]).to be_a(User)
+              [alternate_category.id.to_s]
+            end
+
+          DiscoursePluginRegistry.register_modifier(plugin, modifier, &block)
+
+          user = Fabricate(:user)
+
+          expect(
+            SidebarSectionLink.where(linkable_type: "Category", user_id: user.id).pluck(
+              :linkable_id,
+            ),
+          ).to contain_exactly(alternate_category.id)
+        ensure
+          DiscoursePluginRegistry.unregister_modifier(plugin, modifier, &block)
+        end
+
+        it "passes the user to the modifier so plugins can branch on user attributes" do
+          received_users = []
+          block =
+            Proc.new do |default_categories, opts|
+              received_users << opts[:user]
+              default_categories
+            end
+
+          DiscoursePluginRegistry.register_modifier(plugin, modifier, &block)
+
+          user = Fabricate(:user)
+
+          expect(received_users).to contain_exactly(user)
+        ensure
+          DiscoursePluginRegistry.unregister_modifier(plugin, modifier, &block)
+        end
+      end
     end
 
     describe "#change_display_name" do


### PR DESCRIPTION
This is useful for plugins that want to dynamically change the default categories for the default sidebar categories(anonymous and regular users when registering)
