### PR TITLE
DEV: Fix flaky select-kit test selectors

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -371,8 +371,24 @@ module SystemHelpers
     element.with_playwright_element_handle do |playwright_element|
       playwright_element.wait_for_element_state("hidden")
     rescue Playwright::Error => e
-      raise e unless e.message.match?(/Element is not attached to the DOM/)
+      raise if !detached_element_error?(e)
     end
+  end
+
+  # Retries the block on "Element is not attached to the DOM" error.
+  # That's usually a `find(...).click` racing a re-render.
+  def with_dom_retry(timeout: Capybara.default_max_wait_time)
+    deadline = Time.current + timeout.seconds
+    begin
+      yield
+    rescue Playwright::Error => e
+      retry if detached_element_error?(e) && Time.current < deadline
+      raise
+    end
+  end
+
+  def detached_element_error?(error)
+    error.is_a?(Playwright::Error) && error.message.include?("Element is not attached to the DOM")
   end
 
   def locator(selector, locator = nil)

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -115,19 +115,19 @@ module PageObjects
       end
 
       def select_row_by_value(value)
-        expanded_component.find(".select-kit-row[data-value='#{value}']").click
+        with_dom_retry { expanded_component.find(".select-kit-row[data-value='#{value}']").click }
       end
 
       def select_row_by_name(name)
-        expanded_component.find(".select-kit-row[data-name='#{name}']").click
+        with_dom_retry { expanded_component.find(".select-kit-row[data-name='#{name}']").click }
       end
 
       def select_row_by_index(index)
-        expanded_component.find(".select-kit-row[data-index='#{index}']").click
+        with_dom_retry { expanded_component.find(".select-kit-row[data-index='#{index}']").click }
       end
 
       def unselect_by_name(name)
-        expanded_component.find(".selected-choice[data-name='#{name}']").click
+        with_dom_retry { expanded_component.find(".selected-choice[data-name='#{name}']").click }
       end
 
       def clear


### PR DESCRIPTION
`select_row_by_value` and friends were sometimes raising `Playwright::Error: Element is not attached to the DOM` when CI was under increased load