### PR TITLE
DEV: Fixup the calendar test helper

### DIFF
--- a/plugins/discourse-calendar/test/javascripts/acceptance/topic-calendar-events-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/topic-calendar-events-test.js
@@ -31,6 +31,7 @@ acceptance("Topic Calendar Events", function (needs) {
     pretender.get("/t/252.json", () => fixtureWithFullDay("true"));
     await visit("/t/-/252");
 
+    assert.dom(".fc-daygrid-day").exists("the calendar rendered");
     assert.dom(getEventByText("Event 1")).exists();
     assert.dom(getEventByText("Event 2")).exists();
   });
@@ -39,6 +40,7 @@ acceptance("Topic Calendar Events", function (needs) {
     pretender.get("/t/252.json", () => fixtureWithFullDay("false"));
     await visit("/t/-/252");
 
+    assert.dom(".fc-daygrid-day").exists("the calendar rendered");
     assert.dom(getEventByText("Event 1")).exists();
     assert.dom(getEventByText("Event 2")).exists();
   });

--- a/plugins/discourse-calendar/test/javascripts/acceptance/topic-calendar-events-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/topic-calendar-events-test.js
@@ -1,4 +1,4 @@
-import { visit } from "@ember/test-helpers";
+import { visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
@@ -30,6 +30,7 @@ acceptance("Topic Calendar Events", function (needs) {
   test("renders calendar events with fullDay='true'", async function (assert) {
     pretender.get("/t/252.json", () => fixtureWithFullDay("true"));
     await visit("/t/-/252");
+    await waitFor(".fc-daygrid-event-harness");
 
     assert.dom(".fc-daygrid-day").exists("the calendar rendered");
     assert.dom(getEventByText("Event 1")).exists();
@@ -39,6 +40,7 @@ acceptance("Topic Calendar Events", function (needs) {
   test("renders calendar events with fullDay='false'", async function (assert) {
     pretender.get("/t/252.json", () => fixtureWithFullDay("false"));
     await visit("/t/-/252");
+    await waitFor(".fc-daygrid-event-harness");
 
     assert.dom(".fc-daygrid-day").exists("the calendar rendered");
     assert.dom(getEventByText("Event 1")).exists();

--- a/plugins/discourse-calendar/test/javascripts/helpers/get-event-by-text.js
+++ b/plugins/discourse-calendar/test/javascripts/helpers/get-event-by-text.js
@@ -1,6 +1,9 @@
 export default function getEventByText(text) {
-  const events = [...document.querySelectorAll(".fc-day-grid-event")].filter(
-    (event) => event.textContent.includes(text)
+  const events = [
+    ...document.querySelectorAll(".fc-daygrid-event-harness"),
+  ].filter(
+    (event) =>
+      event.querySelector(".fc-event-title")?.textContent.trim() === text
   );
 
   switch (events.length) {


### PR DESCRIPTION
This was causing flakiness (depending on test order it could still have the other element, which made it pass)

Added more assertions to have more info in case it fails again.