### PR TITLE
FIX: Canonical URL overwritten by client on embedded topics

### DIFF
--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -81,6 +81,7 @@ class TopicViewSerializer < ApplicationSerializer
     :has_localized_content,
     :can_localize_topic,
     :is_nested_view,
+    :canonical_url,
   )
 
   has_one :details, serializer: TopicViewDetailsSerializer, root: false, embed: :objects
@@ -346,5 +347,13 @@ class TopicViewSerializer < ApplicationSerializer
 
   def include_is_nested_view?
     SiteSetting.nested_replies_enabled && !object.topic.private_message?
+  end
+
+  def canonical_url
+    object.topic.topic_embed&.embed_url
+  end
+
+  def include_canonical_url?
+    SiteSetting.embed_set_canonical_url && object.topic.topic_embed.present?
   end
 end

--- a/frontend/discourse/app/instance-initializers/meta-tag-updater.js
+++ b/frontend/discourse/app/instance-initializers/meta-tag-updater.js
@@ -11,9 +11,11 @@ export default {
     const twitterUrl = document.querySelector("meta[name='twitter:url']");
 
     // workaround for mobile Chrome, which uses the canonical url when sharing
-    const canonicalUrl = document.querySelector("link[rel='canonical']");
+    const canonicalUrlElement = document.querySelector("link[rel='canonical']");
 
     const appEvents = owner.lookup("service:app-events");
+    const canonicalUrlService = owner.lookup("service:canonical-url");
+
     appEvents.on("page:changed", ({ title, url }) => {
       const absoluteUrl = getAbsoluteURL(url);
 
@@ -22,8 +24,9 @@ export default {
       twitterTitle?.setAttribute("content", title);
       twitterUrl?.setAttribute("content", absoluteUrl);
 
-      if (canonicalUrl) {
-        canonicalUrl.setAttribute("href", getCanonicalUrl(absoluteUrl));
+      if (canonicalUrlElement) {
+        const href = canonicalUrlService.url || getCanonicalUrl(absoluteUrl);
+        canonicalUrlElement.setAttribute("href", href);
       }
     });
   },

--- a/frontend/discourse/app/routes/topic.js
+++ b/frontend/discourse/app/routes/topic.js
@@ -26,6 +26,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 const SCROLL_DELAY = 500;
 
 export default class TopicRoute extends DiscourseRoute {
+  @service canonicalUrl;
   @service composer;
   @service screenTrack;
   @service currentUser;
@@ -404,6 +405,8 @@ export default class TopicRoute extends DiscourseRoute {
     this.appEvents.trigger("header:hide-topic");
 
     this.controllerFor("topic").set("model", null);
+
+    this.canonicalUrl.clear();
   }
 
   setupController(controller, model) {
@@ -424,6 +427,8 @@ export default class TopicRoute extends DiscourseRoute {
 
     // We reset screen tracking every time a topic is entered
     this.screenTrack.start(model.get("id"), controller);
+
+    this.canonicalUrl.set(model.get("canonical_url") || null);
 
     schedule("afterRender", () =>
       this.appEvents.trigger("header:update-topic", model)

--- a/frontend/discourse/app/services/canonical-url.js
+++ b/frontend/discourse/app/services/canonical-url.js
@@ -1,0 +1,16 @@
+import { tracked } from "@glimmer/tracking";
+import Service from "@ember/service";
+import { disableImplicitInjections } from "discourse/lib/implicit-injections";
+
+@disableImplicitInjections
+export default class CanonicalUrlService extends Service {
+  @tracked url = null;
+
+  set(url) {
+    this.url = url;
+  }
+
+  clear() {
+    this.url = null;
+  }
+}

--- a/frontend/discourse/tests/acceptance/meta-tag-updater-test.js
+++ b/frontend/discourse/tests/acceptance/meta-tag-updater-test.js
@@ -31,3 +31,103 @@ acceptance("Meta Tag Updater", function (needs) {
       .hasAttribute("href", /\/about$/, "updates the canonical URL");
   });
 });
+
+acceptance("Meta Tag Updater - Embedded Topics", function (needs) {
+  const embedUrl = "https://example.com/original-article";
+
+  needs.pretender((server, helper) => {
+    server.get("/t/280.json", () =>
+      helper.response({
+        post_stream: {
+          posts: [
+            {
+              id: 398,
+              name: null,
+              username: "tms",
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+              created_at: "2019-07-03T02:47:42.619Z",
+              raw: "This is a test topic",
+              cooked: "<p>This is a test topic</p>",
+              post_number: 1,
+              post_type: 1,
+              updated_at: "2019-07-03T02:47:42.619Z",
+              reply_count: 0,
+              quote_count: 0,
+              incoming_link_count: 0,
+              reads: 1,
+              readers_count: 0,
+              score: 0,
+              yours: true,
+              topic_id: 280,
+              topic_slug: "internationalization-localization",
+              user_id: 1,
+              primary_group_name: null,
+              trust_level: 1,
+              can_edit: true,
+              can_delete: false,
+              can_recover: false,
+              can_wiki: true,
+            },
+          ],
+          stream: [398],
+        },
+        id: 280,
+        title: "Internationalization / localization",
+        fancy_title: "Internationalization / localization",
+        posts_count: 1,
+        created_at: "2019-07-03T02:47:42.215Z",
+        views: 1,
+        reply_count: 0,
+        like_count: 0,
+        visible: true,
+        closed: false,
+        archived: false,
+        archetype: "regular",
+        slug: "internationalization-localization",
+        category_id: 1,
+        word_count: 4,
+        user_id: 1,
+        canonical_url: embedUrl,
+        chunk_size: 20,
+        details: {
+          can_create_post: true,
+          participants: [
+            {
+              id: 1,
+              username: "tms",
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+              post_count: 1,
+              primary_group_name: null,
+            },
+          ],
+          created_by: {
+            id: 1,
+            username: "tms",
+            avatar_template:
+              "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+          },
+          last_poster: {
+            id: 1,
+            username: "tms",
+            avatar_template:
+              "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+          },
+        },
+      })
+    );
+  });
+
+  test("uses canonical_url from topic when present", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    assert
+      .dom("link[rel='canonical']", document)
+      .hasAttribute(
+        "href",
+        embedUrl,
+        "uses the embed URL as canonical for embedded topics"
+      );
+  });
+});

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -749,4 +749,36 @@ RSpec.describe TopicViewSerializer do
       expect(json[:has_localized_content]).to eq(nil)
     end
   end
+
+  describe "#canonical_url" do
+    fab!(:topic_embed) { Fabricate(:topic_embed, topic: topic) }
+
+    context "when embed_set_canonical_url is enabled" do
+      before { SiteSetting.embed_set_canonical_url = true }
+
+      it "returns the embed_url for topics with topic_embed" do
+        json = serialize_topic(topic, user)
+        expect(json[:canonical_url]).to eq(topic_embed.embed_url)
+      end
+    end
+
+    context "when embed_set_canonical_url is disabled" do
+      before { SiteSetting.embed_set_canonical_url = false }
+
+      it "does not include canonical_url" do
+        json = serialize_topic(topic, user)
+        expect(json[:canonical_url]).to eq(nil)
+      end
+    end
+
+    context "when topic has no topic_embed" do
+      before { SiteSetting.embed_set_canonical_url = true }
+
+      it "does not include canonical_url" do
+        topic_without_embed = Fabricate(:topic)
+        json = serialize_topic(topic_without_embed, user)
+        expect(json[:canonical_url]).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description

When embed_set_canonical_url is enabled, the server correctly renders `<link rel="canonical">` with the embed URL in the initial HTML. However, the Ember app's `meta-tag-updater` immediately overwrites it with the Discourse topic URL on every `page: changed` event, making the setting ineffective for browser visitors.

This fix adds `canonical_url` to the topic serializer response (when setting enabled + topic has embed), along with the `canonical-url `, and uses this to modify the current logic, allowing the `canonical-url` to be set correctly.

See `t/182457` for more context