### PR TITLE
Fix missing topic link when private email enabled

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -673,7 +673,7 @@ class UserNotifications < ActionMailer::Base
       participants = self.class.participants(post, user)
     end
 
-    if SiteSetting.private_email?
+    if SiteSetting.private_email? && !user.staged?
       title = I18n.t("system_messages.private_topic_title", id: post.topic_id)
     end
 
@@ -708,7 +708,7 @@ class UserNotifications < ActionMailer::Base
       topic_excerpt = post.excerpt.tr("\n", " ") if post.is_first_post? && post.excerpt
       topic_url = post.topic&.url
 
-      if SiteSetting.private_email?
+      if SiteSetting.private_email? && !user.staged?
         topic_excerpt = ""
         topic_url = ""
       end
@@ -734,7 +734,7 @@ class UserNotifications < ActionMailer::Base
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
 
-      if SiteSetting.private_email?
+      if SiteSetting.private_email? && !user.staged?
         message = I18n.t("system_messages.contents_hidden")
       else
         message =
@@ -766,6 +766,7 @@ class UserNotifications < ActionMailer::Base
               classes: Rtl.new(user).css_class,
               first_footer_classes: first_footer_classes,
               reply_above_line: false,
+              show_post_content: !SiteSetting.private_email? || user.staged?,
             },
           )
       end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -673,7 +673,7 @@ class UserNotifications < ActionMailer::Base
       participants = self.class.participants(post, user)
     end
 
-    if SiteSetting.private_email? && !user.staged?
+    if SiteSetting.private_email?
       title = I18n.t("system_messages.private_topic_title", id: post.topic_id)
     end
 
@@ -708,7 +708,7 @@ class UserNotifications < ActionMailer::Base
       topic_excerpt = post.excerpt.tr("\n", " ") if post.is_first_post? && post.excerpt
       topic_url = post.topic&.url
 
-      if SiteSetting.private_email? && !user.staged?
+      if SiteSetting.private_email?
         topic_excerpt = ""
         topic_url = ""
       end
@@ -734,7 +734,7 @@ class UserNotifications < ActionMailer::Base
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
 
-      if SiteSetting.private_email? && !user.staged?
+      if SiteSetting.private_email?
         message = I18n.t("system_messages.contents_hidden")
       else
         message =
@@ -749,7 +749,8 @@ class UserNotifications < ActionMailer::Base
       end
 
       first_footer_classes = "highlight"
-      if (allow_reply_by_email && user.staged) || (user.suspended? || user.staged?)
+      if (allow_reply_by_email && user.staged && !SiteSetting.private_email?) || user.suspended? ||
+           (user.staged? && !SiteSetting.private_email?)
         first_footer_classes = ""
       end
 
@@ -766,7 +767,7 @@ class UserNotifications < ActionMailer::Base
               classes: Rtl.new(user).css_class,
               first_footer_classes: first_footer_classes,
               reply_above_line: false,
-              show_post_content: !SiteSetting.private_email? || user.staged?,
+              show_post_content: !SiteSetting.private_email?,
             },
           )
       end
@@ -786,7 +787,7 @@ class UserNotifications < ActionMailer::Base
       mailing_list_mode: user.user_option.mailing_list_mode,
       unsubscribe_url: post.unsubscribe_url(user),
       allow_reply_by_email: allow_reply_by_email,
-      only_reply_by_email: allow_reply_by_email && user.staged,
+      only_reply_by_email: allow_reply_by_email && user.staged && !SiteSetting.private_email,
       use_site_subject: use_site_subject,
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
@@ -794,7 +795,8 @@ class UserNotifications < ActionMailer::Base
       private_reply: post.topic.private_message?,
       subject_pm: subject_pm,
       participants: participants,
-      include_respond_instructions: !(user.suspended? || user.staged?),
+      include_respond_instructions:
+        !(user.suspended? || (user.staged? && !SiteSetting.private_email)),
       notification_type: notification_type,
       template: template,
       use_topic_title_subject: use_topic_title_subject,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -674,7 +674,7 @@ class UserNotifications < ActionMailer::Base
       participants = self.class.participants(post, user)
     end
 
-    if SiteSetting.private_email? && !user.staged?
+    if SiteSetting.private_email?
       title = I18n.t("system_messages.private_topic_title", id: post.topic_id)
     end
 
