### PR TITLE
PERF: Cache `has_unseen_features?` to avoid per-request git shell-outs

### DIFF
--- a/app/services/upcoming_changes/action/track_notify_status_changes.rb
+++ b/app/services/upcoming_changes/action/track_notify_status_changes.rb
@@ -87,6 +87,7 @@ class UpcomingChanges::Action::TrackNotifyStatusChanges < Service::ActionBase
     end
 
     Discourse.cache.delete(UpcomingChanges.current_statuses_cache_key)
+    DiscourseUpdates.clear_latest_new_feature_created_at_cache
 
     { status_changes:, notified_changes: }
   end

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -164,6 +164,7 @@ module DiscourseUpdates
     def update_new_features(response_json = nil)
       response_json ||= new_features_response_json
       Discourse.redis.set(new_features_key, response_json)
+      Discourse.redis.del(latest_new_feature_created_at_key)
     end
 
     def new_features_response_json
@@ -234,27 +235,44 @@ module DiscourseUpdates
     end
 
     def has_unseen_features?(user_id)
+      latest_ts = latest_new_feature_created_at
+      return false if latest_ts.nil?
+
+      last_seen = new_features_last_seen(user_id)
+      return true if last_seen.nil?
+
+      latest_ts.to_i > last_seen.to_i
+    end
+
+    def latest_new_feature_created_at
+      cached = Discourse.redis.get(latest_new_feature_created_at_key)
+      return Time.zone.parse(cached) if cached.present?
+
       entries =
         merge_new_features_with_upcoming_changes(
           new_features&.map { |item| item.symbolize_keys } || [],
         )
-      return false if entries.nil?
+      return nil if entries.blank?
 
-      last_seen = new_features_last_seen(user_id)
-
-      if last_seen.present?
-        entries.select! do |item|
-          created_at =
-            if item[:created_at].is_a?(String)
-              Time.zone.parse(item[:created_at])
-            else
-              item[:created_at]
-            end
-          created_at.to_i > last_seen.to_i
+      max_entry =
+        entries.max_by do |item|
+          val = item[:created_at]
+          val.is_a?(String) ? Time.zone.parse(val).to_i : val.to_i
         end
-      end
 
-      entries.size > 0
+      max_created_at =
+        if max_entry[:created_at].is_a?(String)
+          Time.zone.parse(max_entry[:created_at])
+        else
+          max_entry[:created_at]
+        end
+
+      Discourse.redis.set(latest_new_feature_created_at_key, max_created_at.iso8601)
+      max_created_at
+    end
+
+    def clear_latest_new_feature_created_at_cache
+      Discourse.redis.del(latest_new_feature_created_at_key)
     end
 
     def new_features_last_seen(user_id)
@@ -301,6 +319,7 @@ module DiscourseUpdates
         missing_versions_list_key,
         new_features_key,
         last_viewed_feature_dates_for_users_key,
+        latest_new_feature_created_at_key,
         *Discourse.redis.keys("#{missing_versions_key_prefix}*"),
         *Discourse.redis.keys(new_features_last_seen_key("*")),
       )
@@ -357,6 +376,10 @@ module DiscourseUpdates
 
     def new_features_last_seen_key(user_id)
       "new_features_last_seen_user_#{user_id}"
+    end
+
+    def latest_new_feature_created_at_key
+      "latest_new_feature_created_at"
     end
 
     def last_viewed_feature_dates_for_users_key

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -288,6 +288,7 @@ module UpcomingChanges
   def self.clear_caches!
     Discourse.cache.delete(current_statuses_cache_key)
     Discourse.cache.delete(permanent_upcoming_changes_cache_key)
+    DiscourseUpdates.clear_latest_new_feature_created_at_cache
   end
 
   def self.current_statuses_cache_key

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe DiscourseUpdates do
       ]
       updated_features += sample_features
 
-      Discourse.redis.set("new_features", MultiJson.dump(updated_features))
+      DiscourseUpdates.update_new_features(MultiJson.dump(updated_features))
       expect(DiscourseUpdates.has_unseen_features?(admin.id)).to eq(true)
     end
 
@@ -366,6 +366,82 @@ RSpec.describe DiscourseUpdates do
         freeze_time
         expect(DiscourseUpdates.has_unseen_features?(admin.id)).to eq(true)
         DiscourseUpdates.mark_new_features_as_seen(admin.id)
