### PR TITLE
DEV: Drop d-teambuild from CI

### DIFF
--- a/config/official_plugins.json
+++ b/config/official_plugins.json
@@ -63,7 +63,6 @@
   "discourse-steam-login",
   "discourse-subscriptions",
   "discourse-tag-by-group",
-  "discourse-teambuild",
   "discourse-templates",
   "discourse-tooltips",
   "discourse-topic-voting",


### PR DESCRIPTION
This plugin has not been maintained for some time