### PR TITLE
FIX: Render breadcrumb separator from data instead of `:last-child`

### DIFF
--- a/app/assets/stylesheets/common/components/d-breadcrumbs.scss
+++ b/app/assets/stylesheets/common/components/d-breadcrumbs.scss
@@ -23,10 +23,4 @@
       }
     }
   }
-
-  li:last-child {
-    .separator {
-      display: none;
-    }
-  }
 }

--- a/frontend/discourse/app/components/d-breadcrumbs-container.gjs
+++ b/frontend/discourse/app/components/d-breadcrumbs-container.gjs
@@ -27,6 +27,7 @@ export default class DBreadcrumbsContainer extends Component {
               "d-breadcrumbs__link"
               @additionalLinkClasses
             }}
+            @isLast={{eq index this.lastItemIndex}}
             aria-current={{if (eq index this.lastItemIndex) "page"}}
             class={{concatClass "d-breadcrumbs__item" @additionalItemClasses}}
           />

--- a/frontend/discourse/app/components/d-breadcrumbs-item.gjs
+++ b/frontend/discourse/app/components/d-breadcrumbs-item.gjs
@@ -33,9 +33,11 @@ export default class DBreadcrumbsItem extends Component {
             {{label}}
           </a>
         {{/if}}
-        <span class="separator">
-          {{~icon "angle-right"~}}
-        </span>
+        {{#unless @isLast}}
+          <span class="separator">
+            {{~icon "angle-right"~}}
+          </span>
+        {{/unless}}
       </li>
     </template>;
   }

--- a/frontend/discourse/tests/integration/components/d-breadcrumbs-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-breadcrumbs-test.gjs
@@ -46,6 +46,20 @@ module(
         .exists();
     });
 
+    test("separator is rendered on every item except the last", async function (assert) {
+      await render(
+        <template>
+          <DBreadcrumbsContainer />
+          <DBreadcrumbsItem @path="/admin" @label="Admin" />
+          <DBreadcrumbsItem @path="/admin/backups" @label="Backups" />
+          <DBreadcrumbsItem @path="/admin/backups/logs" @label="Logs" />
+        </template>
+      );
+
+      assert.dom(".d-breadcrumbs li .separator").exists({ count: 2 });
+      assert.dom(".d-breadcrumbs li:last-child .separator").doesNotExist();
+    });
+
     test("it renders multiple DBreadcrumbsContainer elements with the same DBreadcrumbsItem links", async function (assert) {
       await render(
         <template>


### PR DESCRIPTION
The breadcrumb `>` separator was rendered on every item and hidden on the last one via a `li:last-child` CSS rule. That worked for static breadcrumbs, but `DeferredTrackedSet.add()` defers item registration through `next()`. When navigating into a child route (e.g. `/admin/backups/logs`), the new `DBreadcrumbsItem` mounts and renders before its `add()` flushes — leaving the previously-last `<li>` as the DOM's actual `:last-child` for one tick, so its `>` disappears until the next re-render brings everything back into sync. On the backups page, frequent MessageBus updates during a running backup made that window visible: the arrow would intermittently drop until the user navigated out and back in.

Bind separator visibility to the tracked-set index instead: `DBreadcrumbsContainer` passes `@isLast` to each item, and `DBreadcrumbsItem` only renders the separator when `@isLast` is false. The CSS rule is gone. Separator presence now tracks the authoritative Set state rather than the DOM's transient structure, closing the stale-last-child window.

https://meta.discourse.org/t/400730