### PR TITLE
DEV: Simplify multisite:migrate to call Process.fork directly

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -133,13 +133,13 @@ task "multisite:migrate" => %w[
 
     puts "Running migrations and seeds for #{databases.join(", ")} database(s)"
 
-    migrate_database =
-      lambda do |db|
-        output = StringIO.new
-        error = nil
+    should_fork = concurrency > 1 && databases.length > 1
 
-        begin
-          $stdout = $stderr = output
+    ENV["RAISE_SEED_ERRORS"] = "1"
+
+    migrate_databases =
+      lambda do |shard|
+        shard.each do |db|
           RailsMultisite::ConnectionManagement.with_connection(db) do
             puts "-" * 40
             start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -148,52 +148,47 @@ task "multisite:migrate" => %w[
             puts "Migrating #{db} done (#{(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).round(2)}s)"
             puts "Completed"
           end
-        rescue => e
-          error = e
-        ensure
-          $stdout = STDOUT
-          $stderr = STDERR
+        end
+      end
+
+    log_dir = nil
+
+    begin
+      if should_fork
+        log_dir = Dir.mktmpdir("multisite-migrate-")
+
+        database_shard_size = (databases.size.to_f / concurrency).ceil
+        database_shards = databases.each_slice(database_shard_size).to_a
+
+        Discourse.before_fork
+
+        pids =
+          database_shards.map do |database_shard|
+            Process.fork do
+              Discourse.after_fork
+              $stdout.reopen(File.join(log_dir, "worker-#{Process.pid}.log"), "w")
+              $stderr.reopen($stdout)
+              $stdout.sync = true
+              migrate_databases.call(database_shard)
+            end
+          end
+
+        remaining = pids.to_set
+        failed = false
+        until remaining.empty?
+          pid, status = Process.waitpid2(-1)
+          next unless remaining.delete?(pid)
+          failed = true unless status.success?
+          log_path = File.join(log_dir, "worker-#{pid}.log")
+          puts File.read(log_path) if File.exist?(log_path)
         end
 
-        { db: db, output: output.string, error: error }
+        raise "One or more child processes failed while migrating" if failed
+      else
+        migrate_databases.call(databases)
       end
-
-    should_fork = concurrency > 1 && databases.length > 1
-
-    Discourse.before_fork if should_fork
-
-    results =
-      Parallel.map(
-        databases,
-        in_processes: should_fork ? concurrency : 0,
-        isolation: false,
-        finish_in_order: true,
-        finish:
-          lambda do |db, _index, result|
-            result[:output]&.lines&.each { |line| puts "[#{db}] #{line}" }
-          end,
-      ) do |db|
-        $after_fork_called ||= (Discourse.after_fork || true) if should_fork
-        ENV["RAISE_SEED_ERRORS"] = "1"
-        migrate_database.call(db)
-      end
-
-    errors = results.select { |r| r[:error] }
-
-    if errors.any?
-      $stderr.puts
-      $stderr.puts "-" * 80
-      $stderr.puts "#{errors.length} database(s) failed!"
-
-      errors.each do |result|
-        $stderr.puts
-        $stderr.puts "Failed to process #{result[:db]}"
-        $stderr.puts result[:error].inspect
-        $stderr.puts result[:error].backtrace
-        $stderr.puts
-      end
-
-      raise errors.first[:error]
+    ensure
+      FileUtils.rm_rf(log_dir) if log_dir
     end
 
     Rake::Task["db:_dump"].invoke


### PR DESCRIPTION
Each `multisite:migrate` child process buffers its output in an instance of `StringIO` held in memory. When a child crashes unexpectedly, the buffer dies with it and we only get generic error traces like the following from the `parallel` gem:

```
Parallel::DeadWorker: Parallel::DeadWorker (Parallel::DeadWorker)
/var/www/discourse/vendor/bundle/ruby/3.4.0/gems/parallel-1.27.0/lib/parallel.rb:83:in 'Parallel::Worker#work'
...

Caused by:
EOFError: end of file reached (EOFError)
/var/www/discourse/vendor/bundle/ruby/3.4.0/gems/parallel-1.27.0/lib/parallel.rb:81:in 'Parallel::Worker#work'
...
```

This PR replaces the `parallel` gem with `Process.fork`. Databases are sharded across multiple child processes where each child process reopens stdout/stderr to a temp log file. The trade-off here is that logs are no longer streamed to the parent's stdout as they are written in the child process. This is OK since it is rare for someone to be watching the logs while running migrations for multisite and we also get to reduce a huge amount of complexity if we don't have to stream the logs from child to parent.