### PR TITLE
UX: Surface upcoming-change default overrides via site setting filter

### DIFF
--- a/.skills/discourse-upcoming-changes-authoring/SKILL.md
+++ b/.skills/discourse-upcoming-changes-authoring/SKILL.md
@@ -127,7 +127,6 @@ When `increase_suggested_topics_max_days_old_default` is enabled (either manuall
 - **Non-destructive**: If an admin has manually set a custom value for the target setting, the override does not apply — it only affects the default.
 - **Reversible**: Disabling the upcoming change deactivates the override and restores the original default.
 - **Default-locale only**: Overrides currently only apply on the default locale.
-- **Related setting link**: `UpcomingChanges.find_related_default_override_for_change` finds the target setting for a given upcoming change, used to show cross-links in the UI.
 
 ## Key Design Decisions
 

--- a/app/services/upcoming_changes/list.rb
+++ b/app/services/upcoming_changes/list.rb
@@ -61,7 +61,10 @@ class UpcomingChanges::List
           :plugin,
         ).merge(
           dependents: UpcomingChanges.find_dependents_for_change(setting[:setting]),
-          related: UpcomingChanges.find_related_default_override_for_change(setting[:setting]),
+          overriding_defaults:
+            SiteSetting.upcoming_change_default_overrides.values.any? do |override|
+              override[:upcoming_change] == setting[:setting]
+            end,
         )
       end
   end

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -95,8 +95,15 @@ export default class UpcomingChangeItem extends Component {
     );
   }
 
