### PR TITLE
UX: Make user-notes textarea full-width

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -15,7 +15,7 @@
 
   &-textarea {
     @include viewport.from(sm) {
-      .form-kit__container-content {
+      &:not(.--full) .form-kit__container-content {
         min-width: var(--form-kit-large-input);
         width: fit-content !important;
       }

--- a/plugins/discourse-user-notes/assets/stylesheets/user_notes.scss
+++ b/plugins/discourse-user-notes/assets/stylesheets/user_notes.scss
@@ -3,6 +3,11 @@
     width: 100%;
   }
 
+  .form-kit__control-textarea {
+    max-width: 100%;
+    min-width: 100%;
+  }
+
   .posted-by {
     width: 40px;
     float: left;


### PR DESCRIPTION
and do not allow it to be resized horizontally