### PR TITLE
DEV: Improve testem logging

### DIFF
--- a/frontend/discourse/patch-testem-output.js
+++ b/frontend/discourse/patch-testem-output.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+const BrowserTestRunner = require("testem/lib/runners/browser_test_runner");
+
+function labelForRunner(runner) {
+  const testPage = runner?.launcher?.settings?.test_page || "";
+  const url = new URL(testPage, "http://localhost");
+
+  // Plugins
+  const target = url.searchParams.get("target");
+  if (target && target !== "core") {
+    return target;
+  }
+
+  // load-balanced ember-exam:
+  const browser = url.searchParams.get("browser");
+  if (browser) {
+    return `Browser ${browser}`;
+  }
+
+  // Themes / non-parallel core
+  return "log";
+}
+
+let patched = false;
+
+module.exports = function patchTestemOutput() {
+  if (patched) {
+    return;
+  }
+  patched = true;
+
+  const originalTryAttach = BrowserTestRunner.prototype.tryAttach;
+  BrowserTestRunner.prototype.tryAttach = function (browser, id, socket) {
+    const result = originalTryAttach.call(this, browser, id, socket);
+    if (result === false) {
+      return result;
+    }
+
+    const label = labelForRunner(this);
+    socket.on("browser-console", (type, ...args) => {
+      console.log(`[${label}] [${type}] ${args.join(" ")}`);
+    });
+    socket.on("top-level-error", (msg, url, line) => {
+      console.log(`[${label}] [error] ${msg} at ${url}:${line}`);
+    });
+
+    return result;
+  };
+};

--- a/frontend/discourse/testem.js
+++ b/frontend/discourse/testem.js
@@ -3,6 +3,8 @@ const fs = require("fs");
 const displayUtils = require("testem/lib/utils/displayutils");
 const colors = require("@colors/colors/safe");
 
+require("./patch-testem-output")();
+
 const SANDBOX_DISABLE_VALUES = ["1", "true"];
 const sandboxDisabled =
   process.env.CI ||


### PR DESCRIPTION
Browser logs & errors will now be printed to the console immediately, without waiting for a test to finish. This should help with debugging stuck tests.