### PR TITLE
UX: add pointer to reactions panel

### DIFF
--- a/frontend/discourse/app/components/post/menu/liked-users-list.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-list.gjs
@@ -25,8 +25,9 @@ export default class LikedUsersList extends Component {
       component: PostLikedUsersMenu,
       modalForMobile: true,
       closeOnScroll: true,
+      arrow: true,
       placement: "bottom",
-      offset: 10,
+      offset: 15,
       data: { post: this.args.post },
     });
   }

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -85,8 +85,9 @@ export default class DiscourseReactionsCounter extends Component {
       component: DiscourseReactionsUsersMenu,
       modalForMobile: true,
       closeOnScroll: true,
+      arrow: true,
       placement: "bottom",
-      offset: 10,
+      offset: 15,
       data: { post: this.args.post },
     });
   }


### PR DESCRIPTION
Small cosmetic change to add the pointer to the reactions/likes panel, along with a little extra spacing.

## How it looks

<img width="335" height="189" alt="Screenshot 2026-04-21 at 12 19 38 PM" src="https://github.com/user-attachments/assets/7218e18a-6668-44b7-9850-1dece6830c93" />
