### PR TITLE
DEV: Improve `Plugin::Instance#humanized_name`

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -183,7 +183,7 @@ class Plugin::Instance
   delegate :name, to: :metadata
 
   def humanized_name
-    (setting_category_name || name).sub(/\Adiscourse[\s-]+/i, "").gsub("-", " ").upcase_first
+    (setting_category_name || name).sub(/\Adiscourse[\s\-_]+/i, "").tr("-_", "  ").upcase_first
   end
 
   def add_to_serializer(

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -46,6 +46,11 @@ TEXT
       expect(plugin_instance.humanized_name).to eq("Sample plugin")
     end
 
+    it "converts underscores in the plugin name to spaces" do
+      plugin_instance.metadata.stubs(:name).returns("docker_manager")
+      expect(plugin_instance.humanized_name).to eq("Docker manager")
+    end
+
     it "removes any Discourse prefix from the setting category name" do
       TranslationOverride.upsert!(
         "en",


### PR DESCRIPTION
Replace underscores with spaces, so "docker_manger" becomes "Docker manager" instead of "Docker_manager"