### PR TITLE
PERF: Skip locale param rewriting for upload paths in `CrawlerHooks`

### DIFF
--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -2,6 +2,8 @@
 
 module Middleware
   class CrawlerHooks
+    NON_LOCALIZABLE_PATH_PREFIXES = %w[/uploads/ /secure-uploads/ /secure-media-uploads/].freeze
+
     def initialize(app)
       @app = app
     end
@@ -32,6 +34,7 @@ module Middleware
           .css("a[href^='/'], a[href^='#{Discourse.base_url}']")
           .each do |link|
             uri = Addressable::URI.parse(link["href"])
+            next if non_localizable_path?(uri.path)
             uri.query_values = (uri.query_values || {}).merge(Discourse::LOCALE_PARAM => locale)
             link["href"] = uri.to_s
           end
@@ -41,6 +44,11 @@ module Middleware
       end
 
       response
+    end
+
+    def non_localizable_path?(path)
+      return false if path.blank?
+      NON_LOCALIZABLE_PATH_PREFIXES.any? { |prefix| path.start_with?(prefix) }
     end
   end
 end

--- a/spec/lib/middleware/crawler_hooks_spec.rb
+++ b/spec/lib/middleware/crawler_hooks_spec.rb
@@ -176,6 +176,49 @@ describe Middleware::CrawlerHooks do
       expect(response).to eq(html_response)
     end
 
+    it "does not append the locale param to upload download links" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_crawler_param = true
+
+      base_url = Discourse.base_url
+      html = [
+        "<html><body>" \
+          "<a href=\"/t/topic-slug/123\">Topic</a>" \
+          "<a href=\"/uploads/short-url/abc.zip\">Download</a>" \
+          "<a href=\"#{base_url}/uploads/default/original/1X/abc.png\">Image</a>" \
+          "<a href=\"/secure-uploads/original/1X/def.pdf\">Secure</a>" \
+          "<a href=\"/secure-media-uploads/original/1X/ghi.pdf\">Legacy secure</a>" \
+          "</body></html>",
+      ]
+      def html.body
+        join("")
+      end
+
+      test_env =
+        Rack::MockRequest.env_for(
+          "https://discourse.site/t/topic-slug/123",
+          params: {
+            Discourse::LOCALE_PARAM => "fr",
+          },
+        )
+      request = Rack::Request.new(test_env)
+
+      middleware_instance =
+        Middleware::CrawlerHooks.new(
+          lambda { |_| [200, { "X-Discourse-Crawler-View" => "true" }, []] },
+        )
+
+      transformed_response =
+        middleware_instance.send(:transform_response, request: request, response: html)
+
+      transformed = transformed_response.first
+      expect(transformed).to include("href=\"/t/topic-slug/123?#{Discourse::LOCALE_PARAM}=fr\"")
+      expect(transformed).to include("href=\"/uploads/short-url/abc.zip\"")
+      expect(transformed).to include("href=\"#{base_url}/uploads/default/original/1X/abc.png\"")
+      expect(transformed).to include("href=\"/secure-uploads/original/1X/def.pdf\"")
+      expect(transformed).to include("href=\"/secure-media-uploads/original/1X/ghi.pdf\"")
+    end
+
     it "modifies external links that start with the base URL" do
       SiteSetting.content_localization_enabled = true
       SiteSetting.content_localization_crawler_param = true


### PR DESCRIPTION
**Previously**, the `CrawlerHooks` middleware appended `?tl=<locale>` to every internal `<a>` href in the crawler-rendered HTML, including links to `/uploads/`, `/secure-uploads/`, and `/secure-media-uploads/` — which are binary file downloads where the locale param has no effect, but it created duplicate per-locale variants for crawlers to fetch.

**In this update**, paths under those prefixes are skipped during link rewriting so each upload has a single canonical URL.