### PR TITLE
FIX: Overly aggressive fuzzy matching in site setting matcher

### DIFF
--- a/frontend/discourse/admin/lib/site-setting-matcher.js
+++ b/frontend/discourse/admin/lib/site-setting-matcher.js
@@ -1,3 +1,8 @@
+// Fuzzy name matches with strength below this (more negative) are order-only
+// subsequence matches that are too weak to show, unless the stripped query
+// appears as a contiguous block in the stripped name (see isFuzzyNameMatch).
+const MIN_FUZZY_NAME_MATCH_STRENGTH = -2;
+
 export default class SiteSettingMatcher {
   constructor(filter, siteSetting) {
     this.filter = filter;
@@ -61,6 +66,12 @@ export default class SiteSettingMatcher {
       return false;
     }
 
+    // Contiguous block in the de-punctuated name: keep matchStrength 0 and
+    // skip gap scoring (subsequence can still look "weak" for long names).
+    if (strippedSetting.includes(this.strippedQuery)) {
+      return true;
+    }
+
     const gapResult = strippedSetting.match(this.fuzzyRegexGaps);
 
     if (gapResult) {
@@ -68,6 +79,12 @@ export default class SiteSettingMatcher {
       const numberOfGaps = gapResult.filter((gap) => gap !== "").length - 1;
 
       this.matchStrength -= numberOfGaps;
+    }
+
+    // Order-only subsequence: drop very weak matches (e.g. "teams" matched
+    // across letters in "…telegram…" in a long `chat_integration_*` name).
+    if (this.matchStrength < MIN_FUZZY_NAME_MATCH_STRENGTH) {
+      return false;
     }
 
     return true;

--- a/frontend/discourse/tests/unit/lib/site-setting-matcher-test.js
+++ b/frontend/discourse/tests/unit/lib/site-setting-matcher-test.js
@@ -68,4 +68,29 @@ module("Unit | Lib | SiteSettingMatcher", function (hooks) {
     assert.true(matchingMatcher.isFuzzyNameMatch);
     assert.strictEqual(matchingMatcher.matchStrength, -1); // Smallest number of gaps.
   });
+
+  test("#isFuzzyNameMatch requires contiguous stripped query or sufficient matchStrength", function (assert) {
+    const teamsEnabled = SiteSetting.create({
+      setting: "chat_integration_teams_enabled",
+      description: "x",
+    });
+    const telegram = SiteSetting.create({
+      setting: "chat_integration_telegram_access_token",
+      description: "x",
+    });
+
+    const query = "chat_integration_teams";
+    const good = new SiteSettingMatcher(query, teamsEnabled);
+    const tooWeak = new SiteSettingMatcher(query, telegram);
+
+    assert.true(
+      good.isFuzzyNameMatch,
+      "name contains the full stripped query consecutively"
+    );
+
+    assert.false(
+      tooWeak.isFuzzyNameMatch,
+      "order-only match on a different long token is dropped"
+    );
+  });
 });


### PR DESCRIPTION
This commit fixes an issue where if you are searching for
something like "chat_integration_teams" in the site settings
you would get all settings including that string, plus
ones that weakly match a name fuzzy match like the following:

* `chat_integration_telegram_access_token`
* `chat_integration_groupme_instance_names`

This was just happening because the fuzzy name matching is
"characters of the search string in order, with anything in between"
(a.*b.*c… on the lowercased name), plus a negative matchStrength for
each "gap" in the fuzzyRegexGaps path.
A long chat_integration_* name is still a short subsequence of something
like chatintegrationteams, so “t” … “e” … a … m” can be found inside
telegram and still pass, which produces the weak scores (-3, -4, -6) in your table.

To fix this we can drop fuzzy name matches that don't match
a minimum strength threshold, and have stronger substring
matching based on setting names.
