### PR TITLE
FIX: user action notifications and list should not list ignored users

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -421,6 +421,7 @@ class UserAction < ActiveRecord::Base
 
     filter_private_messages(builder, user_id, guardian, ignore_private_messages)
     filter_categories(builder, guardian)
+    filter_ignored_users(builder, guardian)
   end
 
   def self.filter_private_messages(builder, user_id, guardian, ignore_private_messages = false)
@@ -465,6 +466,22 @@ class UserAction < ActiveRecord::Base
       end
     end
     builder
+  end
+
+  def self.filter_ignored_users(builder, guardian)
+    return unless guardian.user
+
+    builder.where(<<~SQL, current_user_id: guardian.user.id)
+      NOT EXISTS (
+        SELECT 1 FROM ignored_users ig
+        INNER JOIN users iu ON iu.id = ig.ignored_user_id
+        WHERE ig.user_id = :current_user_id
+          AND ig.ignored_user_id = a.acting_user_id
+          AND ig.ignored_user_id <> :current_user_id
+          AND NOT iu.admin
+          AND NOT iu.moderator
+      )
+    SQL
   end
 
   def self.require_parameters(data, *params)

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -240,7 +240,6 @@ class UserAction < ActiveRecord::Base
     SQL
 
     apply_common_filters(builder, user_id, guardian, ignore_private_messages)
-    filter_ignored_users(builder, guardian)
 
     if action_id
       builder.where("a.id = :id", id: action_id.to_i)
@@ -422,6 +421,7 @@ class UserAction < ActiveRecord::Base
 
     filter_private_messages(builder, user_id, guardian, ignore_private_messages)
     filter_categories(builder, guardian)
+    filter_ignored_users(builder, guardian)
   end
 
   def self.filter_private_messages(builder, user_id, guardian, ignore_private_messages = false)
@@ -478,8 +478,6 @@ class UserAction < ActiveRecord::Base
         WHERE ig.user_id = :current_user_id
           AND ig.ignored_user_id = a.acting_user_id
           AND ig.ignored_user_id <> :current_user_id
-          AND NOT iu.admin
-          AND NOT iu.moderator
       )
     SQL
   end

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -240,6 +240,7 @@ class UserAction < ActiveRecord::Base
     SQL
 
     apply_common_filters(builder, user_id, guardian, ignore_private_messages)
+    filter_ignored_users(builder, guardian)
 
     if action_id
       builder.where("a.id = :id", id: action_id.to_i)
@@ -421,7 +422,6 @@ class UserAction < ActiveRecord::Base
 
     filter_private_messages(builder, user_id, guardian, ignore_private_messages)
     filter_categories(builder, guardian)
-    filter_ignored_users(builder, guardian)
   end
 
   def self.filter_private_messages(builder, user_id, guardian, ignore_private_messages = false)

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -469,7 +469,7 @@ class UserAction < ActiveRecord::Base
   end
 
   def self.filter_ignored_users(builder, guardian)