-  get showRelatedSettingLink() {
-    return this.args.change.related && this.bufferedEnabledFor !== "no_one";
+  get showDefaultOverrideSettingLink() {
+    return (
+      this.args.change.overriding_defaults &&
+      this.bufferedEnabledFor !== "no_one"
+    );
+  }
+
+  get defaultOverrideSettingFilter() {
+    return `upcoming_change_default_override:${this.args.change.setting}`;
   }
 
   @action
@@ -359,11 +366,11 @@ export default class UpcomingChangeItem extends Component {
           </div>
         {{/if}}
 
-        {{#if this.showRelatedSettingLink}}
-          <div class="upcoming-change__related">
+        {{#if this.showDefaultOverrideSettingLink}}
+          <div class="upcoming-change__default-override-setting">
             <LinkTo
               @route="adminSiteSettings"
-              @query={{hash filter=@change.related}}
+              @query={{hash filter=this.defaultOverrideSettingFilter}}
             >
               {{i18n "admin.upcoming_changes.show_related_settings"}}
             </LinkTo>

--- a/frontend/discourse/admin/lib/site-setting-filter.js
+++ b/frontend/discourse/admin/lib/site-setting-filter.js
@@ -20,6 +20,7 @@ export default class SiteSettingFilter {
     opts.includeAllCategory ??= true;
 
     let pluginFilter;
+    let upcomingChangeDefaultOverrideFilter;
 
     if (filter) {
       filter = filter
@@ -32,6 +33,13 @@ export default class SiteSettingFilter {
 
           if (word.startsWith("plugin:")) {
             pluginFilter = word.slice("plugin:".length).trim();
+            return false;
+          }
+
+          if (word.startsWith("upcoming_change_default_override:")) {
+            upcomingChangeDefaultOverrideFilter = word
+              .slice("upcoming_change_default_override:".length)
+              .trim();
             return false;
           }
 
@@ -74,6 +82,14 @@ export default class SiteSettingFilter {
           }
 
           if (pluginFilter && siteSetting.plugin !== pluginFilter) {
+            return false;
+          }
+
+          if (
+            upcomingChangeDefaultOverrideFilter &&
+            siteSetting.get("upcoming_change_default_override_metadata")
+              ?.change_setting_name !== upcomingChangeDefaultOverrideFilter
+          ) {
             return false;
           }
 

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -12,7 +12,7 @@ function buildChange(overrides = {}) {
     value: true,
     plugin: null,
     dependents: [],
-    related: null,
+    overriding_defaults: false,
     groups: "",
     upcoming_change: {
       status: "beta",
@@ -71,9 +71,9 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
       .doesNotExist("does not show the dependent settings link");
   });
 
-  test("renders related setting link when related exists and enabled", async function (assert) {
+  test("renders default override setting link when overriding defaults and enabled", async function (assert) {
     const change = buildChange({
-      related: "some_other_setting",
+      overriding_defaults: true,
     });
 
     await render(
@@ -85,11 +85,11 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
     );
 
     assert
-      .dom(".upcoming-change__related a")
-      .exists("shows the related setting link");
+      .dom(".upcoming-change__default-override-setting a")
+      .exists("shows the default override setting link");
   });
 
-  test("does not render related setting link when related is null", async function (assert) {
+  test("does not render default override setting link when overriding defaults is false", async function (assert) {
     const change = buildChange();
 
     await render(
@@ -101,13 +101,13 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
     );
 
     assert
-      .dom(".upcoming-change__related")
-      .doesNotExist("does not show the related setting link");
+      .dom(".upcoming-change__default-override-setting")
+      .doesNotExist("does not show the default override setting link");
   });
 
-  test("does not render related setting link when enabled_for is no_one", async function (assert) {
+  test("does not render default override setting link when enabled_for is no_one", async function (assert) {
     const change = buildChange({
-      related: "some_other_setting",
+      overriding_defaults: true,
       upcoming_change: {
         status: "beta",
         impact: "feature,all_members",
@@ -126,8 +126,10 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
     );
 
     assert
-      .dom(".upcoming-change__related")
-      .doesNotExist("does not show the related setting link when disabled");
+      .dom(".upcoming-change__default-override-setting")
+      .doesNotExist(
+        "does not show the default override setting link when disabled"
+      );
   });
 
   test("renders the permanent soon notice when status is stable", async function (assert) {

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -373,15 +373,4 @@ module UpcomingChanges
   def self.find_dependents_for_change(change_setting_name)
     settings_provider.type_supervisor.dependencies.dependents(change_setting_name.to_s)
   end
-
-  # Some upcoming changes when enabled will override the default value
-  # of another setting.
-  #
-  # This is done via upcoming_change_default_override in site_settings.yml.
-  def self.find_related_default_override_for_change(change_setting_name)
-    settings_provider
-      .upcoming_change_default_overrides
-      .find { |_, override| override[:upcoming_change] == change_setting_name.to_sym }
-      &.first
-  end
 end

--- a/spec/services/upcoming_changes/list_spec.rb
+++ b/spec/services/upcoming_changes/list_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe UpcomingChanges::List do
         expect(mock_setting[:groups]).to eq("trust_level_0,trust_level_1")
       end
 
-      describe "related setting" do
+      describe "overriding defaults setting" do
         context "when an upcoming_change_default_override points to the change" do
           before do
             mock_upcoming_change_default_overrides(
@@ -100,17 +100,17 @@ RSpec.describe UpcomingChanges::List do
             )
           end
 
-          it "includes the related setting name" do
+          it "includes overriding_defaults as true" do
             results = result.upcoming_changes
             mock_setting = results.find { |change| change[:setting] == :enable_upload_debug_mode }
-            expect(mock_setting[:related]).to eq(:suggested_topics_max_days_old)
+            expect(mock_setting[:overriding_defaults]).to eq(true)
           end
         end
 
-        it "returns nil for related when no upcoming_change_default_override points to the change" do
+        it "returns false for overriding_defaults when no upcoming_change_default_override points to the change" do
           results = result.upcoming_changes
           mock_setting = results.find { |change| change[:setting] == :allow_user_locale }
-          expect(mock_setting[:related]).to be_nil
+          expect(mock_setting[:overriding_defaults]).to eq(false)
         end
       end
 


### PR DESCRIPTION
Replaces the single `related` setting lookup on UpcomingChanges::List
with an `overriding_defaults` boolean, and renders the admin UI link
through a new `upcoming_change_default_override:<change>` token in
SiteSettingFilter. This lets a single upcoming change link to all
settings whose defaults it overrides, not just the first one found.
