### PR TITLE
DEV: Remove ComboBox usage from category forms

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5027,7 +5027,7 @@ en:
           high: "High"
           very_high: "Very high"
       sort_options:
-        default: "default"
+        default: "Default"
         likes: "Likes"
         op_likes: "Original post likes"
         views: "Views"
@@ -5038,6 +5038,7 @@ en:
         created: "Created"
       sort_ascending: "Ascending"
       sort_descending: "Descending"
+      sort_direction: "Sort direction"
       subcategory_list_styles:
         rows: "Rows"
         rows_with_featured_topics: "Rows with featured topics"

--- a/frontend/discourse/admin/components/upsert-category/appearance.gjs
+++ b/frontend/discourse/admin/components/upsert-category/appearance.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { fn, hash } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -8,7 +8,6 @@ import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { CATEGORY_TEXT_COLORS } from "discourse/lib/constants";
 import { applyMutableValueTransformer } from "discourse/lib/transformer";
-import ComboBox from "discourse/select-kit/components/combo-box";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -54,11 +53,6 @@ export default class UpsertCategoryAppearance extends Component {
   @action
   onUploadDeleted(field) {
     this.args.form.set(field, { id: null, url: null });
-  }
-
-  @action
-  onSortAscendingChange(value) {
-    this.args.form.set("sort_ascending", value);
   }
 
   get subcategoryListStyles() {
@@ -221,18 +215,18 @@ export default class UpsertCategoryAppearance extends Component {
         @name="default_view"
         @title={{i18n "category.default_view"}}
         @format="max"
-        @type="custom"
+        @type="select"
         as |field|
       >
-        <field.Control>
-          <ComboBox
-            @id="category-default-view"
-            @content={{this.availableViews}}
-            @value={{field.value}}
-            @valueProperty="value"
-            @onChange={{field.set}}
-            @options={{hash none="category.sort_options.default"}}
-          />
+        <field.Control
+          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          as |select|
+        >
+          {{#each this.availableViews as |availableView|}}
+            <select.Option
+              @value={{availableView.value}}
+            >{{availableView.name}}</select.Option>
+          {{/each}}
         </field.Control>
       </@form.Field>
 
@@ -240,18 +234,18 @@ export default class UpsertCategoryAppearance extends Component {
         @name="default_top_period"
         @title={{i18n "category.default_top_period"}}
         @format="max"
-        @type="custom"
+        @type="select"
         as |field|
       >
-        <field.Control>
-          <ComboBox
-            @id="category-default-top-period"
-            @content={{this.topPeriods}}
-            @value={{field.value}}
-            @valueProperty="value"
-            @onChange={{field.set}}
-            @options={{hash none="category.sort_options.default"}}
-          />
+        <field.Control
+          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          as |select|
+        >
+          {{#each this.topPeriods as |period|}}
+            <select.Option
+              @value={{period.value}}
+            >{{period.name}}</select.Option>
+          {{/each}}
         </field.Control>
       </@form.Field>
 
@@ -259,48 +253,56 @@ export default class UpsertCategoryAppearance extends Component {
         @name="sort_order"
         @title={{i18n "category.sort_order"}}
         @format="max"
-        @type="custom"
+        @type="select"
         as |field|
       >
-        <field.Control>
-          <ComboBox
-            @id="category-sort-order"
-            @content={{this.sortOrders}}
-            @value={{field.value}}
-            @valueProperty="value"
-            @onChange={{field.set}}
-            @options={{hash none="category.sort_options.default"}}
-          />
-
-          {{#unless this.isDefaultSortOrder}}
-            <ComboBox
-              @id="category-sort-ascending"
-              @content={{this.sortAscendingOptions}}
-              @value={{this.sortAscendingOption}}
-              @valueProperty="value"
-              @onChange={{this.onSortAscendingChange}}
-              @options={{hash none="category.sort_options.default"}}
-            />
-          {{/unless}}
+        <field.Control
+          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          as |select|
+        >
+          {{#each this.sortOrders as |sort|}}
+            <select.Option @value={{sort.value}}>{{sort.name}}</select.Option>
+          {{/each}}
         </field.Control>
       </@form.Field>
+
+      {{#unless this.isDefaultSortOrder}}
+        <@form.Field
+          @name="sort_ascending"
+          @title={{i18n "category.sort_direction"}}
+          @format="max"
+          @type="select"
+          as |field|
+        >
+          <field.Control
+            @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+            as |select|
+          >
+            {{#each this.sortAscendingOptions as |option|}}
+              <select.Option
+                @value={{option.value}}
+              >{{option.name}}</select.Option>
+            {{/each}}
+          </field.Control>
+        </@form.Field>
+      {{/unless}}
 
       <@form.Field
         @name="default_list_filter"
         @title={{i18n "category.default_list_filter"}}
         @format="max"
-        @type="custom"
+        @type="select"
         as |field|
       >
-        <field.Control>
-          <ComboBox
-            @id="category-default-list-filter"
-            @content={{this.listFilters}}
-            @value={{field.value}}
-            @valueProperty="value"
-            @onChange={{field.set}}
-            @options={{hash none="category.sort_options.default"}}
-          />
+        <field.Control
+          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          as |select|
+        >
+          {{#each this.listFilters as |filter|}}
+            <select.Option
+              @value={{filter.value}}
+            >{{filter.name}}</select.Option>
+          {{/each}}
         </field.Control>
       </@form.Field>
 
@@ -320,17 +322,18 @@ export default class UpsertCategoryAppearance extends Component {
             @name="subcategory_list_style"
             @title={{i18n "category.subcategory_list_style"}}
             @format="max"
-            @type="custom"
+            @type="select"
             as |field|
           >
-            <field.Control>
-              <ComboBox
-                @id="subcategory-list-style"
-                @content={{this.subcategoryListStyles}}
-                @value={{field.value}}
-                @valueProperty="value"
-                @onChange={{field.set}}
-              />
+            <field.Control
+              @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+              as |select|
+            >
+              {{#each this.subcategoryListStyles as |style|}}
+                <select.Option
+                  @value={{style.value}}
+                >{{style.name}}</select.Option>
+              {{/each}}
             </field.Control>
           </@form.Field>
         {{/if}}

--- a/frontend/discourse/admin/components/upsert-category/appearance.gjs
+++ b/frontend/discourse/admin/components/upsert-category/appearance.gjs
@@ -219,7 +219,7 @@ export default class UpsertCategoryAppearance extends Component {
         as |field|
       >
         <field.Control
-          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          @nonePlaceholder={{i18n "category.sort_options.default"}}
           as |select|
         >
           {{#each this.availableViews as |availableView|}}
@@ -238,7 +238,7 @@ export default class UpsertCategoryAppearance extends Component {
         as |field|
       >
         <field.Control
-          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          @nonePlaceholder={{i18n "category.sort_options.default"}}
           as |select|
         >
           {{#each this.topPeriods as |period|}}
@@ -257,7 +257,7 @@ export default class UpsertCategoryAppearance extends Component {
         as |field|
       >
         <field.Control
-          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          @nonePlaceholder={{i18n "category.sort_options.default"}}
           as |select|
         >
           {{#each this.sortOrders as |sort|}}
@@ -275,7 +275,7 @@ export default class UpsertCategoryAppearance extends Component {
           as |field|
         >
           <field.Control
-            @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+            @nonePlaceholder={{i18n "category.sort_options.default"}}
             as |select|
           >
             {{#each this.sortAscendingOptions as |option|}}
@@ -295,7 +295,7 @@ export default class UpsertCategoryAppearance extends Component {
         as |field|
       >
         <field.Control
-          @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+          @nonePlaceholder={{i18n "category.sort_options.default"}}
           as |select|
         >
           {{#each this.listFilters as |filter|}}
@@ -326,7 +326,7 @@ export default class UpsertCategoryAppearance extends Component {
             as |field|
           >
             <field.Control
-              @nonePlaceholderLabel={{i18n "category.sort_options.default"}}
+              @nonePlaceholder={{i18n "category.sort_options.default"}}
               as |select|
             >
               {{#each this.subcategoryListStyles as |style|}}

--- a/frontend/discourse/admin/components/upsert-category/security.gjs
+++ b/frontend/discourse/admin/components/upsert-category/security.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { isNone } from "@ember/utils";
 import UpsertCategoryPermissionRow from "discourse/admin/components/upsert-category/permission-row";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import concatClass from "discourse/helpers/concat-class";
@@ -9,7 +9,6 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import Category from "discourse/models/category";
 import PermissionType from "discourse/models/permission-type";
-import ComboBox from "discourse/select-kit/components/combo-box";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -118,6 +117,16 @@ export default class UpsertCategorySecurity extends Component {
       },
     ];
     this.#setFormPermissions(newPermissions);
+  }
+
+  @action
+  onSecurityAddGroupSet(value) {
+    if (isNone(value)) {
+      return;
+    }
+
+    const groupId = typeof value === "string" ? parseInt(value, 10) : value;
+    this.onSelectGroup(Number.isNaN(groupId) ? value : groupId);
   }
 
   @action
@@ -234,15 +243,29 @@ export default class UpsertCategorySecurity extends Component {
               >
                 <div class="add-group">
                   <span class="group-name">
-                    <ComboBox
-                      @content={{this.availableGroups}}
-                      @onChange={{this.onSelectGroup}}
-                      @value={{null}}
-                      @valueProperty="id"
-                      @nameProperty="name"
-                      @options={{hash none="category.security_add_group"}}
-                      class="available-groups"
-                    />
+                    <@form.Field
+                      @name="security_add_group_id"
+                      @title={{i18n "category.security_add_group"}}
+                      @showTitle={{false}}
+                      @format="max"
+                      @type="select"
+                      @onSet={{this.onSecurityAddGroupSet}}
+                      as |field|
+                    >
+                      <field.Control
+                        class="available-groups"
+                        @nonePlaceholderLabel={{i18n
+                          "category.security_add_group"
+                        }}
+                        as |select|
+                      >
+                        {{#each this.availableGroups as |group|}}
+                          <select.Option
+                            @value={{group.id}}
+                          >{{group.name}}</select.Option>
+                        {{/each}}
+                      </field.Control>
+                    </@form.Field>
                   </span>
                 </div>
               </PluginOutlet>

--- a/frontend/discourse/admin/components/upsert-category/security.gjs
+++ b/frontend/discourse/admin/components/upsert-category/security.gjs
@@ -254,9 +254,7 @@ export default class UpsertCategorySecurity extends Component {
                     >
                       <field.Control
                         class="available-groups"
-                        @nonePlaceholderLabel={{i18n
-                          "category.security_add_group"
-                        }}
+                        @nonePlaceholder={{i18n "category.security_add_group"}}
                         as |select|
                       >
                         {{#each this.availableGroups as |group|}}

--- a/frontend/discourse/admin/components/upsert-category/settings.gjs
+++ b/frontend/discourse/admin/components/upsert-category/settings.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -7,7 +6,6 @@ import concatClass from "discourse/helpers/concat-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { SEARCH_PRIORITIES } from "discourse/lib/constants";
 import getUrl from "discourse/lib/get-url";
-import ComboBox from "discourse/select-kit/components/combo-box";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -50,6 +48,7 @@ export default class UpsertCategorySettings extends Component {
         @title={{i18n "category.slug"}}
         @format="max"
         @type="input"
+        @validation="required"
         as |field|
       >
         <field.Control
@@ -88,18 +87,16 @@ export default class UpsertCategorySettings extends Component {
         @name="search_priority"
         @title={{i18n "category.search_priority.label"}}
         @format="max"
-        @type="custom"
+        @type="select"
+        @validation="required"
         as |field|
       >
-        <field.Control>
-          <ComboBox
-            @valueProperty="value"
-            @id="category-search-priority"
-            @content={{this.searchPrioritiesOptions}}
-            @value={{field.value}}
-            @onChange={{field.set}}
-            @options={{hash placementStrategy="absolute"}}
-          />
+        <field.Control @includeNone={{false}} as |select|>
+          {{#each this.searchPrioritiesOptions as |searchPriority|}}
+            <select.Option
+              @value={{searchPriority.value}}
+            >{{searchPriority.name}}</select.Option>
+          {{/each}}
         </field.Control>
       </@form.Field>
 

--- a/frontend/discourse/app/components/d-select.gjs
+++ b/frontend/discourse/app/components/d-select.gjs
@@ -70,8 +70,8 @@ export default class DSelect extends Component {
     >
       {{#if this.includeNone}}
         <DSelectOption @value={{NO_VALUE_OPTION}}>
-          {{#if @nonePlaceholderLabel}}
-            {{@nonePlaceholderLabel}}
+          {{#if @nonePlaceholder}}
+            {{@nonePlaceholder}}
           {{else}}
             {{#if this.hasSelectedValue}}
               {{i18n "none_placeholder"}}

--- a/frontend/discourse/app/components/d-select.gjs
+++ b/frontend/discourse/app/components/d-select.gjs
@@ -33,6 +33,17 @@ export class DSelectOption extends Component {
 }
 
 export default class DSelect extends Component {
+  get htmlSelectValue() {
+    const value = this.args.value;
+    if (value === NO_VALUE_OPTION) {
+      return NO_VALUE_OPTION;
+    }
+    if (isNone(value) || value === "") {
+      return NO_VALUE_OPTION;
+    }
+    return value;
+  }
+
   @action
   handleInput(event) {
     // if an option has no value, event.target.value will be the content of the option
@@ -52,22 +63,28 @@ export default class DSelect extends Component {
 
   <template>
     <select
-      value={{@value}}
+      value={{this.htmlSelectValue}}
       ...attributes
       class="d-select"
       {{on "input" this.handleInput}}
     >
       {{#if this.includeNone}}
         <DSelectOption @value={{NO_VALUE_OPTION}}>
-          {{#if this.hasSelectedValue}}
-            {{i18n "none_placeholder"}}
+          {{#if @nonePlaceholderLabel}}
+            {{@nonePlaceholderLabel}}
           {{else}}
-            {{i18n "select_placeholder"}}
+            {{#if this.hasSelectedValue}}
+              {{i18n "none_placeholder"}}
+            {{else}}
+              {{i18n "select_placeholder"}}
+            {{/if}}
           {{/if}}
         </DSelectOption>
       {{/if}}
 
-      {{yield (hash Option=(component DSelectOption selected=@value))}}
+      {{yield
+        (hash Option=(component DSelectOption selected=this.htmlSelectValue))
+      }}
     </select>
   </template>
 }

--- a/frontend/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/select.gjs
@@ -33,7 +33,7 @@ export default class FKControlSelect extends FKBaseControl {
       @value={{@field.value}}
       @onChange={{@field.set}}
       @includeNone={{this.includeNone}}
-      @nonePlaceholderLabel={{@nonePlaceholderLabel}}
+      @nonePlaceholder={{@nonePlaceholder}}
       id={{@field.id}}
       name={{@field.name}}
       aria-invalid={{if @field.error "true"}}

--- a/frontend/discourse/app/form-kit/components/fk/control/select.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/select.gjs
@@ -33,6 +33,7 @@ export default class FKControlSelect extends FKBaseControl {
       @value={{@field.value}}
       @onChange={{@field.set}}
       @includeNone={{this.includeNone}}
+      @nonePlaceholderLabel={{@nonePlaceholderLabel}}
       id={{@field.id}}
       name={{@field.name}}
       aria-invalid={{if @field.error "true"}}

--- a/spec/system/category_moderator_self_lockout_spec.rb
+++ b/spec/system/category_moderator_self_lockout_spec.rb
@@ -16,15 +16,14 @@ describe "Category moderator self-lockout warning" do
   let(:category_page) { PageObjects::Pages::Category.new }
   let(:permission_row) { PageObjects::Components::CategoryPermissionRow.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
-  let(:group_chooser) { PageObjects::Components::SelectKit.new(".available-groups") }
+  let(:form) { PageObjects::Components::FormKit.new(".form-kit") }
 
   before { SiteSetting.moderators_manage_categories = true }
 
   def remove_everyone_and_add_restricted_group
     category_page.visit_security(category)
     permission_row.remove_group_permission("everyone")
-    group_chooser.expand
-    group_chooser.select_row_by_name(restricted_group.name)
+    form.field("security_add_group_id").select(restricted_group.id)
   end
 
   context "when moderator would lose access" do

--- a/spec/system/edit_category_settings_spec.rb
+++ b/spec/system/edit_category_settings_spec.rb
@@ -16,15 +16,10 @@ describe "Edit Category Settings" do
     it "allows selecting hot as the default view" do
       category_page.visit_appearance(category)
 
-      category_default_view_select_kit.expand
-      expect(category_default_view_select_kit).to have_option_value("hot")
-      expect(category_default_view_select_kit).to have_option_value("latest")
-      expect(category_default_view_select_kit).to have_option_value("top")
-
-      category_default_view_select_kit.select_row_by_value("hot")
+      form.field("default_view").select("hot")
       category_page.save_settings
 
-      expect(category_default_view_select_kit.value).to eq("hot")
+      expect(form.field("default_view").value).to eq("hot")
 
       visit "/c/#{category.slug}/#{category.id}"
       expect(page).to have_css(".navigation-container .hot.active", text: "Hot")

--- a/spec/system/simplified_category_creation_spec.rb
+++ b/spec/system/simplified_category_creation_spec.rb
@@ -372,18 +372,16 @@ describe "Simplified Category Creation" do
     end
 
     it "sets default view to latest" do
-      category_page.visit_images(category)
+      category_page.visit_appearance(category)
 
-      default_view_selector = PageObjects::Components::SelectKit.new("#category-default-view")
-      default_view_selector.expand
-      default_view_selector.select_row_by_value("latest")
+      form.field("default_view").select("latest")
       category_page.save_settings
 
       expect(category.reload.default_view).to eq("latest")
     end
 
     it "uploads a category logo" do
-      category_page.visit_images(category)
+      category_page.visit_appearance(category)
 
       attach_file(
         "category-logo-uploader__input",


### PR DESCRIPTION
Instead of using ComboBox, we can use the native
select field type in FormKit. This commit updates
the Appearance, Settings, and Moderations new category
forms.

Also included are a couple of FormKit tweaks:

* DSelect now has special handling for when the value
  arg is null, underfined, or "", resolving it to the
  special NO_VALUE_OPTION under the hood to avoid
  strange rerender issues
* The FormKit select field now accepts a @nonePlaceholderLabel
  arg to override the Select.../None label in the dropdown when
  no value is selected
