### PR TITLE
FIX: Incorrect "unsaved changes" dialog in table editor

### DIFF
--- a/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -88,7 +88,6 @@ export default class SpreadsheetEditor extends Component {
 
     return this.dialog.yesNoConfirm({
       message: i18n("table_builder.modal.confirm_close"),
-      didConfirm: () => this.args.closeModal(),
     });
   }
 

--- a/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -29,6 +29,7 @@ export default class SpreadsheetEditor extends Component {
   defaultColWidth = 150;
   isEditingTable = !!this.args.model.tableTokens;
   alignments = null;
+  initialSnapshot = null;
 
   constructor() {
     super(...arguments);
@@ -70,6 +71,8 @@ export default class SpreadsheetEditor extends Component {
     } else {
       this.buildNewTable();
     }
+
+    this.initialSnapshot = this.captureSnapshot();
   }
 
   @action
@@ -79,7 +82,7 @@ export default class SpreadsheetEditor extends Component {
 
   @action
   interceptCloseModal() {
-    if (this._hasChanges()) {
+    if (this.hasChanges) {
       this.dialog.yesNoConfirm({
         message: i18n("table_builder.modal.confirm_close"),
         didConfirm: () => this.args.closeModal(),
@@ -106,25 +109,18 @@ export default class SpreadsheetEditor extends Component {
     }
   }
 
-  _hasChanges() {
-    if (this.isEditingTable) {
-      const originalSpreadsheetData = this.extractTableContent(
-        tokenRange(this.args.model.tableTokens, "tr_open", "tr_close")
-      );
-      const currentHeaders = this.spreadsheet.getHeaders().split(",");
-      const currentRows = this.spreadsheet.getData();
-      const currentSpreadsheetData = currentHeaders.concat(currentRows.flat());
+  captureSnapshot() {
+    return JSON.stringify({
+      headers: this.spreadsheet.getHeaders(),
+      data: this.spreadsheet.getData(),
+    });
+  }
 
-      return (
-        JSON.stringify(currentSpreadsheetData) !==
-        JSON.stringify(originalSpreadsheetData)
-      );
-    } else {
-      return this.spreadsheet
-        .getData()
-        .flat()
-        .some((element) => element !== "");
-    }
+  get hasChanges() {
+    return (
+      this.initialSnapshot !== null &&
+      this.captureSnapshot() !== this.initialSnapshot
+    );
   }
 
   async loadJspreadsheet() {

--- a/spec/system/table_builder_spec.rb
+++ b/spec/system/table_builder_spec.rb
@@ -155,6 +155,14 @@ describe "Table Builder" do
         expect(page).to have_no_css(".insert-table-modal")
       end
 
+      it "closes the modal if there are no changes in a table with empty headers" do
+        topic_page.visit_topic(topic2)
+        topic_page.find(".btn-edit-table", visible: :all).click
+        insert_table_modal.cancel
+
+        expect(page).to have_no_css(".insert-table-modal")
+      end
+
       it "should show a warning popup if there are unsaved changes" do
         topic_page.visit_topic(topic)
         topic_page.find(".btn-edit-table", visible: :all).click


### PR DESCRIPTION
Tables with empty headers triggered the dialog on close even without edits.