-    return unless guardian.user
+    return unless guardian&.user
 
     builder.where(<<~SQL, current_user_id: guardian.user.id)
       NOT EXISTS (

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -325,7 +325,13 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   def secure_reaction_users!(reaction_users)
     builder = DB.build("/*where*/")
     UserAction.apply_common_filters(builder, current_user.id, guardian)
-    reaction_users.where(builder.to_sql.delete_prefix("/*where*/").delete_prefix("WHERE"))
+    sql =
+      builder
+        .to_sql
+        .delete_prefix("/*where*/")
+        .delete_prefix("WHERE")
+        .gsub("a.acting_user_id", "discourse_reactions_reaction_users.user_id")
+    reaction_users.where(sql)
   end
 
   def translate_to_reactions(likes)

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -270,14 +270,6 @@ RSpec.describe UserAction do
         expect(likee_stream_for(other).count).to eq(old_count + 1)
       end
 
-      %i[admin moderator].each do |role|
-        it "does not hide likes from ignored #{role}s" do
-          liker.update!(role => true)
-          PostActionCreator.like(liker, post)
-          expect(likee_stream_for(likee).count).to eq(old_count + 1)
-        end
-      end
-
       it "hides only the ignored user's actions, not other users' actions on the same topic" do
         normal_user = Fabricate(:user)
         PostActionCreator.like(normal_user, post)

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -270,42 +270,22 @@ RSpec.describe UserAction do
         expect(likee_stream_for(other).count).to eq(old_count + 1)
       end
 
-      it "does not hide likes from ignored admins" do
-        liker.update!(admin: true)
-        PostActionCreator.like(liker, post)
-        expect(likee_stream_for(likee).count).to eq(old_count + 1)
+      %i[admin moderator].each do |role|
+        it "does not hide likes from ignored #{role}s" do
+          liker.update!(role => true)
+          PostActionCreator.like(liker, post)
+          expect(likee_stream_for(likee).count).to eq(old_count + 1)
+        end
       end
 
-      it "does not hide likes from ignored moderators" do
-        liker.update!(moderator: true)
-        PostActionCreator.like(liker, post)
-        expect(likee_stream_for(likee).count).to eq(old_count + 1)
-      end
-
-      it "only hides the ignored user's rows when normal and ignored users both engage with the same topic" do
-        normal_user = Fabricate(:user, refresh_auto_groups: true)
-
+      it "hides only the ignored user's actions, not other users' actions on the same topic" do
+        normal_user = Fabricate(:user)
         PostActionCreator.like(normal_user, post)
-        normal_reply =
-          create_post(topic: post.topic, user: normal_user, reply_to_post_number: post.post_number)
-        PostAlerter.post_created(normal_reply)
-
         PostActionCreator.like(liker, post)
-        ignored_reply =
-          create_post(topic: post.topic, user: liker, reply_to_post_number: post.post_number)
-        PostAlerter.post_created(ignored_reply)
 
-        actions = likee_stream_for(likee)
-        acting_user_ids = actions.map(&:acting_user_id).uniq
-
+        acting_user_ids = likee_stream_for(likee).map(&:acting_user_id).uniq
         expect(acting_user_ids).to include(normal_user.id)
         expect(acting_user_ids).not_to include(liker.id)
-
-        post_ids = actions.map(&:post_id).compact
-        expect(post_ids).to include(normal_reply.id)
-        expect(post_ids).not_to include(ignored_reply.id)
-
-        expect(actions.map(&:topic_id)).to include(post.topic_id)
       end
     end
   end

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -246,6 +246,68 @@ RSpec.describe UserAction do
         expect(likee_stream.count).not_to eq(old_count + 1)
       end
     end
+
+    context "with ignored users" do
+      before { Fabricate(:ignored_user, user: likee, ignored_user: liker) }
+
+      def likee_stream_for(viewer)
+        UserAction.stream(user_id: likee.id, guardian: Guardian.new(viewer))
+      end
+
+      it "hides likes from ignored users when the ignorer views the stream" do
+        PostActionCreator.like(liker, post)
+        expect(likee_stream_for(likee).count).to eq(old_count)
+      end
+
+      it "still shows the likes to anonymous viewers" do
+        PostActionCreator.like(liker, post)
+        expect(likee_stream.count).to eq(old_count + 1)
+      end
+
+      it "still shows the likes to other logged-in viewers who aren't ignoring the liker" do
+        other = Fabricate(:user)
+        PostActionCreator.like(liker, post)
+        expect(likee_stream_for(other).count).to eq(old_count + 1)
+      end
+
+      it "does not hide likes from ignored admins" do
+        liker.update!(admin: true)
+        PostActionCreator.like(liker, post)
+        expect(likee_stream_for(likee).count).to eq(old_count + 1)
+      end
+
+      it "does not hide likes from ignored moderators" do
+        liker.update!(moderator: true)
+        PostActionCreator.like(liker, post)
+        expect(likee_stream_for(likee).count).to eq(old_count + 1)
+      end
+
+      it "only hides the ignored user's rows when normal and ignored users both engage with the same topic" do
+        normal_user = Fabricate(:user, refresh_auto_groups: true)
+
+        PostActionCreator.like(normal_user, post)
+        normal_reply =
+          create_post(topic: post.topic, user: normal_user, reply_to_post_number: post.post_number)
+        PostAlerter.post_created(normal_reply)
+
+        PostActionCreator.like(liker, post)
+        ignored_reply =
+          create_post(topic: post.topic, user: liker, reply_to_post_number: post.post_number)
+        PostAlerter.post_created(ignored_reply)
+
+        actions = likee_stream_for(likee)
+        acting_user_ids = actions.map(&:acting_user_id).uniq
+
+        expect(acting_user_ids).to include(normal_user.id)
+        expect(acting_user_ids).not_to include(liker.id)
+
+        post_ids = actions.map(&:post_id).compact
+        expect(post_ids).to include(normal_reply.id)
+        expect(post_ids).not_to include(ignored_reply.id)
+
+        expect(actions.map(&:topic_id)).to include(post.topic_id)
+      end
+    end
   end
 
   describe "when a user posts a new topic" do


### PR DESCRIPTION
We should filter out ignored users in the notifications feed.

Here is a before:


https://github.com/user-attachments/assets/47d963ce-b66c-4f34-82b8-73c1a63722b7



And after:



https://github.com/user-attachments/assets/c176db1a-cb93-4df5-870b-df95e66f56ac



