### PR TITLE
FIX: Search tags by localized name when content localization is enabled

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -572,12 +572,19 @@ module DiscourseTagging
       builder_params[:cleaned_term] = term
 
       if opts[:term_type] == DiscourseTagging.term_types[:starts_with]
-        builder.where("starts_with(LOWER(name), LOWER(:cleaned_term))")
-        sql.gsub!("/*and_name_like*/", "AND starts_with(LOWER(t.name), LOWER(:cleaned_term))")
+        name_match_sql = "starts_with(LOWER(t.name), LOWER(:cleaned_term))"
       else
-        builder.where("position(LOWER(:cleaned_term) IN LOWER(t.name)) <> 0")
-        sql.gsub!("/*and_name_like*/", "AND position(LOWER(:cleaned_term) IN LOWER(t.name)) <> 0")
+        name_match_sql = "position(LOWER(:cleaned_term) IN LOWER(t.name)) <> 0"
       end
+
+      localized_tag_ids = tag_ids_matching_localizations(term, term_type: opts[:term_type])
+      if localized_tag_ids.present?
+        builder_params[:localized_tag_ids] = localized_tag_ids
+        name_match_sql = "(#{name_match_sql} OR t.id IN (:localized_tag_ids))"
+      end
+
+      builder.where(name_match_sql)
+      sql.gsub!("/*and_name_like*/", "AND #{name_match_sql}")
     else
       sql.gsub!("/*and_name_like*/", "")
     end
@@ -818,6 +825,19 @@ module DiscourseTagging
     tag.gsub!(TAGS_FILTER_REGEXP, "")
     tag.squeeze!("-")
     truncate ? tag[0...SiteSetting.max_tag_length] : tag
+  end
+
+  def self.tag_ids_matching_localizations(term, term_type:)
+    return [] if !SiteSetting.content_localization_enabled
+
+    match_sql =
+      if term_type == term_types[:starts_with]
+        "starts_with(LOWER(name), LOWER(?))"
+      else
+        "position(LOWER(?) IN LOWER(name)) <> 0"
+      end
+
+    TagLocalization.where(locale: I18n.locale.to_s).where(match_sql, term).pluck(:tag_id)
   end
 
   def self.tags_for_saving(tags_arg, guardian, opts = {})

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -248,5 +248,29 @@ RSpec.describe(Tags::Search) do
         expect(result[:required_tag_group][:min_count]).to eq(1)
       end
     end
+
+    context "with content localization enabled" do
+      fab!(:strategy_tag) { Fabricate(:tag, name: "strategy", locale: "en") }
+      fab!(:strategy_ja_localization) do
+        Fabricate(:tag_localization, tag: strategy_tag, locale: "ja", name: "戦略")
+      end
+
+      let(:params) { { q: "戦" } }
+
+      before do
+        SiteSetting.content_localization_enabled = true
+        SiteSetting.content_localization_supported_locales = "en|ja"
+      end
+
+      it "matches tags by their localized name in the current locale" do
+        I18n.with_locale(:ja) do
+          expect(result[:tags].map { |t| t[:name] }).to contain_exactly("戦略")
+        end
+      end
+
+      it "does not match localizations from other locales" do
+        I18n.with_locale(:en) { expect(result[:tags].map { |t| t[:name] }).to be_empty }
+      end
+    end
   end
 end

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -112,6 +112,11 @@ module PageObjects
 
       def search(value = nil)
         expanded_component.find(".select-kit-filter .filter-input").fill_in(with: value)
+        wait_for_loaded
+      end
+
+      def wait_for_loaded
+        has_no_css?("#{@context}.is-loading")
       end
 
       def select_row_by_value(value)


### PR DESCRIPTION
Previously, `DiscourseTagging.filter_allowed_tags` only matched against `tags.name`, so a user typing a tag's localized name into the tag chooser got no results.

Existing system specs already asserted this should work but only passed by racing against the empty server response.

Also in this commit: make the select-kit search spec helper wait for loading to finish. Should fix e.g. `system/tag_group_spec.rb:106` flake.