### PR TITLE
FEATURE: Link staff action log entries to originating reviewable

### DIFF
--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -149,7 +149,7 @@ module ReviewableActionBuilder
   def delete_user(user, delete_options, performed_by)
     email = user.email
 
-    UserDestroyer.new(performed_by).destroy(user, delete_options)
+    UserDestroyer.new(performed_by).destroy(user, delete_options.merge(reviewable: self))
 
     message = UserNotifications.account_deleted(email, self)
     Email::Sender.new(message, :account_deleted).send

--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -82,7 +82,7 @@ module ReviewableActionBuilder
   end
 
   def perform_delete_post(performed_by, _args)
-    PostDestroyer.new(performed_by, target_post, reviewable: self).destroy
+    PostDestroyer.new(performed_by, target_post, reviewable_id: self.id).destroy
     create_result(:success, :rejected, [created_by_id], false)
   end
 
@@ -149,7 +149,7 @@ module ReviewableActionBuilder
   def delete_user(user, delete_options, performed_by)
     email = user.email
 
-    UserDestroyer.new(performed_by).destroy(user, delete_options.merge(reviewable: self))
+    UserDestroyer.new(performed_by).destroy(user, delete_options.merge(reviewable_id: self.id))
 
     message = UserNotifications.account_deleted(email, self)
     Email::Sender.new(message, :account_deleted).send

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -257,7 +257,7 @@ class ReviewableFlaggedPost < Reviewable
 
   def perform_delete_and_ignore_replies(performed_by, args)
     result = perform_ignore_and_do_nothing(performed_by, args)
-    PostDestroyer.delete_with_replies(performed_by, post, self)
+    PostDestroyer.delete_with_replies(performed_by, post, self.id)
 
     result
   end
@@ -270,7 +270,7 @@ class ReviewableFlaggedPost < Reviewable
 
   def perform_delete_and_agree_replies(performed_by, args)
     result = agree(performed_by, args)
-    PostDestroyer.delete_with_replies(performed_by, post, self)
+    PostDestroyer.delete_with_replies(performed_by, post, self.id)
     result
   end
 
@@ -345,7 +345,7 @@ class ReviewableFlaggedPost < Reviewable
   private
 
   def destroyer(performed_by, post)
-    PostDestroyer.new(performed_by, post, reviewable: self)
+    PostDestroyer.new(performed_by, post, reviewable_id: self.id)
   end
 
   def notify_poster(performed_by)

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -115,7 +115,7 @@ class ReviewablePost < Reviewable
   end
 
   def perform_reject_and_delete(performed_by, _args)
-    PostDestroyer.new(performed_by, post, reviewable: self).destroy
+    PostDestroyer.new(performed_by, post, reviewable_id: self.id).destroy
 
     create_result(:success, :rejected, [created_by_id], false)
   end

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -114,9 +114,13 @@ class ReviewableQueuedPost < Reviewable
     self.topic_id = created_post.topic_id if topic_id.nil?
     save
 
-    UserSilencer.unsilence(target_created_by, performed_by) if target_created_by.silenced?
+    if target_created_by.silenced?
+      UserSilencer.unsilence(target_created_by, performed_by, reviewable: self)
+    end
 
-    StaffActionLogger.new(performed_by).log_post_approved(created_post) if performed_by.staff?
+    if performed_by.staff?
+      StaffActionLogger.new(performed_by, reviewable: self).log_post_approved(created_post)
+    end
 
     # Backwards compatibility, new code should listen for `reviewable_transitioned_to`
     DiscourseEvent.trigger(:approved_post, self, created_post)
@@ -148,7 +152,9 @@ class ReviewableQueuedPost < Reviewable
     # Backwards compatibility, new code should listen for `reviewable_transitioned_to`
     DiscourseEvent.trigger(:rejected_post, self)
 
-    StaffActionLogger.new(performed_by).log_post_rejected(self, DateTime.now) if performed_by.staff?
+    if performed_by.staff?
+      StaffActionLogger.new(performed_by, reviewable: self).log_post_rejected(self, DateTime.now)
+    end
 
     create_result(:success, :rejected)
   end
@@ -190,7 +196,9 @@ class ReviewableQueuedPost < Reviewable
       ),
       pm_translation_args,
     )
-    StaffActionLogger.new(performed_by).log_post_rejected(self, DateTime.now) if performed_by.staff?
+    if performed_by.staff?
+      StaffActionLogger.new(performed_by, reviewable: self).log_post_rejected(self, DateTime.now)
+    end
     create_result(:success, :rejected)
   end
 

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -115,11 +115,11 @@ class ReviewableQueuedPost < Reviewable
     save
 
     if target_created_by.silenced?
-      UserSilencer.unsilence(target_created_by, performed_by, reviewable: self)
+      UserSilencer.unsilence(target_created_by, performed_by, reviewable_id: self.id)
     end
 
     if performed_by.staff?
-      StaffActionLogger.new(performed_by, reviewable: self).log_post_approved(created_post)
+      StaffActionLogger.new(performed_by).log_post_approved(created_post, reviewable_id: self.id)
     end
 
     # Backwards compatibility, new code should listen for `reviewable_transitioned_to`
@@ -152,9 +152,7 @@ class ReviewableQueuedPost < Reviewable
     # Backwards compatibility, new code should listen for `reviewable_transitioned_to`
     DiscourseEvent.trigger(:rejected_post, self)
 
-    if performed_by.staff?
-      StaffActionLogger.new(performed_by, reviewable: self).log_post_rejected(self, DateTime.now)
-    end
+    StaffActionLogger.new(performed_by).log_post_rejected(self, DateTime.now) if performed_by.staff?
 
     create_result(:success, :rejected)
   end
@@ -196,9 +194,7 @@ class ReviewableQueuedPost < Reviewable
       ),
       pm_translation_args,
     )
