### PR TITLE
UX: Keep usable tags before disabled rows when sorted alphabetically

### DIFF
--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -185,16 +185,12 @@ export default class MiniTagChooser extends MultiSelectComponent {
       return [];
     }
 
-    let results = json.results;
-
     this.setProperties({
       termMatchesForbidden: json.forbidden ? true : false,
       termMatchErrorMessage: json.forbidden_message,
     });
 
-    if (this.siteSettings.tags_sort_alphabetically) {
-      results = results.sort((a, b) => a.name.localeCompare(b.name));
-    }
+    let results = this.tagUtils.sortSearchResults(json.results);
 
     if (json.required_tag_group) {
       this.set(

--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -184,16 +184,12 @@ export default class MiniTagChooser extends MultiSelectComponent {
       return [];
     }
 
-    let results = json.results;
-
     this.setProperties({
       termMatchesForbidden: json.forbidden ? true : false,
       termMatchErrorMessage: json.forbidden_message,
     });
 
-    if (this.siteSettings.tags_sort_alphabetically) {
-      results = results.sort((a, b) => a.name.localeCompare(b.name));
-    }
+    let results = this.tagUtils.sortSearchResults(json.results);
 
     if (json.required_tag_group) {
       this.set(

--- a/frontend/discourse/select-kit/components/tag-chooser-row.gjs
+++ b/frontend/discourse/select-kit/components/tag-chooser-row.gjs
@@ -6,5 +6,8 @@ import dDiscourseTag from "discourse/ui-kit/helpers/d-discourse-tag";
 export default class TagChooserRow extends SelectKitRowComponent {
   <template>
     {{dDiscourseTag this.rowName count=this.item.count noHref=true}}
+    {{#if this.rowDisabled}}
+      <span class="disabled-reason">{{this.title}}</span>
+    {{/if}}
   </template>
 }

--- a/frontend/discourse/select-kit/components/tag-chooser-row.gjs
+++ b/frontend/discourse/select-kit/components/tag-chooser-row.gjs
@@ -6,5 +6,8 @@ import SelectKitRowComponent from "discourse/select-kit/components/select-kit/se
 export default class TagChooserRow extends SelectKitRowComponent {
   <template>
     {{discourseTag this.rowName count=this.item.count noHref=true}}
+    {{#if this.rowDisabled}}
+      <span class="disabled-reason">{{this.title}}</span>
+    {{/if}}
   </template>
 }

--- a/frontend/discourse/select-kit/components/tag-chooser.js
+++ b/frontend/discourse/select-kit/components/tag-chooser.js
@@ -193,7 +193,6 @@ export default class TagChooser extends MultiSelectComponent {
 
     const blockedTags = this._normalizedBlockedTags;
     if (blockedTags.length) {
-      // extract names from blockedTags (may be strings or objects)
       const blockedNames = blockedTags.map((t) =>
         typeof t === "string" ? t : t.name
       );
@@ -202,9 +201,7 @@ export default class TagChooser extends MultiSelectComponent {
       });
     }
 
-    if (this.siteSettings.tags_sort_alphabetically) {
-      results = results.sort((a, b) => a.name > b.name);
-    }
+    results = this.tagUtils.sortSearchResults(results);
 
     return uniqueItemsFromArray(results, "name");
   }

--- a/frontend/discourse/select-kit/components/tag-chooser.js
+++ b/frontend/discourse/select-kit/components/tag-chooser.js
@@ -187,7 +187,6 @@ export default class TagChooser extends MultiSelectComponent {
     });
 
     if (this.blockedTags) {
-      // extract names from blockedTags (may be strings or objects)
       const blockedNames = this.blockedTags.map((t) =>
         typeof t === "string" ? t : t.name
       );
@@ -196,9 +195,7 @@ export default class TagChooser extends MultiSelectComponent {
       });
     }
 
-    if (this.siteSettings.tags_sort_alphabetically) {
-      results = results.sort((a, b) => a.name > b.name);
-    }
+    results = this.tagUtils.sortSearchResults(results);
 
     return uniqueItemsFromArray(results, "name");
   }

--- a/frontend/discourse/select-kit/services/tag-utils.js
+++ b/frontend/discourse/select-kit/services/tag-utils.js
@@ -15,6 +15,16 @@ export default class TagUtils extends Service {
       .catch(popupAjaxError);
   }
 
+  sortSearchResults(results) {
+    if (!this.siteSettings.tags_sort_alphabetically) {
+      return results;
+    }
+    const byName = (a, b) => a.name.localeCompare(b.name);
+    const enabled = results.filter((r) => !r.disabled).sort(byName);
+    const disabled = results.filter((r) => r.disabled).sort(byName);
+    return [...enabled, ...disabled];
+  }
+
   validateCreate(
     filter,
     content,

--- a/frontend/discourse/tests/unit/services/tag-utils-test.js
+++ b/frontend/discourse/tests/unit/services/tag-utils-test.js
@@ -49,4 +49,20 @@ module("Unit | Service | tag-utils", function (hooks) {
       "node.js"
     );
   });
+
+  test("sortSearchResults keeps usable tags before disabled ones when sorting alphabetically", function (assert) {
+    this.tagUtils.siteSettings.tags_sort_alphabetically = true;
+
+    const results = [
+      { name: "z-ready", disabled: false },
+      { name: "ready-to-deploy", disabled: true },
+      { name: "apple-ready", disabled: false },
+      { name: "boom-ready", disabled: true },
+    ];
+
+    assert.deepEqual(
+      this.tagUtils.sortSearchResults(results).map((r) => r.name),
+      ["apple-ready", "z-ready", "boom-ready", "ready-to-deploy"]
+    );
+  });
 });

--- a/frontend/discourse/tests/unit/services/tag-utils-test.js
+++ b/frontend/discourse/tests/unit/services/tag-utils-test.js
@@ -38,4 +38,20 @@ module("Unit | Service | tag-utils", function (hooks) {
       "specialchars"
     );
   });
+
+  test("sortSearchResults keeps usable tags before disabled ones when sorting alphabetically", function (assert) {
+    this.tagUtils.siteSettings.tags_sort_alphabetically = true;
+
+    const results = [
+      { name: "z-ready", disabled: false },
+      { name: "ready-to-deploy", disabled: true },
+      { name: "apple-ready", disabled: false },
+      { name: "boom-ready", disabled: true },
+    ];
+
+    assert.deepEqual(
+      this.tagUtils.sortSearchResults(results).map((r) => r.name),
+      ["apple-ready", "z-ready", "boom-ready", "ready-to-deploy"]
+    );
+  });
 });

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -156,6 +156,26 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "with a mix of allowed and disabled matches" do
+      fab!(:blocked_sibling) { Fabricate(:tag, name: "alphablocked") }
+      fab!(:tag_group) do
+        Fabricate(
+          :tag_group,
+          name: "Exclusive Group",
+          one_per_topic: true,
+          tags: [tag2, blocked_sibling],
+        )
+      end
+
+      let(:params) { { q: "alpha", filterForInput: true, selected_tags: [tag2.name] } }
+
+      it "lists allowed tags before disabled tags" do
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).to include("alpha", "alphablocked")
+        expect(names.index("alpha")).to be < names.index("alphablocked")
+      end
+    end
+
     context "when allowed tags are cut off by the limit" do
       fab!(:tag_foo1) { Fabricate(:tag, name: "foomatch1") }
       fab!(:tag_foo2) { Fabricate(:tag, name: "foomatch2") }

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -393,6 +393,26 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "with a mix of allowed and disabled matches" do
+      fab!(:blocked_sibling) { Fabricate(:tag, name: "alphablocked") }
+      fab!(:tag_group) do
+        Fabricate(
+          :tag_group,
+          name: "Exclusive Group",
+          one_per_topic: true,
+          tags: [tag2, blocked_sibling],
+        )
+      end
+
+      let(:params) { { q: "alpha", filterForInput: true, selected_tags: [tag2.name] } }
+
+      it "lists allowed tags before disabled tags" do
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).to include("alpha", "alphablocked")
+        expect(names.index("alpha")).to be < names.index("alphablocked")
+      end
+    end
+
     context "when allowed tags are cut off by the limit" do
       fab!(:tag_foo1) { Fabricate(:tag, name: "foomatch1") }
       fab!(:tag_foo2) { Fabricate(:tag, name: "foomatch2") }

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -142,6 +142,16 @@ module PageObjects
         expanded_component.has_no_css?(".select-kit-row.is-selected")
       end
 
