### PR TITLE
FIX: Digest excerpt emoji

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -344,7 +344,7 @@ module Email
         "max-width: 50%; max-height: #{MAX_IMAGE_DIMENSION}px;",
       )
 
-      style(".post-excerpt img.emoji", "max-height: 20px;")
+      style(".post-excerpt img.emoji", "max-height: 20px; vertical-align: middle;")
 
       format_custom
     end

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -339,7 +339,12 @@ module Email
       plugin_styles
       dark_mode_styles
 
-      style(".post-excerpt img", "max-width: 50%; max-height: #{MAX_IMAGE_DIMENSION}px;")
+      style(
+        ".post-excerpt img:not(.emoji)",
+        "max-width: 50%; max-height: #{MAX_IMAGE_DIMENSION}px;",
+      )
+
+      style(".post-excerpt img.emoji", "max-height: 20px;")
 
       format_custom
     end


### PR DESCRIPTION
This PR fixes an issue with enlarged emojis on the latest version of Apple Mail on iOS and macOS.

## Before
<img width="716" height="229" alt="Screenshot 2026-04-30 at 10 23 50 AM" src="https://github.com/user-attachments/assets/181c019c-4ea1-4607-bc96-acda43d58c39" />

## After
<img width="717" height="166" alt="Screenshot 2026-04-30 at 10 31 18 AM" src="https://github.com/user-attachments/assets/edb48637-4041-4249-bce1-12d32a590183" />

