### PR TITLE
FIX: Don't mark messages as seen on non-user scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -499,7 +499,9 @@ export default class ChatChannel extends Component {
     this.atBottom = state.atBottom;
 
     if (state.atBottom) {
-      this.paneState.clearPendingMessages();
+      if (this.paneState.userIsPresent) {
+        this.paneState.clearPendingMessages();
+      }
       this.fetchMoreMessages({ direction: FUTURE });
       this.chatChannelScrollPositions.delete(this.args.channel.id);
     } else {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -149,7 +149,9 @@ export default class ChatThread extends Component {
     this.atBottom = state.atBottom;
 
     if (state.atBottom) {
-      this.paneState.clearPendingMessages();
+      if (this.paneState.userIsPresent) {
+        this.paneState.clearPendingMessages();
+      }
       this.fetchMoreMessages({ direction: FUTURE });
     } else {
       this.paneState.updatePendingContentFromScrollState({


### PR DESCRIPTION
Not all scroll events are user-initiated, so ensure that chat messages aren't accidentally marked as "seen".

Should fix a test flake.