### PR TITLE
FIX: Drafts/reviewables API returned 404 when acting on own resource

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -576,6 +576,15 @@ class ApplicationController < ActionController::Base
     user
   end
 
+  def fetch_target_user
+    if is_api? && guardian.is_admin? &&
+         (params[:username].present? || params[:external_id].present?)
+      fetch_user_from_params
+    else
+      current_user
+    end
+  end
+
   def post_ids_including_replies
     post_ids = params[:post_ids].map(&:to_i)
     post_ids |= PostReply.where(post_id: params[:reply_post_ids]).pluck(:reply_post_id) if params[

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -577,8 +577,8 @@ class ApplicationController < ActionController::Base
   end
 
   def fetch_target_user
-    if is_api? && guardian.is_admin? &&
-         (params[:username].present? || params[:external_id].present?)
+    if params[:username].present? || params[:external_id].present?
+      raise Discourse::InvalidAccess if !is_api? || !guardian.is_admin?
       fetch_user_from_params
     else
       current_user

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -138,16 +138,7 @@ class DraftsController < ApplicationController
   end
 
   def destroy
-    user =
-      if is_api?
-        if @guardian.is_admin?
-          fetch_user_from_params
-        else
-          raise Discourse::InvalidAccess
-        end
-      else
-        current_user
-      end
+    user = fetch_target_user
 
     begin
       Draft.clear(user, params[:id], params[:sequence].to_i)
@@ -176,16 +167,7 @@ class DraftsController < ApplicationController
 
     return render json: success_json.merge(deleted_count: 0) if draft_keys.empty?
 
-    user =
-      if is_api?
-        if @guardian.is_admin?
-          fetch_user_from_params
-        else
-          raise Discourse::InvalidAccess
-        end
-      else
-        current_user
-      end
+    user = fetch_target_user
 
     # Validate all sequences first (fail fast)
     sequence_errors = []

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -174,16 +174,7 @@ class ReviewablesController < ApplicationController
   end
 
   def destroy
-    user =
-      if is_api?
-        if @guardian.is_admin?
-          fetch_user_from_params
-        else
-          raise Discourse::InvalidAccess
-        end
-      else
-        current_user
-      end
+    user = fetch_target_user
 
     reviewable =
       Reviewable.find_by_flagger_or_queued_post_creator(

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -942,13 +942,7 @@ class TopicsController < ApplicationController
   end
 
   def set_notifications
-    user =
-      if is_api? && @guardian.is_admin? &&
-           (params[:username].present? || params[:external_id].present?)
-        fetch_user_from_params
-      else
-        current_user
-      end
+    user = fetch_target_user
 
     topic = Topic.find(params[:topic_id].to_i)
     guardian.ensure_can_see!(topic)

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -440,64 +440,96 @@ RSpec.describe DraftsController do
       expect(Draft.get(user, "xxx", 0)).to be_present
     end
 
-    shared_examples "for a passed user" do
-      it "deletes draft" do
-        api_key = Fabricate(:api_key).key
-        Draft.set(recipient, "xxx", 0, "hi")
+    describe "via API" do
+      fab!(:admin)
+      fab!(:other_user, :user)
+
+      it "admin can target another user with `username` param" do
+        api_key = Fabricate(:api_key, user: admin).key
+        Draft.set(other_user, "xxx", 0, "hi")
 
         delete "/drafts/xxx.json",
                params: {
                  sequence: 0,
-                 username: recipient.username,
+                 username: other_user.username,
                },
                headers: {
-                 HTTP_API_USERNAME: caller.username,
+                 HTTP_API_USERNAME: admin.username,
                  HTTP_API_KEY: api_key,
                }
 
-        expect(response.status).to eq(response_code)
-
-        if draft_deleted
-          expect(Draft.get(recipient, "xxx", 0)).to eq(nil)
-        else
-          expect(Draft.get(recipient, "xxx", 0)).to be_present
-        end
+        expect(response.status).to eq(200)
+        expect(Draft.get(other_user, "xxx", 0)).to eq(nil)
       end
-    end
 
-    describe "api called by admin" do
-      include_examples "for a passed user" do
-        let(:caller) { Fabricate(:admin) }
-        let(:recipient) { Fabricate(:user) }
-        let(:response_code) { 200 }
-        let(:draft_deleted) { true }
+      it "admin acts on self when `username` param is absent" do
+        api_key = Fabricate(:api_key, user: admin).key
+        Draft.set(admin, "xxx", 0, "hi")
+
+        delete "/drafts/xxx.json",
+               params: {
+                 sequence: 0,
+               },
+               headers: {
+                 HTTP_API_USERNAME: admin.username,
+                 HTTP_API_KEY: api_key,
+               }
+
+        expect(response.status).to eq(200)
+        expect(Draft.get(admin, "xxx", 0)).to eq(nil)
       end
-    end
 
-    describe "api called by tl4 user" do
-      include_examples "for a passed user" do
-        let(:caller) { Fabricate(:trust_level_4) }
-        let(:recipient) { Fabricate(:user) }
-        let(:response_code) { 403 }
-        let(:draft_deleted) { false }
+      it "non-admin ignores `username` param and acts on self" do
+        api_key = Fabricate(:api_key, user: user).key
+        Draft.set(user, "xxx", 0, "hi")
+        Draft.set(other_user, "xxx", 0, "hi")
+
+        delete "/drafts/xxx.json",
+               params: {
+                 sequence: 0,
+                 username: other_user.username,
+               },
+               headers: {
+                 HTTP_API_USERNAME: user.username,
+                 HTTP_API_KEY: api_key,
+               }
+
+        expect(response.status).to eq(200)
+        expect(Draft.get(user, "xxx", 0)).to eq(nil)
+        expect(Draft.get(other_user, "xxx", 0)).to be_present
       end
-    end
 
-    describe "api called by regular user" do
-      include_examples "for a passed user" do
-        let(:caller) { Fabricate(:user) }
-        let(:recipient) { Fabricate(:user) }
-        let(:response_code) { 403 }
-        let(:draft_deleted) { false }
+      it "non-admin acts on self when `username` param is absent" do
+        api_key = Fabricate(:api_key, user: user).key
+        Draft.set(user, "xxx", 0, "hi")
+
+        delete "/drafts/xxx.json",
+               params: {
+                 sequence: 0,
+               },
+               headers: {
+                 HTTP_API_USERNAME: user.username,
+                 HTTP_API_KEY: api_key,
+               }
+
+        expect(response.status).to eq(200)
+        expect(Draft.get(user, "xxx", 0)).to eq(nil)
       end
-    end
 
-    describe "api called by admin for another admin" do
-      include_examples "for a passed user" do
-        let(:caller) { Fabricate(:admin) }
-        let(:recipient) { Fabricate(:admin) }
-        let(:response_code) { 200 }
-        let(:draft_deleted) { true }
+      it "returns 404 when admin targets a nonexistent `username`" do
+        api_key = Fabricate(:api_key, user: admin).key
+
+        delete "/drafts/xxx.json",
+               params: {
+                 sequence: 0,
+                 username: "does_not_exist",
+               },
+               headers: {
+                 HTTP_API_USERNAME: admin.username,
+                 HTTP_API_KEY: api_key,
+               }
+
+        expect(response.status).to eq(404)
       end
     end
   end
@@ -629,11 +661,11 @@ RSpec.describe DraftsController do
       expect(user.user_stat.draft_count).to eq(initial_draft_count - 3)
     end
 
-    context "when using API access" do
-      it "allows admin to delete other user's drafts via API" do
-        admin = Fabricate(:admin)
-        api_key = Fabricate(:api_key, user: admin)
+    describe "via API" do
+      fab!(:admin)
 
+      it "admin can target another user with `username` param" do
+        api_key = Fabricate(:api_key, user: admin).key
         Draft.set(user, "draft1", 0, '{"reply": "draft content"}')
 
         delete "/drafts/bulk_destroy.json",
@@ -645,7 +677,7 @@ RSpec.describe DraftsController do
                  username: user.username,
                },
                headers: {
-                 "Api-Key" => api_key.key,
+                 "Api-Key" => api_key,
                  "Api-Username" => admin.username,
                }
 
@@ -653,10 +685,29 @@ RSpec.describe DraftsController do
         expect(Draft.get(user, "draft1", 0)).to eq(nil)
       end
 
-      it "denies non-admin API access to other user's drafts" do
-        non_admin = Fabricate(:user)
-        api_key = Fabricate(:api_key, user: non_admin)
+      it "admin acts on self when `username` param is absent" do
+        api_key = Fabricate(:api_key, user: admin).key
+        Draft.set(admin, "draft1", 0, '{"reply": "draft content"}')
 
+        delete "/drafts/bulk_destroy.json",
+               params: {
+                 draft_keys: ["draft1"],
+                 sequences: {
+                   "draft1" => 0,
+                 },
+               },
+               headers: {
+                 "Api-Key" => api_key,
+                 "Api-Username" => admin.username,
+               }
+
+        expect(response.status).to eq(200)
+        expect(Draft.get(admin, "draft1", 0)).to eq(nil)
+      end
+
+      it "non-admin ignores `username` param and acts on self" do
+        non_admin = Fabricate(:user)
+        api_key = Fabricate(:api_key, user: non_admin).key
         Draft.set(user, "draft1", 0, '{"reply": "draft content"}')
 
         delete "/drafts/bulk_destroy.json",
@@ -668,11 +719,11 @@ RSpec.describe DraftsController do
                  username: user.username,
                },
                headers: {
-                 "Api-Key" => api_key.key,
+                 "Api-Key" => api_key,
                  "Api-Username" => non_admin.username,
                }
 
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(200)
         expect(Draft.get(user, "draft1", 0)).to be_present
       end
     end

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe DraftsController do
         expect(Draft.get(admin, "xxx", 0)).to eq(nil)
       end
 
