### PR TITLE
DEV: Modal PageObject improvements

### DIFF
--- a/spec/system/page_objects/modals/base.rb
+++ b/spec/system/page_objects/modals/base.rb
@@ -9,36 +9,57 @@ module PageObjects
       BODY_SELECTOR = ""
       MODAL_SELECTOR = ""
 
+      def initialize(body_selector: MODAL_SELECTOR, modal_selector: MODAL_SELECTOR)
+        # This can be used as an alternative to making a whole new
+        # modal PageObject when there isn't a lot of specific custom stuff
+        # in that modal's UI -- in many cases just having the modal scoping
+        # is enough.
+        @body_selector = body_selector
+        @modal_selector = modal_selector
+      end
+
+      def full_body_selector
+        ".d-modal__body#{@body_selector}"
+      end
+
+      def full_modal_selector
+        ".modal.d-modal#{@modal_selector}"
+      end
+
+      def footer_selector
+        "#{full_modal_selector} .d-modal__footer"
+      end
+
       def header
         find(".d-modal__header")
       end
 
       def body
-        find(".d-modal__body#{BODY_SELECTOR}")
+        find(full_body_selector)
       end
 
       def footer
-        find(".d-modal__footer")
+        find(footer_selector)
       end
 
       def has_footer?
-        has_css?(".d-modal__footer")
+        has_css?(footer_selector)
       end
 
       def has_no_footer?
-        has_no_css?(".d-modal__footer")
+        has_no_css?(footer_selector)
       end
 
       def close
-        find(".modal-close").click
+        find("#{full_modal_selector} .modal-close").click
       end
 
       def cancel
-        find(".d-modal-cancel").click
+        find("#{full_modal_selector} .d-modal-cancel").click
       end
 
       def click_outside
-        find(".d-modal").click(x: 0, y: 0)
+        find("#{full_modal_selector}").click(x: 0, y: 0)
       end
 
       def click_primary_button
@@ -50,11 +71,11 @@ module PageObjects
       end
 
       def open?
-        has_css?(".modal.d-modal#{MODAL_SELECTOR}")
+        has_css?(full_modal_selector)
       end
 
       def closed?
-        has_no_css?(".modal.d-modal#{MODAL_SELECTOR}")
+        has_no_css?(full_modal_selector)
       end
     end
   end


### PR DESCRIPTION
Allows initializing the Modals::Base page object
with body_selector and modal_selector arguments.

This can be used as an alternative to making a whole new
modal PageObject and using BODY_SELECTOR and MODAL_SELECTOR
consts when there isn't a lot of specific custom stuff
in that modal's UI -- in many cases just having the modal scoping
is enough.

Also made the specificity of the CSS selectors a little better
and exposed the full selectors as public methods.
