### PR TITLE
FIX: prevent schema leak in ineligible answer posts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -779,9 +779,6 @@ module ApplicationHelper
     (itemprop.present? && itemprop != "comment") || hash[:data].present?
   end
 
-  # When a non-first post has no itemscope, its itemprops would leak into the
-  # enclosing Question scope (duplicate datePublished etc.). First posts
-  # legitimately leak into the parent topic scope.
   def crawler_post_emits_microdata?(post, topic)
     post.is_first_post? || crawler_post_schema_hash(post, topic)[:itemscope]
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -779,6 +779,13 @@ module ApplicationHelper
     (itemprop.present? && itemprop != "comment") || hash[:data].present?
   end
 
+  # When a non-first post has no itemscope, its itemprops would leak into the
+  # enclosing Question scope (duplicate datePublished etc.). First posts
+  # legitimately leak into the parent topic scope.
+  def crawler_post_emits_microdata?(post, topic)
+    post.is_first_post? || crawler_post_schema_hash(post, topic)[:itemscope]
+  end
+
   def crawler_post_schema_skip?(post, topic)
     DiscoursePluginRegistry.apply_modifier(:topic_crawler_skip_post, false, post, topic)
   end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -72,11 +72,12 @@
       <% @topic_view.crawler_posts.each do |post| %>
         <% next if crawler_post_schema_skip?(post, @topic_view.topic) %>
         <% if (u = post.user) && !post.hidden && post.cooked && !post.cooked.strip.empty? %>
+          <% emit_md = crawler_post_emits_microdata?(post, @topic_view.topic) %>
           <div id='post_<%= post.post_number %>' <%= crawler_post_schema(post, @topic_view.topic) %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>
-              <span class="creator" itemprop="author" itemscope itemtype="http://schema.org/Person">
-                <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span itemprop='name'><%= u.username %></span></a>
-                <meta itemprop='url' content='<%= Discourse.base_url %>/u/<%= u.username %>'>
+              <span class="creator" <% if emit_md %>itemprop="author" itemscope itemtype="http://schema.org/Person"<% end %>>
+                <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span <% if emit_md %>itemprop='name'<% end %>><%= u.username %></span></a>
+                <% if emit_md %><meta itemprop='url' content='<%= Discourse.base_url %>/u/<%= u.username %>'><% end %>
                 <%= "(#{u.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names? && !u.name.blank?) %>
                 <%
                   post_custom_fields = @topic_view.post_custom_fields[post.id] || {}
@@ -92,30 +93,34 @@
                 <link itemprop="mainEntityOfPage" href="<%= post.topic.url %>">
               <% end %>
 
-              <% if post.image_url %>
+              <% if post.image_url && emit_md %>
                 <link itemprop="image" href="<%= post.image_url %>">
               <% end %>
 
               <span class="crawler-post-infos">
-                  <time <%= post.is_first_post? ? "" : "itemprop='datePublished'".html_safe %> datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
+                  <time <%= "itemprop='datePublished'".html_safe if emit_md && !post.is_first_post? %> datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
                     <%= l post.created_at, format: :long %>
                   </time>
-                <% if post.version > 1 %>
-                  <meta itemprop='dateModified' content='<%= post.last_version_at.to_formatted_s(:iso8601) %>'>
-                <% else %>
-                  <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
+                <% if emit_md %>
+                  <% if post.version > 1 %>
+                    <meta itemprop='dateModified' content='<%= post.last_version_at.to_formatted_s(:iso8601) %>'>
+                  <% else %>
+                    <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
+                  <% end %>
                 <% end %>
-              <span itemprop='position'><%= post.post_number %></span>
+              <span <%= "itemprop='position'".html_safe if emit_md %>><%= post.post_number %></span>
               </span>
             </div>
-            <div class='post' itemprop='text'>
+            <div class='post' <%= "itemprop='text'".html_safe if emit_md %>>
               <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
             </div>
 
             <% unless crawler_post_schema_overridden?(post, @topic_view.topic) %>
-              <div itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter">
-                <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
-                <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />
+              <div <%= 'itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter"'.html_safe if emit_md %>>
+                <% if emit_md %>
+                  <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
+                  <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />
+                <% end %>
                 <span class='post-likes'><%= post.like_count > 0 ? t('post.has_likes', count: post.like_count) : '' %></span>
               </div>
             <% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -75,9 +75,11 @@
           <% emit_md = crawler_post_emits_microdata?(post, @topic_view.topic) %>
           <div id='post_<%= post.post_number %>' <%= crawler_post_schema(post, @topic_view.topic) %> class='topic-body crawler-post'>
             <div class='crawler-post-meta'>
