### PR TITLE
DEV: Add sidebar-blocks BlockOutlet to anonymous sidebar

### DIFF
--- a/frontend/discourse/app/components/sidebar/anonymous/sections.gjs
+++ b/frontend/discourse/app/components/sidebar/anonymous/sections.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import BlockOutlet from "discourse/blocks/block-outlet";
 import CategoriesSection from "./categories-section";
 import CustomSections from "./custom-sections";
 import TagsSection from "./tags-section";
@@ -9,6 +10,8 @@ export default class SidebarAnonymousSections extends Component {
 
   <template>
     <div class="sidebar-sections sidebar-sections-anonymous">
+      <BlockOutlet @name="sidebar-blocks" />
+
       <CustomSections
         @collapsable={{@collapsableSections}}
         @toggleNavigationMenu={{@toggleNavigationMenu}}


### PR DESCRIPTION
Adds the sidebar-blocks BlockOutlet to the anonymous sidebar so it renders for logged-out users too. 