@@ -709,7 +709,7 @@ class UserNotifications < ActionMailer::Base
       topic_excerpt = post.excerpt.tr("\n", " ") if post.is_first_post? && post.excerpt
       topic_url = post.topic&.url
 
-      if SiteSetting.private_email? && !user.staged?
+      if SiteSetting.private_email?
         topic_excerpt = ""
         topic_url = ""
       end
@@ -735,7 +735,7 @@ class UserNotifications < ActionMailer::Base
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
 
-      if SiteSetting.private_email? && !user.staged?
+      if SiteSetting.private_email?
         message = I18n.t("system_messages.contents_hidden")
       else
         message =
@@ -750,7 +750,8 @@ class UserNotifications < ActionMailer::Base
       end
 
       first_footer_classes = "highlight"
-      if (allow_reply_by_email && user.staged) || (user.suspended? || user.staged?)
+      if (allow_reply_by_email && user.staged && !SiteSetting.private_email?) || user.suspended? ||
+           (user.staged? && !SiteSetting.private_email?)
         first_footer_classes = ""
       end
 
@@ -767,7 +768,7 @@ class UserNotifications < ActionMailer::Base
               classes: Rtl.new(user).css_class,
               first_footer_classes: first_footer_classes,
               reply_above_line: false,
-              show_post_content: !SiteSetting.private_email? || user.staged?,
+              show_post_content: !SiteSetting.private_email?,
             },
           )
       end
@@ -787,7 +788,7 @@ class UserNotifications < ActionMailer::Base
       mailing_list_mode: user.user_option.mailing_list_mode,
       unsubscribe_url: post.unsubscribe_url(user),
       allow_reply_by_email: allow_reply_by_email,
-      only_reply_by_email: allow_reply_by_email && user.staged,
+      only_reply_by_email: allow_reply_by_email && user.staged && !SiteSetting.private_email,
       use_site_subject: use_site_subject,
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
@@ -795,7 +796,8 @@ class UserNotifications < ActionMailer::Base
       private_reply: post.topic.private_message?,
       subject_pm: subject_pm,
       participants: participants,
-      include_respond_instructions: !(user.suspended? || user.staged?),
+      include_respond_instructions:
+        !(user.suspended? || (user.staged? && !SiteSetting.private_email)),
       notification_type: notification_type,
       template: template,
       use_topic_title_subject: use_topic_title_subject,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -674,7 +674,7 @@ class UserNotifications < ActionMailer::Base
       participants = self.class.participants(post, user)
     end
 
-    if SiteSetting.private_email?
+    if SiteSetting.private_email? && !user.staged?
       title = I18n.t("system_messages.private_topic_title", id: post.topic_id)
     end
 
@@ -709,7 +709,7 @@ class UserNotifications < ActionMailer::Base
       topic_excerpt = post.excerpt.tr("\n", " ") if post.is_first_post? && post.excerpt
       topic_url = post.topic&.url
 
-      if SiteSetting.private_email?
+      if SiteSetting.private_email? && !user.staged?
         topic_excerpt = ""
         topic_url = ""
       end
@@ -735,7 +735,7 @@ class UserNotifications < ActionMailer::Base
 
       in_reply_to_post = post.reply_to_post if user.user_option.email_in_reply_to
 
-      if SiteSetting.private_email?
+      if SiteSetting.private_email? && !user.staged?
         message = I18n.t("system_messages.contents_hidden")
       else
         message =
@@ -767,6 +767,7 @@ class UserNotifications < ActionMailer::Base
               classes: Rtl.new(user).css_class,
               first_footer_classes: first_footer_classes,
               reply_above_line: false,
+              show_post_content: !SiteSetting.private_email? || user.staged?,
             },
           )
       end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -750,10 +750,7 @@ class UserNotifications < ActionMailer::Base
       end
 
       first_footer_classes = "highlight"
-      if (allow_reply_by_email && user.staged && !SiteSetting.private_email?) || user.suspended? ||
-           (user.staged? && !SiteSetting.private_email?)
-        first_footer_classes = ""
-      end
+      first_footer_classes = "" if user.suspended? || (user.staged? && !SiteSetting.private_email?)
 
       unless translation_override_exists
         html =
@@ -768,7 +765,6 @@ class UserNotifications < ActionMailer::Base
               classes: Rtl.new(user).css_class,
               first_footer_classes: first_footer_classes,
               reply_above_line: false,
-              show_post_content: !SiteSetting.private_email?,
             },
           )
       end
