### PR TITLE
DEV: Fix "Composer Proofreading" and "Thread Indicator"  flakes

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/thread_indicator.rb
@@ -13,44 +13,44 @@ module PageObjects
         end
 
         def click
-          find(@context).find(SELECTOR).click
+          find("#{@context} #{SELECTOR}").click
         end
 
         def exists?(**args)
-          find(@context).has_css?(SELECTOR)
+          has_css?("#{@context} #{SELECTOR}")
         end
 
         def does_not_exist?(**args)
-          find(@context).has_no_css?(SELECTOR)
+          has_no_css?("#{@context} #{SELECTOR}")
         end
 
         def has_reply_count?(count)
-          find(@context).has_css?(
-            "#{SELECTOR}__replies-count",
+          has_css?(
+            "#{@context} #{SELECTOR}__replies-count",
             text: I18n.t("js.chat.thread.replies", count: count),
           )
         end
 
         def has_participant?(user)
-          find(@context).has_css?(
-            ".chat-thread-participants__avatar-group .chat-user-avatar[data-username=\"#{user.username}\"] img",
+          has_css?(
+            "#{@context} .chat-thread-participants__avatar-group .chat-user-avatar[data-username=\"#{user.username}\"] img",
           )
         end
 
         def has_no_participants?
-          find(@context).has_no_css?(".chat-thread-participants")
+          has_no_css?("#{@context} .chat-thread-participants")
         end
 
         def has_excerpt?(text)
-          find(@context).find("#{SELECTOR}__last-reply-excerpt", text: text)
+          has_css?("#{@context} #{SELECTOR}__last-reply-excerpt", text: text)
         end
 
         def has_user?(user)
-          find(@context).find("#{SELECTOR}__last-reply-username", text: user.username)
+          has_css?("#{@context} #{SELECTOR}__last-reply-username", text: user.username)
         end
 
         def excerpt
-          find(@context).find("#{SELECTOR}__last-reply-excerpt")
+          find("#{@context} #{SELECTOR}__last-reply-excerpt")
         end
       end
     end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -67,7 +67,7 @@ module PageObjects
       end
 
       def has_input_title?(value)
-        expect(find("#{@composer_id} input#reply-title").value).to eq(value)
+        has_field?("reply-title", with: value)
       end
 
       def fill_content(content)
@@ -105,7 +105,7 @@ module PageObjects
       end
 
       def has_value?(value)
-        expect(composer_input.value).to eq(value)
+        within(@composer_id) { has_field?(class: "d-editor-input", with: value) }
       end
 
       def has_popup_content?(content)

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -105,7 +105,13 @@ module PageObjects
       end
 
       def has_value?(value)
-        within(@composer_id) { has_field?(class: "d-editor-input", with: value) }
+        within(@composer_id) do
+          if value.nil?
+            has_no_field?(class: "d-editor-input")
+          else
+            has_field?(class: "d-editor-input", with: value)
+          end
+        end
       end
 
       def has_popup_content?(content)


### PR DESCRIPTION
…by using auto-retrying assertions and avoiding stale element issues with non-chained `find` and using `has_css` without `find`.

The original errors:

```
  1) AI Composer Proofreading Features when triggering via keyboard shortcut confirms changes when pressing Enter
     Failure/Error: expect(composer_input.value).to eq(value)

       expected: "hello world"
            got: "hello worrld"

       (compared using ==)
```

```
  1) Thread indicator for chat messages when threading is enabled for the channel updates the last reply excerpt and participants when a new message is added to the thread
     Failure/Error:
       expect(channel_page.message_thread_indicator(thread_1.original_message)).to have_participant(
         new_user,
       )
     
       expected `#<PageObjects::Components::Chat::ThreadIndicator:0x00007f6760a37680 @context=".chat-channel .chat-messages-container .chat-message-container[data-id=\"10000000001\"]">.has_participant?(#<User …)` to be truthy, got false
```