### PR TITLE
FEATURE: Allow editing a post's reply target from the composer

### DIFF
--- a/app/assets/stylesheets/common/modal/_index.scss
+++ b/app/assets/stylesheets/common/modal/_index.scss
@@ -1,3 +1,4 @@
 @import "modal-overrides";
 @import "user-status";
 @import "discourse-reactions-popup";
+@import "change-reply-to";

--- a/app/assets/stylesheets/common/modal/change-reply-to.scss
+++ b/app/assets/stylesheets/common/modal/change-reply-to.scss
@@ -1,0 +1,50 @@
+.change-reply-to-modal {
+  .d-modal__container {
+    max-width: 720px;
+    width: 100%;
+  }
+
+  .d-modal__body {
+    padding-bottom: 0;
+  }
+
+  .change-reply-to-modal__hint,
+  .change-reply-to-modal__selection {
+    margin: 0 0 var(--space-2) 0;
+    color: var(--primary-medium);
+  }
+
+  // Re-flow the fullscreen timeline inline inside the modal body.
+  .timeline-container.timeline-fullscreen {
+    position: static;
+    max-height: none;
+    padding: var(--space-2) 0 0 0;
+    margin: 0;
+    box-shadow: none;
+    border-top: none;
+    background-color: transparent;
+    z-index: auto;
+
+    &.show {
+      max-height: none;
+    }
+
+    .topic-timeline {
+      display: block;
+      width: auto;
+      table-layout: auto;
+    }
+
+    // The timeline footer has "jump to post" and notification controls that
+    // are irrelevant inside this picker; hide them.
+    .timeline-footer-controls {
+      display: none;
+    }
+
+    // Keep the excerpt readable; the fullscreen styles line-clamp to 8 which
+    // is fine here too.
+    .post-excerpt {
+      margin-bottom: var(--space-2);
+    }
+  }
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -232,6 +232,10 @@ class PostsController < ApplicationController
       locale: params[:post][:locale],
     }
 
+    if params[:post].key?(:reply_to_post_number)
+      changes[:reply_to_post_number] = params[:post][:reply_to_post_number]
+    end
+
     Post.plugin_permitted_update_params.keys.each { |param| changes[param] = params[:post][param] }
 
     # keep `raw_old` for backwards compatibility

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -586,7 +586,8 @@ class PostsController < ApplicationController
     guardian.ensure_can_edit!(post)
     if post_revision.modifications["raw"].blank? && post_revision.modifications["title"].blank? &&
          post_revision.modifications["category_id"].blank? &&
-         post_revision.modifications["tags"].blank?
+         post_revision.modifications["tags"].blank? &&
+         post_revision.modifications["reply_to_post_number"].blank?
       return render_json_error(I18n.t("revert_version_same"))
     end
 
@@ -596,6 +597,10 @@ class PostsController < ApplicationController
     changes[:raw] = post_revision.modifications["raw"][0] if post_revision.modifications[
       "raw"
     ].present? && post_revision.modifications["raw"][0] != post.raw
+    if post_revision.modifications["reply_to_post_number"].present? &&
+         post_revision.modifications["reply_to_post_number"][0] != post.reply_to_post_number
+      changes[:reply_to_post_number] = post_revision.modifications["reply_to_post_number"][0]
+    end
     if post.is_first_post?
       changes[:title] = post_revision.modifications["title"][0] if post_revision.modifications[
         "title"

--- a/app/models/concerns/has_nested_reply_stats.rb
+++ b/app/models/concerns/has_nested_reply_stats.rb
@@ -8,19 +8,79 @@ module HasNestedReplyStats
     after_destroy :nested_replies_decrement_stats
   end
 
+  # Moves this post's subtree from `previous_reply_to_post_number` to its
+  # current `reply_to_post_number` on the nested stats tree. Shared ancestors
+  # are left alone — their total descendant count is unchanged — while
+  # ancestors unique to either chain are adjusted by this post's subtree size.
+  def nested_replies_apply_reparent(previous_reply_to_post_number)
+    return unless SiteSetting.nested_replies_enabled
+    return if previous_reply_to_post_number == reply_to_post_number
+
+    subtree_size, whisper_subtree_size = nested_replies_subtree_sizes
+    is_whisper = post_type == Post.types[:whisper] ? 1 : 0
+
+    old_ancestors = nested_replies_walk(previous_reply_to_post_number)
+    new_ancestors = nested_replies_walk(reply_to_post_number)
+
+    old_ids = old_ancestors.map(&:id)
+    new_ids = new_ancestors.map(&:id)
+    old_only_ids = old_ids - new_ids
+    new_only_ids = new_ids - old_ids
+
+    old_direct_parent_id = old_ancestors.find { |a| a.depth == 1 }&.id
+    new_direct_parent_id = new_ancestors.find { |a| a.depth == 1 }&.id
+
+    if old_only_ids.any?
+      DB.exec(<<~SQL, ids: old_only_ids, subtree: subtree_size, whisper: whisper_subtree_size)
+        UPDATE nested_view_post_stats
+        SET total_descendant_count = GREATEST(total_descendant_count - :subtree, 0),
+            whisper_total_descendant_count = GREATEST(whisper_total_descendant_count - :whisper, 0),
+            updated_at = NOW()
+        WHERE post_id = ANY(ARRAY[:ids]::int[])
+      SQL
+    end
+
+    if new_only_ids.any?
+      DB.exec(<<~SQL, ids: new_only_ids, subtree: subtree_size, whisper: whisper_subtree_size)
+        INSERT INTO nested_view_post_stats (post_id, direct_reply_count, total_descendant_count,
+                                             whisper_direct_reply_count, whisper_total_descendant_count,
+                                             created_at, updated_at)
+        SELECT aid, 0, :subtree, 0, :whisper, NOW(), NOW()
+        FROM unnest(ARRAY[:ids]::int[]) AS aid
+        ON CONFLICT (post_id) DO UPDATE SET
+          total_descendant_count = nested_view_post_stats.total_descendant_count + :subtree,
+          whisper_total_descendant_count = nested_view_post_stats.whisper_total_descendant_count + :whisper,
+          updated_at = NOW()
+      SQL
+    end
+
+    DB.exec(<<~SQL, id: old_direct_parent_id, is_whisper: is_whisper) if old_direct_parent_id
+        UPDATE nested_view_post_stats
+        SET direct_reply_count = GREATEST(direct_reply_count - 1, 0),
+            whisper_direct_reply_count = GREATEST(whisper_direct_reply_count - :is_whisper, 0),
+            updated_at = NOW()
+        WHERE post_id = :id
+      SQL
+
+    DB.exec(<<~SQL, id: new_direct_parent_id, is_whisper: is_whisper) if new_direct_parent_id
+        INSERT INTO nested_view_post_stats (post_id, direct_reply_count, total_descendant_count,
+                                             whisper_direct_reply_count, whisper_total_descendant_count,
+                                             created_at, updated_at)
+        VALUES (:id, 1, 0, :is_whisper, 0, NOW(), NOW())
+        ON CONFLICT (post_id) DO UPDATE SET
+          direct_reply_count = nested_view_post_stats.direct_reply_count + 1,
+          whisper_direct_reply_count = nested_view_post_stats.whisper_direct_reply_count + :is_whisper,
+          updated_at = NOW()
+      SQL
+  end
+
   private
 
   def nested_replies_increment_stats
     return unless SiteSetting.nested_replies_enabled
     return if reply_to_post_number.blank?
 
-    ancestors =
-      NestedReplies.walk_ancestors(
-        topic_id: topic_id,
-        start_post_number: reply_to_post_number,
-        exclude_deleted: false,
-      )
-
+    ancestors = nested_replies_walk(reply_to_post_number)
     return if ancestors.empty?
 
     ancestor_ids = ancestors.map(&:id).uniq
@@ -52,25 +112,10 @@ module HasNestedReplyStats
   def nested_replies_decrement_stats
     return unless SiteSetting.nested_replies_enabled
     if reply_to_post_number.present?
-      stat =
-        NestedViewPostStat.where(post_id: id).pick(
-          :total_descendant_count,
-          :whisper_total_descendant_count,
-        )
-      my_descendants = stat&.first || 0
-      my_whisper_descendants = stat&.second || 0
-      removed = 1 + my_descendants
+      subtree_size, whisper_subtree_size = nested_replies_subtree_sizes
       is_whisper = post_type == Post.types[:whisper] ? 1 : 0
-      whisper_removed = is_whisper + my_whisper_descendants
 
-      # Include deleted ancestors — they may still have stat rows from when
-      # they were alive, and those counts need to be decremented.
-      ancestors =
-        NestedReplies.walk_ancestors(
-          topic_id: topic_id,
-          start_post_number: reply_to_post_number,
-          exclude_deleted: false,
-        )
+      ancestors = nested_replies_walk(reply_to_post_number)
 
       if ancestors.present?
         ancestor_ids = ancestors.map(&:id)
@@ -94,13 +139,34 @@ module HasNestedReplyStats
         SQL
           ids: ancestor_ids,
           parent_id: direct_parent_id,
-          removed: removed,
-          whisper_removed: whisper_removed,
+          removed: subtree_size,
+          whisper_removed: whisper_subtree_size,
           is_whisper: is_whisper,
         )
       end
     end
 
     NestedViewPostStat.where(post_id: id).delete_all
+  end
+
+  def nested_replies_subtree_sizes
+    stat =
+      NestedViewPostStat.where(post_id: id).pick(
+        :total_descendant_count,
+        :whisper_total_descendant_count,
+      )
+    is_whisper = post_type == Post.types[:whisper] ? 1 : 0
+    [1 + (stat&.first || 0), is_whisper + (stat&.second || 0)]
+  end
+
+  def nested_replies_walk(start_post_number)
+    return [] if start_post_number.blank?
+    # Include deleted ancestors — they may still have stat rows from when they
+    # were alive, and those counts need to stay consistent.
+    NestedReplies.walk_ancestors(
+      topic_id: topic_id,
+      start_post_number: start_post_number,
+      exclude_deleted: false,
+    )
   end
 end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -338,11 +338,16 @@ class PostRevisionSerializer < ApplicationSerializer
 
     target = Post.where(topic_id: topic.id, post_number: post_number).first
     info = { post_number: post_number }
-    if target&.user
+
+    # Only enrich with the target's author if the current viewer can see
+    # that post. Deleted posts, whispers, and posts in restricted
+    # categories must not leak their author through the revision history.
+    if target && scope.can_see?(target) && target.user
       info[:username] = target.user.username_lower
       info[:display_username] = target.user.username
       info[:avatar_template] = target.user.avatar_template
     end
+
     info
   end
 end

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -25,6 +25,7 @@ class PostRevisionSerializer < ApplicationSerializer
              :body_changes,
              :title_changes,
              :user_changes,
+             :reply_to_post_number_changes,
              :tags_changes,
              :category_id_changes,
              :can_edit,
