### PR TITLE
FIX: prevent shadow likes leaking to post reaction modal

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -154,13 +154,14 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     post = fetch_post_from_params
     page = params[:page].to_i.clamp(0..)
     limit = params[:limit].present? ? params[:limit].to_i.clamp(1, 50) : 30
-    offset = page * limit
-    main_reaction = DiscourseReactions::Reaction.main_reaction_id
-    like_type = PostActionType::LIKE_POST_ACTION_ID
-    reaction_filter = params[:reaction_value]
 
     rows, total =
-      fetch_reaction_rows(post, reaction_filter, main_reaction, like_type, limit, offset)
+      DiscourseReactions::PostReactionsQuery.call(
+        post: post,
+        reaction_filter: params[:reaction_value],
+        limit: limit,
+        offset: page * limit,
+      )
 
     users =
       rows.map do |row|
@@ -177,101 +178,6 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   end
 
   private
-
-  def plain_likes_scope(post, like_type)
-    PostAction.where(post_id: post.id).where(
-      DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql,
-      like: like_type,
-    )
-  end
-
-  def fetch_reaction_rows(post, reaction_filter, main_reaction, like_type, limit, offset)
-    if reaction_filter.present? && reaction_filter != main_reaction
-      total =
-        DiscourseReactions::ReactionUser
-          .joins(:reaction)
-          .where(
-            post_id: post.id,
-            discourse_reactions_reactions: {
-              reaction_value: reaction_filter,
-            },
-          )
-          .count
-
-      rows =
-        DB.query(
-          <<~SQL,
-            SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
-                   dr.reaction_value AS reaction, drru.created_at
-            FROM discourse_reactions_reaction_users drru
-            INNER JOIN discourse_reactions_reactions dr ON dr.id = drru.reaction_id
-            INNER JOIN users u ON u.id = drru.user_id
-            WHERE drru.post_id = :post_id AND dr.reaction_value = :reaction_filter
-            ORDER BY drru.created_at ASC
-            LIMIT :limit OFFSET :offset
-          SQL
-          post_id: post.id,
-          reaction_filter: reaction_filter,
-          limit: limit,
-          offset: offset,
-        )
-    elsif reaction_filter == main_reaction
-      total = plain_likes_scope(post, like_type).count
-
-      rows =
-        DB.query(
-          <<~SQL,
-            SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
-                   :main_reaction AS reaction, post_actions.created_at
-            FROM post_actions
-            INNER JOIN users u ON u.id = post_actions.user_id
-            WHERE post_actions.post_id = :post_id
-              AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
-            ORDER BY post_actions.created_at ASC
-            LIMIT :limit OFFSET :offset
-          SQL
-          post_id: post.id,
-          like: like_type,
-          main_reaction: main_reaction,
-          limit: limit,
-          offset: offset,
-        )
-    else
-      reaction_user_count = DiscourseReactions::ReactionUser.where(post_id: post.id).count
-      plain_like_count = plain_likes_scope(post, like_type).count
-      total = reaction_user_count + plain_like_count
-
-      rows =
-        DB.query(
-          <<~SQL,
-            SELECT * FROM (
-              SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
-                     dr.reaction_value AS reaction, drru.created_at
-              FROM discourse_reactions_reaction_users drru
-              INNER JOIN discourse_reactions_reactions dr ON dr.id = drru.reaction_id
-              INNER JOIN users u ON u.id = drru.user_id
-              WHERE drru.post_id = :post_id
-              UNION ALL
-              SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
-                     :main_reaction AS reaction, post_actions.created_at
-              FROM post_actions
-              INNER JOIN users u ON u.id = post_actions.user_id
-              WHERE post_actions.post_id = :post_id
-                AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
-            ) combined
-            ORDER BY created_at ASC
-            LIMIT :limit OFFSET :offset
-          SQL
-          post_id: post.id,
-          like: like_type,
-          main_reaction: main_reaction,
-          limit: limit,
-          offset: offset,
-        )
-    end
-
-    [rows, total]
-  end
 
   def post_serializer(post)
     PostSerializer.new(post, scope: guardian, root: false)

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -180,7 +180,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
   def plain_likes_scope(post, like_type)
     PostAction.where(post_id: post.id).where(
-      DiscourseReactions::PostActionExtension.filter_reaction_likes_sql,
+      DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql,
       like: like_type,
     )
   end