-    if performed_by.staff?
-      StaffActionLogger.new(performed_by, reviewable: self).log_post_rejected(self, DateTime.now)
-    end
+    StaffActionLogger.new(performed_by).log_post_rejected(self, DateTime.now) if performed_by.staff?
     create_result(:success, :rejected)
   end
 

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -59,7 +59,7 @@ class ReviewableUser < Reviewable
     if args[:send_email] != false && SiteSetting.must_approve_users?
       Jobs.enqueue(:critical_user_email, type: "signup_after_approval", user_id: target.id)
     end
-    StaffActionLogger.new(performed_by, reviewable: self).log_user_approve(target)
+    StaffActionLogger.new(performed_by).log_user_approve(target, reviewable_id: self.id)
 
     create_result(:success, :approved)
   end
@@ -126,7 +126,7 @@ class ReviewableUser < Reviewable
         else
           I18n.t("user.destroy_reasons.reviewable_reject")
         end
-        delete_args[:reviewable] = self
+        delete_args[:reviewable_id] = self.id
 
         destroyer.destroy(target, delete_args)
       rescue UserDestroyer::PostsExistError, Discourse::InvalidAccess

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -59,7 +59,7 @@ class ReviewableUser < Reviewable
     if args[:send_email] != false && SiteSetting.must_approve_users?
       Jobs.enqueue(:critical_user_email, type: "signup_after_approval", user_id: target.id)
     end
-    StaffActionLogger.new(performed_by).log_user_approve(target)
+    StaffActionLogger.new(performed_by, reviewable: self).log_user_approve(target)
 
     create_result(:success, :approved)
   end
@@ -126,7 +126,7 @@ class ReviewableUser < Reviewable
         else
           I18n.t("user.destroy_reasons.reviewable_reject")
         end
-        delete_args[:from_reviewable] = true
+        delete_args[:reviewable] = self
 
         destroyer.destroy(target, delete_args)
       rescue UserDestroyer::PostsExistError, Discourse::InvalidAccess

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -10,6 +10,7 @@ class UserHistory < ActiveRecord::Base
   belongs_to :post
   belongs_to :topic
   belongs_to :category
+  belongs_to :reviewable, optional: true
 
   # Each value in the context should be shorter than this
   MAX_CONTEXT_LENGTH = 50_000
@@ -485,6 +486,7 @@ end
 #  post_id        :integer
 #  custom_type    :string
 #  category_id    :integer
+#  reviewable_id  :bigint
 #
 # Indexes
 #
@@ -492,6 +494,7 @@ end
 #  index_user_histories_on_action_and_id                           (action,id)
 #  index_user_histories_on_category_id                             (category_id)
 #  index_user_histories_on_post_id                                 (post_id)
+#  index_user_histories_on_reviewable_id                           (reviewable_id)
 #  index_user_histories_on_subject_and_id                          (subject,id)
 #  index_user_histories_on_target_user_id_and_id                   (target_user_id,id)
 #  index_user_histories_on_topic_id_and_target_user_id_and_action  (topic_id,target_user_id,action)

--- a/app/serializers/user_history_serializer.rb
+++ b/app/serializers/user_history_serializer.rb
@@ -13,6 +13,7 @@ class UserHistorySerializer < ApplicationSerializer
              :topic_id,
              :post_id,
              :category_id,
+             :reviewable_id,
              :action,
              :custom_type,
              :id
@@ -54,6 +55,10 @@ class UserHistorySerializer < ApplicationSerializer
   def ip_address
     return nil unless scope.can_see_ip?
     object.ip_address.try(:to_s)
+  end
+
+  def include_reviewable_id?
+    object.reviewable_id.present?
   end
 
   private

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -6,8 +6,9 @@ class StaffActionLogger
     %i[topic_id post_id category_id context subject ip_address previous_value new_value]
   end
 
-  def initialize(admin)
+  def initialize(admin, reviewable: nil)
     @admin = admin
+    @reviewable = reviewable
     raise Discourse::InvalidParameters.new(:admin) unless @admin && @admin.is_a?(User)
   end
 
@@ -42,6 +43,7 @@ class StaffActionLogger
     attrs[:acting_user_id] = @admin.id
     attrs[:action] = UserHistory.actions[:custom_staff]
     attrs[:custom_type] = custom_type
+    attrs[:reviewable_id] = @reviewable&.id
 
     UserHistory.create!(attrs)
   end
@@ -1185,7 +1187,12 @@ class StaffActionLogger
 
   def params(opts = nil)
     opts ||= {}
-    { acting_user_id: @admin.id, context: opts[:context], details: opts[:details] }
+    {
+      acting_user_id: @admin.id,
+      context: opts[:context],
+      details: opts[:details],
+      reviewable_id: @reviewable&.id,
+    }
   end
 
   def validate_category(category)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -3,12 +3,21 @@
 # Responsible for logging the actions of admins and moderators.
 class StaffActionLogger
   def self.base_attrs
-    %i[topic_id post_id category_id context subject ip_address previous_value new_value]
+    %i[
+      topic_id
+      post_id
+      category_id
+      context
+      subject
+      ip_address
+      previous_value
+      new_value
+      reviewable_id
+    ]
   end
 
-  def initialize(admin, reviewable: nil)
+  def initialize(admin)
     @admin = admin
-    @reviewable = reviewable
     raise Discourse::InvalidParameters.new(:admin) unless @admin && @admin.is_a?(User)
   end
 
@@ -43,7 +52,6 @@ class StaffActionLogger
     attrs[:acting_user_id] = @admin.id
     attrs[:action] = UserHistory.actions[:custom_staff]
     attrs[:custom_type] = custom_type
-    attrs[:reviewable_id] = @reviewable&.id
 
     UserHistory.create!(attrs)
   end
