### PR TITLE
DEV: Migrate default database first in multisite:migrate

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -119,6 +119,7 @@ task "multisite:migrate" => %w[
        environment
        set_locale
        assets:precompile:asset_processor
+       db:migrate
      ] do |_, args|
   DistributedMutex.synchronize(
     "db_migration",
@@ -129,7 +130,9 @@ task "multisite:migrate" => %w[
 
     puts "Multisite migrator is running using #{concurrency} processes"
 
-    databases = RailsMultisite::ConnectionManagement.all_dbs
+    # `db:migrate` prereq already migrated the default database.
+    databases =
+      RailsMultisite::ConnectionManagement.all_dbs - [RailsMultisite::ConnectionManagement::DEFAULT]
 
     puts "Running migrations and seeds for #{databases.join(", ")} database(s)"
 


### PR DESCRIPTION
Discourse's [`db:seed` definition](https://github.com/discourse/discourse/blob/72c300a1510f4e3237d66adb6a2bbc3710d4e01f/lib/tasks/db.rake#L238C1-L238C35) appends to the Rails defined task rather than replacing it. The Rails defined [`db:seed` action](https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/railties/databases.rake#L388-L391) calls [`db:abort_if_pending_migrations`](https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/railties/databases.rake#L329-L347) which checks the default database's `schema_migrations` table regardless of the currently connected rails_multisite database. When a forked worker in `multisite:migrate` migrates a rails_multisite database before the default database has been migrated, the check aborts with a pending migration error.

This commit adds `db:migrate` as a prerequisite of `multisite:migrate` so the default database is always migrated first, then excludes it from the parallel list to avoid redundant work.