### PR TITLE
UX: Fix mobile alignment for category events header

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
@@ -56,7 +56,11 @@
 .fc-header-toolbar {
   .fc-button,
   .fc-toolbar-title {
-    font-size: var(--font-down-1) !important;
+    font-size: var(--font-0);
+
+    @include viewport.from(md) {
+      font-size: var(--font-down-1);
+    }
   }
 }
 
@@ -89,15 +93,12 @@
 @include viewport.until(md) {
   .fc-header-toolbar {
     display: flex;
-    flex-direction: column;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .fc-toolbar-chunk {
-    width: 100%;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
   }
 
   .post-calendar {

--- a/themes/horizon/scss/topic.scss
+++ b/themes/horizon/scss/topic.scss
@@ -133,3 +133,9 @@ nav.post-controls .actions button {
     }
   }
 }
+
+@include viewport.until(md) {
+  #category-events-calendar {
+    padding: var(--space-4);
+  }
+}


### PR DESCRIPTION
Before / After screenshots for mobile Foundation and Horizon

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7bd0dda8-ec76-423b-bc1c-21dcb0ede1e2" /><img width="300" alt="image" src="https://github.com/user-attachments/assets/0fa1e8ea-f448-4675-9cab-348f5bf25dfc" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/157cbf01-c96f-416d-b435-454b69bbd6d8" /><img width="300" alt="image" src="https://github.com/user-attachments/assets/49dd0bd8-58c9-4e35-884f-1eeaa636a3bc" />
