### PR TITLE
FIX: Show suggested and related topics on nested replies view

### DIFF
--- a/app/services/nested_topic/list_roots.rb
+++ b/app/services/nested_topic/list_roots.rb
@@ -20,6 +20,7 @@ class NestedTopic::ListRoots
   step :prepare_posts
   step :serialize_roots
   only_if(:initial_page) { step :enrich_with_topic_metadata }
+  only_if(:final_page) { step :attach_suggested_and_related }
 
   private
 
@@ -46,6 +47,10 @@ class NestedTopic::ListRoots
 
   def initial_page(params:)
     params.page == 0
+  end
+
+  def final_page(has_more_roots:)
+    !has_more_roots
   end
 
   def load_roots(params:, loader:, topic_view:)
@@ -112,12 +117,34 @@ class NestedTopic::ListRoots
     reply_counts:,
     descendant_counts:,
     response:,
-    pinned_post_ids:
+    pinned_post_ids:,
+    has_more_roots:
   )
+    suppress_suggested_and_related_queries(topic_view) if has_more_roots
     response[:topic] = serializer.serialize_topic
     response[:op_post] = serializer.serialize_post(loader.op_post, reply_counts, descendant_counts)
     response[:sort] = params.sort
     response[:message_bus_last_id] = topic_view.message_bus_last_id
     response[:pinned_post_ids] = pinned_post_ids if pinned_post_ids.present?
+  end
+
+  def attach_suggested_and_related(serializer:, response:)
+    response.merge!(serializer.serialize_suggested_and_related)
+  end
+
+  # Match flat view behavior: don't run the suggested/related queries
+  # when there are more pages of roots coming. The core suggested/related
+  # queries honor these include_* flags. The discourse-ai plugin's
+  # `related_topics` serializer attribute gates on `object.next_page.nil?`
+  # (plugins/discourse-ai/lib/embeddings/entry_point.rb), and also uses
+  # `related_topics` in its `TopicView#categories` override to preload
+  # category badges on lazy_load_categories sites — so we set @next_page
+  # to a non-nil value here, which both short-circuits the AI serializer
+  # gate and lets the categories override continue to run unchanged.
+  # TopicView's skip_post_loading: true otherwise leaves next_page nil.
+  def suppress_suggested_and_related_queries(topic_view)
+    topic_view.include_suggested = false
+    topic_view.include_related = false
+    topic_view.instance_variable_set(:@next_page, topic_view.page + 1)
   end
 end

--- a/frontend/discourse/app/components/nested-view.gjs
+++ b/frontend/discourse/app/components/nested-view.gjs
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
 import DButton from "discourse/components/d-button";
 import LoadMore from "discourse/components/load-more";
