### PR TITLE
DEV: add plugin outlets to new post reactions menu

### DIFF
--- a/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
@@ -1,4 +1,7 @@
 import Component from "@glimmer/component";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import UserAvatar from "discourse/components/user-avatar";
+import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { i18n } from "discourse-i18n";
 import PostUsersMenu from "./post-users-menu";
@@ -36,6 +39,15 @@ export default class PostLikedUsersMenu extends Component {
     <PostUsersMenu
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
-    />
+    >
+      <:avatar as |user|>
+        <PluginOutlet
+          @name="liked-users-list-avatar"
+          @outletArgs={{lazyHash user=user post=this.post}}
+        >
+          <UserAvatar class="trigger-user-card" @user={{user}} @size="small" />
+        </PluginOutlet>
+      </:avatar>
+    </PostUsersMenu>
   </template>
 }

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -106,7 +106,11 @@ export default class PostUsersMenu extends Component {
                 @username={{user.username}}
                 class="post-users-popup__avatar-link"
               >
-                <UserAvatar @user={{user}} @size="small" />
+                {{#if (has-block "avatar")}}
+                  {{yield user to="avatar"}}
+                {{else}}
+                  <UserAvatar @user={{user}} @size="small" />
+                {{/if}}
               </UserLink>
               <div class="post-users-popup__user-info">
                 <UserLink


### PR DESCRIPTION
When adding the new post reaction menu the plugin outlet did not get carried over previously.

Since the outlet only existed for likes (not reactions), we've used a named block in the likes list component but not in the reactions list component. Then in the shared post users menu component we check for the named block and yield the value passed to the plugin outlet.