@@ -895,6 +903,7 @@ class StaffActionLogger
         details: details.join("\n"),
         topic_id: topic&.id,
         category_id: reviewable.category_id,
+        reviewable_id: reviewable.id,
       ),
     )
   end
@@ -1191,7 +1200,7 @@ class StaffActionLogger
       acting_user_id: @admin.id,
       context: opts[:context],
       details: opts[:details],
-      reviewable_id: @reviewable&.id,
+      reviewable_id: opts[:reviewable_id],
     }
   end
 

--- a/app/services/user/action/silence_all.rb
+++ b/app/services/user/action/silence_all.rb
@@ -13,10 +13,6 @@ class User::Action::SilenceAll < Service::ActionBase
 
   private
 
-  def reviewable
-    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
-  end
-
   def silenced_users
     users.map do |user|
       UserSilencer
@@ -28,7 +24,7 @@ class User::Action::SilenceAll < Service::ActionBase
           silenced_till:,
           reason:,
           post_id:,
-          reviewable:,
+          reviewable_id:,
         )
         .tap do |silencer|
           next unless silencer.silence

--- a/app/services/user/action/silence_all.rb
+++ b/app/services/user/action/silence_all.rb
@@ -5,13 +5,17 @@ class User::Action::SilenceAll < Service::ActionBase
   option :actor
   option :params
 
-  delegate :message, :post_id, :silenced_till, :reason, to: :params, private: true
+  delegate :message, :post_id, :silenced_till, :reason, :reviewable_id, to: :params, private: true
 
   def call
     silenced_users.first.try(:user_history).try(:details)
   end
 
   private
+
+  def reviewable
+    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
+  end
 
   def silenced_users
     users.map do |user|
@@ -24,6 +28,7 @@ class User::Action::SilenceAll < Service::ActionBase
           silenced_till:,
           reason:,
           post_id:,
+          reviewable:,
         )
         .tap do |silencer|
           next unless silencer.silence

--- a/app/services/user/action/suspend_all.rb
+++ b/app/services/user/action/suspend_all.rb
@@ -13,10 +13,6 @@ class User::Action::SuspendAll < Service::ActionBase
 
   private
 
-  def reviewable
-    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
-  end
-
   def suspended_users
     users.map do |user|
       UserSuspender.new(
@@ -26,7 +22,7 @@ class User::Action::SuspendAll < Service::ActionBase
         by_user: actor,
         message: message,
         post_id: post_id,
-        reviewable: reviewable,
+        reviewable_id: reviewable_id,
       ).tap(&:suspend)
     rescue => err
       Discourse.warn_exception(err, message: "failed to suspend user with ID #{user.id}")

--- a/app/services/user/action/suspend_all.rb
+++ b/app/services/user/action/suspend_all.rb
@@ -5,13 +5,17 @@ class User::Action::SuspendAll < Service::ActionBase
   option :actor
   option :params
 
-  delegate :message, :post_id, :suspend_until, :reason, to: :params, private: true
+  delegate :message, :post_id, :suspend_until, :reason, :reviewable_id, to: :params, private: true
 
   def call
     suspended_users.first.try(:user_history).try(:details)
   end
 
   private
+
+  def reviewable
+    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
+  end
 
   def suspended_users
     users.map do |user|
@@ -22,6 +26,7 @@ class User::Action::SuspendAll < Service::ActionBase
         by_user: actor,
         message: message,
         post_id: post_id,
+        reviewable: reviewable,
       ).tap(&:suspend)
     rescue => err
       Discourse.warn_exception(err, message: "failed to suspend user with ID #{user.id}")

--- a/app/services/user/action/trigger_post_action.rb
+++ b/app/services/user/action/trigger_post_action.rb
@@ -16,18 +16,14 @@ class User::Action::TriggerPostAction < Service::ActionBase
 
   private
 
-  def reviewable
-    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
-  end
-
   def delete
     return unless guardian.can_delete_post_or_topic?(post)
-    PostDestroyer.new(user, post, reviewable: reviewable).destroy
+    PostDestroyer.new(user, post, reviewable_id: reviewable_id).destroy
   end
 
   def delete_replies
     return unless guardian.can_delete_post_or_topic?(post)
-    PostDestroyer.delete_with_replies(user, post, reviewable)
+    PostDestroyer.delete_with_replies(user, post, reviewable_id)
   end
 
   def edit

--- a/app/services/user/action/trigger_post_action.rb
+++ b/app/services/user/action/trigger_post_action.rb
@@ -5,7 +5,7 @@ class User::Action::TriggerPostAction < Service::ActionBase
   option :post
   option :params
 
-  delegate :post_action, to: :params, private: true
+  delegate :post_action, :reviewable_id, to: :params, private: true
   delegate :user, to: :guardian, private: true
 
   def call
@@ -16,14 +16,18 @@ class User::Action::TriggerPostAction < Service::ActionBase
 
   private
 
+  def reviewable
+    @reviewable ||= Reviewable.find_by(id: reviewable_id) if reviewable_id
+  end
+
   def delete
     return unless guardian.can_delete_post_or_topic?(post)
-    PostDestroyer.new(user, post).destroy
+    PostDestroyer.new(user, post, reviewable: reviewable).destroy
   end
 
   def delete_replies
     return unless guardian.can_delete_post_or_topic?(post)
-    PostDestroyer.delete_with_replies(user, post)
+    PostDestroyer.delete_with_replies(user, post, reviewable)
   end
 
   def edit

--- a/app/services/user/silence.rb
+++ b/app/services/user/silence.rb
@@ -12,6 +12,7 @@ class User::Silence
     attribute :post_id, :integer
     attribute :post_action, :string
     attribute :post_edit, :string
+    attribute :reviewable_id, :integer
 
     validates :user_id, presence: true
     validates :reason, presence: true, length: { maximum: 300 }

