### PR TITLE
DEV: Fix letter avatar alignment on macOS

### DIFF
--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -71,7 +71,7 @@ class LetterAvatar
 
       filename = fullsize_path(identity)
 
-      # Use Helvetica on macOS (where NimbusSans-Regular is unavailable)
+      # Use NimbusSans-Regular, except for macOS where it is unavailable, use Helvetica there
       font = RbConfig::CONFIG["host_os"].match?(/darwin/i) ? "Helvetica" : "NimbusSans-Regular"
       # and adjust vertical offset accordingly
       vertical_offset = font == "Helvetica" ? 26 : 34

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -71,6 +71,11 @@ class LetterAvatar
 
       filename = fullsize_path(identity)
 
+      # Use Helvetica on macOS (where NimbusSans-Regular is unavailable)
+      font = RbConfig::CONFIG["host_os"].match?(/darwin/i) ? "Helvetica" : "NimbusSans-Regular"
+      # and adjust vertical offset accordingly
+      vertical_offset = font == "Helvetica" ? 26 : 34
+
       instructions = %W[
         -size
         #{FULLSIZE}x#{FULLSIZE}
@@ -80,11 +85,11 @@ class LetterAvatar
         -fill
         #FFFFFFCC
         -font
-        NimbusSans-Regular
+        #{font}
         -gravity
         Center
         -annotate
-        -0+34
+        -0+#{vertical_offset}
         #{letter}
         -depth
         8


### PR DESCRIPTION
When taking screenshots in system specs on macOS, letter avatars are off-centre. This is because the font we use isn't available on Mac. This restores Helvetica as the letter avatar font on Mac, and that fixes screenshots. 

<img width="1188" height="1058" alt="image" src="https://github.com/user-attachments/assets/c4957b24-2c4f-4064-991c-d86fd68d20e5" />
