### PR TITLE
DEV: Fix a site_icon_manager spec flake

### DIFF
--- a/spec/lib/site_icon_manager_spec.rb
+++ b/spec/lib/site_icon_manager_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SiteIconManager do
     SiteSetting.logo = ""
     SiteSetting.logo_small = ""
 
-    Upload.find_by(id: SiteIconManager::SKETCH_LOGO_ID)&.destroy
+    Upload.find_by(id: SiteIconManager::SKETCH_LOGO_ID)&.delete
 
     expect(SiteIconManager.favicon).to eq(nil)
     expect(SiteIconManager.large_icon).to eq(nil)


### PR DESCRIPTION
```
  1) StaticController#favicon with local store returns the default favicon if favicon has not been configured
     Failure/Error: expect(response.status).to eq(200)

       expected: 200
            got: 500

       (compared using ==)
```

Using `#delete` instead of `#destroy` to avoid it moving/deleting the upload file (that further specs might rely on)