### PR TITLE
UX: Formkit fixes

### DIFF
--- a/app/assets/stylesheets/admin/admin_config_area.scss
+++ b/app/assets/stylesheets/admin/admin_config_area.scss
@@ -170,7 +170,7 @@
     background-clip: border-box;
   }
 
-  .form-kit__field-toggle .form-kit__container-content.--full {
+  .form-kit__field-toggle.--full .form-kit__container-content {
     // avoid label wrapping
     width: var(--form-kit-small-input) !important;
   }
@@ -278,7 +278,7 @@
 
 .admin-welcome-banner-form {
   #control-enabledThemes {
-    .form-kit__container-content.--large {
+    .form-kit__field.--large .form-kit__container-content {
       .d-multi-select-trigger__selection-label {
         // show selection full names (overrides unnecessary truncation)
         max-width: unset;

--- a/app/assets/stylesheets/common/form-kit/_conditional-display.scss
+++ b/app/assets/stylesheets/common/form-kit/_conditional-display.scss
@@ -16,7 +16,7 @@
   width: 100%;
 
   .form-kit__conditional-display,
-  .form-kit__container-content.--large {
+  .form-kit__field.--large .form-kit__container-content {
     width: 100%;
   }
 

--- a/app/assets/stylesheets/common/form-kit/_container.scss
+++ b/app/assets/stylesheets/common/form-kit/_container.scss
@@ -1,8 +1,14 @@
+@use "lib/viewport";
+
 .form-kit__container {
   display: flex;
   gap: 0.25rem;
   flex-direction: column;
   align-items: flex-start;
+
+  @include viewport.until(sm) {
+    width: 100%;
+  }
 
   &.--column {
     .form-kit__container-content {
@@ -44,11 +50,48 @@
     flex-direction: row;
     align-items: flex-start;
     max-width: 100%;
+    width: var(--form-kit-medium-input);
 
-    &.--small {
-      width: var(--form-kit-small-input) !important;
+    @include viewport.until(sm) {
+      width: 100%;
+    }
+  }
+}
+
+.form-kit__container-title,
+.form-kit__container-description,
+.form-kit__container-content {
+  .--small & {
+    width: var(--form-kit-small-input);
+  }
+
+  @include viewport.from(sm) {
+    .--medium & {
+      width: var(--form-kit-medium-input);
     }
 
+    .--large & {
+      width: var(--form-kit-large-input);
+    }
+
+    .--full & {
+      width: 100%;
+      min-width: var(--form-kit-small-input);
+    }
+  }
+}
+
+// Override: child has its own modifier from @titleFormat / @descriptionFormat.
+// Lives in a separate block AFTER the cascade so on equal specificity, source
+// order makes the explicit override win. Yes, this one sucks a bit. I know.
+.form-kit__container-title,
+.form-kit__container-description,
+.form-kit__container-content {
+  &.--small {
+    width: var(--form-kit-small-input);
+  }
+
+  @include viewport.from(sm) {
     &.--medium {
       width: var(--form-kit-medium-input);
     }
@@ -57,13 +100,9 @@
       width: var(--form-kit-large-input);
     }
 
-    &.--max {
-      max-width: var(--form-kit-max-input);
-      width: 100%;
-    }
-
     &.--full {
-      width: 100% !important;
+      width: 100%;
+      min-width: var(--form-kit-small-input);
     }
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_container.scss
+++ b/app/assets/stylesheets/common/form-kit/_container.scss
@@ -74,6 +74,11 @@
       width: var(--form-kit-large-input);
     }
 
+    .--max & {
+      max-width: var(--form-kit-max-input);
+      width: 100%;
+    }
+
     .--full & {
       width: 100%;
       min-width: var(--form-kit-small-input);
@@ -98,6 +103,11 @@
 
     &.--large {
       width: var(--form-kit-large-input);
+    }
+
+    &.--max {
+      max-width: var(--form-kit-max-input);
+      width: 100%;
     }
 
     &.--full {

--- a/app/assets/stylesheets/common/form-kit/_control-custom.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-custom.scss
@@ -1,7 +1,4 @@
 .form-kit__field-custom {
-  width: auto !important;
-  min-width: var(--form-kit-small-input);
-
   .form-kit__control-custom {
     width: 100%;
   }

--- a/app/assets/stylesheets/common/form-kit/_control-input.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-input.scss
@@ -35,15 +35,11 @@
 .form-kit__after-input {
   border: 1px solid var(--primary-low-mid);
   padding-inline: 0.5em;
-  height: 2em;
+  height: var(--space-9);
   box-sizing: border-box;
   background: var(--primary-low);
   display: flex;
   align-items: center;
-
-  @include viewport.until(sm) {
-    height: 2.25em;
-  }
 }
 
 .form-kit__before-input {

--- a/app/assets/stylesheets/common/form-kit/_control-select.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-select.scss
@@ -9,6 +9,9 @@
   }
 }
 
-.select-kit.multi-select.form-kit__control-tag-chooser {
-  width: 100%;
+.form-kit {
+  // standard select has 300px which requires constant specificty override; can be removed once everything is formkit
+  .select-kit.multi-select {
+    width: 100%;
+  }
 }

--- a/app/assets/stylesheets/common/form-kit/_control-select.scss
+++ b/app/assets/stylesheets/common/form-kit/_control-select.scss
@@ -8,3 +8,7 @@
     height: 2.25em;
   }
 }
+
+.select-kit.multi-select.form-kit__control-tag-chooser {
+  width: 100%;
+}

--- a/app/assets/stylesheets/common/form-kit/_errors-summary.scss
+++ b/app/assets/stylesheets/common/form-kit/_errors-summary.scss
@@ -6,11 +6,7 @@
   border: 1px solid var(--danger);
   background-color: var(--danger-low);
   border-radius: var(--d-border-radius);
-  width: var(--form-kit-large-input);
-
-  @include viewport.until(sm) {
-    width: 100%;
-  }
+  width: 100%;
 
   h2 {
     font-size: var(--font-0);

--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -2,20 +2,7 @@
 
 .form-kit__field {
   .form-kit__container-content {
-    align-items: flex-start;
     flex-direction: column;
-    width: var(--form-kit-medium-input);
-  }
-
-  @include viewport.until(sm) {
-    .form-kit__container-content,
-    .form-kit__container {
-      width: 100% !important;
-    }
-  }
-
-  &.--full {
-    width: 100%;
   }
 
   &-composer,
@@ -27,9 +14,11 @@
   }
 
   &-textarea {
-    .form-kit__container-content {
-      min-width: var(--form-kit-large-input);
-      width: fit-content !important;
+    @include viewport.from(sm) {
+      .form-kit__container-content {
+        min-width: var(--form-kit-large-input);
+        width: fit-content !important;
+      }
     }
   }
 
@@ -37,7 +26,10 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    width: var(--form-kit-medium-input);
+
+    @include viewport.from(sm) {
+      width: var(--form-kit-medium-input);
+    }
 
     .form-kit__container-content {
       align-items: flex-end;
@@ -62,33 +54,6 @@
   .form-kit__container-help-text {
     margin: 0;
     font-size: var(--font-down-1);
-    color: var(--primary-high-or-secondary-low);
-  }
-}
-
-.form-kit__container,
-.form-kit__container-title,
-.form-kit__container-description,
-.form-kit__container-content {
-  &.--small {
-    width: var(--form-kit-small-input) !important;
-  }
-
-  &.--medium {
-    width: var(--form-kit-medium-input);
-  }
-
-  &.--large {
-    width: var(--form-kit-large-input);
-  }
-
-  &.--max {
-    max-width: var(--form-kit-max-input);
-    width: 100%;
-  }
-
-  &.--full {
-    width: 100% !important;
-    min-width: var(--form-kit-small-input);
+    color: var(--primary-medium);
   }
 }

--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -64,30 +64,31 @@
     font-size: var(--font-down-1);
     color: var(--primary-high-or-secondary-low);
   }
+}
 
-  .form-kit__container-title,
-  .form-kit__container-description,
-  .form-kit__container-content {
-    &.--small {
-      width: var(--form-kit-small-input) !important;
-    }
+.form-kit__container,
+.form-kit__container-title,
+.form-kit__container-description,
+.form-kit__container-content {
+  &.--small {
+    width: var(--form-kit-small-input) !important;
+  }
 
-    &.--medium {
-      width: var(--form-kit-medium-input);
-    }
+  &.--medium {
+    width: var(--form-kit-medium-input);
+  }
 
-    &.--large {
-      width: var(--form-kit-large-input);
-    }
+  &.--large {
+    width: var(--form-kit-large-input);
+  }
 
-    &.--max {
-      max-width: var(--form-kit-max-input);
-      width: 100%;
-    }
+  &.--max {
+    max-width: var(--form-kit-max-input);
+    width: 100%;
+  }
 
-    &.--full {
-      width: 100% !important;
-      min-width: var(--form-kit-small-input);
-    }
+  &.--full {
+    width: 100% !important;
+    min-width: var(--form-kit-small-input);
   }
 }

--- a/docs/developer-guides/docs/03-code-internals/21-form-kit.md
+++ b/docs/developer-guides/docs/03-code-internals/21-form-kit.md
@@ -564,13 +564,9 @@ Additionally, the following CSS variables are provided to customize these defaul
 - medium: `--form-kit-medium-input`
 - large: `--form-kit-large-input`
 
-## @titleFormat
+## @labelFormat
 
-Allows to override `@format` for the title. See `@format` for details.
-
-## @descriptionFormat
-
-Allows to override `@format` for the description. See `@format` for details.
+Overrides the width of the title and description (the label area) independently of `@format`. Useful when long descriptions need more room than the input itself — e.g. `@format="small"` with `@labelFormat="full"` keeps a small input but lets the description span the form. Only emit it when the label area should differ from the field; otherwise both inherit from `@format`. See `@format` for the available values.
 
 ## Checkbox
 

--- a/frontend/discourse/app/components/edit-category-type-schema-fields.gjs
+++ b/frontend/discourse/app/components/edit-category-type-schema-fields.gjs
@@ -57,8 +57,7 @@ const SchemaFormField = <template>
       @title={{@entry.label}}
       @description={{@entry.description}}
       @validation={{if @entry.required "required"}}
-      @titleFormat="full"
-      @descriptionFormat="full"
+      @labelFormat="full"
       @format="large"
       as |field|
     >

--- a/frontend/discourse/app/components/edit-category-type-schema-fields.gjs
+++ b/frontend/discourse/app/components/edit-category-type-schema-fields.gjs
@@ -28,8 +28,6 @@ const SchemaFormField = <template>
       @title={{@entry.label}}
       @description={{@entry.description}}
       @validation={{if @entry.required "required"}}
-      @titleFormat="full"
-      @descriptionFormat="full"
       @format="full"
       @type="custom"
       as |field|
@@ -46,8 +44,6 @@ const SchemaFormField = <template>
       @title={{@entry.label}}
       @description={{@entry.description}}
       @validation={{if @entry.required "required"}}
-      @titleFormat="full"
-      @descriptionFormat="full"
       @format="full"
       @type="input-number"
       as |field|

--- a/frontend/discourse/app/form-kit/components/fk/col.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/col.gjs
@@ -2,7 +2,10 @@ import { concat } from "@ember/helper";
 import concatClass from "discourse/helpers/concat-class";
 
 const FKCol = <template>
-  <div class={{concatClass "form-kit__col" (if @size (concat "--col-" @size))}}>
+  <div
+    class={{concatClass "form-kit__col" (if @size (concat "--col-" @size))}}
+    ...attributes
+  >
     {{yield}}
   </div>
 </template>;

--- a/frontend/discourse/app/form-kit/components/fk/container.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/container.gjs
@@ -1,6 +1,7 @@
 import { concat } from "@ember/helper";
 import FormText from "discourse/form-kit/components/fk/text";
 import concatClass from "discourse/helpers/concat-class";
+import { eq } from "discourse/truth-helpers";
 
 const FKContainer = <template>
   <div
@@ -8,6 +9,7 @@ const FKContainer = <template>
       "form-kit__container"
       @class
       (if @direction (concat "--" @direction))
+      (if (eq @format "full") "--full")
     }}
     ...attributes
   >

--- a/frontend/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/field-data.gjs
@@ -126,19 +126,13 @@ export default class FKFieldData extends Component {
   }
 
   /**
-   * Format of the title.
+   * Format of the title and description (label area). Overrides @format
+   * for the title and description, leaving the field's content area at
+   * @format. Useful when long descriptions need more room than the input.
    * @type {string}
    */
-  get titleFormat() {
-    return this.args.titleFormat || this.format;
-  }
-
-  /**
-   * Format of the description.
-   * @type {string}
-   */
-  get descriptionFormat() {
-    return this.args.descriptionFormat || this.format;
+  get labelFormat() {
+    return this.args.labelFormat;
   }
 
   /**

--- a/frontend/discourse/app/form-kit/components/fk/field.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/field.gjs
@@ -132,7 +132,7 @@ export default class FKField extends Component {
                 (if field.type (concat "form-kit__field-" field.type))
                 (if field.error "has-error")
                 (if field.disabled "is-disabled")
-                (if (eq field.format "full") "--full")
+                (if field.format (concat "--" field.format))
               }}
               data-disabled={{field.disabled}}
               data-name={{field.name}}
@@ -144,7 +144,7 @@ export default class FKField extends Component {
                 <FKLabel
                   class={{concatClass
                     "form-kit__container-title"
-                    (if field.titleFormat (concat "--" field.titleFormat))
+                    (if field.labelFormat (concat "--" field.labelFormat))
                   }}
                   @fieldId={{field.id}}
                 >
@@ -159,20 +159,12 @@ export default class FKField extends Component {
                 <FKText
                   class={{concatClass
                     "form-kit__container-description"
-                    (if
-                      field.descriptionFormat
-                      (concat "--" field.descriptionFormat)
-                    )
+                    (if field.labelFormat (concat "--" field.labelFormat))
                   }}
                 >{{field.description}}</FKText>
               {{/if}}
 
-              <div
-                class={{concatClass
-                  "form-kit__container-content"
-                  (if field.format (concat "--" field.format))
-                }}
-              >
+              <div class="form-kit__container-content">
                 {{#if field.hasExplicitType}}
                   {{yield field}}
                 {{else}}

--- a/frontend/discourse/tests/integration/components/form-kit/field-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/field-test.gjs
@@ -270,14 +270,14 @@ module("Integration | Component | FormKit | Field", function (hooks) {
       .dom(".form-kit__field.--full")
       .exists("it applies the --full class to the field");
     assert
-      .dom(".form-kit__container-description.--full")
-      .exists("it applies the --full class to the description");
+      .dom(".form-kit__container-description:not([class*='--'])")
+      .exists("it does not apply a format class to the description");
     assert
-      .dom(".form-kit__container-title.--full")
-      .exists("it applies the --full class to the title");
+      .dom(".form-kit__container-title:not([class*='--'])")
+      .exists("it does not apply a format class to the title");
   });
 
-  test("@descriptionFormat", async function (assert) {
+  test("@labelFormat", async function (assert) {
     await render(
       <template>
         <Form as |form|>
@@ -286,8 +286,8 @@ module("Integration | Component | FormKit | Field", function (hooks) {
             @name="foo"
             @title="Foo"
             @description="foo description"
-            @format="full"
-            @descriptionFormat="large"
+            @format="large"
+            @labelFormat="full"
             as |field|
           ><field.Control /></form.Field>
         </Form>
@@ -295,35 +295,14 @@ module("Integration | Component | FormKit | Field", function (hooks) {
     );
 
     assert
-      .dom(".form-kit__field.--full")
-      .exists("it applies the --full class to the field");
+      .dom(".form-kit__field.--large")
+      .exists("it applies the --large class to the field");
     assert
-      .dom(".form-kit__container-description.--large")
-      .exists("it applies the --large class to the description");
-  });
-
-  test("@titleFormat", async function (assert) {
-    await render(
-      <template>
-        <Form as |form|>
-          <form.Field
-            @type="input"
-            @name="foo"
-            @title="Foo"
-            @format="full"
-            @titleFormat="large"
-            as |field|
-          ><field.Control /></form.Field>
-        </Form>
-      </template>
-    );
-
+      .dom(".form-kit__container-title.--full")
+      .exists("it applies the --full class to the title");
     assert
-      .dom(".form-kit__field.--full")
-      .exists("it applies the --full class to the field");
-    assert
-      .dom(".form-kit__container-title.--large")
-      .exists("it applies the --large class to the title");
+      .dom(".form-kit__container-description.--full")
+      .exists("it applies the --full class to the description");
   });
 
   test("@onSet", async function (assert) {


### PR DESCRIPTION
### CSS
* adjust input before/after height to use vars
* moving the `--small` / `--medium` / `--large` / `--full` width rules to the `form-kit__container`
* undid the limit on form-error-summary as this doesn't look good in full-width forms, essentially shifting the problem
* wrap width classes in MQ so that they remain full width on SM views 
* globally override select-kit width within formkit

### `form.Container @format="full"` now applies `--full` to the outer container
`form.Field` already adds `--full` to its root div when `@format="full"`, but `form.Container` only applied `@format` to its inner content div. This left the outer `.form-kit__container` at its default width, even though `@format` is documented as supported on Container. 

### `row.Col` passes HTML attributes
`form.Row` already used `...attributes`, but `row.Col` did not — passing `class`, `data-*`, or any HTML attribute to a Col silently dropped it. Classes can be needed on specific cols.

### FormKit size modifiers                 
  FormKit applied size modifiers (`--small`/`--medium`/`--large`/`--full`) to   `form-kit__container-content` and to its children. It also had a separate `@titleFormat` and `@descriptionFormat` args, which made label/description
   widths drift apart and required scattered CSS overrides.                                                              
                                                                                                                         
  Changed to: Size modifiers move up to `form-kit__field` so title, description, and content share one width, the
   title/description args collapse into a single `@labelFormat` which can override the field level modifier.

#### Example
```
<div id="control-username" class="form-kit__container form-kit__field form-kit__field-input --large" data-name="username" data-control-type="input">
     <label for="d07b0c2a-42bb-45f1-881e-4ca441f10add" class="form-kit__container-title">.   <span>Username</span>
    <div class="form-kit__container-content --small">
     </div>
</div>
```
Would result in a `--large` field/label with a `--small'` input field (typical usecase would be a number, not text):
<img width="796" height="344" alt="CleanShot 2026-04-27 at 15 39 27@2x" src="https://github.com/user-attachments/assets/58ffff48-99d2-4b3d-be4e-d2fb382ca89a" />


