### PR TITLE
UX: Move more plugin settings out of Plugin category

### DIFF
--- a/plugins/discourse-data-explorer/config/locales/client.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_data_explorer: "Discourse Data Explorer"
   js:
     discourse_ai:
       features:

--- a/plugins/discourse-data-explorer/config/settings.yml
+++ b/plugins/discourse-data-explorer/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_data_explorer:
   data_explorer_enabled:
     default: false
     client: true

--- a/plugins/discourse-login-with-amazon/config/locales/client.en.yml
+++ b/plugins/discourse-login-with-amazon/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_login_with_amazon: "Discourse Login with Amazon"
   js:
     login:
       amazon:

--- a/plugins/discourse-login-with-amazon/config/settings.yml
+++ b/plugins/discourse-login-with-amazon/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_login_with_amazon:
   enable_login_with_amazon:
     default: false
     validator: "EnableLoginWithAmazonValidator"

--- a/plugins/discourse-math/config/locales/client.en.yml
+++ b/plugins/discourse-math/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_math: "Discourse Math"
   js:
     discourse_math:
       edit_math: "Edit math"

--- a/plugins/discourse-math/config/settings.yml
+++ b/plugins/discourse-math/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_math:
   discourse_math_enabled:
     default: false
     client: true

--- a/plugins/discourse-post-voting/config/locales/client.en.yml
+++ b/plugins/discourse-post-voting/config/locales/client.en.yml
@@ -1,8 +1,9 @@
 en:
   admin_js:
-    site_settings:
-      categories:
-        post_voting: Post Voting
+    admin:
+      site_settings:
+        categories:
+          discourse_post_voting: "Discourse Post Voting"
   post_voting:
     reviewables:
       comment_already_handled: "Thanks, but we've already reviewed this comment and determined it does not need to be flagged again."

--- a/plugins/discourse-post-voting/config/settings.yml
+++ b/plugins/discourse-post-voting/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_post_voting:
   post_voting_enabled:
     client: true
     default: false

--- a/plugins/poll/config/settings.yml
+++ b/plugins/poll/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+poll:
   poll_enabled:
     default: true
     client: true


### PR DESCRIPTION
Similar to https://github.com/discourse/discourse/pull/39475, move
the settings out of Plugins and into dedicated setting categories
for:

* Data Explorer
* Login with Amazon
* Math
* Post Voting
* Poll
