### PR TITLE
FEATURE: award badges based on topic votes received

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -570,6 +570,12 @@ class BadgeGranter
     is_old_bronze_badge = badge.badge_type_id == BadgeType::Bronze && granted_at < 2.days.ago
     skip_beginner_badge = skip_new_user_tips && badge.for_beginners?
 
-    is_old_bronze_badge || skip_beginner_badge
+    DiscoursePluginRegistry.apply_modifier(
+      :badge_granter_suppress_notification,
+      is_old_bronze_badge || skip_beginner_badge,
+      badge,
+      granted_at,
+      skip_new_user_tips,
+    )
   end
 end

--- a/plugins/discourse-topic-voting/app/jobs/regular/discourse_topic_voting/backfill_badges.rb
+++ b/plugins/discourse-topic-voting/app/jobs/regular/discourse_topic_voting/backfill_badges.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Jobs
+  module DiscourseTopicVoting
+    class BackfillBadges < ::Jobs::Base
+      def execute(args)
+        return unless SiteSetting.enable_badges
+
+        first_post_id = Post.where(topic_id: args[:topic_id], post_number: 1).pick(:id)
+        return if first_post_id.blank?
+
+        Badge
+          .enabled
+          .where(name: ::DiscourseTopicVoting::BADGE_NAMES)
+          .find_each { |badge| BadgeGranter.backfill(badge, post_ids: [first_post_id]) }
+      end
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/app/jobs/regular/discourse_topic_voting/vote_reclaim.rb
+++ b/plugins/discourse-topic-voting/app/jobs/regular/discourse_topic_voting/vote_reclaim.rb
@@ -14,6 +14,8 @@ module Jobs
           ::DiscourseTopicVoting::Vote.where(topic_id: topic.id).update_all(archive: false)
           topic.update_vote_count
         end
+
+        Jobs.enqueue(Jobs::DiscourseTopicVoting::BackfillBadges, topic_id: topic.id)
       end
     end
   end

--- a/plugins/discourse-topic-voting/app/services/discourse_topic_voting/votes/cast.rb
+++ b/plugins/discourse-topic-voting/app/services/discourse_topic_voting/votes/cast.rb
@@ -23,6 +23,7 @@ module DiscourseTopicVoting
         step :refresh_vote_count
       end
 
+      step :enqueue_backfill_badges
       step :enqueue_topic_upvote_webhook
 
       private
@@ -53,6 +54,10 @@ module DiscourseTopicVoting
 
       def refresh_vote_count(topic:)
         topic.update_vote_count
+      end
+
+      def enqueue_backfill_badges(topic:)
+        Jobs.enqueue(Jobs::DiscourseTopicVoting::BackfillBadges, topic_id: topic.id)
       end
 
       def enqueue_topic_upvote_webhook(guardian:, topic:)

--- a/plugins/discourse-topic-voting/config/locales/server.en.yml
+++ b/plugins/discourse-topic-voting/config/locales/server.en.yml
@@ -49,3 +49,21 @@ en:
         topic_votes_max: "Maximum number of topic votes"
         order_topic_votes: "Order topics by most votes"
         order_topic_votes_asc: "Order topics by fewest votes"
+
+  badges:
+    daydreamer:
+      name: "Daydreamer"
+      description: "Receive a vote on your topic"
+      long_description: "This badge is granted for receiving a vote on one of your topics. :white_check_mark: Nice idea. :+1:"
+    brainstormer:
+      name: "Brainstormer"
+      description: "Receive 5 votes on your topic"
+      long_description: "This badge is granted for receiving 5 votes on one of your topics. :white_check_mark: Your topic is getting traction."
+    innovator:
+      name: "Innovator"
+      description: "Receive 15 votes on your topic"
+      long_description: "This badge is granted for receiving 15 votes on one of your topics. :white_check_mark: So good it can't be ignored."
+    visionary:
+      name: "Visionary"
+      description: "Receive 25 votes on your topic"
+      long_description: "This badge is granted for receiving 25 votes on one of your topics. :white_check_mark: Give the people what they want! :clap:"

