### PR TITLE
DEV: Fix the channel archive spec flake (again)

### DIFF
--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -114,8 +114,11 @@ module Chat
 
         chat_channel
           .chat_messages
-          .order("created_at ASC, id ASC")
-          .find_in_batches(batch_size: ARCHIVED_MESSAGES_PER_POST) do |message_batch|
+          .find_in_batches(
+            batch_size: ARCHIVED_MESSAGES_PER_POST,
+            cursor: %i[created_at id],
+            order: :asc,
+          ) do |message_batch|
             thread_ids = message_batch.map(&:thread_id).compact.uniq
             threads =
               chat_channel


### PR DESCRIPTION
A follow-up to 6e96da1a6aef9c6aab4dc817fb652e5056983a5e

`#order` doesn't  have any effect when used with `#find_in_batches` so that line was a no-op even before. Using the `:cursor` option instead.