### PR TITLE
UX: Don't include `powered_by` string in site text overrides

### DIFF
--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -15,7 +15,8 @@ class Admin::SiteTextsController < Admin::AdminController
       "user_notifications.confirm_old_email.text_body_template",
       "user_notifications.confirm_old_email_add.title",
       "user_notifications.confirm_old_email_add.subject_template",
-      "user_notifications.confirm_old_email_add.text_body_template"
+      "user_notifications.confirm_old_email_add.text_body_template",
+      "js.powered_by_discourse"
     ].freeze
 
   def self.restricted_key?(key)

--- a/db/migrate/20260430142946_drop_powered_by_discourse_translation_override.rb
+++ b/db/migrate/20260430142946_drop_powered_by_discourse_translation_override.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class DropPoweredByDiscourseTranslationOverride < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM translation_overrides WHERE translation_key = 'js.powered_by_discourse'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -335,6 +335,11 @@ RSpec.describe Admin::SiteTextsController do
         expect(response.status).to eq(200)
         returned_ids = response.parsed_body["site_texts"].map { |t| t["id"] }
         expect((returned_ids & Admin::SiteTextsController::RESTRICTED_KEYS.to_a)).to be_empty
+
+        get "/admin/customize/site_texts.json", params: { q: "powered_by", locale: }
+        expect(response.status).to eq(200)
+        returned_ids = response.parsed_body["site_texts"].map { |t| t["id"] }
+        expect(returned_ids).not_to include("js.powered_by_discourse")
       end
     end
 


### PR DESCRIPTION
The element's link is hardcoded, allowing overrides causes confusion. Site admins can still remove this widget entirely or override with themes/components.