--- a/app/services/user/suspend.rb
+++ b/app/services/user/suspend.rb
@@ -12,6 +12,7 @@ class User::Suspend
     attribute :post_id, :integer
     attribute :post_action, :string
     attribute :post_edit, :string
+    attribute :reviewable_id, :integer
 
     validates :user_id, presence: true
     validates :reason, presence: true, length: { maximum: 300 }

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -110,7 +110,10 @@ class UserDestroyer
           else
             deleted_by = @actor
           end
-          StaffActionLogger.new(deleted_by).log_user_deletion(user, opts.slice(:context))
+          StaffActionLogger.new(deleted_by, reviewable: opts[:reviewable]).log_user_deletion(
+            user,
+            opts.slice(:context),
+          )
           if opts.slice(:context).blank?
             Rails.logger.warn("User destroyed without context from: #{caller_locations(14, 1)[0]}")
           end
@@ -120,7 +123,7 @@ class UserDestroyer
     end
 
     # After the user is deleted, remove the reviewable unless request comes from reviewable
-    return result if opts[:from_reviewable]
+    return result if opts[:reviewable]
     reviewable = ReviewableUser.pending.find_by(target: user)
     reviewable.perform(@actor, :delete_user) if reviewable
 
@@ -165,6 +168,7 @@ class UserDestroyer
           @actor.staff? ? @actor : Discourse.system_user,
           post,
           context: I18n.t("staff_action_logs.user_associated_posts_deleted"),
+          reviewable: opts[:reviewable],
         ).destroy
       end
 

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -110,9 +110,9 @@ class UserDestroyer
           else
             deleted_by = @actor
           end
-          StaffActionLogger.new(deleted_by, reviewable: opts[:reviewable]).log_user_deletion(
+          StaffActionLogger.new(deleted_by).log_user_deletion(
             user,
-            opts.slice(:context),
+            opts.slice(:context, :reviewable_id),
           )
           if opts.slice(:context).blank?
             Rails.logger.warn("User destroyed without context from: #{caller_locations(14, 1)[0]}")
@@ -123,7 +123,7 @@ class UserDestroyer
     end
 
     # After the user is deleted, remove the reviewable unless request comes from reviewable
-    return result if opts[:reviewable]
+    return result if opts[:reviewable_id]
     reviewable = ReviewableUser.pending.find_by(target: user)
     reviewable.perform(@actor, :delete_user) if reviewable
 
@@ -168,7 +168,7 @@ class UserDestroyer
           @actor.staff? ? @actor : Discourse.system_user,
           post,
           context: I18n.t("staff_action_logs.user_associated_posts_deleted"),
-          reviewable: opts[:reviewable],
+          reviewable_id: opts[:reviewable_id],
         ).destroy
       end
 

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -37,14 +37,10 @@ class UserSilencer
       context = "#{message_type}: #{@opts[:reason]}"
 
       if @by_user
-        log_params = { context: context, details: details }
+        log_params = { context: context, details: details, reviewable_id: @opts[:reviewable_id] }
         log_params[:post_id] = @opts[:post_id].to_i if @opts[:post_id]
 
-        @user_history =
-          StaffActionLogger.new(@by_user, reviewable: @opts[:reviewable]).log_silence_user(
-            @user,
-            log_params,
-          )
+        @user_history = StaffActionLogger.new(@by_user).log_silence_user(@user, log_params)
       end
 
       silence_message_params = {}
@@ -102,7 +98,10 @@ class UserSilencer
       DiscourseEvent.trigger(:user_unsilenced, user: @user, by_user: @by_user)
       SystemMessage.create(@user, :unsilenced)
       if @by_user
-        StaffActionLogger.new(@by_user, reviewable: @opts[:reviewable]).log_unsilence_user(@user)
+        StaffActionLogger.new(@by_user).log_unsilence_user(
+          @user,
+          reviewable_id: @opts[:reviewable_id],
+        )
       end
     end
   end

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -40,7 +40,11 @@ class UserSilencer
         log_params = { context: context, details: details }
         log_params[:post_id] = @opts[:post_id].to_i if @opts[:post_id]
 
-        @user_history = StaffActionLogger.new(@by_user).log_silence_user(@user, log_params)
+        @user_history =
+          StaffActionLogger.new(@by_user, reviewable: @opts[:reviewable]).log_silence_user(
+            @user,
+            log_params,
+          )
       end
 
       silence_message_params = {}
@@ -97,7 +101,9 @@ class UserSilencer
     if @user.save
       DiscourseEvent.trigger(:user_unsilenced, user: @user, by_user: @by_user)
       SystemMessage.create(@user, :unsilenced)
-      StaffActionLogger.new(@by_user).log_unsilence_user(@user) if @by_user
+      if @by_user
+        StaffActionLogger.new(@by_user, reviewable: @opts[:reviewable]).log_unsilence_user(@user)
+      end
     end
   end
 

--- a/app/services/user_suspender.rb
+++ b/app/services/user_suspender.rb
@@ -3,13 +3,22 @@
 class UserSuspender
   attr_reader :user_history
 
-  def initialize(user, suspended_till:, reason:, by_user:, message: nil, post_id: nil)
+  def initialize(
+    user,
+    suspended_till:,
+    reason:,
+    by_user:,
+    message: nil,
+    post_id: nil,
+    reviewable: nil
+  )
     @user = user
     @suspended_till = suspended_till
     @reason = reason
     @by_user = by_user
     @message = message
     @post_id = post_id
+    @reviewable = reviewable
   end
 
   def suspend
@@ -22,7 +31,7 @@ class UserSuspender
       @user.save!
 
       @user_history =
