### PR TITLE
UX: Onboarding style tweaks

### DIFF
--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -2,7 +2,7 @@
 @import "common/foundation/mixins";
 
 .admin-onboarding-banner {
-  margin-bottom: 1em;
+  margin-block: var(--space-8) var(--space-4);
   color: var(--secondary);
 
   @include viewport.until(sm) {

--- a/app/assets/stylesheets/common/login/omniauth-confirm.scss
+++ b/app/assets/stylesheets/common/login/omniauth-confirm.scss
@@ -168,7 +168,7 @@ body.no-ember:has(.omniauth-confirm) {
     &.btn-primary {
       background: var(--omniauth-primary);
       color: #fff;
-      border: none;
+      border: var(--d-button-primary-border);
 
       &:hover,
       &:focus {

--- a/themes/horizon/scss/desktop-full-width.scss
+++ b/themes/horizon/scss/desktop-full-width.scss
@@ -32,7 +32,7 @@ $sidebar-width: 17em;
 }
 
 .d-header #site-text-logo {
-  font-size: clamp(var(--font-0), 2.5vw, var(--font-up-2));
+  font-size: clamp(var(--font-0), 2.5vw, var(--font-up-1));
 
   .has-sidebar-page & {
     white-space: wrap;


### PR DESCRIPTION
This PR adjusts some minor styling issues.
- Adds spacing above onboarding banner
- Adds border to omniauth button to prevent shift on hover
- Reduces site logo text a bit so it plays nicely with longer names