### PR TITLE
FEATURE: Add impact type badge for upcoming change items

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6237,6 +6237,10 @@ en:
           staff: "Staff"
           all_members: "All members"
           developers: "Developers"
+        impact_types:
+          feature_type: "Feature"
+          other_type: "Other"
+          site_setting_default_type: "Setting default"
         filter:
           search_placeholder: "Filter by name, description, or plugin..."
           no_results: "No upcoming changes match your filter"

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-badges.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-badges.gjs
@@ -1,0 +1,91 @@
+import Component from "@glimmer/component";
+import { concat } from "@ember/helper";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
+import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const UpcomingChangeBadge = <template>
+  <span
+    class={{concatClass "upcoming-change__badge" "--has-tooltip" @badgeClass}}
+  >
+    <span class="upcoming-change__badge-content">
+      {{icon @icon}}
+      {{i18n @badgeLabelKey}}
+    </span>
+    {{yield}}
+  </span>
+</template>;
+
+export default class UpcomingChangeBadges extends Component {
+  impactRoleIcon(impactRole) {
+    switch (impactRole) {
+      case "admins":
+      case "moderators":
+      case "staff":
+        return "shield-halved";
+      case "all_members":
+        return "users";
+      case "developers":
+        return "code";
+    }
+  }
+
+  impactTypeIcon(impactType) {
+    switch (impactType) {
+      case "feature":
+        return "wand-magic-sparkles";
+      case "other":
+        return "discourse-other-tab";
+      case "site_setting_default":
+        return "gear";
+    }
+  }
+
+  <template>
+    <div class="upcoming-change__badges">
+      <DTooltip
+        @content={{i18n
+          (concat
+            "admin.upcoming_changes.status_descriptions." @upcomingChange.status
+          )
+        }}
+      >
+        <:trigger>
+          <UpcomingChangeBadge
+            @icon="flask"
+            @badgeClass={{concat "--status-" @upcomingChange.status}}
+            @badgeLabelKey={{concat
+              "admin.upcoming_changes.statuses."
+              @upcomingChange.status
+            }}
+          >
+
+            <span class="upcoming-change__badge-info">
+              {{icon "info"}}
+            </span>
+          </UpcomingChangeBadge>
+        </:trigger>
+      </DTooltip>
+
+      <UpcomingChangeBadge
+        @icon={{this.impactRoleIcon @upcomingChange.impact_role}}
+        @badgeClass={{concat "--impact-role-" @upcomingChange.impact_role}}
+        @badgeLabelKey={{concat
+          "admin.upcoming_changes.impact_roles."
+          @upcomingChange.impact_role
+        }}
+      />
+
+      <UpcomingChangeBadge
+        @icon={{this.impactTypeIcon @upcomingChange.impact_type}}
+        @badgeClass={{concat "--impact-type-" @upcomingChange.impact_type}}
+        @badgeLabelKey={{concat
+          "admin.upcoming_changes.impact_types."
+          @upcomingChange.impact_type
+          "_type"
+        }}
+      />
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-tracked-properties-from-args */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, hash } from "@ember/helper";
+import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
@@ -10,11 +10,11 @@ import { service } from "@ember/service";
 import { capitalize } from "@ember/string";
 import { trustHTML } from "@ember/template";
 import { modifier } from "ember-modifier";
+import UpcomingChangeBadges from "discourse/admin/components/admin-config-areas/upcoming-change-badges";
 import DButton from "discourse/components/d-button";
 import DSelect from "discourse/components/d-select";
 import GroupSelector from "discourse/components/group-selector";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
