### PR TITLE
FIX: Ensure moderators do not clear group email domain

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -69,6 +69,7 @@ class Admin::GroupsController < Admin::StaffController
   end
 
   def automatic_membership_count
+    raise Discourse::InvalidAccess unless guardian.can_create_group?
     domains = Group.get_valid_email_domains(params.require(:automatic_membership_email_domains))
     group_id = params[:id]
     user_count = 0

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -69,7 +69,7 @@ class Admin::GroupsController < Admin::StaffController
   end
 
   def automatic_membership_count
-    raise Discourse::InvalidAccess unless guardian.can_create_group?
+    guardian.ensure_can_create_group!
     domains = Group.get_valid_email_domains(params.require(:automatic_membership_email_domains))
     group_id = params[:id]
     user_count = 0

--- a/app/serializers/group_show_serializer.rb
+++ b/app/serializers/group_show_serializer.rb
@@ -20,8 +20,13 @@ class GroupShowSerializer < BasicGroupSerializer
 
   has_one :smtp_updated_by, embed: :object, serializer: BasicUserSerializer
 
-  admin_attributes :automatic_membership_email_domains,
-                   :smtp_server,
+  attributes :automatic_membership_email_domains
+
+  def include_automatic_membership_email_domains?
+    scope.can_admin_group?(object)
+  end
+
+  admin_attributes :smtp_server,
                    :smtp_port,
                    :smtp_ssl_mode,
                    :smtp_enabled,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,10 +128,9 @@ Discourse::Application.routes.draw do
           delete "owners" => "groups#remove_owner"
           put "primary" => "groups#set_primary"
         end
-      end
-      resources :groups, only: [:destroy], constraints: AdminConstraint.new do
         collection { put "automatic_membership_count" => "groups#automatic_membership_count" }
       end
+      resources :groups, only: [:destroy], constraints: AdminConstraint.new
 
       resources :users, id: RouteFormat.username, only: %i[index destroy] do
         collection do

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -495,13 +495,32 @@ RSpec.describe Admin::GroupsController do
       context "with moderators_manage_groups enabled" do
         before { SiteSetting.moderators_manage_groups = true }
 
-        include_examples "automatic membership count inaccessible"
+        it "returns count of users whose emails match the domain" do
+          Fabricate(:user, email: "user1@somedomain.org")
+
+          put "/admin/groups/automatic_membership_count.json",
+              params: {
+                automatic_membership_email_domains: "somedomain.org",
+                id: group.id,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["user_count"]).to eq(1)
+        end
       end
 
       context "with moderators_manage_groups disabled" do
         before { SiteSetting.moderators_manage_groups = false }
 
-        include_examples "automatic membership count inaccessible"
+        it "denies access with a 403 response" do
+          put "/admin/groups/automatic_membership_count.json",
+              params: {
+                automatic_membership_email_domains: "somedomain.org",
+                id: group.id,
+              }
+
+          expect(response.status).to eq(403)
+        end
       end
     end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -535,6 +535,22 @@ RSpec.describe GroupsController do
     describe "when accessing by id" do
       include_examples "group show behavior", "/groups/by-id", :id
     end
+
+    context "as a moderator with moderators_manage_groups enabled" do
+      before { SiteSetting.moderators_manage_groups = true }
+
+      it "includes automatic_membership_email_domains in the response" do
+        group.update!(automatic_membership_email_domains: "test.org")
+        sign_in(moderator)
+
+        get "/groups/#{group.name}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["group"]["automatic_membership_email_domains"]).to eq(
+          "test.org",
+        )
+      end
+    end
   end
 
   describe "#mentions" do

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe GroupShowSerializer do
 
     it "should include email domains for moderator when moderators_manage_groups is enabled" do
       SiteSetting.moderators_manage_groups = true
-      moderator_guardian = Guardian.new(Fabricate(:moderator))
+      moderator_guardian = Fabricate(:moderator).guardian
       subject =
         described_class.new(
           group,

--- a/spec/serializers/group_show_serializer_spec.rb
+++ b/spec/serializers/group_show_serializer_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe GroupShowSerializer do
         described_class.new(group, scope: Guardian.new, root: false, owner_group_ids: [group.id])
       expect(subject.as_json[:automatic_membership_email_domains]).to eq(nil)
     end
+
+    it "should include email domains for moderator when moderators_manage_groups is enabled" do
+      SiteSetting.moderators_manage_groups = true
+      moderator_guardian = Guardian.new(Fabricate(:moderator))
+      subject =
+        described_class.new(
+          group,
+          scope: moderator_guardian,
+          root: false,
+          owner_group_ids: [group.id],
+        )
+      expect(subject.as_json[:automatic_membership_email_domains]).to eq("ilovediscourse.com")
+    end
   end
 
   describe "admin only fields" do


### PR DESCRIPTION
When a moderator (who can manage groups via `moderators_manage_groups`) edits a group's profile and saves, the `automatic_membership_email_domains` gets silently cleared now.

One issue that leads to another:
- `GroupShowSerializer gated automatic_membership_email_domains` behind `is_admin?`, so moderators never received the value. The frontend model defaulted to "", and on save ... 💥 (it gets cleared)
- -> Then, the "save" flow calls `/admin/groups/automatic_membership_count.json` to check if new users would be auto-added, but that route sat behind `AdminConstraint`, so moderators got a 404.

This PR fixes by using `can_admin_group?` visibility check (covers admins + moderators with the setting enabled), and moving the `automatic_membership_count` route to the staff-accessible block + adding a `can_create_group?` guard in the controller so moderators without moderators_manage_groups still can't access it.