### PR TITLE
DEV: Fix a chat archive edge-case

### DIFF
--- a/plugins/chat/lib/chat/channel_archive_service.rb
+++ b/plugins/chat/lib/chat/channel_archive_service.rb
@@ -135,7 +135,13 @@ module Chat
                 .to_a
 
             full_batch = (buffer + message_batch + threads).uniq { |msg| msg.id }
-            message_chunk = full_batch.group_by { |msg| msg.thread_id || msg.id }.values.flatten
+
+            # Namespacing the key prevents collisions between chat_message id and chat_thread id.
+            message_chunk =
+              full_batch
+                .group_by { |msg| msg.thread_id ? [:thread, msg.thread_id] : [:message, msg.id] }
+                .values
+                .flatten
 
             buffer.clear
 

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -277,7 +277,10 @@ module Chat
     private
 
     def group_messages(messages)
-      messages.group_by { |msg| msg.thread_id || msg.id }.values
+      # Namespacing the key prevents collisions between chat_message id and chat_thread id.
+      messages
+        .group_by { |msg| msg.thread_id ? [:thread, msg.thread_id] : [:message, msg.id] }
+        .values
     end
 
     def messages

--- a/plugins/chat/spec/lib/chat/transcript_service_spec.rb
+++ b/plugins/chat/spec/lib/chat/transcript_service_spec.rb
@@ -468,6 +468,35 @@ describe Chat::TranscriptService do
     MARKDOWN
   end
 
+  it "doesn't collapse a regular message into a thread group when their ids collide" do
+    regular_message = Fabricate(:chat_message, user: user1, chat_channel: channel)
+    thread =
+      Fabricate(
+        :chat_thread,
+        replies_count: 1,
+        id: regular_message.id,
+        original_message: Fabricate(:chat_message, user: user1, chat_channel: channel),
+      )
+    reply = Fabricate(:chat_message, user: user1, chat_channel: channel, thread: thread)
+
+    rendered = service([regular_message.id, thread.original_message.id, reply.id]).generate_markdown
+
+    expect(rendered).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{regular_message.id};#{regular_message.created_at.iso8601}" channel="The Beam Discussions" channelId="#{channel.id}" multiQuote="true"]
+    #{regular_message.message}
+    [/chat]
+
+    [chat quote="martinchat;#{thread.original_message.id};#{thread.original_message.created_at.iso8601}" threadId="#{thread.id}" threadTitle="#{I18n.t("chat.transcript.default_thread_title")}"]
+    #{thread.original_message.message}
+
+    [chat quote="martinchat;#{reply.id};#{reply.created_at.iso8601}"]
+    #{reply.message}
+    [/chat]
+
+    [/chat]
+    MARKDOWN
+  end
+
   it "doesn't add thread info for threads with no replies" do
     thread =
       Fabricate(


### PR DESCRIPTION
When a chat_message and chat_thread happened to share the same id, their archive could miss some thread messages or have a regular message show up in a middle of a thread.