### PR TITLE
UX: improve review queue layout for small screens

### DIFF
--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -1,6 +1,7 @@
 @use "lib/viewport";
 
 .review-item {
+  --review-item-padding: var(--space-4);
   display: flex;
   flex-wrap: nowrap;
   gap: var(--space-4) 0;
@@ -8,12 +9,14 @@
   margin-bottom: var(--space-8);
   position: relative;
   z-index: z("base");
+  border-radius: var(--d-border-radius);
 
   &:has(.select-kit.is-expanded) {
     z-index: z("dropdown");
   }
 
   @include viewport.until(sm) {
+    --review-item-padding: var(--space-2);
     border: 1px solid var(--content-border-color);
     flex-direction: column;
   }
@@ -39,13 +42,21 @@
     align-self: baseline;
     padding-block: var(--space-1);
     line-height: var(--line-height-small);
+
+    @include viewport.until(sm) {
+      justify-self: end;
+      padding-inline: 0.15em;
+    }
   }
 
   .reviewable-permalink-copy {
     position: relative;
     right: calc(var(--space-2) * -1);
     padding-block: 0.15em;
-    align-self: center;
+
+    @include viewport.until(sm) {
+      justify-self: end;
+    }
 
     .post-action-feedback-alert {
       top: -0.95rem;
@@ -130,8 +141,20 @@
     gap: var(--space-2);
     align-items: start;
     background-color: var(--primary);
-    padding: var(--space-3) var(--space-4);
+    padding: var(--space-3) var(--review-item-padding);
     color: var(--secondary);
+    border-radius: calc(var(--d-border-radius) - 1px)
+      calc(var(--d-border-radius) - 1px) 0 0;
+
+    @include viewport.until(sm) {
+      display: grid;
+      grid-template-columns: auto auto;
+      grid-template-rows: auto auto;
+
+      .post-action-feedback-button {
+        height: auto;
+      }
+    }
   }
 
   &__label-badges {
@@ -139,6 +162,7 @@
     gap: var(--space-1);
     align-items: baseline;
     flex-wrap: wrap;
+    line-height: var(--line-height-small);
   }
 
   &__flag-label,
@@ -174,10 +198,14 @@
 
   &__meta-content {
     display: grid;
-    row-gap: var(--space-4);
-    column-gap: var(--space-4);
-    padding: var(--space-4);
+    gap: var(--space-4);
+    padding: var(--review-item-padding);
     grid-template-columns: auto 1fr;
+
+    @include viewport.until(sm) {
+      gap: var(--space-2);
+      grid-template-columns: auto;
+    }
 
     .reviewable-user & {
       grid-template-columns: 1fr;
@@ -214,7 +242,7 @@
 
   &__post {
     display: flex;
-    padding: var(--space-4);
+    padding: var(--review-item-padding);
 
     &-content-wrapper {
       width: 100%;
@@ -233,7 +261,7 @@
       transition: scrollbar-color 0.25s ease-in-out;
       transition-delay: 0.5s;
       background: var(--primary-very-low);
-      padding: var(--space-4);
+      padding: var(--review-item-padding);
       border-radius: var(--d-border-radius);
 
       .lightbox-wrapper img {
@@ -290,7 +318,7 @@
   }
 
   &__insights {
-    padding-inline: var(--space-4);
+    padding-inline: var(--review-item-padding);
 
     .nav-pills.action-list {
       margin-bottom: 0;
@@ -339,7 +367,7 @@
 
   .editable-fields {
     box-sizing: border-box;
-    padding: var(--space-4);
+    padding: var(--review-item-padding);
 
     .d-editor-button-bar {
       flex: 1 0 auto;
@@ -366,6 +394,10 @@
   line-height: 1;
   background-color: var(--secondary-high);
   color: var(--primary);
+
+  @include viewport.until(sm) {
+    justify-self: start;
+  }
 
   &.--pending {
     background: var(--secondary-low);
@@ -431,6 +463,7 @@
   &__description {
     font-size: var(--font-down-1);
     color: var(--primary-high);
+    overflow-wrap: anywhere;
   }
 
   .reviewable-ip-lookup {
@@ -514,6 +547,10 @@
       padding-left: var(--space-2);
       padding-top: 0.2em;
       color: var(--primary-medium);
+
+      @include viewport.until(sm) {
+        width: 1rem;
+      }
     }
 
     &__content {
@@ -547,6 +584,7 @@
     &__description {
       color: var(--primary-high);
       font-size: var(--font-down-1);
+      overflow-wrap: anywhere;
 
       :first-child {
         margin-top: 0;

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -195,25 +195,33 @@
   }
 
   .reviewable-user-details {
+    --name-width: 8em;
+    --name-margin: 1em;
     padding-bottom: 0.25em;
     display: flex;
     margin-bottom: 0.5em;
+
+    @include viewport.until(sm) {
+      flex-direction: column;
+    }
 
     &:not(:last-child) {
       border-bottom: 1px solid var(--content-border-color);
     }
 
     .name {
-      width: 8em;
+      width: var(--name-width);
       font-weight: bold;
-      margin-right: 1em;
+      margin-right: var(--name-margin);
     }
 
     .value {
-      max-width: calc(
-        100% - 8em - 1em
-      ); // subtracting width of name and margin-right
-      overflow-wrap: break-word;
+      max-width: calc(100% - var(--name-width) - var(--name-margin));
+      overflow-wrap: anywhere;
+
+      @include viewport.until(sm) {
+        width: auto;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_control-textarea.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-textarea.scss
@@ -8,5 +8,6 @@
     // reset textarea styles
     height: 150px;
     padding: 0.5em !important;
+    min-width: var(--form-kit-small-input);
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -87,6 +87,7 @@
 
     &.--full {
       width: 100% !important;
+      min-width: var(--form-kit-small-input);
     }
   }
 }

--- a/frontend/discourse/app/templates/review/index.gjs
+++ b/frontend/discourse/app/templates/review/index.gjs
@@ -1,6 +1,7 @@
 import { LinkTo } from "@ember/routing";
 import { trustHTML } from "@ember/template";
 import DButton from "discourse/components/d-button";
+import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import NavItem from "discourse/components/nav-item";
 import ReviewIndex from "discourse/components/reviewable/index";
 import icon from "discourse/helpers/d-icon";
@@ -8,7 +9,7 @@ import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 <template>
-  <ul class="nav nav-pills reviewable-title">
+  <HorizontalOverflowNav @ariaLabel="Review" class="reviewable-title">
     <NavItem @route="review.index" @label="review.view_all" />
     <NavItem @route="review.topics" @label="review.grouped_by_topic" />
     {{#if @controller.currentUser.admin}}
@@ -18,7 +19,7 @@ import { i18n } from "discourse-i18n";
         @icon="wrench"
       />
     {{/if}}
-  </ul>
+  </HorizontalOverflowNav>
   {{#if @controller.displayUnknownReviewableTypesWarning}}
     <div class="alert alert-info unknown-reviewables">
       <span class="text">{{i18n

--- a/frontend/discourse/app/templates/review/settings.gjs
+++ b/frontend/discourse/app/templates/review/settings.gjs
@@ -1,11 +1,12 @@
 import { fn } from "@ember/helper";
 import DButton from "discourse/components/d-button";
+import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import NavItem from "discourse/components/nav-item";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  <ul class="nav nav-pills reviewable-title">
+  <HorizontalOverflowNav @ariaLabel="Review" class="reviewable-title">
     <NavItem @route="review.index" @label="review.view_all" />
     <NavItem @route="review.topics" @label="review.grouped_by_topic" />
     {{#if @controller.currentUser.admin}}
@@ -15,7 +16,7 @@ export default <template>
         @icon="wrench"
       />
     {{/if}}
-  </ul>
+  </HorizontalOverflowNav>
 
   <div class="reviewable-settings">
     <h4>{{i18n "review.settings.priorities.title"}}</h4>

--- a/frontend/discourse/app/templates/review/topics.gjs
+++ b/frontend/discourse/app/templates/review/topics.gjs
@@ -1,5 +1,6 @@
 import { fn, hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
+import HorizontalOverflowNav from "discourse/components/horizontal-overflow-nav";
 import NavItem from "discourse/components/nav-item";
 import ReviewableClaimedTopic from "discourse/components/reviewable-claimed-topic";
 import TopicStatus from "discourse/components/topic-status";
@@ -8,7 +9,7 @@ import replaceEmoji from "discourse/helpers/replace-emoji";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  <ul class="nav nav-pills reviewable-title">
+  <HorizontalOverflowNav @ariaLabel="Review" class="reviewable-title">
     <NavItem @route="review.index" @label="review.view_all" />
     <NavItem @route="review.topics" @label="review.grouped_by_topic" />
     {{#if @controller.currentUser.admin}}
@@ -18,7 +19,7 @@ export default <template>
         @icon="wrench"
       />
     {{/if}}
-  </ul>
+  </HorizontalOverflowNav>
 
   {{#if @controller.reviewableTopics.content}}
     <table class="reviewable-topics">


### PR DESCRIPTION
This adds some breakpoints and utilizes our horizontalOverflowNav component to make the review queue layout better on small screens.


Before:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/65ed1903-f263-4ba1-a279-17be068a5129" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8f06fd34-ecdc-4f7e-8a16-4601be28df4d" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/353b9e41-b82d-48df-80b7-f225523bc46e" />



After:

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/ee5c6562-7311-497f-a59d-63911a192822" />
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/21968af7-c1e6-4517-a021-bf3c2f62630b" />
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/ab3cf57f-38df-46ce-b4a8-953adefc6b9d" />
