### PR TITLE
UX: update icon to calendar-day

### DIFF
--- a/frontend/discourse/app/lib/time-shortcut.js
+++ b/frontend/discourse/app/lib/time-shortcut.js
@@ -112,7 +112,7 @@ export function timeShortcuts(timezone) {
     tomorrow() {
       return {
         id: TIME_SHORTCUT_TYPES.TOMORROW,
-        icon: "far-sun",
+        icon: "calendar-day",
         label: "time_shortcut.tomorrow",
         time: tomorrow(timezone),
         timeFormatKey: "dates.time_short_day",


### PR DESCRIPTION
Old:
<img width="590" height="618" alt="CleanShot 2026-04-28 at 11 11 22@2x" src="https://github.com/user-attachments/assets/33484248-6b9d-4025-8dc4-5e260a3f44dd" />

New:
<img width="588" height="636" alt="CleanShot 2026-04-28 at 11 10 13@2x" src="https://github.com/user-attachments/assets/41ffd6f0-0766-4076-affc-a4516311b01c" />
