### PR TITLE
UX: Shorten can_permanently_delete confirm button label

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8995,7 +8995,7 @@ en:
             confirm: "Yes, I understand that inactive users will be permanently deleted unless I set this value to 0"
           can_permanently_delete:
             prompt: "Enabling this allows admins to permanently destroy posts, topics, and post revisions. Permanently deleted data cannot be recovered. This may also affect data integrity and break existing links."
-            confirm: "Yes, I understand permanently deleted data cannot be recovered"
+            confirm: "I understand"
         job_status:
           completed: "Update completed"
           enqueued: "Update in progress"


### PR DESCRIPTION
The previous confirm button label ("Yes, I understand permanently deleted data cannot be recovered") was long enough to truncate on narrow widths. The modal description already conveys the consequences and an admin must type a confirmation phrase, so "I understand" is sufficient.

Ref - t/181345