### PR TITLE
UX: post liked users mobile header fix

### DIFF
--- a/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
+++ b/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
@@ -1,7 +1,8 @@
 @use "lib/viewport";
 
 // specific d-modal overrules
-.fk-d-menu-modal.discourse-reactions-users-menu-content {
+.fk-d-menu-modal.discourse-reactions-users-menu-content,
+.fk-d-menu-modal.post-liked-users-menu-content {
   .d-modal {
     &__container {
       height: clamp(50dvh, 50dvh, 60dvh);


### PR DESCRIPTION
Makes the likes/reaction panel styles (mobile modal height and fixing padding issue) apply when the reactions plugin is disabled.

_Noting that I haven't done it here, but we may want to adjust the naming of this stylesheet to prevent confusion in the future as it covers both reactions and regular likes._

## Before

<img width="390" height="424" alt="Screenshot 2026-04-29 at 11 31 59 AM" src="https://github.com/user-attachments/assets/4e650208-ee54-4e2c-8d3d-25ab46bb396b" />

## After

<img width="391" height="660" alt="Screenshot 2026-04-29 at 11 32 18 AM" src="https://github.com/user-attachments/assets/307bd406-0857-4240-a9ae-f8e087776fc2" />
