### PR TITLE
DEV: Don't forward cookies on onebox redirects

### DIFF
--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -106,18 +106,12 @@ module Onebox
             headers["Cookie"] = cookie_header if allow_cross_domain_cookies
 
             if redirect_location = response["location"]
-              redirect_uri = Addressable::URI.parse(redirect_location)
-              redirect_uri =
-                Addressable::URI.join(
-                  "#{uri.scheme}://#{uri.host}",
-                  redirect_uri,
-                ) if !redirect_uri.host
-
-              redirect_header = { "Cookie" => cookie_header } if redirect_uri.host == uri.host
+              redirect_host = Addressable::URI.parse(redirect_location).host
+              if redirect_host.nil? || redirect_host == uri.host
+                redirect_header = { "Cookie" => cookie_header }
+              end
             end
           end
-
-          redirect_header = nil unless redirect_header.is_a? Hash
 
           code = response.code.to_i
           unless code === 200

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -99,8 +99,11 @@ module Onebox
 
         size_bytes = Onebox.options.max_download_kb * 1024
         http.request(request) do |response|
-          if cookie = response.get_fields("set-cookie")
-            headers["Cookie"] = cookie.join("; ") if allow_cross_domain_cookies
+          if set_cookies = response.get_fields("set-cookie")
+            cookie_header =
+              set_cookies.map { |c| c.split(";", 2).first.strip }.reject(&:empty?).join("; ")
+
+            headers["Cookie"] = cookie_header if allow_cross_domain_cookies
 
             if redirect_location = response["location"]
               redirect_uri = Addressable::URI.parse(redirect_location)
@@ -110,7 +113,7 @@ module Onebox
                   redirect_uri,
                 ) if !redirect_uri.host
 
-              redirect_header = { "Cookie" => cookie.join("; ") } if redirect_uri.host == uri.host
+              redirect_header = { "Cookie" => cookie_header } if redirect_uri.host == uri.host
             end
           end
 

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -101,12 +101,20 @@ module Onebox
         http.request(request) do |response|
           if cookie = response.get_fields("set-cookie")
             headers["Cookie"] = cookie.join("; ") if allow_cross_domain_cookies
-            # HACK: If this breaks again in the future, use HTTP::CookieJar from gem 'http-cookie'
-            # See test: it "does not send cookies to the wrong domain"
-            redir_header = { "Cookie" => cookie.join("; ") }
+
+            if redirect_location = response["location"]
+              redirect_uri = Addressable::URI.parse(redirect_location)
+              redirect_uri =
+                Addressable::URI.join(
+                  "#{uri.scheme}://#{uri.host}",
+                  redirect_uri,
+                ) if !redirect_uri.host
+
+              redirect_header = { "Cookie" => cookie.join("; ") } if redirect_uri.host == uri.host
+            end
           end
 
-          redir_header = nil unless redir_header.is_a? Hash
+          redirect_header = nil unless redirect_header.is_a? Hash
 
           code = response.code.to_i
           unless code === 200
@@ -117,7 +125,7 @@ module Onebox
                 response["location"],
                 redirect_limit: redirect_limit - 1,
                 domain: "#{uri.scheme}://#{uri.host}",
-                headers: allow_cross_domain_cookies ? headers : redir_header,
+                headers: allow_cross_domain_cookies ? headers : redirect_header,
                 allow_cross_domain_cookies: allow_cross_domain_cookies,
               )
             )

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -172,20 +172,20 @@ RSpec.describe Onebox::Helpers do
     end
 
     describe "cookie handling" do
-      it "naively forwards cookies to the next request" do
+      it "forwards cookies on same-host redirects, stripping attributes" do
         stub_request(:get, "https://httpbin.org/cookies/set/a/b").to_return(
           status: 302,
           headers: {
             location: "/cookies",
-            "set-cookie": "a=b; Path=/",
+            "set-cookie": ["a=b; Path=/; Secure", "c=d; HttpOnly; Max-Age=3600"],
           },
         )
 
         stub_request(:get, "https://httpbin.org/cookies").with(
           headers: {
-            cookie: "a=b; Path=/",
+            cookie: "a=b; c=d",
           },
-        ).to_return(status: 200, body: "success, cookie readback not implemented")
+        ).to_return(status: 200, body: "success")
 
         expect(described_class.fetch_response("https://httpbin.org/cookies/set/a/b")).to match(
           "success",

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -193,8 +193,6 @@ RSpec.describe Onebox::Helpers do
       end
 
       it "does not send cookies to the wrong domain" do
-        skip("unimplemented")
-
         stub_request(:get, "https://httpbin.org/cookies/set/a/b").to_return(
           status: 302,
           headers: {
@@ -203,13 +201,13 @@ RSpec.describe Onebox::Helpers do
           },
         )
 
-        stub_request(:get, "https://evil.com/show_cookies").with(
-          headers: {
-            cookie: nil,
-          },
-        ).to_return(status: 200, body: "success, cookie readback not implemented")
+        stub_request(:get, "https://evil.com/show_cookies").to_return(status: 200, body: "ok")
 
         described_class.fetch_response("https://httpbin.org/cookies/set/a/b")
+
+        expect(WebMock).to have_requested(:get, "https://evil.com/show_cookies").with { |req|
+          !req.headers.key?("Cookie")
+        }
       end
     end
   end


### PR DESCRIPTION
…and strip unnecessary cookie attributes.

Resolves a long-standing todo/disabled spec.