### PR TITLE
PERF: speed up chat channel and thread unread queries

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -406,27 +406,28 @@ end
 # Table name: chat_messages
 #
 #  id              :bigint           not null, primary key
-#  chat_channel_id :bigint           not null
-#  user_id         :integer
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  deleted_at      :datetime
-#  deleted_by_id   :integer
-#  in_reply_to_id  :bigint
-#  message         :text
+#  blocks          :jsonb
 #  cooked          :text
 #  cooked_version  :integer
+#  created_by_sdk  :boolean          default(FALSE), not null
+#  deleted_at      :datetime
+#  excerpt         :string(1000)
+#  message         :text
+#  streaming       :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  chat_channel_id :bigint           not null
+#  deleted_by_id   :integer
+#  in_reply_to_id  :bigint
 #  last_editor_id  :integer          not null
 #  thread_id       :bigint
-#  streaming       :boolean          default(FALSE), not null
-#  excerpt         :string(1000)
-#  created_by_sdk  :boolean          default(FALSE), not null
-#  blocks          :jsonb
+#  user_id         :integer
 #
 # Indexes
 #
 #  idx_chat_messages_by_created_at_not_deleted            (created_at) WHERE (deleted_at IS NULL)
 #  idx_chat_messages_by_thread_id_not_deleted             (thread_id) WHERE (deleted_at IS NULL)
+#  idx_chat_messages_thread_id_id_user_id_not_deleted     (thread_id,id) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
 #  index_chat_messages_on_chat_channel_id_and_id          (chat_channel_id,id) WHERE (deleted_at IS NOT NULL)
 #  index_chat_messages_on_last_editor_id                  (last_editor_id)

--- a/plugins/chat/app/models/chat/null_message.rb
+++ b/plugins/chat/app/models/chat/null_message.rb
@@ -25,27 +25,28 @@ end
 # Table name: chat_messages
 #
 #  id              :bigint           not null, primary key
-#  chat_channel_id :bigint           not null
-#  user_id         :integer
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  deleted_at      :datetime
-#  deleted_by_id   :integer
-#  in_reply_to_id  :bigint
-#  message         :text
+#  blocks          :jsonb
 #  cooked          :text
 #  cooked_version  :integer
+#  created_by_sdk  :boolean          default(FALSE), not null
+#  deleted_at      :datetime
+#  excerpt         :string(1000)
+#  message         :text
+#  streaming       :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  chat_channel_id :bigint           not null
+#  deleted_by_id   :integer
+#  in_reply_to_id  :bigint
 #  last_editor_id  :integer          not null
 #  thread_id       :bigint
-#  streaming       :boolean          default(FALSE), not null
-#  excerpt         :string(1000)
-#  created_by_sdk  :boolean          default(FALSE), not null
-#  blocks          :jsonb
+#  user_id         :integer
 #
 # Indexes
 #
 #  idx_chat_messages_by_created_at_not_deleted            (created_at) WHERE (deleted_at IS NULL)
 #  idx_chat_messages_by_thread_id_not_deleted             (thread_id) WHERE (deleted_at IS NULL)
+#  idx_chat_messages_thread_id_id_user_id_not_deleted     (thread_id,id) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
 #  index_chat_messages_on_chat_channel_id_and_id          (chat_channel_id,id) WHERE (deleted_at IS NOT NULL)
 #  index_chat_messages_on_last_editor_id                  (last_editor_id)

--- a/plugins/chat/app/queries/chat/channel_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/channel_unreads_query.rb
@@ -20,68 +20,115 @@ module Chat
     #   is a member of where they have read all the messages. This overrides
     #   include_missing_memberships.
     def self.call(channel_ids:, user_id:, include_missing_memberships: false, include_read: true)
