### PR TITLE
FIX: allow my route for alphanumeric params

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -493,7 +493,7 @@ class UsersController < ApplicationController
   end
 
   def my_redirect
-    raise Discourse::NotFound if params[:path] !~ %r{\A[a-zA-Z_\-/]+\z}
+    raise Discourse::NotFound if params[:path] !~ %r{\A[a-zA-Z0-9_\-/]+\z}
 
     if current_user.blank?
       cookies[:destination_url] = path("/my/#{params[:path]}")

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4204,6 +4204,11 @@ RSpec.describe UsersController do
         get "/my/messages/group/#{group.name}"
         expect(response).to redirect_to("/u/#{user1.username}/messages/group/#{group.name}")
       end
+
+      it "works with alphanumeric params" do
+        get "/my/messages/tags/example-123"
+        expect(response).to redirect_to("/u/#{user1.username}/messages/tags/example-123")
+      end
     end
   end
 


### PR DESCRIPTION
Allows the special `/my/` route to work with alphanumeric params for things like tags or group names.

Internal ref - /t/182633