### PR TITLE
UX: Introduce anonymous and logged_in_users auto groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -686,12 +686,17 @@ class GroupsController < ApplicationController
   end
 
   def search
-    include_everyone = params[:include_everyone] == "true"
+    include_everyone =
+      (params[:include_everyone] == "true" || params[:include_pseudogroups] == "true")
+    include_pseudogroups = params[:include_pseudogroups] == "true"
     order = ["name"]
     groups =
-      Group.visible_groups(current_user, order, include_everyone: include_everyone).includes(
-        :flair_upload,
-      )
+      Group.visible_groups(
+        current_user,
+        order,
+        include_everyone: include_everyone,
+        include_pseudogroups: include_pseudogroups,
+      ).includes(:flair_upload)
 
     if (term = params[:term]).present?
       groups =

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -153,7 +153,15 @@ class Group < ActiveRecord::Base
 
     return [] if lower_group.blank? || upper_group.blank?
 
-    (lower_group..upper_group).to_a & AUTO_GROUPS.values
+    (lower_group..upper_group).to_a &
+      (
+        AUTO_GROUPS.values -
+          [
+            Group::AUTO_GROUPS[:anonymous],
+            Group::AUTO_GROUPS[:logged_in_users],
+            Group::AUTO_GROUPS[:everyone],
+          ]
+      )
   end
 
   validates :mentionable_level, inclusion: { in: ALIAS_LEVELS.values }
@@ -169,11 +177,8 @@ class Group < ActiveRecord::Base
 
           opts ||= {}
 
-          if !opts[:include_everyone] && !opts[:include_pseudogroups]
-            groups = groups.where("groups.id > 0")
-          end
-
           if !opts[:include_pseudogroups]
