### PR TITLE
FIX: Skip third-party analytics tags in full app embed iframes

### DIFF
--- a/app/helpers/common_helper.rb
+++ b/app/helpers/common_helper.rb
@@ -2,22 +2,32 @@
 
 module CommonHelper
   def render_google_universal_analytics_code
+    return if suppress_analytics_in_embed?
     if Rails.env.production? && SiteSetting.ga_universal_tracking_code.present?
       render partial: "common/google_universal_analytics"
     end
   end
 
   def render_google_tag_manager_head_code
+    return if suppress_analytics_in_embed?
     render partial: "common/google_tag_manager_head" if SiteSetting.gtm_container_id.present?
   end
 
   def render_google_tag_manager_body_code
+    return if suppress_analytics_in_embed?
     render partial: "common/google_tag_manager_body" if SiteSetting.gtm_container_id.present?
   end
 
   def render_adobe_analytics_tags_code
+    return if suppress_analytics_in_embed?
     if SiteSetting.adobe_analytics_tags_url.present?
       content_tag(:script, "", src: SiteSetting.adobe_analytics_tags_url, async: true)
     end
+  end
+
+  private
+
+  def suppress_analytics_in_embed?
+    params[:embed_mode].present? && SiteSetting.suppress_third_party_analytics_in_embed
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2570,6 +2570,7 @@ en:
     allowed_embed_selectors: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."
     embed_full_app: "Enable full app mode for embedded comments. When enabled, embedded comments will load the full Discourse application in an iframe, allowing users to interact with topics directly"
+    suppress_third_party_analytics_in_embed: "Skip rendering third-party analytics scripts (Google Tag Manager, Google Analytics, Adobe Analytics) when Discourse is loaded inside a full app embed iframe. Prevents duplicate pageviews and tag firing when the host page already loads the same scripts."
     embed_post_limit: "Maximum number of posts to embed."
     embed_username_required: "The username for topic creation is required."
     notify_about_reviewable_item_after: "If there are reviewable items that haven’t been handled after this many hours, send a personal message to moderators. Set to 0 to disable."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3284,6 +3284,9 @@ embedding:
     default: false
     client: true
     area: "embedding"
+  suppress_third_party_analytics_in_embed:
+    default: true
+    area: "embedding"
   embed_by_username:
     default: ""
     type: username

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7254,4 +7254,43 @@ RSpec.describe TopicsController do
       expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
     end
   end
+
+  describe "third-party analytics in embed mode" do
+    fab!(:topic)
+
+    before do
+      SiteSetting.embed_full_app = true
+      SiteSetting.gtm_container_id = "GTM-ABCDEF"
+      SiteSetting.adobe_analytics_tags_url = "https://assets.adobedtm.com/launch-EN.min.js"
+    end
+
+    def parsed_body
+      Nokogiri::HTML5.fragment(response.body)
+    end
+
+    it "renders analytics tags by default" do
+      get "/t/#{topic.slug}/#{topic.id}"
+      expect(parsed_body.css("#data-google-tag-manager")).to be_present
+      expect(
+        parsed_body.css("script[src='https://assets.adobedtm.com/launch-EN.min.js']"),
+      ).to be_present
+    end
+
+    it "skips analytics tags when loaded in embed mode" do
+      get "/t/#{topic.slug}/#{topic.id}", params: { embed_mode: "true" }
+      expect(parsed_body.css("#data-google-tag-manager")).to be_empty
+      expect(
+        parsed_body.css("script[src='https://assets.adobedtm.com/launch-EN.min.js']"),
+      ).to be_empty
+    end
+
+    it "still renders analytics tags in embed mode when suppression setting is disabled" do
+      SiteSetting.suppress_third_party_analytics_in_embed = false
+      get "/t/#{topic.slug}/#{topic.id}", params: { embed_mode: "true" }
+      expect(parsed_body.css("#data-google-tag-manager")).to be_present
+      expect(
+        parsed_body.css("script[src='https://assets.adobedtm.com/launch-EN.min.js']"),
+      ).to be_present
+    end
+  end
 end


### PR DESCRIPTION
**Previously**, loading Discourse inside a full app embed iframe caused the host page's `GTM`, Google Analytics, and Adobe Analytics scripts to fire a second time, doubling pageviews and re-injecting ad pixels.

**In this update**, introduce the `suppress_third_party_analytics_in_embed` site setting (default on) which omits those script tags from responses served with `?embed_mode=true`.