-      it "non-admin ignores `username` param and acts on self" do
+      it "non-admin gets 403 when passing `username` to target another user" do
         api_key = Fabricate(:api_key, user: user).key
         Draft.set(user, "xxx", 0, "hi")
         Draft.set(other_user, "xxx", 0, "hi")
@@ -494,8 +494,8 @@ RSpec.describe DraftsController do
                  HTTP_API_KEY: api_key,
                }
 
-        expect(response.status).to eq(200)
-        expect(Draft.get(user, "xxx", 0)).to eq(nil)
+        expect(response.status).to eq(403)
+        expect(Draft.get(user, "xxx", 0)).to be_present
         expect(Draft.get(other_user, "xxx", 0)).to be_present
       end
 
@@ -705,7 +705,7 @@ RSpec.describe DraftsController do
         expect(Draft.get(admin, "draft1", 0)).to eq(nil)
       end
 
-      it "non-admin ignores `username` param and acts on self" do
+      it "non-admin gets 403 when passing `username` to target another user" do
         non_admin = Fabricate(:user)
         api_key = Fabricate(:api_key, user: non_admin).key
         Draft.set(user, "draft1", 0, '{"reply": "draft content"}')
@@ -723,7 +723,7 @@ RSpec.describe DraftsController do
                  "Api-Username" => non_admin.username,
                }
 
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(403)
         expect(Draft.get(user, "draft1", 0)).to be_present
       end
     end

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -1000,62 +1000,68 @@ RSpec.describe ReviewablesController do
         expect(queued_post.reload).to be_present
       end
 
