### PR TITLE
DEV: Label plugin qunit test output with target plugin name

### DIFF
--- a/app/helpers/qunit_helper.rb
+++ b/app/helpers/qunit_helper.rb
@@ -11,6 +11,6 @@ module QunitHelper
         "#{Discourse.base_path}" \
         "/theme-javascripts/tests/#{theme.id}-#{digest}.js" \
         "?__ws=#{Discourse.current_hostname}"
-    "<link rel='modulepreload' href='#{src}' data-theme-id='#{theme.id}' nonce='#{ThemeField::CSP_NONCE_PLACEHOLDER}' />".html_safe
+    "<link rel='modulepreload' href='#{src}' data-theme-id='#{theme.id}' data-theme-name='#{Rack::Utils.escape_html(theme.name)}' nonce='#{ThemeField::CSP_NONCE_PLACEHOLDER}' />".html_safe
   end
 end

--- a/frontend/discourse/tests/test-boot-ember-cli.js
+++ b/frontend/discourse/tests/test-boot-ember-cli.js
@@ -50,6 +50,12 @@ document.addEventListener("discourse-init", async () => {
   setupTests(config.APP);
   let loader = loadEmberExam();
 
+  if (window.Testem && target && target !== "core") {
+    window.Testem.on("test-result", (t) => {
+      t.name = `Target: ${target} - ${t.name}`;
+    });
+  }
+
   if (QUnit.config.seed === undefined) {
     // If we're running in browser, default to random order. Otherwise, let Ember Exam
     // handle randomization.

--- a/frontend/discourse/tests/test-boot-ember-cli.js
+++ b/frontend/discourse/tests/test-boot-ember-cli.js
@@ -28,7 +28,7 @@ document.addEventListener("discourse-init", async () => {
   const disableAutoStart = params.get("qunit_disable_auto_start") === "1";
   const themeName = document.querySelector(
     "link[rel=modulepreload][data-theme-name]"
-  ).dataset.themeName;
+  )?.dataset.themeName;
   const hasThemeJs = !!themeName;
 
   document.body.insertAdjacentHTML(

--- a/frontend/discourse/tests/test-boot-ember-cli.js
+++ b/frontend/discourse/tests/test-boot-ember-cli.js
@@ -26,9 +26,10 @@ document.addEventListener("discourse-init", async () => {
   const params = new URLSearchParams(window.location.search);
   const target = params.get("target") || "core";
   const disableAutoStart = params.get("qunit_disable_auto_start") === "1";
-  const hasThemeJs = !!document.querySelector(
-    "link[rel=modulepreload][data-theme-id]"
-  );
+  const themeName = document.querySelector(
+    "link[rel=modulepreload][data-theme-name]"
+  ).dataset.themeName;
+  const hasThemeJs = !!themeName;
 
   document.body.insertAdjacentHTML(
     "afterbegin",
@@ -50,9 +51,9 @@ document.addEventListener("discourse-init", async () => {
   setupTests(config.APP);
   let loader = loadEmberExam();
 
-  if (window.Testem && target && target !== "core") {
+  if (window.Testem && (hasThemeJs || target !== "core")) {
     window.Testem.on("test-result", (t) => {
-      t.name = `${target} - ${t.name}`;
+      t.name = `${themeName || target} - ${t.name}`;
     });
   }
 

--- a/frontend/discourse/tests/test-boot-ember-cli.js
+++ b/frontend/discourse/tests/test-boot-ember-cli.js
@@ -52,7 +52,7 @@ document.addEventListener("discourse-init", async () => {
 
   if (window.Testem && target && target !== "core") {
     window.Testem.on("test-result", (t) => {
-      t.name = `Target: ${target} - ${t.name}`;
+      t.name = `${target} - ${t.name}`;
     });
   }
 


### PR DESCRIPTION
Previously, plugin qunit test output only showed `Chrome 147.0` with no indication of which plugin a test belonged to.

This commit registers a `Testem.on("test-result")` hook that prepends `Target: <plugin>` to each test name when the `target` URL param identifies a plugin, mirroring how `ember-exam` patches testem output.