### PR TITLE
FIX: Make tag search consistently honour category access

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -560,7 +560,11 @@ class TagsController < ::ApplicationController
 
   def self.tag_counts_json(tags, guardian)
     show_pm_tags = guardian.can_tag_pms?
-    target_tags = Tag.where(id: tags.map(&:target_tag_id).compact.uniq).select(:id, :name, :slug)
+    target_tags =
+      Tag
+        .visible(guardian)
+        .where(id: tags.filter_map(&:target_tag_id).uniq)
+        .select(:id, :name, :slug)
 
     tags
       .map do |t|

--- a/app/services/tags/search.rb
+++ b/app/services/tags/search.rb
@@ -88,8 +88,9 @@ class Tags::Search
 
   private
 
-  def fetch_category(params:)
-    Category.find_by(id: params.categoryId) if params.categoryId.present?
+  def fetch_category(params:, guardian:)
+    return if params.categoryId.blank?
+    Category.where(id: params.categoryId).where(id: guardian.allowed_category_ids).first
   end
 
   def has_term_for_input(params:)
@@ -98,6 +99,14 @@ class Tags::Search
 
   def has_term(params:)
     params.term.present?
+  end
+
+  def visible_tags(guardian)
+    DiscourseTagging.visible_tags(guardian)
+  end
+
+  def tag_visible?(tag_id, guardian)
+    DiscourseTagging.visible_tags(guardian).exists?(id: tag_id)
   end
 
   def search_tags(params:, category:, guardian:)
@@ -119,11 +128,8 @@ class Tags::Search
     skip_ids = tags.map { |t| t[:id] } | selected_ids
 
     candidate_tags =
-      DiscourseTagging
-        .filter_visible(
-          Tag.where("position(LOWER(?) IN LOWER(tags.name)) <> 0", params.term),
-          guardian,
-        )
+      visible_tags(guardian)
+        .where("position(LOWER(?) IN LOWER(tags.name)) <> 0", params.term)
         .where.not(id: skip_ids)
         .limit(SiteSetting.max_tag_search_results)
         .to_a
@@ -144,8 +150,8 @@ class Tags::Search
   def detect_forbidden_tag(params:, category:, tags:, guardian:)
     return if tags.any? { |h| h[:name].downcase == params.term.downcase }
 
-    tag = Tag.where_name(params.term).first
-    return unless tag && guardian.can_see_tag?(tag)
+    tag = visible_tags(guardian).where_name(params.term).first
+    return unless tag
     return if reject_allowed_tags([tag], params:, category:, tags:, guardian:).empty?
 
     context[:forbidden] = params.q
@@ -175,7 +181,7 @@ class Tags::Search
   end
 
   def explain_exclusion(tag, params, selected_ids, guardian)
-    if params.excludeSynonyms && tag.synonym?
+    if params.excludeSynonyms && tag.synonym? && tag_visible?(tag.target_tag_id, guardian)
       return I18n.t("tags.forbidden.synonym", tag_name: tag.target_tag.name)
     end
 
@@ -201,7 +207,7 @@ class Tags::Search
           .where.not(parent_tag_id: [nil, *selected_ids])
           .includes(:parent_tag)
           .first
-      if group&.parent_tag && guardian.can_see_tag?(group.parent_tag)
+      if group&.parent_tag && tag_visible?(group.parent_tag_id, guardian)
         return(
           I18n.t(
             "tags.forbidden.missing_parent_tag",
@@ -238,8 +244,10 @@ class Tags::Search
           category_names: category_names.join(", "),
         )
       end
-    else
+    elsif params.categoryId.present?
       I18n.t("tags.forbidden.in_this_category", tag_name: tag.name)
+    else
+      I18n.t("tags.forbidden.not_allowed", tag_name: tag.name)
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5659,6 +5659,7 @@ en:
         one: "The tag you selected cannot be used"
         other: "None of the tags you selected can be used"
       in_this_category: '"%{tag_name}" cannot be used in this category'
+      not_allowed: '"%{tag_name}" cannot be used'
       restricted_to:
         one: '"%{tag_name}" is restricted to the "%{category_names}" category'
         other: '"%{tag_name}" is restricted to the following categories: %{category_names}'

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -620,27 +620,7 @@ module DiscourseTagging
       end
     end
 
-    if filter_for_non_admin
-      group_ids = permitted_group_ids(guardian)
-
-      builder.where(<<~SQL, group_ids, group_ids)
-        id NOT IN (
-          (SELECT tgm.tag_id
-           FROM tag_group_permissions tgp
-           INNER JOIN tag_groups tg ON tgp.tag_group_id = tg.id
-           INNER JOIN tag_group_memberships tgm ON tg.id = tgm.tag_group_id
-           WHERE tgp.group_id NOT IN (?))
-
-          EXCEPT
-
-          (SELECT tgm.tag_id
-           FROM tag_group_permissions tgp
-           INNER JOIN tag_groups tg ON tgp.tag_group_id = tg.id
-           INNER JOIN tag_group_memberships tgm ON tg.id = tgm.tag_group_id
-           WHERE tgp.group_id IN (?))
-        )
-      SQL
-    end
+    builder.where("t.id IN (#{visible_tags(guardian).select(:id).to_sql})") if filter_for_non_admin
 
     if builder_params[:selected_tag_ids] && (opts[:for_input] || opts[:for_topic])
       one_tag_per_group_sql = +<<~SQL
@@ -712,10 +692,9 @@ module DiscourseTagging
   end
 
   def self.visible_tags(guardian)
-    if guardian&.is_admin?
-      Tag.all
-    else
-      # Visible tags either have no permissions or have allowable permissions
+    return Tag.all if guardian&.is_admin?
+
+    permitted =
       Tag
         .where.not(id: TagGroupMembership.joins(tag_group: :tag_group_permissions).select(:tag_id))
         .or(
@@ -727,11 +706,34 @@ module DiscourseTagging
                 .select("tag_group_memberships.tag_id"),
           ),
         )
