### PR TITLE
DEV: Restore and fix composer body test

### DIFF
--- a/frontend/discourse/app/components/composer-body.js
+++ b/frontend/discourse/app/components/composer-body.js
@@ -6,6 +6,7 @@ import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { classNameBindings } from "@ember-decorators/component";
 import { observes } from "@ember-decorators/object";
+import { waitForTransitionEnd } from "discourse/lib/animation-utils";
 import discourseDebounce from "discourse/lib/debounce";
 import discourseLater from "discourse/lib/later";
 import Composer from "discourse/models/composer";
@@ -72,6 +73,36 @@ export default class ComposerBody extends Component {
     });
   }
 
+  @observes("composeState")
+  async _onComposerOpen() {
+    // Skip if not opening, unmounted, or already awaiting the open transition —
+    // the in-flight wait will fire (or not) based on state at resolution time.
+    if (
+      !this.element ||
+      this.composeState !== Composer.OPEN ||
+      this._awaitingComposerOpen
+    ) {
+      return;
+    }
+
+    this._awaitingComposerOpen = true;
+    try {
+      await waitForTransitionEnd(this.element, "height");
+
+      if (
+        this.isDestroying ||
+        this.isDestroyed ||
+        this.composeState !== Composer.OPEN
+      ) {
+        return;
+      }
+
+      this.appEvents.trigger("composer:opened");
+    } finally {
+      this._awaitingComposerOpen = false;
+    }
+  }
+
   composerResized() {
     if (!this.element || this.isDestroying || this.isDestroyed) {
       return;
@@ -83,17 +114,12 @@ export default class ComposerBody extends Component {
   didInsertElement() {
     super.didInsertElement(...arguments);
 
-    const triggerOpen = () => {
-      if (this.get("composer.composeState") === Composer.OPEN) {
-        this.appEvents.trigger("composer:opened");
-      }
-    };
-    triggerOpen();
+    if (this.composeState === Composer.OPEN) {
+      this.appEvents.trigger("composer:opened");
+    }
 
     this.element.addEventListener("transitionend", (event) => {
-      if (event.propertyName === "height") {
-        triggerOpen();
-      } else if (event.propertyName === "max-width") {
+      if (event.propertyName === "max-width") {
         this.composerResized();
       }
     });

--- a/frontend/discourse/app/lib/animation-utils.js
+++ b/frontend/discourse/app/lib/animation-utils.js
@@ -4,31 +4,33 @@ import { prefersReducedMotion } from "discourse/lib/utilities";
 
 // Resolves on the animationend/transitionend event, or on a timeout if the event never triggers.
 function waitForEndEvent(element, eventName, styleKey, filter) {
-  return new Promise((resolve) => {
-    const style = window.getComputedStyle(element);
-    const duration = parseFloat(style[`${styleKey}Duration`]) * 1000 || 0;
-    const delay = parseFloat(style[`${styleKey}Delay`]) * 1000 || 0;
+  return waitForPromise(
+    new Promise((resolve) => {
+      const style = window.getComputedStyle(element);
+      const duration = parseFloat(style[`${styleKey}Duration`]) * 1000 || 0;
+      const delay = parseFloat(style[`${styleKey}Delay`]) * 1000 || 0;
 
-    const handler = (event) => {
-      if (filter && !filter(event)) {
-        return;
-      }
+      const handler = (event) => {
+        if (filter && !filter(event)) {
+          return;
+        }
 
-      clearTimeout(timeoutId);
-      element.removeEventListener(eventName, handler);
-      resolve();
-    };
-
-    const timeoutId = setTimeout(
-      () => {
+        clearTimeout(timeoutId);
         element.removeEventListener(eventName, handler);
         resolve();
-      },
-      Math.max(duration + delay + 50, 50)
-    );
+      };
 
-    element.addEventListener(eventName, handler);
-  });
+      const timeoutId = setTimeout(
+        () => {
+          element.removeEventListener(eventName, handler);
+          resolve();
+        },
+        Math.max(duration + delay + 50, 50)
+      );
+
+      element.addEventListener(eventName, handler);
+    })
+  );
 }
 
 export function waitForAnimationEnd(element) {
@@ -50,7 +52,7 @@ export async function animateClosing(element, className = "-closing") {
   }
   element.classList.add(className);
 
-  await waitForPromise(waitForAnimationEnd(element));
+  await waitForAnimationEnd(element);
 
   element.classList.remove(className);
 }

--- a/frontend/discourse/app/lib/animation-utils.js
+++ b/frontend/discourse/app/lib/animation-utils.js
@@ -2,30 +2,46 @@ import { waitForPromise } from "@ember/test-waiters";
 import { isTesting } from "discourse/lib/environment";
 import { prefersReducedMotion } from "discourse/lib/utilities";
 
-export async function waitForAnimationEnd(element) {
+// Resolves on the animationend/transitionend event, or on a timeout if the event never triggers.
+function waitForEndEvent(element, eventName, styleKey, filter) {
   return new Promise((resolve) => {
     const style = window.getComputedStyle(element);
-    const duration = parseFloat(style.animationDuration) * 1000 || 0;
-    const delay = parseFloat(style.animationDelay) * 1000 || 0;
-    const totalTime = duration + delay;
+    const duration = parseFloat(style[`${styleKey}Duration`]) * 1000 || 0;
+    const delay = parseFloat(style[`${styleKey}Delay`]) * 1000 || 0;
 
-    const handleAnimationEnd = () => {
+    const handler = (event) => {
+      if (filter && !filter(event)) {
+        return;
+      }
+
       clearTimeout(timeoutId);
-      element.removeEventListener("animationend", handleAnimationEnd);
+      element.removeEventListener(eventName, handler);
       resolve();
     };
 
     const timeoutId = setTimeout(
       () => {
-        element.removeEventListener("animationend", handleAnimationEnd);
+        element.removeEventListener(eventName, handler);
         resolve();
       },
-      // The timeout acts as a fallback in case the "animationend" event does not fire (e.g., when no animation is present).
-      Math.max(totalTime + 50, 50)
+      Math.max(duration + delay + 50, 50)
     );
 
-    element.addEventListener("animationend", handleAnimationEnd);
+    element.addEventListener(eventName, handler);
   });
+}
+
+export function waitForAnimationEnd(element) {
+  return waitForEndEvent(element, "animationend", "animation");
+}
+
+export function waitForTransitionEnd(element, propertyName) {
+  return waitForEndEvent(
+    element,
+    "transitionend",
+    "transition",
+    (event) => event.propertyName === propertyName
+  );
 }
 
 export async function animateClosing(element, className = "-closing") {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -160,7 +160,6 @@ module TestSetup
       unique_posts_mins: 0,
       max_consecutive_replies: 0,
       allow_uncategorized_topics: true,
-      educate_until_posts: 0,
     }.each { |k, v| SiteSetting.set(k, v) }
 
     SiteSetting.refresh!(refresh_site_settings: false, refresh_theme_site_settings: true)
@@ -872,6 +871,11 @@ RSpec.configure do |config|
     setup_system_test
 
     BlockRequestsMiddleware.current_example_location = example.location
+
+    # Suppress the "Before you post, please select a category or tag" education
+    # popup — it intercepts pointer events and makes system specs flaky when
+    # they click things in the composer.
+    SiteSetting.educate_until_posts = 0
 
     if example.metadata[:video]
       Capybara.current_session.driver.on_save_screenrecord do |video|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -160,6 +160,7 @@ module TestSetup
       unique_posts_mins: 0,
       max_consecutive_replies: 0,
       allow_uncategorized_topics: true,
+      educate_until_posts: 0,
     }.each { |k, v| SiteSetting.set(k, v) }
 
     SiteSetting.refresh!(refresh_site_settings: false, refresh_theme_site_settings: true)

--- a/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
+++ b/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
@@ -12,10 +12,6 @@ describe "Composer don't feed the trolls popup" do
   before { sign_in user }
 
   it "shows a popup when about to reply to a troll" do
-    skip(
-      "TGX: This does not work when Capybara.disable_animation is set to true. We're in the midst of fixing this.",
-    )
-
     SiteSetting.educate_until_posts = 0
 
     topic_page.visit_topic(topic)

--- a/spec/system/topic_list/glimmer_spec.rb
+++ b/spec/system/topic_list/glimmer_spec.rb
@@ -68,8 +68,6 @@ describe "glimmer topic list" do
   end
 
   describe "topic highlighting" do
-    # TODO: Those require `Capybara.disable_animation = false`
-
     it "highlights newly received topics" do
       Fabricate(:read_topic, current_user: user)
 


### PR DESCRIPTION
…that needed a `transitionend` event. Use the pattern already established by `waitForAnimationEnd`.