+            groups = groups.where("groups.id > 0") unless opts[:include_everyone]
             groups =
               groups.where(
                 "groups.id NOT IN (:ids)",
@@ -236,11 +241,8 @@ class Group < ActiveRecord::Base
 
           opts ||= {}
 
-          if !opts[:include_everyone] && !opts[:include_pseudogroups]
-            groups = groups.where("groups.id > 0")
-          end
-
           if !opts[:include_pseudogroups]
+            groups = groups.where("groups.id > 0") unless opts[:include_everyone]
             groups =
               groups.where(
                 "groups.id NOT IN (:ids)",

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -104,6 +104,8 @@ class Group < ActiveRecord::Base
     admins: 1,
     moderators: 2,
     staff: 3,
+    anonymous: 4,
+    logged_in_users: 5,
     trust_level_0: 10,
     trust_level_1: 11,
     trust_level_2: 12,
@@ -528,10 +530,11 @@ class Group < ActiveRecord::Base
       group.name = default_name
     end
 
-    # the everyone group is special, it can include non-users so there is no
-    # way to have the membership in a table
+    # the everyone, anonymous, and logged_in_users groups are special — they
+    # represent implicit populations (unauthenticated visitors, or all logged-in
+    # users) that cannot be enumerated via group_users rows.
     case name
-    when :everyone
+    when :everyone, :anonymous, :logged_in_users
       group.visibility_level = Group.visibility_levels[:staff]
       group.save!
       return group

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -167,7 +167,19 @@ class Group < ActiveRecord::Base
           groups = groups.order(order) if order
           groups = groups.order("groups.name ASC") unless order&.include?("name")
 
-          groups = groups.where("groups.id > 0") if !opts || !opts[:include_everyone]
+          opts ||= {}
+
+          if !opts[:include_everyone] && !opts[:include_pseudogroups]
+            groups = groups.where("groups.id > 0")
+          end
+
+          if !opts[:include_pseudogroups]
+            groups =
+              groups.where(
+                "groups.id NOT IN (:ids)",
+                ids: [Group::AUTO_GROUPS[:anonymous], Group::AUTO_GROUPS[:logged_in_users]],
+              )
+          end
 
           if !user&.admin
             is_staff = !!user&.staff?
@@ -222,7 +234,19 @@ class Group < ActiveRecord::Base
         Proc.new { |user, order, opts|
           groups = self.order(order || "name ASC")
 
-          groups = groups.where("groups.id > 0") if !opts || !opts[:include_everyone]
+          opts ||= {}
+
+          if !opts[:include_everyone] && !opts[:include_pseudogroups]
+            groups = groups.where("groups.id > 0")
+          end
+
+          if !opts[:include_pseudogroups]
+            groups =
+              groups.where(
+                "groups.id NOT IN (:ids)",
+                ids: [Group::AUTO_GROUPS[:anonymous], Group::AUTO_GROUPS[:logged_in_users]],
+              )
+          end
 
           if !user&.admin
             is_staff = !!user&.staff?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -544,9 +544,23 @@ class User < ActiveRecord::Base
   end
 
   def in_any_groups?(group_ids)
-    group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
-      (is_system_user? && (Group.auto_groups_between(:admins, :trust_level_4) & group_ids).any?) ||
-      (group_ids & belonging_to_group_ids).any?
+    everyone_or_logged_in =
+      group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+        group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
+
+    system_user_in_required_groups =
+      (
+        is_system_user? &&
+          (
+            (
+              Group.auto_groups_between(:admins, :trust_level_4) - [Group::AUTO_GROUPS[:anonymous]]
+            ) & group_ids
+          ).any?
+      )
+
+    has_required_groups = (group_ids & belonging_to_group_ids).any?
+
+    everyone_or_logged_in || system_user_in_required_groups || has_required_groups
   end
 
   def belonging_to_group_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -544,23 +544,21 @@ class User < ActiveRecord::Base
   end
 
   def in_any_groups?(group_ids)
-    everyone_or_logged_in =
-      group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
-        group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
+    # We can avoid looking up the user's actual groups
+    # for these global pseudogroups. In Guardian::AnonymousUser#in_any_groups?,
+    # we only return true if group_ids include the :anonymous auto group.
+    if group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+         group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
+      return true
+    end
 
-    system_user_in_required_groups =
-      (
-        is_system_user? &&
-          (
-            (
-              Group.auto_groups_between(:admins, :trust_level_4) - [Group::AUTO_GROUPS[:anonymous]]
-            ) & group_ids
-          ).any?
-      )
+    # Sometimes the system user doesn't have their auto groups
+    # from some strange edge case, this handles it.
+    if (is_system_user? && ((Group.auto_groups_between(:admins, :trust_level_4)) & group_ids).any?)
+      return true
+    end
 
-    has_required_groups = (group_ids & belonging_to_group_ids).any?
-
-    everyone_or_logged_in || system_user_in_required_groups || has_required_groups
+    (group_ids & belonging_to_group_ids).any?
   end
 
   def belonging_to_group_ids

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -671,6 +671,8 @@ en:
       admins: "admins"
       moderators: "moderators"
       staff: "staff"
+      anonymous: "anonymous"
+      logged_in_users: "logged_in_users"
       trust_level_0: "trust_level_0"
       trust_level_1: "trust_level_1"
       trust_level_2: "trust_level_2"
@@ -679,6 +681,8 @@ en:
     default_descriptions:
       everyone: "Automatic group including all members"
       staff: "Automatic group including admins and moderators"
+      anonymous: "Automatic pseudogroup representing unauthenticated visitors"
+      logged_in_users: "Automatic pseudogroup including every logged-in user"
       admins: "Responsible for configuring and maintaining this site, with access to all member and activity data"
       moderators: "Responsible for responding to flags, moderating discussions, and helping members with their accounts"
       trust_level_0: "New members with limited abilities, who are learning community norms and functionality"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -456,7 +456,7 @@ basic:
     default: ""
     allow_any: false
     refresh: true
-    disallowed_groups: "0"
+    disallowed_groups: "0|4"
     area: "group_permissions"
   hidden_post_visible_groups:
     type: group_list
@@ -464,6 +464,7 @@ basic:
     default: "14"
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   push_notifications_prompt:
     default: true
@@ -541,11 +542,13 @@ basic:
   about_page_hidden_groups:
     default: ""
     type: group_list
+    disallowed_groups: "4"
     area: "group_permissions"
   about_page_extra_groups:
     client: true
     default: ""
     type: group_list
+    disallowed_groups: "4"
     area: "about"
   about_page_extra_groups_initial_members:
     client: true
@@ -1076,6 +1079,7 @@ users:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     validator: "AtLeastOneGroupValidator"
     area: "group_permissions"
   anonymous_account_duration_minutes:
@@ -1343,6 +1347,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   editing_grace_period:
     default: 300
@@ -1365,6 +1370,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     validator: "AtLeastOneGroupValidator"
     area: "group_permissions"
   post_edit_time_limit:
@@ -1469,6 +1475,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   title_max_word_length:
     default: 30
@@ -1600,6 +1607,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   approve_new_topics_unless_allowed_groups:
     default: "1|2|10" # auto groups admins, moderators, trust_level_0
@@ -1607,6 +1615,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   approve_suspect_users:
     default: true
@@ -1701,6 +1710,7 @@ posting:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   blur_tl0_flagged_posts_media:
     default: true
@@ -1769,6 +1779,7 @@ content_localization:
     allow_any: false
     client: true
     default: "1|2" # admin, moderator
+    disallowed_groups: "4"
     area: "localization"
   content_localization_allow_author_localization:
     default: true
@@ -1862,6 +1873,7 @@ nested_replies:
     default: "3"
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "posts_and_topics"
     depends_on:
       - "nested_replies_enabled"
@@ -1989,6 +2001,7 @@ email:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   email_in_authserv_id:
     default: ""
@@ -2189,6 +2202,7 @@ email:
     default: "1|2"
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
 
 files:
@@ -2376,6 +2390,7 @@ files:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   default_avatars:
     default: ""
@@ -2534,6 +2549,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   edit_wiki_post_allowed_groups:
     default: "1|2|11" # auto group admins, moderators, trust_level_1
@@ -2541,6 +2557,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   edit_post_allowed_groups:
     default: "1|2|10" # auto group admins, moderators, trust_level_0
@@ -2548,6 +2565,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   self_wiki_allowed_groups:
     default: "1|2|13" # auto group admins, moderators, trust_level_3
@@ -2555,6 +2573,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   send_email_messages_allowed_groups:
     default: "1|2|14" # auto group admins, moderators, trust_level_4
@@ -2562,6 +2581,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   flag_post_allowed_groups:
     default: "1|2|11" # auto group admins, moderators, trust_level_1
@@ -2569,6 +2589,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "flags|group_permissions"
   allow_all_users_to_flag_illegal_content:
     default: false
@@ -2584,6 +2605,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   embedded_media_post_allowed_groups:
     default: "1|2|10" # auto group admins, moderators, trust_level_0
@@ -2591,6 +2613,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   profile_background_allowed_groups:
     default: "1|2|10" # auto group admins, moderators, trust_level_0
@@ -2598,6 +2621,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   user_card_background_allowed_groups:
     default: "1|2|10" # auto group admins, moderators, trust_level_0
@@ -2605,6 +2629,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   invite_allowed_groups:
     default: "1|2|12" # auto group admins, moderators, trust_level_2
@@ -2612,6 +2637,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   ignore_allowed_groups:
     default: "1|2|12" # auto group admins, moderators, trust_level_2
@@ -2619,6 +2645,7 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   allow_flagging_staff: true
   send_tl1_welcome_message: true
@@ -2711,15 +2738,18 @@ trust:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   edit_all_topic_groups:
     default: "13"
     type: group_list
+    disallowed_groups: "4"
     area: "group_permissions"
   edit_all_post_groups:
     default: "1|2|14" # auto group admins, moderators, and TL4
     mandatory_values: "1|2" # auto group admins, moderators
     type: group_list
+    disallowed_groups: "4"
     area: "group_permissions"
 
 security:
@@ -2767,6 +2797,7 @@ security:
     type: group_list
     list_type: compact
     default: ""
+    disallowed_groups: "4"
   moderators_view_emails:
     client: true
     default: false
@@ -4117,6 +4148,7 @@ user_api:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   allowed_user_api_push_urls:
     default: ""
@@ -4180,6 +4212,7 @@ tags:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   edit_tags_allowed_groups:
     default: "1|2" # auto group admins, moderators
@@ -4187,6 +4220,7 @@ tags:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   tag_topic_allowed_groups:
     default: "1|2|10" # auto group admins, moderators, trust_level_0
@@ -4194,6 +4228,7 @@ tags:
     type: group_list
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     client: true
     area: "group_permissions"
   max_tag_search_results:
@@ -4223,6 +4258,7 @@ tags:
     default: ""
     allow_any: false
     refresh: true
+    disallowed_groups: "4"
     area: "group_permissions"
   suppress_overlapping_tags_in_list:
     default: false

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -456,7 +456,7 @@ basic:
     default: ""
     allow_any: false
     refresh: true
-    disallowed_groups: "0|4"
+    disallowed_groups: "0|4|5"
     area: "group_permissions"
   hidden_post_visible_groups:
     type: group_list

--- a/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
+++ b/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class EnsureAnonymousAndLoggedInUsersAutoGroups < ActiveRecord::Migration[8.0]
+  def up
+    # The `anonymous` (id 4) and `logged_in_users` (id 5) auto groups are
+    # pseudogroups — they have no group_users rows; membership is implicit.
+    # Seed the rows here so callers that look them up by id don't fail before
+    # db/fixtures/002_groups.rb runs.
+    execute(<<~SQL)
+      INSERT INTO groups (id, name, automatic, visibility_level, created_at, updated_at)
+      VALUES
+        (4, 'anonymous', true, 3, NOW(), NOW()),
+        (5, 'logged_in_users', true, 3, NOW(), NOW())
+      ON CONFLICT (id) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
+++ b/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
@@ -2,6 +2,43 @@
 
 class EnsureAnonymousAndLoggedInUsersAutoGroups < ActiveRecord::Migration[8.0]
   def up
+    legacy_anonymous_group_id = DB.query_single(<<~SQL).first
+      SELECT id FROM groups WHERE name = 'anonymous' AND id <> 4;
+    SQL
+
+    legacy_logged_in_users_group_id = DB.query_single(<<~SQL).first
+      SELECT id FROM groups WHERE name = 'logged_in_users' AND id <> 5;
+    SQL
+
+    # Make sure any existing groups with the name `anonymous` or
+    # `logged_in_users` are renamed to avoid conflicts with the
+    # new auto groups. Also make sure to rebake posts & update group mentions.
+    if legacy_anonymous_group_id.present?
+      execute(<<~SQL)
+        UPDATE groups SET name = 'anonymous_legacy_' || id::text
+        WHERE name = 'anonymous' AND id <> 4;
+      SQL
+
+      update_group_mentions(
+        "anonymous",
+        "anonymous_legacy_#{legacy_anonymous_group_id}",
+        legacy_anonymous_group_id,
+      )
+    end
+
+    if legacy_logged_in_users_group_id.present?
+      execute(<<~SQL)
+        UPDATE groups SET name = 'logged_in_users_legacy_' || id::text
+        WHERE name = 'logged_in_users' AND id <> 5;
+      SQL
+
+      update_group_mentions(
+        "logged_in_users",
+        "logged_in_users_legacy_#{legacy_logged_in_users_group_id}",
+        legacy_logged_in_users_group_id,
+      )
+    end
+
     # The `anonymous` (id 4) and `logged_in_users` (id 5) auto groups are
     # pseudogroups — they have no group_users rows; membership is implicit.
     # Seed the rows here so callers that look them up by id don't fail before
@@ -17,5 +54,26 @@ class EnsureAnonymousAndLoggedInUsersAutoGroups < ActiveRecord::Migration[8.0]
 
   def down
     raise ActiveRecord::IrreversibleMigration
+  end
+
+  def update_group_mentions(old_slug, new_slug, legacy_group_id)
+    DB.exec(<<~SQL, old_slug:, new_slug:, group_id: legacy_group_id)
+      UPDATE posts AS p  SET
+          raw = regexp_replace(
+            p.raw,
+            '(^|\s)(@' || :old_slug || ')(\s|$)',
+            E'\\1@' || :new_slug || E'\\3',
+            'g'
+          ),
+          baked_version = NULL
+        WHERE p.deleted_at IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM group_mentions gm
+            WHERE gm.post_id = p.id
+              AND gm.group_id = :group_id
+          )
+          AND p.raw LIKE '%@' || :old_slug || '%';
+    SQL
   end
 end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -100,7 +100,7 @@ class Guardian
     end
 
     def in_any_groups?(group_ids)
-      false
+      group_ids.include?(Group::AUTO_GROUPS[:anonymous])
     end
   end
 

--- a/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
@@ -98,7 +98,10 @@ RSpec.describe DiscourseAi::CreditStatusChecker do
             Fabricate(
               :ai_agent,
               default_llm_id: llm_model.id,
-              allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+              allowed_group_ids: [
+                Group::AUTO_GROUPS[:everyone],
+                Group::AUTO_GROUPS[:logged_in_users],
+              ],
             )
           params[:agent_ids] = [ai_agent.id, agent2.id]
 
@@ -123,7 +126,7 @@ RSpec.describe DiscourseAi::CreditStatusChecker do
         Fabricate(
           :ai_agent,
           default_llm_id: llm_model.id,
-          allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+          allowed_group_ids: [Group::AUTO_GROUPS[:everyone], Group::AUTO_GROUPS[:logged_in_users]],
         )
       end
 

--- a/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe DiscourseAi::CreditStatusChecker do
 
           select_queries = queries.select { |q| q.include?("SELECT") && !q.include?("SELECT 1") }
 
-          expect(select_queries.length).to be <= 6
+          expect(select_queries.length).to be <= 5
         end
 
         it "handles mixed valid and invalid IDs" do

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -37,6 +37,24 @@ RSpec.describe Guardian do
     expect { Guardian.new(user) }.not_to raise_error
   end
 
+  describe "AnonymousUser#in_any_groups?" do
+    let(:anon) { Guardian::AnonymousUser.new }
+
+    it "returns true when the anonymous auto group is in the list" do
+      expect(anon.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(true)
+      expect(
+        anon.in_any_groups?([Group::AUTO_GROUPS[:admins], Group::AUTO_GROUPS[:anonymous]]),
+      ).to eq(true)
+    end
+
+    it "returns false for any other group, including everyone and logged_in_users" do
+      expect(anon.in_any_groups?([Group::AUTO_GROUPS[:everyone]])).to eq(false)
+      expect(anon.in_any_groups?([Group::AUTO_GROUPS[:logged_in_users]])).to eq(false)
+      expect(anon.in_any_groups?([Group::AUTO_GROUPS[:admins]])).to eq(false)
+      expect(anon.in_any_groups?([])).to eq(false)
+    end
+  end
+
   describe "can_enable_safe_mode" do
     fab!(:user)
     fab!(:moderator)

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1391,7 +1391,7 @@ RSpec.describe SiteSettingExtension do
 
     it "is included in all_settings output" do
       setting = SiteSetting.all_settings.find { |s| s[:setting] == :whispers_allowed_groups }
-      expect(setting[:disallowed_groups]).to eq("0")
+      expect(setting[:disallowed_groups]).to eq("0|4")
     end
   end
 

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1391,7 +1391,7 @@ RSpec.describe SiteSettingExtension do
 
     it "is included in all_settings output" do
       setting = SiteSetting.all_settings.find { |s| s[:setting] == :whispers_allowed_groups }
-      expect(setting[:disallowed_groups]).to eq("0|4")
+      expect(setting[:disallowed_groups]).to eq("0|4|5")
     end
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -301,8 +301,6 @@ RSpec.describe Group do
         1,
         2,
         3,
-        4,
-        5,
         10,
       )
     end
@@ -313,6 +311,16 @@ RSpec.describe Group do
 
     it "returns an empty array when passing an unknown group" do
       expect(described_class.auto_groups_between(:trust_level_0, :trust_level_1337)).to be_empty
+    end
+
+    it "excludes pseudogroups that encompass large sets of users" do
+      expect(described_class.auto_groups_between(:admins, :trust_level_1)).to contain_exactly(
+        1,
+        2,
+        3,
+        10,
+        11,
+      )
     end
   end
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -947,6 +947,39 @@ RSpec.describe Group do
       ).to eq(false)
     end
 
+    it "includes logged_in_users, anonymous and everyone groups when include_pseudogroups is true" do
+      expect(
+        Group
+          .visible_groups(admin, [], include_pseudogroups: true)
+          .where(id: Group::AUTO_GROUPS[:everyone])
+          .exists?,
+      ).to eq(true)
+      expect(
+        Group
+          .visible_groups(admin, [], include_pseudogroups: true)
+          .where(id: Group::AUTO_GROUPS[:anonymous])
+          .exists?,
+      ).to eq(true)
+      expect(
+        Group
+          .visible_groups(admin, [], include_pseudogroups: true)
+          .where(id: Group::AUTO_GROUPS[:logged_in_users])
+          .exists?,
+      ).to eq(true)
+    end
+
+    it "does not include logged_in_users, anonymous and everyone groups by default" do
+      expect(
+        Group.visible_groups(admin, []).where(id: Group::AUTO_GROUPS[:everyone]).exists?,
+      ).to eq(false)
+      expect(
+        Group.visible_groups(admin, []).where(id: Group::AUTO_GROUPS[:anonymous]).exists?,
+      ).to eq(false)
+      expect(
+        Group.visible_groups(admin, []).where(id: Group::AUTO_GROUPS[:logged_in_users]).exists?,
+      ).to eq(false)
+    end
+
     it "correctly restricts group visibility" do
       group = Fabricate(:group, visibility_level: Group.visibility_levels[:owners])
       logged_on_user = Fabricate(:user)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -301,6 +301,8 @@ RSpec.describe Group do
         1,
         2,
         3,
+        4,
+        5,
         10,
       )
     end
