### PR TITLE
FIX: escape HTML characters in watched word reason

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -93,20 +93,16 @@ class ReviewableScoreSerializer < ApplicationSerializer
     words = watched_words_found
 
     if words.nil? || words.empty?
-      text =
-        I18n.t("reviewables.reasons.no_context.watched_word", link: link, default: "watched_word")
+      I18n.t("reviewables.reasons.no_context.watched_word", link: link, default: "watched_word")
     else
-      text =
-        I18n.t(
-          "reviewables.reasons.watched_word",
-          link: link,
-          words: words.join(", "),
-          count: words.length,
-          default: "watched_word",
-        )
+      I18n.t(
+        "reviewables.reasons.watched_word",
+        link: link,
+        words: words.map { |w| CGI.escapeHTML(w) }.join(", "),
+        count: words.length,
+        default: "watched_word",
+      )
     end
-
-    text
   end
 
   def watched_words_found

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe ReviewableScoreSerializer do
         expect(queued_reviewable.payload["raw"]).to eq(raw)
       end
 
+      it "HTML-escapes matched words so angle brackets can't break the rendered reason" do
+        score =
+          ReviewableScore.new(
+            reviewable: reviewable,
+            reason: "watched_word",
+            context: "<notifications@example.discoursemail.com>,plain",
+          )
+        serialized = described_class.new(score, scope: Guardian.new(admin), root: nil)
+
+        expect(serialized.reason).to include(
+          "&lt;notifications@example.discoursemail.com&gt;",
+          "plain",
+        )
+        expect(serialized.reason).not_to include("<notifications@")
+      end
+
       it "uses the no-context message if the post has no watched words" do
         reviewable.target = Fabricate(:post, raw: "This post contains no bad words.")
 


### PR DESCRIPTION
Our watched words use RegExp so things like *mail.com were picking up "<example@discoursemail.com>" and mapping those to watched_word_reason.

The HTML was not escaped, and the `<` was rendering as a non-existant HTML element inside of the i18n string, hiding it from the UI.

This fix adds CGI.escapeHTML to the words in the message so that they can display properly.