### PR TITLE
FIX: Allow typing inside float-kit menus rendered from within a modal

### DIFF
--- a/frontend/discourse/app/components/d-modal.gjs
+++ b/frontend/discourse/app/components/d-modal.gjs
@@ -195,8 +195,15 @@ export default class DModal extends Component {
       return;
     }
 
-    // Prevent keyboard events from leaking to elements behind the modal
-    if (!this.wrapperElement.contains(document.activeElement)) {
+    // Prevent keyboard events from leaking to elements behind the modal.
+    // Allow events when focus is inside a float-kit portal (menu/tooltip)
+    // opened from this modal, since those render outside the modal DOM.
+    if (
+      !this.wrapperElement.contains(document.activeElement) &&
+      !document.activeElement?.closest(
+        ".fk-d-menu, .fk-d-menu-modal, .fk-d-tooltip"
+      )
+    ) {
       event.stopPropagation();
       event.preventDefault();
     }

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -176,6 +176,18 @@ describe "Custom sidebar sections" do
     expect(sidebar).to have_section_link("Faq", target: "_self", href: "/faq#someheading")
   end
 
+  it "allows typing in the icon picker filter input" do
+    sign_in user
+    visit("/latest")
+    sidebar.click_add_section_button
+
+    picker = section_modal.first_link_icon_picker
+    picker.expand.type_filter("globe")
+
+    expect(picker.filter_input.value).to eq("globe")
+    expect(picker).to have_icon("globe")
+  end
+
   it "accessibility - when new row is added in custom section, first new input is focused" do
     sign_in user
     visit("/latest")

--- a/spec/system/page_objects/components/d_icon_grid_picker.rb
+++ b/spec/system/page_objects/components/d_icon_grid_picker.rb
@@ -9,6 +9,7 @@ module PageObjects
 
       def expand
         trigger.click
+        self
       end
 
       def select_icon(icon_id)
@@ -20,7 +21,20 @@ module PageObjects
       end
 
       def filter(term)
-        find(".d-icon-grid-picker__filter .filter-input").fill_in(with: term)
+        filter_input.fill_in(with: term)
+      end
+
+      def type_filter(term)
+        filter_input.send_keys(term)
+        self
+      end
+
+      def filter_input
+        find(".d-icon-grid-picker__filter .filter-input")
+      end
+
+      def has_icon?(icon_id)
+        page.has_css?("[data-icon-id='#{icon_id}']")
       end
 
       def clear

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -10,11 +10,16 @@ module PageObjects
       def fill_link(name, url, icon = "link")
         fill_in("link-name", with: name, match: :first)
         fill_in("link-url", with: url, match: :first)
-        first_link = find(".sidebar-section-form-link", match: :first)
-        icon_picker = PageObjects::Components::DIconGridPicker.new(first_link)
+        icon_picker = first_link_icon_picker
         icon_picker.expand
         icon_picker.filter(icon)
         icon_picker.select_icon(icon)
+      end
+
+      def first_link_icon_picker
+        PageObjects::Components::DIconGridPicker.new(
+          find(".sidebar-section-form-link", match: :first),
+        )
       end
 
       def mark_as_public


### PR DESCRIPTION
`DModal` listens for `keydown` on `documentElement` in the capture phase and cancels events whose `activeElement` is not inside the modal wrapper, to prevent keyboard shortcuts from leaking to the page behind the modal.

Since `DIconGridPicker` replaced the select-kit `IconPicker` in the custom sidebar section modal (#38943), the picker's filter input renders inside the `#d-menu-portal-outlet` portal — outside the modal DOM — so every keystroke was cancelled and typing silently failed.

Allow keydown through when `activeElement` is inside a float-kit portal (`.fk-d-menu`, `.fk-d-menu-modal`, `.fk-d-tooltip`), which covers any menu/tooltip opened from within a modal without weakening the leak guard for elements actually behind the modal.

Also adds a system spec that catches this with real keyboard typing (the existing `icon_picker.filter` helper used `fill_in` + clicked the target icon which was already visible without filtering, so the bug slipped past the suite).

https://meta.discourse.org/t/400945