### PR TITLE
FIX: User options take precedence over show-original anon cookie

### DIFF
--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -7,6 +7,7 @@ class ContentLocalization
   # @return [Boolean] if the cookie is set, false otherwise
   def self.show_original?(scope)
     return true if scope&.user&.user_option&.show_original_content
+    return false if scope&.user
     scope&.request&.cookies&.key?(SHOW_ORIGINAL_COOKIE)
   end
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/translation.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/translation.js
@@ -15,9 +15,9 @@ export default apiInitializer((api) => {
     "localized",
     (topicController, data) => {
       const currentUser = api.getCurrentUser();
-      const showOriginal =
-        currentUser?.user_option?.show_original_content ||
-        cookie("content-localization-show-original");
+      const showOriginal = currentUser
+        ? currentUser.user_option?.show_original_content
+        : cookie("content-localization-show-original");
 
       if (!showOriginal) {
         const postStream = topicController.get("model.postStream");

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -37,9 +37,15 @@ describe ContentLocalization do
       expect(ContentLocalization.show_original?(scope)).to be false
     end
 
-    it "returns true when user preference is not set but cookie is present" do
+    it "returns false when user preference is not set but cookie is present for a logged-in user" do
       user = Fabricate(:user)
       scope = create_scope(user: user, cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
+
+      expect(ContentLocalization.show_original?(scope)).to be false
+    end
+
+    it "returns true when cookie is present for an anonymous user" do
+      scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
 
       expect(ContentLocalization.show_original?(scope)).to be true
     end

--- a/spec/system/content_localization_language_switcher_spec.rb
+++ b/spec/system/content_localization_language_switcher_spec.rb
@@ -6,6 +6,7 @@ describe "Content localization language switcher" do
 
   let(:topic_list) { PageObjects::Components::TopicList.new }
   let(:switcher) { PageObjects::Components::DMenu.new(switcher_selector) }
+  let(:language_switcher) { PageObjects::Components::LanguageSwitcher.new }
 
   fab!(:japanese_user) { Fabricate(:user, locale: "ja") }
 
@@ -106,10 +107,10 @@ describe "Content localization language switcher" do
     visit("/")
     expect(page.find(switcher_selector)).to have_content("EN")
 
-    select_language("ja")
+    language_switcher.select_language("ja")
     expect(page.find(switcher_selector)).to have_content("JA")
 
-    select_language("es")
+    language_switcher.select_language("es")
     expect(page.find(switcher_selector)).to have_content("ES")
   end
 
@@ -119,7 +120,7 @@ describe "Content localization language switcher" do
     visit("/")
     expect(topic_list).to have_content("Life strategies from The Art of War")
 
-    select_language("es")
+    language_switcher.select_language("es")
 
     expect(topic_list).to have_content("Estrategias de vida de El arte de la guerra")
     I18n.with_locale("es") do
@@ -134,7 +135,7 @@ describe "Content localization language switcher" do
       expect(page.find("#navigation-bar")).to have_content(I18n.t("js.filters.latest.title"))
     end
 
-    select_language("es")
+    language_switcher.select_language("es")
 
     expect(topic_list).to have_content("Estrategias de vida de El arte de la guerra")
     I18n.with_locale("es") do
@@ -147,7 +148,7 @@ describe "Content localization language switcher" do
 
     visit("/t/#{topic.id}")
 
-    select_language("ja")
+    language_switcher.select_language("ja")
 
     expect(topic_list).to have_content("孫子兵法からの人生戦略")
     I18n.with_locale(:ja) do
@@ -164,7 +165,7 @@ describe "Content localization language switcher" do
       )
     end
 
-    select_language("es")
+    language_switcher.select_language("es")
 
     expect(topic_list).to have_content("Estrategias de vida de El arte de la guerra")
     I18n.with_locale("es") do
@@ -185,16 +186,11 @@ describe "Content localization language switcher" do
     expect(page).to have_no_css("[data-menu-option-id='es'].--selected")
 
     switcher.collapse
-    select_language("ja")
+    language_switcher.select_language("ja")
     switcher.expand
 
     expect(page).to have_css("[data-menu-option-id='ja'].--selected")
     expect(page).to have_no_css("[data-menu-option-id='en'].--selected")
     expect(page).to have_no_css("[data-menu-option-id='es'].--selected")
-  end
-
-  def select_language(locale)
-    switcher.expand
-    switcher.option("[data-menu-option-id='#{locale}']").click
   end
 end

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -241,21 +241,16 @@ describe "Content Localization" do
     end
 
     context "when transitioning from anonymous to logged-in" do
-      let(:switcher) { PageObjects::Components::DMenu.new(switcher_selector) }
+      let(:language_switcher) { PageObjects::Components::LanguageSwitcher.new }
 
       before do
         SiteSetting.set_locale_from_cookie = true
         SiteSetting.content_localization_language_switcher = "all"
       end
 
-      def select_language(locale)
-        switcher.expand
-        switcher.option("[data-menu-option-id='#{locale}']").click
-      end
-
       it "ignores the show-original cookie for logged-in users" do
         visit("/")
-        select_language("ja")
+        language_switcher.select_language("ja")
 
         visit("/t/#{topic.id}")
         expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -240,6 +240,36 @@ describe "Content Localization" do
       end
     end
 
+    context "when transitioning from anonymous to logged-in" do
+      let(:switcher) { PageObjects::Components::DMenu.new(switcher_selector) }
+
+      before do
+        SiteSetting.set_locale_from_cookie = true
+        SiteSetting.content_localization_language_switcher = "all"
+      end
+
+      def select_language(locale)
+        switcher.expand
+        switcher.option("[data-menu-option-id='#{locale}']").click
+      end
+
+      it "ignores the show-original cookie for logged-in users" do
+        visit("/")
+        select_language("ja")
+
+        visit("/t/#{topic.id}")
+        expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
+
+        page.find(toggle_localize_button_selector).click
+        expect(topic_page.has_topic_title?("Life strategies from The Art of War")).to eq(true)
+
+        sign_in(japanese_user)
+
+        visit("/t/#{topic.id}")
+        expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
+      end
+    end
+
     context "when editing" do
       let(:edit_localized_post_dialog) { PageObjects::Components::Dialog.new }
       let(:fast_editor) { PageObjects::Components::FastEditor.new }

--- a/spec/system/page_objects/components/language_switcher.rb
+++ b/spec/system/page_objects/components/language_switcher.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class LanguageSwitcher < PageObjects::Components::Base
+      SELECTOR = "button[data-identifier='language-switcher']"
+
+      def initialize
+        @menu = PageObjects::Components::DMenu.new(SELECTOR)
+      end
+
+      def visible?
+        page.has_css?(SELECTOR)
+      end
+
+      def not_visible?
+        page.has_no_css?(SELECTOR)
+      end
+
+      def select_language(locale)
+        @menu.expand
+        @menu.option("[data-menu-option-id='#{locale}']").click
+      end
+    end
+  end
+end


### PR DESCRIPTION
Repro:
  1. anonymous user browsing
  2. sets content language switcher to "Japanese"
  3. sees japanese
  4. clicks on "show original" in the post
  5. sees original
  6. logs in to their account
  7. (their account should see Japanese - UNCHECKED user pref "Show original content instead of translated content.")
  8. BUG: but they see original because of the anon cookie
  
This PR fixes the bug by only using the user option if they're logged in.