@@ -406,6 +408,18 @@ RSpec.describe Group do
     it "makes sure the everyone group is not visible except to staff" do
       g = Group.refresh_automatic_group!(:everyone)
       expect(g.visibility_level).to eq(Group.visibility_levels[:staff])
+    end
+
+    it "makes sure the anonymous and logged_in_users pseudogroups are hidden and have no members" do
+      anon = Group.refresh_automatic_group!(:anonymous)
+      expect(anon.id).to eq(Group::AUTO_GROUPS[:anonymous])
+      expect(anon.visibility_level).to eq(Group.visibility_levels[:staff])
+      expect(GroupUser.where(group_id: anon.id).count).to eq(0)
+
+      logged_in = Group.refresh_automatic_group!(:logged_in_users)
+      expect(logged_in.id).to eq(Group::AUTO_GROUPS[:logged_in_users])
+      expect(logged_in.visibility_level).to eq(Group.visibility_levels[:staff])
+      expect(GroupUser.where(group_id: logged_in.id).count).to eq(0)
     end
 
     it "makes sure automatic groups are visible to logged on users" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe User do
       expect(user.in_any_groups?([group.id, Group::AUTO_GROUPS[:everyone]])).to eq(true)
     end
 
+    it "returns true if any of the group IDs are the 'logged_in_users' auto group" do
+      expect(user.in_any_groups?([Group::AUTO_GROUPS[:logged_in_users]])).to eq(true)
+    end
+
+    it "never returns true for the 'anonymous' auto group — logged-in users are not anonymous" do
+      GroupUser.where(user_id: Discourse::SYSTEM_USER_ID).delete_all
+      Discourse.system_user.reload
+      expect(user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
+      expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
+    end
+
+    it "returns true for the 'anonymous' auto group for anonymous users" do
+      expect(
+        Guardian.new.instance_variable_get(:@user).in_any_groups?([Group::AUTO_GROUPS[:anonymous]]),
+      ).to eq(true)
+    end
+
     it "returns true if the user is in the group" do
       expect(user.in_any_groups?([group.id])).to eq(false)
       group.add(user)
@@ -43,17 +60,6 @@ RSpec.describe User do
       expect(Discourse.system_user.in_any_groups?([group.id])).to eq(false)
       expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:trust_level_4]])).to eq(true)
       expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:admins]])).to eq(true)