-    end
+
+    filter_visible_in_accessible_categories(permitted, guardian)
   end
 
   def self.filter_visible(query, guardian = nil)
     guardian&.is_admin? ? query : query.where(id: visible_tags(guardian).select(:id))
+  end
+
+  def self.filter_visible_in_accessible_categories(query, guardian = nil)
+    return query if guardian.nil? || guardian.is_admin?
+
+    query.where(<<~SQL, ids: guardian.allowed_category_ids)
+      tags.id NOT IN (
+        SELECT tag_id FROM category_tags
+        UNION
+        SELECT tgm.tag_id
+        FROM tag_group_memberships tgm
+        INNER JOIN category_tag_groups ctg ON ctg.tag_group_id = tgm.tag_group_id
+      )
+      OR tags.id IN (
+        SELECT tag_id FROM category_tags WHERE category_id IN (:ids)
+        UNION
+        SELECT tgm.tag_id
+        FROM tag_group_memberships tgm
+        INNER JOIN category_tag_groups ctg
+          ON ctg.tag_group_id = tgm.tag_group_id AND ctg.category_id IN (:ids)
+      )
+    SQL
   end
 
   def self.hidden_tags(guardian = nil)

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -156,6 +156,243 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "with a tag restricted to a category the user cannot access (via CategoryTag)" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "bots-gone-mad") }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_tag) }
+
+      let(:params) { { q: "bots", filterForInput: true } }
+
+      it "does not leak the tag name to unauthorized users" do
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).not_to include("bots-gone-mad")
+      end
+
+      it "still shows the tag to admins" do
+        admin = Fabricate(:admin)
+        admin_result =
+          described_class.call(params:, **dependencies.merge(guardian: Guardian.new(admin)))
+        expect(admin_result[:tags].map { |t| t[:name] }).to include("bots-gone-mad")
+      end
+
+      it "still shows the tag to users who can access the category" do
+        staff = Fabricate(:user)
+        staff_group.add(staff)
+        staff_result =
+          described_class.call(params:, **dependencies.merge(guardian: Guardian.new(staff)))
+        expect(staff_result[:tags].map { |t| t[:name] }).to include("bots-gone-mad")
+      end
+
+      it "still shows the tag when it is also attached to a category the user can access" do
+        public_category = Fabricate(:category)
+        CategoryTag.create!(category: public_category, tag: secret_tag)
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).to include("bots-gone-mad")
+      end
+    end
+
+    context "with a tag restricted to a category the user cannot access (via CategoryTagGroup)" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "insider-info") }
+      fab!(:tag_group) { Fabricate(:tag_group, name: "Insider", tags: [secret_tag]) }
+
+      before { CategoryTagGroup.create!(category: private_category, tag_group: tag_group) }
+
+      let(:params) { { q: "insider", filterForInput: true } }
+
+      it "does not leak the tag name to unauthorized users" do
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).not_to include("insider-info")
+      end
+    end
+
+    context "when searching without filterForInput for a tag restricted to an inaccessible category" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "bots-gone-mad") }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_tag) }
+
+      let(:params) { { q: "bots" } }
+
+      it "does not leak the tag name as an allowed result" do
+        expect(result[:tags].map { |t| t[:name] }).not_to include("bots-gone-mad")
+      end
+    end
+
+    context "with a categoryId pointing to a category the user cannot see" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:restricted_tag) { Fabricate(:tag, name: "restricted-tag") }
+      fab!(:global_tag) { Fabricate(:tag, name: "alpha-global") }
+
+      before { CategoryTag.create!(category: private_category, tag: restricted_tag) }
+
+      let(:params) { { q: "alpha-global", categoryId: private_category.id } }
+
+      it "behaves as if the category did not exist (no enumeration vector)" do
+        blind =
+          described_class.call(params: { q: "alpha-global", categoryId: -999 }, **dependencies)
+        expect(result[:tags].map { |t| t[:name] }).to eq(blind[:tags].map { |t| t[:name] })
+      end
+    end
+
+    context "with excludeHasSynonyms" do
+      fab!(:target_with_syn) { Fabricate(:tag, name: "maintag2") }
+      fab!(:its_syn) { Fabricate(:tag, name: "syn-for-main", target_tag: target_with_syn) }
+
+      let(:params) { { q: "maintag2", filterForInput: true, excludeHasSynonyms: true } }
+
+      it "marks the tag as disabled with a synonyms reason" do
+        disabled = result[:tags].find { |t| t[:name] == "maintag2" && t[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).to include("synonyms")
+      end
+    end
+
+    context "with an anonymous guardian" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "anon-secret") }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_tag) }
+
+      let(:dependencies) { { guardian: Guardian.new } }
+      let(:params) { { q: "anon-secret", filterForInput: true } }
+
+      it "does not leak tags restricted to inaccessible categories" do
+        names = result[:tags].map { |t| t[:name] }
+        expect(names).not_to include("anon-secret")
+      end
+    end
+
+    context "with an admin guardian" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "admin-visible") }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_tag) }
+
+      let(:dependencies) { { guardian: Guardian.new(Fabricate(:admin)) } }
+      let(:params) { { q: "admin-visible" } }
+
+      it "sees tags restricted to any category" do
+        expect(result[:tags].map { |t| t[:name] }).to include("admin-visible")
+      end
+    end
+
+    context "with a global tag disabled inside a category that disallows globals" do
+      fab!(:strict_category) do
+        Fabricate(:category).tap do |c|
+          c.update!(allow_global_tags: false)
+          Fabricate(:tag_group, tags: [Fabricate(:tag, name: "strict-only")]).tap do |tg|
+            CategoryTagGroup.create!(category: c, tag_group: tg)
+          end
+        end
+      end
+      fab!(:global_tag) { Fabricate(:tag, name: "truly-global") }
+
+      let(:params) { { q: "truly-global", filterForInput: true, categoryId: strict_category.id } }
+
+      it "uses the 'in this category' fallback wording" do
+        disabled = result[:tags].find { |t| t[:name] == "truly-global" && t[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).to include("this category")
+      end
+    end
+
+    context "with a synonym whose target is restricted to an inaccessible category (output payload)" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_target) { Fabricate(:tag, name: "payload-secret") }
+      fab!(:public_synonym) { Fabricate(:tag, name: "payload-syn", target_tag: secret_target) }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_target) }
+
+      let(:params) { { q: "payload-syn" } }
+
+      it "does not leak the target tag name in the serialized payload" do
+        entry = result[:tags].find { |t| t[:name] == "payload-syn" }
+        expect(entry).to be_present
+        expect(entry[:target_tag]).to be_nil
+      end
+    end
+
+    context "with a synonym whose target is restricted to an inaccessible category" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_target) { Fabricate(:tag, name: "secret-target") }
+      fab!(:public_synonym) { Fabricate(:tag, name: "public-syn", target_tag: secret_target) }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_target) }
+
+      let(:params) { { q: "public-syn", filterForInput: true, excludeSynonyms: true } }
+
+      it "does not leak the target tag name in the disabled reason" do
+        disabled = result[:tags].find { |t| t[:name] == "public-syn" && t[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).not_to include("secret-target")
+      end
+    end
+
+    context "with a global tag disabled without category context" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_parent) { Fabricate(:tag, name: "secret-parent2") }
+      fab!(:orphan_tag) { Fabricate(:tag, name: "orphan-tag") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Orphans", parent_tag: secret_parent, tags: [orphan_tag])
+      end
+
+      before { CategoryTag.create!(category: private_category, tag: secret_parent) }
+
+      let(:params) { { q: "orphan-tag", filterForInput: true } }
+
+      it "does not mention 'this category' when there is no category context" do
+        disabled = result[:tags].find { |t| t[:name] == "orphan-tag" && t[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).not_to include("this category")
+      end
+    end
+
+    context "with a missing parent tag that is restricted to an inaccessible category" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_parent) { Fabricate(:tag, name: "secret-parent") }
+      fab!(:child_tag) { Fabricate(:tag, name: "public-child") }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, name: "Kids", parent_tag: secret_parent, tags: [child_tag])
+      end
+
+      before { CategoryTag.create!(category: private_category, tag: secret_parent) }
+
+      let(:params) { { q: "public-child", filterForInput: true } }
+
+      it "does not leak the parent tag name in the disabled reason" do
+        disabled = result[:tags].find { |t| t[:name] == "public-child" && t[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).not_to include("secret-parent")
+      end
+    end
+
+    context "when a user types the exact name of a tag restricted to an inaccessible category" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:secret_tag) { Fabricate(:tag, name: "bots-gone-mad") }
+
+      before { CategoryTag.create!(category: private_category, tag: secret_tag) }
+
+      let(:params) { { q: "bots-gone-mad", filterForInput: true } }
+
+      it "does not confirm the tag exists via forbidden_message" do
+        expect(result[:forbidden]).to be_nil
+        expect(result[:forbidden_message]).to be_nil
+      end
+    end
+
     context "when allowed tags are cut off by the limit" do
       fab!(:tag_foo1) { Fabricate(:tag, name: "foomatch1") }
       fab!(:tag_foo2) { Fabricate(:tag, name: "foomatch2") }


