### PR TITLE
FIX: Self-canonicalize tl= translated pages

### DIFF
--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -34,15 +34,19 @@ module CanonicalURL
     private
 
     def append_content_localization_param(url)
-      return url if !SiteSetting.content_localization_enabled
-      return url if !SiteSetting.content_localization_crawler_param
-      return url if !use_crawler_layout?
+      return url unless SiteSetting.content_localization_enabled
+      return url unless SiteSetting.content_localization_crawler_param
+      return url unless use_crawler_layout?
+
       locale = params[Discourse::LOCALE_PARAM]
       return url if locale.blank?
+
       supported = SiteSetting.content_localization_supported_locales.to_s.split("|")
-      return url if !supported.include?(locale)
-      separator = url.include?("?") ? "&" : "?"
-      "#{url}#{separator}#{Discourse::LOCALE_PARAM}=#{CGI.escape(locale)}"
+      return url if supported.exclude?(locale)
+
+      uri = Addressable::URI.parse(url)
+      uri.query_values = (uri.query_values || {}).merge(Discourse::LOCALE_PARAM => locale)
+      uri.to_s
     end
   end
 

--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -5,12 +5,14 @@ module CanonicalURL
     ALLOWED_CANONICAL_PARAMS = %w[page]
 
     def canonical_url(url_for_options = {})
-      case url_for_options
-      when Hash
-        @canonical_url = url_for(url_for_options)
-      else
-        @canonical_url = url_for_options
-      end
+      url =
+        case url_for_options
+        when Hash
+          url_for(url_for_options)
+        else
+          url_for_options
+        end
+      @canonical_url = append_content_localization_param(url)
     end
 
     def default_canonical
@@ -21,12 +23,26 @@ module CanonicalURL
           if allowed_params.present?
             canonical << "?#{allowed_params.keys.zip(allowed_params.values).map { |key, value| "#{key}=#{value}" }.join("&")}"
           end
-          canonical
+          append_content_localization_param(canonical)
         end
     end
 
     def self.included(base)
       base.helper_method :default_canonical
+    end
+
+    private
+
+    def append_content_localization_param(url)
+      return url if !SiteSetting.content_localization_enabled
+      return url if !SiteSetting.content_localization_crawler_param
+      return url if !use_crawler_layout?
+      locale = params[Discourse::LOCALE_PARAM]
+      return url if locale.blank?
+      supported = SiteSetting.content_localization_supported_locales.to_s.split("|")
+      return url if !supported.include?(locale)
+      separator = url.include?("?") ? "&" : "?"
+      "#{url}#{separator}#{Discourse::LOCALE_PARAM}=#{CGI.escape(locale)}"
     end
   end
 

--- a/spec/lib/canonical_url_spec.rb
+++ b/spec/lib/canonical_url_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+describe CanonicalURL::ControllerExtensions do
+  let(:host_class) do
+    Class.new do
+      def self.helper_method(*)
+      end
+
+      include CanonicalURL::ControllerExtensions
+
+      attr_accessor :params, :use_crawler_layout
+
+      def initialize(params = {})
+        @params = params
+        @use_crawler_layout = true
+      end
+
+      def use_crawler_layout?
+        @use_crawler_layout
+      end
+    end
+  end
+
+  describe "#append_content_localization_param" do
+    let(:instance) { host_class.new(Discourse::LOCALE_PARAM => "ja") }
+
+    before do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_crawler_param = true
+      SiteSetting.content_localization_supported_locales = "en|ja|es"
+    end
+
+    it "returns the url unchanged when content_localization_enabled is false" do
+      SiteSetting.content_localization_enabled = false
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "returns the url unchanged when content_localization_crawler_param is false" do
+      SiteSetting.content_localization_crawler_param = false
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "returns the url unchanged for non-crawler requests" do
+      instance.use_crawler_layout = false
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "returns the url unchanged when the locale param is absent" do
+      instance.params = {}
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "returns the url unchanged when the locale is not in the supported list" do
+      instance.params = { Discourse::LOCALE_PARAM => "xyz" }
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "appends the locale param to a url without query string" do
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq(
+        "/latest?#{Discourse::LOCALE_PARAM}=ja",
+      )
+    end
+
+    it "appends the locale param to a url with an existing query string" do
+      expect(instance.send(:append_content_localization_param, "/latest?page=2")).to eq(
+        "/latest?page=2&#{Discourse::LOCALE_PARAM}=ja",
+      )
+    end
+
+    it "replaces an existing locale param instead of duplicating it" do
+      result =
+        instance.send(:append_content_localization_param, "/latest?#{Discourse::LOCALE_PARAM}=en")
+      expect(result).to eq("/latest?#{Discourse::LOCALE_PARAM}=ja")
+    end
+
+    it "preserves url fragments" do
+      expect(instance.send(:append_content_localization_param, "/t/slug/1#post_5")).to eq(
+        "/t/slug/1?#{Discourse::LOCALE_PARAM}=ja#post_5",
+      )
+    end
+  end
+end