+        expect(DiscourseUpdates.has_unseen_features?(admin.id)).to eq(false)
+      end
+    end
+  end
+
+  describe ".latest_new_feature_created_at" do
+    let!(:newest_date) { 5.minutes.ago }
+    let!(:sample_features) do
+      [
+        { "emoji" => "🤾", "title" => "Old Feature", "created_at" => 40.minutes.ago },
+        { "emoji" => "🙈", "title" => "Middle Feature", "created_at" => 15.minutes.ago },
+        { "emoji" => "🤾", "title" => "Newest Feature", "created_at" => newest_date },
+      ]
+    end
+
+    before { Discourse.redis.set("new_features", MultiJson.dump(sample_features)) }
+    after { DiscourseUpdates.clean_state }
+
+    it "returns the max created_at from merged features" do
+      result = DiscourseUpdates.latest_new_feature_created_at
+      expect(result).to be_within(1.second).of(newest_date)
+    end
+
+    it "caches the result in Redis on subsequent calls" do
+      DiscourseUpdates.latest_new_feature_created_at
+
+      Discourse.redis.set("new_features", MultiJson.dump([]))
+      result = DiscourseUpdates.latest_new_feature_created_at
+      expect(result).to be_within(1.second).of(newest_date)
+    end
+
+    it "returns nil when no features exist" do
+      Discourse.redis.set("new_features", MultiJson.dump([]))
+      expect(DiscourseUpdates.latest_new_feature_created_at).to be_nil
+    end
+
+    it "is invalidated by update_new_features" do
+      DiscourseUpdates.latest_new_feature_created_at
+
+      new_date = 1.minute.ago
+      new_features = [{ "emoji" => "🤾", "title" => "Brand New", "created_at" => new_date }]
+      DiscourseUpdates.update_new_features(MultiJson.dump(new_features))
+
+      result = DiscourseUpdates.latest_new_feature_created_at
+      expect(result).to be_within(1.second).of(new_date)
+    end
+
+    it "is invalidated by clean_state" do
+      DiscourseUpdates.latest_new_feature_created_at
+      expect(Discourse.redis.get("latest_new_feature_created_at")).to be_present
+
+      DiscourseUpdates.clean_state
+      expect(Discourse.redis.get("latest_new_feature_created_at")).to be_nil
+    end
+  end
+
+  describe "has_unseen_features? caching" do
+    fab!(:admin)
+    let!(:feature_date) { 5.minutes.ago }
+    let!(:sample_features) do
+      [{ "emoji" => "🤾", "title" => "A Feature", "created_at" => feature_date }]
+    end
+
+    before { Discourse.redis.set("new_features", MultiJson.dump(sample_features)) }
+    after { DiscourseUpdates.clean_state }
+
+    it "uses the cached timestamp instead of recomputing on repeated calls" do
+      DiscourseUpdates.latest_new_feature_created_at
+
+      Discourse.redis.set("new_features", "invalid json")
+      expect(DiscourseUpdates.has_unseen_features?(admin.id)).to eq(true)
+    end
+
+    it "returns false when the latest feature timestamp equals last_seen" do
+      freeze_time do
+        Discourse.redis.set("new_features_last_seen_user_#{admin.id}", feature_date.iso8601)
         expect(DiscourseUpdates.has_unseen_features?(admin.id)).to eq(false)
       end
     end

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -579,6 +579,14 @@ RSpec.describe UpcomingChanges do
     end
   end
 
+  describe ".clear_caches!" do
+    it "clears the latest new feature created_at cache" do
+      Discourse.redis.set("latest_new_feature_created_at", Time.zone.now.iso8601)
+      described_class.clear_caches!
+      expect(Discourse.redis.get("latest_new_feature_created_at")).to be_nil
+    end
+  end
+
   describe ".enabled_for_user?" do
     context "for logged-in user" do
       fab!(:user)

--- a/spec/services/upcoming_changes/action/track_notify_status_changes_spec.rb
+++ b/spec/services/upcoming_changes/action/track_notify_status_changes_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe UpcomingChanges::Action::TrackNotifyStatusChanges do
       end
     end
 
+    it "clears the latest new feature created_at cache" do
+      Discourse.redis.set("latest_new_feature_created_at", Time.zone.now.iso8601)
+      result
+      expect(Discourse.redis.get("latest_new_feature_created_at")).to be_nil
+    end
+
     context "when there are added changes in the same run" do
       let(:added_changes) { [:enable_upload_debug_mode] }
 


### PR DESCRIPTION
Previously, `DiscourseUpdates.has_unseen_features?` ran the full new features pipeline on every request for staff users — parsing JSON, shelling out to `git merge-base` per entry via `GitUtils.has_commit?`, merging with upcoming changes, and sorting — taking 300-400ms to produce a single boolean.

In this update, the max `created_at` timestamp across all valid merged features is computed once and cached in Redis, reducing `has_unseen_features?` to two Redis GETs and an integer comparison; the cache is invalidated when the daily job fetches new features, on deploy/restart, and when an upcoming change transitions to permanent.