+      def has_disabled_row_name?(name)
+        expanded_component.has_css?(".select-kit-row.disabled[data-name='#{name}']")
+      end
+
+      def has_disabled_row_reason?(name)
+        expanded_component.has_css?(
+          ".select-kit-row.disabled[data-name='#{name}'] .disabled-reason",
+        )
+      end
+
       def option_names
         expanded_component.all(".select-kit-row").map { |row| row["data-name"] }
       end

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -171,13 +171,10 @@ module PageObjects
         has_no_css?("#{@context}.is-expanded .select-kit-row.is-selected")
       end
 
-      def has_disabled_row_name?(name)
-        expanded_component.has_css?(".select-kit-row.disabled[data-name='#{name}']")
-      end
-
       def has_disabled_row_reason?(name)
-        expanded_component.has_css?(
-          ".select-kit-row.disabled[data-name='#{name}'] .disabled-reason",
+        expanded_component
+        has_css?(
+          "#{@context}.is-expanded .select-kit-row.disabled[data-name='#{name}'] .disabled-reason",
         )
       end
 

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -171,6 +171,16 @@ module PageObjects
         has_no_css?("#{@context}.is-expanded .select-kit-row.is-selected")
       end
 
+      def has_disabled_row_name?(name)
+        expanded_component.has_css?(".select-kit-row.disabled[data-name='#{name}']")
+      end
+
+      def has_disabled_row_reason?(name)
+        expanded_component.has_css?(
+          ".select-kit-row.disabled[data-name='#{name}'] .disabled-reason",
+        )
+      end
+
       def option_names
         expanded_component
           .locator(".select-kit-row")

--- a/spec/system/tags/tag_search_hints_spec.rb
+++ b/spec/system/tags/tag_search_hints_spec.rb
@@ -1,61 +1,110 @@
 # frozen_string_literal: true
 
-describe "Tag search hints in composer" do
+describe "Tag search: disabled hints" do
   fab!(:admin)
 
   let(:composer) { PageObjects::Components::Composer.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer_tag_chooser) do
+    PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
+  end
 
   before do
     SiteSetting.tagging_enabled = true
     SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
   end
 
-  context "with one_per_topic tag group" do
-    fab!(:todo_tag) { Fabricate(:tag, name: "todo") }
-    fab!(:ready_tag) { Fabricate(:tag, name: "ready-to-deploy") }
+  def open_topic_for_edit(topic, post)
+    sign_in(admin)
+    visit topic.url
+    topic_page.click_post_action_button(post, :edit)
+    expect(composer).to be_opened
+  end
 
-    fab!(:tag_group) do
-      Fabricate(:tag_group, name: "Workflow", tags: [todo_tag, ready_tag], one_per_topic: true)
+  describe "in the composer (mini-tag-chooser)" do
+    context "with a one_per_topic tag group" do
+      fab!(:todo_tag) { Fabricate(:tag, name: "todo") }
+      fab!(:ready_tag) { Fabricate(:tag, name: "ready-to-deploy") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Workflow", tags: [todo_tag, ready_tag], one_per_topic: true)
+      end
+      fab!(:topic) { Fabricate(:topic, user: admin, tags: [todo_tag]) }
+      fab!(:post) { Fabricate(:post, topic:, user: admin) }
+
+      it "marks the sibling tag as disabled" do
+        open_topic_for_edit(topic, post)
+        composer_tag_chooser.expand
+        composer_tag_chooser.search("ready-to-deploy")
+
+        expect(composer_tag_chooser).to have_disabled_row_name("ready-to-deploy")
+      end
+
+      context "with tags_sort_alphabetically enabled" do
+        fab!(:usable_tag) { Fabricate(:tag, name: "z-ready") }
+
+        before { SiteSetting.tags_sort_alphabetically = true }
+
+        it "lists usable tags before disabled tags" do
+          open_topic_for_edit(topic, post)
+          composer_tag_chooser.expand
+          composer_tag_chooser.search("ready")
+
+          expect(composer_tag_chooser).to have_disabled_row_name("ready-to-deploy")
+
+          names = composer_tag_chooser.option_names
+          expect(names.index("z-ready")).to be < names.index("ready-to-deploy")
+        end
+      end
     end
 
-    fab!(:topic) { Fabricate(:topic, user: admin, tags: [todo_tag]) }
-    fab!(:post) { Fabricate(:post, topic: topic, user: admin) }
+    context "with a missing parent tag" do
+      fab!(:parent_tag) { Fabricate(:tag, name: "vehicles") }
+      fab!(:child_tag) { Fabricate(:tag, name: "sedan") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag:)
+      end
 
-    it "shows sibling tag as disabled with tooltip" do
-      sign_in(admin)
-      visit topic.url
+      it "marks the child tag as disabled" do
+        sign_in(admin)
+        visit "/new-topic"
+        expect(composer).to be_opened
 
-      find("#post_1 .post-controls .edit").click
-      expect(composer).to be_opened
+        composer_tag_chooser.expand
+        composer_tag_chooser.search("sedan")
 
-      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
-      tag_chooser.expand
-      tag_chooser.search("ready-to-deploy")
-
-      expect(page).to have_css(
-        ".mini-tag-chooser .select-kit-row.disabled[data-name='ready-to-deploy']",
-      )
+        expect(composer_tag_chooser).to have_disabled_row_name("sedan")
+      end
     end
   end
 
-  context "with parent tag group" do
+  describe "in bulk-actions (tag-chooser)" do
     fab!(:parent_tag) { Fabricate(:tag, name: "vehicles") }
     fab!(:child_tag) { Fabricate(:tag, name: "sedan") }
-
     fab!(:tag_group) do
-      Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag: parent_tag)
+      Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag:)
     end
