### PR TITLE
DEV: cache post reactions results

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -15,21 +15,56 @@ export default class DiscourseReactionsUsersMenu extends Component {
   @tracked activeFilter = null;
 
   fetchUsers = async (page, pageSize) => {
+    const filter = this.activeFilter;
+    const isFirstPage = page === 0;
+    const isUnfiltered = filter === null;
+    const offset = page * pageSize;
+    const nextOffset = offset + pageSize;
+    const entry = this.#tabCache.get(filter);
+
+    if (entry) {
+      const haveRequestedPage = entry.users.length >= nextOffset;
+      const haveLastPartialPage =
+        !entry.canLoadMore && entry.users.length > offset;
+      if (haveRequestedPage || haveLastPartialPage) {
+        return {
+          users: entry.users.slice(offset, nextOffset),
+          canLoadMore: entry.users.length > nextOffset || entry.canLoadMore,
+        };
+      }
+    }
+
     const result = await CustomReaction.fetchReactionsUsersList(
       this.post.id,
       page,
       pageSize,
-      this.activeFilter
+      filter
     );
-
-    const loadedSoFar = page * pageSize + (result.users?.length ?? 0);
+    const users = result.users ?? [];
+    const isCompleteResult = users.length === result.total_rows;
     const canLoadMore = result.total_rows
-      ? loadedSoFar < result.total_rows
-      : (result.users?.length ?? 0) >= pageSize;
+      ? offset + users.length < result.total_rows
+      : users.length >= pageSize;
 
-    return { users: result.users ?? [], canLoadMore };
+    const existing = entry?.users ?? [];
+    this.#tabCache.set(filter, {
+      users: [...existing.slice(0, offset), ...users],
+      canLoadMore,
+    });
+
+    if (isFirstPage && isUnfiltered && isCompleteResult) {
+      for (const reaction of this.reactions) {
+        this.#tabCache.set(reaction.id, {
+          users: users.filter((u) => u.reaction === reaction.id),
+          canLoadMore: false,
+        });
+      }
+    }
+
+    return { users, canLoadMore };
   };
   #resetCallback = null;
