### PR TITLE
FIX: Persist group default tag notification settings

### DIFF
--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -216,18 +216,22 @@ class TagUser < ActiveRecord::Base
 
       muted_tag_names = SiteSetting.default_tags_muted.split("|")
 
-      tag_data = Tag.where(name: default_tag_names + muted_tag_names).pluck(:name, :id).to_h
+      tag_data =
+        Tag
+          .where(name: default_tag_names + muted_tag_names)
+          .pluck(:name, :id, :slug)
+          .to_h { |name, id, slug| [name, [id, slug]] }
 
       notification_levels =
         default_tag_names.filter_map do |name|
-          id = tag_data[name]
-          [id, { level: self.notification_levels[:regular], name: }] if id
+          id, slug = tag_data[name]
+          [id, { level: self.notification_levels[:regular], name:, slug: }] if id
         end
 
       notification_levels +=
         muted_tag_names.filter_map do |name|
-          id = tag_data[name]
-          [id, { level: self.notification_levels[:muted], name: }] if id
+          id, slug = tag_data[name]
+          [id, { level: self.notification_levels[:muted], name:, slug: }] if id
         end
     else
       notification_levels =
@@ -235,8 +239,8 @@ class TagUser < ActiveRecord::Base
           .notification_level_visible
           .where(user:)
           .joins(:tag)
-          .pluck("tags.id", "tags.name", :notification_level)
-          .map { |id, name, level| [id, { level:, name: }] }
+          .pluck("tags.id", "tags.name", "tags.slug", :notification_level)
+          .map { |id, name, slug, level| [id, { level:, name:, slug: }] }
     end
 
     notification_levels.to_h

--- a/app/serializers/concerns/user_tag_notifications_mixin.rb
+++ b/app/serializers/concerns/user_tag_notifications_mixin.rb
@@ -23,7 +23,9 @@ module UserTagNotificationsMixin
 
   def tags_with_notification_level(lookup_level)
     tag_user_notification_levels.filter_map do |id, data|
-      { id:, name: data[:name] } if data[:level] == TagUser.notification_levels[lookup_level]
+      if data[:level] == TagUser.notification_levels[lookup_level]
+        { id:, name: data[:name], slug: data[:slug] }
+      end
     end
   end
 

--- a/app/serializers/group_show_serializer.rb
+++ b/app/serializers/group_show_serializer.rb
@@ -150,10 +150,10 @@ class GroupShowSerializer < BasicGroupSerializer
       GroupTagNotificationDefault
         .where(group_id: object.id)
         .joins(:tag)
-        .pluck(:notification_level, :name)
-        .inject({}) do |h, arr|
-          h[arr[0]] ||= []
-          h[arr[0]] << arr[1]
+        .pluck(:notification_level, "tags.id", "tags.name", "tags.slug")
+        .inject({}) do |h, (level, id, name, slug)|
+          h[level] ||= []
+          h[level] << { id:, name:, slug: }
           h
         end
   end

--- a/frontend/discourse/app/models/group.js
+++ b/frontend/discourse/app/models/group.js
@@ -380,7 +380,10 @@ export default class Group extends RestModel {
         let tags = this.get(s + "_tags");
 
         if (tags) {
-          attrs[s + "_tags"] = tags.length > 0 ? tags : [""];
+          attrs[s + "_tags"] =
+            tags.length > 0
+              ? tags.map((t) => (typeof t === "object" ? t.name : t))
+              : [""];
         }
       }
     );

--- a/frontend/discourse/tests/unit/models/group-test.js
+++ b/frontend/discourse/tests/unit/models/group-test.js
@@ -26,4 +26,22 @@ module("Unit | Model | group", function (hooks) {
       "it should return the group's name"
     );
   });
+
+  test("asJSON extracts tag names when tags are objects", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const group = store.createRecord("group", { name: "test" });
+
+    group.set("watching_tags", [
+      { id: 1, name: "art", slug: "art" },
+      { id: 2, name: "music", slug: "music" },
+    ]);
+    group.set("tracking_tags", ["books"]);
+    group.set("muted_tags", []);
+
+    const json = group.asJSON();
+
+    assert.deepEqual(json.watching_tags, ["art", "music"]);
+    assert.deepEqual(json.tracking_tags, ["books"]);
+    assert.deepEqual(json.muted_tags, [""]);
+  });
 });

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -2190,7 +2190,7 @@ RSpec.describe TagsController do
       expect(response.parsed_body["watched_tags"]).to eq([])
       expect(response.parsed_body["watching_first_post_tags"]).to eq([])
       expect(response.parsed_body["tracked_tags"]).to eq(
-        [{ "id" => tag.id, "name" => tag.name, "slug" => tag.name }],
+        [{ "id" => tag.id, "name" => tag.name, "slug" => tag.slug }],
       )
       expect(response.parsed_body["muted_tags"]).to eq([])
       expect(response.parsed_body["regular_tags"]).to eq([])

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -2189,7 +2189,9 @@ RSpec.describe TagsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["watched_tags"]).to eq([])
       expect(response.parsed_body["watching_first_post_tags"]).to eq([])
