### PR TITLE
UX: prevent iOS from scrolling modal out of view on dropdown input focus

### DIFF
--- a/frontend/discourse/app/components/d-modal.gjs
+++ b/frontend/discourse/app/components/d-modal.gjs
@@ -60,11 +60,13 @@ export default class DModal extends Component {
     return () => {
       unlock(el);
 
-      this.appEvents.off(
-        "keyboard-visibility-change",
-        this,
-        this.resetDocumentScrollOnIOS
-      );
+      if (this.capabilities.isIOS) {
+        this.appEvents.off(
+          "keyboard-visibility-change",
+          this,
+          this.resetDocumentScrollOnIOS
+        );
+      }
     };
   });
 

--- a/frontend/discourse/app/components/d-modal.gjs
+++ b/frontend/discourse/app/components/d-modal.gjs
@@ -71,7 +71,7 @@ export default class DModal extends Component {
   @action
   resetDocumentScrollOnIOS(visible) {
     // iOS scrolls the page to the focused input when the keyboard opens
-    // as a result when a dropdown is within a modal, the modal is scrolled out of view.
+    // as a result when an input is within a dropdown within a modal, the modal is scrolled out of view.
     // This forces the modal back to the correct visible position.
     if (!visible) {
       return;

--- a/frontend/discourse/app/components/d-modal.gjs
+++ b/frontend/discourse/app/components/d-modal.gjs
@@ -29,6 +29,8 @@ export const CLOSE_INITIATED_BY_SWIPE_DOWN = "initiatedBySwipeDown";
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
 
 export default class DModal extends Component {
+  @service appEvents;
+  @service capabilities;
   @service modal;
   @service site;
 
@@ -46,10 +48,37 @@ export default class DModal extends Component {
 
     lock(el);
 
+    if (this.capabilities.isIOS) {
+      this.lockedScrollY = window.scrollY;
+      this.appEvents.on(
+        "keyboard-visibility-change",
+        this,
+        this.resetDocumentScrollOnIOS
+      );
+    }
+
     return () => {
       unlock(el);
+
+      this.appEvents.off(
+        "keyboard-visibility-change",
+        this,
+        this.resetDocumentScrollOnIOS
+      );
     };
   });
+
+  @action
+  resetDocumentScrollOnIOS(visible) {
+    // iOS scrolls the page to the focused input when the keyboard opens
+    // as a result when a dropdown is within a modal, the modal is scrolled out of view.
+    // This forces the modal back to the correct visible position.
+    if (!visible) {
+      return;
+    }
+
+    window.scrollTo(0, this.lockedScrollY ?? 0);
+  }
 
   @action
   async setupModal(el) {


### PR DESCRIPTION
When we have a dropdown with an input inside of a modal, iOS will attempt to position the input and ends up shifting up the entire modal to be unreachable. 

This change avoids the issue by: 

1. capturing the current scroll position
2. set `window.scrollTo(0, lockedScrollY)` to undo iOS' scroll attempt 
3. on close, resets to the `lockedScrollY` position 

Before: 

https://github.com/user-attachments/assets/5e2fe34a-bb24-49c4-849a-d910150d389b


After: 

https://github.com/user-attachments/assets/70c51e3f-36d9-4eca-93cf-fd43e4b29878