+  #tabCache = new Map();
 
   get post() {
     return this.args.data.post;

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -21,12 +21,12 @@ export default class DiscourseReactionsUsersMenu extends Component {
     const entry = this.#tabCache.get(filter);
 
     if (entry) {
-      const haveRequestedPage = entry.users.length >= nextOffset;
-      const haveLastPartialPage =
-        !entry.canLoadMore && entry.users.length > offset;
-      if (haveRequestedPage || haveLastPartialPage) {
+      const cached = entry.users.slice(offset, nextOffset);
+      const fullPage = cached.length === pageSize;
+      const lastPartialPage = !entry.canLoadMore && cached.length > 0;
+      if (fullPage || lastPartialPage) {
         return {
-          users: entry.users.slice(offset, nextOffset),
+          users: cached,
           canLoadMore: entry.users.length > nextOffset || entry.canLoadMore,
         };
       }

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -16,8 +16,6 @@ export default class DiscourseReactionsUsersMenu extends Component {
 
   fetchUsers = async (page, pageSize) => {
     const filter = this.activeFilter;
-    const isFirstPage = page === 0;
-    const isUnfiltered = filter === null;
     const offset = page * pageSize;
     const nextOffset = offset + pageSize;
     const entry = this.#tabCache.get(filter);
@@ -41,21 +39,18 @@ export default class DiscourseReactionsUsersMenu extends Component {
       filter
     );
     const users = result.users ?? [];
-    const isCompleteResult = users.length === result.total_rows;
     const canLoadMore = result.total_rows
       ? offset + users.length < result.total_rows
       : users.length >= pageSize;
 
     const existing = entry?.users ?? [];
-    this.#tabCache.set(filter, {
-      users: [...existing.slice(0, offset), ...users],
-      canLoadMore,
-    });
+    const merged = [...existing.slice(0, offset), ...users];
+    this.#tabCache.set(filter, { users: merged, canLoadMore });
 
-    if (isFirstPage && isUnfiltered && isCompleteResult) {
+    if (filter === null && !canLoadMore) {
       for (const reaction of this.reactions) {
         this.#tabCache.set(reaction.id, {
-          users: users.filter((u) => u.reaction === reaction.id),
+          users: merged.filter((u) => u.reaction === reaction.id),
           canLoadMore: false,
         });
       }

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
@@ -1,0 +1,160 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import ReactionsTopics from "../fixtures/reactions-topic-fixtures";
+
+function makeUser(id, reaction) {
+  return {
+    id,
+    username: `u${id}`,
+    name: `User ${id}`,
+    avatar_template: "/user_avatar/avatar/{size}/1_1.png",
+    reaction,
+  };
+}
+
+const SETTINGS = {
+  discourse_reactions_enabled: true,
+  discourse_reactions_enabled_reactions: "laughing|open_mouth",
+  discourse_reactions_reaction_for_like: "heart",
+  discourse_reactions_like_icon: "heart",
+  enable_new_post_reactions_menu: true,
+};
+
+acceptance(
+  "Discourse Reactions - Users menu caches when total fits in one page",
+  function (needs) {
+    needs.user();
+    needs.settings(SETTINGS);
+
+    let fetchCount = 0;
+    let lastReactionValue;
+
+    needs.hooks.beforeEach(() => {
+      fetchCount = 0;
+      lastReactionValue = undefined;
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/t/374.json", () =>
+        helper.response(ReactionsTopics["/t/374.json"])
+      );
+
+      server.get(
+        "/discourse-reactions/posts/:id/reactions-users-list.json",
+        (request) => {
+          fetchCount++;
+          lastReactionValue = request.queryParams.reaction_value;
+
+          const allUsers = [
+            makeUser(1, "heart"),
+            makeUser(2, "heart"),
+            makeUser(3, "heart"),
+            makeUser(4, "laughing"),
+            makeUser(5, "laughing"),
+          ];
+
+          return helper.response({ users: allUsers, total_rows: 5 });
+        }
+      );
+    });
+
+    test("filters cached users client-side when switching tabs", async function (assert) {
+      await visit("/t/topic_with_reactions_and_likes/374");
+      await click("#post_1 .discourse-reactions-counter");
+
+      assert.strictEqual(fetchCount, 1, "fetches once when opening the menu");
+      assert.strictEqual(
+        lastReactionValue,
+        undefined,
+        "first fetch has no reaction_value"
+      );
+      assert.dom(".post-users-popup__item").exists({ count: 5 });
+
+      await click('[data-reaction-filter="heart"]');
+      assert.strictEqual(
+        fetchCount,
+        1,
+        "does not refetch when filtering by heart"
+      );
+      assert.dom(".post-users-popup__item").exists({ count: 3 });
+
+      await click('[data-reaction-filter="laughing"]');
+      assert.strictEqual(
+        fetchCount,
+        1,
+        "does not refetch when filtering by laughing"
+      );
+      assert.dom(".post-users-popup__item").exists({ count: 2 });
+
+      await click('[data-reaction-filter="all"]');
+      assert.strictEqual(
+        fetchCount,
+        1,
+        "does not refetch when returning to all"
+      );
+      assert.dom(".post-users-popup__item").exists({ count: 5 });
+    });
+  }
+);
+
+acceptance(
+  "Discourse Reactions - Users menu fetches per tab when total exceeds one page",
+  function (needs) {
+    needs.user();
+    needs.settings(SETTINGS);
+
+    let fetchCount = 0;
+    let lastReactionValue;
+
+    needs.hooks.beforeEach(() => {
+      fetchCount = 0;
+      lastReactionValue = undefined;
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/t/374.json", () =>
+        helper.response(ReactionsTopics["/t/374.json"])
+      );
+
+      server.get(
+        "/discourse-reactions/posts/:id/reactions-users-list.json",
+        (request) => {
+          fetchCount++;
+          lastReactionValue = request.queryParams.reaction_value;
+
+          const pageUsers = Array.from({ length: 30 }, (_, i) =>
+            makeUser(i + 1, i < 25 ? "heart" : "laughing")
+          );
+
+          return helper.response({ users: pageUsers, total_rows: 45 });
+        }
+      );
+    });
+
+    test("fetches once per tab and serves cached tabs on return", async function (assert) {
+      await visit("/t/topic_with_reactions_and_likes/374");
+      await click("#post_1 .discourse-reactions-counter");
+
+      assert.strictEqual(fetchCount, 1, "fetches once when opening the menu");
+
+      await click('[data-reaction-filter="laughing"]');
+      assert.strictEqual(fetchCount, 2, "fetches when opening laughing tab");
+      assert.strictEqual(
+        lastReactionValue,
+        "laughing",
+        "second fetch sends reaction_value=laughing"
+      );
+
+      await click('[data-reaction-filter="all"]');
+      assert.strictEqual(
+        fetchCount,
+        2,
+        "does not refetch when returning to a previously-loaded tab"
+      );
+
+      await click('[data-reaction-filter="laughing"]');
+      assert.strictEqual(fetchCount, 2, "does not refetch laughing tab either");
+    });
+  }
+);


### PR DESCRIPTION
The reactions users menu is paginated and lets the user filter by reaction (emoji tab) or view all reactions ("All" tab). Without caching, every tab switch and every scroll-driven page request hits the server.

This change introduces a per-instance `#tabCache: Map<filter, { users, canLoadMore }>` keyed by the active filter (null for "All", or a reaction id), so already-fetched results can be reused.

On each `fetchUsers` call, we slice the cached users for the requested range. We serve from cache when either:
- Full page - the cache holds at least pageSize users at this offset, so we can return a complete page directly.
- Partial page - the server has already told us there are no more users to fetch (entry.canLoadMore is false), and the cache still has at least one user at this offset. We return whatever's left, even if it's fewer than pageSize. 

Other things to note:

- After a fetch we splice the new page onto whatever was already cached for that filter (existing.slice(0, offset) + users) and store the updated `canLoadMore`. Slicing up to offset (rather than appending blindly) keeps the cache coherent if pages are ever requested out of order.

- When the "All" tab finishes loading every user, we already know the full reaction set client-side and can eagerly populate per-reaction tab caches by partitioning that list. Switching to an emoji tab afterwards is then a zero-network operation.
 
- The cache lives on the component instance, so it's discarded when the menu is closed. Live reaction changes from other users still flow in via MessageBus → addTrackedPostProperties("reactions", …), which re-renders the menu while it's open; the cache simply avoids redundant network calls within a single open session.