-        StaffActionLogger.new(@by_user).log_user_suspend(
+        StaffActionLogger.new(@by_user, reviewable: @reviewable).log_user_suspend(
           @user,
           @reason,
           message: @message,

--- a/app/services/user_suspender.rb
+++ b/app/services/user_suspender.rb
@@ -10,7 +10,7 @@ class UserSuspender
     by_user:,
     message: nil,
     post_id: nil,
-    reviewable: nil
+    reviewable_id: nil
   )
     @user = user
     @suspended_till = suspended_till
@@ -18,7 +18,7 @@ class UserSuspender
     @by_user = by_user
     @message = message
     @post_id = post_id
-    @reviewable = reviewable
+    @reviewable_id = reviewable_id
   end
 
   def suspend
@@ -31,11 +31,12 @@ class UserSuspender
       @user.save!
 
       @user_history =
-        StaffActionLogger.new(@by_user, reviewable: @reviewable).log_user_suspend(
+        StaffActionLogger.new(@by_user).log_user_suspend(
           @user,
           @reason,
           message: @message,
           post_id: @post_id,
+          reviewable_id: @reviewable_id,
         )
     end
     @user.logged_out

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7987,6 +7987,7 @@ en:
         topic_id: "Topic ID"
         post_id: "Post ID"
         category_id: "Category ID"
+        reviewable_id: "Review"
         delete: "Delete"
         edit: "Edit"
         save: "Save"

--- a/db/migrate/20260415082426_add_reviewable_id_to_user_histories.rb
+++ b/db/migrate/20260415082426_add_reviewable_id_to_user_histories.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddReviewableIdToUserHistories < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :user_histories, :reviewable_id, :bigint, null: true
+    remove_index :user_histories, :reviewable_id, algorithm: :concurrently, if_exists: true
+    add_index :user_histories, :reviewable_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260415082426_add_reviewable_id_to_user_histories.rb
+++ b/db/migrate/20260415082426_add_reviewable_id_to_user_histories.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 class AddReviewableIdToUserHistories < ActiveRecord::Migration[8.0]
-  disable_ddl_transaction!
-
   def change
-    add_column :user_histories, :reviewable_id, :bigint, null: true
-    remove_index :user_histories, :reviewable_id, algorithm: :concurrently, if_exists: true
-    add_index :user_histories, :reviewable_id, algorithm: :concurrently
+    add_column :user_histories, :reviewable_id, :bigint
   end
 end

--- a/db/migrate/20260428072232_add_index_on_reviewable_id_to_user_histories.rb
+++ b/db/migrate/20260428072232_add_index_on_reviewable_id_to_user_histories.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIndexOnReviewableIdToUserHistories < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :user_histories, :reviewable_id, algorithm: :concurrently, if_exists: true
+    add_index :user_histories, :reviewable_id, algorithm: :concurrently
+  end
+end

--- a/frontend/discourse/admin/components/modal/penalize-user.gjs
+++ b/frontend/discourse/admin/components/modal/penalize-user.gjs
@@ -103,6 +103,7 @@ export default class PenalizeUser extends Component {
         post_action: this.postAction,
         post_edit: this.postEdit,
         other_user_ids: this.otherUserIds,
+        reviewable_id: this.args.model.reviewableId,
       };
 
       if (this.args.model.penaltyType === "suspend") {

--- a/frontend/discourse/admin/models/staff-action-log.js
+++ b/frontend/discourse/admin/models/staff-action-log.js
@@ -48,6 +48,7 @@ export default class StaffActionLog extends RestModel {
     "topic_id",
     "post_id",
     "category_id",
+    "reviewable_id",
     "new_value",
     "previous_value",
     "details",
@@ -63,12 +64,17 @@ export default class StaffActionLog extends RestModel {
       ? `<a href data-link-topic-id="${this.topic_id}">${this.topic_id}</a>`
       : null;
 
+    const reviewableLink = this.reviewable_id
+      ? `<a href="/review/${this.reviewable_id}">${this.reviewable_id}</a>`
+      : null;
+
     let lines = [
       format("email", this.email),
       format("admin.logs.ip_address", this.ip_address),
       format("admin.logs.topic_id", topicLink, false),
       format("admin.logs.post_id", postLink, false),
       format("admin.logs.category_id", this.category_id),
+      format("admin.logs.reviewable_id", reviewableLink, false),
     ];
 
     if (!this.useCustomModalForDetails) {

--- a/frontend/discourse/admin/services/admin-tools.js
+++ b/frontend/discourse/admin/services/admin-tools.js
@@ -51,6 +51,7 @@ export default class AdminToolsService extends Service {
         penaltyType: type,
         postId: opts.postId,
         postEdit: opts.postEdit,
+        reviewableId: opts.reviewableId,
         user: loadedUser,
         before: opts.before,
         successCallback: async (result) => {

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -550,6 +550,7 @@ export default class ReviewableItem extends Component {
       return adminTools[adminToolMethod](createdBy, {
         postId,
         postEdit,
+        reviewableId: reviewable.get("id"),
         before: performAction,
       });
     }

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -46,14 +46,14 @@ class PostDestroyer
       .find_each { |post| PostDestroyer.new(Discourse.system_user, post, context: context).destroy }
   end
 
-  def self.delete_with_replies(performed_by, post, reviewable = nil, defer_reply_flags: true)
+  def self.delete_with_replies(performed_by, post, reviewable_id = nil, defer_reply_flags: true)
     reply_ids = post.reply_ids(Guardian.new(performed_by), only_replies_to_single_post: false)
     replies = Post.where(id: reply_ids.map { |r| r[:id] })
-    PostDestroyer.new(performed_by, post, reviewable: reviewable).destroy
+    PostDestroyer.new(performed_by, post, reviewable_id: reviewable_id).destroy
 
     options = { defer_flags: defer_reply_flags }
     if SiteSetting.notify_users_after_responses_deleted_on_flagged_post
-      options.merge!({ reviewable: reviewable, notify_responders: true, parent_post: post })
+      options.merge!({ reviewable_id: reviewable_id, notify_responders: true, parent_post: post })
     end
     replies.each { |reply| PostDestroyer.new(performed_by, reply, options).destroy }
   end
@@ -203,16 +203,20 @@ class PostDestroyer
       remove_associated_notifications
 
       if @user.id != @post.user_id && !@opts[:skip_staff_log]
-        logger = StaffActionLogger.new(@user, reviewable: @opts[:reviewable])
+        logger = StaffActionLogger.new(@user)
 
         if @post.topic && @post.is_first_post?
           logger.log_topic_delete_recover(
             @post.topic,
             permanent? ? "delete_topic_permanently" : "delete_topic",
-            @opts.slice(:context),
+            @opts.slice(:context, :reviewable_id),
           )
         else
-          logger.log_post_deletion(@post, **@opts.slice(:context), permanent: permanent?)
+          logger.log_post_deletion(
+            @post,
+            **@opts.slice(:context, :reviewable_id),
+            permanent: permanent?,
+          )
         end
       end
 
@@ -387,7 +391,7 @@ class PostDestroyer
   end
 
   def handle_reviewable_after_deletion
-    if @opts[:reviewable]
+    if @opts[:reviewable_id]
       handle_explicit_reviewable
     elsif @post.reviewable_flag
       handle_post_reviewable_flag
@@ -395,8 +399,11 @@ class PostDestroyer
   end
 
   def handle_explicit_reviewable
+    reviewable = Reviewable.find_by(id: @opts[:reviewable_id])
+    return unless reviewable
+
     notify_deletion(
-      @opts[:reviewable],
+      reviewable,
       { notify_responders: @opts[:notify_responders], parent_post: @opts[:parent_post] },
     )
 

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -203,18 +203,16 @@ class PostDestroyer
       remove_associated_notifications
 
       if @user.id != @post.user_id && !@opts[:skip_staff_log]
+        logger = StaffActionLogger.new(@user, reviewable: @opts[:reviewable])
+
         if @post.topic && @post.is_first_post?
-          StaffActionLogger.new(@user).log_topic_delete_recover(
+          logger.log_topic_delete_recover(
             @post.topic,
             permanent? ? "delete_topic_permanently" : "delete_topic",
             @opts.slice(:context),
           )
         else
-          StaffActionLogger.new(@user).log_post_deletion(
-            @post,
-            **@opts.slice(:context),
-            permanent: permanent?,
-          )
+          logger.log_post_deletion(@post, **@opts.slice(:context), permanent: permanent?)
         end
       end
 

--- a/plugins/discourse-ai/app/models/reviewable_ai_post.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_post.rb
@@ -138,25 +138,25 @@ class ReviewableAiPost < Reviewable
   end
 
   def perform_delete_and_ignore_replies(performed_by, args)
-    PostDestroyer.delete_with_replies(performed_by, post, self)
+    PostDestroyer.delete_with_replies(performed_by, post, id)
 
     perform_ignore(performed_by, args)
   end
 
   def perform_delete_and_agree_replies(performed_by, args)
-    PostDestroyer.delete_with_replies(performed_by, post, self)
+    PostDestroyer.delete_with_replies(performed_by, post, id)
 
     agree
   end
 
   def perform_delete_user(performed_by, args)
-    UserDestroyer.new(performed_by).destroy(post.user, delete_opts)
+    UserDestroyer.new(performed_by).destroy(post.user, delete_opts.merge(reviewable_id: id))
 
     agree
   end
 
   def perform_delete_user_block(performed_by, args)
-    delete_options = delete_opts
+    delete_options = delete_opts.merge(reviewable_id: id)
 
     delete_options.merge!(block_email: true, block_ip: true) if Rails.env.production?
 
@@ -172,7 +172,7 @@ class ReviewableAiPost < Reviewable
   end
 
   def destroyer(performed_by)
-    PostDestroyer.new(performed_by, post, reviewable: self)
+    PostDestroyer.new(performed_by, post, reviewable_id: id)
   end
 
   def agree

--- a/plugins/discourse-ai/spec/models/reviewable_ai_post_spec.rb
+++ b/plugins/discourse-ai/spec/models/reviewable_ai_post_spec.rb
@@ -234,6 +234,15 @@ describe ReviewableAiPost do
         expect(result.transition_to).to eq :approved
         expect { target.user.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      it "links the staff action log to the reviewable" do
+        expect { reviewable.perform(admin, :delete_user) }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:delete_user],
+            reviewable_id: reviewable.id,
+          ).count
+        }.by(1)
+      end
     end
 
     it "ignores the reviewable" do

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -700,6 +700,20 @@ RSpec.describe PostDestroyer do
         expect(author.post_count).to eq(post_count - 1)
         expect(UserHistory.count).to eq(history_count + 1)
       end
+
+      it "links the staff action log to the reviewable when passed via opts" do
+        reply = create_post(topic_id: post.topic_id, user: post.user)
+        reviewable = Fabricate(:reviewable_flagged_post, target: reply)
+
+        expect {
+          PostDestroyer.new(moderator, reply, reviewable_id: reviewable.id).destroy
+        }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:delete_post],
+            reviewable_id: reviewable.id,
+          ).count
+        }.by(1)
+      end
     end
 
     context "when deleted by user with access to moderate topic category" do
@@ -1106,7 +1120,7 @@ RSpec.describe PostDestroyer do
 
         it "does not ignore a potentially illegal flag on the reply" do
           expect {
-            PostDestroyer.new(moderator, second_post, reviewable: parent_reviewable).destroy
+            PostDestroyer.new(moderator, second_post, reviewable_id: parent_reviewable.id).destroy
           }.not_to change { reply_reviewable.reload.pending? }
         end
       end
@@ -1124,7 +1138,7 @@ RSpec.describe PostDestroyer do
           is_warning: false,
           flag_topic: true,
         ).perform
-        PostDestroyer.new(moderator, third_post, { reviewable: Reviewable.last }).destroy
+        PostDestroyer.new(moderator, third_post, { reviewable_id: Reviewable.last.id }).destroy
         jobs = Jobs::SendSystemMessage.jobs
         expect(jobs.size).to eq(1)
 

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -332,6 +332,30 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(nested_reply.reload.deleted_at).to be_present
     end
 
+    it "delete_and_ignore_replies links the staff action log to the reviewable" do
+      create_reply(post)
+      post.reload
+
+      expect { reviewable.perform(moderator, :delete_and_ignore_replies) }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:delete_topic],
+          reviewable_id: reviewable.id,
+        ).count
+      }.by(1)
+    end
+
+    it "delete_and_agree_replies links the staff action log to the reviewable" do
+      create_reply(post)
+      post.reload
+
+      expect { reviewable.perform(moderator, :delete_and_agree_replies) }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:delete_topic],
+          reviewable_id: reviewable.id,
+        ).count
+      }.by(1)
+    end
+
     it "disagrees with the flags" do
       reviewable.perform(moderator, :disagree)
       expect(reviewable).to be_rejected

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -102,6 +102,15 @@ RSpec.describe ReviewableQueuedPost, type: :model do
           result = reviewable.perform(moderator, :approve_post)
           expect(result.success?).to eq(true)
         end