-      shared_examples "for a passed user" do
-        it "deletes reviewable" do
-          api_key = Fabricate(:api_key).key
-          queued_post = Fabricate(:reviewable_queued_post, target_created_by: recipient)
+      describe "via API" do
+        it "admin can target another user with `username` param" do
+          api_key = Fabricate(:api_key, user: admin).key
+          queued_post = Fabricate(:reviewable_queued_post, target_created_by: user)
+
           delete "/review/#{queued_post.id}.json",
                  params: {
-                   username: recipient.username,
+                   username: user.username,
                  },
                  headers: {
-                   HTTP_API_USERNAME: caller.username,
+                   HTTP_API_USERNAME: admin.username,
                    HTTP_API_KEY: api_key,
                  }
 
-          expect(response.status).to eq(response_code)
-
-          if reviewable_deleted
-            expect(queued_post.reload).to be_deleted
-          else
-            expect(queued_post.reload).to be_present
-          end
+          expect(response.status).to eq(200)
+          expect(queued_post.reload).to be_deleted
         end
-      end
 
-      describe "api called by admin" do
-        include_examples "for a passed user" do
-          let(:caller) { Fabricate(:admin) }
-          let(:recipient) { user }
-          let(:response_code) { 200 }
-          let(:reviewable_deleted) { true }
+        it "admin acts on self when `username` param is absent" do
+          api_key = Fabricate(:api_key, user: admin).key
+          queued_post = Fabricate(:reviewable_queued_post, target_created_by: admin)
+
+          delete "/review/#{queued_post.id}.json",
+                 headers: {
+                   HTTP_API_USERNAME: admin.username,
+                   HTTP_API_KEY: api_key,
+                 }
+
+          expect(response.status).to eq(200)
+          expect(queued_post.reload).to be_deleted
         end
