### PR TITLE
Allow mapping of OpenID Connect groups to Discourse Groups and add openid_connect_match_by_username option

### DIFF
--- a/plugins/discourse-openid-connect/config/locales/server.en.yml
+++ b/plugins/discourse-openid-connect/config/locales/server.en.yml
@@ -18,6 +18,16 @@ en:
     openid_connect_groups_claim: "The name of the claim in the OIDC token that contains the user's groups as an array of strings. Leave blank to disable group syncing."
     openid_connect_match_by_email: "Use email address to match OpenID Connect authentications to existing Discourse user accounts."
     openid_connect_use_pkce: "Enable Proof Key for Code Exchange (PKCE) for OpenID Connect authentication."
+    openid_connect_match_by_username: "Use username to match OpenID Connect authentications to existing Discourse user accounts. username_change_period must be 0."
+    openid_connect_groups_enabled: "Enable group membership from mapping of OpenID Connect group membership."
+    openid_connect_groups_maps: "Mappings of OpenID Connect group names to comma-separated list of discourse group names, e.g. '/keycloak-developers:discourse_devgroup_members,discourse_usergroup_moderators' will add a user in keycloak group '/keycloak-developers' to both groups 'discourse_devgroup_members' and 'discourse_usergroup_moderators'.  Discourse groups can appear more than once."
+    openid_connect_groups_remove_unmapped_groups: "If user is not in any OpenID Connect group that maps to a discourse group, remove existing membership from that discourse group.  Only groups set in openid_connect_groups_maps will be removed."
+    openid_connect_gitlab_override_if_user_exists: "If the user exists in gitlab, use group membership decisions from that and ignore the OpenID Connect group membership."
+    openid_connect_gitlab_api_base: "API base for your gitlab instance, e.g. https://gitlab.example.com/api/v4 .  Uses env DISCOURSE_OPENID_CONNECT_GITLAB_API_BASE if not set here."
+    openid_connect_gitlab_api_private_token: "API private token for Gitlab access.  Uses env DISCOURSE_OPENID_CONNECT_GITLAB_API_PRIVATE_TOKEN (recommended) if not set here."
+    openid_connect_groups_gitlab_repository_role_maps: "'Minimum role value;Project name' to Group mapping (Developer value is 30, see https://docs.gitlab.com/api/members/ ), e.g 'excalibur-devs-group:30;Camelot/excalibur'"
+    openid_connect_gitlab_remove_unmapped_groups: "Remove group access if a 'minimum role value;Project name' is not met."
+    openid_connect_gitlab_api_verbose_log: "Verbose logs for Gitlab API project/role check."
   login:
     omniauth_error:
       openid_connect_discovery_error: Unable to fetch configuration from identity provider. Please try again.

--- a/plugins/discourse-openid-connect/config/settings.yml
+++ b/plugins/discourse-openid-connect/config/settings.yml
@@ -59,3 +59,29 @@ discourse_openid_connect:
   openid_connect_use_pkce:
     default: false
     area: "oidc"
+  openid_connect_match_by_username:
+    default: false
+  openid_connect_groups_enabled:
+    default: false
+    client: true
+  openid_connect_groups_maps:
+    default: ""
+    type: list
+    list_type: simple
+  openid_connect_groups_remove_unmapped_groups:
+    default: true
+  openid_connect_gitlab_override_if_user_exists:
+    default: true
+  openid_connect_gitlab_api_base:
+    default: ""
+  openid_connect_gitlab_api_private_token:
+    default: ""
+    secret: true
+  openid_connect_groups_gitlab_repository_role_maps:
+    default: ""
+    type: list
+    list_type: simple
+  openid_connect_gitlab_remove_unmapped_groups:
+    default: true
+  openid_connect_gitlab_api_verbose_log:
+    default: false

--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -203,6 +203,7 @@ module OmniAuth
           last_name: data_source["family_name"],
           nickname: data_source["preferred_username"],
           image: data_source["picture"],