@@ -186,6 +187,17 @@ class PostRevisionSerializer < ApplicationSerializer
     previous["user_id"] != current["user_id"]
   end
 
+  def reply_to_post_number_changes
+    {
+      previous: reply_to_info(previous["reply_to_post_number"]),
+      current: reply_to_info(current["reply_to_post_number"]),
+    }
+  end
+
+  def include_reply_to_post_number_changes?
+    previous["reply_to_post_number"] != current["reply_to_post_number"]
+  end
+
   def tags_changes
     pre = filter_tags previous["tags"]
     cur = filter_tags current["tags"]
@@ -243,6 +255,7 @@ class PostRevisionSerializer < ApplicationSerializer
       "post_type" => [post.post_type],
       "user_id" => [post.user_id],
       "locale" => [post.locale],
+      "reply_to_post_number" => [post.reply_to_post_number],
     }
 
     # Retrieve any `tracked_topic_fields`
@@ -318,5 +331,18 @@ class PostRevisionSerializer < ApplicationSerializer
   def filter_category_id(category_id)
     return if category_id.blank?
     Category.secured(scope).find_by(id: category_id)&.id
+  end
+
+  def reply_to_info(post_number)
+    return nil if post_number.blank?
+
+    target = Post.where(topic_id: topic.id, post_number: post_number).first
+    info = { post_number: post_number }
+    if target&.user
+      info[:username] = target.user.username_lower
+      info[:display_username] = target.user.username
+      info[:avatar_template] = target.user.avatar_template
+    end
+    info
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4741,6 +4741,8 @@ en:
         locale:
           no_locale_set: "No language set"
           locale_removed: "Language removed"
+        reply_to:
+          none: "No reply target"
         controls:
           first: "First revision"
           previous: "Previous revision"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3139,7 +3139,7 @@ en:
         post_number_label: "Post number"
         submit: "Set reply target"
         open: "Change which post this replies to"
-        remove: "No longer a reply to anyone"
+        remove: "Remove reply target"
         not_found: "No post with that number was found in this topic."
 
       group_mentioned_limit:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3135,12 +3135,12 @@ en:
 
       change_reply_to:
         title: "Change reply target"
-        description: "Enter the post number this post should reply to (1–%{max})."
-        post_number_label: "Post number"
+        hint: "Scroll the timeline to find the post you'd like to reply to."
+        current_selection: "Selected: post #%{post_number} by @%{username}"
+        invalid_target: "Choose a post earlier than the one you're editing."
         submit: "Set reply target"
         open: "Change which post this replies to"
         remove: "Remove reply target"
-        not_found: "No post with that number was found in this topic."
 
       group_mentioned_limit:
         one: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} user. Nobody will be notified."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3140,6 +3140,7 @@ en:
         invalid_target: "Choose a post earlier than the one you're editing."
         submit: "Set reply target"
         open: "Change which post this replies to"
+        open_from_menu: "Reply to another post"
         remove: "Remove reply target"
 
       group_mentioned_limit:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3133,6 +3133,15 @@ en:
         placeholder: "Enter translation for post here..."
         show_raw_markdown: "Show raw"
 
+      change_reply_to:
+        title: "Change reply target"
+        description: "Enter the post number this post should reply to (1–%{max})."
+        post_number_label: "Post number"
+        submit: "Set reply target"
+        open: "Change which post this replies to"
+        remove: "No longer a reply to anyone"
+        not_found: "No post with that number was found in this topic."
+
       group_mentioned_limit:
         one: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} user. Nobody will be notified."
         other: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} users. Nobody will be notified."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -917,6 +917,8 @@ en:
     change_failed_explanation: "You attempted to demote %{user_name} to '%{new_trust_level}'. However their trust level is already '%{current_trust_level}'. %{user_name} will remain at '%{current_trust_level}' - if you wish to demote user lock trust level first"
 
   post:
+    errors:
+      invalid_reply_to: "The selected post isn't a valid reply target. It must be an earlier post in the same topic."
     image_placeholder:
       broken: "This image is broken"
       blocked_hotlinked_title: "Image hosted on another site. Click to open in a new tab."

--- a/frontend/discourse/app/components/composer-action-title.gjs
+++ b/frontend/discourse/app/components/composer-action-title.gjs
@@ -1,11 +1,11 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { action, computed, set } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
-import DButton from "discourse/components/d-button";
 import ChangeReplyTo from "discourse/components/modal/change-reply-to";
 import escape from "discourse/lib/escape";
 import { iconHTML } from "discourse/lib/icon-library";
@@ -64,11 +64,6 @@ export default class ComposerActionTitle extends Component {
   }
 
   @action
