### PR TITLE
FIX: Skip full app embed iframes in push notification click handler

### DIFF
--- a/app/views/static/service-worker.js.erb
+++ b/app/views/static/service-worker.js.erb
@@ -78,7 +78,13 @@ self.addEventListener('notificationclick', function(event) {
     // focuses if it is
     event.waitUntil(
       clients.matchAll({ type: "window" }).then(function (clientList) {
-        var reusedClientWindow = clientList.some(function (client) {
+        // Skip nested frames (e.g. full-app embed iframes) — we want to
+        // focus/open a standalone Discourse window, not navigate an embed.
+        var topLevelClients = clientList.filter(function (client) {
+          return client.frameType !== "nested";
+        });
+
+        var reusedClientWindow = topLevelClients.some(function (client) {
           if (client.url === baseUrl + url && "focus" in client) {
             client.focus();
             return true;


### PR DESCRIPTION
**Previously**, clicking a web push notification could focus a full app embed iframe on an external page and navigate it to the target URL (via `postMessage({ url })` → router transition), instead of opening or focusing a standalone Discourse window.

**In this update**, the service worker's `notificationclick` handler filters out clients with `frameType === "nested"` before considering them for reuse, so embed iframes are ignored and a real top-level Discourse window is focused — or a new one is opened via `clients.openWindow` when none exists.