+
+        it "logs a staff action linked to the reviewable" do
+          expect { reviewable.perform(moderator, :approve_post) }.to change {
+            UserHistory.where(
+              action: UserHistory.actions[:post_approved],
+              reviewable_id: reviewable.id,
+            ).count
+          }.by(1)
+        end
       end
 
       context "with reject_post" do
@@ -123,6 +132,15 @@ RSpec.describe ReviewableQueuedPost, type: :model do
           expect { reviewable.perform(moderator, :reject_post) }.to raise_error(
             Reviewable::InvalidAction,
           )
+        end
+
+        it "logs a staff action linked to the reviewable" do
+          expect { reviewable.perform(moderator, :reject_post) }.to change {
+            UserHistory.where(
+              action: UserHistory.actions[:post_rejected],
+              reviewable_id: reviewable.id,
+            ).count
+          }.by(1)
         end
       end
 

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe ReviewableUser, type: :model do
         expect(reviewable.target.approved_at).to be_present
         expect(reviewable.version > 0).to eq(true)
       end
+
+      it "logs a staff action linked to the reviewable" do
+        expect { reviewable.perform(moderator, :approve_user) }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:approve_user],
+            reviewable_id: reviewable.id,
+          ).count
+        }.by(1)
+      end
     end
 
     context "when rejecting" do
