### PR TITLE
UX: Add a "micro" avatar size option

### DIFF
--- a/frontend/discourse/app/lib/avatar-utils.js
+++ b/frontend/discourse/app/lib/avatar-utils.js
@@ -7,6 +7,8 @@ let allowedSizes = null;
 
 export function translateSize(size) {
   switch (size) {
+    case "micro":
+      return 12;
     case "tiny":
       return 24;
     case "small":


### PR DESCRIPTION
Size is 12, half the size of tiny. For uses like that
shown in https://github.com/discourse/discourse-kanban/pull/37