+      # The CTE picks the candidate channel set up front and resolves the
+      # static per-channel filters (chatable_type, threading_enabled, muted,
+      # last_read_message_id) into columns. The three LATERAL aggregates then
+      # run once per candidate, instead of three correlated subqueries each
+      # joining tables that explode with the user's full membership lists.
+      #
+      # The unread_count aggregate is split into three additive pieces so the
+      # planner can use index-friendly filters per piece, instead of an
+      # OR-bag that forces a sequential scan over every message past
+      # last_read_message_id (the previous bottleneck).
       sql = <<~SQL
-        SELECT (
-          SELECT COUNT(*) AS unread_count
-          FROM chat_messages
-          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_channels.id
-          LEFT JOIN chat_threads ON chat_threads.id = chat_messages.thread_id
-          LEFT JOIN user_chat_thread_memberships ON user_chat_thread_memberships.thread_id = chat_messages.thread_id AND user_chat_thread_memberships.user_id = :user_id
-          WHERE chat_channels.id = memberships.chat_channel_id
-          AND user_chat_channel_memberships.user_id = :user_id
-          AND chat_messages.id > COALESCE(user_chat_channel_memberships.last_read_message_id, 0)
-          AND chat_messages.deleted_at IS NULL
-          AND (
-            chat_messages.thread_id IS NULL
-            OR chat_messages.id = chat_threads.original_message_id
-            OR (
-              chat_channels.chatable_type = 'DirectMessage'
-              AND NOT chat_channels.threading_enabled
-              AND user_chat_thread_memberships.id IS NOT NULL
-              AND chat_messages.id > COALESCE(user_chat_thread_memberships.last_read_message_id, 0)
-              AND chat_messages.user_id != :user_id
+        WITH limited_channels AS (
+          SELECT
+            memberships.chat_channel_id,
+            memberships.last_read_message_id,
+            memberships.muted,
+            chat_channels.chatable_type,
+            chat_channels.threading_enabled
+          FROM user_chat_channel_memberships AS memberships
+          INNER JOIN chat_channels ON chat_channels.id = memberships.chat_channel_id
+          WHERE memberships.user_id = :user_id
+            AND memberships.chat_channel_id IN (:channel_ids)
+          LIMIT :limit
+        )
+        SELECT
+          lc.chat_channel_id AS channel_id,
+          CASE WHEN lc.muted THEN 0 ELSE COALESCE(unread_calc.cnt, 0) END AS unread_count,
+          COALESCE(mention_calc.cnt, 0) AS mention_count,
+          COALESCE(watched_calc.cnt, 0) AS watched_threads_unread_count
+        FROM limited_channels lc
+        LEFT JOIN LATERAL (
+          SELECT
+            -- (1) Standalone channel messages (not in any thread).
+            (
+              SELECT COUNT(*)
+              FROM chat_messages cm
+              WHERE cm.chat_channel_id = lc.chat_channel_id
+                AND cm.thread_id IS NULL
+                AND cm.id > COALESCE(lc.last_read_message_id, 0)
+                AND cm.deleted_at IS NULL
             )
-          )
-          AND NOT user_chat_channel_memberships.muted
-        ) AS unread_count,
-        (
-          SELECT COUNT(*) AS mention_count
-          FROM notifications
-          INNER JOIN user_chat_channel_memberships AS uccm ON uccm.user_id = :user_id
-          INNER JOIN chat_messages ON (data::json->>'chat_message_id')::bigint = chat_messages.id
-          LEFT JOIN chat_threads ON chat_threads.id = chat_messages.thread_id
-          LEFT JOIN user_chat_thread_memberships AS uctm ON uctm.thread_id = chat_messages.thread_id AND uctm.user_id = :user_id
-          WHERE NOT read
-          AND uccm.chat_channel_id = memberships.chat_channel_id
-          AND notifications.user_id = :user_id
-          AND notifications.notification_type = :notification_type_mention
-          AND (data::json->>'chat_channel_id')::bigint = memberships.chat_channel_id
-          AND (((chat_messages.thread_id IS NULL OR chat_messages.id = chat_threads.original_message_id) AND chat_messages.id > COALESCE(uccm.last_read_message_id, 0))
-          OR (chat_messages.thread_id IS NOT NULL AND uctm.id IS NOT NULL AND chat_messages.id > COALESCE(uctm.last_read_message_id, 0)))
-        ) AS mention_count,
-        (
-          SELECT COUNT(*) AS watched_threads_unread_count
-          FROM chat_messages
-          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
-          INNER JOIN chat_threads ON chat_threads.id = chat_messages.thread_id AND chat_threads.channel_id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_thread_memberships ON user_chat_thread_memberships.thread_id = chat_threads.id
-          WHERE chat_messages.chat_channel_id = memberships.chat_channel_id
-          AND chat_messages.thread_id = user_chat_thread_memberships.thread_id
-          AND chat_messages.user_id != :user_id
-          AND chat_messages.deleted_at IS NULL
-          AND chat_messages.thread_id IS NOT NULL
-          AND chat_messages.id != chat_threads.original_message_id
-          AND chat_messages.id > COALESCE(user_chat_thread_memberships.last_read_message_id, 0)
-          AND user_chat_thread_memberships.user_id = :user_id
-          AND user_chat_thread_memberships.notification_level = :watching_level
-          AND (chat_channels.threading_enabled OR chat_threads.force = true)
-        ) AS watched_threads_unread_count,
-        memberships.chat_channel_id AS channel_id
-        FROM user_chat_channel_memberships AS memberships
-        WHERE memberships.user_id = :user_id AND memberships.chat_channel_id IN (:channel_ids)
-        GROUP BY memberships.chat_channel_id
-        #{include_missing_memberships ? "" : "LIMIT :limit"}
+            +
+            -- (2) Thread original messages, which count at the channel level.
+            (
+              SELECT COUNT(*)
+              FROM chat_threads ct
+              INNER JOIN chat_messages cm ON cm.id = ct.original_message_id
+              WHERE ct.channel_id = lc.chat_channel_id
+                AND ct.original_message_id > COALESCE(lc.last_read_message_id, 0)
+                AND cm.deleted_at IS NULL
+            )
+            +
+            -- (3) DM channel + threading disabled: thread replies the user is
+            -- a member of and hasn't read. Only fires for DM channels with
+            -- threading off (auto-enrolled DM threads).
+            (
+              SELECT COUNT(*)
+              FROM chat_messages cm
+              INNER JOIN chat_threads ct ON ct.id = cm.thread_id
+              INNER JOIN user_chat_thread_memberships uctm
+                      ON uctm.thread_id = cm.thread_id
+                     AND uctm.user_id = :user_id
+              WHERE lc.chatable_type = 'DirectMessage'
+                AND NOT lc.threading_enabled
+                AND cm.chat_channel_id = lc.chat_channel_id
+                AND cm.thread_id IS NOT NULL
+                AND cm.id != ct.original_message_id
+                AND cm.id > COALESCE(lc.last_read_message_id, 0)
+                AND cm.id > COALESCE(uctm.last_read_message_id, 0)
+                AND cm.user_id != :user_id
+                AND cm.deleted_at IS NULL
+            ) AS cnt
+        ) unread_calc ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt
+          FROM notifications n
+          INNER JOIN chat_messages cm ON cm.id = (n.data::json->>'chat_message_id')::bigint
+          LEFT JOIN chat_threads ct ON ct.id = cm.thread_id
+          LEFT JOIN user_chat_thread_memberships uctm
+                 ON uctm.thread_id = cm.thread_id AND uctm.user_id = :user_id
+          WHERE n.user_id = :user_id
+            AND n.notification_type = :notification_type_mention
+            AND NOT n.read
+            AND (n.data::json->>'chat_channel_id')::bigint = lc.chat_channel_id
+            AND (
+              ((cm.thread_id IS NULL OR cm.id = ct.original_message_id)
+                AND cm.id > COALESCE(lc.last_read_message_id, 0))
+              OR (cm.thread_id IS NOT NULL
+                AND uctm.id IS NOT NULL
+                AND cm.id > COALESCE(uctm.last_read_message_id, 0))
+            )
+        ) mention_calc ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt
+          FROM chat_threads ct
+          INNER JOIN user_chat_thread_memberships uctm
+                  ON uctm.thread_id = ct.id
+                 AND uctm.user_id = :user_id
+                 AND uctm.notification_level = :watching_level
+          INNER JOIN chat_messages cm
+                  ON cm.thread_id = ct.id
+                 AND cm.chat_channel_id = lc.chat_channel_id
+          WHERE ct.channel_id = lc.chat_channel_id
+            AND (lc.threading_enabled OR ct.force)
+            AND cm.id != ct.original_message_id
+            AND cm.user_id != :user_id
+            AND cm.deleted_at IS NULL
+            AND cm.id > COALESCE(uctm.last_read_message_id, 0)
+        ) watched_calc ON true
       SQL
 
       sql = <<~SQL if !include_read
