### PR TITLE
FIX: Allow showing expanded results table

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { capitalize } from "@ember/string";
 import moment from "moment";
@@ -49,6 +50,8 @@ export default class QueryResult extends Component {
 
   @tracked showChart;
   @tracked showTable;
+  @tracked tableExpanded = false;
+  @tracked hasOverflow = false;
 
   constructor() {
     super(...arguments);
@@ -78,6 +81,24 @@ export default class QueryResult extends Component {
     if (queryId) {
       store.set({ key: `showTable_${queryId}`, value: this.showTable });
     }
+  }
+
+  get showExpandButton() {
+    return this.hasOverflow && !this.tableExpanded;
+  }
+
+  @action
+  checkOverflow(element) {
+    if (!this.chartVisible) {
+      this.tableExpanded = true;
+      return;
+    }
+    this.hasOverflow = element.scrollHeight > element.clientHeight;
+  }
+
+  @action
+  expandTable() {
+    this.tableExpanded = true;
   }
 
   get chartVisible() {
@@ -391,7 +412,11 @@ export default class QueryResult extends Component {
         {{/if}}
 
         {{#if this.showTable}}
-          <div class="query-results-table-wrapper">
+          <div
+            class="query-results-table-wrapper
+              {{if this.tableExpanded '--expanded'}}"
+            {{didInsert this.checkOverflow}}
+          >
             <table class="query-results-table">
               <thead>
                 <tr class="headers">
@@ -424,6 +449,14 @@ export default class QueryResult extends Component {
               </tbody>
             </table>
           </div>
+          {{#if this.showExpandButton}}
+            <DButton
+              @action={{this.expandTable}}
+              @icon="chevron-down"
+              @translatedTitle={{i18n "show_more"}}
+              class="btn-flat query-results-expand-btn"
+            />
+          {{/if}}
         {{/if}}
 
       </section>

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -538,7 +538,15 @@ table.group-reports {
 
   .query-results-table-wrapper {
     overflow: auto;
-    max-height: 300px;
+    max-height: 350px;
+
+    &.--expanded {
+      max-height: none;
+    }
+  }
+
+  .query-results-expand-btn {
+    width: 100%;
   }
 
   .query-results-modes {

--- a/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "Data explorer query runner" do
       visit("/admin/plugins/discourse-data-explorer/queries/#{query_a.id}")
       find(".query-run .btn-primary").click
       expect(page).to have_css(".query-results .result-header")
+      expect(page).to have_css(".query-results-table-wrapper.--expanded")
 
       find(".back-button").click
       first("a[href='/admin/plugins/discourse-data-explorer/queries/#{query_b.id}']").click

--- a/plugins/discourse-data-explorer/spec/system/reports_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/reports_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Reports" do
     expect(page).not_to have_css(".query-results .result-header")
     find(".query-run .btn-primary").click
     expect(page).to have_css(".query-results .result-header")
+    expect(page).to have_css(".query-results-table-wrapper.--expanded")
 
     find(".group-reports-nav-item-outlet a").click
     all(".group-reports a ").last.click


### PR DESCRIPTION
Related: https://meta.discourse.org/t/explorer-reports-limited-to-5-rows-no-matter-how-much-data-you-have/401611

The results table in Data Explorer was constrained, showing only ~5 rows with internal scrolling even when there was plenty of page space. This affected both the admin query view and group reports view.

- When there's no chart (text-only columns, or chart toggled off), the table auto-expands to show all rows
- When there's an accompanying chart, default table height capped at 350px (matches chart height) with a chevron expand button to remove the limit


https://github.com/user-attachments/assets/186e2cfb-77cf-41d3-b91c-cd7b8dcf988e

