### PR TITLE
FIX: Prevent tag group from saving if private + no group selected

### DIFF
--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -3,6 +3,7 @@
 class TagGroup < ActiveRecord::Base
   validates :name, length: { maximum: 100 }
   validates :name, uniqueness: { case_sensitive: false }
+  validate :ensure_permissions_not_empty, on: :update
 
   scope :where_name,
         ->(name) do
@@ -104,6 +105,10 @@ class TagGroup < ActiveRecord::Base
       end
       @permissions = nil
     end
+  end
+
+  def ensure_permissions_not_empty
+    errors.add(:base, I18n.t("tags.groups.errors.empty_permissions")) if @permissions&.empty?
   end
 
   def remove_parent_from_group

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5615,6 +5615,9 @@ en:
 
   tags:
     title: "Tags"
+    groups:
+      errors:
+        empty_permissions: "Tag group must have at least one permission."
     restricted_tag_disallowed: 'You cannot apply the tag "%{tag}".'
     restricted_tag_remove_disallowed: 'You cannot remove the tag "%{tag}".'
     minimum_required_tags:

--- a/frontend/discourse/app/components/tag-groups-form.gjs
+++ b/frontend/discourse/app/components/tag-groups-form.gjs
@@ -92,7 +92,7 @@ export default class TagGroupsForm extends Component {
       return false;
     }
 
-    attrs.permissions ??= {};
+    attrs.permissions = { ...(attrs.permissions ?? {}) };
 
     const permissionName = this.buffered.get("permissionName");
 
@@ -102,9 +102,16 @@ export default class TagGroupsForm extends Component {
       attrs.permissions[0] = PermissionType.READONLY;
     } else if (permissionName === "private") {
       delete attrs.permissions[0];
-    } else {
-      this.dialog.alert(i18n("tagging.groups.cannot_save.no_groups"));
-      return false;
+    }
+
+    if (permissionName === "private") {
+      const hasGroups = Object.keys(attrs.permissions).some(
+        (k) => parseInt(k, 10) !== AUTO_GROUPS.everyone.id
+      );
+      if (!hasGroups) {
+        this.dialog.alert(i18n("tagging.groups.cannot_save.no_groups"));
+        return false;
+      }
     }
 
     this.model

--- a/frontend/discourse/app/components/tag-groups-form.gjs
+++ b/frontend/discourse/app/components/tag-groups-form.gjs
@@ -102,9 +102,7 @@ export default class TagGroupsForm extends Component {
       attrs.permissions[0] = PermissionType.READONLY;
     } else if (permissionName === "private") {
       delete attrs.permissions[0];
-    }
 
