### PR TITLE
DEV: Add `occurred_at` to browser pageview event payload

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -231,6 +231,7 @@ class Middleware::RequestTracker
       timing: timing,
       queue_seconds: env[Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY],
       request_remote_ip: request_remote_ip,
+      occurred_at: Time.zone.now,
     }.merge(view_tracking_data)
 
     if request_data[:is_background]
@@ -673,6 +674,7 @@ class Middleware::RequestTracker
       referrer: data[:tracking_referrer],
       session_id: data[:tracking_session_id],
       topic_id: data[:topic_id],
+      occurred_at: data[:occurred_at],
     }
   end
   private_class_method :build_browser_pageview_event_payload


### PR DESCRIPTION
The browser pageview events are triggered inside `log_later` which runs asynchronously via `Scheduler::Defer`. This means plugins listening to the `:browser_pageview` event cannot rely on `Time.zone.now` or `created_at` timestamps to know exactly when the page view occurred.

By capturing `occurred_at` synchronously during request processing and passing it through to the event payload, plugins can now accurately record the time the page view happened.