### PR TITLE
UX: narrow post reactions panel

### DIFF
--- a/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
+++ b/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
@@ -14,7 +14,7 @@
 }
 
 .post-users-popup {
-  width: 300px;
+  width: 250px;
   background: var(--secondary);
   color: var(--primary);
   line-height: normal;
@@ -163,7 +163,7 @@
 
   &__username {
     color: var(--primary-medium) !important;
-    font-size: var(--font-down-2);
+    font-size: var(--font-down-1);
     text-decoration: none;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Small cosmetic improvement to reduce dead space. The default max username length is 20 characters, which we can easily fit in a more narrow reactions panel. For longer names or usernames we already apply ellipsis.

The username font size is increased slightly when underneath the full name to make it a bit more legible.

## Before

<img width="331" height="426" alt="Screenshot 2026-04-22 at 11 17 24 AM" src="https://github.com/user-attachments/assets/417a60bf-dc36-4592-9ec8-638790a57000" />

## After

When the site setting prioritize username in ux is disabled:

<img width="263" height="297" alt="Screenshot 2026-04-22 at 11 51 20 AM" src="https://github.com/user-attachments/assets/25906568-823f-447e-a520-4ac883947e8e" />


When prioritize username in ux is enabled:

<img width="261" height="259" alt="Screenshot 2026-04-22 at 11 50 39 AM" src="https://github.com/user-attachments/assets/9dfed24b-149f-4131-a3bd-1dfc998a4136" />


With longer names:

<img width="272" height="153" alt="Screenshot 2026-04-22 at 11 37 36 AM" src="https://github.com/user-attachments/assets/fbfec5a7-b15a-4757-b375-b157b85e2730" />

With longer usernames:

<img width="268" height="169" alt="Screenshot 2026-04-22 at 11 39 00 AM" src="https://github.com/user-attachments/assets/59051385-eb88-461b-96e8-db38ebaeac52" />

