### PR TITLE
DEV: Fix a shoulda-matchers warning

### DIFF
--- a/spec/services/nested_topic/toggle_spec.rb
+++ b/spec/services/nested_topic/toggle_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe NestedTopic::Toggle do
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:topic_id) }
-    it { is_expected.to validate_inclusion_of(:enabled).in_array([true, false]) }
   end
 
   describe ".call" do


### PR DESCRIPTION
that matcher wasn't useful (rails ensures that values are casted to true or false)

```
************************************************************************
Warning from shoulda-matchers:

You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
************************************************************************
```