### PR TITLE
DEV: Remove too-specific CSS color for admin link

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -862,10 +862,6 @@ $mobile-breakpoint: 700px;
 
   .nav-stacked {
     margin: 0;
-
-    a.active {
-      color: var(--primary);
-    }
   }
 
   .admin-site-settings-category-nav__item:hover {


### PR DESCRIPTION
No need to override this, removing this line means that the more themeable `var(--d-selected-text-color)` is used here.