@@ -93,7 +140,7 @@ module Chat
 
       sql += <<~SQL if include_missing_memberships && include_read
         UNION ALL
-        SELECT 0 AS unread_count, 0 AS mention_count, 0 AS watched_threads_unread_count, chat_channels.id AS channel_id
+        SELECT chat_channels.id AS channel_id, 0 AS unread_count, 0 AS mention_count, 0 AS watched_threads_unread_count
         FROM chat_channels
         LEFT JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_channels.id
           AND user_chat_channel_memberships.user_id = :user_id

--- a/plugins/chat/app/queries/chat/thread_unreads_query.rb
+++ b/plugins/chat/app/queries/chat/thread_unreads_query.rb
@@ -12,9 +12,15 @@ module Chat
   # the result. Only threads inside a channel that has threading_enabled
   # will be counted.
   class ThreadUnreadsQuery
-    # NOTE: This is arbitrary at this point in time, we may want to increase
-    # or decrease this as we find performance issues.
-    MAX_THREADS = 3000
+    # Cap on threads counted in a single call. Heavily-tracked users can have
+    # tens of thousands of memberships; computing per-thread counts for all of
+    # them blows past the worker timeout. We deliberately trade fidelity for
+    # latency: only the most-recently-active threads (by chat_threads.last_message_id)
+    # are included in the result. Threads outside the top MAX_THREADS are
+    # omitted entirely (no row returned) — acceptable for the unread-indicator
+    # UI this drives. Callers passing an explicit thread_ids list are unaffected
+    # because the LIMIT is applied after the thread_ids filter.
+    MAX_THREADS = 500
 
     ##
     # @param channel_ids [Array<Integer>] (Optional) The IDs of the channels to count threads for.