@@ -188,6 +197,17 @@ RSpec.describe ReviewableUser, type: :model do
         reviewable.reload
         expect(reviewable.target).to be_present
         expect(reviewable.target.approved).to eq(false)
+      end
+
+      it "logs a staff action linked to the reviewable" do
+        expect {
+          reviewable.perform(moderator, :delete_user, reject_reason: "reject reason")
+        }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:delete_user],
+            reviewable_id: reviewable.id,
+          ).count
+        }.by(1)
       end
     end
   end

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -129,9 +129,13 @@ RSpec.describe Admin::StaffActionLogsController do
       end
 
       describe "reviewable_id" do
-        it "is included for post_approved actions" do
+        it "is included when the staff action log is linked to a reviewable" do
           reviewable = Fabricate(:reviewable_queued_post_topic)
-          reviewable.perform(admin, :approve_post)
+          UserHistory.create!(
+            action: UserHistory.actions[:post_approved],
+            acting_user_id: admin.id,
+            reviewable_id: reviewable.id,
+          )
 
           get "/admin/logs/staff_action_logs.json",
               params: {
@@ -143,95 +147,7 @@ RSpec.describe Admin::StaffActionLogsController do
           )
         end
 
-        it "is included for post_rejected actions" do
-          reviewable = Fabricate(:reviewable_queued_post_topic)
-          reviewable.perform(admin, :reject_post)
-
-          get "/admin/logs/staff_action_logs.json",
-              params: {
-                action_id: UserHistory.actions[:post_rejected],
-              }
-
-          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
-            reviewable.id,
-          )
-        end
-
-        it "is included for approve_user actions" do
-          reviewable = ReviewableUser.create_for(user)
-          reviewable.perform(admin, :approve_user)
-
-          get "/admin/logs/staff_action_logs.json",
-              params: {
-                action_id: UserHistory.actions[:approve_user],
-              }
-
-          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
-            reviewable.id,
-          )
-        end
-
-        it "is included for delete_user actions from reviewable" do
-          target = Fabricate(:user)
-          reviewable = ReviewableUser.create_for(target)
-          reviewable.perform(admin, :delete_user)
-
-          get "/admin/logs/staff_action_logs.json",
-              params: {
-                action_id: UserHistory.actions[:delete_user],
-              }
-
-          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
-            reviewable.id,
-          )
-        end
-
-        it "is included for delete_post actions from reviewable" do
-          topic = Fabricate(:topic)
-          Fabricate(:post, topic: topic)
-          reply = Fabricate(:post, topic: topic)
-          flagger = Fabricate(:user, refresh_auto_groups: true)
-          reviewable = PostActionCreator.off_topic(flagger, reply).reviewable
-          reviewable.perform(admin, :delete_and_agree)
-
-          get "/admin/logs/staff_action_logs.json",
-              params: {
-                action_id: UserHistory.actions[:delete_post],
-              }
-
-          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
-            reviewable.id,
-          )
-        end
-
-        it "is included for suspend_user actions from reviewable flows" do
-          target = Fabricate(:user)
-          reviewable = Fabricate(:reviewable_flagged_post, target_created_by: target)
-
-          User::Action::SuspendAll.call(
-            users: [target],
-            actor: admin,
-            params:
-              OpenStruct.new(
-                message: "suspending from reviewable",
-                post_id: reviewable.target_id,
-                suspend_until: 1.day.from_now,
-                reason: "spam",
-                reviewable_id: reviewable.id,
-              ),
-          )
-
-          get "/admin/logs/staff_action_logs.json",
-              params: {
-                action_id: UserHistory.actions[:suspend_user],
-              }
-
-          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
-            reviewable.id,
-          )
-        end
-
-        it "is not included when no reviewable exists" do
+        it "is omitted when the staff action log has no reviewable" do
           StaffActionLogger.new(admin).log_site_setting_change("title", "old", "new")
 
           get "/admin/logs/staff_action_logs.json",

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -128,6 +128,121 @@ RSpec.describe Admin::StaffActionLogsController do
         expect(response.parsed_body["staff_action_logs"].first["details"]).to include(pm.title)
       end
 
