### PR TITLE
PERF: Lazy-load translation progress chart on admin AI translations page

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
 import Chart from "discourse/admin/components/chart";
+import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
@@ -25,9 +26,10 @@ export default class AiTranslations extends Component {
   @service site;
   @service siteSettings;
 
-  @tracked data = this.args.model?.translation_progress;
-  @tracked done = this.args.model?.posts_with_detected_locale;
-  @tracked total = this.args.model?.total;
+  @tracked data = null;
+  @tracked done = null;
+  @tracked total = null;
+  @tracked loadingProgress = false;
   @tracked
   translationEnabled =
     this.args.model?.translation_enabled &&
@@ -44,22 +46,41 @@ export default class AiTranslations extends Component {
   @tracked isSavingLocales = false;
   @tracked isSavingCategories = false;
   @tracked isTogglingTranslation = false;
-  @tracked hourlyRate = this.args.model?.hourly_rate || 0;
   @tracked creditStatus = null;
   @tracked creditCheckComplete = false;
   @tracked selectedCategories = [];
   @tracked originalCategoryIds = this.args.model?.target_category_ids || [];
+  hourlyRate = this.args.model?.hourly_rate || 0;
 
   constructor() {
     super(...arguments);
     this._checkCredits();
     this._loadTargetCategories();
+    if (this.enabled) {
+      this._loadProgress();
+    }
   }
 
   async _loadTargetCategories() {
     const ids = this.args.model?.target_category_ids || [];
     if (ids.length) {
       this.selectedCategories = await Category.asyncFindByIds(ids);
+    }
+  }
+
+  async _loadProgress() {
+    this.loadingProgress = true;
+    try {
+      const response = await ajax(
+        "/admin/plugins/discourse-ai/ai-translations/progress.json"
+      );
+      this.data = response.translation_progress;
+      this.total = response.total;
+      this.done = response.posts_with_detected_locale;
+    } catch (e) {
+      popupAjaxError(e);
+    } finally {
+      this.loadingProgress = false;
     }
   }
 
@@ -260,16 +281,8 @@ export default class AiTranslations extends Component {
       this.translationEnabled = !this.translationEnabled;
 
       if (this.translationEnabled && !this.args.model.no_locales_configured) {
-        const response = await ajax(
-          "/admin/plugins/discourse-ai/ai-translations"
-        );
-        if (response.enabled) {
-          this.data = response.translation_progress;
-          this.total = response.total;
-          this.done = response.posts_with_detected_locale;
-          this.enabled = response.enabled;
-          this.hourlyRate = response.hourly_rate || 0;
-        }
+        this.enabled = true;
+        this._loadProgress();
       } else {
         this.enabled = false;
       }
@@ -617,30 +630,33 @@ export default class AiTranslations extends Component {
       </div>
 
       {{#if this.enabled}}
-        <AdminConfigAreaCard class="ai-translations__charts">
-          <:header>
-            {{i18n "discourse_ai.translations.progress_chart.title"}}
-          </:header>
-          <:content>
-            <div class="ai-translations__stats-container">
-              {{#if this.backfillStatusMessage}}
-                <div class="ai-translations__stat-item">
-                  <span class="ai-translations__stat-label">
-                    {{this.backfillStatusMessage}}
-                  </span>
+        <ConditionalLoadingSpinner @condition={{this.loadingProgress}}>
+          {{#if this.data}}
+            <AdminConfigAreaCard class="ai-translations__charts">
+              <:header>
+                {{i18n "discourse_ai.translations.progress_chart.title"}}
+              </:header>
+              <:content>
+                <div class="ai-translations__stats-container">
+                  {{#if this.backfillStatusMessage}}
+                    <div class="ai-translations__stat-item">
+                      <span class="ai-translations__stat-label">
+                        {{this.backfillStatusMessage}}
+                      </span>
+                    </div>
+                  {{/if}}
                 </div>
-              {{/if}}
-            </div>
-            <div class="ai-translations__chart-container">
-              <Chart
-                @chartConfig={{this.chartConfig}}
-                @loadChartDataLabelsPlugin={{true}}
-                class="ai-translations__chart"
-              />
-            </div>
-          </:content>
-        </AdminConfigAreaCard>
-
+                <div class="ai-translations__chart-container">
+                  <Chart
+                    @chartConfig={{this.chartConfig}}
+                    @loadChartDataLabelsPlugin={{true}}
+                    class="ai-translations__chart"
+                  />
+                </div>
+              </:content>
+            </AdminConfigAreaCard>
+          {{/if}}
+        </ConditionalLoadingSpinner>
       {{/if}}
 
     </div>

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -9,23 +9,28 @@ module DiscourseAi
         supported_locales =
           SiteSetting.content_localization_supported_locales.presence&.split("|") || []
 
+        result = base_result
+        result[:no_locales_configured] = true if supported_locales.empty?
+
+        render json: result
+      end
+
+      def progress
+        unless DiscourseAi::Translation.enabled? &&
+                 SiteSetting.ai_translation_backfill_max_age_days > 0
+          return(render json: { translation_progress: [], total: 0, posts_with_detected_locale: 0 })
+        end
+
+        supported_locales =
+          SiteSetting.content_localization_supported_locales.presence&.split("|") || []
+
         if supported_locales.empty?
-          return(
-            render json:
-                     base_result.merge(
-                       {
-                         translation_progress: [],
-                         total: 0,
-                         posts_with_detected_locale: 0,
-                         no_locales_configured: true,
-                       },
-                     )
-          )
+          return(render json: { translation_progress: [], total: 0, posts_with_detected_locale: 0 })
         end
 
         data = DiscourseAi::Translation::PostCandidates.get_completion_all_locales
 
-        render json: base_result.merge(data)
+        render json: data
       end
 
       private

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -21,13 +21,6 @@ module DiscourseAi
           return(render json: { translation_progress: [], total: 0, posts_with_detected_locale: 0 })
         end
 
-        supported_locales =
-          SiteSetting.content_localization_supported_locales.presence&.split("|") || []
-
-        if supported_locales.empty?
-          return(render json: { translation_progress: [], total: 0, posts_with_detected_locale: 0 })
-        end
-
         data = DiscourseAi::Translation::PostCandidates.get_completion_all_locales
 
         render json: data

--- a/plugins/discourse-ai/config/routes.rb
+++ b/plugins/discourse-ai/config/routes.rb
@@ -149,6 +149,7 @@ Discourse::Application.routes.draw do
     post "/ai-spam/fix-errors", to: "discourse_ai/admin/ai_spam#fix_errors"
 
     get "/ai-translations", to: "discourse_ai/admin/ai_translations#show"
+    get "/ai-translations/progress", to: "discourse_ai/admin/ai_translations#progress"
     post "/ai-theme-translations", to: "discourse_ai/admin/ai_theme_translations#create"
 
     resources :ai_llms,

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -8,7 +8,8 @@ module DiscourseAi
       # Also returns aggregate counts for total eligible posts and posts with detected locale.
       # @return [Hash] a hash with keys :translation_progress (array), :total (integer), and :posts_with_detected_locale (integer)
       def self.get_completion_all_locales
-        completion_all_locales
+        cache_key = "ai-translations-progress-#{SiteSetting.content_localization_supported_locales}"
+        Discourse.cache.fetch(cache_key, expires_in: 30.minutes) { completion_all_locales }
       end
 
       private

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -105,6 +105,7 @@ describe DiscourseAi::Translation::PostCandidates do
     fab!(:target_category, :category)
 
     before do
+      Discourse.cache.clear
       SiteSetting.content_localization_supported_locales = "en_GB|pt|es"
       SiteSetting.ai_translation_backfill_max_age_days = 30
       SiteSetting.ai_translation_target_categories = target_category.id.to_s

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -21,159 +21,27 @@ describe DiscourseAi::Admin::AiTranslationsController do
         SiteSetting.ai_translation_target_categories = target_category.id.to_s
       end
 
-      it "returns translation progress data" do
+      it "returns base configuration data without progress" do
         SiteSetting.ai_translation_backfill_max_age_days = 30
-        SiteSetting.ai_translation_personal_messages = "group"
         SiteSetting.ai_translation_backfill_hourly_rate = 100
 
-        english_posts =
-          Fabricate.times(
-            14,
-            :post,
-            locale: "en",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        french_post =
-          Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: target_category))
-        Fabricate.times(4, :post, topic: Fabricate(:topic, category: target_category))
-
-        PostLocalization.create!(
-          post: french_post,
-          locale: "en",
-          raw: "Translated to English",
-          cooked: "<p>Translated to English</p>",
-          post_version: french_post.version,
-          localizer_user_id: admin.id,
-        )
-
         get "/admin/plugins/discourse-ai/ai-translations.json"
 
         expect(response.status).to eq(200)
         json = response.parsed_body
 
-        expect(json["translation_progress"]).to be_an(Array)
-        expect(json["translation_progress"].length).to eq(3)
         expect(json["translation_id"]).to eq(DiscourseAi::Configuration::Module::TRANSLATION_ID)
         expect(json["enabled"]).to be_in([true, false])
-        expect(json["total"]).to eq(19)
-        expect(json["posts_with_detected_locale"]).to eq(15)
+        expect(json["translation_enabled"]).to eq(true)
         expect(json["hourly_rate"]).to eq(100)
+        expect(json["backfill_enabled"]).to be_in([true, false])
 
-        # Check structure of first locale data
-        locale_data = json["translation_progress"].first
-        expect(locale_data["locale"]).to eq("en")
-        # en is the default locale, so total should only be posts requiring translation (1 French post)
-        expect(locale_data["total"]).to eq(1)
-        # done should be 1 because we translated the French post to English
-        expect(locale_data["done"]).to eq(1)
+        expect(json).not_to have_key("translation_progress")
+        expect(json).not_to have_key("total")
+        expect(json).not_to have_key("posts_with_detected_locale")
       end
 
-      it "shows only posts requiring translation for all locales (consistent behavior)" do
-        SiteSetting.ai_translation_backfill_max_age_days = 30
-        SiteSetting.ai_translation_personal_messages = "group"
-        SiteSetting.default_locale = "en"
-
-        english_posts =
-          Fabricate.times(
-            100,
-            :post,
-            locale: "en",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        french_posts =
-          Fabricate.times(
-            10,
-            :post,
-            locale: "fr",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        spanish_posts =
-          Fabricate.times(
-            5,
-            :post,
-            locale: "es",
-            topic: Fabricate(:topic, category: target_category),
-          )
-
-        french_posts
-          .take(8)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "en",
-              raw: "Translated to English",
-              cooked: "<p>Translated to English</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-        spanish_posts
-          .take(3)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "en",
-              raw: "Translated to English",
-              cooked: "<p>Translated to English</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-
-        english_posts
-          .take(50)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "fr",
-              raw: "Translated to French",
-              cooked: "<p>Translated to French</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-
-        english_posts
-          .drop(50)
-          .take(30)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "es",
-              raw: "Translated to Spanish",
-              cooked: "<p>Translated to Spanish</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-
-        get "/admin/plugins/discourse-ai/ai-translations.json"
-
-        expect(response.status).to eq(200)
-        json = response.parsed_body
-        progress = json["translation_progress"]
-
-        en_data = progress.find { |p| p["locale"] == "en" }
-        fr_data = progress.find { |p| p["locale"] == "fr" }
-        es_data = progress.find { |p| p["locale"] == "es" }
-
-        # 15 non-English posts (10 fr + 5 es)
-        expect(en_data["total"]).to eq(15)
-        # 11 translated to English (8 fr + 3 es)
-        expect(en_data["done"]).to eq(11)
-
-        # 105 non-French posts (100 en + 5 es)
-        expect(fr_data["total"]).to eq(105)
-        # 50 translated to French
-        expect(fr_data["done"]).to eq(50)
-
-        # 110 non-Spanish posts (100 en + 10 fr)
-        expect(es_data["total"]).to eq(110)
-        # 30 translated to Spanish
-        expect(es_data["done"]).to eq(30)
-      end
-
-      it "returns empty when no locales are supported" do
+      it "returns no_locales_configured when no locales are supported" do
         SiteSetting.content_localization_supported_locales = ""
 
         get "/admin/plugins/discourse-ai/ai-translations.json"
@@ -181,10 +49,16 @@ describe DiscourseAi::Admin::AiTranslationsController do
         expect(response.status).to eq(200)
         json = response.parsed_body
 
-        expect(json["translation_progress"]).to eq([])
-        expect(json["total"]).to eq(0)
-        expect(json["posts_with_detected_locale"]).to eq(0)
         expect(json["no_locales_configured"]).to eq(true)
+      end
+
+      it "does not include no_locales_configured when locales are set" do
+        get "/admin/plugins/discourse-ai/ai-translations.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+
+        expect(json).not_to have_key("no_locales_configured")
       end
 
       it "returns translation_enabled field" do
@@ -299,6 +173,219 @@ describe DiscourseAi::Admin::AiTranslationsController do
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["enabled"]).to eq(false)
+      end
+    end
+  end
+
+  describe "#progress" do
+    context "when logged in as admin" do
+      fab!(:target_category, :category)
+
+      before do
+        Discourse.cache.clear
+        sign_in(admin)
+        SiteSetting.discourse_ai_enabled = true
+        SiteSetting.ai_translation_enabled = true
+        SiteSetting.content_localization_supported_locales = "en|fr|es"
+        SiteSetting.ai_translation_target_categories = target_category.id.to_s
+      end
+
+      it "returns translation progress data" do
+        SiteSetting.ai_translation_backfill_max_age_days = 30
+        SiteSetting.ai_translation_personal_messages = "group"
+        SiteSetting.ai_translation_backfill_hourly_rate = 100
+
+        english_posts =
+          Fabricate.times(
+            14,
+            :post,
+            locale: "en",
+            topic: Fabricate(:topic, category: target_category),
+          )
+        french_post =
+          Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: target_category))
+        Fabricate.times(4, :post, topic: Fabricate(:topic, category: target_category))
+
+        PostLocalization.create!(
+          post: french_post,
+          locale: "en",
+          raw: "Translated to English",
+          cooked: "<p>Translated to English</p>",
+          post_version: french_post.version,
+          localizer_user_id: admin.id,
+        )
+
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+
+        expect(json["translation_progress"]).to be_an(Array)
+        expect(json["translation_progress"].length).to eq(3)
+        expect(json["total"]).to eq(19)
+        expect(json["posts_with_detected_locale"]).to eq(15)
+
+        locale_data = json["translation_progress"].first
+        expect(locale_data["locale"]).to eq("en")
+        expect(locale_data["total"]).to eq(1)
+        expect(locale_data["done"]).to eq(1)
+      end
+
+      it "shows only posts requiring translation for all locales (consistent behavior)" do
+        SiteSetting.ai_translation_backfill_max_age_days = 30
+        SiteSetting.ai_translation_personal_messages = "group"
+        SiteSetting.default_locale = "en"
+
+        english_posts =
+          Fabricate.times(
+            100,
+            :post,
+            locale: "en",
+            topic: Fabricate(:topic, category: target_category),
+          )
+        french_posts =
+          Fabricate.times(
+            10,
+            :post,
+            locale: "fr",
+            topic: Fabricate(:topic, category: target_category),
+          )
+        spanish_posts =
+          Fabricate.times(
+            5,
+            :post,
+            locale: "es",
+            topic: Fabricate(:topic, category: target_category),
+          )
+
+        french_posts
+          .take(8)
+          .each do |post|
+            PostLocalization.create!(
+              post: post,
+              locale: "en",
+              raw: "Translated to English",
+              cooked: "<p>Translated to English</p>",
+              post_version: post.version,
+              localizer_user_id: admin.id,
+            )
+          end
+        spanish_posts
+          .take(3)
+          .each do |post|
+            PostLocalization.create!(
+              post: post,
+              locale: "en",
+              raw: "Translated to English",
+              cooked: "<p>Translated to English</p>",
+              post_version: post.version,
+              localizer_user_id: admin.id,
+            )
+          end
+
+        english_posts
+          .take(50)
+          .each do |post|
+            PostLocalization.create!(
+              post: post,
+              locale: "fr",
+              raw: "Translated to French",
+              cooked: "<p>Translated to French</p>",
+              post_version: post.version,
+              localizer_user_id: admin.id,
+            )
+          end
+
+        english_posts
+          .drop(50)
+          .take(30)
+          .each do |post|
+            PostLocalization.create!(
+              post: post,
+              locale: "es",
+              raw: "Translated to Spanish",
+              cooked: "<p>Translated to Spanish</p>",
+              post_version: post.version,
+              localizer_user_id: admin.id,
+            )
+          end
+
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        progress = json["translation_progress"]
+
+        en_data = progress.find { |p| p["locale"] == "en" }
+        fr_data = progress.find { |p| p["locale"] == "fr" }
+        es_data = progress.find { |p| p["locale"] == "es" }
+
+        expect(en_data["total"]).to eq(15)
+        expect(en_data["done"]).to eq(11)
+
+        expect(fr_data["total"]).to eq(105)
+        expect(fr_data["done"]).to eq(50)
+
+        expect(es_data["total"]).to eq(110)
+        expect(es_data["done"]).to eq(30)
+      end
+
+      it "returns empty when no locales are supported" do
+        SiteSetting.content_localization_supported_locales = ""
+
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+
+        expect(json["translation_progress"]).to eq([])
+        expect(json["total"]).to eq(0)
+        expect(json["posts_with_detected_locale"]).to eq(0)
+      end
+    end
+
+    context "when not logged in as admin" do
+      it "returns 404 for anonymous users" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+        expect(response.status).to eq(404)
+      end
+
+      it "returns 404 for regular users" do
+        sign_in(user)
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when plugin is disabled" do
+      before do
+        sign_in(admin)
+        SiteSetting.discourse_ai_enabled = false
+      end
+
+      it "returns 404" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when translation is not fully enabled" do
+      before do
+        sign_in(admin)
+        SiteSetting.discourse_ai_enabled = true
+        SiteSetting.ai_translation_enabled = false
+        SiteSetting.content_localization_supported_locales = "en|fr"
+      end
+
+      it "returns empty progress" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+
+        expect(json["translation_progress"]).to eq([])
+        expect(json["total"]).to eq(0)
+        expect(json["posts_with_detected_locale"]).to eq(0)
       end
     end
   end

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -31,7 +31,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
         json = response.parsed_body
 
         expect(json["translation_id"]).to eq(DiscourseAi::Configuration::Module::TRANSLATION_ID)
-        expect(json["enabled"]).to be_in([true, false])
+        expect(json["enabled"]).to eq(true)
         expect(json["translation_enabled"]).to eq(true)
         expect(json["hourly_rate"]).to eq(100)
         expect(json["backfill_enabled"]).to be_in([true, false])

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "Admin AI translations" do
   fab!(:admin)
-  let(:page_header) { PageObjects::Components::DPageHeader.new }
+  let(:translations_page) { PageObjects::Pages::AdminAiTranslations.new }
 
   before do
     enable_current_plugin
@@ -34,27 +34,25 @@ RSpec.describe "Admin AI translations" do
       SiteSetting.ai_translation_backfill_hourly_rate = 10
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
     end
 
     it "displays the translations page with chart" do
+      expect(translations_page).to have_translations_page
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.title"))
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.description"))
 
-      # Verify the action buttons are present with their CSS classes
-      expect(page).to have_css(".ai-translation-settings-button")
-      expect(page).to have_css(".ai-localization-settings-button")
+      expect(translations_page).to have_translation_settings_button
+      expect(translations_page).to have_localization_settings_button
 
-      # Verify chart container is present
-      expect(page).to have_css(".ai-translations__charts")
-      expect(page).to have_css(".ai-translations__chart")
+      expect(translations_page).to have_charts_section
+      expect(translations_page).to have_chart
     end
 
     it "navigates to translation settings when clicking the settings button" do
       translation_id = DiscourseAi::Configuration::Module::TRANSLATION_ID
       find(".ai-translation-settings-button").click
 
-      # Verify we navigated to the correct route
       expect(page).to have_current_path(
         "/admin/plugins/discourse-ai/ai-features/#{translation_id}/edit",
       )
@@ -63,7 +61,6 @@ RSpec.describe "Admin AI translations" do
     it "navigates to localization settings when clicking the localization button" do
       find(".ai-localization-settings-button").click
 
-      # Verify we navigated to the correct route
       expect(page).to have_current_path("/admin/config/localization")
     end
   end
@@ -78,17 +75,17 @@ RSpec.describe "Admin AI translations" do
       SiteSetting.ai_translation_target_categories = category.id.to_s
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
     end
 
     it "shows the toggle in off state and no chart" do
-      expect(page).to have_css(".d-toggle-switch")
+      expect(translations_page).to have_toggle
 
-      expect(page).to have_no_css(".ai-translations__chart")
+      expect(translations_page).to have_no_chart
     end
 
     it "shows localization settings button" do
-      expect(page).to have_css(".ai-localization-settings-button")
+      expect(translations_page).to have_localization_settings_button
     end
 
     it "keeps language and category selectors visible" do
@@ -104,13 +101,12 @@ RSpec.describe "Admin AI translations" do
       SiteSetting.content_localization_supported_locales = ""
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
     end
 
     it "displays the alert with locale selector" do
-      expect(page).to have_css(".alert.alert-info")
+      expect(translations_page).to have_locale_selector
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.supported_locales"))
-      expect(page).to have_css(".multi-select")
     end
 
     it "displays the category selector alongside the locale selector" do
@@ -185,37 +181,37 @@ RSpec.describe "Admin AI translations" do
     it "displays the translation toggle" do
       SiteSetting.ai_translation_enabled = false
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
 
-      expect(page).to have_css(".ai-translations__toggle-container .d-toggle-switch")
+      expect(translations_page).to have_toggle
     end
 
     it "shows charts when translations are enabled" do
       SiteSetting.ai_translation_enabled = true
       SiteSetting.ai_translation_backfill_hourly_rate = 10
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
 
-      expect(page).to have_css(".ai-translations__toggle-container")
-      expect(page).to have_css(".ai-translations__charts")
+      expect(translations_page).to have_toggle
+      expect(translations_page).to have_charts_section
     end
 
     it "hides charts when translations are disabled" do
       SiteSetting.ai_translation_enabled = false
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
 
-      expect(page).to have_css(".ai-translations__toggle-container")
-      expect(page).to have_no_css(".ai-translations__charts")
+      expect(translations_page).to have_toggle
+      expect(translations_page).to have_no_chart
     end
 
     it "keeps toggle disabled when no locales are configured" do
       SiteSetting.ai_translation_enabled = false
       SiteSetting.content_localization_supported_locales = ""
 
-      visit "/admin/plugins/discourse-ai/ai-translations"
+      translations_page.visit
 
-      expect(page).to have_css(".d-toggle-switch__checkbox[disabled]")
+      expect(translations_page).to have_toggle_disabled
     end
   end
 end

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
@@ -19,14 +19,6 @@ module PageObjects
         page.has_css?(".d-toggle-switch__checkbox[disabled]")
       end
 
-      def has_loading_spinner?
-        page.has_css?(".ai-translations .loading-container .spinner")
-      end
-
-      def has_no_loading_spinner?
-        page.has_no_css?(".ai-translations .loading-container .spinner")
-      end
-
       def has_chart?
         page.has_css?(".ai-translations__chart")
       end

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminAiTranslations < PageObjects::Pages::Base
+      def visit
+        page.visit "/admin/plugins/discourse-ai/ai-translations"
+      end
+
+      def has_translations_page?
+        page.has_css?(".ai-translations")
+      end
+
+      def has_toggle?
+        page.has_css?(".ai-translations__toggle-container .d-toggle-switch")
+      end
+
+      def has_toggle_disabled?
+        page.has_css?(".d-toggle-switch__checkbox[disabled]")
+      end
+
+      def has_loading_spinner?
+        page.has_css?(".ai-translations .loading-container .spinner")
+      end
+
+      def has_no_loading_spinner?
+        page.has_no_css?(".ai-translations .loading-container .spinner")
+      end
+
+      def has_chart?
+        page.has_css?(".ai-translations__chart")
+      end
+
+      def has_no_chart?
+        page.has_no_css?(".ai-translations__chart")
+      end
+
+      def has_charts_section?
+        page.has_css?(".ai-translations__charts")
+      end
+
+      def has_locale_selector?
+        page.has_css?(".alert.alert-info .multi-select")
+      end
+
+      def has_translation_settings_button?
+        page.has_css?(".ai-translation-settings-button")
+      end
+
+      def has_localization_settings_button?
+        page.has_css?(".ai-localization-settings-button")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, the admin AI translations page blocked rendering on an expensive SQL query (CROSS JOIN of all eligible posts × all supported locales with EXISTS subqueries) with no caching, causing multi-second blank page loads on large sites.

In this update, the endpoint is split into a fast config endpoint (show) and a lazy-loaded progress endpoint (progress), the expensive query is cached for 30 minutes (keyed by locale config), and the frontend renders the page instantly with a loading spinner while chart data loads asynchronously.

