### PR TITLE
UX: Normalize nested view floating btns and center content

### DIFF
--- a/app/assets/stylesheets/common/nested-view.scss
+++ b/app/assets/stylesheets/common/nested-view.scss
@@ -3,6 +3,7 @@
 // ── Top-level nested view ──────────────────────────────────────────
 .nested-view {
   background: var(--secondary);
+  margin: 0 auto;
   padding: var(--space-4);
   border-radius: var(--d-border-radius-large);
   max-width: calc(
@@ -244,8 +245,6 @@
 
   &__floating-reply {
     box-shadow: var(--shadow-dropdown);
-    border-radius: 2em;
-    padding: 0.65em 1.25em;
   }
 }
 


### PR DESCRIPTION
The nested topic view is less wide without the topic timeline. Add auto margin so it's centered, and then remove some dumb hard-coded styles on the reply button:

<img width="1513" height="1325" alt="Screenshot 2026-04-30 at 11 11 12 AM" src="https://github.com/user-attachments/assets/d9c70619-fd3a-4475-b16a-cbadcd742396" />
