### PR TITLE
DEV: Fix (again) composer body test flakes

### DIFF
--- a/frontend/discourse/app/components/composer-body.js
+++ b/frontend/discourse/app/components/composer-body.js
@@ -6,7 +6,6 @@ import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { classNameBindings } from "@ember-decorators/component";
 import { observes } from "@ember-decorators/object";
-import { waitForTransitionEnd } from "discourse/lib/animation-utils";
 import discourseDebounce from "discourse/lib/debounce";
 import discourseLater from "discourse/lib/later";
 import Composer from "discourse/models/composer";
@@ -25,6 +24,7 @@ import Composer from "discourse/models/composer";
   "currentUserPrimaryGroupClass"
 )
 export default class ComposerBody extends Component {
+  @service appEvents;
   @service capabilities;
 
   elementId = "reply-control";
@@ -74,32 +74,9 @@ export default class ComposerBody extends Component {
   }
 
   @observes("composeState")
-  async _onComposerOpen() {
-    // Skip if not opening, unmounted, or already awaiting the open transition —
-    // the in-flight wait will fire (or not) based on state at resolution time.
-    if (
-      !this.element ||
-      this.composeState !== Composer.OPEN ||
-      this._awaitingComposerOpen
-    ) {
-      return;
-    }
-
-    this._awaitingComposerOpen = true;
-    try {
-      await waitForTransitionEnd(this.element, "height");
-
-      if (
-        this.isDestroying ||
-        this.isDestroyed ||
-        this.composeState !== Composer.OPEN
-      ) {
-        return;
-      }
-
+  _onComposerOpen() {
+    if (this.composeState === Composer.OPEN) {
       this.appEvents.trigger("composer:opened");
-    } finally {
-      this._awaitingComposerOpen = false;
     }
   }
 
@@ -119,7 +96,10 @@ export default class ComposerBody extends Component {
     }
 
     this.element.addEventListener("transitionend", (event) => {
-      if (event.propertyName === "max-width") {
+      if (
+        event.propertyName === "height" ||
+        event.propertyName === "max-width"
+      ) {
         this.composerResized();
       }
     });

--- a/frontend/discourse/app/lib/animation-utils.js
+++ b/frontend/discourse/app/lib/animation-utils.js
@@ -2,47 +2,30 @@ import { waitForPromise } from "@ember/test-waiters";
 import { isTesting } from "discourse/lib/environment";
 import { prefersReducedMotion } from "discourse/lib/utilities";
 
-// Resolves on the animationend/transitionend event, or on a timeout if the event never triggers.
-function waitForEndEvent(element, eventName, styleKey, filter) {
+export function waitForAnimationEnd(element) {
   return waitForPromise(
     new Promise((resolve) => {
       const style = window.getComputedStyle(element);
-      const duration = parseFloat(style[`${styleKey}Duration`]) * 1000 || 0;
-      const delay = parseFloat(style[`${styleKey}Delay`]) * 1000 || 0;
+      const duration = parseFloat(style.animationDuration) * 1000 || 0;
+      const delay = parseFloat(style.animationDelay) * 1000 || 0;
 
-      const handler = (event) => {
-        if (filter && !filter(event)) {
-          return;
-        }
-
+      const handleAnimationEnd = () => {
         clearTimeout(timeoutId);
-        element.removeEventListener(eventName, handler);
+        element.removeEventListener("animationend", handleAnimationEnd);
         resolve();
       };
 
+      // Fallback in case the `animationend` event does not fire (e.g., when no animation is present).
       const timeoutId = setTimeout(
         () => {
-          element.removeEventListener(eventName, handler);
+          element.removeEventListener("animationend", handleAnimationEnd);
           resolve();
         },
         Math.max(duration + delay + 50, 50)
       );
 
-      element.addEventListener(eventName, handler);
+      element.addEventListener("animationend", handleAnimationEnd);
     })
-  );
-}
-
-export function waitForAnimationEnd(element) {
-  return waitForEndEvent(element, "animationend", "animation");
-}
-
-export function waitForTransitionEnd(element, propertyName) {
-  return waitForEndEvent(
-    element,
-    "transitionend",
-    "transition",
-    (event) => event.propertyName === propertyName
   );
 }
 

--- a/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
+++ b/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
@@ -12,8 +12,6 @@ describe "Composer don't feed the trolls popup" do
   before { sign_in user }
 
   it "shows a popup when about to reply to a troll" do
-    SiteSetting.educate_until_posts = 0
-
     topic_page.visit_topic(topic)
     topic_page.click_post_action_button(reply, :reply)
 


### PR DESCRIPTION
A follow-up/different approach to 9f3b694d6d08dfe5e6adbb2031ce1f856a46ca2e.

Waiting for `transitionend` turned out to be also flaky, just in a different way.