-import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -42,21 +42,6 @@ export default class UpcomingChangeItem extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     cancel(this._savingEnabledForTimeout);
-  }
-
-  impactRoleIcon(impactRole) {
-    switch (impactRole) {
-      case "admins":
-        return "shield-halved";
-      case "moderators":
-        return "shield-halved";
-      case "staff":
-        return "shield-halved";
-      case "all_members":
-        return "users";
-      case "developers":
-        return "code";
-    }
   }
 
   get enabledForOptions() {
@@ -334,63 +319,7 @@ export default class UpcomingChangeItem extends Component {
           </div>
         {{/if}}
 
-        <div class="upcoming-change__badges">
-          <DTooltip
-            @content={{i18n
-              (concat
-                "admin.upcoming_changes.status_descriptions."
-                @change.upcoming_change.status
-              )
-            }}
-          >
-            <:trigger>
-              <span
-                class={{concatClass
-                  "upcoming-change__badge"
-                  "--has-tooltip"
-                  (concat "--status-" @change.upcoming_change.status)
-                }}
-              >
-                <span class="upcoming-change__badge-content">
-
-                  {{icon "flask"}}
-                  {{i18n
-                    (concat
-                      "admin.upcoming_changes.statuses."
-                      @change.upcoming_change.status
-                    )
-                  }}
-                </span>
-                <span class="upcoming-change__badge-info">
-                  {{icon "info"}}
-                </span>
-              </span>
-            </:trigger>
-          </DTooltip>
-
-          <span
-            title={{i18n
-              (concat
-                "admin.upcoming_changes.impact_roles."
-                @change.upcoming_change.impact_role
-              )
-            }}
-            class={{concatClass
-              "upcoming-change__badge"
-              (concat "--impact-role-" @change.upcoming_change.impact_role)
-            }}
-          >
-            <span class="upcoming-change__badge-content">
-              {{icon (this.impactRoleIcon @change.upcoming_change.impact_role)}}
-              {{i18n
-                (concat
-                  "admin.upcoming_changes.impact_roles."
-                  @change.upcoming_change.impact_role
-                )
-              }}
-            </span>
-          </span>
-        </div>
+        <UpcomingChangeBadges @upcomingChange={{@change.upcoming_change}} />
       </td>
       <td class="d-table__cell --detail upcoming-change__toggle-cell">
         <div class="d-table__mobile-label">

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-badges-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-badges-test.gjs
@@ -1,0 +1,196 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import UpcomingChangeBadges from "discourse/admin/components/admin-config-areas/upcoming-change-badges";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+function buildUpcomingChange(overrides = {}) {
+  return {
+    status: "beta",
+    impact: "feature,all_members",
+    impact_type: "feature",
+    impact_role: "all_members",
+    enabled_for: "everyone",
+    ...overrides,
+  };
+}
+
+module("Integration | Component | UpcomingChangeBadges", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders status, impact type, and impact role badges", async function (assert) {
+    const upcomingChange = buildUpcomingChange();
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert.dom(".upcoming-change__badges").exists();
+    assert
+      .dom(".upcoming-change__badge.--status-beta")
+      .exists("renders the status badge with the status modifier class");
+    assert
+      .dom(".upcoming-change__badge.--impact-type-feature")
+      .exists("renders the impact type badge");
+    assert
+      .dom(".upcoming-change__badge.--impact-role-all_members")
+      .exists("renders the impact role badge");
+  });
+
+  test("status badge uses the tooltip trigger class", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ status: "experimental" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--status-experimental.--has-tooltip")
+      .exists();
+    assert.dom(".upcoming-change__badge-info").exists("renders the info icon");
+  });
+
+  test("renders feature impact type with wand icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_type: "feature" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-type-feature")
+      .exists()
+      .containsText(i18n("admin.upcoming_changes.impact_types.feature_type"));
+    assert
+      .dom(
+        ".upcoming-change__badge.--impact-type-feature .d-icon-wand-magic-sparkles"
+      )
+      .exists();
+  });
+
+  test("renders other impact type with discourse-other-tab icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_type: "other" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-type-other")
+      .exists()
+      .containsText(i18n("admin.upcoming_changes.impact_types.other_type"));
+    assert
+      .dom(
+        ".upcoming-change__badge.--impact-type-other .d-icon-discourse-other-tab"
+      )
+      .exists();
+  });
+
+  test("renders site setting default impact type with gear icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({
+      impact_type: "site_setting_default",
+    });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-type-site_setting_default")
+      .exists()
+      .containsText(
+        i18n("admin.upcoming_changes.impact_types.site_setting_default_type")
+      );
+    assert
+      .dom(
+        ".upcoming-change__badge.--impact-type-site_setting_default .d-icon-gear"
+      )
+      .exists();
+  });
+
+  test("renders admins impact role with shield icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_role: "admins" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-role-admins")
+      .exists()
+      .containsText(i18n("admin.upcoming_changes.impact_roles.admins"));
+    assert
+      .dom(".upcoming-change__badge.--impact-role-admins .d-icon-shield-halved")
+      .exists();
+  });
+
+  test("renders moderators impact role with shield icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_role: "moderators" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(
+        ".upcoming-change__badge.--impact-role-moderators .d-icon-shield-halved"
+      )
+      .exists();
+  });
+
+  test("renders staff impact role with shield icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_role: "staff" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-role-staff .d-icon-shield-halved")
+      .exists();
+  });
+
+  test("renders all_members impact role with users icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_role: "all_members" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-role-all_members .d-icon-users")
+      .exists();
+  });
+
+  test("renders developers impact role with code icon", async function (assert) {
+    const upcomingChange = buildUpcomingChange({ impact_role: "developers" });
+
+    await render(
+      <template>
+        <UpcomingChangeBadges @upcomingChange={{upcomingChange}} />
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__badge.--impact-role-developers .d-icon-code")
+      .exists();
+  });
+});


### PR DESCRIPTION
Also refactor badge into its own component to reduce
complexity of `UpcomingChangeItem`

<img width="985" height="499" alt="image" src="https://github.com/user-attachments/assets/c9034b08-8ebd-4a2c-922c-013ecb028647" />
