### PR TITLE
FIX: Do not show permanent notice for setting default upcoming changes

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -97,6 +97,13 @@ export default class UpcomingChangeItem extends Component {
     return this.savingEnabledFor;
   }
 
+  get showPermanentSoonNotice() {
+    return (
+      this.args.change.upcoming_change.status === "stable" &&
+      this.args.change.upcoming_change.impact_type !== "site_setting_default"
+    );
+  }
+
   get showDependentSettingsLink() {
     return (
       this.args.change.dependents.length && this.bufferedEnabledFor !== "no_one"
@@ -327,7 +334,7 @@ export default class UpcomingChangeItem extends Component {
           </div>
         {{/if}}
 
-        {{#if (eq @change.upcoming_change.status "stable")}}
+        {{#if this.showPermanentSoonNotice}}
           <div class="upcoming-change__status-notice">
             {{icon "triangle-exclamation"}}
             {{i18n "admin.upcoming_changes.permanent_soon_notice"}}

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -2,6 +2,7 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import UpcomingChangeItem from "discourse/admin/components/admin-config-areas/upcoming-change-item";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
 
 function buildChange(overrides = {}) {
   return {
@@ -127,5 +128,86 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
     assert
       .dom(".upcoming-change__related")
       .doesNotExist("does not show the related setting link when disabled");
+  });
+
+  test("renders the permanent soon notice when status is stable", async function (assert) {
+    const change = buildChange({
+      upcoming_change: {
+        status: "stable",
+        impact: "feature,all_members",
+        impact_type: "feature",
+        impact_role: "all_members",
+        enabled_for: "everyone",
+      },
+    });
+
+    await render(
+      <template>
+        <table>
+          <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+        </table>
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__status-notice")
+      .hasText(
+        new RegExp(i18n("admin.upcoming_changes.permanent_soon_notice")),
+        "shows the permanent soon notice"
+      );
+  });
+
+  test("does not render the permanent soon notice when impact_type is site_setting_default", async function (assert) {
+    const change = buildChange({
+      upcoming_change: {
+        status: "stable",
+        impact: "site_setting_default,all_members",
+        impact_type: "site_setting_default",
+        impact_role: "all_members",
+        enabled_for: "everyone",
+      },
+    });
+
+    await render(
+      <template>
+        <table>
+          <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+        </table>
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__status-notice")
+      .doesNotExist(
+        "does not show the permanent soon notice for site setting default changes"
+      );
+  });
+
+  ["experimental", "alpha", "beta"].forEach((status) => {
+    test(`does not render the permanent soon notice when status is ${status}`, async function (assert) {
+      const change = buildChange({
+        upcoming_change: {
+          status,
+          impact: "feature,all_members",
+          impact_type: "feature",
+          impact_role: "all_members",
+          enabled_for: "everyone",
+        },
+      });
+
+      await render(
+        <template>
+          <table>
+            <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+          </table>
+        </template>
+      );
+
+      assert
+        .dom(".upcoming-change__status-notice")
+        .doesNotExist(
+          `does not show the permanent soon notice for ${status} changes`
+        );
+    });
   });
 });

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -62,6 +62,34 @@ describe "Admin upcoming changes" do
     expect(upcoming_changes_page).to have_no_change(:about_page_extra_groups_show_description)
   end
 
+  it "shows the permanent soon notice for stable changes but not for site_setting_default types" do
+    mock_upcoming_change_metadata(
+      {
+        about_page_extra_groups_show_description: {
+          impact: "feature,all_members",
+          status: :stable,
+          impact_type: "feature",
+          impact_role: "all_members",
+        },
+        enable_upload_debug_mode: {
+          impact: "site_setting_default,all_members",
+          status: :stable,
+          impact_type: "site_setting_default",
+          impact_role: "all_members",
+        },
+      },
+    )
+
+    upcoming_changes_page.visit
+
+    expect(
+      upcoming_changes_page.change_item(:about_page_extra_groups_show_description),
+    ).to have_permanent_soon_notice
+    expect(
+      upcoming_changes_page.change_item(:enable_upload_debug_mode),
+    ).to have_no_permanent_soon_notice
+  end
+
   it "does not show permanent upcoming changes" do
     mock_upcoming_change_metadata(
       {

--- a/spec/system/page_objects/pages/admin_upcoming_change_item.rb
+++ b/spec/system/page_objects/pages/admin_upcoming_change_item.rb
@@ -39,6 +39,14 @@ module PageObjects
         find_item(@setting_name).find(".upcoming-change__plugin").has_text?(plugin_name)
       end
 
+      def has_permanent_soon_notice?
+        find_item(@setting_name).has_css?(".upcoming-change__status-notice")
+      end
+
+      def has_no_permanent_soon_notice?
+        find_item(@setting_name).has_no_css?(".upcoming-change__status-notice")
+      end
+
       def select_enabled_for(option)
         enabled_for_dropdown.select(option)
       end


### PR DESCRIPTION
It is misleading to tell admins that a change will soon become permanent
when it's in the stable status for site setting default type upcoming
changes.

This is because those changes are merely indicating that a
setting default is changing, not that existing behaviour will be removed
altogether. When the upcoming change is removed, the setting will still
stay available for admins to change themselves in future.

c.f. https://meta.discourse.org/t/automatically-apply-grids-to-image-uploads/394784/10?u=martin

Example of setting that should show the warning:

<img width="974" height="172" alt="image" src="https://github.com/user-attachments/assets/41a9ca5c-052a-4c67-b81d-63fb31d54626" />

Example of one which shouldn't:

<img width="971" height="147" alt="image" src="https://github.com/user-attachments/assets/aca96a72-1ac3-4185-b7ed-951ddd7acc15" />
