### PR TITLE
DEV: Don't leak composer mesages cache between tests

### DIFF
--- a/frontend/discourse/app/components/composer-messages.gjs
+++ b/frontend/discourse/app/components/composer-messages.gjs
@@ -21,6 +21,10 @@ import { autoTrackedArray } from "../lib/tracked-tools";
 
 let _messagesCache = {};
 
+export function resetComposerMessagesCache() {
+  _messagesCache = {};
+}
+
 @tagName("")
 export default class ComposerMessages extends Component {
   @tracked showShareModal;

--- a/frontend/discourse/tests/helpers/qunit-helpers.js
+++ b/frontend/discourse/tests/helpers/qunit-helpers.js
@@ -22,6 +22,7 @@ import {
   cleanUpComposerUploadMarkdownResolver,
   cleanUpComposerUploadPreProcessor,
 } from "discourse/components/composer-editor";
+import { resetComposerMessagesCache } from "discourse/components/composer-messages";
 import { clearPluginDocumentTitleCounters } from "discourse/components/d-document";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";
 import { resetHtmlDecorators } from "discourse/components/decorated-html";
@@ -233,6 +234,7 @@ export function testCleanup(container, app) {
   cleanUpComposerUploadHandler();
   cleanUpComposerUploadMarkdownResolver();
   cleanUpComposerUploadPreProcessor();
+  resetComposerMessagesCache();
   clearTopicFooterDropdowns();
   clearTopicFooterButtons();
   clearDesktopNotificationHandlers();


### PR DESCRIPTION
Fixes a flake:

```
not ok 206 #2 [3872 ms] - Acceptance: Composer - Messages - Duplicate links: Shows the warning
    ---
        stack: >
            Error: waitUntil timed out
        message: >
            Promise rejected during "Shows the warning": waitUntil timed out
        negative: >
            false
        browser log: |
    ...
```