@@ -37,75 +43,76 @@ module Chat
     )
       return [] if channel_ids.blank? && thread_ids.blank?
 
+      # The CTE picks the candidate thread set up front — at most MAX_THREADS,
+      # ordered by recency — and resolves the static per-thread filters
+      # (muted channel, threading_enabled, force) into columns. The two
+      # LATERAL aggregates then run once per candidate, instead of three
+      # correlated subqueries running per row of every membership the user has.
+      #
+      # The user_chat_channel_memberships join is INNER on purpose: a thread
+      # membership can outlive channel access (group removal, leave, etc.),
+      # and we must not surface unread/mention metadata for a channel the
+      # user can no longer access.
       sql = <<~SQL
-        SELECT (
-          SELECT COUNT(*) AS unread_count
-          FROM chat_messages
-          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
-          INNER JOIN chat_threads ON chat_threads.id = chat_messages.thread_id AND chat_threads.channel_id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_thread_memberships ON user_chat_thread_memberships.thread_id = chat_threads.id
-          INNER JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_messages.chat_channel_id
-          INNER JOIN chat_messages AS original_message ON original_message.id = chat_threads.original_message_id
-          WHERE chat_messages.thread_id = memberships.thread_id
-          AND chat_messages.user_id != :user_id
-          AND user_chat_thread_memberships.user_id = :user_id
-          AND chat_messages.id > COALESCE(user_chat_thread_memberships.last_read_message_id, 0)
-          AND chat_messages.deleted_at IS NULL
-          AND chat_messages.thread_id IS NOT NULL
-          AND chat_messages.id != chat_threads.original_message_id
-          AND (chat_channels.threading_enabled OR chat_threads.force = true)
-          AND user_chat_thread_memberships.notification_level = :tracking_level
-          AND original_message.deleted_at IS NULL
-          AND user_chat_channel_memberships.muted = false
-          AND user_chat_channel_memberships.user_id = :user_id
-        ) AS unread_count,
-        (
-          SELECT COUNT(*) AS mention_count
-          FROM notifications
-          INNER JOIN chat_messages ON chat_messages.id = (data::json->>'chat_message_id')::bigint
-          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_channel_memberships AS uccm ON uccm.chat_channel_id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_thread_memberships AS uctm ON uctm.thread_id = chat_messages.thread_id AND uctm.user_id = :user_id
-          WHERE NOT read
-          AND notifications.user_id = :user_id
-          AND notifications.notification_type = :notification_type_mention
-          AND uccm.user_id = :user_id
-          AND chat_channels.threading_enabled
-          AND chat_messages.deleted_at IS NULL
-          AND chat_messages.thread_id = memberships.thread_id
-          AND (uctm.id IS NOT NULL AND chat_messages.id > COALESCE(uctm.last_read_message_id, 0))
-          AND NOT uccm.muted
-        ) AS mention_count,
-        (
-          SELECT COUNT(*) AS watched_threads_unread_count
-          FROM chat_messages
-          INNER JOIN chat_channels ON chat_channels.id = chat_messages.chat_channel_id
-          INNER JOIN chat_threads ON chat_threads.id = chat_messages.thread_id AND chat_threads.channel_id = chat_messages.chat_channel_id
-          INNER JOIN user_chat_thread_memberships ON user_chat_thread_memberships.thread_id = chat_threads.id
-          INNER JOIN user_chat_channel_memberships ON user_chat_channel_memberships.chat_channel_id = chat_messages.chat_channel_id
-          INNER JOIN chat_messages AS original_message ON original_message.id = chat_threads.original_message_id
-          WHERE chat_messages.thread_id = memberships.thread_id
-          AND chat_messages.user_id != :user_id
-          AND user_chat_thread_memberships.user_id = :user_id
-          AND chat_messages.id > COALESCE(user_chat_thread_memberships.last_read_message_id, 0)
-          AND chat_messages.deleted_at IS NULL
-          AND chat_messages.thread_id IS NOT NULL
-          AND chat_messages.id != chat_threads.original_message_id
-          AND (chat_channels.threading_enabled OR chat_threads.force = true)
-          AND user_chat_thread_memberships.notification_level = :watching_level
-          AND original_message.deleted_at IS NULL
-          AND user_chat_channel_memberships.user_id = :user_id
-          AND NOT user_chat_channel_memberships.muted
-        ) AS watched_threads_unread_count,
-        chat_threads.channel_id,
-        memberships.thread_id
-        FROM user_chat_thread_memberships AS memberships
-        INNER JOIN chat_threads ON chat_threads.id = memberships.thread_id
-        WHERE memberships.user_id = :user_id
-        #{channel_ids.present? ? "AND chat_threads.channel_id IN (:channel_ids)" : ""}
-        #{thread_ids.present? ? "AND chat_threads.id IN (:thread_ids)" : ""}
-        GROUP BY memberships.thread_id, chat_threads.channel_id
-        #{include_missing_memberships ? "" : "LIMIT :limit"}
+        WITH limited_memberships AS (
+          SELECT
+            memberships.thread_id,
+            memberships.last_read_message_id,
+            memberships.notification_level,
+            chat_threads.channel_id,
+            chat_threads.original_message_id,
+            chat_threads.force,
+            chat_channels.threading_enabled,
+            uccm.muted AS channel_muted
+          FROM user_chat_thread_memberships AS memberships
+          INNER JOIN chat_threads ON chat_threads.id = memberships.thread_id
+          INNER JOIN chat_channels ON chat_channels.id = chat_threads.channel_id
+          INNER JOIN user_chat_channel_memberships AS uccm
+                  ON uccm.chat_channel_id = chat_channels.id
+                 AND uccm.user_id = :user_id
+          WHERE memberships.user_id = :user_id
+          #{channel_ids.present? ? "AND chat_threads.channel_id IN (:channel_ids)" : ""}
+          #{thread_ids.present? ? "AND chat_threads.id IN (:thread_ids)" : ""}
+          ORDER BY chat_threads.last_message_id DESC NULLS LAST
+          LIMIT :limit
+        )
+        SELECT
+          CASE WHEN lm.notification_level = :tracking_level
+               THEN COALESCE(unread_calc.cnt, 0) ELSE 0 END AS unread_count,
+          COALESCE(mention_calc.cnt, 0) AS mention_count,
+          CASE WHEN lm.notification_level = :watching_level
+               THEN COALESCE(unread_calc.cnt, 0) ELSE 0 END AS watched_threads_unread_count,
+          lm.channel_id,
+          lm.thread_id
+        FROM limited_memberships lm
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt
+          FROM chat_messages cm
+          WHERE cm.thread_id = lm.thread_id
+            AND cm.user_id != :user_id
+            AND cm.id > COALESCE(lm.last_read_message_id, 0)
+            AND cm.deleted_at IS NULL
+            AND cm.id != lm.original_message_id
+            AND NOT lm.channel_muted
+            AND (lm.threading_enabled OR lm.force)
+            AND EXISTS (
+              SELECT 1 FROM chat_messages om
+              WHERE om.id = lm.original_message_id AND om.deleted_at IS NULL
+            )
+        ) unread_calc ON true
+        LEFT JOIN LATERAL (
+          SELECT COUNT(*) AS cnt
+          FROM notifications n
+          INNER JOIN chat_messages cm ON cm.id = (n.data::json->>'chat_message_id')::bigint
+          WHERE n.user_id = :user_id
+            AND n.notification_type = :notification_type_mention
+            AND NOT n.read
+            AND cm.thread_id = lm.thread_id
+            AND cm.deleted_at IS NULL
+            AND cm.id > COALESCE(lm.last_read_message_id, 0)
+            AND lm.threading_enabled
+            AND NOT lm.channel_muted
+        ) mention_calc ON true
       SQL
 
       sql = <<~SQL if !include_read
