### PR TITLE
DEV: Restore ember-this-fallback runtime components

### DIFF
--- a/frontend/discourse/app/lib/ember-this-fallback/deprecations-helper.js
+++ b/frontend/discourse/app/lib/ember-this-fallback/deprecations-helper.js
@@ -1,0 +1,8 @@
+import { helper } from "@ember/component/helper";
+import { deprecate } from "@ember/debug";
+
+export default helper(([deprecationsJson]) => {
+  for (const deprecation of JSON.parse(deprecationsJson)) {
+    deprecate(...deprecation);
+  }
+});

--- a/frontend/discourse/app/lib/ember-this-fallback/is-component.js
+++ b/frontend/discourse/app/lib/ember-this-fallback/is-component.js
@@ -1,0 +1,8 @@
+import Helper from "@ember/component/helper";
+import { getOwner } from "@ember/owner";
+
+export default class IsComponent extends Helper {
+  compute([name]) {
+    return Boolean(getOwner(this).factoryFor(`component:${name}`));
+  }
+}

--- a/frontend/discourse/app/lib/ember-this-fallback/this-fallback-helper.js
+++ b/frontend/discourse/app/lib/ember-this-fallback/this-fallback-helper.js
@@ -1,0 +1,10 @@
+import { helper } from "@ember/component/helper";
+import { deprecate } from "@ember/debug";
+import { get } from "@ember/object";
+
+export default helper(([context, path, deprecationJson]) => {
+  if (deprecationJson) {
+    deprecate(...JSON.parse(deprecationJson));
+  }
+  return get(context, path);
+});

--- a/frontend/discourse/app/lib/ember-this-fallback/try-lookup-helper.js
+++ b/frontend/discourse/app/lib/ember-this-fallback/try-lookup-helper.js
@@ -1,0 +1,8 @@
+import Helper from "@ember/component/helper";
+import { getOwner } from "@ember/owner";
+
+export default class TryLookupHelper extends Helper {
+  compute([name]) {
+    return getOwner(this).factoryFor(`helper:${name}`)?.class;
+  }
+}

--- a/frontend/discourse/app/loader-shims.js
+++ b/frontend/discourse/app/loader-shims.js
@@ -115,3 +115,15 @@ loaderShim("xss", () => importSync("xss"));
 loaderShim("discourse/lib/transformer/registry", () =>
   importSync("discourse/lib/registry/transformers")
 );
+loaderShim("ember-this-fallback/deprecations-helper", () =>
+  importSync("./lib/ember-this-fallback/deprecations-helper")
+);
+loaderShim("ember-this-fallback/is-component", () =>
+  importSync("./lib/ember-this-fallback/is-component")
+);
+loaderShim("ember-this-fallback/this-fallback-helper", () =>
+  importSync("./lib/ember-this-fallback/this-fallback-helper")
+);
+loaderShim("ember-this-fallback/try-lookup-helper", () =>
+  importSync("./lib/ember-this-fallback/try-lookup-helper")
+);

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -54,6 +54,28 @@ describe "JS Deprecation Handling" do
     expect(message).to have_text(SiteSetting.warn_critical_js_deprecations_message)
   end
 
+  it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback" do
+    t = Fabricate(:theme, name: "Theme With Hbs Connector")
+    t.set_field(
+      target: :extra_js,
+      name: "discourse/connectors/below-footer/my-connector.hbs",
+      value: "{{someProperty}}",
+    )
+    t.save!
+    SiteSetting.default_theme_id = t.id
+
+    visit "/latest"
+    expect(find("#main-outlet-wrapper")).to be_visible
+
+    try_until_success do
+      expect(
+        $playwright_logger.logs.any? do |log|
+          log[:message].include?("ember-this-fallback.this-property-fallback")
+        end,
+      ).to eq(true)
+    end
+  end
+
   it "can show warnings triggered during initial render" do
     sign_in Fabricate(:admin)
 


### PR DESCRIPTION
These were previously included in requirejs modules transitively, via the `discourse-plugins` addon. That was removed in b27530cdb100c0b8c913ce37643db6613b0a3c08.

This commit adds the minimum required modules as vendored shims, and adds a simple system spec to prevent future regressions of hbs/this-fallback functionality.