### PR TITLE
UX: Move topic voting settings into dedicated setting category

### DIFF
--- a/plugins/discourse-topic-voting/config/locales/client.en.yml
+++ b/plugins/discourse-topic-voting/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_topic_voting: "Discourse Topic Voting"
   js:
     category:
       sort_options:

--- a/plugins/discourse-topic-voting/config/settings.yml
+++ b/plugins/discourse-topic-voting/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_topic_voting:
   topic_voting_enabled:
     default: true
     client: true


### PR DESCRIPTION
Instead of showing the settings in the generic "Plugins" setting category

<img width="1163" height="804" alt="image" src="https://github.com/user-attachments/assets/883623f8-a953-46ea-aebe-7158c711f31a" />
