### PR TITLE
DEV: Fix a GroupsController timestamp flake

### DIFF
--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -753,8 +753,9 @@ RSpec.describe GroupsController do
       get "/groups/#{group.name}/members.json", params: { order: "added_at" }
       members = response.parsed_body["members"]
 
+      first_group_user = group.group_users.find_by(user_id: first_user.id)
       expect(Time.zone.parse(members.last["added_at"])).to be_within_one_second_of(
-        first_user.created_at,
+        first_group_user.created_at,
       )
     end
 


### PR DESCRIPTION
The spec is: "GroupsController#members ensures that membership can be paginated"