### PR TITLE
PERF: use correlated EXISTS for tags: search filter

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -953,7 +953,7 @@ class Search
     else
       tags = resolve_tag_synonyms(match.split(","))
       tag_ids = Tag.where_name(tags).pluck(:id)
-      return positive ? posts.where("1=0") : posts if tag_ids.empty?
+      return positive ? posts.none : posts if tag_ids.empty?
 
       posts.where(
         "#{modifier} EXISTS (

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -952,14 +952,15 @@ class Search
       )
     else
       tags = resolve_tag_synonyms(match.split(","))
+      tag_ids = Tag.where_name(tags).pluck(:id)
+      return positive ? posts.where("1=0") : posts if tag_ids.empty?
 
       posts.where(
-        "topics.id #{modifier} IN (
-        SELECT DISTINCT(tt.topic_id)
-        FROM topic_tags tt, tags
-        WHERE tt.tag_id = tags.id AND lower(tags.name) IN (?)
+        "#{modifier} EXISTS (
+        SELECT 1 FROM topic_tags tt
+        WHERE tt.topic_id = topics.id AND tt.tag_id IN (?)
       )",
-        tags,
+        tag_ids,
       )
     end
   end


### PR DESCRIPTION
## Summary

- The `tags:` advanced search filter emitted `topics.id IN (SELECT DISTINCT tt.topic_id FROM topic_tags tt, tags WHERE lower(tags.name) IN (...))`. On forums where a filter tag covers the majority of topics, the planner materialises a huge topic-id set and picks a bad plan for the downstream full-text aggregate — a common term combined with a near-universal tag turned a ~1s search into 20–30s.
- Resolve tag names to IDs in Ruby and emit a correlated `EXISTS` against `topic_tags` instead. The planner now uses the `(topic_id, tag_id)` index for an O(1) probe per candidate topic, and the extra `tags`-table join plus `lower(name)` comparison are dropped from the hot SQL.
- Measured **26× speedup** on a production dataset (29.35s → 1.12s) for a common term plus a near-universal tag — matching the baseline of the same search with no tag filter at all.
- Negative-filter behaviour is preserved: `NOT EXISTS` is equivalent to the original `NOT IN` because `topic_tags.topic_id` is NOT NULL. When the requested tag name doesn't resolve to any tag, a positive filter returns no results and a negative filter is a no-op — matching the prior `IN (empty)` semantics.

The `+` (AND) branch is intentionally left alone. Its `GROUP BY … HAVING to_tsvector(...)` shape has different semantics and wasn't the slow path here.

## Test plan

- [x] `bin/rspec spec/lib/search_spec.rb:2749` — existing `"with tags"` context (14 examples, including comma/synonym/negation/plus-syntax variants) all pass.
- [ ] Verify on a production dataset that `tags:<broad-tag>` searches return the same result sets as before, just faster.