### PR TITLE
DEV: Fix a `SiteSetting::Update` leak

### DIFF
--- a/app/services/site_setting/update.rb
+++ b/app/services/site_setting/update.rb
@@ -7,7 +7,7 @@ class SiteSetting::Update
 
   options do
     attribute :allow_changing_hidden, :array, default: []
-    attribute :overridden_setting_names, default: {}
+    attribute :overridden_setting_names, default: -> { {} }
   end
 
   policy :current_user_is_admin


### PR DESCRIPTION
The `default: {}` object is shared across all instances. We need to create a new one for each use.