### PR TITLE
DEV: Wait for loading to finish in select-kit search spec helper

### DIFF
--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -112,6 +112,11 @@ module PageObjects
 
       def search(value = nil)
         expanded_component.find(".select-kit-filter .filter-input").fill_in(with: value)
+        wait_for_loaded
+      end
+
+      def wait_for_loaded
+        has_no_css?("#{@context}.is-loading")
       end
 
       def select_row_by_value(value)


### PR DESCRIPTION
Should (hopefully) fix e.g. `system/tag_group_spec.rb:106` flake