+      describe "reviewable_id" do
+        it "is included for post_approved actions" do
+          reviewable = Fabricate(:reviewable_queued_post_topic)
+          reviewable.perform(admin, :approve_post)
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:post_approved],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is included for post_rejected actions" do
+          reviewable = Fabricate(:reviewable_queued_post_topic)
+          reviewable.perform(admin, :reject_post)
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:post_rejected],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is included for approve_user actions" do
+          reviewable = ReviewableUser.create_for(user)
+          reviewable.perform(admin, :approve_user)
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:approve_user],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is included for delete_user actions from reviewable" do
+          target = Fabricate(:user)
+          reviewable = ReviewableUser.create_for(target)
+          reviewable.perform(admin, :delete_user)
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:delete_user],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is included for delete_post actions from reviewable" do
+          topic = Fabricate(:topic)
+          Fabricate(:post, topic: topic)
+          reply = Fabricate(:post, topic: topic)
+          flagger = Fabricate(:user, refresh_auto_groups: true)
+          reviewable = PostActionCreator.off_topic(flagger, reply).reviewable
+          reviewable.perform(admin, :delete_and_agree)
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:delete_post],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is included for suspend_user actions from reviewable flows" do
+          target = Fabricate(:user)
+          reviewable = Fabricate(:reviewable_flagged_post, target_created_by: target)
+
+          User::Action::SuspendAll.call(
+            users: [target],
+            actor: admin,
+            params:
+              OpenStruct.new(
+                message: "suspending from reviewable",
+                post_id: reviewable.target_id,
+                suspend_until: 1.day.from_now,
+                reason: "spam",
+                reviewable_id: reviewable.id,
+              ),
+          )
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:suspend_user],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first["reviewable_id"]).to eq(
+            reviewable.id,
+          )
+        end
+
+        it "is not included when no reviewable exists" do
+          StaffActionLogger.new(admin).log_site_setting_change("title", "old", "new")
+
+          get "/admin/logs/staff_action_logs.json",
+              params: {
+                action_id: UserHistory.actions[:change_site_setting],
+              }
+
+          expect(response.parsed_body["staff_action_logs"].first).not_to have_key("reviewable_id")
+        end
+      end
+
       context "when staff actions are extended" do
         let(:plugin_extended_action) { :confirmed_ham }
         before { UserHistory.stubs(:staff_actions).returns([plugin_extended_action]) }

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -157,6 +157,17 @@ RSpec.describe UserDestroyer do
 
         expect(reviewable.reload).to be_rejected
       end
+
+      it "links the staff action log to the reviewable when passed via opts" do
+        expect {
+          UserDestroyer.new(admin).destroy(reviewable.target, reviewable_id: reviewable.id)
+        }.to change {
+          UserHistory.where(
+            action: UserHistory.actions[:delete_user],
+            reviewable_id: reviewable.id,
+          ).count
+        }.by(1)
+      end
     end
 
     context "with a directory item record" do

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe UserSilencer do
       expect(old_post.topic).to be_visible
     end
 
+    it "links the staff action log to the reviewable when passed via opts" do
+      reviewable = Fabricate(:reviewable_flagged_post, target_created_by: user)
+
+      expect { UserSilencer.silence(user, admin, reviewable_id: reviewable.id) }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:silence_user],
+          reviewable_id: reviewable.id,
+        ).count
+      }.by(1)
+    end
+
     context "with a plugin hook" do
       before do
         @override_silence_message = ->(opts) do

--- a/spec/services/user_suspender_spec.rb
+++ b/spec/services/user_suspender_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe UserSuspender do
       }.from(0).to(1)
     end
 
+    it "links the staff action log to the reviewable when passed via opts" do
+      reviewable = Fabricate(:reviewable_flagged_post, target_created_by: user)
+      suspender =
+        UserSuspender.new(
+          user,
+          suspended_till: 5.hours.from_now,
+          reason: "because",
+          by_user: admin,
+          post_id: post.id,
+          message: "you have been suspended",
+          reviewable_id: reviewable.id,
+        )
+
+      expect { suspender.suspend }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:suspend_user],
+          reviewable_id: reviewable.id,
+        ).count
+      }.by(1)
+    end
+
     it "logs the user out" do
       messages = MessageBus.track_publish("/logout/#{user.id}") { suspend_user }
       expect(messages.size).to eq(1)


### PR DESCRIPTION
The staff action log records moderation actions (post deletions, user suspensions, silences, user approvals, etc.) as `UserHistory` rows, but entries triggered from the reviewable queue have no reference back to the reviewable that caused them. When auditing a decision in the log, staff can't jump to the flagged post, queued post, or user-approval review that produced it.

Link to review is visible in the log:
<img width="900" height="674" alt="Screenshot 2026-04-24 at 2 17 04 pm" src="https://github.com/user-attachments/assets/791ebc58-0a4d-4c2c-a363-efe482f5f755" />

