### PR TITLE
DEV: Avoid halfvec mini_sql warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,12 +277,12 @@ jobs:
       - name: Check SKIP_DB_AND_REDIS bootability
         if: matrix.build_type == 'backend'
         run: |
-          if ! (SKIP_DB_AND_REDIS=1 DISCOURSE_DEV_DB="nonexist" bin/rails runner "puts 'booted successfully'"); then
+          if ! (SKIP_DB_AND_REDIS=1 RAILS_DB="nonexistent" bin/rails runner "puts 'booted successfully'"); then
             echo
             echo "---------------------------------------------"
             echo
             echo "::error::SKIP_DB_AND_REDIS boot failed. Make sure the database is not being accessed during the Rails boot process."
-            echo "To reproduce locally, run \`SKIP_DB_AND_REDIS=1 DISCOURSE_DEV_DB='nonexist' bin/rails runner \"puts 'booted successfully'\"\`."
+            echo "To reproduce locally, run \`SKIP_DB_AND_REDIS=1 RAILS_DB='nonexistent' bin/rails runner \"puts 'booted successfully'\"\`."
             echo
             exit 1
           fi

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -86,6 +86,13 @@ after_initialize do
     Rack::MiniProfiler.config.skip_paths << "/discourse-ai/ai-bot/artifacts"
   end
 
+  # Avoid a mini_sql warning ("no type cast defined") by registering a halfvec text decoder.
+  if !GlobalSetting.skip_db?
+    if halfvec_oid = DB.query_single("SELECT oid FROM pg_type WHERE typname = 'halfvec'").first
+      DB.type_map.add_coder(PG::TextDecoder::String.new(oid: halfvec_oid))
+    end
+  end
+
   # do not autoload this cause we may have no namespace
   require_relative "discourse_automation/llm_triage"
   require_relative "discourse_automation/llm_report"


### PR DESCRIPTION
A re-land of #39592.

In test env `DISCOURSE_DEV_DB` is ignored, `RAILS_DB` is used instead. So we weren't actually checking the code with a missing db.