### PR TITLE
FIX: tighten ineligible answer schema

### DIFF
--- a/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
@@ -38,7 +38,7 @@ class DiscourseSolved::BuildSchemaMarkup
   def fetch_accepted_answer(topic:)
     post = topic.solved&.answer_post
     return unless post.present? && Guardian.new.can_see_post?(post)
-    post if post.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present?
+    post if post.cooked.present? && Nokogiri::HTML5.fragment(post.cooked).text.strip.present?
   end
 
   def fetch_suggested_answers(params:, topic:, accepted_answer:)
@@ -50,7 +50,7 @@ class DiscourseSolved::BuildSchemaMarkup
       .where(post_type: Post.types[:regular], hidden: false)
       .order(:post_number)
       .to_a
-      .select { |p| p.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present? }
+      .select { |p| p.cooked.present? && Nokogiri::HTML5.fragment(p.cooked).text.strip.present? }
   end
 
   def fetch_html(topic:, accepted_answer:, suggested_answers:)

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -82,7 +82,7 @@ module DiscourseSolved
 
     private_class_method def self.eligible_answer?(post)
       !post.is_first_post? && post.post_type == Post.types[:regular] && !post.hidden &&
-        post.excerpt(nil, keep_onebox_body: true, keep_quotes: true).present?
+        post.cooked.present? && Nokogiri::HTML5.fragment(post.cooked).text.strip.present?
     end
   end
 end

--- a/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
@@ -108,35 +108,87 @@ RSpec.describe DiscourseSolved::BuildSchemaMarkup do
       end
     end
 
-    context "when the accepted answer has no text content" do
-      fab!(:answer_post) do
-        Fabricate(
-          :post,
-          topic:,
-          raw: "https://www.youtube.com/watch?v=test",
-          cooked:
-            '<div class="onebox video-onebox"><iframe src="https://youtube.com/embed/test"></iframe></div>',
-        )
-      end
+    context "with a non-text post" do
+      before { SiteSetting.solved_add_schema_markup = "always" }
 
-      before do
-        SiteSetting.solved_add_schema_markup = "always"
-        Fabricate(:solved_topic, topic:, answer_post:)
-      end
+      context "when video-only" do
+        fab!(:non_text_post) do
+          Fabricate(
+            :post,
+            topic:,
+            raw: "https://www.youtube.com/watch?v=test",
+            cooked:
+              '<div class="onebox video-onebox"><iframe src="https://youtube.com/embed/test"></iframe></div>',
+          )
+        end
 
-      context "when there are other visible replies" do
-        fab!(:visible_reply) { Fabricate(:post, topic:) }
+        context "when it is the only reply" do
+          it { is_expected.to fail_a_policy(:has_answers) }
+        end
 
-        it "excludes the text-less accepted answer but includes suggested answers" do
-          html = result[:html]
-          expect(html).not_to include('"acceptedAnswer"')
-          expect(html).to include('"suggestedAnswer"')
-          expect(html).to include('"answerCount":1')
+        context "with other replies" do
+          fab!(:visible_reply) { Fabricate(:post, topic:) }
+
+          before { Fabricate(:solved_topic, topic:, answer_post: non_text_post) }
+
+          it "excludes the accepted answer and falls back to suggested answers" do
+            html = result[:html]
+            expect(html).not_to include('"acceptedAnswer"')
+            expect(html).to include('"suggestedAnswer"')
+            expect(html).to include('"answerCount":1')
+          end
         end
       end
 
-      context "when there are no other replies" do
-        it { is_expected.to fail_a_policy(:has_answers) }
+      context "when image-only" do
+        fab!(:non_text_post) do
+          Fabricate(:post, topic:, cooked: '<p><img src="/uploads/foo.png"></p>')
+        end
+
+        context "when it is the only reply" do
+          it { is_expected.to fail_a_policy(:has_answers) }
+        end
+
+        context "with other replies" do
+          fab!(:visible_reply) { Fabricate(:post, topic:) }
+
+          before { Fabricate(:solved_topic, topic:, answer_post: non_text_post) }
+
+          it "excludes the accepted answer and falls back to suggested answers" do
+            html = result[:html]
+            expect(html).not_to include('"acceptedAnswer"')
+            expect(html).to include('"suggestedAnswer"')
+            expect(html).to include('"answerCount":1')
+          end
+        end
+      end
+
+      context "when emoji-only" do
+        fab!(:non_text_post) do
+          Fabricate(
+            :post,
+            topic:,
+            cooked:
+              '<p><img src="/images/emoji/twitter/smile.png" class="emoji" alt=":smile:"></p>',
+          )
+        end
+
+        context "when it is the only reply" do
+          it { is_expected.to fail_a_policy(:has_answers) }
+        end
+
+        context "with other replies" do
+          fab!(:visible_reply) { Fabricate(:post, topic:) }
+
+          before { Fabricate(:solved_topic, topic:, answer_post: non_text_post) }
+
+          it "excludes the accepted answer and falls back to suggested answers" do
+            html = result[:html]
+            expect(html).not_to include('"acceptedAnswer"')
+            expect(html).to include('"suggestedAnswer"')
+            expect(html).to include('"answerCount":1')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Improves the schema markup by filtering non-text posts (image/emoji/video-only) from QAPage schema in discourse-solved.