### PR TITLE
UX: Use DSegmentedControl for new report page period selector

### DIFF
--- a/app/assets/stylesheets/admin/admin_report_chart.scss
+++ b/app/assets/stylesheets/admin/admin_report_chart.scss
@@ -73,33 +73,8 @@ body.uc-reporting-improvements .admin-contents:not(.dashboard) .chart {
     }
 
     .chart-groupings {
-      display: flex;
-      gap: var(--space-2);
-      background-color: var(--primary-very-low);
-      border-radius: var(--d-border-radius-large);
-      padding: var(--space-1) var(--space-2);
-
       @include viewport.from(sm) {
         margin-right: auto;
-      }
-
-      .chart-grouping {
-        border-radius: var(--d-border-radius-large);
-        background: transparent;
-
-        @include viewport.until(sm) {
-          flex-grow: 1;
-        }
-
-        &:hover {
-          background: transparent;
-          color: var(--primary);
-        }
-
-        &.active {
-          background: var(--secondary);
-          box-shadow: var(--shadow-card);
-        }
       }
     }
   }

--- a/app/assets/stylesheets/common/components/d-segmented-control.scss
+++ b/app/assets/stylesheets/common/components/d-segmented-control.scss
@@ -81,5 +81,11 @@
       background: transparent;
       color: var(--primary);
     }
+
+    &.is-disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+      pointer-events: none;
+    }
   }
 }

--- a/frontend/discourse/admin/components/admin-report-new.gjs
+++ b/frontend/discourse/admin/components/admin-report-new.gjs
@@ -4,6 +4,7 @@ import AdminReport from "discourse/admin/components/admin-report";
 import ConditionalLoadingSection from "discourse/components/conditional-loading-section";
 import DButton from "discourse/components/d-button";
 import DPageSubheader from "discourse/components/d-page-subheader";
+import DSegmentedControl from "discourse/components/d-segmented-control";
 import DateTimeInputRange from "discourse/components/date-time-input-range";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import concatClass from "discourse/helpers/concat-class";
@@ -92,23 +93,14 @@ import { i18n } from "discourse-i18n";
             <div class="chart__filters">
               {{#if @report.isChartMode}}
 
-                <div
+                <DSegmentedControl
                   class="chart-groupings"
-                  role="tablist"
-                  aria-label={{i18n
-                    "admin.dashboard.reports.chart_group_period"
-                  }}
-                >
-                  {{#each @report.chartGroupings as |chartGrouping|}}
-                    <DButton
-                      @label={{chartGrouping.label}}
-                      @action={{fn @report.changeGrouping chartGrouping.id}}
-                      @disabled={{chartGrouping.disabled}}
-                      class={{chartGrouping.class}}
-                      role="tab"
-                    />
-                  {{/each}}
-                </div>
+                  @name={{concat "chart-grouping-" @report.model.type}}
+                  @label="admin.dashboard.reports.chart_group_period"
+                  @items={{@report.chartGroupingSegmentItems}}
+                  @value={{@report.options.chartGrouping}}
+                  @onSelect={{@report.changeGrouping}}
+                />
               {{/if}}
 
               {{#if @report.showDatesOptions}}

--- a/frontend/discourse/admin/components/admin-report-new.gjs
+++ b/frontend/discourse/admin/components/admin-report-new.gjs
@@ -95,7 +95,7 @@ import { i18n } from "discourse-i18n";
 
                 <DSegmentedControl
                   class="chart-groupings"
-                  @name={{concat "chart-grouping-" @report.model.type}}
+                  @name="chart-grouping-{{@report.model.type}}"
                   @label="admin.dashboard.reports.chart_group_period"
                   @items={{@report.chartGroupingSegmentItems}}
                   @value={{@report.options.chartGrouping}}

--- a/frontend/discourse/admin/components/admin-report.gjs
+++ b/frontend/discourse/admin/components/admin-report.gjs
@@ -323,6 +323,15 @@ export default class AdminReport extends Component {
     });
   }
 
+  get chartGroupingSegmentItems() {
+    return this.chartGroupings.map((g) => ({
+      value: g.id,
+      label: i18n(g.label),
+      disabled: g.disabled,
+      class: `chart-grouping ${g.id}`,
+    }));
+  }
+
   @action
   onChangeDateRange(range) {
     this.userHasCustomDates = true;

--- a/frontend/discourse/app/components/d-segmented-control.gjs
+++ b/frontend/discourse/app/components/d-segmented-control.gjs
@@ -3,6 +3,7 @@ import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { modifier as modifierFn } from "ember-modifier";
+import concatClass from "discourse/helpers/concat-class";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -58,12 +59,19 @@ export default class DSegmentedControl extends Component {
       <span class="d-segmented-control__slider"></span>
 
       {{#each @items as |item|}}
-        <label class="d-segmented-control__label">
+        <label
+          class={{concatClass
+            "d-segmented-control__label"
+            item.class
+            (if item.disabled "is-disabled")
+          }}
+        >
           <input
             type="radio"
             name={{@name}}
             value={{item.value}}
             checked={{eq @value item.value}}
+            disabled={{item.disabled}}
             class="d-segmented-control__input"
             {{on "change" (fn this.handleChange item.value)}}
           />


### PR DESCRIPTION
DSegmentedControl was added in https://github.com/discourse/discourse/pull/38242
but wasn't applied to the new report page, which is using the same
style but not the component. This commit changes the new report page
to use the component.

<img width="1153" height="531" alt="image" src="https://github.com/user-attachments/assets/456083f0-28a7-48fa-b515-f73bc98300f3" />

