### PR TITLE
PERF: add index for audit log post ids

### DIFF
--- a/.skills/discourse-migration/SKILL.md
+++ b/.skills/discourse-migration/SKILL.md
@@ -268,13 +268,11 @@ The same pattern works for plugin migrations — just adjust the `require` path 
 
 ## Running annotations
 
-After any migration that alters table schema (add/remove/rename columns, create tables), run:
+After a schema-altering migration (columns, tables, indexes), `bin/rake db:migrate` then annotate the affected models by path — core or plugin, same command:
 
 ```bash
-bin/annotate --models
+bin/annotaterb models app/models/widget.rb plugins/my-plugin/app/models/gadget.rb
 ```
-
-This updates the schema comments at the top of model files to reflect the current database schema.
 
 ## Review checklist
 
@@ -290,4 +288,4 @@ This updates the schema comments at the top of model files to reflect the curren
 10. No foreign keys unless strong justification
 11. No application code (models, `SiteSetting`) — query DB directly
 12. `execute` for SQL; `DB.exec`/`DB.query` only when param binding or return values needed
-13. Run `bin/annotate --models` after schema-altering migrations
+13. Run `bin/annotaterb models <paths>` on affected model files after schema-altering migrations

--- a/plugins/discourse-ai/app/models/ai_api_audit_log.rb
+++ b/plugins/discourse-ai/app/models/ai_api_audit_log.rb
@@ -60,5 +60,6 @@ end
 #  index_ai_api_audit_logs_on_created_at_and_language_model  (created_at,language_model)
 #  index_ai_api_audit_logs_on_created_at_and_user_id         (created_at,user_id)
 #  index_ai_api_audit_logs_on_llm_id                         (llm_id)
+#  index_ai_api_audit_logs_on_post_id                        (post_id)
 #  index_ai_api_audit_logs_on_topic_id                       (topic_id)
 #

--- a/plugins/discourse-ai/db/migrate/20260420014648_add_post_id_index_to_ai_api_audit_logs.rb
+++ b/plugins/discourse-ai/db/migrate/20260420014648_add_post_id_index_to_ai_api_audit_logs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class AddPostIdIndexToAiApiAuditLogs < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :ai_api_audit_logs, :post_id, algorithm: :concurrently, if_exists: true
+    add_index :ai_api_audit_logs, :post_id, algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
Add a concurrent index on ai_api_audit_logs.post_id to speed up lookups
and keep the model schema annotation in sync. Also update the migration
skill.
