### PR TITLE
FIX: Update post-voting test selectors to match BEM rename

### DIFF
--- a/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
+++ b/plugins/discourse-post-voting/test/javascripts/acceptance/post-voting-test.js
@@ -675,31 +675,28 @@ acceptance("logged in user", function (needs) {
     await visit("/t/280");
 
     assert
-      .dom("#post_2 .post-voting-post-toggle-voters")
+      .dom("#post_2 .post-voting-post__toggle-voters")
       .hasText("2", "displays the initial post vote count");
 
-    await click("#post_2 .post-voting-button-upvote");
+    await click("#post_2 .post-voting-button.--upvote");
 
     assert
-      .dom("#post_2 .post-voting-post-toggle-voters")
+      .dom("#post_2 .post-voting-post__toggle-voters")
       .hasText("1", "decrements the post vote count after removing upvote");
 
     assert
-      .dom("#post_2 .post-voting-button-upvote")
-      .doesNotHaveClass(
-        "post-voting-button-voted",
-        "unhighlights the upvote button"
-      );
+      .dom("#post_2 .post-voting-button.--upvote")
+      .doesNotHaveClass("--voted", "unhighlights the upvote button");
 
-    await click("#post_2 .post-voting-button-downvote");
+    await click("#post_2 .post-voting-button.--downvote");
 
     assert
-      .dom("#post_2 .post-voting-post-toggle-voters")
+      .dom("#post_2 .post-voting-post__toggle-voters")
       .hasText("0", "decrements the post vote count after downvoting");
 
     assert
-      .dom("#post_2 .post-voting-button-downvote")
-      .hasClass("post-voting-button-voted", "highlights the downvote button");
+      .dom("#post_2 .post-voting-button.--downvote")
+      .hasClass("--voted", "highlights the downvote button");
   });
 
   test("topic list link overrides work", async function (assert) {


### PR DESCRIPTION
The acceptance test added in c5a6754e29f ("voting on a post and removing vote updates the count reactively") was written against the pre-BEM class names and has been failing on `main` ever since.

PR #39443 (8e44060201a) renamed the post-voting button and vote-count classes to BEM form — `.post-voting-post-toggle-voters` → `.post-voting-post__toggle-voters`, `.post-voting-button-upvote` → `.post-voting-button.--upvote`, `.post-voting-button-voted` → `--voted`, etc. It landed before #39416, but #39416 rebased over it without updating the new test's selectors, so the assertions look for elements that no longer exist and every frontend CI run now fails with "Element #post_2 .post-voting-post-toggle-voters should exist".

Point the selectors at the current BEM names. The sibling tests in the same file (e.g. the comment-voting test just above) already use this form, so this only brings the new test in line with the rest.