-      end
 
-      describe "api called by tl4 user" do
-        include_examples "for a passed user" do
-          let(:caller) { Fabricate(:trust_level_4) }
-          let(:recipient) { user }
-          let(:response_code) { 403 }
-          let(:reviewable_deleted) { false }
+        it "non-admin ignores `username` param and acts on self" do
+          other_user = Fabricate(:user)
+          api_key = Fabricate(:api_key, user: user).key
+          queued_post = Fabricate(:reviewable_queued_post, target_created_by: other_user)
+
+          delete "/review/#{queued_post.id}.json",
+                 params: {
+                   username: other_user.username,
+                 },
+                 headers: {
+                   HTTP_API_USERNAME: user.username,
+                   HTTP_API_KEY: api_key,
+                 }
+
+          expect(response.status).to eq(404)
+          expect(queued_post.reload).to be_present
         end
-      end
 
-      describe "api called by regular user" do
-        include_examples "for a passed user" do
-          let(:caller) { user }
-          let(:recipient) { Fabricate(:user) }
-          let(:response_code) { 403 }
-          let(:reviewable_deleted) { false }
-        end
-      end
+        it "non-admin acts on self when `username` param is absent" do
+          api_key = Fabricate(:api_key, user: user).key
+          queued_post = Fabricate(:reviewable_queued_post, target_created_by: user)
 
-      describe "api called by admin for another admin" do
-        include_examples "for a passed user" do
-          let(:caller) { Fabricate(:admin) }
-          let(:recipient) { Fabricate(:admin) }
-          let(:response_code) { 200 }
-          let(:reviewable_deleted) { true }
+          delete "/review/#{queued_post.id}.json",
+                 headers: {
+                   HTTP_API_USERNAME: user.username,
+                   HTTP_API_KEY: api_key,
+                 }
+
+          expect(response.status).to eq(200)
+          expect(queued_post.reload).to be_deleted
         end
       end
     end

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -1032,7 +1032,7 @@ RSpec.describe ReviewablesController do
           expect(queued_post.reload).to be_deleted
         end
 
-        it "non-admin ignores `username` param and acts on self" do
+        it "non-admin gets 403 when passing `username` to target another user" do
           other_user = Fabricate(:user)
           api_key = Fabricate(:api_key, user: user).key
           queued_post = Fabricate(:reviewable_queued_post, target_created_by: other_user)
@@ -1046,7 +1046,7 @@ RSpec.describe ReviewablesController do
                    HTTP_API_KEY: api_key,
                  }
 
-          expect(response.status).to eq(404)
+          expect(response.status).to eq(403)
           expect(queued_post.reload).to be_present
         end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7422,7 +7422,7 @@ RSpec.describe TopicsController do
   describe "#set_notifications" do
     let(:watching) { NotificationLevels.topic_levels[:watching] }
 
-    it "ignores `username` param for session requests" do
+    it "rejects `username` param for session requests" do
       sign_in(user)
       post "/t/#{topic.id}/notifications.json",
            params: {
@@ -7430,7 +7430,8 @@ RSpec.describe TopicsController do
              notification_level: watching,
            }
 
-      expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
+      expect(response.status).to eq(403)
+      expect(TopicUser.find_by(user: user, topic: topic)).to be_blank
       expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
     end
 
@@ -7464,7 +7465,7 @@ RSpec.describe TopicsController do
         expect(TopicUser.find_by(user: admin, topic: topic).notification_level).to eq(watching)
       end
 
-      it "non-admin ignores `username` param and acts on self" do
+      it "non-admin gets 403 when passing `username` to target another user" do
         api_key = Fabricate(:api_key, user: user).key
         post "/t/#{topic.id}/notifications",
              params: {
@@ -7476,7 +7477,8 @@ RSpec.describe TopicsController do
                HTTP_API_USERNAME: user.username,
              }
 
-        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
+        expect(response.status).to eq(403)
+        expect(TopicUser.find_by(user: user, topic: topic)).to be_blank
         expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
       end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7420,73 +7420,78 @@ RSpec.describe TopicsController do
   end
 
   describe "#set_notifications" do
