### PR TITLE
FIX: Correctly handle table editor closing

### DIFF
--- a/frontend/discourse/app/components/d-modal.gjs
+++ b/frontend/discourse/app/components/d-modal.gjs
@@ -200,6 +200,13 @@ export default class DModal extends Component {
       return;
     }
 
+    if (this.args.beforeClose) {
+      const canClose = await this.args.beforeClose({ initiatedBy });
+      if (canClose === false) {
+        return;
+      }
+    }
+
     try {
       this.animating = true;
 

--- a/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -78,13 +78,19 @@ export default class SpreadsheetEditor extends Component {
   }
 
   @action
-  interceptCloseModal() {
-    if (this._hasChanges()) {
-      this.dialog.yesNoConfirm({
-        message: i18n("table_builder.modal.confirm_close"),
-        didConfirm: () => this.args.closeModal(),
-      });
-    } else {
+  confirmClose() {
+    if (!this._hasChanges()) {
+      return true;
+    }
+
+    return this.dialog.yesNoConfirm({
+      message: i18n("table_builder.modal.confirm_close"),
+    });
+  }
+
+  @action
+  async cancelClose() {
+    if (await this.confirmClose()) {
       this.args.closeModal();
     }
   }
@@ -354,7 +360,8 @@ export default class SpreadsheetEditor extends Component {
   <template>
     <DModal
       @title={{i18n this.modalAttributes.title}}
-      @closeModal={{this.interceptCloseModal}}
+      @closeModal={{@closeModal}}
+      @beforeClose={{this.confirmClose}}
       class="insert-table-modal"
     >
       <:body>
@@ -377,7 +384,7 @@ export default class SpreadsheetEditor extends Component {
               class="btn-insert-table"
             />
 
-            <DModalCancel @close={{this.interceptCloseModal}} />
+            <DModalCancel @close={{this.cancelClose}} />
           </div>
 
           <div class="secondary-actions">

--- a/frontend/discourse/tests/integration/components/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-modal-test.gjs
@@ -154,6 +154,39 @@ module("Integration | Component | d-modal", function (hooks) {
     );
   });
 
+  test("beforeClose can abort closing", async function (assert) {
+    let allowClose = false;
+    const closeModal = () => assert.step("closeModal");
+    const beforeClose = ({ initiatedBy }) => {
+      assert.strictEqual(initiatedBy, "initiatedByCloseButton");
+      assert.step("beforeClose");
+      return allowClose;
+    };
+
+    await render(
+      <template>
+        <DModal
+          @inline={{true}}
+          @closeModal={{closeModal}}
+          @beforeClose={{beforeClose}}
+        />
+      </template>
+    );
+
+    await click(".d-modal .modal-close");
+    assert.verifySteps(
+      ["beforeClose"],
+      "closeModal is not called when beforeClose returns false"
+    );
+
+    allowClose = true;
+    await click(".d-modal .modal-close");
+    assert.verifySteps(
+      ["beforeClose", "closeModal"],
+      "closeModal is called when beforeClose returns true"
+    );
+  });
+
   test("header and body classes", async function (assert) {
     await render(
       <template>


### PR DESCRIPTION
If you closed the table editor modal via the "X" button, and then clicked "No" on the confirmation dialog it would 1. still close the editor 2. the app would be in a state where it still acts as a modal was still there (e.g. blocked scrolling)