+import MoreTopics from "discourse/components/more-topics";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TopicMap from "discourse/components/topic-map";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -164,11 +165,21 @@ export default class NestedView extends Component {
         @outletArgs={{lazyHash model=@topic}}
       />
 
-      <PluginOutlet
-        @name="topic-above-suggested"
-        @connectorTagName="div"
-        @outletArgs={{lazyHash model=@topic}}
-      />
+      {{#unless @hasMoreRoots}}
+        <PluginOutlet
+          @name="topic-above-suggested"
+          @connectorTagName="div"
+          @outletArgs={{lazyHash model=@topic}}
+        />
+
+        <MoreTopics @topic={{@topic}} />
+
+        <PluginOutlet
+          @name="topic-below-suggested"
+          @connectorTagName="div"
+          @outletArgs={{lazyHash model=@topic}}
+        />
+      {{/unless}}
 
       <PluginOutlet
         @name="topic-navigation-bottom"

--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -110,6 +110,7 @@ export default class NestedController extends Controller {
       this.rootNodes = [...this.rootNodes, ...newNodes];
       this.page = data.page;
       this.hasMoreRoots = data.has_more_roots || false;
+      this.#assignSuggestedAndRelated(data);
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -539,5 +540,23 @@ export default class NestedController extends Controller {
 
   #processNode(nodeData) {
     return processNode(this.store, this.topic, nodeData);
+  }
+
+  #assignSuggestedAndRelated(data) {
+    if (!this.topic) {
+      return;
+    }
+    if (data.suggested_topics !== undefined) {
+      this.topic.suggested_topics = data.suggested_topics;
+    }
+    if (data.related_topics !== undefined) {
+      this.topic.related_topics = data.related_topics;
+    }
+    if (data.related_messages !== undefined) {
+      this.topic.related_messages = data.related_messages;
+    }
+    if (data.suggested_group_name !== undefined) {
+      this.topic.suggested_group_name = data.suggested_group_name;
+    }
   }
 }

--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -8,6 +8,7 @@ import processNode from "../lib/process-node";
 export default class NestedRoute extends Route {
   @service nestedViewCache;
   @service screenTrack;
+  @service site;
   @service siteSettings;
   @service store;
 
@@ -168,8 +169,30 @@ export default class NestedRoute extends Route {
   }
 
   _processResponse(data, params) {
+    // Match Topic.find: seed the site category store from the topic
+    // payload so lazy_load_categories installs can resolve category
+    // badges on the topic itself and on piggybacked suggested/related
+    // rows that only carry category_id.
+    data.topic?.categories?.forEach((c) => this.site.updateCategory(c));
+
     const topic = this.store.createRecord("topic", data.topic);
     topic.set("is_nested_view", true);
+
+    // Suggested/related are piggybacked at top-level on whichever
+    // response has has_more_roots=false — here, a short topic that
+    // fits in one page; otherwise they arrive via loadMoreRoots.
+    if (data.suggested_topics !== undefined) {
+      topic.suggested_topics = data.suggested_topics;
+    }
+    if (data.related_topics !== undefined) {
+      topic.related_topics = data.related_topics;
+    }
+    if (data.related_messages !== undefined) {
+      topic.related_messages = data.related_messages;
+    }
+    if (data.suggested_group_name !== undefined) {
+      topic.suggested_group_name = data.suggested_group_name;
+    }
 
     const assignTopic = (postData) => {
       const post = this.store.createRecord("post", postData);
@@ -205,6 +228,8 @@ export default class NestedRoute extends Route {
   }
 
   _processContextResponse(data, params, sort) {
+    data.topic?.categories?.forEach((c) => this.site.updateCategory(c));
+
     const topic = this.store.createRecord("topic", data.topic);
     topic.set("is_nested_view", true);
 

--- a/lib/nested_replies/post_tree_serializer.rb
+++ b/lib/nested_replies/post_tree_serializer.rb
@@ -8,10 +8,26 @@ module NestedReplies
       @guardian = guardian
     end
 
+    SUGGESTED_AND_RELATED_KEYS = %i[
+      suggested_topics
+      suggested_group_name
+      related_topics
+      related_messages
+    ].freeze
+
     def serialize_topic
       serializer = TopicViewSerializer.new(@topic_view, scope: @guardian, root: false)
       json = serializer.as_json
-      json.except(:post_stream, :timeline_lookup, :user_badges)
+      json.except(:post_stream, :timeline_lookup, :user_badges, *SUGGESTED_AND_RELATED_KEYS)
+    end
+
+    # Produces the suggested/related payload we piggyback on whichever
+    # response has has_more_roots=false — mirroring how the flat view
+    # ships suggested_topics on the final /t/:id/posts.json chunk.
+    def serialize_suggested_and_related
+      serializer = TopicViewSerializer.new(@topic_view, scope: @guardian, root: false)
+      json = serializer.as_json
+      json.slice(*SUGGESTED_AND_RELATED_KEYS)
     end
 
     def serialize_post(post, reply_counts, descendant_counts = {})

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -121,6 +121,54 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(json["page"]).to eq(0)
     end
 
+    it "piggybacks suggested topics at the top level when the first page is the last page" do
+      Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      suggested = Fabricate(:post).topic
+      sign_in(user)
+
+      get show_url(topic, page: 0)
+      expect(response.status).to eq(200)
+
+      json = response.parsed_body
+      expect(json["has_more_roots"]).to eq(false)
+      expect(json["topic"]).not_to have_key("suggested_topics")
+      expect(json).to have_key("suggested_topics")
+      expect(json["suggested_topics"].map { |t| t["id"] }).to include(suggested.id)
+    end
+
+    it "omits suggested topics on page 0 when there are more pages to load" do
+      (NestedReplies::TreeLoader::ROOTS_PER_PAGE + 1).times do
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      end
+      Fabricate(:post).topic
+      sign_in(user)
+
+      get show_url(topic, page: 0)
+      expect(response.status).to eq(200)
+
+      json = response.parsed_body
+      expect(json["has_more_roots"]).to eq(true)
+      expect(json).not_to have_key("suggested_topics")
+      expect(json["topic"]).not_to have_key("suggested_topics")
+    end
+
+    it "piggybacks suggested topics on the final loadMore page" do
+      (NestedReplies::TreeLoader::ROOTS_PER_PAGE + 1).times do
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      end
+      suggested = Fabricate(:post).topic
+      sign_in(user)
+
+      get show_url(topic, page: 1)
+      expect(response.status).to eq(200)
+
+      json = response.parsed_body
+      expect(json["has_more_roots"]).to eq(false)
+      expect(json).not_to have_key("topic")
+      expect(json).to have_key("suggested_topics")
+      expect(json["suggested_topics"].map { |t| t["id"] }).to include(suggested.id)
+    end
+
     it "does not include topic metadata on subsequent pages" do
       25.times { Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil) }
       sign_in(user)

--- a/spec/system/nested_view_spec.rb
+++ b/spec/system/nested_view_spec.rb
@@ -283,6 +283,18 @@ RSpec.describe "Nested view" do
     end
   end
 
+  describe "suggested topics" do
+    fab!(:root_reply) { Fabricate(:post, topic: topic, user: Fabricate(:user), raw: "A reply") }
+    fab!(:other_topic) { Fabricate(:post).topic }
+
+    it "renders suggested topics at the end of the nested view" do
+      nested_view.visit_nested(topic)
+
+      expect(nested_view).to have_suggested_topics
+      expect(nested_view).to have_suggested_topic(other_topic)
+    end
+  end
+
   describe "plugin disabled" do
     it "returns 404 when plugin is disabled" do
       SiteSetting.nested_replies_enabled = false

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -435,6 +435,20 @@ module PageObjects
           has_css?("[data-post-number='#{post.post_number}']")
       end
 
+      # ── Suggested topics ──────────────────────────────────────────
+
+      def has_suggested_topics?
+        has_css?("#suggested-topics")
+      end
+
+      def has_no_suggested_topics?
+        has_no_css?("#suggested-topics")
+      end
+
+      def has_suggested_topic?(topic)
+        has_css?("#suggested-topics .topic-list-item[data-topic-id='#{topic.id}']")
+      end
+
       private
 
       def post_container(post)


### PR DESCRIPTION
**Previously**, the nested replies view (`/n/:slug/:id`) was missing the Suggested/Related Topics widget. The backend was still serializing `suggested_topics`/`related_topics` on every initial page-0 response — running the core suggested-topics query and the discourse-ai embedding similarity query — but the frontend never rendered the data, so the cost was entirely wasted.

**In this update**, `<MoreTopics>` now renders at the end of the nested view, and the payload piggybacks `suggested_topics`/`related_topics` only on whichever response has `has_more_roots: false` — mirroring the flat view's lazy-load contract so the embedding query runs once, when the reader has paginated through all roots.