### PR TITLE
FEATURE: Also allow users to choose categories on the ai-translations 'wizard'

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -13,6 +13,8 @@ import DToggleSwitch from "discourse/components/d-toggle-switch";
 import icon from "discourse/helpers/d-icon";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import Category from "discourse/models/category";
+import CategorySelector from "discourse/select-kit/components/category-selector";
 import MultiSelect from "discourse/select-kit/components/multi-select";
 import { i18n } from "discourse-i18n";
 
@@ -40,14 +42,25 @@ export default class AiTranslations extends Component {
     ? this.siteSettings.content_localization_supported_locales.split("|")
     : [];
   @tracked isSavingLocales = false;
+  @tracked isSavingCategories = false;
   @tracked isTogglingTranslation = false;
   @tracked hourlyRate = this.args.model?.hourly_rate || 0;
   @tracked creditStatus = null;
   @tracked creditCheckComplete = false;
+  @tracked selectedCategories = [];
+  @tracked originalCategoryIds = this.args.model?.target_category_ids || [];
 
   constructor() {
     super(...arguments);
     this._checkCredits();
+    this._loadTargetCategories();
+  }
+
+  async _loadTargetCategories() {
+    const ids = this.args.model?.target_category_ids || [];
+    if (ids.length) {
+      this.selectedCategories = await Category.asyncFindByIds(ids);
+    }
   }
 
   async _checkCredits() {
@@ -90,14 +103,15 @@ export default class AiTranslations extends Component {
   }
 
   get showLocaleSelector() {
-    const noLocales =
-      this.args.model?.no_locales_configured ||
-      this.originalLocales.length === 0;
-    return noLocales && !this.translationEnabled;
+    return !this.translationEnabled;
   }
 
-  get showLocalizationSettingsButton() {
-    return this.enabled || !this.showLocaleSelector;
+  get categoriesChanged() {
+    const current = [...this.selectedCategories.map((c) => c.id)]
+      .sort()
+      .join("|");
+    const original = [...this.originalCategoryIds].sort().join("|");
+    return current !== original;
   }
 
   get isToggleDisabled() {
@@ -182,6 +196,42 @@ export default class AiTranslations extends Component {
   @action
   resetLocales() {
     this.selectedLocales = [];
+  }
+
+  @action
+  updateSelectedCategories(categories) {
+    this.selectedCategories = categories;
+  }
+
+  @action
+  async saveCategories() {
+    this.isSavingCategories = true;
+    try {
+      const ids = this.selectedCategories.map((c) => c.id);
+      await ajax("/admin/site_settings/ai_translation_target_categories", {
+        type: "PUT",
+        data: {
+          ai_translation_target_categories: ids.join("|"),
+        },
+      });
+      this.originalCategoryIds = ids;
+    } catch (e) {
+      popupAjaxError(e);
+    } finally {
+      this.isSavingCategories = false;
+    }
+  }
+
+  @action
+  async cancelCategories() {
+    this.selectedCategories = await Category.asyncFindByIds(
+      this.originalCategoryIds
+    );
+  }
+
+  @action
+  resetCategories() {
+    this.selectedCategories = [];
   }
 
   @action
@@ -439,21 +489,17 @@ export default class AiTranslations extends Component {
         @learnMoreUrl="https://meta.discourse.org/t/-/370969"
       >
         <:actions as |actions|>
-          {{#if this.enabled}}
-            <actions.Default
-              @label="discourse_ai.translations.admin_actions.translation_settings"
-              @route="adminPlugins.show.discourse-ai-features.edit"
-              @routeModels={{@model.translation_id}}
-              class="ai-translation-settings-button"
-            />
-          {{/if}}
-          {{#if this.showLocalizationSettingsButton}}
-            <actions.Default
-              @label="discourse_ai.translations.admin_actions.localization_settings"
-              @route="adminConfig.localization.settings"
-              class="ai-localization-settings-button"
-            />
-          {{/if}}
+          <actions.Default
+            @label="discourse_ai.translations.admin_actions.translation_settings"
+            @route="adminPlugins.show.discourse-ai-features.edit"
+            @routeModels={{@model.translation_id}}
+            class="ai-translation-settings-button"
+          />
+          <actions.Default
+            @label="discourse_ai.translations.admin_actions.localization_settings"
+            @route="adminConfig.localization.settings"
+            class="ai-localization-settings-button"
+          />
         </:actions>
       </DPageSubheader>
 
@@ -511,6 +557,49 @@ export default class AiTranslations extends Component {
                 </div>
                 <div class="desc">{{i18n
                     "discourse_ai.translations.supported_locales_description"
+                  }}</div>
+              </div>
+            </div>
+            <div class="setting">
+              <div class="setting-label">
+                <label>{{i18n
+                    "discourse_ai.translations.translatable_categories"
+                  }}</label>
+              </div>
+              <div class="setting-value">
+                <div class="ai-translations__category-input-row">
+                  <CategorySelector
+                    @categories={{this.selectedCategories}}
+                    @onChange={{this.updateSelectedCategories}}
+                  />
+                  {{#if this.categoriesChanged}}
+                    <div class="setting-controls">
+                      <DButton
+                        @action={{this.saveCategories}}
+                        @icon="check"
+                        @isLoading={{this.isSavingCategories}}
+                        @ariaLabel="save"
+                        class="ok setting-controls__ok"
+                      />
+                      <DButton
+                        @action={{this.cancelCategories}}
+                        @icon="xmark"
+                        @isLoading={{this.isSavingCategories}}
+                        @ariaLabel="cancel"
+                        class="cancel setting-controls__cancel"
+                      />
+                    </div>
+                  {{else if this.selectedCategories.length}}
+                    <DButton
+                      @action={{this.resetCategories}}
+                      @icon="arrow-rotate-left"
+                      @label="admin.settings.reset"
+                      class="undo setting-controls__undo"
+                    />
+                  {{/if}}
+                </div>
+                <div class="desc">{{i18n
+                    "discourse_ai.translations.translatable_categories_description"
                   }}</div>
               </div>
             </div>

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -41,6 +41,8 @@ module DiscourseAi
           translation_enabled: SiteSetting.ai_translation_enabled,
           hourly_rate: SiteSetting.ai_translation_backfill_hourly_rate,
           backfill_max_age_days: SiteSetting.ai_translation_backfill_max_age_days,
+          target_category_ids:
+            SiteSetting.ai_translation_target_categories.to_s.split("|").map(&:to_i),
         }
       end
     end

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/common/admin-translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/common/admin-translations.scss
@@ -8,12 +8,14 @@
     margin-top: 2em;
   }
 
-  &__locale-input-row {
+  &__locale-input-row,
+  &__category-input-row {
     display: flex;
     align-items: center;
     gap: 0.5em;
 
-    .multi-select {
+    .multi-select,
+    .category-selector {
       flex: 1;
     }
 

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -381,6 +381,8 @@ en:
         description: "Automatically translate all content on your forum to the user's preferred language"
         supported_locales: "Supported languages"
         supported_locales_description: "This site setting also allows visitors to contribute post translations."
+        translatable_categories: "Translatable categories"
+        translatable_categories_description: "Only content in the selected categories will be translated. Subcategories must be added separately."
         admin_actions:
           translation_settings: "Translation settings"
           localization_settings: "Localization settings"

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -223,6 +223,28 @@ describe DiscourseAi::Admin::AiTranslationsController do
         expect(response.parsed_body["backfill_enabled"]).to eq(false)
       end
 
+      it "returns target_category_ids from ai_translation_target_categories" do
+        other_category = Fabricate(:category)
+        SiteSetting.ai_translation_target_categories = "#{target_category.id}|#{other_category.id}"
+
+        get "/admin/plugins/discourse-ai/ai-translations.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["target_category_ids"]).to contain_exactly(
+          target_category.id,
+          other_category.id,
+        )
+      end
+
+      it "returns an empty array when no target categories are configured" do
+        SiteSetting.ai_translation_target_categories = ""
+
+        get "/admin/plugins/discourse-ai/ai-translations.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["target_category_ids"]).to eq([])
+      end
+
       it "correctly indicates if feature is enabled" do
         SiteSetting.ai_translation_backfill_max_age_days = 30
 

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -69,10 +69,13 @@ RSpec.describe "Admin AI translations" do
   end
 
   describe "when translations are disabled" do
+    fab!(:category)
+
     before do
       SiteSetting.discourse_ai_enabled = true
       SiteSetting.ai_translation_enabled = false
       SiteSetting.content_localization_supported_locales = "en|fr|es"
+      SiteSetting.ai_translation_target_categories = category.id.to_s
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
       visit "/admin/plugins/discourse-ai/ai-translations"
@@ -86,6 +89,11 @@ RSpec.describe "Admin AI translations" do
 
     it "shows localization settings button" do
       expect(page).to have_css(".ai-localization-settings-button")
+    end
+
+    it "keeps language and category selectors visible" do
+      expect(page).to have_css(".ai-translations__locale-input-row .multi-select")
+      expect(page).to have_css(".ai-translations__category-input-row .category-selector")
     end
   end
 
@@ -105,18 +113,52 @@ RSpec.describe "Admin AI translations" do
       expect(page).to have_css(".multi-select")
     end
 
+    it "displays the category selector alongside the locale selector" do
+      expect(page).to have_css(".alert.alert-info")
+      expect(page).to have_content(I18n.t("js.discourse_ai.translations.translatable_categories"))
+      expect(page).to have_css(".category-selector")
+    end
+
     it "allows adding and saving languages" do
-      find(".multi-select").click
+      within(".ai-translations__locale-input-row") do
+        find(".multi-select").click
+        find(".select-kit-row[data-value='en']").click
+        find(".setting-controls__ok").click
+      end
 
-      find(".select-kit-row[data-value='en']").click
-
-      expect(page).to have_css(".setting-controls__ok")
-
-      find(".setting-controls__ok").click
-
-      expect(page).to have_no_css(".setting-controls__ok")
+      expect(page).to have_no_css(".ai-translations__locale-input-row .setting-controls__ok")
 
       expect(SiteSetting.content_localization_supported_locales).to eq("en")
+    end
+  end
+
+  describe "when categories are not configured" do
+    fab!(:category)
+
+    before do
+      SiteSetting.discourse_ai_enabled = true
+      SiteSetting.ai_translation_enabled = false
+      SiteSetting.content_localization_supported_locales = "en|fr"
+      SiteSetting.ai_translation_target_categories = ""
+      SiteSetting.ai_translation_backfill_max_age_days = 30
+
+      visit "/admin/plugins/discourse-ai/ai-translations"
+    end
+
+    it "displays the setup alert with the category selector" do
+      expect(page).to have_css(".alert.alert-info")
+      expect(page).to have_content(I18n.t("js.discourse_ai.translations.translatable_categories"))
+      expect(page).to have_css(".category-selector")
+    end
+
+    it "allows adding and saving translatable categories" do
+      find(".category-selector").click
+      find(".category-row[data-value='#{category.id}']").click
+
+      within(".ai-translations__category-input-row") { find(".setting-controls__ok").click }
+
+      expect(page).to have_no_css(".ai-translations__category-input-row .setting-controls__ok")
+      expect(SiteSetting.ai_translation_target_categories).to eq(category.id.to_s)
     end
   end
 


### PR DESCRIPTION
Since https://github.com/discourse/discourse/pull/39000, it is not obvious that categories also need to be selected. We are ensuring this is shown to the user in the 'wizard'.

Additionally, currently (e.g. on `/admin/plugins/discourse-ai/ai-translations`) if you turn off the "Enable automatic translations", it doesn't show the language settings if the language is already set. Now, _both_ will show up if the "Enable automatic translations" is disabled.


https://github.com/user-attachments/assets/546049f5-21f2-4a89-8273-e8c5a493e69a

