### PR TITLE
FIX: Routing from chat in subfolder setups

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Service, { service } from "@ember/service";
+import { withoutPrefix } from "discourse/lib/get-url";
 import KeyValueStore from "discourse/lib/key-value-store";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { MAIN_PANEL } from "discourse/lib/sidebar/panels";
@@ -184,13 +185,13 @@ export default class ChatStateManager extends Service {
   }
 
   get lastKnownAppURL() {
-    const url = this._appURL;
+    let url = this._appURL;
 
-    if (url && url !== "/") {
-      return url;
+    if (!url || url === "/") {
+      url = this.router.urlFor(`discovery.${defaultHomepage()}`);
     }
 
-    return this.router.urlFor(`discovery.${defaultHomepage()}`);
+    return withoutPrefix(url);
   }
 
   get lastKnownChatURL() {

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -209,6 +209,23 @@ RSpec.describe "Drawer" do
 
       expect(drawer_page).to have_open_channel(channel)
     end
+
+    it "returns to the homepage when toggling chat icon after expanding drawer to full page" do
+      SiteSetting.chat_separate_sidebar_mode = "fullscreen"
+      SiteSetting.top_menu = "categories|latest|new"
+
+      visit("/discuss/")
+      chat_page.open_from_header
+      expect(page).to have_css("body.has-drawer-chat")
+
+      drawer_page.maximize
+      expect(page).to have_css("body.has-full-page-chat")
+
+      find(".chat-header-icon").click
+
+      expect(page).to have_current_path("/discuss/categories")
+      expect(page).to have_no_css("body.has-full-page-chat")
+    end
   end
 
   context "when sending a message from a thread while viewing a topic" do


### PR DESCRIPTION
In some edge cases, returning to a forum route from a chat route was failing, with the subfolder appended twice in the URL. This fixes the issue by ensuring the `lastKnownAppURL` is stored without a prefix.