@@ -226,7 +226,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
             FROM post_actions
             INNER JOIN users u ON u.id = post_actions.user_id
             WHERE post_actions.post_id = :post_id
-              AND (#{DiscourseReactions::PostActionExtension.filter_reaction_likes_sql})
+              AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
             ORDER BY post_actions.created_at ASC
             LIMIT :limit OFFSET :offset
           SQL
@@ -257,7 +257,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
               FROM post_actions
               INNER JOIN users u ON u.id = post_actions.user_id
               WHERE post_actions.post_id = :post_id
-                AND (#{DiscourseReactions::PostActionExtension.filter_reaction_likes_sql})
+                AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
             ) combined
             ORDER BY created_at ASC
             LIMIT :limit OFFSET :offset

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -11,14 +11,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     post = fetch_post_from_params
     reaction = params[:reaction]
 
-    invalid_reaction =
-      if SiteSetting.discourse_reactions_allow_any_emoji
-        !Emoji.exists?(reaction)
-      else
-        DiscourseReactions::Reaction.valid_reactions.exclude?(params[:reaction])
-      end
-
-    return render_json_error(post) if invalid_reaction
+    return render_json_error(post) unless DiscourseReactions::Reaction.valid?(reaction)
 
     begin
       manager =
@@ -189,7 +182,6 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     PostAction.where(post_id: post.id).where(
       DiscourseReactions::PostActionExtension.filter_reaction_likes_sql,
       like: like_type,
-      valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
     )
   end
 
@@ -240,7 +232,6 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           SQL
           post_id: post.id,
           like: like_type,
-          valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
           main_reaction: main_reaction,
           limit: limit,
           offset: offset,
@@ -273,7 +264,6 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           SQL
           post_id: post.id,
           like: like_type,
-          valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
           main_reaction: main_reaction,
           limit: limit,
           offset: offset,

--- a/plugins/discourse-reactions/app/models/discourse_reactions/reaction.rb
+++ b/plugins/discourse-reactions/app/models/discourse_reactions/reaction.rb
@@ -24,6 +24,16 @@ module DiscourseReactions
       ]
     end
 
+    def self.valid?(reaction_value)
+      return false if reaction_value.blank?
+
+      if SiteSetting.discourse_reactions_allow_any_emoji
+        Emoji.exists?(reaction_value)
+      else
+        valid_reactions.include?(reaction_value)
+      end
+    end
+
     def self.main_reaction_id
       SiteSetting.discourse_reactions_reaction_for_like.gsub("-", "")
     end

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_action_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_action_extension.rb
@@ -24,10 +24,8 @@ module DiscourseReactions::PostActionExtension
     <<~SQL
       SELECT discourse_reactions_reaction_users.post_id
       FROM discourse_reactions_reaction_users
-      INNER JOIN discourse_reactions_reactions ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
       WHERE discourse_reactions_reaction_users.user_id = post_actions.user_id
         AND discourse_reactions_reaction_users.post_id = post_actions.post_id
-      AND discourse_reactions_reactions.reaction_value IN (:valid_reactions)
     SQL
   end
 end

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_action_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_action_extension.rb
@@ -24,8 +24,26 @@ module DiscourseReactions::PostActionExtension
     <<~SQL
       SELECT discourse_reactions_reaction_users.post_id
       FROM discourse_reactions_reaction_users
+      INNER JOIN discourse_reactions_reactions ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
       WHERE discourse_reactions_reaction_users.user_id = post_actions.user_id
         AND discourse_reactions_reaction_users.post_id = post_actions.post_id
