### PR TITLE
FIX: Scope `no_password` to staff and self in user serializer

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -355,7 +355,7 @@ class UserSerializer < UserCardSerializer
   end
 
   def include_no_password?
-    !object.has_password?
+    (user_is_current_user || scope.is_staff?) && !object.has_password?
   end
 
   private

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -514,6 +514,73 @@ RSpec.describe UserSerializer do
     end
   end
 
+  context "with no_password" do
+    fab!(:passwordless_user) { Fabricate(:user, password: nil) }
+
+    it "is not included for anonymous viewers" do
+      json = UserSerializer.new(passwordless_user, scope: Guardian.new, root: false).as_json
+
+      expect(json).not_to have_key(:no_password)
+    end
+
+    it "is not included when viewed by another non-staff user" do
+      json =
+        UserSerializer.new(
+          passwordless_user,
+          scope: Guardian.new(Fabricate(:user)),
+          root: false,
+        ).as_json
+
+      expect(json).not_to have_key(:no_password)
+    end
+
+    it "is included when viewed by an admin" do
+      json =
+        UserSerializer.new(
+          passwordless_user,
+          scope: Guardian.new(Fabricate(:admin)),
+          root: false,
+        ).as_json
+
+      expect(json[:no_password]).to eq(true)
+    end
+
+    it "is included when viewed by a moderator" do
+      json =
+        UserSerializer.new(
+          passwordless_user,
+          scope: Guardian.new(Fabricate(:moderator)),
+          root: false,
+        ).as_json
+
+      expect(json[:no_password]).to eq(true)
+    end
+
+    it "is included when the user views their own profile and has no password" do
+      json =
+        UserSerializer.new(
+          passwordless_user,
+          scope: Guardian.new(passwordless_user),
+          root: false,
+        ).as_json
+
+      expect(json[:no_password]).to eq(true)
+    end
+
+    it "is not included when the user views their own profile but has a password" do
+      json = UserSerializer.new(user, scope: Guardian.new(user), root: false).as_json
+
+      expect(json).not_to have_key(:no_password)
+    end
+
+    it "is not included for staff when the target user has a password" do
+      json =
+        UserSerializer.new(user, scope: Guardian.new(Fabricate(:admin)), root: false).as_json
+
+      expect(json).not_to have_key(:no_password)
+    end
+  end
+
   context "for user sidebar attributes" do
     include_examples "User Sidebar Serializer Attributes", described_class
 

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -574,8 +574,7 @@ RSpec.describe UserSerializer do
     end
 
     it "is not included for staff when the target user has a password" do
-      json =
-        UserSerializer.new(user, scope: Guardian.new(Fabricate(:admin)), root: false).as_json
+      json = UserSerializer.new(user, scope: Guardian.new(Fabricate(:admin)), root: false).as_json
 
       expect(json).not_to have_key(:no_password)
     end


### PR DESCRIPTION
`UserSerializer#include_no_password?` had no scope gate, so any
  profile viewer (including anonymous via `/u/{username}.json`) received
  `no_password: true` for users with no local password. This disclosed
  which accounts authenticate solely via SSO/OAuth.

This commit gates the attribute on `user_is_current_user || scope.is_staff?`.