### PR TITLE
UX: Open bulk manage tags replace tag choosers above field on mobile

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -31,6 +31,17 @@
     pointer-events: none;
   }
 
+  &.is-placed-above.is-expanded {
+    .select-kit-body {
+      flex-direction: column-reverse;
+    }
+
+    .select-kit-collection {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+  }
+
   &.is-expanded {
     z-index: z("dropdown");
 

--- a/frontend/discourse/app/components/modal/bulk-topic-actions/manage-tags-form.gjs
+++ b/frontend/discourse/app/components/modal/bulk-topic-actions/manage-tags-form.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import Form from "discourse/components/form";
 import icon from "discourse/helpers/d-icon";
+import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
 
 export default class ManageTagsForm extends Component {
@@ -42,6 +43,15 @@ export default class ManageTagsForm extends Component {
   blockedTagsFor(rows, index, side) {
     const tags = rows?.[index]?.[side];
     return tags?.length ? tags : undefined;
+  }
+
+  @bind
+  mobilePlacementForReplaceRowTagChooser(rows, index) {
+    const rowsBelow = rows.length - 1 - index;
+    if (rowsBelow < 3) {
+      return "top";
+    }
+    return null;
   }
 
   @action
@@ -228,6 +238,10 @@ export default class ManageTagsForm extends Component {
                     index
                     "to"
                   }}
+                  @mobilePlacement={{this.mobilePlacementForReplaceRowTagChooser
+                    transientData.replace_rows
+                    index
+                  }}
                 />
               </collection.Field>
             </row.Col>
@@ -256,6 +270,10 @@ export default class ManageTagsForm extends Component {
                     transientData.replace_rows
                     index
                     "from"
+                  }}
+                  @mobilePlacement={{this.mobilePlacementForReplaceRowTagChooser
+                    transientData.replace_rows
+                    index
                   }}
                 />
               </collection.Field>

--- a/frontend/discourse/app/form-kit/components/fk/control/tag-chooser.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/tag-chooser.gjs
@@ -26,6 +26,7 @@ export default class FKControlTagChooser extends FKBaseControl {
         disabled=@field.disabled
         filterPlaceholder=@placeholder
         maximum=@maximum
+        mobilePlacement=@mobilePlacement
       }}
       class="form-kit__control-tag-chooser"
     />

--- a/frontend/discourse/select-kit/components/select-kit.js
+++ b/frontend/discourse/select-kit/components/select-kit.js
@@ -127,6 +127,7 @@ function protoProp(prototype, key, descriptor) {
 @classNameBindings(
   "selectKit.isLoading:is-loading",
   "selectKit.isExpanded:is-expanded",
+  "selectKit.isPlacedAbove:is-placed-above",
   "selectKit.options.disabled:is-disabled",
   "selectKit.isHidden:is-hidden",
   "selectKit.hasSelection:has-selection"
@@ -161,6 +162,7 @@ function protoProp(prototype, key, descriptor) {
   autofocus: false,
   placementStrategy: null,
   mobilePlacementStrategy: null,
+  mobilePlacement: null,
   desktopPlacementStrategy: null,
   hiddenValues: null,
   disabled: false,
@@ -214,6 +216,7 @@ export default class SelectKit extends Component {
         isLoading: false,
         isHidden: false,
         isExpanded: false,
+        isPlacedAbove: false,
         isFilterExpanded: false,
         enterDisabled: false,
         hasSelection: false,
@@ -959,6 +962,7 @@ export default class SelectKit extends Component {
 
     this.selectKit.setProperties({
       isExpanded: false,
+      isPlacedAbove: false,
       filter: null,
     });
   }
@@ -972,16 +976,12 @@ export default class SelectKit extends Component {
     this.clearErrors();
     this.selectKit.onOpen(event);
 
-    if (this.site.desktopView) {
-      this.cleanupFloatingUi?.();
-      this.cleanupFloatingUi = autoUpdate(
-        this.getHeader(),
-        this._bodyElement(),
-        () => this.updateFloatingUiPosition()
-      );
-    } else {
-      this.updateFloatingUiPosition();
-    }
+    this.cleanupFloatingUi?.();
+    this.cleanupFloatingUi = autoUpdate(
+      this.getHeader(),
+      this._bodyElement(),
+      () => this.updateFloatingUiPosition()
+    );
 
     this.selectKit.setProperties({
       isExpanded: true,
@@ -1094,11 +1094,11 @@ export default class SelectKit extends Component {
       hide(),
     ];
 
-    computePosition(referenceElement, floatingElement, {
-      placement: this.selectKit.options.placement,
+    return computePosition(referenceElement, floatingElement, {
+      placement: this._computePlacement(),
       strategy,
       middleware,
-    }).then(({ x, y, middlewareData }) => {
+    }).then(({ x, y, placement, middlewareData }) => {
       const style = {
         width,
         minWidth,
@@ -1117,6 +1117,7 @@ export default class SelectKit extends Component {
         }
       }
 
+      this.selectKit.set("isPlacedAbove", placement.startsWith("top"));
       Object.assign(floatingElement.style, style);
     });
   }
@@ -1210,6 +1211,14 @@ export default class SelectKit extends Component {
     }
 
     return placementStrategy;
+  }
+
+  _computePlacement() {
+    if (this.site.mobileView && this.selectKit.options.mobilePlacement) {
+      return this.selectKit.options.mobilePlacement;
+    }
+
+    return this.selectKit.options.placement;
   }
 
   _deprecated(text) {

--- a/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import { find, render, tab } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DButton from "discourse/components/d-button";
+import { forceMobile } from "discourse/lib/mobile";
 import SingleSelect from "discourse/select-kit/components/single-select";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -504,6 +505,30 @@ module("Integration | Component | select-kit/single-select", function (hooks) {
     const body = find(".select-kit-body").getBoundingClientRect();
 
     assert.true(header.bottom > body.top, "correctly offsets the body");
+  });
+
+  test("options.mobilePlacement", async function (assert) {
+    forceMobile();
+    setDefaultState(this);
+
+    await render(
+      <template>
+        <div style="position: fixed; top: 50%; left: 0; right: 0;">
+          <SingleSelect
+            @value={{this.value}}
+            @content={{this.content}}
+            @options={{hash mobilePlacement="top"}}
+          />
+        </div>
+      </template>
+    );
+    await this.subject.expand();
+
+    const header = find(".select-kit-header").getBoundingClientRect();
+    const body = find(".select-kit-body").getBoundingClientRect();
+
+    assert.true(body.bottom < header.top, "body opens above the header");
+    assert.dom(".select-kit").hasClass("is-placed-above");
   });
 
   test("options.expandedOnInsert", async function (assert) {


### PR DESCRIPTION
Opening either tag chooser in the bulk manage tags modal for tag replacement on mobile opened the tag chooser below the trigger where there isn't sufficient vertical space to display select-kit's full content. 

This commit introduces a `mobilePlacement` option on select-kit and where we set `top` so that the tag-chooser dropdown will be rendered above the  trigger. 

#### Before

<img width="350" height="629" alt="Screenshot 2026-05-04 at 7 40 15 PM" src="https://github.com/user-attachments/assets/24b9e7ce-d88e-47d0-a6ed-7f69830a15eb" />

#### After

<img width="348" height="594" alt="Screenshot 2026-05-04 at 7 40 41 PM" src="https://github.com/user-attachments/assets/824db83f-7f00-4ba3-a694-021a451d31f7" />

https://github.com/user-attachments/assets/a469bb2f-24d2-4ad2-b7d0-27046ef3a089