-      expect(response.parsed_body["tracked_tags"]).to eq([{ "id" => tag.id, "name" => tag.name }])
+      expect(response.parsed_body["tracked_tags"]).to eq(
+        [{ "id" => tag.id, "name" => tag.name, "slug" => tag.name }],
+      )
       expect(response.parsed_body["muted_tags"]).to eq([])
       expect(response.parsed_body["regular_tags"]).to eq([])
 
@@ -2210,7 +2212,9 @@ RSpec.describe TagsController do
         expect(response.parsed_body["watched_tags"]).to eq([])
         expect(response.parsed_body["watching_first_post_tags"]).to eq([])
         expect(response.parsed_body["tracked_tags"]).to eq([])
-        expect(response.parsed_body["muted_tags"]).to eq([{ "id" => tag.id, "name" => tag.name }])
+        expect(response.parsed_body["muted_tags"]).to eq(
+          [{ "id" => tag.id, "name" => tag.name, "slug" => tag.name }],
+        )
         expect(response.parsed_body["regular_tags"]).to eq([])
       end.to change { user.tag_users.count }.by(1)
 

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CurrentUserSerializer do
 
     it "includes muted tags" do
       payload = serializer.as_json
-      expect(payload[:muted_tags]).to eq([{ id: tag.id, name: tag.name }])
+      expect(payload[:muted_tags]).to eq([{ id: tag.id, name: tag.name, slug: tag.slug }])
     end
   end
 

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -137,8 +137,12 @@ RSpec.describe GroupShowSerializer do
         expect(serializer.as_json[:regular_category_ids]).to eq([])
         expect(serializer.as_json[:muted_category_ids]).to eq([])
 
-        expect(serializer.as_json[:watching_tags]).to eq([tag1.name])
-        expect(serializer.as_json[:tracking_tags]).to eq([tag2.name])
+        expect(serializer.as_json[:watching_tags]).to eq(
+          [{ id: tag1.id, name: tag1.name, slug: tag1.slug }],
+        )
+        expect(serializer.as_json[:tracking_tags]).to eq(
+          [{ id: tag2.id, name: tag2.name, slug: tag2.slug }],
+        )
         expect(serializer.as_json[:watching_first_post_tags]).to eq([])
         expect(serializer.as_json[:regular_tags]).to eq([])
         expect(serializer.as_json[:muted_tags]).to eq([])

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -173,10 +173,12 @@ RSpec.describe UserSerializer do
           notification_level: TagUser.notification_levels[:watching_first_post],
         )
 
-        expect(json[:muted_tags]).to eq([{ id: tag1.id, name: tag1.name }])
-        expect(json[:tracked_tags]).to eq([{ id: tag2.id, name: tag2.name }])
-        expect(json[:watched_tags]).to eq([{ id: tag3.id, name: tag3.name }])
-        expect(json[:watching_first_post_tags]).to eq([{ id: tag4.id, name: tag4.name }])
+        expect(json[:muted_tags]).to eq([{ id: tag1.id, name: tag1.name, slug: tag1.slug }])
+        expect(json[:tracked_tags]).to eq([{ id: tag2.id, name: tag2.name, slug: tag2.slug }])
+        expect(json[:watched_tags]).to eq([{ id: tag3.id, name: tag3.name, slug: tag3.slug }])
+        expect(json[:watching_first_post_tags]).to eq(
+          [{ id: tag4.id, name: tag4.name, slug: tag4.slug }],
+        )
       end
     end
 


### PR DESCRIPTION
**Previously**, editing a group's default tag notifications silently failed to save because `TagChooser` set `watching_tags`/`tracking_tags`/etc. to arrays of `{id, name}` objects after the tag objects refactor (#36678) and Rails scalar-array permits dropped the hash values.

**Now**, `Group#asJSON` extracts tag names before sending, and `GroupShowSerializer` / `UserTagNotificationsMixin` now return `{id, name, slug}` tag objects for consistency with the rest of the refactor.

Ref - t/181980