### PR TITLE
FIX: Remove `script` tags that failed to load

### DIFF
--- a/frontend/discourse/app/lib/load-script.js
+++ b/frontend/discourse/app/lib/load-script.js
@@ -17,6 +17,7 @@ function loadWithTag(path, cb, errorCb) {
 
   s.onerror = function () {
     s.onload = s.onreadystatechange = null;
+    s.remove();
     WAITER.endAsync(token);
     if (errorCb) {
       run(null, errorCb);


### PR DESCRIPTION
…so that further `loadScript` calls can retry loading.