### PR TITLE
DEV: Add `--d-selected-text-color` variable

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -16,6 +16,7 @@
   --success: #{$success};
   --love: #{$love};
   --d-selected: #{$selected};
+  --d-selected-text-color: var(--primary);
   --d-selected-hover: #{$selected-hover};
   --d-hover: #{$hover};
   --always-black-rgb: 0, 0, 0;

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -771,7 +771,7 @@ textarea {
 
         &.active {
           font-weight: bold;
-          color: var(--primary);
+          color: var(--d-selected-text-color);
           background: var(--d-selected);
         }
       }

--- a/app/assets/stylesheets/common/base/list-controls.scss
+++ b/app/assets/stylesheets/common/base/list-controls.scss
@@ -142,6 +142,7 @@
 
         &.active {
           background: var(--d-selected);
+          color: var(--d-selected-text-color);
           font-weight: bold;
         }
       }

--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -223,7 +223,7 @@
 
       .btn.is-selected {
         background: var(--d-selected);
-        color: var(--primary);
+        color: var(--d-selected-text-color);
       }
     }
   }

--- a/app/assets/stylesheets/common/components/autocomplete.scss
+++ b/app/assets/stylesheets/common/components/autocomplete.scss
@@ -43,6 +43,7 @@
 
         &.selected {
           background-color: var(--d-selected);
+          color: var(--d-selected-text-color);
         }
 
         .avatar {

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -100,7 +100,7 @@
     }
 
     &.active {
-      color: var(--primary);
+      color: var(--d-selected-text-color);
       background-color: var(--d-selected);
       font-weight: bold;
       font-weight: var(--d-sidebar-active-font-weight);

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -473,6 +473,7 @@
 
   &.--active {
     background: var(--d-selected);
+    color: var(--d-selected-text-color);
 
     &.btn:hover .d-icon {
       color: var(--primary-high);

--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -342,6 +342,7 @@
 
     &.--active {
       background: var(--d-selected);
+      color: var(--d-selected-text-color);
     }
   }
 

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -244,6 +244,7 @@
     &.is-selected,
     &.is-selected.is-highlighted {
       background: var(--d-selected);
+      color: var(--d-selected-text-color);
     }
 
     .discourse-tag,


### PR DESCRIPTION
Allows easier overrides for `d-selected` in themes, especially when using bright colors and wanting the selected text to be different from the primary text color.

Example: 

<img width="1526" height="927" alt="image" src="https://github.com/user-attachments/assets/3a6c8f9f-ea08-4c29-a0a1-362296e76041" />

Without this change in core, we'd need to target each place where `d-selected` is used. With this change, the theme only needs to override `--d-selected-text-color`. 