+    fab!(:topic)
+    fab!(:post) { Fabricate(:post, topic:) }
 
-    it "shows child tag as disabled when parent is not selected" do
+    let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+    let(:topic_list) { PageObjects::Components::TopicList.new }
+    let(:bulk_modal) { PageObjects::Modals::TopicBulkActions.new }
+
+    it "shows disabled rows with a visible reason" do
       sign_in(admin)
-      visit "/new-topic"
-      expect(composer).to be_opened
+      visit "/latest"
+      topic_list_header.click_bulk_select_button
+      topic_list.click_topic_checkbox(topic)
+      topic_list_header.click_bulk_select_topics_dropdown
+      topic_list_header.click_bulk_button("append-tags")
+      expect(bulk_modal).to be_open
 
-      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
-      tag_chooser.expand
-      tag_chooser.search("sedan")
+      chooser = bulk_modal.tag_selector
+      chooser.expand
+      chooser.search("sedan")
 
-      expect(page).to have_css(".mini-tag-chooser .select-kit-row.disabled[data-name='sedan']")
+      expect(chooser).to have_disabled_row_name("sedan")
+      expect(chooser).to have_disabled_row_reason("sedan")
     end
   end
 end

--- a/spec/system/tags/tag_search_hints_spec.rb
+++ b/spec/system/tags/tag_search_hints_spec.rb
@@ -1,77 +1,127 @@
 # frozen_string_literal: true
 
-describe "Tag search hints in composer" do
+describe "Tag search: disabled hints" do
   fab!(:admin)
 
   let(:composer) { PageObjects::Components::Composer.new }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer_tag_chooser) do
+    PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
+  end
 
   before do
     SiteSetting.tagging_enabled = true
     SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
   end
 
-  context "with one_per_topic tag group" do
-    fab!(:todo_tag) { Fabricate(:tag, name: "todo") }
-    fab!(:ready_tag) { Fabricate(:tag, name: "ready-to-deploy") }
+  def open_topic_for_edit(topic, post)
+    sign_in(admin)
+    visit topic.url
+    topic_page.click_post_action_button(post, :edit)
+    expect(composer).to be_opened
+  end
 
-    fab!(:tag_group) do
-      Fabricate(:tag_group, name: "Workflow", tags: [todo_tag, ready_tag], one_per_topic: true)
+  describe "in the composer (mini-tag-chooser)" do
+    context "with a one_per_topic tag group" do
+      fab!(:todo_tag) { Fabricate(:tag, name: "todo") }
+      fab!(:ready_tag) { Fabricate(:tag, name: "ready-to-deploy") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Workflow", tags: [todo_tag, ready_tag], one_per_topic: true)
+      end
+      fab!(:topic) { Fabricate(:topic, user: admin, tags: [todo_tag]) }
+      fab!(:post) { Fabricate(:post, topic:, user: admin) }
+
+      it "marks the sibling tag as disabled" do
+        open_topic_for_edit(topic, post)
+        composer_tag_chooser.expand
+        composer_tag_chooser.search("ready-to-deploy")
+
+        expect(composer_tag_chooser).to have_disabled_row_name("ready-to-deploy")
+      end
+
+      context "with tags_sort_alphabetically enabled" do
+        fab!(:usable_tag) { Fabricate(:tag, name: "z-ready") }
+
+        before { SiteSetting.tags_sort_alphabetically = true }
+
+        it "lists usable tags before disabled tags" do
+          open_topic_for_edit(topic, post)
+          composer_tag_chooser.expand
+          composer_tag_chooser.search("ready")
+
+          expect(composer_tag_chooser).to have_disabled_row_name("ready-to-deploy")
+
+          names = composer_tag_chooser.option_names
+          expect(names.index("z-ready")).to be < names.index("ready-to-deploy")
+        end
+      end
     end
 
-    fab!(:topic) { Fabricate(:topic, user: admin, tags: [todo_tag]) }
-    fab!(:post) { Fabricate(:post, topic: topic, user: admin) }
+    context "with a missing parent tag" do
+      fab!(:parent_tag) { Fabricate(:tag, name: "vehicles") }
+      fab!(:child_tag) { Fabricate(:tag, name: "sedan") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag:)
+      end
 
-    it "shows sibling tag as disabled with tooltip" do
-      sign_in(admin)
-      visit topic.url
+      it "marks the child tag as disabled" do
+        sign_in(admin)
+        visit "/new-topic"
+        expect(composer).to be_opened
 
-      find("#post_1 .post-controls .edit").click
-      expect(composer).to be_opened
+        composer_tag_chooser.expand
+        composer_tag_chooser.search("sedan")
 
-      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
-      tag_chooser.expand
-      tag_chooser.search("ready-to-deploy")
+        expect(composer_tag_chooser).to have_disabled_row_name("sedan")
+      end
+    end
 
-      expect(tag_chooser).to have_disabled_row_name("ready-to-deploy")
+    context "with a synonym tag" do
+      fab!(:apple_tag) { Fabricate(:tag, name: "apple-inc") }
+      fab!(:aapl_tag) { Fabricate(:tag, name: "aapl", target_tag: apple_tag) }
+
+      it "shows the synonym as selectable with a hint pointing to the target tag" do
+        sign_in(admin)
+        visit "/new-topic"
+        expect(composer).to be_opened
+
+        composer_tag_chooser.expand
+        composer_tag_chooser.search("aapl")
+
+        expect(composer_tag_chooser).to have_no_disabled_row_name("aapl")
+        expect(composer_tag_chooser).to have_row_synonym_hint("aapl", "→ apple-inc")
+      end
     end
   end
 
-  context "with parent tag group" do
+  describe "in bulk-actions (tag-chooser)" do
     fab!(:parent_tag) { Fabricate(:tag, name: "vehicles") }
     fab!(:child_tag) { Fabricate(:tag, name: "sedan") }
-
     fab!(:tag_group) do
-      Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag: parent_tag)
+      Fabricate(:tag_group, name: "Vehicle Types", tags: [child_tag], parent_tag:)
     end
