### PR TITLE
FIX: use `next` instead of `return` in sidekiq_retry_in blocks

### DIFF
--- a/app/jobs/regular/group_smtp_email.rb
+++ b/app/jobs/regular/group_smtp_email.rb
@@ -15,7 +15,7 @@ module Jobs
       # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
       case exception.wrapped
       when Net::SMTPServerBusy
-        return 1.hour + (rand(30) * (count + 1))
+        next 1.hour + (rand(30) * (count + 1))
       end
     end
 

--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -25,7 +25,7 @@ module Jobs
       # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
       case exception.wrapped
       when SocketError
-        return RETRY_TIMES[count]
+        next RETRY_TIMES[count]
       end
     end
 

--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -17,7 +17,7 @@ module Jobs
       # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
       case exception.wrapped
       when Net::SMTPServerBusy
-        return 1.hour + (rand(30) * (count + 1))
+        next 1.hour + (rand(30) * (count + 1))
       end
     end
 

--- a/plugins/automation/app/jobs/regular/discourse_automation/trigger.rb
+++ b/plugins/automation/app/jobs/regular/discourse_automation/trigger.rb
@@ -14,7 +14,7 @@ module Jobs
         # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
         case exception.wrapped
         when SocketError
-          return RETRY_TIMES[count]
+          next RETRY_TIMES[count]
         end
       end
 


### PR DESCRIPTION
Using `return` inside a block attempts to return from the enclosing method rather than from the block itself. In Sidekiq's `job_retry` context this raises `LocalJumpError: unexpected return`, which shows up in logs as:

```
Job exception: unexpected return
```

The correct Ruby idiom for exiting a block with a value is `next <value>`.

Four jobs had the same pattern:
- `app/jobs/regular/user_email.rb`
- `app/jobs/regular/group_smtp_email.rb`
- `app/jobs/regular/notify_mailing_list_subscribers.rb`
- `plugins/automation/app/jobs/regular/discourse_automation/trigger.rb`