### PR TITLE
UX: reactions mobile menu scroll fix

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -2333,26 +2333,18 @@ html.discourse-no-touch .fullscreen-table-wrapper:hover {
     }
 
     .d-modal__body {
-      display: flex;
-      flex-direction: column;
       flex: 1;
       min-height: 0;
-      overflow: hidden;
     }
 
     .post-users-popup {
       width: 100%;
-      height: auto;
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
     }
 
     .post-users-popup__body {
-      flex: 1;
       height: auto;
-      min-height: 0;
+      overflow: visible;
+      overscroll-behavior: auto;
     }
   }
 }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -2318,7 +2318,7 @@ html.discourse-no-touch .fullscreen-table-wrapper:hover {
     }
   }
 
-  &__loading {
+  .loading-container {
     display: flex;
     justify-content: center;
     padding: 0.75em;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -2325,16 +2325,35 @@ html.discourse-no-touch .fullscreen-table-wrapper:hover {
   }
 }
 
-.mobile-view .post-users-popup {
-  width: 100%;
-  height: 400px;
-  display: flex;
-  flex-direction: column;
+.mobile-view {
+  .post-liked-users-menu-content,
+  .discourse-reactions-users-menu-content {
+    .d-modal__container {
+      height: min(80dvh, 560px);
+    }
 
-  .post-users-popup__body {
-    flex: 1;
-    height: auto;
-    min-height: 0;
+    .d-modal__body {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .post-users-popup {
+      width: 100%;
+      height: auto;
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .post-users-popup__body {
+      flex: 1;
+      height: auto;
+      min-height: 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -2335,10 +2335,19 @@ html.discourse-no-touch .fullscreen-table-wrapper:hover {
     .d-modal__body {
       flex: 1;
       min-height: 0;
+      padding: 0;
     }
 
     .post-users-popup {
       width: 100%;
+    }
+
+    .post-users-popup__sticky-header {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      padding-top: 0.75em;
+      background: var(--secondary);
     }
 
     .post-users-popup__body {

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
+import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import LoadMore from "discourse/components/load-more";
 import UserAvatar from "discourse/components/user-avatar";
 import UserLink from "discourse/components/user-link";
@@ -110,11 +111,10 @@ export default class PostUsersMenu extends Component {
               {{/if}}
             </div>
           {{/each}}
-          {{#if this.loading}}
-            <div class="post-users-popup__loading">
-              <div class="spinner small"></div>
-            </div>
-          {{/if}}
+          <ConditionalLoadingSpinner
+            @condition={{this.loading}}
+            @size="small"
+          />
         </LoadMore>
       </div>
     </div>

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -64,11 +64,13 @@ export default class PostUsersMenu extends Component {
 
   <template>
     <div class="post-users-popup">
-      {{#if this.site.mobileView}}
-        <div class="post-users-popup__title">{{@titleText}}</div>
-      {{/if}}
+      <div class="post-users-popup__sticky-header">
+        {{#if this.site.mobileView}}
+          <div class="post-users-popup__title">{{@titleText}}</div>
+        {{/if}}
 
-      {{yield this.resetAndReload to="header"}}
+        {{yield this.resetAndReload to="header"}}
+      </div>
 
       <div class="post-users-popup__body" {{didInsert this.loadInitial}}>
         <LoadMore

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -1,9 +1,9 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
+import LoadMore from "discourse/components/load-more";
 import UserAvatar from "discourse/components/user-avatar";
 import UserLink from "discourse/components/user-link";
 import icon from "discourse/helpers/d-icon";
@@ -24,7 +24,6 @@ export default class PostUsersMenu extends Component {
     }
     return user.username;
   };
-
   resetAndReload = () => {
     this.users = [];
     this.#page = 0;
@@ -39,11 +38,8 @@ export default class PostUsersMenu extends Component {
   }
 
   @action
-  onScroll(event) {
-    const el = event.target;
-    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
-      this.#loadMore();
-    }
+  loadMore() {
+    return this.#loadMore();
   }
 
   async #loadMore() {
@@ -74,47 +70,50 @@ export default class PostUsersMenu extends Component {
 
       {{yield this.resetAndReload to="header"}}
 
-      <div
-        class="post-users-popup__body"
-        {{on "scroll" this.onScroll}}
-        {{didInsert this.loadInitial}}
-      >
-        {{#each this.users as |user|}}
-          <div class="post-users-popup__item">
-            <UserLink
-              @username={{user.username}}
-              class="post-users-popup__avatar-link"
-            >
-              <UserAvatar @user={{user}} @size="small" />
-            </UserLink>
-            <div class="post-users-popup__user-info">
+      <div class="post-users-popup__body" {{didInsert this.loadInitial}}>
+        <LoadMore
+          @action={{this.loadMore}}
+          @enabled={{this.canLoadMore}}
+          @isLoading={{this.loading}}
+          @rootMargin="100px"
+        >
+          {{#each this.users as |user|}}
+            <div class="post-users-popup__item">
               <UserLink
                 @username={{user.username}}
-                class="post-users-popup__name"
+                class="post-users-popup__avatar-link"
               >
-                {{this.displayName user}}
+                <UserAvatar @user={{user}} @size="small" />
               </UserLink>
-              {{#unless this.siteSettings.prioritize_username_in_ux}}
+              <div class="post-users-popup__user-info">
                 <UserLink
                   @username={{user.username}}
-                  class="post-users-popup__username"
+                  class="post-users-popup__name"
                 >
-                  @{{user.username}}
+                  {{this.displayName user}}
                 </UserLink>
-              {{/unless}}
+                {{#unless this.siteSettings.prioritize_username_in_ux}}
+                  <UserLink
+                    @username={{user.username}}
+                    class="post-users-popup__username"
+                  >
+                    @{{user.username}}
+                  </UserLink>
+                {{/unless}}
+              </div>
+              {{#if (has-block "reaction")}}
+                {{yield user to="reaction"}}
+              {{else}}
+                {{icon "d-liked" class="post-users-popup__reaction"}}
+              {{/if}}
             </div>
-            {{#if (has-block "reaction")}}
-              {{yield user to="reaction"}}
-            {{else}}
-              {{icon "d-liked" class="post-users-popup__reaction"}}
-            {{/if}}
-          </div>
-        {{/each}}
-        {{#if this.loading}}
-          <div class="post-users-popup__loading">
-            <div class="spinner small"></div>
-          </div>
-        {{/if}}
+          {{/each}}
+          {{#if this.loading}}
+            <div class="post-users-popup__loading">
+              <div class="spinner small"></div>
+            </div>
+          {{/if}}
+        </LoadMore>
       </div>
     </div>
   </template>


### PR DESCRIPTION
Scroll was not working correctly on iOS due to how we apply scroll lock on the body.

This change swaps the scroll-event infinite loader for the `LoadMore` component so it works regardless of which ancestor scrolls. Also wraps the title + filter row in a position: sticky header so they stay pinned while the list scrolls on mobile.

Adds the conditional loading spinner component for load more.