### PR TITLE
FIX: Handle missing Redis in `clear_latest_new_feature_created_at_cache`

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -273,6 +273,7 @@ module DiscourseUpdates
 
     def clear_latest_new_feature_created_at_cache
       Discourse.redis.del(latest_new_feature_created_at_key)
+    rescue Redis::CannotConnectError
     end
 
     def new_features_last_seen(user_id)


### PR DESCRIPTION
**Previously**, the `UpcomingChanges.clear_caches!` call in the `after_initialize` hook would crash during Docker image builds because `clear_latest_new_feature_created_at_cache` used a raw `Discourse.redis.del` call and Redis is not running during the build.

**In this update**, added a rescue for `Redis::CannotConnectError` so the cache clear is safely skipped when Redis is unavailable.