### PR TITLE
DEV: Don't print out Ember version in test env

### DIFF
--- a/frontend/discourse/config/environment.js
+++ b/frontend/discourse/config/environment.js
@@ -37,6 +37,7 @@ module.exports = function (environment) {
     ENV.locationType = "none";
 
     // keep test console output quieter
+    ENV.EmberENV.LOG_VERSION = false;
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 


### PR DESCRIPTION
Makes the failure output less noisy