### PR DESCRIPTION
Tag search (`/tags/filter/search`) was not fully consistent with category-based tag visibility. A tag restricted to a private category via `CategoryTag` or `CategoryTagGroup` could still appear in several of the endpoint's outputs for users who did not have access to that category: as a disabled entry with an explanation in the composer autocomplete, as a regular allowed result when the tag filter dropdown on topic lists queried without `filterForInput`, or as a `forbidden_message` when the exact tag name was typed. The missing-parent-tag reason could include a parent tag name even when the parent itself was restricted to a category the viewer could not access, and the synonym-exclusion reason could include the synonym's target name without checking whether the target was itself visible. The serialized tag payload also included the `target_tag: { id, name, slug }` field for every synonym regardless of target visibility, and `fetch_category` resolved any `categoryId` the caller passed without checking visibility, which made the behaviour for an invisible existing category distinguishable from the behaviour for a non-existent one. Finally, the fallback disabled-tag reason always said "cannot be used in this category" even when the request had no category context at all.

The underlying cause is that "visibility" in `DiscourseTagging` was defined purely in terms of `TagGroupPermission` and ignored category access entirely, so each code path in `Tags::Search` was relying on its own partial checks (or none). Most of the behaviour is long-standing; the disabled-entries path in autocomplete is a regression from #39072, but the others have been in place for years.