+    fab!(:topic)
+    fab!(:post) { Fabricate(:post, topic:) }
 
-    it "shows child tag as disabled when parent is not selected" do
+    let(:topic_list_header) { PageObjects::Components::TopicListHeader.new }
+    let(:topic_list) { PageObjects::Components::TopicList.new }
+    let(:bulk_modal) { PageObjects::Modals::ManageTags.new }
+
+    it "shows disabled rows with a visible reason" do
       sign_in(admin)
-      visit "/new-topic"
-      expect(composer).to be_opened
+      visit "/latest"
+      topic_list_header.click_bulk_select_button
+      topic_list.click_topic_checkbox(topic)
+      topic_list_header.click_bulk_select_topics_dropdown
+      topic_list_header.click_bulk_button("manage-tags")
+      expect(bulk_modal).to be_open
 
-      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
-      tag_chooser.expand
-      tag_chooser.search("sedan")
+      chooser = bulk_modal.add_tag_selector
+      chooser.expand
+      chooser.search("sedan")
 
-      expect(tag_chooser).to have_disabled_row_name("sedan")
-    end
-  end
-
-  context "with a synonym tag" do
-    fab!(:apple_tag) { Fabricate(:tag, name: "apple-inc") }
-    fab!(:aapl_tag) { Fabricate(:tag, name: "aapl", target_tag: apple_tag) }
-
-    it "shows the synonym as selectable with a hint pointing to the target tag" do
-      sign_in(admin)
-      visit "/new-topic"
-      expect(composer).to be_opened
-
-      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
-      tag_chooser.expand
-      tag_chooser.search("aapl")
-
-      expect(tag_chooser).to have_no_disabled_row_name("aapl")
-      expect(tag_chooser).to have_row_synonym_hint("aapl", "→ apple-inc")
+      expect(chooser).to have_disabled_row_name("sedan")
+      expect(chooser).to have_disabled_row_reason("sedan")
     end
   end
 end


