### PR TITLE
DEV: Improve vote queries

### DIFF
--- a/plugins/discourse-topic-voting/app/controllers/discourse_topic_voting/votes_controller.rb
+++ b/plugins/discourse-topic-voting/app/controllers/discourse_topic_voting/votes_controller.rb
@@ -11,7 +11,7 @@ module DiscourseTopicVoting
       topic = Topic.find(params[:topic_id].to_i)
       guardian.ensure_can_see!(topic)
 
-      render json: MultiJson.dump(who_voted(topic))
+      render json: MultiJson.dump(who_voted(topic, limit: who_voted_limit))
     end
 
     def vote
@@ -83,14 +83,21 @@ module DiscourseTopicVoting
       }
     end
 
-    def who_voted(topic)
+    def who_voted(topic, limit: DiscourseTopicVoting::VOTER_PREVIEW_LIMIT)
       return nil unless SiteSetting.topic_voting_show_who_voted
 
       ActiveModel::ArraySerializer.new(
-        topic.who_voted,
+        topic.who_voted(limit:),
         scope: guardian,
         each_serializer: BasicUserSerializer,
       )
+    end
+
+    def who_voted_limit
+      limit = params[:limit].presence&.to_i
+      return DiscourseTopicVoting::VOTER_PREVIEW_LIMIT if limit.blank? || limit <= 0
+
+      [limit, DiscourseTopicVoting::VOTER_PREVIEW_LIMIT].min
     end
   end
 end

--- a/plugins/discourse-topic-voting/app/models/discourse_topic_voting/topic_vote_count.rb
+++ b/plugins/discourse-topic-voting/app/models/discourse_topic_voting/topic_vote_count.rb
@@ -4,7 +4,7 @@ module DiscourseTopicVoting
   class TopicVoteCount < ActiveRecord::Base
     self.table_name = "topic_voting_topic_vote_count"
 
-    belongs_to :topic
+    belongs_to :topic, -> { with_deleted }
   end
 end
 

--- a/plugins/discourse-topic-voting/app/models/discourse_topic_voting/vote.rb
+++ b/plugins/discourse-topic-voting/app/models/discourse_topic_voting/vote.rb
@@ -5,7 +5,10 @@ module DiscourseTopicVoting
     self.table_name = "topic_voting_votes"
 
     belongs_to :user
-    belongs_to :topic
+    belongs_to :topic, -> { with_deleted }
+
+    scope :active, -> { where(archive: false) }
+    scope :archived, -> { where(archive: true) }
   end
 end
 

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-count.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-count.gjs
@@ -8,7 +8,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
-import { eq, gt } from "discourse/truth-helpers";
+import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import VoteCountTrigger from "./vote-count-trigger";
 