--- a/plugins/discourse-topic-voting/db/fixtures/001_badges.rb
+++ b/plugins/discourse-topic-voting/db/fixtures/001_badges.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+[
+  ["Daydreamer", BadgeType::Bronze, 1, false],
+  ["Brainstormer", BadgeType::Silver, 5, true],
+  ["Innovator", BadgeType::Silver, 15, true],
+  ["Visionary", BadgeType::Gold, 25, true],
+].each do |name, level, count, allow_title|
+  Badge.seed(:name) do |badge|
+    badge.name = name
+    badge.default_icon = "vote-up-filled"
+    badge.badge_type_id = level
+    badge.default_badge_grouping_id = BadgeGrouping::Community
+    badge.query = DiscourseTopicVoting::BadgeQueries.for_threshold(count)
+    badge.listable = true
+    badge.target_posts = true
+    badge.multiple_grant = true
+    badge.default_enabled = false
+    badge.default_allow_title = allow_title
+    badge.trigger = Badge::Trigger::None
+    badge.auto_revoke = true
+    badge.show_posts = true
+    badge.system = true
+  end
+end

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/badge_queries.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/badge_queries.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DiscourseTopicVoting
+  module BadgeQueries
+    def self.for_threshold(count)
+      <<~SQL
+        SELECT post_id, user_id, granted_at
+        FROM (
+          SELECT
+            p.id AS post_id,
+            t.user_id,
+            v.created_at AS granted_at,
+            ROW_NUMBER() OVER (PARTITION BY p.id ORDER BY v.created_at) AS rn
+          FROM topic_voting_votes v
+          JOIN topics t ON t.id = v.topic_id
+          JOIN badge_posts p ON p.topic_id = t.id AND p.post_number = 1
+          WHERE v.user_id <> t.user_id
+            AND (:backfill OR p.id IN (:post_ids))
+        ) q
+        WHERE rn = #{count}
+      SQL
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_merger.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_merger.rb
@@ -45,6 +45,8 @@ module DiscourseTopicVoting
         @source_topic.update_vote_count
         @target_topic.update_vote_count
 
+        Jobs.enqueue(Jobs::DiscourseTopicVoting::BackfillBadges, topic_id: @target_topic.id)
+
         if moderator_post = @source_topic.ordered_posts.where(action_code: "split_topic").last
           moderator_post.raw << "\n\n#{I18n.t("topic_voting.votes_moved", count: moved_votes)}"
           if duplicated_votes > 0

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -24,12 +24,19 @@ module ::DiscourseTopicVoting
   PLUGIN_NAME = "discourse-topic-voting"
   ENABLE_TOPIC_VOTING_SETTING = "enable_topic_voting"
   VOTER_PREVIEW_LIMIT = 104
+  BADGE_NAMES = %w[Daydreamer Brainstormer Innovator Visionary].freeze
 end
 
+require_relative "lib/discourse_topic_voting/badge_queries"
 require_relative "lib/discourse_topic_voting/engine"
 require_relative "lib/discourse_topic_voting/topic_votes_filter"
 
 after_initialize do
+  SeedFu.fixture_paths << Rails
+    .root
+    .join("plugins", "discourse-topic-voting", "db", "fixtures")
+    .to_s
+
   reloadable_patch do
     register_category_type(DiscourseTopicVoting::Categories::Types::Ideas)
     CategoriesController.prepend(DiscourseTopicVoting::CategoriesControllerExtension)
@@ -112,6 +119,11 @@ after_initialize do
     posts.reorder(
       "COALESCE((SELECT dvtvc.votes_count FROM topic_voting_topic_vote_count dvtvc WHERE dvtvc.topic_id = topics.id), 0) DESC",
     )
+  end
+
+  register_modifier(:badge_granter_suppress_notification) do |suppress, badge, granted_at, _|
+    next true if DiscourseTopicVoting::BADGE_NAMES.include?(badge.name) && granted_at < 2.weeks.ago
+    suppress
   end
 
   register_modifier(:topics_filter_options) do |results, _guardian|

