### PR TITLE
FIX: Post voting count not updating reactively

### DIFF
--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-vote-controls.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-vote-controls.gjs
@@ -16,7 +16,7 @@ export default class PostVotingVoteControls extends Component {
   @tracked showWhoVoted = false;
 
   get count() {
-    return this.args.post_voting_vote_count || 0;
+    return this.args.post.post_voting_vote_count || 0;
   }
 
   get disabled() {
@@ -37,26 +37,10 @@ export default class PostVotingVoteControls extends Component {
 
   @action
   async removeVote(direction) {
-    const post = this.args.post;
     const countChange = direction === "up" ? -1 : 1;
-
-    post.post_voting_user_voted_direction = null;
-    post.post_voting_vote_count = post.post_voting_vote_count + countChange;
-
-    const voteCount = post.post_voting_vote_count;
-
-    this.loading = true;
-
-    try {
-      return await removeVote({ post_id: post.id });
-    } catch (error) {
-      post.post_voting_user_voted_direction = direction;
-      post.post_voting_vote_count = voteCount - countChange;
-
-      popupAjaxError(error);
-    } finally {
-      this.loading = false;
-    }
+    return this.#submitVote(null, countChange, () =>
+      removeVote({ post_id: this.args.post.id })
+    );
   }
 
   @action
@@ -66,35 +50,31 @@ export default class PostVotingVoteControls extends Component {
     }
 
     const post = this.args.post;
-
-    let vote = {
-      post_id: post.id,
-      direction,
-    };
-
-    const isUpVote = direction === "up";
-    let countChange;
-
-    if (post.post_voting_user_voted_direction) {
-      countChange = isUpVote ? 2 : -2;
-    } else {
-      countChange = isUpVote ? 1 : -1;
+    let countChange = post.post_voting_user_voted_direction ? 2 : 1;
+    if (direction === "down") {
+      countChange *= -1;
     }
 
-    post.post_voting_user_voted_direction = direction;
-    post.post_voting_vote_count = post.post_voting_vote_count + countChange;
+    return this.#submitVote(direction, countChange, () =>
+      castVote({ post_id: post.id, direction })
+    );
+  }
 
-    const voteCount = post.post_voting_vote_count;
+  async #submitVote(newDirection, countChange, apiCall) {
+    const post = this.args.post;
+    const originalDirection = post.post_voting_user_voted_direction;
+    const originalCount = post.post_voting_vote_count;
+
+    post.post_voting_user_voted_direction = newDirection;
+    post.post_voting_vote_count = originalCount + countChange;
 
     this.loading = true;
 
     try {
-      return await castVote(vote);
+      return await apiCall();
     } catch (error) {
-      post.setProperties({
-        post_voting_user_voted_direction: null,
-        post_voting_vote_count: voteCount - countChange,
-      });
+      post.post_voting_user_voted_direction = originalDirection;
+      post.post_voting_vote_count = originalCount;
       popupAjaxError(error);
     } finally {
       this.loading = false;

--- a/plugins/discourse-post-voting/assets/javascripts/discourse/initializers/post-voting-edits.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/initializers/post-voting-edits.gjs
@@ -47,7 +47,8 @@ function customizePost(api) {
   api.addTrackedPostProperties(
     "comments_count",
     "post_voting_user_voted_direction",
-    "post_voting_has_votes"
+    "post_voting_has_votes",
+    "post_voting_vote_count"
   );
 
   api.modifyClass(

--- a/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
+++ b/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
@@ -201,6 +201,14 @@ function setupPostVoting(needs) {
       return helper.response({});
     });
 
+    server.post("/post_voting/vote", () => {
+      return helper.response({});
+    });
+
+    server.delete("/post_voting/vote", () => {
+      return helper.response({});
+    });
+
     server.get("/latest.json", () => {
       return helper.response(postVotingTopicListResponse());
     });
@@ -674,6 +682,37 @@ acceptance(`Discourse Post Voting - logged in user`, function (needs) {
         "#post_2 #post-voting-comment-2 .post-voting-comment-actions-vote-count"
       )
       .doesNotExist("updates the comment vote count correctly");
+  });
+
+  test("voting on a post and removing vote updates the count reactively", async function (assert) {
+    await visit("/t/280");
+
+    assert
+      .dom("#post_2 .post-voting-post-toggle-voters")
+      .hasText("2", "displays the initial post vote count");
+
+    await click("#post_2 .post-voting-button-upvote");
+
+    assert
+      .dom("#post_2 .post-voting-post-toggle-voters")
+      .hasText("1", "decrements the post vote count after removing upvote");
+
+    assert
+      .dom("#post_2 .post-voting-button-upvote")
+      .doesNotHaveClass(
+        "post-voting-button-voted",
+        "unhighlights the upvote button"
+      );
+
+    await click("#post_2 .post-voting-button-downvote");
+
+    assert
+      .dom("#post_2 .post-voting-post-toggle-voters")
+      .hasText("0", "decrements the post vote count after downvoting");
+
+    assert
+      .dom("#post_2 .post-voting-button-downvote")
+      .hasClass("post-voting-button-voted", "highlights the downvote button");
   });
 
   test("topic list link overrides work", async function (assert) {


### PR DESCRIPTION
In a post-voting topic, the vote count on posts and answers did not update after a vote was cast — a full page refresh was required to see the new value. Comments were unaffected.

The root cause is that `post_voting_vote_count` is missing from the plugin's `api.addTrackedPostProperties(...)` call. The local vote path writes directly to `post.post_voting_vote_count`, which bypasses Ember's notification layer and only dirties a tracking tag when the property has been installed via `defineTrackedProperty`. Without it, the template's read of `@post.post_voting_vote_count` never picked up the change. Existing acceptance coverage went through `publishToMessageBus` → `post.setProperties(...)`, which *does* notify and so masked the bug.

While in there:

- Fix a typo in `PostVotingVoteControls#count` — it read `this.args.post_voting_vote_count` instead of `this.args.post.post_voting_vote_count`. The component only receives `@post` and `@showLogin`, so the original was always `undefined`. Cosmetic today (the getter is only read in the zero-vote branch where the value is always 0), but incorrect.

- Extract the optimistic-update / rollback logic from `vote` and `removeVote` into a shared `#submitVote` helper. This also fixes a latent rollback bug: when the user switched direction (up → down or down → up) and the server rejected the vote, `vote` restored `post_voting_user_voted_direction` to `null` instead of the original direction, leaving the UI inconsistent.

Adds an acceptance test for the local-click path, which was not previously covered.

Ref - t/182181