### PR TITLE
FIX: remove embed mode horizontal overflow and z-index issue

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -105,10 +105,9 @@ body.embed-mode {
     }
   }
 
+  // prevent horizontal overflow
   .topic-meta-data {
     @include viewport.until(sm) {
-      // prevent horizontal overflow
-
       .post-infos {
         position: relative;
         overflow: hidden;
@@ -117,6 +116,7 @@ body.embed-mode {
 
       .read-state {
         right: 1px;
+
         svg {
           right: 0;
         }

--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 // Styles for the full Ember app when rendered in embed mode (iframe)
 // Activated when ?embed_mode=true is in the URL
 body.embed-mode {
@@ -103,6 +105,25 @@ body.embed-mode {
     }
   }
 
+  .topic-meta-data {
+    @include viewport.until(sm) {
+      // prevent horizontal overflow
+
+      .post-infos {
+        position: relative;
+        overflow: hidden;
+        padding-right: 6px;
+      }
+
+      .read-state {
+        right: 1px;
+        svg {
+          right: 0;
+        }
+      }
+    }
+  }
+
   // Hide the docked timeline sidebar (fullscreen timeline still works)
   .timeline-container:not(.timeline-fullscreen) {
     display: none !important;
@@ -154,7 +175,7 @@ body.embed-mode {
   .embed-mode-composer {
     position: sticky;
     bottom: 0;
-    z-index: 50;
+    z-index: z("composer", "content");
     background: var(--secondary);
     padding-inline: 0.5em;
 


### PR DESCRIPTION
**Before** on small widths, there is an horizontal overflow beyond the document width. This is caused by the `.read-state` indicator being placed in the `#main-outlet-wrapper` padding in regular mode. In embed mode, the wrapper does not have a padding, and thus the indicator forces the overflow.

There is also an issue where the topic progress overlaps over the docked composer.

Screen recording of blog.discourse.org:

https://github.com/user-attachments/assets/ffabbef8-beb5-495a-b383-082bb165958c

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/0cbfcd64-ddaa-48de-975c-ddcf14f25ff6

</details>

**This commit** adjusts the `post-infos` div to the left a bit so that the `.read-state` indicator can still be within the window frame while keeping the timestamp close to the right.

Also updates the z-index of the docked composer in embed mode.

https://github.com/user-attachments/assets/a4578057-46e5-440e-9684-18f83c536a17