+      AND discourse_reactions_reactions.reaction_value IN (:valid_reactions)
+    SQL
+  end
+
+  # Suppresses shadow likes for any user who has a reaction on the post, regardless of
+  # whether the reaction's value is currently in discourse_reactions_enabled_reactions
+  # Required if `SiteSetting.discourse_reactions_allow_any_emoji` is enabled
+  def self.strict_filter_reaction_likes_sql
+    <<~SQL
+      post_actions.post_action_type_id = :like
+      AND post_actions.deleted_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM discourse_reactions_reaction_users
+        WHERE discourse_reactions_reaction_users.user_id = post_actions.user_id
+          AND discourse_reactions_reaction_users.post_id = post_actions.post_id
+      )
     SQL
   end
 end

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module DiscourseReactions
+  class PostReactionsQuery
+    def self.call(post:, reaction_filter: nil, limit: 30, offset: 0)
+      new(post: post, reaction_filter: reaction_filter, limit: limit, offset: offset).call
+    end
+
+    def initialize(post:, reaction_filter: nil, limit: 30, offset: 0)
+      @post = post
+      @reaction_filter = reaction_filter
+      @limit = limit
+      @offset = offset
+    end
+
+    def call
+      [rows, total]
+    end
+
+    private
+
+    attr_reader :post, :reaction_filter, :limit, :offset
+
+    def main_reaction
+      @main_reaction ||= DiscourseReactions::Reaction.main_reaction_id
+    end
+
+    def like_type
+      PostActionType::LIKE_POST_ACTION_ID
+    end
+
+    def specific_reaction?
+      reaction_filter.present? && reaction_filter != main_reaction
+    end
+
+    def main_reaction_filter?
+      reaction_filter == main_reaction
+    end
+
+    def bindings
+      {
+        post_id: post.id,
+        like: like_type,
+        main_reaction: main_reaction,
+        limit: limit,
+        offset: offset,
+      }
+    end
+
+    def total
+      if specific_reaction?
+        DiscourseReactions::ReactionUser
+          .joins(:reaction)
+          .where(
+            post_id: post.id,
+            discourse_reactions_reactions: {
+              reaction_value: reaction_filter,
+            },
+          )
+          .count
+      elsif main_reaction_filter?
+        plain_likes_scope.count
+      else
+        DiscourseReactions::ReactionUser.where(post_id: post.id).count + plain_likes_scope.count
+      end
+    end
+
+    def rows
+      if specific_reaction?
+        DB.query(<<~SQL, **bindings, reaction_filter: reaction_filter)
+          #{reactions_select_sql}
+          AND dr.reaction_value = :reaction_filter
+          ORDER BY drru.created_at ASC
+          LIMIT :limit OFFSET :offset
+        SQL
+      elsif main_reaction_filter?
+        DB.query(<<~SQL, **bindings)
+          #{plain_likes_select_sql}
+          ORDER BY post_actions.created_at ASC
+          LIMIT :limit OFFSET :offset
+        SQL
+      else
+        DB.query(<<~SQL, **bindings)
+          SELECT * FROM (
+            #{reactions_select_sql}
+            UNION ALL
+            #{plain_likes_select_sql}
+          ) combined
+          ORDER BY created_at ASC
+          LIMIT :limit OFFSET :offset
+        SQL
+      end
+    end
+
+    def plain_likes_scope
+      PostAction.where(post_id: post.id).where(
+        DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql,
+        like: like_type,
+      )
+    end
+
+    def reactions_select_sql
+      <<~SQL
+        SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
+               dr.reaction_value AS reaction, drru.created_at
+        FROM discourse_reactions_reaction_users drru
+        INNER JOIN discourse_reactions_reactions dr ON dr.id = drru.reaction_id
+        INNER JOIN users u ON u.id = drru.user_id
+        WHERE drru.post_id = :post_id
+      SQL
+    end
+
+    def plain_likes_select_sql
+      <<~SQL
+        SELECT u.id, u.username, u.name, u.uploaded_avatar_id,
+               :main_reaction AS reaction, post_actions.created_at
+        FROM post_actions
+        INNER JOIN users u ON u.id = post_actions.user_id
+        WHERE post_actions.post_id = :post_id
+          AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
+      SQL
+    end
+  end
+end

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
@@ -3,7 +3,8 @@
 module DiscourseReactions
   class PostReactionsQuery
     def self.call(post:, reaction_filter: nil, limit: 30, offset: 0)
-      new(post: post, reaction_filter: reaction_filter, limit: limit, offset: offset).call
+      query = new(post: post, reaction_filter: reaction_filter, limit: limit, offset: offset)
+      [query.rows, query.total]
     end
 
     def initialize(post:, reaction_filter: nil, limit: 30, offset: 0)
