### PR TITLE
FIX: Stop sending unnecessary request when show more is clicked

### DIFF
--- a/frontend/discourse/app/components/post/menu.gjs
+++ b/frontend/discourse/app/components/post/menu.gjs
@@ -40,7 +40,6 @@ import PostMenuReplyButton from "./menu/buttons/reply";
 import PostMenuShareButton from "./menu/buttons/share";
 import PostMenuShowMoreButton from "./menu/buttons/show-more";
 
-const LIKE_ACTION = 2;
 const VIBRATE_DURATION = 5;
 
 const buttonKeys = Object.freeze({
@@ -96,9 +95,7 @@ export default class PostMenu extends Component {
     true,
     this.#prepareStaticMethodsState({ collapsed: true })
   );
-  @tracked isWhoLikedVisible = false;
-  @tracked likedUsers = [];
-  @tracked totalLikedUsers;
+
   @tracked isWhoReadVisible = false;
   @tracked readers = [];
   @tracked totalReaders;

--- a/frontend/discourse/app/components/post/menu.gjs
+++ b/frontend/discourse/app/components/post/menu.gjs
@@ -476,10 +476,6 @@ export default class PostMenu extends Component {
         }
 
         await this.args.toggleLike();
-
-        if (!this.collapsed) {
-          await this.#fetchWhoLiked();
-        }
       },
       this.staticMethodsArgs
     );
@@ -526,23 +522,12 @@ export default class PostMenu extends Component {
     this.collapsed = false;
 
     const fetchData = [
-      !this.isWhoLikedVisible && this.#fetchWhoLiked(),
       !this.isWhoReadVisible &&
         this.args.showReadIndicator &&
         this.#fetchWhoRead(),
     ].filter(Boolean);
 
     await Promise.all(fetchData);
-  }
-
-  @action
-  toggleWhoLiked() {
-    if (this.isWhoLikedVisible) {
-      this.isWhoLikedVisible = false;
-      return;
-    }
-
-    this.#fetchWhoLiked();
   }
 
   @action
@@ -569,17 +554,6 @@ export default class PostMenu extends Component {
         (itemKey) =>
           !this.args.post.bookmarked || itemKey !== buttonKeys.BOOKMARK
       );
-  }
-
-  async #fetchWhoLiked() {
-    const users = await this.store.find("post-action-user", {
-      id: this.args.post.id,
-      post_action_type_id: LIKE_ACTION,
-    });
-
-    this.likedUsers = users.content.map(smallUserAttrs);
-    this.totalLikedUsers = users.totalRows;
-    this.isWhoLikedVisible = true;
   }
 
   async #fetchWhoRead() {

--- a/frontend/discourse/app/components/post/menu.gjs
+++ b/frontend/discourse/app/components/post/menu.gjs
@@ -117,7 +117,6 @@ export default class PostMenu extends Component {
       showMoreActions: this.showMoreActions,
       showLogin: this.args.showLogin,
       toggleReplies: this.args.toggleReplies,
-      toggleWhoLiked: this.toggleWhoLiked,
       toggleWhoRead: this.toggleWhoRead,
     };
   }
@@ -428,10 +427,6 @@ export default class PostMenu extends Component {
     return this.registeredButtons.get(buttonKeys.SHOW_MORE);
   }
 
-  get remainingLikedUsers() {
-    return this.totalLikedUsers - this.likedUsers.length;
-  }
-
   get remainingReaders() {
     return this.totalReaders - this.readers.length;
   }
@@ -569,7 +564,6 @@ export default class PostMenu extends Component {
       collapsed: collapsed ?? this.collapsed,
       currentUser: this.currentUser,
       filteredRepliesView: this.args.filteredRepliesView,
-      isWhoLikedVisible: this.isWhoLikedVisible,
       isWhoReadVisible: this.isWhoReadVisible,
       isWikiMode: this.isWikiMode,
       repliesShown: this.args.repliesShown,

--- a/frontend/discourse/tests/unit/components/post-menu-test.gjs
+++ b/frontend/discourse/tests/unit/components/post-menu-test.gjs
@@ -4,6 +4,7 @@ import { module, test } from "qunit";
 import PostMenu from "discourse/components/post/menu";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module("Unit | Component | post-menu", function (hooks) {
   setupRenderingTest(hooks);
@@ -67,6 +68,22 @@ module("Unit | Component | post-menu", function (hooks) {
       ["transformer called"],
       "behavior transformer was called"
     );
+  });
+
+  test("show more does not request who liked the post", async function (assert) {
+    this.siteSettings.post_menu_hidden_items = "bookmark|copyLink";
+
+    let requested = false;
+    pretender.get("/post_action_users", () => {
+      requested = true;
+      return response({ post_action_users: [] });
+    });
+
+    const post = this.post;
+    await render(<template><PostMenu @post={{post}} /></template>);
+    await click(".post-action-menu__show-more");
+
+    assert.false(requested, "no request is sent to /post_action_users");
   });
 
   module("post-menu value transformer", function () {


### PR DESCRIPTION
Currently, when clicking the show more button on a post, it sends a `post_action_users` request, as a leftover from the old like system (discontinued a while back)

<img width="1750" height="892" alt="image" src="https://github.com/user-attachments/assets/1fa2c492-7e99-4aa0-ba11-93dd48d1c1b6" />

This PR makes it so there is no more request sent when you click the button:

https://github.com/user-attachments/assets/fdb67634-d31e-4151-bc78-bd52a3abc8f8

There should not be able functional changes.