### PR TITLE
DEV: Bump minio_runner to 1.0.1 [backport 2026.1]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     mini_sql (1.6.0)
     mini_suffix (0.3.3)
       ffi (~> 1.9)
-    minio_runner (1.0.0)
+    minio_runner (1.0.1)
     minitest (5.26.2)
     mocha (2.8.2)
       ruby2_keywords (>= 0.0.5)
@@ -1069,7 +1069,7 @@ CHECKSUMS
   mini_scheduler (0.18.0) sha256=d2f084f38da8d76c5844a92f0d6bd01fc9982a8b5e6c7679b6cf44c82da33503
   mini_sql (1.6.0) sha256=5296637f6a4af5bb43e06788037e9a2968ff9c8eb65928befcba8cb41f42d6ee
   mini_suffix (0.3.3) sha256=8d1d33f92f69a2247c9b7d27173235da90479d955cdb863b63a7f53843b722e7
-  minio_runner (1.0.0) sha256=ca0fc56a90c63b65a26cda632938c9075046835d41f4b9d1e165b0550eae0538
+  minio_runner (1.0.1) sha256=3675ad7abd79177b3fdd9f37e20fe46f7d4dcbb41f3f30a53db2207277241795
   minitest (5.26.2) sha256=f021118a6185b9ba9f5af71f2ba103ad770c75afde9f2ab8da512677c550cde3
   mocha (2.8.2) sha256=1f77e729db47e72b4ef776461ce20caeec2572ffdf23365b0a03608fee8f4eee
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732


### PR DESCRIPTION
- Backport [this](https://github.com/discourse/discourse/commit/98c894572bf16677f0811f9fd81ed2d9177a57f7) commit to prevent ci errors