@@ -13,8 +14,51 @@ module DiscourseReactions
       @offset = offset
     end
 
-    def call
-      [rows, total]
+    def rows
+      @rows ||=
+        if specific_reaction?
+          DB.query(<<~SQL, **bindings, reaction_filter: reaction_filter)
+            #{reactions_select_sql}
+            AND dr.reaction_value = :reaction_filter
+            ORDER BY drru.created_at ASC
+            LIMIT :limit OFFSET :offset
+          SQL
+        elsif main_reaction_filter?
+          DB.query(<<~SQL, **bindings)
+            #{plain_likes_select_sql}
+            ORDER BY post_actions.created_at ASC
+            LIMIT :limit OFFSET :offset
+          SQL
+        else
+          DB.query(<<~SQL, **bindings)
+            SELECT * FROM (
+              #{reactions_select_sql}
+              UNION ALL
+              #{plain_likes_select_sql}
+            ) combined
+            ORDER BY created_at ASC
+            LIMIT :limit OFFSET :offset
+          SQL
+        end
+    end
+
+    def total
+      @total ||=
+        if specific_reaction?
+          ReactionUser
+            .joins(:reaction)
+            .where(
+              post_id: post.id,
+              discourse_reactions_reactions: {
+                reaction_value: reaction_filter,
+              },
+            )
+            .count
+        elsif main_reaction_filter?
+          plain_likes_scope.count
+        else
+          ReactionUser.where(post_id: post.id).count + plain_likes_scope.count
+        end
     end
 
     private
@@ -22,11 +66,15 @@ module DiscourseReactions
     attr_reader :post, :reaction_filter, :limit, :offset
 
     def main_reaction
-      @main_reaction ||= DiscourseReactions::Reaction.main_reaction_id
+      @main_reaction ||= Reaction.main_reaction_id
     end
 
     def like_type
       PostActionType::LIKE_POST_ACTION_ID
+    end
+
+    def shadow_like_filter
+      PostActionExtension.strict_filter_reaction_likes_sql
     end
 
     def specific_reaction?
@@ -47,56 +95,8 @@ module DiscourseReactions
       }
     end
 
-    def total
-      if specific_reaction?
-        DiscourseReactions::ReactionUser
-          .joins(:reaction)
-          .where(
-            post_id: post.id,
-            discourse_reactions_reactions: {
-              reaction_value: reaction_filter,
-            },
-          )
-          .count
-      elsif main_reaction_filter?
-        plain_likes_scope.count
-      else
-        DiscourseReactions::ReactionUser.where(post_id: post.id).count + plain_likes_scope.count
-      end
-    end
-
-    def rows
-      if specific_reaction?
-        DB.query(<<~SQL, **bindings, reaction_filter: reaction_filter)
-          #{reactions_select_sql}
-          AND dr.reaction_value = :reaction_filter
-          ORDER BY drru.created_at ASC
-          LIMIT :limit OFFSET :offset
-        SQL
-      elsif main_reaction_filter?
-        DB.query(<<~SQL, **bindings)
-          #{plain_likes_select_sql}
-          ORDER BY post_actions.created_at ASC
-          LIMIT :limit OFFSET :offset
-        SQL
-      else
-        DB.query(<<~SQL, **bindings)
-          SELECT * FROM (
-            #{reactions_select_sql}
-            UNION ALL
-            #{plain_likes_select_sql}
-          ) combined
-          ORDER BY created_at ASC
-          LIMIT :limit OFFSET :offset
-        SQL
-      end
-    end
-
     def plain_likes_scope
-      PostAction.where(post_id: post.id).where(
-        DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql,
-        like: like_type,
-      )
+      PostAction.where(post_id: post.id).where(shadow_like_filter, like: like_type)
     end
 
     def reactions_select_sql
@@ -117,7 +117,7 @@ module DiscourseReactions
         FROM post_actions
         INNER JOIN users u ON u.id = post_actions.user_id
         WHERE post_actions.post_id = :post_id
-          AND (#{DiscourseReactions::PostActionExtension.strict_filter_reaction_likes_sql})
+          AND (#{shadow_like_filter})
       SQL
     end
   end

--- a/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -11,10 +11,17 @@ module DiscourseReactions::TopicViewSerializerExtension
       .where(post_id: post_ids)
       .where("post_actions.deleted_at IS NULL")
       .where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
-      .where(
-        "post_actions.post_id IN (#{DiscourseReactions::PostActionExtension.post_action_with_reaction_user_sql})",
-        valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like,
-      )
+      .where(<<~SQL, valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like)
+          post_actions.post_id IN (
+            SELECT discourse_reactions_reaction_users.post_id
+            FROM discourse_reactions_reaction_users
+            INNER JOIN discourse_reactions_reactions
+              ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
+            WHERE discourse_reactions_reaction_users.user_id = post_actions.user_id
+              AND discourse_reactions_reaction_users.post_id = post_actions.post_id
+              AND discourse_reactions_reactions.reaction_value IN (:valid_reactions)
+          )
+        SQL
       .reduce({}) do |hash, post_action|
         hash[post_action.post_id] ||= {}
         hash[post_action.post_id][post_action.id] = post_action

--- a/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -11,17 +11,10 @@ module DiscourseReactions::TopicViewSerializerExtension
       .where(post_id: post_ids)
       .where("post_actions.deleted_at IS NULL")
       .where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
-      .where(<<~SQL, valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like)
-          post_actions.post_id IN (
-            SELECT discourse_reactions_reaction_users.post_id
-            FROM discourse_reactions_reaction_users
-            INNER JOIN discourse_reactions_reactions
-              ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
-            WHERE discourse_reactions_reaction_users.user_id = post_actions.user_id
-              AND discourse_reactions_reaction_users.post_id = post_actions.post_id
-              AND discourse_reactions_reactions.reaction_value IN (:valid_reactions)
-          )
-        SQL
+      .where(
+        "post_actions.post_id IN (#{DiscourseReactions::PostActionExtension.post_action_with_reaction_user_sql})",
+        valid_reactions: DiscourseReactions::Reaction.reactions_counting_as_like,
+      )
       .reduce({}) do |hash, post_action|
         hash[post_action.post_id] ||= {}
         hash[post_action.post_id][post_action.id] = post_action

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -46,6 +46,7 @@ after_initialize do
     lib/discourse_reactions/topic_view_serializer_extension.rb
     lib/discourse_reactions/topic_view_posts_serializer_extension.rb
     lib/discourse_reactions/migration_report.rb
+    lib/discourse_reactions/post_reactions_query.rb
     app/jobs/regular/discourse_reactions/like_synchronizer.rb
     app/jobs/scheduled/discourse_reactions/scheduled_like_synchronizer.rb
   ].each { |path| require_relative path }

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -451,6 +451,7 @@ after_initialize do
         start_date: report.start_date.to_date,
         end_date: report.end_date.to_date,
         like: PostActionType::LIKE_POST_ACTION_ID,
+        valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
       )
 
     (report.start_date.to_date..report.end_date.to_date).each do |date|

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -451,7 +451,6 @@ after_initialize do
         start_date: report.start_date.to_date,
         end_date: report.end_date.to_date,
         like: PostActionType::LIKE_POST_ACTION_ID,
-        valid_reactions: DiscourseReactions::Reaction.valid_reactions.to_a,
       )
 
     (report.start_date.to_date..report.end_date.to_date).each do |date|

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -491,6 +491,17 @@ describe DiscourseReactions::CustomReactionsController do
       get "/discourse-reactions/posts/#{private_post.id}/reactions-users-list.json"
       expect(response.status).to eq(200)
     end
+
+    it "does not duplicate a user whose reaction value is no longer in enabled_reactions" do
+      SiteSetting.discourse_reactions_enabled_reactions = "laughing|open_mouth"
+
+      get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
+
+      expect(response.status).to eq(200)
+      user_4_rows = response.parsed_body["users"].select { |u| u["username"] == user_4.username }
+      expect(user_4_rows.size).to eq(1)
+      expect(user_4_rows.first["reaction"]).to eq("hugs")
+    end
   end
 
   describe "positive notifications" do


### PR DESCRIPTION
Hardens the discourse-reactions plugin so shadow likes don't leak as duplicate rows.