### PR TITLE
FIX: Allow fullApp embed iframe to shrink with content

### DIFF
--- a/frontend/discourse/app/instance-initializers/embed-mode-resize.js
+++ b/frontend/discourse/app/instance-initializers/embed-mode-resize.js
@@ -1,15 +1,44 @@
 import EmbedMode from "discourse/lib/embed-mode";
 
-let resizeObserver;
+const THROTTLE_MS = 1000;
+const MAX_MESSAGES = 10;
 
-function postHeight() {
+let resizeObserver;
+let trailingTimeout;
+let lastSentAt = 0;
+let messageCount = 0;
+
+function sendHeightMessage(element) {
   if (parent === window) {
     return;
   }
+  messageCount++;
+  lastSentAt = Date.now();
   parent.postMessage(
-    { type: "discourse-resize", height: document.body.scrollHeight },
+    { type: "discourse-resize", height: element.scrollHeight },
     "*"
   );
+  if (messageCount >= MAX_MESSAGES) {
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+  }
+}
+
+function scheduleHeightMessage(element) {
+  if (messageCount >= MAX_MESSAGES) {
+    return;
+  }
+  const elapsed = Date.now() - lastSentAt;
+  if (elapsed >= THROTTLE_MS) {
+    clearTimeout(trailingTimeout);
+    trailingTimeout = null;
+    sendHeightMessage(element);
+  } else if (!trailingTimeout) {
+    trailingTimeout = setTimeout(() => {
+      trailingTimeout = null;
+      sendHeightMessage(element);
+    }, THROTTLE_MS - elapsed);
+  }
 }
 
 export default {
@@ -18,12 +47,23 @@ export default {
       return;
     }
 
-    resizeObserver = new ResizeObserver(postHeight);
-    resizeObserver.observe(document.body);
+    // The body grows with the iframe, so measuring it prevents shrinking.
+    // Observe the Ember root element instead to report actual content height.
+    const element = document.querySelector("#main");
+    if (!element) {
+      return;
+    }
+
+    resizeObserver = new ResizeObserver(() => scheduleHeightMessage(element));
+    resizeObserver.observe(element);
   },
 
   teardown() {
     resizeObserver?.disconnect();
     resizeObserver = null;
+    clearTimeout(trailingTimeout);
+    trailingTimeout = null;
+    lastSentAt = 0;
+    messageCount = 0;
   },
 };


### PR DESCRIPTION
**Previously**, the fullApp embed measured `document.body.scrollHeight` to report its height to the parent. Because the body grows to match the iframe, Discourse could never report a height smaller than the current iframe, so the iframe never shrank when content got shorter.

**In this update**, we observe `#main` (the Ember root element) instead, which reflects the actual content height. Height messages are throttled to at most once per second with a lifetime cap of 10 messages as a safety net against runaway resizes.