### PR TITLE
UX: Minor improvements to user api key flow

### DIFF
--- a/app/views/user_api_keys/new.html.erb
+++ b/app/views/user_api_keys/new.html.erb
@@ -21,6 +21,12 @@
     </ul>
   </div>
 
+  <% if @scopes&.split(",")&.include?("write") %>
+  <div class='authorize-api-key__write-warning alert alert-warning'>
+    <p><%= t("user_api_key.write_scope_warning") %></p>
+  </div>
+  <% end %>
+
   <% if @redirect_uri %>
   <div class='authorize-api-key__redirect'>
     <p class="authorize-api-key__redirect-url">

--- a/app/views/user_api_keys/show.html.erb
+++ b/app/views/user_api_keys/show.html.erb
@@ -1,4 +1,4 @@
-<p><%= t("user_api_key.instructions", application_name: @application_name) %></p>
+<p><%= t("user_api_key.instructions", application_name: @client.application_name) %></p>
 <div class="user-api-key-display">
   <code id="user-api-key-payload"><%= @payload %></code>
 </div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1274,6 +1274,7 @@ en:
     logged_in_as: "Logged in as"
     permissions_header: 'This will allow "%{application_name}" to:'
     redirect_warning: "Authorizing will redirect you to"
+    write_scope_warning: "Full write access requested — this application will be able to post, edit, and delete content. Proceed only if you fully trust it."
     instructions: 'We just generated a new user API key for you to use with "%{application_name}", please paste the following key into your application:'
     copy_key: "Copy Key"
     copied: "Copied!"

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe UserApiKeysController do
         expect(response.status).to eq(400)
       end
 
+      it "shows write scope warning when write scope is requested" do
+        get "/user-api-key/new", params: args.merge(scopes: "write")
+        expect(response.body).to include(I18n.t("user_api_key.write_scope_warning"))
+      end
+
+      it "does not show write scope warning for read-only scopes" do
+        get "/user-api-key/new", params: args
+        expect(response.body).not_to include(I18n.t("user_api_key.write_scope_warning"))
+      end
+
       it "does not show redirect warning when auth_redirect is discourse://auth_redirect" do
         SiteSetting.allowed_user_api_auth_redirects = "discourse://auth_redirect"
 
@@ -191,6 +201,16 @@ RSpec.describe UserApiKeysController do
       encrypted = Base64.decode64(response.parsed_body["payload"])
       parsed = JSON.parse(decrypt_payload(encrypted))
       expect(UserApiKey.with_key(parsed["key"]).first.user_id).to eq(user.id)
+    end
+
+    it "renders show template with application_name when no auth_redirect provided" do
+      SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
+      user = Fabricate(:user, trust_level: TrustLevel[0])
+      sign_in(user)
+
+      post "/user-api-key", params: args.except(:auth_redirect)
+      expect(response.status).to eq(200)
+      expect(response.body).to include(args[:application_name])
     end
 
     it "encrypts payload with OAEP padding when requested" do


### PR DESCRIPTION
Two changes:

- shows a more prominent warning when the "write" scope is requested
- shows the application name when displaying the key

<img width="600" alt="image" src="https://github.com/user-attachments/assets/79a6d906-532f-4f2d-bd7b-54bd70362728" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/08eec177-f43b-4280-8144-267b178bef7f" />
