### PR TITLE
UX: make mobile date display consistent with desktop

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -20,8 +20,7 @@
   }
 }
 
-.link-top-line,
-.header-title {
+.header-topic-title-suffix-outlet {
   .event-date {
     display: inline-flex;
     align-items: center;

--- a/plugins/discourse-calendar/assets/stylesheets/mobile/discourse-post-event-core-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/mobile/discourse-post-event-core-ext.scss
@@ -8,9 +8,3 @@
     }
   }
 }
-
-.header-title {
-  .event-date {
-    display: none;
-  }
-}


### PR DESCRIPTION
This is a minor adjustment to get the topic list date display for events consistent across all screen widths. Currently we style mobile differently, but there's not much reason for this. The current version does wrap better along with title text, but it's also a little confusing visually. Better to have a consistent display. 

I also removed the CSS hiding the date from the docked mobile header. The mobile title truncates if needed, and this includes the date... so we already get this behavior for free. 

Before:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/8de5f92f-efe9-40eb-8a72-8e33d01d299e" />



After: 
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/579e9613-646f-42c0-a250-48bbca0959a5" />


Docked header... 

If it fits:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7d8173fc-5b5d-4dbe-ae90-1898676d8716" />


If it doesn't: 
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/51f57fd1-577b-48fc-8df0-0e0f4b2fa16d" />