### PR TITLE
FIX: Use resolved locale for localizations, instead of param+site default fallback

### DIFF
--- a/lib/topic_list_responder.rb
+++ b/lib/topic_list_responder.rb
@@ -23,7 +23,7 @@ module TopicListResponder
 
   def localize_topic_list_content(list)
     return if list.topics.blank? || !SiteSetting.content_localization_enabled
-    crawl_locale = params[Discourse::LOCALE_PARAM].presence || SiteSetting.default_locale
+    crawl_locale = I18n.locale
 
     list.topics.each do |topic|
       LocalizationAttributesReplacer.replace_topic_attributes(topic, crawl_locale)

--- a/lib/topic_list_responder.rb
+++ b/lib/topic_list_responder.rb
@@ -23,6 +23,8 @@ module TopicListResponder
 
   def localize_topic_list_content(list)
     return if list.topics.blank? || !SiteSetting.content_localization_enabled
+    return if cookies.key?(ContentLocalization::SHOW_ORIGINAL_COOKIE)
+    return if current_user&.user_option&.show_original_content
     crawl_locale = I18n.locale
 
     list.topics.each do |topic|

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -2001,6 +2001,7 @@ RSpec.describe ListController do
       end
 
       before do
+        SiteSetting.set_locale_from_param = true
         topic.update!(locale: "en")
         topic.category.update!(locale: "en")
       end

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -201,6 +201,37 @@ describe "Content Localization" do
         expect(topic_page.topic_title).to have_content("織田信長の生涯")
       end
 
+      fab!(:ja_topic) do
+        topic = Fabricate(:topic, title: "日本語で書かれたトピック", locale: "ja", user: admin)
+        Fabricate(:post, topic:, locale: "ja", raw: "日本語の投稿です")
+        topic
+      end
+      fab!(:ja_topic_en_localization) do
+        Fabricate(
+          :topic_localization,
+          topic: ja_topic,
+          locale: "en",
+          fancy_title: "A topic written in Japanese",
+        )
+      end
+
+      it "shows original title on topic list for anonymous users when topic locale matches browsing locale" do
+        visit("/?tl=ja")
+        expect(page).to have_css(".topic-list-body .raw-topic-link", text: "日本語で書かれたトピック")
+        expect(page).to have_no_css(
+          ".topic-list-body .raw-topic-link",
+          text: "A topic written in Japanese",
+        )
+
+        # navigate away and come back — locale should persist via cookie
+        visit("/")
+        expect(page).to have_css(".topic-list-body .raw-topic-link", text: "日本語で書かれたトピック")
+        expect(page).to have_no_css(
+          ".topic-list-body .raw-topic-link",
+          text: "A topic written in Japanese",
+        )
+      end
+
       it "ignores tl parameter for logged-in users" do
         sign_in(site_local_user)
         visit("/t/#{topic.id}?tl=ja")


### PR DESCRIPTION
Related issue: 
- https://meta.discourse.org/t/localisation-bug-for-anonymous-users-with-tl-lang/400090
- https://meta.discourse.org/t/topic-list-is-shown-in-a-language-de-but-has-one-de-topic-not-translated/400209

Our `TopicListResponder` determined content locale using only the `?tl=` URL param, falling back to `SiteSetting.default_locale`. This ignored the locale cookie set by the language switcher or persisted from a previous `?tl=` visit. The fix is to simply use `I18n.locale` which is already resolved from all sources (?tl= param, cookie, Accept-Language header, site default).

This only affects initial page loads and browser refreshes. Ember internal navigation (format.json) is unaffected since it doesn't call `localize_topic_list_content`.

Scenarios affected and fixed (per related urls):
1. Anonymous user switches to German via language switcher → German-origin topics show English titles on page load
2. User arrives via ?tl=fi from Google → first page works, but subsequent navigations (without ?tl= in URL) fall back to English despite the locale cookie being set