--- a/spec/requests/crawler_hreflang_spec.rb
+++ b/spec/requests/crawler_hreflang_spec.rb
@@ -40,5 +40,84 @@ describe "Crawler hreflang tags" do
 
       expect(response.body).not_to include('hreflang="x-default"')
     end
+
+    it "self-canonicalizes translated topic pages when ?tl= is present" do
+      get "/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=ja",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{Discourse.base_url}/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=ja">),
+      )
+      expect(response.headers["X-Robots-Tag"].to_s).not_to include("noindex")
+    end
+
+    it "self-canonicalizes translated list pages when ?tl= is present" do
+      get "/latest?#{Discourse::LOCALE_PARAM}=ja",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{Discourse.base_url}/latest?#{Discourse::LOCALE_PARAM}=ja">),
+      )
+    end
+
+    it "does not append ?tl= to canonical when locale param is absent" do
+      get "/t/#{post.topic.slug}/#{post.topic.id}",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to match(
+        %r{<link rel="canonical" href="#{Regexp.escape(Discourse.base_url)}/t/#{post.topic.slug}/#{post.topic.id}"\s*/?>},
+      )
+    end
+
+    it "ignores ?tl= when the locale is not in the supported list" do
+      get "/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=xyz",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{Discourse.base_url}/t/#{post.topic.slug}/#{post.topic.id}">),
+      )
+    end
+
+    it "uses & as separator when another allowed param is present" do
+      Fabricate.times(35, :post, topic: post.topic, user:)
+
+      get "/t/#{post.topic.slug}/#{post.topic.id}?page=2&#{Discourse::LOCALE_PARAM}=ja",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to include(
+        %(<link rel="canonical" href="#{Discourse.base_url}/t/#{post.topic.slug}/#{post.topic.id}?page=2&amp;#{Discourse::LOCALE_PARAM}=ja">),
+      )
+    end
+
+    it "does not modify canonical when content_localization_crawler_param is disabled" do
+      SiteSetting.content_localization_crawler_param = false
+
+      get "/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=ja",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to match(
+        %r{<link rel="canonical" href="#{Regexp.escape(Discourse.base_url)}/t/#{post.topic.slug}/#{post.topic.id}"\s*/?>},
+      )
+    end
+
+    it "does not append ?tl= to canonical for non-crawler requests" do
+      get "/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=ja"
+
+      expect(response.body).to match(
+        %r{<link rel="canonical" href="#{Regexp.escape(Discourse.base_url)}/t/#{post.topic.slug}/#{post.topic.id}"\s*/?>},
+      )
+    end
   end
 end


### PR DESCRIPTION
Translated pages served via `content_localization_crawler_param` (e.g. `?tl=ja`) render a `<link rel="canonical">` pointing to the base URL.

But each language variant should be self-canonical.

This PR fixes that.

See: 
- https://developers.google.com/search/docs/specialty/international/localized-versions
- https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls