### PR TITLE
FIX: preserve selection formatting in link-insertion modal

### DIFF
--- a/frontend/discourse/app/components/d-editor.gjs
+++ b/frontend/discourse/app/components/d-editor.gjs
@@ -552,6 +552,7 @@ export default class DEditor extends Component {
         this.textManipulation.applyHeading(selected, level, exampleKey),
       formatCode: () => this.textManipulation.formatCode(),
       addText: (text) => this.textManipulation.addText(selected, text),
+      applyLink: (url) => this.textManipulation.applyLink(url),
       getText: () => this.value,
       toggleDirection: () => this.textManipulation.toggleDirection(),
       replaceText: (oldVal, newVal, opts) =>
@@ -565,16 +566,13 @@ export default class DEditor extends Component {
       return;
     }
 
-    let linkText = "";
     this._lastSel = toolbarEvent.selected;
-
-    if (this._lastSel) {
-      linkText = this._lastSel.value;
-    }
+    const hasSelection =
+      !!this._lastSel && this._lastSel.start !== this._lastSel.end;
 
     this.modal.show(UpsertHyperlink, {
       model: {
-        linkText,
+        hasSelection,
         toolbarEvent,
       },
     });

--- a/frontend/discourse/app/components/modal/upsert-hyperlink.gjs
+++ b/frontend/discourse/app/components/modal/upsert-hyperlink.gjs
@@ -29,6 +29,14 @@ export default class UpsertHyperlink extends Component {
     cancel(this.#debounced);
   }
 
+  get wrapsSelection() {
+    return this.args.model.hasSelection && !this.args.model.editing;
+  }
+
+  get showLinkTextField() {
+    return !this.wrapsSelection;
+  }
+
   @cached
   get data() {
     return {
@@ -172,9 +180,13 @@ export default class UpsertHyperlink extends Component {
       return;
     }
 
-    const sel = this.args.model.toolbarEvent.selected;
-    const linkText = data.linkText || sel.value || origLink || "";
-    this.args.model.toolbarEvent.addText(`[${linkText.trim()}](${linkUrl})`);
+    if (this.wrapsSelection) {
+      this.args.model.toolbarEvent.applyLink(linkUrl);
+    } else {
+      const sel = this.args.model.toolbarEvent.selected;
+      const linkText = data.linkText || sel?.value || origLink || "";
+      this.args.model.toolbarEvent.addText(`[${linkText.trim()}](${linkUrl})`);
+    }
 
     this.args.closeModal();
   }
@@ -264,18 +276,20 @@ export default class UpsertHyperlink extends Component {
               </div>
             {{/if}}
 
-            <form.Field
-              @name="linkText"
-              @type="input"
-              @title={{i18n "composer.link_text_label"}}
-              @format="full"
-              as |field|
-            >
-              <field.Control
-                placeholder={{i18n "composer.link_optional_text"}}
-                class="link-text"
-              />
-            </form.Field>
+            {{#if this.showLinkTextField}}
+              <form.Field
+                @name="linkText"
+                @type="input"
+                @title={{i18n "composer.link_text_label"}}
+                @format="full"
+                as |field|
+              >
+                <field.Control
+                  placeholder={{i18n "composer.link_optional_text"}}
+                  class="link-text"
+                />
+              </form.Field>
+            {{/if}}
           </Form>
         </div>
       </:body>

--- a/frontend/discourse/app/components/modal/upsert-hyperlink.gjs
+++ b/frontend/discourse/app/components/modal/upsert-hyperlink.gjs
@@ -71,7 +71,7 @@ export default class UpsertHyperlink extends Component {
     });
 
     this.selectedRow = -1;
-    document.querySelector("input.link-text").focus();
+    document.querySelector("input.link-text")?.focus();
   }
 
   async triggerSearch(linkUrl) {

--- a/frontend/discourse/app/lib/textarea-text-manipulation.js
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.js
@@ -349,6 +349,15 @@ export default class TextareaTextManipulation {
     schedule("afterRender", this, this.blurAndFocus);
   }
 
+  applyLink(url) {
+    const sel = this.getSelected();
+    if (sel.start === sel.end) {
+      return;
+    }
+    this._insertAt(sel.start, sel.end, `[${sel.value}](${url})`);
+    this.blurAndFocus();
+  }
+
   addText(sel, text, options) {
     if (options && options.ensureSpace) {
       if ((sel.pre + "").length > 0) {

--- a/frontend/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/frontend/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -181,6 +181,18 @@ export default class ProsemirrorTextManipulation {
     );
   }
 
+  applyLink(url) {
+    const { state, dispatch } = this.view;
+    const { from, to, empty } = state.selection;
+    if (empty) {
+      return;
+    }
+    dispatch(
+      state.tr.addMark(from, to, state.schema.marks.link.create({ href: url }))
+    );
+    this.focus();
+  }
+
   addText(sel, text) {
     const doc = this.convertFromMarkdown(text);
 

--- a/frontend/discourse/app/ui-kit/d-editor.gjs
+++ b/frontend/discourse/app/ui-kit/d-editor.gjs
@@ -552,6 +552,7 @@ export default class DEditor extends Component {
         this.textManipulation.applyHeading(selected, level, exampleKey),
       formatCode: () => this.textManipulation.formatCode(),
       addText: (text) => this.textManipulation.addText(selected, text),
+      applyLink: (url) => this.textManipulation.applyLink(url),
       getText: () => this.value,
       toggleDirection: () => this.textManipulation.toggleDirection(),
       replaceText: (oldVal, newVal, opts) =>
@@ -565,16 +566,13 @@ export default class DEditor extends Component {
       return;
     }
 
-    let linkText = "";
     this._lastSel = toolbarEvent.selected;
-
-    if (this._lastSel) {
-      linkText = this._lastSel.value;
-    }
+    const hasSelection =
+      !!this._lastSel && this._lastSel.start !== this._lastSel.end;
 
     this.modal.show(UpsertHyperlink, {
       model: {
-        linkText,
+        hasSelection,
         toolbarEvent,
       },
     });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -425,12 +425,14 @@ export default class ChatComposer extends Component {
     }
 
     const selected = this.composer.textarea.getSelected("", { lineVal: true });
-    const linkText = selected?.value;
+    const hasSelection = !!selected && selected.start !== selected.end;
     this.modal.show(UpsertHyperlink, {
       model: {
-        linkText,
+        hasSelection,
         toolbarEvent: {
+          selected,
           addText: (text) => this.composer.textarea.addText(selected, text),
+          applyLink: (url) => this.composer.textarea.applyLink(url),
         },
       },
     });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -427,12 +427,14 @@ export default class ChatComposer extends Component {
     }
 
     const selected = this.composer.textarea.getSelected("", { lineVal: true });
-    const linkText = selected?.value;
+    const hasSelection = !!selected && selected.start !== selected.end;
     this.modal.show(UpsertHyperlink, {
       model: {
-        linkText,
+        hasSelection,
         toolbarEvent: {
+          selected,
           addText: (text) => this.composer.textarea.addText(selected, text),
+          applyLink: (url) => this.composer.textarea.applyLink(url),
         },
       },
     });

--- a/plugins/chat/assets/javascripts/discourse/lib/textarea-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/textarea-interactor.js
@@ -117,6 +117,11 @@ export default class TextareaInteractor extends EmberObject {
   }
 
   @bind
+  applyLink() {
+    return this.textManipulation.applyLink(...arguments);
+  }
+
+  @bind
   isInside() {
     return this.textManipulation.isInside(...arguments);
   }

--- a/spec/system/composer/prosemirror_links_spec.rb
+++ b/spec/system/composer/prosemirror_links_spec.rb
@@ -204,6 +204,82 @@ describe "Composer - ProseMirror - Links" do
     )
   end
 
+  context "when inserting a link over an existing selection" do
+    it "only shows the URL field in the modal" do
+      open_composer
+      composer.type_content("some text")
+      composer.select_all
+      composer.click_toolbar_button("link")
+
+      expect(upsert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to have_no_link_text_field
+    end
+
+    it "wraps the selection with the link while preserving inline formatting" do
+      open_composer
+      composer.type_content("Example")
+      composer.select_all
+      composer.click_toolbar_button("bold")
+      heading_menu = composer.heading_menu
+      heading_menu.expand
+      heading_menu.option("[data-name='heading-2']").click
+      expect(rich).to have_css("h2 strong", text: "Example")
+
+      composer.select_all
+      composer.click_toolbar_button("link")
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css("h2 strong a[href='https://example.com']", text: "Example")
+      composer.toggle_rich_editor
+      expect(composer).to have_value("## **[Example](https://example.com)**")
+    end
+
+    it "does not leak heading markdown into the resulting link" do
+      open_composer
+      composer.type_content("Example")
+      composer.select_all
+      heading_menu = composer.heading_menu
+      heading_menu.expand
+      heading_menu.option("[data-name='heading-2']").click
+      expect(rich).to have_css("h2", text: "Example")
+
+      composer.select_all
+      composer.click_toolbar_button("link")
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css("h2 a[href='https://example.com']", text: "Example")
+      composer.toggle_rich_editor
+      expect(composer).to have_value("## [Example](https://example.com)")
+    end
+  end
+
+  context "in markdown mode, when inserting a link over an existing selection" do
+    it "only shows the URL field and wraps the selection as-is" do
+      open_composer
+      composer.toggle_rich_editor
+      composer.type_content("`code word`")
+      composer.select_all
+      composer.click_toolbar_button("link")
+
+      expect(upsert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to have_no_link_text_field
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(composer).to have_value("[`code word`](https://example.com)")
+    end
+  end
+
+  it "shows both fields when inserting a link without a selection" do
+    open_composer
+    composer.click_toolbar_button("link")
+
+    expect(upsert_hyperlink_modal).to be_open
+    expect(upsert_hyperlink_modal).to have_link_text_field
+  end
+
   it "does not infinite loop on link rewrite" do
     with_logs do |logger|
       open_composer

--- a/spec/system/composer/prosemirror_links_spec.rb
+++ b/spec/system/composer/prosemirror_links_spec.rb
@@ -200,6 +200,82 @@ describe "Composer - ProseMirror - Links" do
     )
   end
 
+  context "when inserting a link over an existing selection" do
+    it "only shows the URL field in the modal" do
+      open_composer
+      composer.type_content("some text")
+      composer.select_all
+      composer.click_toolbar_button("link")
+
+      expect(upsert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to have_no_link_text_field
+    end
+
+    it "wraps the selection with the link while preserving inline formatting" do
+      open_composer
+      composer.type_content("Example")
+      composer.select_all
+      composer.click_toolbar_button("bold")
+      heading_menu = composer.heading_menu
+      heading_menu.expand
+      heading_menu.option("[data-name='heading-2']").click
+      expect(rich).to have_css("h2 strong", text: "Example")
+
+      composer.select_all
+      composer.click_toolbar_button("link")
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css("h2 strong a[href='https://example.com']", text: "Example")
+      composer.toggle_rich_editor
+      expect(composer).to have_value("## **[Example](https://example.com)**")
+    end
+
+    it "does not leak heading markdown into the resulting link" do
+      open_composer
+      composer.type_content("Example")
+      composer.select_all
+      heading_menu = composer.heading_menu
+      heading_menu.expand
+      heading_menu.option("[data-name='heading-2']").click
+      expect(rich).to have_css("h2", text: "Example")
+
+      composer.select_all
+      composer.click_toolbar_button("link")
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(rich).to have_css("h2 a[href='https://example.com']", text: "Example")
+      composer.toggle_rich_editor
+      expect(composer).to have_value("## [Example](https://example.com)")
+    end
+  end
+
+  context "in markdown mode, when inserting a link over an existing selection" do
+    it "only shows the URL field and wraps the selection as-is" do
+      open_composer
+      composer.toggle_rich_editor
+      composer.type_content("`code word`")
+      composer.select_all
+      composer.click_toolbar_button("link")
+
+      expect(upsert_hyperlink_modal).to be_open
+      expect(upsert_hyperlink_modal).to have_no_link_text_field
+      upsert_hyperlink_modal.fill_in_link_url("https://example.com")
+      upsert_hyperlink_modal.click_primary_button
+
+      expect(composer).to have_value("[`code word`](https://example.com)")
+    end
+  end
+
+  it "shows both fields when inserting a link without a selection" do
+    open_composer
+    composer.click_toolbar_button("link")
+
+    expect(upsert_hyperlink_modal).to be_open
+    expect(upsert_hyperlink_modal).to have_link_text_field
+  end
+
   it "does not infinite loop on link rewrite" do
     with_logs do |logger|
       open_composer

--- a/spec/system/page_objects/modals/upsert_hyperlink.rb
+++ b/spec/system/page_objects/modals/upsert_hyperlink.rb
@@ -26,6 +26,14 @@ module PageObjects
       def link_url_value
         find(LINK_URL_SELECTOR).value
       end
+
+      def has_link_text_field?
+        has_css?(LINK_TEXT_SELECTOR)
+      end
+
+      def has_no_link_text_field?
+        has_no_css?(LINK_TEXT_SELECTOR)
+      end
     end
   end
 end


### PR DESCRIPTION
When CMD+K is pressed (or the link toolbar button clicked) with a non-empty selection, the modal now only asks for the URL — the existing selection is wrapped as the link's display content, keeping every inline mark and block context under it.

Previously the modal pre-filled a "Link text" field from the selection. In the rich-text editor this serialized the selected slice to markdown and leaked syntax the user never typed: selecting a word inside an H2 produced `## word`, selecting text inside an inline code span produced backticks, selecting inside a list produced `- word`, and so on.

The new behavior wraps the selection directly instead of replacing it:

- Rich-text editor: adds a `link` mark over the selection range, preserving every underlying mark (bold, italic, code, emoji, mentions, …) and every surrounding block (heading, list, blockquote, …).
- Markdown editor: inserts `[` at the selection start and `](url)` at the end, preserving any literal characters in between.

Both editors now behave identically for the common "select then link" flow. The link-text field is still shown when:

- Inserting a link with no selection (the user needs to provide display text).
- Editing an existing link via the link-toolbar (the user may want to change the displayed text).

A small `applyLink(url)` method is exposed on the text-manipulation API of each editor, and `toolbarEvent.applyLink` lets the modal pick the right path without knowing which editor is active. The chat composer is wired through the same path.

Ref - t/182095