The fix redefines visibility to include category access and routes every tag-search code path through that single definition.

`DiscourseTagging.visible_tags` now composes a new `filter_visible_in_accessible_categories` helper on top of the existing tag-group-permission check: a tag is kept only if it has no category restriction, or if at least one of its restrictions points to a category in `guardian.allowed_category_ids`. The helper is a single `WHERE` clause with one named bind reused twice.

`DiscourseTagging.filter_allowed_tags` enforces this visibility in-SQL by adding `t.id IN (visible_tags subquery)` to its builder for non-admin callers. That single subquery subsumes the narrower hidden-tag-group `EXCEPT` block the method used to build, so the whole filter is now one trip to the database instead of being post-filtered in Ruby.

`Tags::Search` steps all flow through the new visibility universe. `search_tags` inherits the guarantee through `filter_allowed_tags`. `append_disabled_tags` and `detect_forbidden_tag` both start from `DiscourseTagging.filter_visible(Tag.all, guardian)` via a private `visible_tags` helper, so neither can surface a tag outside the user's scope. `fetch_category` intersects the requested id with `guardian.allowed_category_ids` and returns `nil` otherwise, so categories the caller cannot see are treated the same as categories that do not exist.

`explain_exclusion` gates its two name-surfacing branches on visibility: the synonym-exclusion reason is only emitted when the target tag is visible, and the missing-parent-tag reason is only emitted when the parent tag is visible. When neither of those reasons (nor any category-based reason) applies, the fallback now picks between `tags.forbidden.in_this_category` (when `params.categoryId` is present) and a new `tags.forbidden.not_allowed` wording (when it is not), so the message matches the actual context of the request.

`TagsController.tag_counts_json` filters the `target_tags` lookup through `DiscourseTagging.filter_visible`, so synonyms whose targets are invisible no longer carry a `target_tag` field in the payload. This benefits every caller of `tag_counts_json` (search, tag index, tag show, the hashtag data source, and the detailed tag serializer), not just the tag search endpoint.

The accompanying specs cover each path both positively and negatively: admins and authorized users still see their tags, partial matches still return disabled entries with the right reason, exact matches still produce `forbidden_message` for tags the user can see; unauthorized users, anonymous users, invisible-category probes, synonym payloads, and parent-tag reasons are all verified not to surface anything outside the user's scope.

Ref - t/364105