### PR TITLE
FIX: Prevent automation `set_topic_timer` from reopening closed topics

### DIFF
--- a/plugins/automation/lib/discourse_automation/scripts/set_topic_timer.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/set_topic_timer.rb
@@ -28,6 +28,10 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::SET_TOPIC_TIME
     next if !post.topic
     next unless topic = Topic.find_by(id: post.topic_id)
 
+    # Saving a close timer on a closed topic would reopen it via
+    # TopicTimer#after_save (intended for the "Close Temporarily" UI flow).
+    next if topic.closed? && %w[auto_close auto_close_after_last_post].include?(timer_type)
+
     duration_minutes = fields.dig("duration", "value")
 
     case timer_type

--- a/plugins/automation/spec/scripts/set_topic_timer_spec.rb
+++ b/plugins/automation/spec/scripts/set_topic_timer_spec.rb
@@ -48,6 +48,32 @@ describe "SetTopicTimer" do
     end
   end
 
+  it "skips auto_close timer when topic is already closed" do
+    configure_automation("auto_close", 60)
+
+    post =
+      PostCreator.new(Fabricate(:admin), raw: "my new topic", title: "Test topic for timer").create!
+    post.topic.update_status("closed", true, Discourse.system_user)
+
+    expect { PostRevisor.new(post).revise!(post.user, raw: "an edit") }.not_to change {
+      post.topic.reload.topic_timers.count
+    }
+    expect(post.topic.reload.closed).to eq(true)
+  end
+
+  it "skips auto_close_after_last_post timer when topic is already closed" do
+    configure_automation("auto_close_after_last_post", 60)
+
+    post =
+      PostCreator.new(Fabricate(:admin), raw: "my new topic", title: "Test topic for timer").create!
+    post.topic.update_status("closed", true, Discourse.system_user)
+
+    expect { PostRevisor.new(post).revise!(post.user, raw: "an edit") }.not_to change {
+      post.topic.reload.topic_timers.count
+    }
+    expect(post.topic.reload.closed).to eq(true)
+  end
+
   it "handles auto_close_after_last_post timer" do
     configure_automation("auto_close_after_last_post", 60)
 


### PR DESCRIPTION
When the `set_topic_timer` automation script saves a `:close` or `:silent_close` timer on a topic that is already closed, `TopicTimer#after_save` treats that state mismatch as the "Open Temporarily" UI intent and immediately reopens the topic as the system user.

Example seen on meta: an automation configured to add a 3-day close timer whenever the `fixed` tag is present and a bug post is edited was inadvertently reopening already-closed bug topics. Editing such a topic fired the automation, the `:close` timer was saved, and the topic was reopened by `system` before a moderator noticed and re-closed it.

Guard `auto_close` and `auto_close_after_last_post` in the script with an early `next` when `topic.closed?` so the automation no-ops on closed topics rather than triggering the reopen side-effect.