--- a/plugins/discourse-topic-voting/spec/jobs/backfill_badges_spec.rb
+++ b/plugins/discourse-topic-voting/spec/jobs/backfill_badges_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DiscourseTopicVoting::BackfillBadges do
+  fab!(:topic_author, :user)
+  fab!(:topic) { Fabricate(:topic, user: topic_author) }
+  fab!(:first_post) { Fabricate(:post, topic:, user: topic_author) }
+
+  let(:daydreamer) { Badge.find_by(name: "Daydreamer") }
+  let(:brainstormer) { Badge.find_by(name: "Brainstormer") }
+  let(:innovator) { Badge.find_by(name: "Innovator") }
+  let(:visionary) { Badge.find_by(name: "Visionary") }
+
+  before { Badge.where(name: DiscourseTopicVoting::BADGE_NAMES).update_all(enabled: true) }
+
+  def vote!(topic:, count:)
+    count.times { Fabricate(:topic_voting_votes, topic:) }
+  end
+
+  def user_badge_count(user, badge)
+    UserBadge.where(user:, badge:).count
+  end
+
+  describe "seeded badges" do
+    it "seeds four badges with correct attributes" do
+      expect(daydreamer.badge_type_id).to eq(BadgeType::Bronze)
+      expect(brainstormer.badge_type_id).to eq(BadgeType::Silver)
+      expect(innovator.badge_type_id).to eq(BadgeType::Silver)
+      expect(visionary.badge_type_id).to eq(BadgeType::Gold)
+
+      [daydreamer, brainstormer, innovator, visionary].each do |badge|
+        expect(badge.icon).to eq("vote-up-filled")
+        expect(badge.multiple_grant).to eq(true)
+        expect(badge.target_posts).to eq(true)
+        expect(badge.auto_revoke).to eq(true)
+        expect(badge.system).to eq(true)
+        expect(badge.query).to include("topic_voting_votes")
+      end
+    end
+  end
+
+  describe "#execute" do
+    it "grants Daydreamer for a single vote" do
+      vote!(topic:, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(0)
+      expect(UserBadge.find_by(user_id: topic_author.id, badge_id: daydreamer.id).post_id).to eq(
+        first_post.id,
+      )
+    end
+
+    it "grants Brainstormer at 5 votes" do
+      vote!(topic:, count: 5)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(1)
+      expect(user_badge_count(topic_author, innovator)).to eq(0)
+    end
+
+    it "grants Innovator at 15 votes" do
+      vote!(topic:, count: 15)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(1)
+      expect(user_badge_count(topic_author, innovator)).to eq(1)
+      expect(user_badge_count(topic_author, visionary)).to eq(0)
+    end
+
+    it "grants Visionary at 25 votes" do
+      vote!(topic:, count: 25)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(1)
+      expect(user_badge_count(topic_author, innovator)).to eq(1)
+      expect(user_badge_count(topic_author, visionary)).to eq(1)
+    end
+
+    it "does not count self-votes toward the threshold" do
+      Fabricate(:topic_voting_votes, topic:, user: topic_author)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "ignores self-votes when tallying" do
+      Fabricate(:topic_voting_votes, topic:, user: topic_author)
+      vote!(topic:, count: 4)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(0)
+    end
+
+    it "grants the badge separately for each qualifying topic (multi-grant)" do
+      other_topic = Fabricate(:topic, user: topic_author)
+      other_first_post = Fabricate(:post, topic: other_topic, user: topic_author)
+
+      vote!(topic:, count: 1)
+      vote!(topic: other_topic, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+      described_class.new.execute(topic_id: other_topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(2)
+      grant_post_ids =
+        UserBadge.where(user_id: topic_author.id, badge_id: daydreamer.id).pluck(:post_id)
+      expect(grant_post_ids).to contain_exactly(first_post.id, other_first_post.id)
+    end
+
+    it "is idempotent for the same topic" do
+      vote!(topic:, count: 5)
+
+      described_class.new.execute(topic_id: topic.id)
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(1)
+    end
+
+    it "does not grant when the topic is deleted" do
+      vote!(topic:, count: 5)
+      topic.trash!
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(0)
+    end
+
+    it "does not grant for non-regular archetypes" do
+      topic.update_columns(archetype: Archetype.private_message, category_id: nil)
+      vote!(topic:, count: 5)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "does nothing when badges are disabled site-wide" do
+      SiteSetting.enable_badges = false
+      vote!(topic:, count: 5)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "does nothing when a badge is disabled" do
+      daydreamer.update!(enabled: false)
+      vote!(topic:, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "does not grant for unlisted topics" do
+      topic.update!(visible: false)
+      vote!(topic:, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "does not grant when the category does not allow badges" do
+      topic.category.update!(allow_badges: false)
+      vote!(topic:, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(0)
+    end
+
+    it "suppresses the granted-badge notification when the qualifying votes are older than 2 weeks" do
+      vote!(topic:, count: 5)
+      DiscourseTopicVoting::Vote.update_all(created_at: 3.weeks.ago)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(user_badge_count(topic_author, daydreamer)).to eq(1)
+      expect(user_badge_count(topic_author, brainstormer)).to eq(1)
+      expect(
+        UserBadge.where(user: topic_author, badge: [daydreamer, brainstormer]).pluck(
+          :notification_id,
+        ),
+      ).to all(be_nil)
+    end
+
+    it "still notifies when the qualifying votes are recent" do
+      vote!(topic:, count: 5)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(
+        UserBadge.find_by(user: topic_author, badge: brainstormer).notification_id,
+      ).to be_present
+    end
+
+    it "only notifies for the highest tier reached when older tiers were crossed long ago" do
+      vote!(topic:, count: 4)
+      DiscourseTopicVoting::Vote.update_all(created_at: 3.weeks.ago)
+      vote!(topic:, count: 1)
+
+      described_class.new.execute(topic_id: topic.id)
+
+      expect(UserBadge.find_by(user: topic_author, badge: daydreamer).notification_id).to be_nil
+      expect(
+        UserBadge.find_by(user: topic_author, badge: brainstormer).notification_id,
+      ).to be_present
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/spec/jobs/vote_reclaim_spec.rb
+++ b/plugins/discourse-topic-voting/spec/jobs/vote_reclaim_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Jobs::DiscourseTopicVoting::VoteReclaim do
       }.from(true).to(false)
     end
 
+    it "enqueues the backfill badges job" do
+      Fabricate(:topic_voting_votes, topic:, archive: true)
+      expect { Jobs::DiscourseTopicVoting::VoteReclaim.new.execute(topic_id: topic.id) }.to change(
+        Jobs::DiscourseTopicVoting::BackfillBadges.jobs,
+        :size,
+      ).by(1)
+    end
+
     context "when the topic is deleted" do
       before { topic.trash! }
 

--- a/plugins/discourse-topic-voting/spec/lib/topic_merger_spec.rb
+++ b/plugins/discourse-topic-voting/spec/lib/topic_merger_spec.rb
@@ -43,6 +43,21 @@ describe DiscourseTopicVoting::TopicMerger do
       expect(topic_0.reload.vote_count).to eq(0)
       expect(topic_1.reload.vote_count).to eq(1)
     end
+
+    it "enqueues the backfill badges job for the destination topic when votes move" do
+      topic_0.update_status("closed", true, Discourse.system_user)
+
+      DiscourseTopicVoting::Vote.create!(user: user_0, topic: topic_0)
+      topic_0.update_vote_count
+
+      expect { described_class.merge(topic_0, topic_1) }.to change(
+        Jobs::DiscourseTopicVoting::BackfillBadges.jobs,
+        :size,
+      ).by(1)
+      expect(Jobs::DiscourseTopicVoting::BackfillBadges.jobs.last["args"].first).to include(
+        "topic_id" => topic_1.id,
+      )
+    end
   end
 
   context "when merging topics via move_posts (topic_merged)" do

--- a/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/votes/cast_spec.rb
+++ b/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/votes/cast_spec.rb
@@ -100,6 +100,13 @@ RSpec.describe DiscourseTopicVoting::Votes::Cast do
       it "does not enqueue the upvote webhook when not configured" do
         expect { result }.not_to change(Jobs::EmitWebHookEvent.jobs, :size)
       end
+
+      it "enqueues the backfill badges job" do
+        expect { result }.to change(Jobs::DiscourseTopicVoting::BackfillBadges.jobs, :size).by(1)
+        expect(Jobs::DiscourseTopicVoting::BackfillBadges.jobs.last["args"].first).to include(
+          "topic_id" => topic.id,
+        )
+      end
     end
   end
 end

--- a/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/votes/remove_spec.rb
+++ b/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/votes/remove_spec.rb
@@ -118,6 +118,10 @@ RSpec.describe DiscourseTopicVoting::Votes::Remove do
       it "does not enqueue the unvote webhook when not configured" do
         expect { result }.not_to change(Jobs::EmitWebHookEvent.jobs, :size)
       end
+
+      it "does not enqueue the backfill badges job" do
+        expect { result }.not_to change(Jobs::DiscourseTopicVoting::BackfillBadges.jobs, :size)
+      end
     end
   end
 end

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -874,4 +874,28 @@ RSpec.describe BadgeGranter do
       end
     end
   end
+
+  describe ".suppress_notification?" do
+    fab!(:silver_badge) { Fabricate(:badge, badge_type_id: BadgeType::Silver) }
+
+    it "does not suppress for a fresh silver badge by default" do
+      expect(BadgeGranter.suppress_notification?(silver_badge, 1.hour.ago, false)).to eq(false)
+    end
+
+    it "lets a plugin override via the :badge_granter_suppress_notification modifier" do
+      plugin_instance = Plugin::Instance.new
+      modifier_block =
+        Proc.new { |suppress, _badge, granted_at, _| suppress || granted_at < 1.day.ago }
+      plugin_instance.register_modifier(:badge_granter_suppress_notification, &modifier_block)
+
+      expect(BadgeGranter.suppress_notification?(silver_badge, 2.days.ago, false)).to eq(true)
+      expect(BadgeGranter.suppress_notification?(silver_badge, 1.hour.ago, false)).to eq(false)
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(
+        plugin_instance,
+        :badge_granter_suppress_notification,
+        &modifier_block
+      )
+    end
+  end
 end


### PR DESCRIPTION
Adds four tiered badges to discourse-topic-voting so topic authors are recognized when their ideas get traction:

- Daydreamer (Bronze, 1 vote)
- Brainstormer (Silver, 5 votes)
- Innovator (Silver, 15 votes)
- Visionary (Gold, 25 votes)

Badges are multi-grant and tied to the qualifying topic's first post, so a user earns each tier once per topic that reaches the threshold. Self-votes (voting on your own topic) are excluded. All badges are disabled by default; the Silver and Gold tiers (Brainstormer, Innovator, Visionary) allow the badge to be used as a title when enabled.

<img width="287" height="216" alt="image" src="https://github.com/user-attachments/assets/3a84c2b2-6157-4504-b5a5-45e7c660e90c" />


### How it is wired

- `Votes::Cast` enqueues a `BackfillBadges` job after a vote is cast.
- `TopicMerger.merge` and `VoteReclaim` also enqueue the job so merged or reclaimed topics are re-evaluated immediately rather than having to wait for the daily consistency pass.
- The job calls `BadgeGranter.backfill` scoped to the topic's first post. Queries join `badge_posts`, which already filters out deleted and unlisted topics, read-restricted categories, and categories with `allow_badges` disabled.
- Each query returns `granted_at` as the timestamp of the Nth qualifying vote (via `ROW_NUMBER()`), so every tier reflects when that threshold was actually crossed rather than when the most recent vote landed.
- Revocation (vote removed, topic deleted, category changed) runs on the daily full backfill via `auto_revoke`, consistent with how discourse-solved handles the same pattern.

### Notification handling

To avoid "granted badge" notification avalanches when the feature is first enabled on a community with years of existing votes, core now exposes a `:badge_granter_suppress_notification` modifier. The plugin registers it and suppresses notifications for its four badges when the qualifying vote is older than 2 weeks. Combined with the per-tier `granted_at`, this means only the tier the author just crossed produces a notification; lower tiers whose threshold was reached long ago stay silent.

Ref - t/182304