### PR TITLE
DEV: Add `SystemHelpers::LINE_START_KEY`

### DIFF
--- a/plugins/checklist/spec/system/rich_editor_extension_spec.rb
+++ b/plugins/checklist/spec/system/rich_editor_extension_spec.rb
@@ -98,7 +98,7 @@ describe "Composer - ProseMirror editor - Checklist extension" do
       expect(checklist).to have_checkboxes(count: 2)
       expect(checklist).to have_items(count: 2)
 
-      rich.send_keys(:home)
+      rich.send_keys(SystemHelpers::LINE_START_KEY)
       rich.send_keys(:backspace)
 
       expect(checklist).to have_checkboxes(count: 1)

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -4,6 +4,10 @@ require "highline/import"
 module SystemHelpers
   PLATFORM_KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control
 
+  # Pass to `send_keys` to move the caret to the start of the current line in a
+  # contenteditable. The Home key doesn't move the caret on macOS; Cmd+Left does.
+  LINE_START_KEY = RUBY_PLATFORM =~ /darwin/i ? %i[meta left] : :home
+
   def pause_test
     msg = "Test paused. Press enter to resume, or `d` + enter to start debugger.\n\n"
     msg += "Browser inspection URLs:\n"

--- a/spec/system/composer/prosemirror_code_spec.rb
+++ b/spec/system/composer/prosemirror_code_spec.rb
@@ -237,7 +237,7 @@ describe "Composer - ProseMirror - Code formatting" do
       composer.type_content("`code mark`")
       expect(rich).to have_css("code", text: "code mark")
       # before the code mark
-      composer.send_keys(:home)
+      composer.send_keys(SystemHelpers::LINE_START_KEY)
       composer.send_keys(:left)
       composer.type_content("..")
       # within the code mark

--- a/spec/system/composer/prosemirror_keymap_spec.rb
+++ b/spec/system/composer/prosemirror_keymap_spec.rb
@@ -106,7 +106,7 @@ describe "Composer - ProseMirror - Keyboard shortcuts" do
 
     expect(rich).to have_css("h1", text: "With text")
 
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     wait_for_timeout
     composer.send_keys(:backspace)
 
@@ -116,7 +116,7 @@ describe "Composer - ProseMirror - Keyboard shortcuts" do
   it "supports Backspace to reset a code_block" do
     open_composer
     composer.type_content("```code block")
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     wait_for_timeout
     composer.send_keys(:backspace)
 
@@ -128,7 +128,7 @@ describe "Composer - ProseMirror - Keyboard shortcuts" do
     composer.type_content("1. Item 1\nItem 2")
     composer.send_keys(:down)
     composer.type_content("Item 3")
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     composer.send_keys(:backspace)
 
     expect(rich).to have_css("ol li", text: "Item 1")
@@ -140,7 +140,7 @@ describe "Composer - ProseMirror - Keyboard shortcuts" do
 
     composer.type_content("##{category_with_emoji.slug}")
     composer.send_keys(:space)
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     wait_for_timeout
     composer.send_keys(:enter)
 
@@ -155,7 +155,7 @@ describe "Composer - ProseMirror - Keyboard shortcuts" do
 
     composer.type_content("##{category_with_emoji.slug}")
     composer.send_keys(:space)
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     wait_for_timeout
     composer.send_keys(:backspace)
 

--- a/spec/system/composer/prosemirror_quotes_spec.rb
+++ b/spec/system/composer/prosemirror_quotes_spec.rb
@@ -22,7 +22,7 @@ describe "Composer - ProseMirror - Quotes" do
     composer.type_content("[quote]Text")
     expect(rich).to have_css("aside.quote blockquote p", text: "Text")
 
-    composer.send_keys(:home)
+    composer.send_keys(SystemHelpers::LINE_START_KEY)
     composer.send_keys(:backspace)
 
     expect(rich).to have_no_css("aside.quote")


### PR DESCRIPTION
…as a replacement for `:home`.

This fixes composer/rich editor specs on macOS where "home" button doesn't move text caret, cmd+left does.