@@ -788,7 +784,7 @@ class UserNotifications < ActionMailer::Base
       mailing_list_mode: user.user_option.mailing_list_mode,
       unsubscribe_url: post.unsubscribe_url(user),
       allow_reply_by_email: allow_reply_by_email,
-      only_reply_by_email: allow_reply_by_email && user.staged && !SiteSetting.private_email,
+      only_reply_by_email: allow_reply_by_email && user.staged? && !SiteSetting.private_email?,
       use_site_subject: use_site_subject,
       add_re_to_subject: add_re_to_subject,
       show_category_in_subject: show_category_in_subject,
@@ -797,7 +793,7 @@ class UserNotifications < ActionMailer::Base
       subject_pm: subject_pm,
       participants: participants,
       include_respond_instructions:
-        !(user.suspended? || (user.staged? && !SiteSetting.private_email)),
+        !(user.suspended? || (user.staged? && !SiteSetting.private_email?)),
       notification_type: notification_type,
       template: template,
       use_topic_title_subject: use_topic_title_subject,

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -9,7 +9,7 @@
 
   <div class='header-instructions'>%{header_instructions}</div>
 
-  <%- if SiteSetting.private_email? %>
+  <%- if !show_post_content %>
     <p><%= t('system_messages.contents_hidden') %></p>
   <% else %>
     <%= render partial: 'email/post', locals: { post: post, use_excerpt: SiteSetting.post_excerpts_in_emails } %>

--- a/app/views/email/notification.html.erb
+++ b/app/views/email/notification.html.erb
@@ -9,7 +9,7 @@
 
   <div class='header-instructions'>%{header_instructions}</div>
 
-  <%- if !show_post_content %>
+  <%- if SiteSetting.private_email? %>
     <p><%= t('system_messages.contents_hidden') %></p>
   <% else %>
     <%= render partial: 'email/post', locals: { post: post, use_excerpt: SiteSetting.post_excerpts_in_emails } %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4473,6 +4473,8 @@ en:
 
         %{message}
 
+        %{respond_instructions}
+
     account_suspended:
       title: "Account Suspended"
       subject_template: "[%{email_prefix}] Your account has been suspended"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4806,6 +4806,8 @@ en:
 
         %{message}
 
+        %{respond_instructions}
+
     account_suspended:
       title: "Account Suspended"
       subject_template: "[%{email_prefix}] Your account has been suspended"

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1125,7 +1125,7 @@ RSpec.describe UserNotifications do
 
   shared_examples "respect for private_email" do
     context "with private_email" do
-      it "doesn't support reply by email" do
+      it "doesn't include topic title or slug for regular users" do
         SiteSetting.private_email = true
 
         mailer =
@@ -1143,6 +1143,23 @@ RSpec.describe UserNotifications do
         expect(message.html_part.body.to_s).not_to include(topic.slug)
         expect(message.text_part.body.to_s).not_to include(topic.title)
         expect(message.text_part.body.to_s).not_to include(topic.slug)
+      end
+
+      it "includes full content for staged users" do
+        SiteSetting.private_email = true
+        user.update!(staged: true)
+
+        mailer =
+          UserNotifications.public_send(
+            mail_type,
+            user,
+            notification_type: Notification.types[notification.notification_type],
+            notification_data_hash: notification.data_hash,
+            post: notification.post,
+          )
+        message = mailer.message
+
+        expect(message.text_part.body.to_s).to include(notification.post.raw)
       end
     end
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1146,6 +1146,12 @@ RSpec.describe UserNotifications do
       end
 
       it "includes full content for staged users" do
+        # Staged users don't receive these notification types (see Jobs::NotificationEmail#perform_enqueue)
+        skip_types = %i[linked quoted mentioned group_mentioned]
+        if skip_types.include?(notification_type)
+          skip "Staged users don't receive #{notification_type} emails"
+        end
+
         SiteSetting.private_email = true
         user.update!(staged: true)
 

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1145,11 +1145,15 @@ RSpec.describe UserNotifications do
         expect(message.text_part.body.to_s).not_to include(topic.slug)
       end
 
-      it "includes full content for staged users" do
-        # Staged users don't receive these notification types (see Jobs::NotificationEmail#perform_enqueue)
+      it "includes respond instructions with highlight styling for staged users" do
         skip_types = %i[linked quoted mentioned group_mentioned]
         if skip_types.include?(notification_type)
           skip "Staged users don't receive #{notification_type} emails"
