### PR TITLE
FIX: Delete reviewables when delete_removed_posts_after is 0

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -84,6 +84,8 @@ class PostDestroyer
       mark_for_deletion(delete_removed_posts_after)
     end
 
+    resolve_reviewables_for_author_deletion if @user.id == @post.user_id
+
     UserActionManager.post_destroyed(@post)
 
     DiscourseEvent.trigger(:post_destroyed, @post, @opts, @user)
@@ -278,7 +280,6 @@ class PostDestroyer
         @post.update_column(:user_deleted, true)
         @post.topic_links.each(&:destroy)
         @post.topic.update_column(:closed, true) if @post.is_first_post?
-        resolve_reviewables_for_author_deletion
       end
     end
   end

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -531,6 +531,25 @@ RSpec.describe PostDestroyer do
       expect(reviewable.reload).to be_ignored
     end
 
+    it "resolves reviewable when author deletes their post via perform_delete (delete_removed_posts_after = 0)" do
+      SiteSetting.delete_removed_posts_after = 0
+
+      reply = create_post(topic: post.topic)
+      reviewable =
+        ReviewablePost.needs_review!(
+          target: reply,
+          created_by: Discourse.system_user,
+          reviewable_by_moderator: true,
+        )
+
+      expect(reviewable).to be_pending
+
+      PostDestroyer.new(reply.user, reply).destroy
+
+      expect(reply.reload.deleted_at).to be_present
+      expect(reviewable.reload).to be_ignored
+    end
+
     it "does not auto-ignore reviewable when author was silenced for the post" do
       reply = create_post(topic: post.topic)
       reviewable = PostActionCreator.spam(coding_horror, reply).reviewable


### PR DESCRIPTION
Follow-up to dbcdcdb. When `delete_removed_posts_after` is set to 0, an author's destroy goes through `perform_delete` instead of `mark_for_deletion`, so the reviewable resolver was never called and reviewables stayed pending after the author deleted their own post.