-              <span class="creator" <% if emit_md %>itemprop="author" itemscope itemtype="http://schema.org/Person"<% end %>>
-                <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span <% if emit_md %>itemprop='name'<% end %>><%= u.username %></span></a>
-                <% if emit_md %><meta itemprop='url' content='<%= Discourse.base_url %>/u/<%= u.username %>'><% end %>
+              <span class="creator" <%= tag.attributes(itemprop: "author", itemscope: true, itemtype: "http://schema.org/Person") if emit_md %>>
+                <a rel='nofollow' href='<%= Discourse.base_url %>/u/<%= u.username %>'><span <%= tag.attributes(itemprop: "name") if emit_md %>><%= u.username %></span></a>
+                <% if emit_md %>
+                  <meta itemprop='url' content='<%= Discourse.base_url %>/u/<%= u.username %>'>
+                <% end %>
                 <%= "(#{u.name})" if (SiteSetting.display_name_on_posts && SiteSetting.enable_names? && !u.name.blank?) %>
                 <%
                   post_custom_fields = @topic_view.post_custom_fields[post.id] || {}
@@ -98,25 +100,22 @@
               <% end %>
 
               <span class="crawler-post-infos">
-                  <time <%= "itemprop='datePublished'".html_safe if emit_md && !post.is_first_post? %> datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
+                  <time <%= tag.attributes(itemprop: "datePublished") if emit_md && !post.is_first_post? %> datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
                     <%= l post.created_at, format: :long %>
                   </time>
                 <% if emit_md %>
-                  <% if post.version > 1 %>
-                    <meta itemprop='dateModified' content='<%= post.last_version_at.to_formatted_s(:iso8601) %>'>
-                  <% else %>
-                    <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
-                  <% end %>
+                  <% modified_at = post.version > 1 ? post.last_version_at : post.created_at %>
+                  <meta itemprop='dateModified' content='<%= modified_at.to_formatted_s(:iso8601) %>'>
                 <% end %>
-              <span <%= "itemprop='position'".html_safe if emit_md %>><%= post.post_number %></span>
+              <span <%= tag.attributes(itemprop: "position") if emit_md %>><%= post.post_number %></span>
               </span>
             </div>
-            <div class='post' <%= "itemprop='text'".html_safe if emit_md %>>
+            <div class='post' <%= tag.attributes(itemprop: "text") if emit_md %>>
               <%= post.hidden ? t('flagging.user_must_edit').html_safe : post.cooked.html_safe %>
             </div>
 
             <% unless crawler_post_schema_overridden?(post, @topic_view.topic) %>
-              <div <%= 'itemprop="interactionStatistic" itemscope itemtype="http://schema.org/InteractionCounter"'.html_safe if emit_md %>>
+              <div <%= tag.attributes(itemprop: "interactionStatistic", itemscope: true, itemtype: "http://schema.org/InteractionCounter") if emit_md %>>
                 <% if emit_md %>
                   <meta itemprop="interactionType" content="http://schema.org/LikeAction"/>
                   <meta itemprop="userInteractionCount" content="<%= post.like_count %>" />

--- a/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
@@ -192,6 +192,22 @@ RSpec.describe TopicsController do
       expect(suggested_urls).to include(p3.full_url)
     end
 
+    it "does not leak microdata from ineligible posts into the Question scope" do
+      ineligible =
+        Fabricate(:post, topic:, user: Fabricate(:user), post_type: Post.types[:moderator_action])
+      Fabricate(:solved_topic, topic:, answer_post: p2)
+
+      get "/t/#{topic.slug}/#{topic.id}", env: crawler_env
+      doc = parsed_crawler_body
+
+      question = doc.at_css('[itemtype*="Question"]')
+      ineligible_node = doc.at_css("#post_#{ineligible.post_number}")
+
+      expect(ineligible_node).to be_present
+      expect(question.xpath('./*[@itemprop="datePublished"]').size).to eq(1)
+      expect(ineligible_node.css("[itemprop]")).to be_empty
+    end
+
     it "does not modify schema for topics without solved enabled" do
       SiteSetting.allow_solved_on_all_topics = false
 


### PR DESCRIPTION
Prevents QAPage microdata leaking from ineligible suggested answers. Since we are skipping non-text posts we can omit the microdata entirely from the crawler markup.