-    end
-
-    it "returns true if any of the group IDs are the 'logged_in_users' auto group" do
-      expect(user.in_any_groups?([Group::AUTO_GROUPS[:logged_in_users]])).to eq(true)
-    end
-
-    it "never returns true for the 'anonymous' auto group — logged-in users are not anonymous" do
-      GroupUser.where(user_id: Discourse::SYSTEM_USER_ID).delete_all
-      Discourse.system_user.reload
-      expect(user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
-      expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe User do
       expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:trust_level_4]])).to eq(true)
       expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:admins]])).to eq(true)
     end
+
+    it "returns true if any of the group IDs are the 'logged_in_users' auto group" do
+      expect(user.in_any_groups?([Group::AUTO_GROUPS[:logged_in_users]])).to eq(true)
+    end
+
+    it "never returns true for the 'anonymous' auto group — logged-in users are not anonymous" do
+      GroupUser.where(user_id: Discourse::SYSTEM_USER_ID).delete_all
+      Discourse.system_user.reload
+      expect(user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
+      expect(Discourse.system_user.in_any_groups?([Group::AUTO_GROUPS[:anonymous]])).to eq(false)
+    end
   end
 
   describe "Associations" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe GroupsController do
         expect(group_body["is_group_owner"]).to eq(true)
         expect(group_ids).to include(group.id, staff_group.id)
         expect(body["load_more_groups"]).to eq("/groups?page=1")
-        expect(body["total_rows_groups"]).to eq(10)
+        expect(body["total_rows_groups"]).to eq(12)
 
         expect(body["extras"]["type_filters"].map(&:to_sym)).to eq(
           described_class::TYPE_FILTERS.keys - [:non_automatic],
@@ -2713,6 +2713,8 @@ RSpec.describe GroupsController do
 
         expected_ids = Group::AUTO_GROUPS.map { |name, id| id }
         expected_ids.delete(Group::AUTO_GROUPS[:everyone])
+        expected_ids.delete(Group::AUTO_GROUPS[:logged_in_users])
+        expected_ids.delete(Group::AUTO_GROUPS[:anonymous])
         expected_ids << group.id
 
         expect(groups.map { |group| group["id"] }).to contain_exactly(*expected_ids)
@@ -2765,12 +2767,43 @@ RSpec.describe GroupsController do
 
         expect(groups.map { |group| group["id"] }).to contain_exactly(group.id, hidden_group.id)
 
+        get "/groups/search.json"
+
+        expect(response.status).to eq(200)
+        groups = response.parsed_body
+
+        automatic_ids = Group::AUTO_GROUPS.map { |name, id| id }
+
+        expect(groups.map { |group| group["id"] }).to contain_exactly(
+          group.id,
+          hidden_group.id,
+          *(
+            automatic_ids -
+              [
+                Group::AUTO_GROUPS[:everyone],
+                Group::AUTO_GROUPS[:anonymous],
+                Group::AUTO_GROUPS[:logged_in_users],
+              ]
+          ),
+        )
+
         get "/groups/search.json?include_everyone=true"
 
         expect(response.status).to eq(200)
         groups = response.parsed_body
 
         automatic_ids = Group::AUTO_GROUPS.map { |name, id| id }
+
+        expect(groups.map { |group| group["id"] }).to contain_exactly(
+          group.id,
+          hidden_group.id,
+          *(automatic_ids - [Group::AUTO_GROUPS[:anonymous], Group::AUTO_GROUPS[:logged_in_users]]),
+        )
+
+        get "/groups/search.json?include_pseudogroups=true"
+
+        expect(response.status).to eq(200)
+        groups = response.parsed_body
 
         expect(groups.map { |group| group["id"] }).to contain_exactly(
           group.id,

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe GroupsController do
         expect(group_body["is_group_owner"]).to eq(true)
         expect(group_ids).to include(group.id, staff_group.id)
         expect(body["load_more_groups"]).to eq("/groups?page=1")
-        expect(body["total_rows_groups"]).to eq(12)
+        expect(body["total_rows_groups"]).to eq(10)
 
         expect(body["extras"]["type_filters"].map(&:to_sym)).to eq(
           described_class::TYPE_FILTERS.keys - [:non_automatic],
@@ -379,7 +379,15 @@ RSpec.describe GroupsController do
 
         describe "automatic groups" do
           it "should return the right response" do
-            expect_type_to_return_right_groups("automatic", Group::AUTO_GROUP_IDS.keys - [0])
+            expect_type_to_return_right_groups(
+              "automatic",
+              Group::AUTO_GROUP_IDS.keys -
+                [
+                  Group::AUTO_GROUPS[:everyone],
+                  Group::AUTO_GROUPS[:anonymous],
+                  Group::AUTO_GROUPS[:logged_in_users],
+                ],
+            )
           end
         end
 
@@ -490,6 +498,8 @@ RSpec.describe GroupsController do
 
           groups = Group::AUTO_GROUPS.keys
           groups.delete(:everyone)
+          groups.delete(:anonymous)
+          groups.delete(:logged_in_users)
           groups.push(group.name)
 
           expect(body["extras"]["visible_group_names"]).to contain_exactly(*groups.map(&:to_s))

--- a/spec/services/anonymous_shadow_creator_spec.rb
+++ b/spec/services/anonymous_shadow_creator_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe AnonymousShadowCreator do
       expect(shadow.id).to eq(shadow2.id)
 
       expect(shadow.trust_level).to eq(1)
-      expect(shadow.username).to eq("anonymous")
+      expect(shadow.username).to eq("anonymous1")
 
       expect(shadow.created_at).not_to eq_time(user.created_at)
 
@@ -87,7 +87,7 @@ RSpec.describe AnonymousShadowCreator do
 
       shadow = AnonymousShadowCreator.get(user)
 
-      expect(shadow.username).to eq("anonymous")
+      expect(shadow.username).to eq("anonymous1")
     end
   end
 end


### PR DESCRIPTION
The everyone pseudogroup has long been a source of confusion
for admins and developers, since it's never been clear whether
it is supposed to include anonymous users.

This PR introduces two new auto groups, anonymous_users and
logged_in_users, to replace the everyone group. The everyone group will
continue to exist for backwards compatibility, but it will be deprecated
and eventually removed in a future release. All group_list based site
settings will use the new groups.

In addition, for site settings where it doesn't make sense to allow
anon users, the anonymous group is added as a disallowed_groups
option.

In a followup PR, an upcoming change will be introduced
to phase out the use of the everyone group and use
logged_in_users as a replacement.