### PR DESCRIPTION
Two related issues in the composer and bulk-actions tag pickers:

1. When `tags_sort_alphabetically` is enabled, the alphabetical sort in `mini-tag-chooser` and `tag-chooser` re-ordered the merged results array, interleaving the disabled rows (added in #39072) with usable matches. This defeated the backend's "enabled-first, disabled-appended" ordering and pushed selectable tags below a wall of explanation text.

2. `tag-chooser-row.gjs` (used by bulk-actions, move-to-topic, the reviewable form, form-template fields, and several admin surfaces) never received the disabled-reason rendering that was added to `tag-row.gjs`. Those surfaces silently rendered unclickable rows with no explanation.

This commit:

- Extracts a shared `sortSearchResults` helper on the `tagUtils` service. When alphabetical sort is enabled it partitions results by the `disabled` flag, sorts each partition independently, and concatenates with usable tags first.
- Switches `mini-tag-chooser` and `tag-chooser` to the helper. Also replaces the broken `(a, b) => a.name > b.name` comparator in `tag-chooser` (which returned a boolean instead of -1/0/1) with the helper's `localeCompare` ordering.
- Adds the disabled-reason `<span>` to `tag-chooser-row` for parity with `tag-row`. The existing CSS already covered the `.tag-chooser` selector, so no styling changes were needed.
- Adds a backend assertion in `Tags::Search` spec that allowed tags precede disabled tags in the response, locking in the contract the frontend helper relies on.
- Adds two `SelectKit` page object methods (`has_disabled_row_name?` and `has_disabled_row_reason?`) and reorganises `tag_search_hints_spec.rb` to cover both the composer and the bulk-actions surfaces, including the alphabetical-sort ordering.

Ref - t/181010