### PR TITLE
FIX: Prevent `DockedComposer` from wiping its draft in rich editor mode

### DIFF
--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -45,12 +45,6 @@ export default class DockedComposer extends Component {
   #dragStart = null;
   #rootElement = null;
 
-  #handleInput = (event) => {
-    const value = event?.target?.value ?? "";
-    this.reply = value;
-    this.persistDraft(value);
-  };
-
   #handlePaste = (event) => {
     if (!this.textarea || document.activeElement !== this.textarea) {
       return;
@@ -161,7 +155,6 @@ export default class DockedComposer extends Component {
       // capture phase so Enter-to-send wins over ItsATrap / smart-list handlers
       this.textarea.addEventListener("keydown", this.#handleKeyDown, true);
       this.textarea.addEventListener("paste", this.#handlePaste);
-      this.textarea.addEventListener("input", this.#handleInput);
     }
   }
 
@@ -217,7 +210,6 @@ export default class DockedComposer extends Component {
   teardown() {
     this.textarea?.removeEventListener("keydown", this.#handleKeyDown, true);
     this.textarea?.removeEventListener("paste", this.#handlePaste);
-    this.textarea?.removeEventListener("input", this.#handleInput);
     this.uppyUpload?.teardown();
     this.#rootElement = null;
   }


### PR DESCRIPTION
**Previously**, `DockedComposer` attached a redundant native `input` listener that also bound to the ProseMirror contenteditable in rich editor mode, wiping `reply` and the saved draft on every keystroke because `event.target.value` is `undefined` there.

**In this update**, dropped the listener — input already flows through `DEditor`'s `@change` → `onReplyChange`, which reports the correct value for both the textarea and ProseMirror editors.