-    describe "initiated by admin" do
-      it "can update another user's notification level via API" do
-        api_key = Fabricate(:api_key, user: admin)
+    let(:watching) { NotificationLevels.topic_levels[:watching] }
+
+    it "ignores `username` param for session requests" do
+      sign_in(user)
+      post "/t/#{topic.id}/notifications.json",
+           params: {
+             username: user_2.username,
+             notification_level: watching,
+           }
+
+      expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
+      expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
+    end
+
+    describe "via API" do
+      it "admin can target another user with `username` param" do
+        api_key = Fabricate(:api_key, user: admin).key
         post "/t/#{topic.id}/notifications",
              params: {
                username: user.username,
-               notification_level: NotificationLevels.topic_levels[:watching],
+               notification_level: watching,
              },
              headers: {
-               HTTP_API_KEY: api_key.key,
+               HTTP_API_KEY: api_key,
                HTTP_API_USERNAME: admin.username,
              }
-        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(
-          NotificationLevels.topic_levels[:watching],
-        )
+
+        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
       end
 
-      it "can update own notification level via API" do
-        api_key = Fabricate(:api_key, user: admin)
+      it "admin acts on self when `username` param is absent" do
+        api_key = Fabricate(:api_key, user: admin).key
         post "/t/#{topic.id}/notifications",
              params: {
-               notification_level: NotificationLevels.topic_levels[:watching],
+               notification_level: watching,
              },
              headers: {
-               HTTP_API_KEY: api_key.key,
+               HTTP_API_KEY: api_key,
                HTTP_API_USERNAME: admin.username,
              }
-        expect(TopicUser.find_by(user: admin, topic: topic).notification_level).to eq(
-          NotificationLevels.topic_levels[:watching],
-        )
-      end
-    end
 
-    describe "initiated by non-admin" do
-      it "only acts on current_user and ignores `username` param" do
-        sign_in(user)
-        TopicUser.create!(
-          user: user,
-          topic: topic,
-          notification_level: NotificationLevels.topic_levels[:tracking],
-        )
-        post "/t/#{topic.id}/notifications.json",
+        expect(TopicUser.find_by(user: admin, topic: topic).notification_level).to eq(watching)
+      end
+
+      it "non-admin ignores `username` param and acts on self" do
+        api_key = Fabricate(:api_key, user: user).key
+        post "/t/#{topic.id}/notifications",
              params: {
                username: user_2.username,
-               notification_level: NotificationLevels.topic_levels[:watching],
-             }
-
-        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(
-          NotificationLevels.topic_levels[:watching],
-        )
-        expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
-      end
-
-      it "can update own notification level via API" do
-        api_key = Fabricate(:api_key, user: user)
-        post "/t/#{topic.id}/notifications",
-             params: {
-               notification_level: NotificationLevels.topic_levels[:watching],
+               notification_level: watching,
              },
              headers: {
-               HTTP_API_KEY: api_key.key,
+               HTTP_API_KEY: api_key,
                HTTP_API_USERNAME: user.username,
              }
 
-        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(
-          NotificationLevels.topic_levels[:watching],
-        )
+        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
+        expect(TopicUser.find_by(user: user_2, topic: topic)).to be_blank
+      end
+
+      it "non-admin acts on self when `username` param is absent" do
+        api_key = Fabricate(:api_key, user: user).key
+        post "/t/#{topic.id}/notifications",
+             params: {
+               notification_level: watching,
+             },
+             headers: {
+               HTTP_API_KEY: api_key,
+               HTTP_API_USERNAME: user.username,
+             }
+
+        expect(TopicUser.find_by(user: user, topic: topic).notification_level).to eq(watching)
       end
     end
 


### PR DESCRIPTION
Admin callers using the API to `DELETE /drafts/:id.json` or `DELETE /review/:id.json` received a `not_found` error when the `username` param was omitted, even though the resource existed and was owned by the API user (`Api-Username`). The destroy actions always called `fetch_user_from_params` on the API path, which raises `Discourse::NotFound` when neither `username` nor `external_id` is provided — forcing callers to redundantly pass `username=<self>` to delete their own resources.

Extract the target-user resolution into a shared `fetch_target_user` helper in `ApplicationController` that mirrors the pattern already used by `topics#set_notifications`: for API requests, an admin can target another user via `username`/`external_id`; otherwise the action operates on `current_user`. This also aligns API capabilities with the UI — non-admin API callers can now manage their own drafts/reviewables, matching what they can already do via the web.

Migrated call sites:

- `DraftsController#destroy` and `#bulk_destroy`
- `ReviewablesController#destroy`
- `TopicsController#set_notifications` (now uses the helper instead of its inline version)

https://meta.discourse.org/t/401220