-  removeReplyTo() {
-    this.model?.setReplyTo(null, null);
-  }
-
-  @action
   openChangeReplyToModal() {
     const model = this.model;
     this.modal.show(ChangeReplyTo, {
@@ -77,6 +72,10 @@ export default class ComposerActionTitle extends Component {
         editingPostNumber: model.post?.post_number,
         currentPostNumber: model.reply_to_post_number,
         onSelect: (post) => {
+          if (!post) {
+            model.setReplyTo(null, null);
+            return;
+          }
           model.setReplyTo(post.post_number, {
             id: post.user_id,
             username: post.username,
@@ -119,29 +118,31 @@ export default class ComposerActionTitle extends Component {
         return this._formatEditUserPost(
           this.options.userAvatar,
           this.options.userLink,
-          this.options.postLink,
-          this.options.originalUser
+          this.options.postLink
         );
       }
     }
   }
 
-  _formatEditUserPost(userAvatar, userLink, postLink, originalUser) {
-    let editTitle = `
+  @computed("options.originalUser")
+  get replyTargetSegment() {
+    const originalUser = this.options?.originalUser;
+    if (!originalUser) {
+      return null;
+    }
+    return trustHTML(
+      `${iconHTML("share", { class: "reply-to-glyph" })}
+       ${originalUser.avatar}
+       <span class="original-username">${escape(originalUser.username)}</span>`
+    );
+  }
+
+  _formatEditUserPost(userAvatar, userLink, postLink) {
+    return trustHTML(`
       <a class="post-link" href="${postLink.href}">${postLink.anchor}</a>
       ${userAvatar}
       <span class="username">${escape(userLink.anchor)}</span>
-    `;
-
-    if (originalUser) {
-      editTitle += `
-        ${iconHTML("share", { class: "reply-to-glyph" })}
-        ${originalUser.avatar}
-        <span class="original-username">${escape(originalUser.username)}</span>
-      `;
-    }
-
-    return trustHTML(editTitle);
+    `);
   }
 
   _formatReplyToTopic(link) {
@@ -177,26 +178,19 @@ export default class ComposerActionTitle extends Component {
 
       <span class="action-title" role="heading" aria-level="1">
         {{this.actionTitle}}
-      </span>
-
-      {{#if this.canEditReplyTo}}
-        <span class="composer-edit-reply-to">
-          <DButton
-            @icon="pencil"
-            @action={{this.openChangeReplyToModal}}
-            @title="composer.change_reply_to.open"
-            class="btn-flat composer-edit-reply-to__change"
-          />
-          {{#if this.model.reply_to_post_number}}
-            <DButton
-              @icon="xmark"
-              @action={{this.removeReplyTo}}
-              @title="composer.change_reply_to.remove"
-              class="btn-flat composer-edit-reply-to__remove"
-            />
+        {{#if this.replyTargetSegment}}
+          {{#if this.canEditReplyTo}}
+            <button
+              type="button"
+              class="composer-edit-reply-to"
+              title={{i18n "composer.change_reply_to.open"}}
+              {{on "click" this.openChangeReplyToModal}}
+            >{{this.replyTargetSegment}}</button>
+          {{else}}
+            {{this.replyTargetSegment}}
           {{/if}}
-        </span>
-      {{/if}}
+        {{/if}}
+      </span>
     </div>
   </template>
 }

--- a/frontend/discourse/app/components/composer-action-title.gjs
+++ b/frontend/discourse/app/components/composer-action-title.gjs
@@ -1,9 +1,12 @@
 /* eslint-disable ember/no-classic-components */
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
-import { computed, set } from "@ember/object";
+import { action, computed, set } from "@ember/object";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
+import DButton from "discourse/components/d-button";
+import ChangeReplyTo from "discourse/components/modal/change-reply-to";
 import escape from "discourse/lib/escape";
 import { iconHTML } from "discourse/lib/icon-library";
 import {
@@ -31,6 +34,8 @@ export default class ComposerActionTitle extends Component {
   // Note we update when some other attributes like tag/category change to allow
   // text customizations to use those.
 
+  @service modal;
+
   @computed("model.replyOptions")
   get options() {
     return this.model?.replyOptions;
@@ -47,6 +52,40 @@ export default class ComposerActionTitle extends Component {
 
   set action(value) {
     set(this, "model.action", value);
+  }
+
+  @computed("action", "model.post.can_edit", "model.topic")
+  get canEditReplyTo() {
+    return (
+      this.action === EDIT &&
+      !!this.model?.post?.can_edit &&
+      !!this.model?.topic
+    );
+  }
+
+  @action
+  removeReplyTo() {
+    this.model?.setReplyTo(null, null);
+  }
+
+  @action
+  openChangeReplyToModal() {
+    const model = this.model;
+    this.modal.show(ChangeReplyTo, {
+      model: {
+        topic: model.topic,
+        editingPostNumber: model.post?.post_number,
+        currentPostNumber: model.reply_to_post_number,
+        onSelect: (post) => {
+          model.setReplyTo(post.post_number, {
+            id: post.user_id,
+            username: post.username,
+            name: post.name,
+            avatar_template: post.avatar_template,
+          });
+        },
+      },
+    });
   }
 
   @computed("options", "action", "model.tags", "model.category")
@@ -140,6 +179,24 @@ export default class ComposerActionTitle extends Component {
         {{this.actionTitle}}
       </span>
 
+      {{#if this.canEditReplyTo}}
+        <span class="composer-edit-reply-to">
+          <DButton
+            @icon="pencil"
+            @action={{this.openChangeReplyToModal}}
+            @title="composer.change_reply_to.open"
+            class="btn-flat composer-edit-reply-to__change"
+          />
+          {{#if this.model.reply_to_post_number}}
+            <DButton
+              @icon="xmark"
+              @action={{this.removeReplyTo}}
+              @title="composer.change_reply_to.remove"
+              class="btn-flat composer-edit-reply-to__remove"
+            />
+          {{/if}}
+        </span>
+      {{/if}}
     </div>
   </template>
 }

--- a/frontend/discourse/app/components/composer-action-title.gjs
+++ b/frontend/discourse/app/components/composer-action-title.gjs
@@ -6,7 +6,6 @@ import { action, computed, set } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
-import ChangeReplyTo from "discourse/components/modal/change-reply-to";
 import escape from "discourse/lib/escape";
 import { iconHTML } from "discourse/lib/icon-library";
 import {
@@ -34,7 +33,7 @@ export default class ComposerActionTitle extends Component {
   // Note we update when some other attributes like tag/category change to allow
   // text customizations to use those.
 
-  @service modal;
+  @service composer;
 
   @computed("model.replyOptions")
   get options() {
@@ -65,26 +64,7 @@ export default class ComposerActionTitle extends Component {
 
   @action
   openChangeReplyToModal() {
-    const model = this.model;
-    this.modal.show(ChangeReplyTo, {
-      model: {
-        topic: model.topic,
-        editingPostNumber: model.post?.post_number,
-        currentPostNumber: model.reply_to_post_number,
-        onSelect: (post) => {
-          if (!post) {
-            model.setReplyTo(null, null);
-            return;
-          }
-          model.setReplyTo(post.post_number, {
-            id: post.user_id,
-            username: post.username,
-            name: post.name,
-            avatar_template: post.avatar_template,
-          });
-        },
-      },
-    });
+    this.composer.openChangeReplyToModal();
   }
 
   @computed("options", "action", "model.tags", "model.category")

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -32,6 +32,10 @@ export default class ChangeReplyTo extends Component {
     this.flash = null;
   }
 
+  get canRemove() {
+    return !!this.args.model.currentPostNumber;
+  }
+
   @action
   async submit() {
     const postNumber = parseInt(this.postNumber, 10);
@@ -53,6 +57,12 @@ export default class ChangeReplyTo extends Component {
     } catch (e) {
       this.flash = extractError(e);
     }
+  }
+
+  @action
+  remove() {
+    this.args.model.onSelect(null);
+    this.args.closeModal();
   }
 
   <template>
@@ -83,6 +93,13 @@ export default class ChangeReplyTo extends Component {
           @disabled={{this.submitDisabled}}
           class="btn-primary"
         />
+        {{#if this.canRemove}}
+          <DButton
+            @action={{this.remove}}
+            @label="composer.change_reply_to.remove"
+            class="btn-danger"
+          />
+        {{/if}}
         <DButton @action={{@closeModal}} @label="cancel" />
       </:footer>
     </DModal>

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -1,35 +1,32 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
+import TopicTimeline from "discourse/components/topic-timeline";
 import { extractError } from "discourse/lib/ajax-error";
+import { not } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 export default class ChangeReplyTo extends Component {
-  @tracked postNumber = this.args.model.currentPostNumber ?? "";
-  @tracked flash;
+  @tracked selectedPost = null;
+  @tracked flash = null;
 
-  get maxPostNumber() {
-    return this.args.model.editingPostNumber - 1;
+  noop = () => {};
+
+  get topic() {
+    return this.args.model.topic;
   }
 
-  get submitDisabled() {
-    const n = parseInt(this.postNumber, 10);
-    if (isNaN(n) || n <= 0) {
-      return true;
-    }
-    if (n >= this.args.model.editingPostNumber) {
-      return true;
-    }
-    return false;
+  get editingPostNumber() {
+    return this.args.model.editingPostNumber;
   }
 
-  @action
-  updatePostNumber(event) {
-    this.postNumber = event.target.value;
-    this.flash = null;
+  get canSubmit() {
+    return (
+      !!this.selectedPost &&
+      this.selectedPost.post_number < this.editingPostNumber
+    );
   }
 
   get canRemove() {
@@ -37,26 +34,56 @@ export default class ChangeReplyTo extends Component {
   }
 
   @action
-  async submit() {
-    const postNumber = parseInt(this.postNumber, 10);
-    const postStream = this.args.model.topic?.postStream;
+  async handleJumpToIndex(index) {
+    await this.captureSelectionForIndex(index);
+  }
 
+  @action
+  async handleJumpTop() {
+    await this.captureSelectionForIndex(1);
+  }
+
+  @action
+  async handleJumpBottom() {
+    const total = this.topic?.postStream?.filteredPostsCount;
+    if (total) {
+      await this.captureSelectionForIndex(total);
+    }
+  }
+
+  async captureSelectionForIndex(streamIndex) {
+    const postStream = this.topic?.postStream;
+    if (!postStream) {
+      return;
+    }
+    const postId = postStream.stream[streamIndex - 1];
+    if (!postId) {
+      return;
+    }
     try {
-      let post = postStream?.postForPostNumber(postNumber);
-      if (!post && postStream) {
-        post = await postStream.loadPostByPostNumber(postNumber);
-      }
-
+      let post = postStream.findLoadedPost(postId);
       if (!post) {
-        this.flash = i18n("composer.change_reply_to.not_found");
+        post = await postStream.loadPost(postId);
+      }
+      if (post.post_number >= this.editingPostNumber) {
+        this.flash = i18n("composer.change_reply_to.invalid_target");
+        this.selectedPost = null;
         return;
       }
-
-      this.args.model.onSelect(post);
-      this.args.closeModal();
+      this.flash = null;
+      this.selectedPost = post;
     } catch (e) {
       this.flash = extractError(e);
     }
+  }
+
+  @action
+  submit() {
+    if (!this.canSubmit) {
+      return;
+    }
+    this.args.model.onSelect(this.selectedPost);
+    this.args.closeModal();
   }
 
   @action
@@ -73,24 +100,51 @@ export default class ChangeReplyTo extends Component {
       class="change-reply-to-modal"
     >
       <:body>
-        <p>{{i18n
-            "composer.change_reply_to.description"
-            max=this.maxPostNumber
-          }}</p>
-        <input
-          type="number"
-          min="1"
-          max={{this.maxPostNumber}}
-          value={{this.postNumber}}
-          {{on "input" this.updatePostNumber}}
-          aria-label={{i18n "composer.change_reply_to.post_number_label"}}
+        {{#if this.selectedPost}}
+          <p class="change-reply-to-modal__selection">
+            {{i18n
+              "composer.change_reply_to.current_selection"
+              post_number=this.selectedPost.post_number
+              username=this.selectedPost.username
+            }}
+          </p>
+        {{else}}
+          <p class="change-reply-to-modal__hint">
+            {{i18n "composer.change_reply_to.hint"}}
+          </p>
+        {{/if}}
+
+        <TopicTimeline
+          @model={{this.topic}}
+          @fullscreen={{true}}
+          @enteredIndex={{0}}
+          @jumpTop={{this.handleJumpTop}}
+          @jumpBottom={{this.handleJumpBottom}}
+          @jumpEnd={{this.handleJumpBottom}}
+          @jumpToIndex={{this.handleJumpToIndex}}
+          @jumpToPostPrompt={{this.noop}}
+          @replyToPost={{this.noop}}
+          @showTopReplies={{this.noop}}
+          @toggleMultiSelect={{this.noop}}
+          @showTopicSlowModeUpdate={{this.noop}}
+          @deleteTopic={{this.noop}}
+          @recoverTopic={{this.noop}}
+          @toggleClosed={{this.noop}}
+          @toggleArchived={{this.noop}}
+          @toggleVisibility={{this.noop}}
+          @showTopicTimerModal={{this.noop}}
+          @showFeatureTopic={{this.noop}}
+          @showChangeTimestamp={{this.noop}}
+          @resetBumpDate={{this.noop}}
+          @convertToPublicTopic={{this.noop}}
+          @convertToPrivateMessage={{this.noop}}
         />
       </:body>
       <:footer>
         <DButton
           @action={{this.submit}}
           @label="composer.change_reply_to.submit"
-          @disabled={{this.submitDisabled}}
+          @disabled={{not this.canSubmit}}
           class="btn-primary"
         />
         {{#if this.canRemove}}

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -33,6 +33,19 @@ export default class ChangeReplyTo extends Component {
     return !!this.args.model.currentPostNumber;
   }
 
+  get initialEnteredIndex() {
+    const postNumber = this.args.model.currentPostNumber;
+    if (!postNumber) {
+      return 0;
+    }
+    const postStream = this.topic?.postStream;
+    const post = postStream?.postForPostNumber?.(postNumber);
+    if (!post) {
+      return 0;
+    }
+    return postStream.progressIndexOfPost(post);
+  }
+
   @action
   async handleJumpToIndex(index) {
     await this.captureSelectionForIndex(index);
@@ -117,7 +130,7 @@ export default class ChangeReplyTo extends Component {
         <TopicTimeline
           @model={{this.topic}}
           @fullscreen={{true}}
-          @enteredIndex={{0}}
+          @enteredIndex={{this.initialEnteredIndex}}
           @jumpTop={{this.handleJumpTop}}
           @jumpBottom={{this.handleJumpBottom}}
           @jumpEnd={{this.handleJumpBottom}}

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -68,19 +68,32 @@ export default class ChangeReplyTo extends Component {
     }
   }
 
-  async captureSelectionForIndex(streamIndex) {
+  async captureSelectionForIndex(timelineIndex) {
     const postStream = this.topic?.postStream;
-    if (!postStream) {
+    if (!postStream || !timelineIndex) {
       return;
     }
-    const postId = postStream.stream[streamIndex - 1];
-    if (!postId) {
-      return;
-    }
+
     try {
-      let post = postStream.findLoadedPost(postId);
+      let post;
+      if (postStream.isMegaTopic) {
+        // On mega topics the timeline's `current` / jump callbacks are
+        // post numbers, not stream positions — see `filteredPostsCount`.
+        post =
+          postStream.postForPostNumber(timelineIndex) ||
+          (await postStream.loadPostByPostNumber(timelineIndex));
+      } else {
+        const postId = postStream.stream[timelineIndex - 1];
+        if (!postId) {
+          return;
+        }
+        post =
+          postStream.findLoadedPost(postId) ||
+          (await postStream.loadPost(postId));
+      }
+
       if (!post) {
-        post = await postStream.loadPost(postId);
+        return;
       }
       if (post.post_number >= this.editingPostNumber) {
         this.flash = i18n("composer.change_reply_to.invalid_target");

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -43,7 +43,11 @@ export default class ChangeReplyTo extends Component {
     if (!post) {
       return 0;
     }
-    return postStream.progressIndexOfPost(post);
+    // `TopicTimeline` treats `@enteredIndex` as 0-based (see how its
+    // `prevEvent.postIndex - 1` branch maps a 1-based event index back
+    // down), while `progressIndexOfPost` returns 1-based. Subtract one
+    // so the scrubber lands exactly on the current target.
+    return Math.max(0, postStream.progressIndexOfPost(post) - 1);
   }
 
   @action

--- a/frontend/discourse/app/components/modal/change-reply-to.gjs
+++ b/frontend/discourse/app/components/modal/change-reply-to.gjs
@@ -1,0 +1,90 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import DButton from "discourse/components/d-button";
+import DModal from "discourse/components/d-modal";
+import { extractError } from "discourse/lib/ajax-error";
+import { i18n } from "discourse-i18n";
+
+export default class ChangeReplyTo extends Component {
+  @tracked postNumber = this.args.model.currentPostNumber ?? "";
+  @tracked flash;
+
+  get maxPostNumber() {
+    return this.args.model.editingPostNumber - 1;
+  }
+
+  get submitDisabled() {
+    const n = parseInt(this.postNumber, 10);
+    if (isNaN(n) || n <= 0) {
+      return true;
+    }
+    if (n >= this.args.model.editingPostNumber) {
+      return true;
+    }
+    return false;
+  }
+
+  @action
+  updatePostNumber(event) {
+    this.postNumber = event.target.value;
+    this.flash = null;
+  }
+
+  @action
+  async submit() {
+    const postNumber = parseInt(this.postNumber, 10);
+    const postStream = this.args.model.topic?.postStream;
+
+    try {
+      let post = postStream?.postForPostNumber(postNumber);
+      if (!post && postStream) {
+        post = await postStream.loadPostByPostNumber(postNumber);
+      }
+
+      if (!post) {
+        this.flash = i18n("composer.change_reply_to.not_found");
+        return;
+      }
+
+      this.args.model.onSelect(post);
+      this.args.closeModal();
+    } catch (e) {
+      this.flash = extractError(e);
+    }
+  }
+
+  <template>
+    <DModal
+      @closeModal={{@closeModal}}
+      @title={{i18n "composer.change_reply_to.title"}}
+      @flash={{this.flash}}
+      class="change-reply-to-modal"
+    >
+      <:body>
+        <p>{{i18n
+            "composer.change_reply_to.description"
+            max=this.maxPostNumber
+          }}</p>
+        <input
+          type="number"
+          min="1"
+          max={{this.maxPostNumber}}
+          value={{this.postNumber}}
+          {{on "input" this.updatePostNumber}}
+          aria-label={{i18n "composer.change_reply_to.post_number_label"}}
+        />
+      </:body>
+      <:footer>
+        <DButton
+          @action={{this.submit}}
+          @label="composer.change_reply_to.submit"
+          @disabled={{this.submitDisabled}}
+          class="btn-primary"
+        />
+        <DButton @action={{@closeModal}} @label="cancel" />
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/app/components/modal/history.gjs
+++ b/frontend/discourse/app/components/modal/history.gjs
@@ -231,13 +231,19 @@ export default class History extends Component {
         );
       }
       if (result.post) {
-        // `PostSerializer` omits `reply_to_user` when nil, so the post's
-        // in-memory value isn't cleared after a revert that removes the
-        // reply target. Explicitly mirror the reverted state onto the post.
-        post.setProperties({
+        // `PostSerializer` omits `reply_to_user` when the user is nil OR
+        // when `suppress_reply_when_quoting` is on and the post quotes its
+        // target. Treat a missing key as "leave alone" — only clear it
+        // when the post number is also cleared.
+        const props = {
           reply_to_post_number: result.post.reply_to_post_number ?? null,
-          reply_to_user: result.post.reply_to_user ?? null,
-        });
+        };
+        if ("reply_to_user" in result.post) {
+          props.reply_to_user = result.post.reply_to_user;
+        } else if (result.post.reply_to_post_number == null) {
+          props.reply_to_user = null;
+        }
+        post.setProperties(props);
       }
       this.args.closeModal();
     } catch (e) {

--- a/frontend/discourse/app/components/modal/history.gjs
+++ b/frontend/discourse/app/components/modal/history.gjs
@@ -230,6 +230,15 @@ export default class History extends Component {
           await Category.asyncFindById(result.category_id)
         );
       }
+      if (result.post) {
+        // `PostSerializer` omits `reply_to_user` when nil, so the post's
+        // in-memory value isn't cleared after a revert that removes the
+        // reply target. Explicitly mirror the reverted state onto the post.
+        post.setProperties({
+          reply_to_post_number: result.post.reply_to_post_number ?? null,
+          reply_to_user: result.post.reply_to_user ?? null,
+        });
+      }
       this.args.closeModal();
     } catch (e) {
       if (e.jqXHR.responseJSON?.errors?.[0]) {

--- a/frontend/discourse/app/components/modal/history/revision.gjs
+++ b/frontend/discourse/app/components/modal/history/revision.gjs
@@ -61,6 +61,47 @@ export default class Revision extends Component {
               {{@model.user_changes.current.username}}
             {{/if}}
 
+            {{#if @model.reply_to_post_number_changes}}
+              <span class="reply-to-changes">
+                {{icon "share"}}
+                {{#if @model.reply_to_post_number_changes.previous}}
+                  <span
+                  >#{{@model.reply_to_post_number_changes.previous.post_number}}</span>
+                  {{#if
+                    @model.reply_to_post_number_changes.previous.avatar_template
+                  }}
+                    {{boundAvatarTemplate
+                      @model.reply_to_post_number_changes.previous.avatar_template
+                      "small"
+                    }}
+                    {{@model.reply_to_post_number_changes.previous.username}}
+                  {{/if}}
+                {{else}}
+                  <span class="diff-del">{{i18n
+                      "post.revisions.reply_to.none"
+                    }}</span>
+                {{/if}}
+                &rarr;
+                {{#if @model.reply_to_post_number_changes.current}}
+                  <span
+                  >#{{@model.reply_to_post_number_changes.current.post_number}}</span>
+                  {{#if
+                    @model.reply_to_post_number_changes.current.avatar_template
+                  }}
+                    {{boundAvatarTemplate
+                      @model.reply_to_post_number_changes.current.avatar_template
+                      "small"
+                    }}
+                    {{@model.reply_to_post_number_changes.current.username}}
+                  {{/if}}
+                {{else}}
+                  <span class="diff-ins">{{i18n
+                      "post.revisions.reply_to.none"
+                    }}</span>
+                {{/if}}
+              </span>
+            {{/if}}
+
             {{#if @model.wiki_changes}}
               {{icon
                 "far-pen-to-square"

--- a/frontend/discourse/app/components/modal/history/revisions.gjs
+++ b/frontend/discourse/app/components/modal/history/revisions.gjs
@@ -104,6 +104,44 @@ export default class Revisions extends Component {
             {{@model.user_changes.current.username}}
           </div>
         {{/if}}
+        {{#if @model.reply_to_post_number_changes}}
+          <div class="row reply-to-changes">
+            {{icon "share"}}
+            {{#if @model.reply_to_post_number_changes.previous}}
+              #{{@model.reply_to_post_number_changes.previous.post_number}}
+              {{#if
+                @model.reply_to_post_number_changes.previous.avatar_template
+              }}
+                {{Avatar
+                  @model.reply_to_post_number_changes.previous.avatar_template
+                  "small"
+                }}
+                {{@model.reply_to_post_number_changes.previous.username}}
+              {{/if}}
+            {{else}}
+              <span class="diff-del">{{i18n
+                  "post.revisions.reply_to.none"
+                }}</span>
+            {{/if}}
+            &rarr;
+            {{#if @model.reply_to_post_number_changes.current}}
+              #{{@model.reply_to_post_number_changes.current.post_number}}
+              {{#if
+                @model.reply_to_post_number_changes.current.avatar_template
+              }}
+                {{Avatar
+                  @model.reply_to_post_number_changes.current.avatar_template
+                  "small"
+                }}
+                {{@model.reply_to_post_number_changes.current.username}}
+              {{/if}}
+            {{else}}
+              <span class="diff-ins">{{i18n
+                  "post.revisions.reply_to.none"
+                }}</span>
+            {{/if}}
+          </div>
+        {{/if}}
         {{#if @model.wiki_changes}}
           <div class="row">
             {{icon

--- a/frontend/discourse/app/components/topic-timeline/container.gjs
+++ b/frontend/discourse/app/components/topic-timeline/container.gjs
@@ -107,10 +107,14 @@ export default class TopicTimelineScrollArea extends Component {
       }
     });
 
+    // The timeline is usually rendered on a topic page where both of these
+    // anchors exist. When it's rendered outside of that context (for example,
+    // a modal opened from a floating composer on a non-topic route), they
+    // may be absent — skip observing rather than crashing.
     const elements = [
       document.querySelector(".container.posts"),
       document.querySelector("#topic-bottom"),
-    ];
+    ].filter(Boolean);
 
     for (let i = 0; i < elements.length; i++) {
       this.intersectionObserver.observe(elements[i]);

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -1071,14 +1071,27 @@ export default class Composer extends RestModel {
         // Prefer those values so pending reply-target changes survive a
         // reload or navigation; fall back to the post's stored state
         // otherwise. `undefined` means the key wasn't in the draft at all.
+        //
+        // `post.reply_to_user` is a rich `User` model instance with
+        // circular back-refs (via `statusManager`), so we extract a plain
+        // snapshot — otherwise `JSON.stringify` during periodic draft saves
+        // throws "Converting circular structure to JSON".
         const replyToPostNumber =
           opts.reply_to_post_number !== undefined
             ? opts.reply_to_post_number
             : (post.reply_to_post_number ?? null);
+        const postReplyToUser = post.reply_to_user;
         const replyToUser =
           opts.reply_to_user !== undefined
             ? opts.reply_to_user
-            : (post.reply_to_user ?? null);
+            : postReplyToUser
+              ? {
+                  id: postReplyToUser.id,
+                  username: postReplyToUser.username,
+                  name: postReplyToUser.name,
+                  avatar_template: postReplyToUser.avatar_template,
+                }
+              : null;
         this.setProperties({
           post,
           reply: post.raw,

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -1221,6 +1221,14 @@ export default class Composer extends RestModel {
     return promise
       .then(() => {
         return post.save(props).then((result) => {
+          // The server omits `reply_to_user` from the response when it's
+          // nil, so the post's in-memory value isn't overwritten when the
+          // target is cleared. Mirror the composer's final state onto the
+          // post so reply indicators update without a refresh.
+          post.setProperties({
+            reply_to_post_number: this.reply_to_post_number,
+            reply_to_user: this.reply_to_user,
+          });
           this.clearState();
           return result;
         });

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -81,7 +81,6 @@ const CLOSED = "closed",
     topic_id: "topic.id",
     original_text: "originalText",
     locale: "locale",
-    reply_to_post_number: "reply_to_post_number",
   },
   _edit_topic_serializer = {
     title: "topic.title",
@@ -1227,6 +1226,12 @@ export default class Composer extends RestModel {
     };
 
     this.serialize(_update_serializer, props);
+
+    // Only send when changed; otherwise a stale composer value could
+    // clobber a concurrent reply-target change by another editor.
+    if (this.reply_to_post_number !== (post?.reply_to_post_number ?? null)) {
+      props.reply_to_post_number = this.reply_to_post_number;
+    }
 
     // user clicked "overwrite edits" button
     if (this.editConflict) {

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -81,6 +81,7 @@ const CLOSED = "closed",
     topic_id: "topic.id",
     original_text: "originalText",
     locale: "locale",
+    reply_to_post_number: "reply_to_post_number",
   },
   _edit_topic_serializer = {
     title: "topic.title",
@@ -210,6 +211,8 @@ export default class Composer extends RestModel {
   @tracked post;
   @tracked reply;
   @tracked whisper;
+  @tracked reply_to_post_number = null;
+  @tracked reply_to_user = null;
   @tracked
   locale = this.siteSettings.content_localization_enabled
     ? this.post?.locale
@@ -533,7 +536,7 @@ export default class Composer extends RestModel {
     return this.category?.topic_title_placeholder || null;
   }
 
-  @computed("action", "post", "topic", "topic.title")
+  @computed("action", "post", "topic", "topic.title", "reply_to_user")
   get replyOptions() {
     const options = {
       userLink: null,
@@ -560,10 +563,8 @@ export default class Composer extends RestModel {
       options.userAvatar = tinyAvatar(avatarTemplate);
 
       if (this.site.desktopView) {
-        const originalUserName = this.post.get("reply_to_user.username");
-        const originalUserAvatar = this.post.get(
-          "reply_to_user.avatar_template"
-        );
+        const originalUserName = this.reply_to_user?.username;
+        const originalUserAvatar = this.reply_to_user?.avatar_template;
         if (originalUserName && originalUserAvatar && isEdit(this.action)) {
           options.originalUser = {
             username: originalUserName,
@@ -1068,6 +1069,8 @@ export default class Composer extends RestModel {
           reply: post.raw,
           originalText: post.raw,
           originalTitle: this.topic.title,
+          reply_to_post_number: post.reply_to_post_number ?? null,
+          reply_to_user: post.reply_to_user ?? null,
         });
 
         if (post.post_number === 1 && this.canEditTitle) {
@@ -1143,6 +1146,15 @@ export default class Composer extends RestModel {
       featuredLink: null,
       noBump: false,
       editConflict: false,
+      reply_to_post_number: null,
+      reply_to_user: null,
+    });
+  }
+
+  setReplyTo(postNumber, user) {
+    this.setProperties({
+      reply_to_post_number: postNumber ?? null,
+      reply_to_user: postNumber ? (user ?? null) : null,
     });
   }
 

--- a/frontend/discourse/app/models/composer.js
+++ b/frontend/discourse/app/models/composer.js
@@ -109,6 +109,8 @@ const CLOSED = "closed",
     original_title: "originalTitle",
     original_tags: "originalTags",
     locale: "locale",
+    reply_to_post_number: "reply_to_post_number",
+    reply_to_user: "reply_to_user",
   },
   _add_draft_fields = {},
   FAST_REPLY_LENGTH_THRESHOLD = 10000;
@@ -1064,13 +1066,26 @@ export default class Composer extends RestModel {
 
       promise = promise.then(async () => {
         const post = await this.store.find("post", opts.post.id);
+        // When a draft is being restored, `opts` already carries the
+        // composer's saved `reply_to_*` state (see `_draft_serializer`).
+        // Prefer those values so pending reply-target changes survive a
+        // reload or navigation; fall back to the post's stored state
+        // otherwise. `undefined` means the key wasn't in the draft at all.
+        const replyToPostNumber =
+          opts.reply_to_post_number !== undefined
+            ? opts.reply_to_post_number
+            : (post.reply_to_post_number ?? null);
+        const replyToUser =
+          opts.reply_to_user !== undefined
+            ? opts.reply_to_user
+            : (post.reply_to_user ?? null);
         this.setProperties({
           post,
           reply: post.raw,
           originalText: post.raw,
           originalTitle: this.topic.title,
-          reply_to_post_number: post.reply_to_post_number ?? null,
-          reply_to_user: post.reply_to_user ?? null,
+          reply_to_post_number: replyToPostNumber,
+          reply_to_user: replyToUser,
         });
 
         if (post.post_number === 1 && this.canEditTitle) {

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -7,6 +7,7 @@ import Service, { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { observes } from "@ember-decorators/object";
 import { Promise } from "rsvp";
+import ChangeReplyTo from "discourse/components/modal/change-reply-to";
 import DiscardDraftModal from "discourse/components/modal/discard-draft";
 import PostEnqueuedModal from "discourse/components/modal/post-enqueued";
 import SpreadsheetEditor from "discourse/components/modal/spreadsheet-editor";
@@ -42,6 +43,7 @@ import { parseAttributesString } from "discourse/lib/wrap-utils";
 import Category from "discourse/models/category";
 import Composer, {
   CREATE_TOPIC,
+  EDIT,
   NEW_PRIVATE_MESSAGE_KEY,
   NEW_TOPIC_KEY,
   SAVE_ICONS,
@@ -519,7 +521,13 @@ export default class ComposerService extends Service {
     return this.model?.requiredCategoryMissing && this.model?.replyLength === 0;
   }
 
-  @computed("model.composeState", "model.creatingTopic", "model.post")
+  @computed(
+    "model.composeState",
+    "model.creatingTopic",
+    "model.post",
+    "model.action",
+    "model.reply_to_post_number"
+  )
   get popupMenuOptions() {
     if (
       this.model?.composeState === "open" ||
@@ -556,6 +564,17 @@ export default class ComposerService extends Service {
         })
       );
 
+      if (this.canAddReplyToTarget) {
+        options.push(
+          this._setupPopupMenuOption({
+            name: "change-reply-to",
+            action: this.openChangeReplyToModal,
+            icon: "share",
+            label: "composer.change_reply_to.open_from_menu",
+          })
+        );
+      }
+
       const secondaryOptions = [
         this._setupPopupMenuOption({
           name: "toggle-wrap",
@@ -576,6 +595,44 @@ export default class ComposerService extends Service {
         ...secondaryOptions,
       ];
     }
+  }
+
+  get canAddReplyToTarget() {
+    const model = this.model;
+    return (
+      model?.action === EDIT &&
+      !!model?.post?.can_edit &&
+      !!model?.topic &&
+      !model?.reply_to_post_number
+    );
+  }
+
+  @action
+  openChangeReplyToModal() {
+    const model = this.model;
+    if (!model) {
+      return;
+    }
+
+    this.modal.show(ChangeReplyTo, {
+      model: {
+        topic: model.topic,
+        editingPostNumber: model.post?.post_number,
+        currentPostNumber: model.reply_to_post_number,
+        onSelect: (post) => {
+          if (!post) {
+            model.setReplyTo(null, null);
+            return;
+          }
+          model.setReplyTo(post.post_number, {
+            id: post.user_id,
+            username: post.username,
+            name: post.name,
+            avatar_template: post.avatar_template,
+          });
+        },
+      },
+    });
   }
 
   @computed(

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -564,7 +564,7 @@ export default class ComposerService extends Service {
         })
       );
 
-      if (this.canAddReplyToTarget) {
+      if (this.canOpenReplyToModal) {
         options.push(
           this._setupPopupMenuOption({
             name: "change-reply-to",
@@ -597,14 +597,14 @@ export default class ComposerService extends Service {
     }
   }
 
-  get canAddReplyToTarget() {
+  // Exposed via the composer toolbar popup as a fallback entry point for
+  // the reply-target picker. Needed in contexts where the reply indicator
+  // isn't rendered next to the title (mobile) or is suppressed (e.g.
+  // `suppress_reply_when_quoting`), regardless of whether a target already
+  // exists.
+  get canOpenReplyToModal() {
     const model = this.model;
-    return (
-      model?.action === EDIT &&
-      !!model?.post?.can_edit &&
-      !!model?.topic &&
-      !model?.reply_to_post_number
-    );
+    return model?.action === EDIT && !!model?.post?.can_edit && !!model?.topic;
   }
 
   @action

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -78,6 +78,14 @@ async function loadDraft(store, opts = {}) {
     attrs[f] = draft[f] || opts[f];
   });
 
+  // `||` above collapses explicit `null`; for these fields `null` means
+  // "no reply target" and must round-trip through the draft.
+  ["reply_to_post_number", "reply_to_user"].forEach((f) => {
+    if (draft && f in draft) {
+      attrs[f] = draft[f];
+    }
+  });
+
   const composer = store.createRecord("composer");
   await composer.open(attrs);
 
@@ -602,9 +610,17 @@ export default class ComposerService extends Service {
   // isn't rendered next to the title (mobile) or is suppressed (e.g.
   // `suppress_reply_when_quoting`), regardless of whether a target already
   // exists.
+  //
+  // Post 1 (the OP) has no earlier posts — the picker would have nothing
+  // to select.
   get canOpenReplyToModal() {
     const model = this.model;
-    return model?.action === EDIT && !!model?.post?.can_edit && !!model?.topic;
+    return (
+      model?.action === EDIT &&
+      !!model?.post?.can_edit &&
+      !!model?.topic &&
+      (model?.post?.post_number ?? 0) > 1
+    );
   }
 
   @action

--- a/frontend/discourse/tests/acceptance/composer-reply-to-test.js
+++ b/frontend/discourse/tests/acceptance/composer-reply-to-test.js
@@ -30,6 +30,9 @@ acceptance("Composer - Reply target picker", function (needs) {
 
   async function openEditForReplyPost() {
     await visit("/t/internationalization-localization/280");
+    // Post 6 isn't the current user's, so the edit button is collapsed into
+    // the "show more" overflow by default — expand it first.
+    await click("article#post_6 button.show-more-actions");
     await click("article#post_6 button.edit");
     await waitFor(".d-editor-input");
   }

--- a/frontend/discourse/tests/acceptance/composer-reply-to-test.js
+++ b/frontend/discourse/tests/acceptance/composer-reply-to-test.js
@@ -47,7 +47,7 @@ acceptance("Composer - Reply target picker", function (needs) {
 
   test("the toolbar options menu exposes a 'Reply to another post' entry", async function (assert) {
     await openEditForReplyPost();
-    await click(".d-editor-button-bar .fk-d-menu__trigger");
+    await click(".toolbar-menu__options-trigger");
 
     assert
       .dom("[data-name='change-reply-to']")

--- a/frontend/discourse/tests/acceptance/composer-reply-to-test.js
+++ b/frontend/discourse/tests/acceptance/composer-reply-to-test.js
@@ -1,7 +1,6 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Composer - Reply target picker", function (needs) {
   needs.user({ id: 5, username: "kris" });
@@ -20,9 +19,7 @@ acceptance("Composer - Reply target picker", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     await click(".topic-post[data-post-number='6'] button.edit");
-
-    const popup = selectKit(".toolbar-popup-menu-options");
-    await popup.expand();
+    await click(".d-editor-button-bar .fk-d-menu__trigger");
 
     assert
       .dom("[data-name='change-reply-to']")

--- a/frontend/discourse/tests/acceptance/composer-reply-to-test.js
+++ b/frontend/discourse/tests/acceptance/composer-reply-to-test.js
@@ -1,0 +1,31 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+acceptance("Composer - Reply target picker", function (needs) {
+  needs.user({ id: 5, username: "kris" });
+
+  test("the reply indicator in the edit title is a clickable button", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click(".topic-post[data-post-number='6'] button.edit");
+
+    assert
+      .dom("button.composer-edit-reply-to")
+      .exists("renders the reply target as a button inside the action title");
+  });
+
+  test("the toolbar options menu exposes a 'Reply to another post' entry", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click(".topic-post[data-post-number='6'] button.edit");
+
+    const popup = selectKit(".toolbar-popup-menu-options");
+    await popup.expand();
+
+    assert
+      .dom("[data-name='change-reply-to']")
+      .exists("the menu item is available for editors");
+  });
+});

--- a/frontend/discourse/tests/acceptance/composer-reply-to-test.js
+++ b/frontend/discourse/tests/acceptance/composer-reply-to-test.js
@@ -1,14 +1,41 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Composer - Reply target picker", function (needs) {
   needs.user({ id: 5, username: "kris" });
 
-  test("the reply indicator in the edit title is a clickable button", async function (assert) {
-    await visit("/t/internationalization-localization/280");
+  // The topic fixture caches post 6 without `raw`, so the edit flow's
+  // `store.find("post", ...)` has to fetch it fresh — mock that response
+  // with a reply target set.
+  needs.pretender((server, helper) => {
+    server.get("/posts/3654", () =>
+      helper.response({
+        id: 3654,
+        post_number: 6,
+        topic_id: 280,
+        raw: "Yes, I really like the concept of fuzzy matching for localization.",
+        reply_to_post_number: 5,
+        reply_to_user: {
+          username: "pekka",
+          name: "Pekka",
+          avatar_template: "/images/avatar.png",
+        },
+        can_edit: true,
+        version: 1,
+        locale: null,
+      })
+    );
+  });
 
-    await click(".topic-post[data-post-number='6'] button.edit");
+  async function openEditForReplyPost() {
+    await visit("/t/internationalization-localization/280");
+    await click("article#post_6 button.edit");
+    await waitFor(".d-editor-input");
+  }
+
+  test("the reply indicator in the edit title is a clickable button", async function (assert) {
+    await openEditForReplyPost();
 
     assert
       .dom("button.composer-edit-reply-to")
@@ -16,9 +43,7 @@ acceptance("Composer - Reply target picker", function (needs) {
   });
 
   test("the toolbar options menu exposes a 'Reply to another post' entry", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-
-    await click(".topic-post[data-post-number='6'] button.edit");
+    await openEditForReplyPost();
     await click(".d-editor-button-bar .fk-d-menu__trigger");
 
     assert

--- a/frontend/discourse/tests/unit/models/composer-test.js
+++ b/frontend/discourse/tests/unit/models/composer-test.js
@@ -354,6 +354,22 @@ module("Unit | Model | composer", function (hooks) {
     );
   });
 
+  test("reply_to edits are serialized into drafts", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const composer = createComposer.call(this, {
+      action: EDIT,
+      topic: store.createRecord("topic", { id: 1 }),
+      post: store.createRecord("post", { id: 1, post_number: 3 }),
+      reply_to_post_number: 2,
+      reply_to_user: { username: "alice", avatar_template: "/alice.png" },
+    });
+
+    const draft = composer.serializeDraftData();
+
+    assert.strictEqual(draft.reply_to_post_number, 2);
+    assert.strictEqual(draft.reply_to_user.username, "alice");
+  });
+
   test("initial category when uncategorized is allowed", function (assert) {
     this.siteSettings.allow_uncategorized_topics = true;
     const composer = openComposer.call(this, {

--- a/frontend/discourse/tests/unit/models/composer-test.js
+++ b/frontend/discourse/tests/unit/models/composer-test.js
@@ -294,6 +294,8 @@ module("Unit | Model | composer", function (hooks) {
       reply: "asdf2",
       post: store.createRecord("post", { id: 1 }),
       title: "wat",
+      reply_to_post_number: 3,
+      reply_to_user: { username: "alice" },
     });
 
     composer.clearState();
@@ -302,6 +304,54 @@ module("Unit | Model | composer", function (hooks) {
     assert.blank(composer.reply);
     assert.blank(composer.post);
     assert.blank(composer.title);
+    assert.blank(composer.reply_to_post_number);
+    assert.blank(composer.reply_to_user);
+  });
+
+  test("setReplyTo and replyOptions live updates in edit mode", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const composer = createComposer.call(this, {
+      action: EDIT,
+      topic: store.createRecord("topic", { id: 1, title: "t" }),
+      post: store.createRecord("post", {
+        id: 1,
+        post_number: 3,
+        avatar_template: "/a.png",
+        username: "bob",
+        name: "Bob",
+      }),
+      reply_to_post_number: 2,
+      reply_to_user: {
+        username: "alice",
+        avatar_template: "/alice.png",
+      },
+    });
+
+    assert.strictEqual(
+      composer.replyOptions.originalUser?.username,
+      "alice",
+      "originalUser reflects composer state on open"
+    );
+
+    composer.setReplyTo(null, null);
+    assert.strictEqual(composer.reply_to_post_number, null);
+    assert.strictEqual(composer.reply_to_user, null);
+    assert.strictEqual(
+      composer.replyOptions.originalUser,
+      null,
+      "originalUser clears after removing reply target"
+    );
+
+    composer.setReplyTo(1, {
+      username: "carol",
+      avatar_template: "/carol.png",
+    });
+    assert.strictEqual(composer.reply_to_post_number, 1);
+    assert.strictEqual(
+      composer.replyOptions.originalUser?.username,
+      "carol",
+      "originalUser reflects the newly chosen target"
+    );
   });
 
   test("initial category when uncategorized is allowed", function (assert) {

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -562,13 +562,7 @@ class PostRevisor
       @post.public_send("#{field}=", @fields[field]) if @fields.has_key?(field)
     end
 
-    if @post.reply_to_post_number_changed?
-      @post.reply_to_user_id = @new_reply_to_parent&.user_id
-      # A reply to a whisper is itself a whisper.
-      if @new_reply_to_parent&.post_type == Post.types[:whisper]
-        @post.post_type = Post.types[:whisper]
-      end
-    end
+    @post.reply_to_user_id = @new_reply_to_parent&.user_id if @post.reply_to_post_number_changed?
 
     @post.edit_reason = @fields[:edit_reason] if should_create_new_version?
     @post.last_editor_id = @editor.id

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -82,7 +82,16 @@ class PostRevisor
     end
   end
 
-  POST_TRACKED_FIELDS = %w[raw cooked edit_reason user_id wiki post_type locale]
+  POST_TRACKED_FIELDS = %w[
+    raw
+    cooked
+    edit_reason
+    user_id
+    wiki
+    post_type
+    locale
+    reply_to_post_number
+  ]
 
   # Extensions can inspect revision options via the `:post_edited` event payload.
   attr_reader :category_changed, :post_revision, :opts
@@ -260,6 +269,12 @@ class PostRevisor
     @fields[:user_id] = @fields[:user_id].to_i if @fields.has_key?(:user_id)
     @fields[:category_id] = @fields[:category_id].to_i if @fields.has_key?(:category_id)
     @fields.delete(:tags) if @fields.has_key?(:tags) && @fields[:tags].blank? && @topic.tags.empty?
+
+    if @fields.has_key?(:reply_to_post_number)
+      normalized = @fields[:reply_to_post_number].presence
+      @fields[:reply_to_post_number] = normalized.nil? ? nil : normalized.to_i
+      return false unless resolve_reply_to_change
+    end
 
     # always reset edit_reason unless provided, do not set to nil else
     # previous reasons are lost
@@ -547,6 +562,11 @@ class PostRevisor
       @post.public_send("#{field}=", @fields[field]) if @fields.has_key?(field)
     end
 
+    if @post.reply_to_post_number_changed?
+      @post.reply_to_user_id = @new_reply_to_parent&.user_id
+      @post.instance_variable_set(:@reply_to_post, nil)
+    end
+
     @post.edit_reason = @fields[:edit_reason] if should_create_new_version?
     @post.last_editor_id = @editor.id
     @post.word_count = @fields[:raw].scan(/[[:word:]]+/).size if @fields.has_key?(:raw)
@@ -557,6 +577,7 @@ class PostRevisor
     @post_successfully_saved = @post.save(validate: @validate_post)
     @post.link_post_uploads
     @post.save_reply_relationships
+    cleanup_previous_reply_to_relationship if @post_successfully_saved
 
     # we don't want to increment post count on user merge
     if @post_successfully_saved && @editor.id != Discourse::SYSTEM_USER_ID
@@ -853,5 +874,55 @@ class PostRevisor
 
   def reviewable_content_changed?
     raw_changed? || topic_title_changed?
+  end
+
+  private
+
+  def resolve_reply_to_change
+    new_post_number = @fields[:reply_to_post_number]
+
+    @old_reply_to_parent = @post.reply_to_post
+    @new_reply_to_parent = nil
+
+    return true if new_post_number == @post.reply_to_post_number
+
+    if new_post_number.present?
+      @new_reply_to_parent =
+        Post.where(topic_id: @post.topic_id, post_number: new_post_number).first
+
+      unless valid_reply_to_parent?(@new_reply_to_parent)
+        @post.errors.add(:reply_to_post_number, I18n.t("post.errors.invalid_reply_to"))
+        return false
+      end
+    end
+
+    true
+  end
+
+  def valid_reply_to_parent?(parent)
+    return false if parent.blank?
+    return false if parent.deleted_at.present?
+    return false if parent.id == @post.id
+    return false if @post.post_number.present? && parent.post_number >= @post.post_number
+    true
+  end
+
+  def cleanup_previous_reply_to_relationship
+    return unless @post.saved_change_to_reply_to_post_number?
+    return if @old_reply_to_parent.blank?
+
+    old_post_number = @old_reply_to_parent.post_number
+    still_referenced =
+      @post.reply_to_post_number == old_post_number ||
+        Array(@post.quoted_post_numbers).include?(old_post_number)
+    return if still_referenced
+
+    deleted = PostReply.where(post_id: @old_reply_to_parent.id, reply_post_id: @post.id).delete_all
+
+    if deleted > 0 && Topic.visible_post_types.include?(@post.post_type)
+      Post.where(id: @old_reply_to_parent.id).update_all(
+        "reply_count = GREATEST(reply_count - 1, 0)",
+      )
+    end
   end
 end

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -574,10 +574,18 @@ class PostRevisor
 
     @post.extract_quoted_post_numbers
 
+    previous_reply_to_post_number = @post.reply_to_post_number_was
+
     @post_successfully_saved = @post.save(validate: @validate_post)
     @post.link_post_uploads
-    @post.save_reply_relationships
-    cleanup_previous_reply_to_relationship if @post_successfully_saved
+
+    if @post_successfully_saved
+      @post.save_reply_relationships
+      cleanup_previous_reply_to_relationship
+      if @post.saved_change_to_reply_to_post_number?
+        @post.nested_replies_apply_reparent(previous_reply_to_post_number)
+      end
+    end
 
     # we don't want to increment post count on user merge
     if @post_successfully_saved && @editor.id != Discourse::SYSTEM_USER_ID
@@ -904,6 +912,7 @@ class PostRevisor
     return false if parent.deleted_at.present?
     return false if parent.id == @post.id
     return false if @post.post_number.present? && parent.post_number >= @post.post_number
+    return false unless guardian.can_see?(parent)
     true
   end
 

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -564,7 +564,10 @@ class PostRevisor
 
     if @post.reply_to_post_number_changed?
       @post.reply_to_user_id = @new_reply_to_parent&.user_id
-      @post.instance_variable_set(:@reply_to_post, nil)
+      # A reply to a whisper is itself a whisper.
+      if @new_reply_to_parent&.post_type == Post.types[:whisper]
+        @post.post_type = Post.types[:whisper]
+      end
     end
 
     @post.edit_reason = @fields[:edit_reason] if should_create_new_version?
@@ -889,7 +892,12 @@ class PostRevisor
   def resolve_reply_to_change
     new_post_number = @fields[:reply_to_post_number]
 
-    @old_reply_to_parent = @post.reply_to_post
+    # Resolve trashed prior parents too — their stale `PostReply` row and
+    # `reply_count` need cleanup on reparent.
+    @old_reply_to_parent =
+      if @post.reply_to_post_number.present?
+        Post.with_deleted.find_by(topic_id: @post.topic_id, post_number: @post.reply_to_post_number)
+      end
     @new_reply_to_parent = nil
 
     return true if new_post_number == @post.reply_to_post_number
@@ -909,7 +917,6 @@ class PostRevisor
 
   def valid_reply_to_parent?(parent)
     return false if parent.blank?
-    return false if parent.deleted_at.present?
     return false if parent.id == @post.id
     return false if @post.post_number.present? && parent.post_number >= @post.post_number
     return false unless guardian.can_see?(parent)
@@ -923,7 +930,7 @@ class PostRevisor
     old_post_number = @old_reply_to_parent.post_number
     still_referenced =
       @post.reply_to_post_number == old_post_number ||
-        Array(@post.quoted_post_numbers).include?(old_post_number)
+        @post.quoted_post_numbers.include?(old_post_number)
     return if still_referenced
 
     deleted = PostReply.where(post_id: @old_reply_to_parent.id, reply_post_id: @post.id).delete_all

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -2149,5 +2149,125 @@ describe PostRevisor do
         PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id),
       ).to be_present
     end
+
+    it "rejects a target the editor cannot see" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
+      whisper =
+        PostCreator.create!(
+          admin,
+          topic_id: topic.id,
+          raw: "a whisper the editor cannot see",
+          post_type: Post.types[:whisper],
+        )
+
+      expect(revise(whisper.post_number)).to eq(false)
+      expect(post_to_edit.errors[:reply_to_post_number]).to be_present
+    end
+
+    it "does not create new PostReply rows when the post save fails" do
+      SiteSetting.min_post_length = 500
+      new_parent_reply_count = first_reply.reload.reply_count
+
+      result =
+        PostRevisor.new(post_to_edit).revise!(
+          editor,
+          { raw: "too short", reply_to_post_number: first_reply.post_number },
+          bypass_rate_limiter: true,
+        )
+
+      expect(result).to eq(false)
+      expect(PostReply.where(post_id: first_reply.id, reply_post_id: post_to_edit.id)).to be_empty
+      expect(first_reply.reload.reply_count).to eq(new_parent_reply_count)
+    end
+
+    context "with nested reply stats" do
+      def direct_reply_count(post)
+        NestedViewPostStat.where(post_id: post.id).pick(:direct_reply_count) || 0
+      end
+
+      def total_descendant_count(post)
+        NestedViewPostStat.where(post_id: post.id).pick(:total_descendant_count) || 0
+      end
+
+      it "moves the subtree between ancestor chains on reparent" do
+        SiteSetting.nested_replies_enabled = true
+
+        nested_op = Fabricate(:post, topic: topic, user: op_author)
+        nested_reparent_target =
+          PostCreator.create!(
+            first_reply_author,
+            topic_id: topic.id,
+            raw: "reparent target, long enough to be valid",
+            reply_to_post_number: nested_op.post_number,
+          )
+        moved_post =
+          PostCreator.create!(
+            editor,
+            topic_id: topic.id,
+            raw: "the one we'll reparent, long enough",
+            reply_to_post_number: nested_op.post_number,
+          )
+
+        # Before: nested_op has two direct children (target + moved_post).
+        expect(direct_reply_count(nested_op)).to eq(2)
+        expect(total_descendant_count(nested_op)).to eq(2)
+        expect(direct_reply_count(nested_reparent_target)).to eq(0)
+        expect(total_descendant_count(nested_reparent_target)).to eq(0)
+
+        result =
+          PostRevisor.new(moved_post).revise!(
+            editor,
+            { reply_to_post_number: nested_reparent_target.post_number },
+            bypass_rate_limiter: true,
+          )
+
+        expect(result).to eq(true)
+        # After: moved_post now lives under target. nested_op stays a shared
+        # ancestor (2 total descendants) but loses a direct child; target
+        # gains one direct + one total.
+        expect(direct_reply_count(nested_op)).to eq(1)
+        expect(total_descendant_count(nested_op)).to eq(2)
+        expect(direct_reply_count(nested_reparent_target)).to eq(1)
+        expect(total_descendant_count(nested_reparent_target)).to eq(1)
+      end
+
+      it "moves the subtree up when the new target is the current grandparent" do
+        SiteSetting.nested_replies_enabled = true
+
+        nested_op = Fabricate(:post, topic: topic, user: op_author)
+        middle =
+          PostCreator.create!(
+            first_reply_author,
+            topic_id: topic.id,
+            raw: "middle, long enough to be valid",
+            reply_to_post_number: nested_op.post_number,
+          )
+        moved_post =
+          PostCreator.create!(
+            editor,
+            topic_id: topic.id,
+            raw: "will move up, long enough",
+            reply_to_post_number: middle.post_number,
+          )
+
+        expect(direct_reply_count(nested_op)).to eq(1)
+        expect(total_descendant_count(nested_op)).to eq(2)
+        expect(direct_reply_count(middle)).to eq(1)
+        expect(total_descendant_count(middle)).to eq(1)
+
+        PostRevisor.new(moved_post).revise!(
+          editor,
+          { reply_to_post_number: nested_op.post_number },
+          bypass_rate_limiter: true,
+        )
+
+        # middle loses its only descendant; nested_op's total stays at 2,
+        # its direct child count goes from 1 to 2.
+        expect(direct_reply_count(middle)).to eq(0)
+        expect(total_descendant_count(middle)).to eq(0)
+        expect(direct_reply_count(nested_op)).to eq(2)
+        expect(total_descendant_count(nested_op)).to eq(2)
+      end
+    end
   end
 end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -2180,6 +2180,50 @@ describe PostRevisor do
       expect(first_reply.reload.reply_count).to eq(new_parent_reply_count)
     end
 
+    it "cleans up the PostReply row when the previous parent is already trashed" do
+      original_post.trash!
+
+      expect(
+        PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id),
+      ).to be_present
+
+      expect(revise(first_reply.post_number)).to eq(true)
+
+      expect(PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id)).to be_empty
+    end
+
+    it "mirrors the new parent's whisper post_type" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
+
+      # Whisper must come before the post being revised — fresh topic so
+      # the post ordering is explicit.
+      whisper_topic = Fabricate(:topic, user: admin)
+      Fabricate(:post, topic: whisper_topic, user: admin, post_number: 1)
+      whisper =
+        PostCreator.create!(
+          admin,
+          topic_id: whisper_topic.id,
+          raw: "a whisper, long enough to be valid",
+          post_type: Post.types[:whisper],
+        )
+      regular_reply =
+        PostCreator.create!(
+          admin,
+          topic_id: whisper_topic.id,
+          raw: "a regular reply, long enough to be valid",
+        )
+
+      expect(
+        PostRevisor.new(regular_reply).revise!(
+          admin,
+          { reply_to_post_number: whisper.post_number },
+          bypass_rate_limiter: true,
+        ),
+      ).to eq(true)
+
+      expect(regular_reply.reload.post_type).to eq(Post.types[:whisper])
+    end
+
     context "with nested reply stats" do
       def direct_reply_count(post)
         NestedViewPostStat.where(post_id: post.id).pick(:direct_reply_count) || 0

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -2033,4 +2033,121 @@ describe PostRevisor do
       expect(Draft.find_by(user_id: post.user.id, draft_key: draft_key)).to be_nil
     end
   end
+
+  describe "revising reply_to_post_number" do
+    fab!(:topic)
+    fab!(:op_author, :user)
+    fab!(:first_reply_author, :user)
+    fab!(:second_reply_author, :user)
+    fab!(:editor) { Fabricate(:user, refresh_auto_groups: true) }
+
+    fab!(:original_post) { Fabricate(:post, topic: topic, user: op_author, post_number: 1) }
+    fab!(:first_reply) do
+      PostCreator.create!(
+        first_reply_author,
+        topic_id: topic.id,
+        raw: "first reply body, long enough to be valid",
+        reply_to_post_number: 1,
+      )
+    end
+    fab!(:second_reply) do
+      PostCreator.create!(
+        second_reply_author,
+        topic_id: topic.id,
+        raw: "second reply body, long enough to be valid",
+        reply_to_post_number: 1,
+      )
+    end
+    fab!(:post_to_edit) do
+      PostCreator.create!(
+        editor,
+        topic_id: topic.id,
+        raw: "my reply body, long enough to be valid",
+        reply_to_post_number: 1,
+      )
+    end
+
+    def revise(value, opts = {})
+      PostRevisor.new(post_to_edit).revise!(
+        editor,
+        { reply_to_post_number: value },
+        { bypass_rate_limiter: true }.merge(opts),
+      )
+    end
+
+    it "reparents to another earlier post and syncs reply_to_user_id" do
+      original_parent_reply_count = original_post.reload.reply_count
+
+      expect(revise(first_reply.post_number)).to eq(true)
+
+      post_to_edit.reload
+      expect(post_to_edit.reply_to_post_number).to eq(first_reply.post_number)
+      expect(post_to_edit.reply_to_user_id).to eq(first_reply.user_id)
+      expect(first_reply.reload.reply_count).to eq(1)
+      expect(original_post.reload.reply_count).to eq(original_parent_reply_count - 1)
+    end
+
+    it "removes the reply relationship when set to nil" do
+      expect(revise(nil)).to eq(true)
+
+      post_to_edit.reload
+      expect(post_to_edit.reply_to_post_number).to be_nil
+      expect(post_to_edit.reply_to_user_id).to be_nil
+      expect(PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id)).to be_empty
+    end
+
+    it "tracks the change in a PostRevision" do
+      revise(first_reply.post_number, force_new_version: true)
+
+      revision = post_to_edit.post_revisions.order(:number).last
+      expect(revision.modifications["reply_to_post_number"]).to eq([1, first_reply.post_number])
+    end
+
+    it "does not create a revision when the value is unchanged" do
+      expect { revise(post_to_edit.reply_to_post_number) }.not_to change {
+        post_to_edit.post_revisions.count
+      }
+    end
+
+    it "rejects a self-reference" do
+      expect(revise(post_to_edit.post_number)).to eq(false)
+      expect(post_to_edit.errors[:reply_to_post_number]).to be_present
+      expect(post_to_edit.reload.reply_to_post_number).to eq(1)
+    end
+
+    it "rejects a later post in the topic" do
+      later_post =
+        PostCreator.create!(
+          first_reply_author,
+          topic_id: topic.id,
+          raw: "a later post, long enough to be valid",
+        )
+      expect(revise(later_post.post_number)).to eq(false)
+      expect(post_to_edit.errors[:reply_to_post_number]).to be_present
+    end
+
+    it "rejects a post that does not exist in the topic" do
+      expect(revise(999)).to eq(false)
+      expect(post_to_edit.errors[:reply_to_post_number]).to be_present
+    end
+
+    it "rejects a deleted post" do
+      first_reply.trash!
+      expect(revise(first_reply.post_number)).to eq(false)
+      expect(post_to_edit.errors[:reply_to_post_number]).to be_present
+    end
+
+    it "keeps the PostReply row for the old parent if the post still quotes it" do
+      post_to_edit.update!(
+        raw: "quoting\n[quote=\"#{op_author.username}, post:1, topic:#{topic.id}\"]hi[/quote]",
+      )
+      post_to_edit.extract_quoted_post_numbers
+      post_to_edit.save!
+
+      expect(revise(first_reply.post_number)).to eq(true)
+      expect(
+        PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id),
+      ).to be_present
+    end
+  end
 end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -2192,38 +2192,6 @@ describe PostRevisor do
       expect(PostReply.where(post_id: original_post.id, reply_post_id: post_to_edit.id)).to be_empty
     end
 
-    it "mirrors the new parent's whisper post_type" do
-      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
-
-      # Whisper must come before the post being revised — fresh topic so
-      # the post ordering is explicit.
-      whisper_topic = Fabricate(:topic, user: admin)
-      Fabricate(:post, topic: whisper_topic, user: admin, post_number: 1)
-      whisper =
-        PostCreator.create!(
-          admin,
-          topic_id: whisper_topic.id,
-          raw: "a whisper, long enough to be valid",
-          post_type: Post.types[:whisper],
-        )
-      regular_reply =
-        PostCreator.create!(
-          admin,
-          topic_id: whisper_topic.id,
-          raw: "a regular reply, long enough to be valid",
-        )
-
-      expect(
-        PostRevisor.new(regular_reply).revise!(
-          admin,
-          { reply_to_post_number: whisper.post_number },
-          bypass_rate_limiter: true,
-        ),
-      ).to eq(true)
-
-      expect(regular_reply.reload.post_type).to eq(Post.types[:whisper])
-    end
-
     context "with nested reply stats" do
       def direct_reply_count(post)
         NestedViewPostStat.where(post_id: post.id).pick(:direct_reply_count) || 0

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -3021,6 +3021,25 @@ RSpec.describe PostsController do
         post.topic.reload
         expect(post.topic.tags.pluck(:name).sort).to eq(%w[tag1 tag2])
       end
+
+      it "supports reverting reply-target-only revisions" do
+        earlier_post = Fabricate(:post, topic: post.topic, post_number: post.post_number - 1)
+        post.update!(reply_to_post_number: nil)
+
+        reply_to_revision =
+          Fabricate(
+            :post_revision,
+            post: post,
+            modifications: {
+              "reply_to_post_number" => [earlier_post.post_number, nil],
+            },
+          )
+
+        put "/posts/#{post_id}/revisions/#{reply_to_revision.number}/revert.json"
+
+        expect(response.status).to eq(200)
+        expect(post.reload.reply_to_post_number).to eq(earlier_post.post_number)
+      end
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -919,6 +919,68 @@ RSpec.describe PostsController do
         expect(post.reload.custom_fields[:random_number]).to eq("244")
       end
     end
+
+    describe "reply_to_post_number" do
+      fab!(:topic)
+      fab!(:op) { Fabricate(:post, topic: topic, user: Fabricate(:user)) }
+      fab!(:first_reply) do
+        Fabricate(:post, topic: topic, user: Fabricate(:user), reply_to_post_number: op.post_number)
+      end
+      fab!(:editable_post) do
+        Fabricate(
+          :post,
+          topic: topic,
+          user: user,
+          reply_to_post_number: op.post_number,
+          reply_to_user_id: op.user_id,
+        )
+      end
+
+      before { sign_in(user) }
+
+      it "reparents the post to another earlier post" do
+        put "/posts/#{editable_post.id}.json",
+            params: {
+              post: {
+                raw: editable_post.raw,
+                reply_to_post_number: first_reply.post_number,
+              },
+            }
+
+        expect(response.status).to eq(200)
+        editable_post.reload
+        expect(editable_post.reply_to_post_number).to eq(first_reply.post_number)
+        expect(editable_post.reply_to_user_id).to eq(first_reply.user_id)
+      end
+
+      it "clears the reply relationship when set to null" do
+        put "/posts/#{editable_post.id}.json",
+            params: {
+              post: {
+                raw: editable_post.raw,
+                reply_to_post_number: nil,
+              },
+            }
+
+        expect(response.status).to eq(200)
+        editable_post.reload
+        expect(editable_post.reply_to_post_number).to be_nil
+        expect(editable_post.reply_to_user_id).to be_nil
+      end
+
+      it "returns an error when the target is invalid" do
+        put "/posts/#{editable_post.id}.json",
+            params: {
+              post: {
+                raw: editable_post.raw,
+                reply_to_post_number: editable_post.post_number,
+              },
+            }
+
+        expect(response.status).to eq(422)
+        expect(editable_post.reload.reply_to_post_number).to eq(op.post_number)
+      end
+    end
   end
 
   describe "#destroy_bookmark" do

--- a/spec/serializers/post_revision_serializer_spec.rb
+++ b/spec/serializers/post_revision_serializer_spec.rb
@@ -249,5 +249,38 @@ RSpec.describe PostRevisionSerializer do
 
       expect(json).not_to have_key(:reply_to_post_number_changes)
     end
+
+    it "does not leak author info for a target the viewer cannot see" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
+      whisper =
+        Fabricate(
+          :post,
+          topic: topic,
+          post_number: 4,
+          post_type: Post.types[:whisper],
+          user: Fabricate(:user),
+        )
+      subject_post.update!(reply_to_post_number: whisper.post_number)
+
+      revision =
+        Fabricate(
+          :post_revision,
+          post: subject_post,
+          modifications: {
+            "reply_to_post_number" => [other_parent.post_number, whisper.post_number],
+          },
+        )
+
+      json =
+        PostRevisionSerializer.new(
+          revision,
+          scope: Guardian.new(Fabricate(:user)),
+          root: false,
+        ).as_json
+
+      expect(json[:reply_to_post_number_changes][:current][:post_number]).to eq(whisper.post_number)
+      expect(json[:reply_to_post_number_changes][:current]).not_to have_key(:username)
+      expect(json[:reply_to_post_number_changes][:current]).not_to have_key(:avatar_template)
+    end
   end
 end

--- a/spec/serializers/post_revision_serializer_spec.rb
+++ b/spec/serializers/post_revision_serializer_spec.rb
@@ -176,4 +176,78 @@ RSpec.describe PostRevisionSerializer do
       expect(json[:locale_changes][:current]).to eq("ja")
     end
   end
+
+  describe "reply_to_post_number edits" do
+    fab!(:topic)
+    fab!(:op) { Fabricate(:post, topic: topic, post_number: 1) }
+    fab!(:other_parent) { Fabricate(:post, topic: topic, post_number: 2) }
+    fab!(:subject_post) do
+      Fabricate(
+        :post,
+        topic: topic,
+        post_number: 3,
+        version: 2,
+        reply_to_post_number: other_parent.post_number,
+      )
+    end
+
+    def serialize(revision)
+      PostRevisionSerializer.new(
+        revision,
+        scope: Guardian.new(Fabricate(:user)),
+        root: false,
+      ).as_json
+    end
+
+    it "exposes the change with user info enrichment when the target still exists" do
+      revision =
+        Fabricate(
+          :post_revision,
+          post: subject_post,
+          modifications: {
+            "reply_to_post_number" => [op.post_number, other_parent.post_number],
+          },
+        )
+
+      json = serialize(revision)
+
+      expect(json[:reply_to_post_number_changes][:previous][:post_number]).to eq(op.post_number)
+      expect(json[:reply_to_post_number_changes][:previous][:username]).to eq(
+        op.user.username_lower,
+      )
+      expect(json[:reply_to_post_number_changes][:current][:post_number]).to eq(
+        other_parent.post_number,
+      )
+      expect(json[:reply_to_post_number_changes][:current][:username]).to eq(
+        other_parent.user.username_lower,
+      )
+    end
+
+    it "returns nil on the side that has no reply target" do
+      revision =
+        Fabricate(
+          :post_revision,
+          post: subject_post,
+          modifications: {
+            "reply_to_post_number" => [nil, other_parent.post_number],
+          },
+        )
+
+      json = serialize(revision)
+
+      expect(json[:reply_to_post_number_changes][:previous]).to be_nil
+      expect(json[:reply_to_post_number_changes][:current][:post_number]).to eq(
+        other_parent.post_number,
+      )
+    end
+
+    it "omits the field when reply_to_post_number didn't change" do
+      revision =
+        Fabricate(:post_revision, post: subject_post, modifications: { "raw" => %w[old new] })
+
+      json = serialize(revision)
+
+      expect(json).not_to have_key(:reply_to_post_number_changes)
+    end
+  end
 end


### PR DESCRIPTION
**Previously**, a post's `reply_to_post_number` was fixed at creation time and couldn't be changed, so users who accidentally replied to the wrong post had no way to correct the reply relationship.

**In this update**, the edit composer lets users with edit permission change or remove the post a reply points to; `PostRevisor` validates the new target, keeps `reply_to_user_id` and the parent's `reply_count` in sync, and records the change in post revisions.



https://github.com/user-attachments/assets/1741179c-45e1-4404-88d0-0c97ff0c7969

