### PR TITLE
FEATURE: Show notice on site settings that depend on another setting

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8868,6 +8868,9 @@ en:
       site_settings:
         title: "Site settings"
         description: "Configure the settings for your Discourse site to customize its appearance, functionality, and user experience."
+        depends_on_notice:
+          one: "This setting is only applied when %{dependencyLinks} is enabled."
+          other: "This setting is only applied when %{dependencyLinks} are enabled."
         discard:
           one: "Discard change"
           other: "Discard changes"

--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -153,6 +153,30 @@ export default class SiteSettingComponent extends Component {
     return this.setting.upcoming_change_default_override_metadata;
   }
 
+  get showDependsOnNotice() {
+    return this.setting.depends_on?.length > 0;
+  }
+
+  get dependsOnNoticeText() {
+    const path = basePath();
+    const links = this.setting.depends_on
+      .map((name, index) => {
+        const label = sanitize(
+          this.setting.depends_on_humanized_names?.[index] ||
+            name.replaceAll("_", " ")
+        );
+        return `<a href="${path}/admin/site_settings/category/all_results?filter=${encodeURIComponent(name)}">${label}</a>`;
+      })
+      .join(", ");
+
+    return trustHTML(
+      i18n("admin.site_settings.depends_on_notice", {
+        count: this.setting.depends_on.length,
+        dependencyLinks: links,
+      })
+    );
+  }
+
   get themeSiteSettingWarningText() {
     return trustHTML(
       i18n("admin.theme_site_settings.site_setting_warning", {
@@ -553,6 +577,14 @@ export default class SiteSettingComponent extends Component {
               <p class="setting-upcoming-change-warning__text">
                 {{icon "flask"}}
                 {{this.upcomingChangeDefaultWarningText}}
+              </p>
+            </div>
+          {{/if}}
+          {{#if this.showDependsOnNotice}}
+            <div class="setting-override-warning setting-depends-on-notice">
+              <p class="setting-depends-on-notice__text">
+                {{icon "link"}}
+                {{this.dependsOnNoticeText}}
               </p>
             </div>
           {{/if}}

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -406,6 +406,56 @@ module(
 
       assert.dom(".setting-theme-warning__text").includesHtml(expectedText);
     });
+
+    test("shows notice for settings that depend on another setting", async function (assert) {
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "dependent_setting",
+          value: "1",
+          type: "integer",
+          depends_on: ["parent_setting"],
+          depends_on_humanized_names: ["Parent setting"],
+        })
+      );
+
+      await render(
+        <template><SiteSettingComponent @setting={{this.setting}} /></template>
+      );
+
+      assert
+        .dom(".setting-depends-on-notice")
+        .exists("notice wrapper is displayed");
+      assert
+        .dom(".setting-depends-on-notice__text")
+        .includesText(
+          "This setting is only applied when Parent setting is enabled"
+        );
+      assert
+        .dom(".setting-depends-on-notice__text a")
+        .hasAttribute(
+          "href",
+          "/admin/site_settings/category/all_results?filter=parent_setting"
+        )
+        .hasText("Parent setting");
+    });
+
+    test("does not show the depends_on notice when setting has no dependencies", async function (assert) {
+      this.set(
+        "setting",
+        SiteSetting.create({
+          setting: "plain_setting",
+          value: "1",
+          type: "integer",
+        })
+      );
+
+      await render(
+        <template><SiteSettingComponent @setting={{this.setting}} /></template>
+      );
+
+      assert.dom(".setting-depends-on-notice").doesNotExist();
+    });
   }
 );
 

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -496,8 +496,12 @@ module SiteSettingExtension
             requires_confirmation: requires_confirmation_settings[s],
             upcoming_change: only_upcoming_changes ? upcoming_change_metadata[s] : nil,
             themeable: themeable[s],
-            depends_on: type_supervisor.dependencies[s],
           }
+
+          if depends_on = type_supervisor.dependencies[s]
+            opts_data[:depends_on] = depends_on
+            opts_data[:depends_on_humanized_names] = depends_on.map { |dep| humanized_names(dep) }
+          end
 
           if upcoming_change_default_override_metadata
             opts_data[

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -767,6 +767,12 @@ RSpec.describe SiteSettingExtension do
             settings.all_settings.find { |s| s[:setting] == :cool_thing_image },
           ).not_to be_blank
         end
+
+        it "serializes depends_on and the matching humanized names" do
+          setting = settings.all_settings.find { |s| s[:setting] == :cool_thing_image }
+          expect(setting[:depends_on]).to eq([:enable_cool_thing])
+          expect(setting[:depends_on_humanized_names]).to eq(["Enable cool thing"])
+        end
       end
 
       context "when the depends_on setting is false" do


### PR DESCRIPTION
When a site setting declares `depends_on` another setting (e.g. `max_form_template_title_length` depends on `enable_form_templates`), admins had no way to know about the relationship. With `depends_behavior: hidden` the dependent setting is hidden entirely while the parent is disabled; once the parent is enabled, the dependent appears with no indication that its effect is coupled to the parent.

This adds a small inline notice under each such setting — mirroring the `setting-override-warning` pattern introduced for upcoming-change default overrides — that reads:

    This setting is only applied when <parent> is enabled.

with the parent name rendered as a link to
`/admin/site_settings/category/all_results?filter=<parent>` so admins can jump straight to it.

The notice is driven by the existing `depends_on` field already serialized from `SiteSetting.all_settings`; the backend additionally exposes `depends_on_humanized_names` so the notice can show the humanized parent label without the frontend having to re-derive it. Singular and plural wording are handled through the standard `one`/`other` keys on `admin.site_settings.depends_on_notice`.

Ref - t/182071