@@ -20,8 +20,6 @@ export default class VoteCount extends Component {
   @tracked lastVoteCount = null;
   @tracked totalVoters = 0;
   @tracked isLoading = false;
-
-  maxDisplayedVoters = 104;
 
   get showVoterMenu() {
     return this.siteSettings.topic_voting_show_who_voted && this.currentUser;
@@ -37,7 +35,11 @@ export default class VoteCount extends Component {
   }
 
   get remainingVoters() {
-    return this.totalVoters - this.maxDisplayedVoters;
+    return Math.max(this.totalVoters - (this.voters?.length || 0), 0);
+  }
+
+  get hasOverflowVoters() {
+    return this.remainingVoters > 0;
   }
 
   @bind
@@ -63,8 +65,8 @@ export default class VoteCount extends Component {
         data: { topic_id: this.args.topic.id },
       });
 
-      this.totalVoters = users.length;
-      this.voters = users.slice(0, this.maxDisplayedVoters).map((user) => ({
+      this.totalVoters = this.args.topic.vote_count;
+      this.voters = users.map((user) => ({
         template: user.avatar_template,
         username: user.username,
         url: getURL("/u/") + user.username.toLowerCase(),
@@ -112,7 +114,7 @@ export default class VoteCount extends Component {
                   {{avatar voter.template "small"}}
                 </a>
               {{/each}}
-              {{#if (gt this.totalVoters this.maxDisplayedVoters)}}
+              {{#if this.hasOverflowVoters}}
                 <div class="voting-voters__overflow">
                   {{i18n
                     "topic_voting.and_more_voters"

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_extension.rb
@@ -46,10 +46,10 @@ module DiscourseTopicVoting
       SQL
     end
 
-    def who_voted
+    def who_voted(limit: DiscourseTopicVoting::VOTER_PREVIEW_LIMIT)
       return if !SiteSetting.topic_voting_show_who_voted
 
-      self.votes.map(&:user)
+      votes.active.includes(:user).order(created_at: :desc).limit(limit).filter_map(&:user)
     end
   end
 end

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_query_extension.rb
@@ -14,7 +14,7 @@ module DiscourseTopicVoting
       create_list(:user_topics) do |topics|
         topics.joins(
           "INNER JOIN topic_voting_votes ON topic_voting_votes.topic_id = topics.id",
-        ).where("topic_voting_votes.user_id = ?", user.id)
+        ).where("topic_voting_votes.user_id = ? AND topic_voting_votes.archive = FALSE", user.id)
       end
     end
 

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -23,6 +23,7 @@ Discourse.anonymous_filters.push(:votes)
 module ::DiscourseTopicVoting
   PLUGIN_NAME = "discourse-topic-voting"
   ENABLE_TOPIC_VOTING_SETTING = "enable_topic_voting"
+  VOTER_PREVIEW_LIMIT = 104
 end
 
 require_relative "lib/discourse_topic_voting/engine"
@@ -64,7 +65,7 @@ after_initialize do
       if options[:state] == "my_votes"
         result =
           result.joins(
-            "INNER JOIN topic_voting_votes ON topic_voting_votes.topic_id = topics.id AND topic_voting_votes.user_id = #{user.id}",
+            "INNER JOIN topic_voting_votes ON topic_voting_votes.topic_id = topics.id AND topic_voting_votes.user_id = #{user.id} AND topic_voting_votes.archive = FALSE",
           )
       end
     end

--- a/plugins/discourse-topic-voting/spec/lib/topic_extension_spec.rb
+++ b/plugins/discourse-topic-voting/spec/lib/topic_extension_spec.rb
@@ -36,4 +36,32 @@ describe DiscourseTopicVoting::TopicExtension do
       expect(topic2.reload.topic_vote_count.votes_count).to eq(1)
     end
   end
+
+  describe "#who_voted" do
+    it "returns recent active voters up to the requested limit" do
+      DiscourseTopicVoting::Vote.create!(user: user, topic: topic, created_at: 2.hours.ago)
+      DiscourseTopicVoting::Vote.create!(user: user2, topic: topic, created_at: 1.hour.ago)
+      archived_user = Fabricate(:user)
+      DiscourseTopicVoting::Vote.create!(
+        user: archived_user,
+        topic: topic,
+        archive: true,
+        created_at: Time.zone.now,
+      )
+
+      expect(topic.who_voted(limit: 1)).to eq([user2])
+    end
+  end
+
+  describe "topic associations" do
+    it "keeps soft-deleted topics available from votes and vote counts" do
+      vote = DiscourseTopicVoting::Vote.create!(user: user, topic: topic)
+      topic_vote_count = DiscourseTopicVoting::TopicVoteCount.create!(topic: topic, votes_count: 1)
+
+      topic.trash!
+
+      expect(vote.reload.topic).to eq(topic)
+      expect(topic_vote_count.reload.topic).to eq(topic)
+    end
+  end
 end

--- a/plugins/discourse-topic-voting/spec/lib/topic_query_spec.rb
+++ b/plugins/discourse-topic-voting/spec/lib/topic_query_spec.rb
@@ -22,6 +22,13 @@ describe TopicQuery do
   end
 
   it "returns topics voted by user" do
+    archived_topic = Fabricate(:topic, category: category1)
+    DiscourseTopicVoting::Vote.create!(
+      topic_id: archived_topic.id,
+      user_id: user0.id,
+      archive: true,
+    )
+
     expect(TopicQuery.new(user0, { state: "my_votes" }).list_latest.topics.map(&:id)).to eq(
       [topic1.id],
     )

--- a/plugins/discourse-topic-voting/spec/requests/lists_controller_spec.rb
+++ b/plugins/discourse-topic-voting/spec/requests/lists_controller_spec.rb
@@ -7,12 +7,14 @@ describe ListController do
   before { SiteSetting.topic_voting_enabled = true }
 
   it "allow anons to view votes" do
+    archived_topic = Fabricate(:topic)
     DiscourseTopicVoting::Vote.create!(user: user, topic: topic)
+    DiscourseTopicVoting::Vote.create!(user: user, topic: archived_topic, archive: true)
 
     get "/topics/voted-by/#{user.username}.json"
-    topic_json = response.parsed_body.dig("topic_list", "topics").first
+    topic_ids = response.parsed_body.dig("topic_list", "topics").pluck("id")
 
-    expect(topic_json["id"]).to eq(topic.id)
+    expect(topic_ids).to eq([topic.id])
   end
 
   it "returns a 404 when we don't show votes on profiles" do

--- a/plugins/discourse-topic-voting/spec/requests/votes_controller_spec.rb
+++ b/plugins/discourse-topic-voting/spec/requests/votes_controller_spec.rb
@@ -99,4 +99,37 @@ describe DiscourseTopicVoting::VotesController do
     expect(payload["voter_id"]).to eq(user.id)
     expect(payload["vote_count"]).to eq(0)
   end
+
+  it "limits who-voted previews to VOTE_PREVIEW_LIMIT users by default" do
+    stub_const(DiscourseTopicVoting, "VOTER_PREVIEW_LIMIT", 10) do
+      Fabricate
+        .times(11, :user)
+        .each { |voter| DiscourseTopicVoting::Vote.create!(user: voter, topic: topic) }
+
+      get "/voting/who.json", params: { topic_id: topic.id }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.length).to eq(DiscourseTopicVoting::VOTER_PREVIEW_LIMIT)
+    end
+  end
+
+  it "excludes archived votes and honors a smaller who-voted limit" do
+    older_voter = Fabricate(:user)
+    newer_voter = Fabricate(:user)
+    archived_voter = Fabricate(:user)
+
+    DiscourseTopicVoting::Vote.create!(user: older_voter, topic: topic, created_at: 2.hours.ago)
+    DiscourseTopicVoting::Vote.create!(user: newer_voter, topic: topic, created_at: 1.hour.ago)
+    DiscourseTopicVoting::Vote.create!(
+      user: archived_voter,
+      topic: topic,
+      archive: true,
+      created_at: Time.zone.now,
+    )
+
+    get "/voting/who.json", params: { topic_id: topic.id, limit: 1 }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body.pluck("id")).to eq([newer_voter.id])
+  end
 end

--- a/plugins/discourse-topic-voting/spec/system/voting_spec.rb
+++ b/plugins/discourse-topic-voting/spec/system/voting_spec.rb
@@ -205,6 +205,22 @@ RSpec.describe "Topic voting" do
       find(".title-voting .voting-wrapper__count").click
       expect(page).to have_css(".voting-voters__empty")
     end
+
+    it "uses the topic vote count for overflow text while only loading preview rows" do
+      stub_const(DiscourseTopicVoting, "VOTER_PREVIEW_LIMIT", 10) do
+        Fabricate
+          .times(11, :user)
+          .each { |user| DiscourseTopicVoting::Vote.create!(user: user, topic: voting_topic1) }
+        voting_topic1.update_vote_count
+
+        sign_in(admin)
+        visit("/t/#{voting_topic1.slug}/#{voting_topic1.id}")
+
+        find(".title-voting .voting-wrapper__count").click
+        expect(page).to have_css(".voting-voters__avatar", count: 10)
+        expect(page).to have_css(".voting-voters__overflow", text: "and 2 more...")
+      end
+    end
   end
 
   context "when viewing navigation tooltips" do


### PR DESCRIPTION
The change is limited to the topic-voting voter preview and vote-list queries.

`/voting/who` now only loads a capped preview of active voters instead of loading every vote and mapping users in Ruby., then limiting on the client. The cap is 104, archived votes are excluded from the preview, and the client now uses `topic.vote_count` as the total so the popup can show “and N more...” without fetching the full voter list.

Also tightened the two vote-list queries so archived votes no longer appear in `state=my_votes` or `/topics/voted-by/:username`.

Finally, the vote and vote-count models now use `with_deleted` for their topic association so soft-deleted topics can still be resolved where those records reference them.