### PR TITLE
DEV: Remove unused helper

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -335,17 +335,6 @@ module Helpers
     SiteSetting.public_send("#{plugin.enabled_site_setting}=", true)
   end
 
-  def try_until_success(timeout: 3, frequency: 0.01)
-    start ||= Time.zone.now
-    backoff ||= frequency
-    yield
-  rescue RSpec::Expectations::ExpectationNotMetError
-    raise if Time.zone.now >= start + timeout.seconds
-    sleep backoff
-    backoff += frequency
-    retry
-  end
-
   def mock_upcoming_change_metadata(metadata)
     # Without ||= here nested blocks would further mutate the instance var so
     # resetting in clear_mocked_upcoming_change_metadata would not work.


### PR DESCRIPTION
The `try_until_success` we're using is in spec/support/system_helpers.rb