@@ -134,7 +141,6 @@ module Chat
         channel_ids: channel_ids,
         thread_ids: thread_ids,
         user_id: user_id,
-        notification_type: ::Notification.types[:chat_mention],
         limit: MAX_THREADS,
         tracking_level: ::Chat::UserChatThreadMembership.notification_levels[:tracking],
         watching_level: ::Chat::UserChatThreadMembership.notification_levels[:watching],

--- a/plugins/chat/db/migrate/20260421061908_add_covering_index_on_chat_messages_thread_id.rb
+++ b/plugins/chat/db/migrate/20260421061908_add_covering_index_on_chat_messages_thread_id.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class AddCoveringIndexOnChatMessagesThreadId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "idx_chat_messages_thread_id_id_user_id_not_deleted"
+
+  def change
+    remove_index :chat_messages, name: INDEX_NAME, algorithm: :concurrently, if_exists: true
+    add_index :chat_messages,
+              %i[thread_id id],
+              include: %i[user_id],
+              where: "deleted_at IS NULL",
+              name: INDEX_NAME,
+              algorithm: :concurrently
+  end
+end

--- a/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/thread_unreads_query_spec.rb
@@ -211,7 +211,7 @@ describe Chat::ThreadUnreadsQuery do
         let!(:message) { create_mention(message_1, channel_1, thread_1) }
 
         it "counts both unread messages and mentions separately" do
