### PR TITLE
FIX: Include tag description in route model from topic list

### DIFF
--- a/frontend/discourse/app/routes/tag/show.js
+++ b/frontend/discourse/app/routes/tag/show.js
@@ -192,6 +192,8 @@ export default class TagShowRoute extends DiscourseRoute {
           name: mainTagData.name,
           slug: mainTagData.slug,
           staff: mainTagData.staff,
+          description: mainTagData.description,
+          topic_count: mainTagData.topic_count,
         });
       } else if (!additionalTags) {
         // tag was a synonym, redirect to canonical tag URL

--- a/frontend/discourse/tests/acceptance/tags-test.js
+++ b/frontend/discourse/tests/acceptance/tags-test.js
@@ -360,6 +360,7 @@ acceptance("Tag info", function (needs) {
               name: "planters",
               slug: "planters",
               topic_count: 1,
+              description: "A tag about planters",
             },
           ],
           topics: [],
@@ -456,6 +457,18 @@ acceptance("Tag info", function (needs) {
         ],
       });
     });
+  });
+
+  test("tag model includes description from topic list", async function (assert) {
+    await visit("/tag/planters/12");
+
+    const router = this.owner.lookup("service:router");
+    const tag = router.currentRoute.attributes.tag;
+    assert.strictEqual(
+      tag.description,
+      "A tag about planters",
+      "tag model has the description from topic list tags"
+    );
   });
 
   test("can filter tags page by category", async function (assert) {


### PR DESCRIPTION

The topic list response for tag pages already includes tag description via TagSerializer, but the tag route only copied id, name, slug, and staff to the tag model. Now we also copy description and topic_count so they're available on the route model without needing a separate fetch.
