### PR TITLE
UX: Ensure hidden upload field does not break layout

### DIFF
--- a/app/assets/stylesheets/common/base/upload.scss
+++ b/app/assets/stylesheets/common/base/upload.scss
@@ -213,8 +213,5 @@
 .hidden-upload-field {
   visibility: hidden;
   position: absolute;
-
-  .admin-backups-upload & {
-    width: 100%;
-  }
+  max-width: 100%;
 }


### PR DESCRIPTION
In the nested view on mobile, this was causing horizontal scrollbars to show. Max width ensures it doesn't exceed parent, in all contexts. 