-          expect(query.map(&:to_h)).to eq(
+          expect(query.map(&:to_h)).to match_array(
             [
               {
                 channel_id: channel_1.id,
@@ -544,6 +544,57 @@ describe Chat::ThreadUnreadsQuery do
             watched_threads_unread_count: 3,
           },
         )
+      end
+    end
+  end
+
+  context "when the user has a thread membership but no channel membership" do
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1) }
+    let(:channel_ids) { [channel_1.id] }
+
+    before do
+      create_mention(message_1, channel_1, thread_1)
+      thread_1.membership_for(current_user).update!(
+        notification_level: ::Chat::NotificationLevels.all[:watching],
+      )
+      channel_1.user_chat_channel_memberships.where(user_id: current_user.id).destroy_all
+    end
+
+    it "does not return unread, mention, or watched counts for the orphaned thread" do
+      expect(query.map(&:to_h)).to be_empty
+    end
+  end
+
+  describe "MAX_THREADS recency cap" do
+    it "still returns an explicitly requested thread_id older than the top MAX_THREADS" do
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_2) # newer activity
+      old_message = Fabricate(:chat_message, chat_channel: channel_1, thread: thread_1)
+      thread_1.update!(last_message_id: old_message.id)
+      Fabricate(:chat_message, chat_channel: channel_1, thread: thread_2) # bump newer again
+
+      stub_const(Chat::ThreadUnreadsQuery, :MAX_THREADS, 1) do
+        result = Chat::ThreadUnreadsQuery.call(thread_ids: [thread_1.id], user_id: current_user.id)
+        expect(result.map(&:thread_id)).to contain_exactly(thread_1.id)
+      end
+    end
+
+    it "honors MAX_THREADS on the include_missing_memberships branch" do
+      # Make thread_1/2 missing-membership candidates in channel_1.
+      Chat::UserChatThreadMembership.where(
+        user_id: current_user.id,
+        thread_id: [thread_1.id, thread_2.id],
+      ).destroy_all
+
+      stub_const(Chat::ThreadUnreadsQuery, :MAX_THREADS, 1) do
+        result =
+          Chat::ThreadUnreadsQuery.call(
+            channel_ids: [channel_1.id],
+            user_id: current_user.id,
+            include_missing_memberships: true,
+          )
+        # Each branch (membership-driven SELECT + missing-memberships UNION)
+        # is independently capped, so we get at most 2 rows total.
+        expect(result.size).to be <= 2
       end
     end
   end


### PR DESCRIPTION
Rewrites the channel and thread unread queries to use a CTE that
picks the candidate set up front, followed by LATERAL subqueries
for each aggregate. The previous form used three correlated
subqueries that each re-joined the user's full membership lists,
and packed the unread predicate into a single OR-bag that forced
a sequential scan over every message past last_read_message_id.

The channel query now:
- Limits candidate channels in a CTE before aggregating.
- Splits unread_count into three additive, index-friendly pieces
  (standalone messages, thread original messages, and DM thread
  replies) instead of one OR branch.
- Pushes the muted check into a CASE on the outer row.

The thread query now:
- Orders candidate memberships by last_message_id and caps them
  at MAX_THREADS in the CTE, so recent threads always win.
- Derives unread and watched counts from a single aggregate
  switched by notification_level.
- Skips threads whose channel membership is missing.

Also adds a covering index on chat_messages(thread_id, id) INCLUDE
(user_id) WHERE deleted_at IS NULL to support the thread aggregates
as index-only scans, and adds specs for the orphaned-thread case
and the MAX_THREADS recency cap.

---

This gives this about 50x perf improvement in testing