+          groups: data_source["groups"],
         )
       end
 

--- a/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
+++ b/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
@@ -172,4 +172,266 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
   def request_timeout_seconds
     GlobalSetting.openid_connect_request_timeout_seconds
   end
+
+  def match_by_username
+    SiteSetting.openid_connect_match_by_username
+  end
+
+
+  def _redact_uri(uri)
+    redacted_uri = uri.clone
+    redacted_uri.query = URI.encode_www_form( Hash[URI.decode_www_form(uri.query)].merge( { "private_token" => "xxxxxx" } ) )
+    return redacted_uri
+  end
+
+  def set_oidc_mapped_groups(user, auth)
+    return unless SiteSetting.openid_connect_groups_enabled
+
+    if !(auth && auth.dig(:extra, :raw_info, :groups))
+      oidc_log("OpenID Connect groups enabled but no group information passed by provider. Not changing groups.")
+      return
+    end
+
+    user_oidc_groups = auth[:extra][:raw_info][:groups]
+    group_map = {}
+    check_groups = {}
+
+    SiteSetting.openid_connect_groups_maps.split("|").each do |map|
+      keyval = map.split(":", 2)
+      group_map[keyval[0]] = keyval[1]
+      keyval[1].split(",").each { |discourse_group|
+        check_groups[discourse_group] = 0
+      }
+    end
+
+    if !(user_oidc_groups == nil || group_map.empty?)
+      user_oidc_groups.each { |user_oidc_group|
+        if group_map.has_key?(user_oidc_group) #??? || !SiteSetting.openid_connect_groups_remove_unmapped_groups
+          result = nil
+
+          discourse_groups = group_map[user_oidc_group] || ""
+          discourse_groups.split(",").each { |discourse_group|
+            next unless discourse_group
+
+            actual_group = Group.find_by(name: discourse_group)
+            if (!actual_group)
+              oidc_log("OIDC group '#{user_oidc_group}' maps to Group '#{discourse_group}' but this does not seem to exist")
+              next
+            end
+            if actual_group.automatic # skip if it's an auto_group
+              oidc_log("Group '#{discourse_group}' is an automatic, cannot change membership")
+              next
+            end
+            check_groups[discourse_group] = 1
+            result = actual_group.add(user)
+            oidc_log("OIDC group '#{user_oidc_group}' mapped to Group '#{discourse_group}'. User '#{user.username}' has been added") if result
+          }
+        end
+      }
+    end
+
+    if SiteSetting.openid_connect_groups_remove_unmapped_groups
+      check_groups.keys.each { |discourse_group|
+        actual_group = Group.find_by(name: discourse_group)
+        if check_groups[discourse_group] > 0
+          next
+        end
+        if !actual_group
+          oidc_log("DEBUG: Group '#{discourse_group}' can't be found, cannot remove user '#{user.username}'")
+          next
+        end
+        if actual_group.automatic # skip if it's an auto_group
+          oidc_log("DEBUG: Group '#{discourse_group}' is automatic, cannot change membership")
+          next
+        end
+        result = actual_group.remove(user)
+        oidc_log("DEBUG: User '#{user.username}' removed from Group '#{discourse_group}'") if result
+      }
+    end
+  end
+
+  def get_gitlab_user_id(gitlab_api_uri, private_token, username)
+    user_id = -1
+    token_hash = { :private_token => private_token }
+
+    user_uri = URI("#{gitlab_api_uri}/users")
+    user_uri.query = URI.encode_www_form( token_hash.merge({ :username => username, :humans => "true", :active => "true" }) )
+    oidc_log("GET #{_redact_uri(user_uri).to_s}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+
+    connection =
+      Faraday.new(request: { timeout: 10 }) do |c|
+        c.use Faraday::Response::RaiseError
+        c.adapter FinalDestination::FaradayAdapter
+      end
+
+    user_json = JSON.parse(connection.get(user_uri).body)
+
+    if (user_json.kind_of?(Array) and user_json.length > 0)
+      user_json = user_json[0]
+      oidc_log("User JSON=#{user_json}")
+      user_id = user_json["id"]
+      oidc_log("User ID=#{user_id}")
+    else
+      oidc_log("No user data returned")
+    end
+  rescue Faraday::Error, JSON::ParserError => e
+    oidc_log("Fetching from gitlab api raised error #{e.class} #{e.message}", error: true)
+  ensure
+    return user_id
+  end
+
+  def set_gitlab_mapped_groups(user)
+    return false unless SiteSetting.openid_connect_gitlab_override_if_user_exists
+
+    gitlab_api_uri = SiteSetting.openid_connect_gitlab_api_base || GlobalSetting.try(:openid_connect_gitlab_api_base)
+    gitlab_api_private_token = SiteSetting.openid_connect_gitlab_api_private_token || GlobalSetting.try(:openid_connect_gitlab_api_private_token)
+    gitlab_user = user.username
+
+    gitlab_user_id = get_gitlab_user_id(gitlab_api_uri, gitlab_api_private_token, gitlab_user)
+    oidc_log("User '#{user.username}' has Gitlab User ID #{gitlab_user_id}")
+
+    return false if gitlab_user_id < 0
+
+    group_map = {}
+    check_groups = {}
+
+    SiteSetting.openid_connect_groups_gitlab_repository_role_maps.split("|").each do |map|
+      keyval = map.split(":", 2)
+      group_map[keyval[0]] = keyval[1]
+      keyval[1].split(",").each do |discourse_group|
+        check_groups[discourse_group] = 0
+      end
+    end
+
+    add_groups = {}
+
+    group_map.keys.each do |role_repo_string|
+      discourse_groups = group_map[role_repo_string] || ""
+      role_repo = role_repo_string.split(";", 2)
+
+      add_these_groups = []
+
+      discourse_groups.split(",").each do |discourse_group|
+        next unless discourse_group
+
+        actual_group = Group.find_by(name: discourse_group)
+        if (!actual_group)
+          oidc_log("Gitlab role/repo '#{role_repo[0]}/#{role_repo[1]}' maps to Group '#{discourse_group}' but this does not seem to exist")
+          next
+        end
+        if actual_group.automatic # skip if it's an auto_group
+          oidc_log("Group '#{discourse_group}' is an automatic, cannot change membership")
+          next
+        end
+        add_these_groups.push(actual_group)
+      end
+
+      if add_these_groups.length > 0
+        begin
+          projectname = role_repo[1]
+          min_access_level = Integer(role_repo[0])
+          has_access = check_gitlab_user_has_access(gitlab_api_uri, gitlab_api_private_token, gitlab_user_id, projectname, min_access_level)
+          if has_access
+            add_these_groups.each do |actual_group|
+              add_groups[actual_group] = 1
+              oidc_log("Gitlab role/repo '#{role_repo[0]}/#{role_repo[1]}' maps to Group '#{actual_group.name}'. User '#{user.username}' will be added")
+              check_groups[actual_group.name] = 1
+            end
+          end
+        rescue ArgumentError => e
+          oidc_log("Checking Gitlab minimum access level raised error #{e.class} #{e.message}", error: true)
+        end
+      end
+    end
+
+    add_groups.keys.each do |actual_group|
+      result = actual_group.add(user)
+      oidc_log("Adding User '#{user.username}' to Group '#{actual_group.name}'") if result
+    end
+
+    if SiteSetting.openid_connect_gitlab_remove_unmapped_groups
+      check_groups.keys.each { |discourse_group|
+        if check_groups[discourse_group] > 0
+          next
+        end
+        actual_group = Group.find_by(name: discourse_group)
+        if !actual_group
+          oidc_log("Group '#{discourse_group}' can't be found, cannot remove user '#{user.username}'")
+          next
+        end
+        if actual_group.automatic # skip if it's an auto_group
+          oidc_log("Group '#{discourse_group}' is automatic, cannot change membership")
+          next
+        end
+        result = actual_group.remove(user)
+        oidc_log("User '#{user.username}' removed from discourse_group '#{discourse_group}'") if result
+      }
+    end
+
+    return true
+  end
+
+  def check_gitlab_user_has_access(gitlab_api_uri, private_token, user_id, repo_string, min_access_level)
+    token_hash = { :private_token => private_token }
+    repo_uri = URI("#{gitlab_api_uri}/projects/#{URI.encode_www_form_component(repo_string)}/members/all/#{user_id}")
+    repo_uri.query = URI.encode_www_form( token_hash )
+    oidc_log("GET #{_redact_uri(repo_uri).to_s}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+
+    connection =
+      Faraday.new(request: { timeout: 10 }) do |c|
+        c.use Faraday::Response::RaiseError
+        c.adapter FinalDestination::FaradayAdapter
+      end
+
+      repo_json = JSON.parse(connection.get( repo_uri ).body)
+
+    access_level = 0
+    if (repo_json.kind_of?(Hash) and repo_json.key?("access_level"))
+      oidc_log("Repo JSON=#{repo_json}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+      oidc_log("Access Level: #{repo_json["access_level"]}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+      access_level = repo_json["access_level"]
+    else
+      oidc_log("No user info for repo") if SiteSetting.openid_connect_gitlab_api_verbose_log
+      return false
+    end
+
+    if (access_level >= min_access_level)
+      oidc_log("User ID #{user_id} HAS minimum access to #{repo_string}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+      return true
+    else
+      oidc_log("User ID #{user_id} DOES NOT have minimum access to #{repo_string}") if SiteSetting.openid_connect_gitlab_api_verbose_log
+      return false
+    end
+  rescue Faraday::Error, JSON::ParserError => e
+    oidc_log("Fetching from gitlab api raised error #{e.class} #{e.message}", error: true)
+    return false
+  end
+
+  def set_groups(user, auth)
+    has_gitlab_user = false
+
+    # gitlab
+    if SiteSetting.openid_connect_gitlab_override_if_user_exists
+      has_gitlab_user = set_gitlab_mapped_groups(user)
+    end
+
+    # oidc
+    if !has_gitlab_user and SiteSetting.openid_connect_groups_enabled
+      set_oidc_mapped_groups(user, auth)
+    end
+  end
+
+  def after_authenticate(auth, existing_account: nil)
+    result = super(auth, existing_account: existing_account)
+    if result.user != nil
+      set_groups(result.user, auth)
+    end
+    result
+  end
+
+  def after_create_account(user, auth)
+    super(user, auth)
+    set_groups(user, auth)
+  end
+
 end


### PR DESCRIPTION
This PR allows mapping of OpenID Connect group membership to Discourse Group membership.
Of mapped Discourse groups, membership is (optionally) removed if the corresponding OpenID Connect group membership is not present.

This is a feature requested several times
(e.g.
https://meta.discourse.org/t/mapping-groups-or-roles-using-keycloak/304277
https://meta.discourse.org/t/does-sso-overrides-groups-work-with-oauth2/175606/13
https://meta.discourse.org/t/managing-group-membership-via-authentication/175950/32 [and others above])
and additionally at
https://meta.discourse.org/t/discourse-openid-connect-oidc/103632/320 since original PR was submitted.

and the feature has been mentioned as #pr-welcome
(https://meta.discourse.org/t/managing-group-membership-via-authentication/175950/30).

I've also added in a match_by_username option since this fits our use-case migrating from Crowd.

Apologies if the code is insufficient, I'm not a native ruby developer! If tests are required please could you point me at documentation that might help me with writing those?

@davidtaylorhq would it be possible to review this PR?

Thank you!

PS Thanks for Discourse!

Original PR submitted https://github.com/discourse/discourse/pull/34763 was closed.
Codebase and PR is now updated for Discourse 2026.5.0

@Dav