+        end
+
+        invite_types = %i[invited_to_private_message invited_to_topic watching_first_post]
+        if invite_types.include?(notification_type)
+          skip "Invite-type emails use a different template structure"
         end
 
         SiteSetting.private_email = true
@@ -1165,7 +1169,8 @@ RSpec.describe UserNotifications do
           )
         message = mailer.message
 
-        expect(message.text_part.body.to_s).to include(notification.post.raw)
+        html_body = message.html_part.body.to_s
+        expect(html_body).to include("footer undecorated-link-footer highlight")
       end
     end
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1178,7 +1178,7 @@ RSpec.describe UserNotifications do
         expect(message.text_part.body.to_s).not_to include(topic.slug)
       end
 
-      it "includes respond instructions with highlight styling for staged users" do
+      it "still links back to the topic for staged users" do
         skip_types = %i[linked quoted mentioned group_mentioned]
         if skip_types.include?(notification_type)
           skip "Staged users don't receive #{notification_type} emails"
@@ -1202,8 +1202,9 @@ RSpec.describe UserNotifications do
           )
         message = mailer.message
 
-        html_body = message.html_part.body.to_s
-        expect(html_body).to include("footer undecorated-link-footer highlight")
+        slugless_path = notification.post.topic.slugless_url
+        expect(message.html_part.body.to_s).to include(slugless_path)
+        expect(message.text_part.body.to_s).to include(slugless_path)
       end
     end
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1178,11 +1178,15 @@ RSpec.describe UserNotifications do
         expect(message.text_part.body.to_s).not_to include(topic.slug)
       end
 
-      it "includes full content for staged users" do
-        # Staged users don't receive these notification types (see Jobs::NotificationEmail#perform_enqueue)
+      it "includes respond instructions with highlight styling for staged users" do
         skip_types = %i[linked quoted mentioned group_mentioned]
         if skip_types.include?(notification_type)
           skip "Staged users don't receive #{notification_type} emails"
+        end
+
+        invite_types = %i[invited_to_private_message invited_to_topic watching_first_post]
+        if invite_types.include?(notification_type)
+          skip "Invite-type emails use a different template structure"
         end
 
         SiteSetting.private_email = true
@@ -1198,7 +1202,8 @@ RSpec.describe UserNotifications do
           )
         message = mailer.message
 
-        expect(message.text_part.body.to_s).to include(notification.post.raw)
+        html_body = message.html_part.body.to_s
+        expect(html_body).to include("footer undecorated-link-footer highlight")
       end
     end
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1179,6 +1179,12 @@ RSpec.describe UserNotifications do
       end
 
       it "includes full content for staged users" do
+        # Staged users don't receive these notification types (see Jobs::NotificationEmail#perform_enqueue)
+        skip_types = %i[linked quoted mentioned group_mentioned]
+        if skip_types.include?(notification_type)
+          skip "Staged users don't receive #{notification_type} emails"
+        end
+
         SiteSetting.private_email = true
         user.update!(staged: true)
 

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1158,7 +1158,7 @@ RSpec.describe UserNotifications do
 
   shared_examples "respect for private_email" do
     context "with private_email" do
-      it "doesn't support reply by email" do
+      it "doesn't include topic title or slug for regular users" do
         SiteSetting.private_email = true
 
         mailer =
@@ -1176,6 +1176,23 @@ RSpec.describe UserNotifications do
         expect(message.html_part.body.to_s).not_to include(topic.slug)
         expect(message.text_part.body.to_s).not_to include(topic.title)
         expect(message.text_part.body.to_s).not_to include(topic.slug)
+      end
+
+      it "includes full content for staged users" do
+        SiteSetting.private_email = true
+        user.update!(staged: true)
+
+        mailer =
+          UserNotifications.public_send(
+            mail_type,
+            user,
+            notification_type: Notification.types[notification.notification_type],
+            notification_data_hash: notification.data_hash,
+            post: notification.post,
+          )
+        message = mailer.message
+
+        expect(message.text_part.body.to_s).to include(notification.post.raw)
       end
     end
   end


### PR DESCRIPTION
#### Description 

Currently, staged users with `private_email enabled` receive emails without any content or link to the topic the conversation is taking place on, making it impossible to navigate to it. This PR adds the response instruction section, which contains the `topic_url` when this happens, so staged users can visit the topic.

meta: [/t/401078](https://meta.discourse.org/t/with-private-email-enabled-we-should-still-link-the-topic-in-outgoing-emails/401078)