-    if (permissionName === "private") {
       const hasGroups = Object.keys(attrs.permissions).some(
         (k) => parseInt(k, 10) !== AUTO_GROUPS.everyone.id
       );

--- a/spec/requests/tag_groups_controller_spec.rb
+++ b/spec/requests/tag_groups_controller_spec.rb
@@ -367,6 +367,28 @@ RSpec.describe TagGroupsController do
       expect(tag_group.reload.name).to eq(original_name)
     end
 
+    it "rejects empty permissions on an existing tag group" do
+      group = Fabricate(:group)
+      tag_group.permissions = { group.id => TagGroupPermission.permission_types[:full] }
+      tag_group.save!
+
+      put "/tag_groups/#{tag_group.id}.json",
+          params: {
+            tag_group: {
+              tags: [{ id: tag1.id, name: tag1.name }],
+              permissions: {
+              },
+            },
+          },
+          as: :json
+
+      expect(response.status).to eq(422)
+
+      tag_group.reload
+      permissions = tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
+      expect(permissions).to eq(group.id => TagGroupPermission.permission_types[:full])
+    end
+
     it "does not create a staff action log entry when update fails" do
       Fabricate(:tag_group, name: "existing_name")
 

--- a/spec/system/page_objects/pages/admin_tag_groups.rb
+++ b/spec/system/page_objects/pages/admin_tag_groups.rb
@@ -84,6 +84,25 @@ module PageObjects
         find("#visible-permission").checked?
       end
 
+      def select_private_permission
+        find("#private-permission").click
+        self
+      end
+
+      def has_private_permission_checked?
+        find("#private-permission").checked?
+      end
+
+      def has_public_permission_checked?
+        find("#public-permission").checked?
+      end
+
+      def private_group_chooser
+        PageObjects::Components::SelectKit.new(
+          ".group-visibility-option:has(#private-permission) .group-chooser",
+        )
+      end
+
       def save
         find(".tag-group-controls .btn-primary").click
         self

--- a/spec/system/page_objects/pages/admin_tag_groups.rb
+++ b/spec/system/page_objects/pages/admin_tag_groups.rb
@@ -84,17 +84,19 @@ module PageObjects
         find("#visible-permission").checked?
       end
 
-      def select_private_permission
-        find("#private-permission").click
-        self
-      end
-
       def has_private_permission_checked?
         find("#private-permission").checked?
       end
 
       def has_public_permission_checked?
         find("#public-permission").checked?
+      end
+
+      def has_private_group?(group_name)
+        has_css?(
+          ".group-visibility-option:has(#private-permission) .group-chooser",
+          text: group_name,
+        )
       end
 
       def private_group_chooser

--- a/spec/system/tag_group_spec.rb
+++ b/spec/system/tag_group_spec.rb
@@ -135,6 +135,88 @@ describe "Tag Groups" do
     end
   end
 
+  describe "editing a private tag group's permissions are preserved" do
+    fab!(:staff_group, :group)
+    fab!(:tag3) { Fabricate(:tag, name: "rats") }
+    fab!(:private_tag_group) do
+      Fabricate(:tag_group, name: "Private Group", tags: [tag1, tag2]).tap do |tg|
+        tg.permissions = { staff_group.id => TagGroupPermission.permission_types[:full] }
+        tg.save!
+      end
+    end
+
+    it "does not wipe permissions when the group chooser clears and re-selects groups" do
+      tag_groups_page.visit_tag_group(private_tag_group)
+      expect(tag_groups_page).to have_private_permission_checked
+
+      tag_groups_page.private_group_chooser.expand
+      tag_groups_page.private_group_chooser.unselect_by_name(staff_group.name)
+      tag_groups_page.private_group_chooser.select_row_by_name(staff_group.name)
+      tag_groups_page.private_group_chooser.collapse
+
+      tag_groups_page.tags_chooser.expand
+      tag_groups_page.tags_chooser.search("rats")
+      tag_groups_page.tags_chooser.select_row_by_name("rats")
+      tag_groups_page.tags_chooser.collapse
+
+      tag_groups_page.save
+
+      try_until_success do
+        private_tag_group.reload
+        expect(private_tag_group.tags.map(&:name)).to include("rats")
+      end
+
+      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
+      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
+      expect(permissions).not_to have_key(0)
+    end
+
+    it "does not change permissions when navigating from a public tag group then editing tags" do
+      public_tag_group = Fabricate(:tag_group, name: "Public Group", tags: [tag1])
+
+      tag_groups_page.visit_tag_group(public_tag_group)
+      expect(tag_groups_page).to have_public_permission_checked
+
+      tag_groups_page.click_tag_group("Private Group")
+      expect(tag_groups_page).to have_private_permission_checked
+
+      tag_groups_page.tags_chooser.expand
+      tag_groups_page.tags_chooser.search("rats")
+      tag_groups_page.tags_chooser.select_row_by_name("rats")
+      tag_groups_page.tags_chooser.collapse
+
+      tag_groups_page.save
+
+      try_until_success do
+        private_tag_group.reload
+        expect(private_tag_group.tags.map(&:name)).to include("rats")
+      end
+
+      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
+      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
+      expect(permissions).not_to have_key(0)
+    end
+
+    it "blocks save and preserves permissions when group chooser is cleared on a private group" do
+      tag_groups_page.visit_tag_group(private_tag_group)
+      expect(tag_groups_page).to have_private_permission_checked
+
+      tag_groups_page.private_group_chooser.expand
+      tag_groups_page.private_group_chooser.unselect_by_name(staff_group.name)
+      tag_groups_page.private_group_chooser.collapse
+
+      tag_groups_page.save
+
+      dialog = PageObjects::Components::Dialog.new
+      expect(dialog).to have_content(I18n.t("js.tagging.groups.cannot_save.no_groups"))
+      dialog.click_yes
+
+      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
+      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
+      expect(permissions).not_to have_key(0)
+    end
+  end
+
   describe "deleting a tag group" do
     fab!(:tag_group) { Fabricate(:tag_group, name: "To Delete", tags: [tag1]) }
 

--- a/spec/system/tag_group_spec.rb
+++ b/spec/system/tag_group_spec.rb
@@ -161,14 +161,12 @@ describe "Tag Groups" do
 
       tag_groups_page.save
 
-      try_until_success do
-        private_tag_group.reload
-        expect(private_tag_group.tags.map(&:name)).to include("rats")
-      end
+      page.refresh
+      tag_groups_page.click_tag_group("Private Group")
 
-      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
-      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
-      expect(permissions).not_to have_key(0)
+      expect(tag_groups_page).to have_tag_in_group("rats")
+      expect(tag_groups_page).to have_private_permission_checked
+      expect(tag_groups_page).to have_private_group(staff_group.name)
     end
 
     it "does not change permissions when navigating from a public tag group then editing tags" do
@@ -187,14 +185,12 @@ describe "Tag Groups" do
 
       tag_groups_page.save
 
-      try_until_success do
-        private_tag_group.reload
-        expect(private_tag_group.tags.map(&:name)).to include("rats")
-      end
+      page.refresh
+      tag_groups_page.click_tag_group("Private Group")
 
-      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
-      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
-      expect(permissions).not_to have_key(0)
+      expect(tag_groups_page).to have_tag_in_group("rats")
+      expect(tag_groups_page).to have_private_permission_checked
+      expect(tag_groups_page).to have_private_group(staff_group.name)
     end
 
     it "blocks save and preserves permissions when group chooser is cleared on a private group" do
@@ -211,9 +207,11 @@ describe "Tag Groups" do
       expect(dialog).to have_content(I18n.t("js.tagging.groups.cannot_save.no_groups"))
       dialog.click_yes
 
-      permissions = private_tag_group.tag_group_permissions.pluck(:group_id, :permission_type).to_h
-      expect(permissions).to eq(staff_group.id => TagGroupPermission.permission_types[:full])
-      expect(permissions).not_to have_key(0)
+      page.refresh
+      tag_groups_page.click_tag_group("Private Group")
+
+      expect(tag_groups_page).to have_private_permission_checked
+      expect(tag_groups_page).to have_private_group(staff_group.name)
     end
   end
 


### PR DESCRIPTION
When "Tags are visible only to the following groups" is selected with no groups, the tag group can still be saved, and will end up defaulting to public.

This often causes unintended side effects. 

Updated: also makes sure we disallow `permissions: {}`

```
curl 'https://d.loc/tag_groups/4' \
  -X 'PUT' \
  ...
  --data-raw '{"tag_group":{"name":"admin-only","tags":[{"id":90,"name":"testtag1"}],"parent_tag":[],"one_per_topic":false,"permissions":{}}}'
{"errors":["Tag group must have at least one permission."]}%
```

### before

https://github.com/user-attachments/assets/4489d048-e59c-4e69-83e9-cdbe138e04aa


### after


https://github.com/user-attachments/assets/22961124-546c-4086-9ead-0d2bc81243f4

