### PR TITLE
UX: Enable onboarding panel for the first admin user

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3884,7 +3884,7 @@ uncategorized:
 
   enable_site_owner_onboarding:
     client: true
-    default: false
+    default: true
     hidden: true
   site_owner_onboarding_max_days:
     default: 5

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -73,6 +73,7 @@ module SvgSprite
         code
         code-branch
         comment
+        comments
         compress
         copy
         crosshairs

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -16,7 +16,6 @@ register_asset "stylesheets/common/index.scss"
 register_asset "stylesheets/desktop/index.scss", :desktop
 register_asset "stylesheets/mobile/index.scss", :mobile
 
-register_svg_icon "comments"
 register_svg_icon "comment-slash"
 register_svg_icon "comment-dots"
 register_svg_icon "lock"


### PR DESCRIPTION
Flips the `enable_site_owner_onboarding` site setting default from `false` to `true`, turning on the first-admin onboarding panel for new sites. The panel will now be shown for the very first admin of a new site, nudging them to invite users, start posting and share the link to the community. By default, the panel is visible for the first 5 days of a site. Admins can also dismiss it with one click. 

<img width="2660" height="1140" alt="image" src="https://github.com/user-attachments/assets/419d4669-91fe-4493-9ed9-97d22aced943" />

<img width="2668" height="1066" alt="image" src="https://github.com/user-attachments/assets/0b82244e-4376-4939-8f94-3af94824bd4c" />
