### PR TITLE
UX: prevent tags from wrapping in docked header

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -436,6 +436,11 @@
 
     .discourse-tags {
       display: inline;
+      color: var(--header_primary-high);
+
+      li {
+        flex-wrap: nowrap;
+      }
 
       @include ellipsis;
 


### PR DESCRIPTION
This fixes an issue on narrow screens where sometimes the comma would wrap and push tags onto a separate line... we never wrap tags in the header so best to just prevent this. Also fixed an issue with the ellipsis color not matching tags. 


Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9e40f9e2-8874-4f21-a890-883ffdc32f15" />

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/7246ae7a-c9b1-40f5-9c4c-d11dd76b9296" />


After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/56be6ed9-ad61-4ff5-9fb3-33ff86664774" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ed5a59b1-14ec-4497-8151-5c9e14f5747f" />

