### PR TITLE
UX: Ignored users reactions/likes should not show up

### DIFF
--- a/app/controllers/post_action_users_controller.rb
+++ b/app/controllers/post_action_users_controller.rb
@@ -15,32 +15,30 @@ class PostActionUsersController < ApplicationController
     post = Post.with_deleted.find_by(id: params[:id].to_i)
     guardian.ensure_can_see!(post)
 
-    post_actions = post.post_actions.where(post_action_type_id: post_action_type_id).includes(:user)
+    post_actions =
+      filter_ignored_users(post.post_actions.where(post_action_type_id: post_action_type_id))
+    filtered_total = post_actions.count if current_user&.ignored_user_ids&.any?
 
-    filtering_active = current_user.present? && current_user.ignored_user_ids.any?
-    post_actions = filter_ignored_users(post_actions)
+    post_actions =
+      post_actions
+        .includes(:user)
+        .offset(page * page_size)
+        .order("post_actions.created_at ASC")
+        .limit(page_size)
 
-    paginated_post_actions =
-      post_actions.offset(page * page_size).order("post_actions.created_at ASC").limit(page_size)
-
-    paginated_post_actions =
-      DiscoursePluginRegistry.apply_modifier(:post_action_users_list, paginated_post_actions, post)
+    post_actions =
+      DiscoursePluginRegistry.apply_modifier(:post_action_users_list, post_actions, post)
 
     can_see_actors = guardian.can_see_post_actors?(post.topic, post_action_type_id)
 
     if !can_see_actors
       raise Discourse::InvalidAccess if current_user.blank?
-      paginated_post_actions = paginated_post_actions.where(user_id: current_user.id)
+      post_actions = post_actions.where(user_id: current_user.id)
     end
 
     action_type = PostActionType.types.key(post_action_type_id)
-    total_count =
-      if filtering_active
-        post_actions.count
-      else
-        post["#{action_type}_count"].to_i
-      end
-    post_actions = paginated_post_actions.to_a
+    total_count = filtered_total || post["#{action_type}_count"].to_i
+    post_actions = post_actions.to_a
     data = {
       post_action_users:
         serialize_data(

--- a/app/controllers/post_action_users_controller.rb
+++ b/app/controllers/post_action_users_controller.rb
@@ -15,14 +15,12 @@ class PostActionUsersController < ApplicationController
     post = Post.with_deleted.find_by(id: params[:id].to_i)
     guardian.ensure_can_see!(post)
 
+    post_actions = post.post_actions.where(post_action_type_id: post_action_type_id).includes(:user)
+
+    post_actions = filter_ignored_users(post_actions)
+
     post_actions =
-      post
-        .post_actions
-        .where(post_action_type_id: post_action_type_id)
-        .includes(:user)
-        .offset(page * page_size)
-        .order("post_actions.created_at ASC")
-        .limit(page_size)
+      post_actions.offset(page * page_size).order("post_actions.created_at ASC").limit(page_size)
 
     post_actions =
       DiscoursePluginRegistry.apply_modifier(:post_action_users_list, post_actions, post)
@@ -52,6 +50,19 @@ class PostActionUsersController < ApplicationController
   end
 
   private
+
+  def filter_ignored_users(scope)
+    return scope if current_user.blank?
+
+    scope.where(<<~SQL, current_user_id: current_user.id)
+      NOT EXISTS (
+        SELECT 1 FROM ignored_users ig
+        WHERE ig.user_id = :current_user_id
+          AND ig.ignored_user_id = post_actions.user_id
+          AND ig.ignored_user_id <> :current_user_id
+      )
+    SQL
+  end
 
   def current_user_muting_or_ignoring_users(user_ids)
     return [] if current_user.blank?

--- a/app/controllers/post_action_users_controller.rb
+++ b/app/controllers/post_action_users_controller.rb
@@ -17,24 +17,30 @@ class PostActionUsersController < ApplicationController
 
     post_actions = post.post_actions.where(post_action_type_id: post_action_type_id).includes(:user)
 
+    filtering_active = current_user.present? && current_user.ignored_user_ids.any?
     post_actions = filter_ignored_users(post_actions)
 
-    post_actions =
+    paginated_post_actions =
       post_actions.offset(page * page_size).order("post_actions.created_at ASC").limit(page_size)
 
-    post_actions =
-      DiscoursePluginRegistry.apply_modifier(:post_action_users_list, post_actions, post)
+    paginated_post_actions =
+      DiscoursePluginRegistry.apply_modifier(:post_action_users_list, paginated_post_actions, post)
 
     can_see_actors = guardian.can_see_post_actors?(post.topic, post_action_type_id)
 
     if !can_see_actors
       raise Discourse::InvalidAccess if current_user.blank?
-      post_actions = post_actions.where(user_id: current_user.id)
+      paginated_post_actions = paginated_post_actions.where(user_id: current_user.id)
     end
 
     action_type = PostActionType.types.key(post_action_type_id)
-    total_count = post["#{action_type}_count"].to_i
-    post_actions = post_actions.to_a
+    total_count =
+      if filtering_active
+        post_actions.count
+      else
+        post["#{action_type}_count"].to_i
+      end
+    post_actions = paginated_post_actions.to_a
     data = {
       post_action_users:
         serialize_data(

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -114,6 +114,7 @@ class PostsController < ApplicationController
             add_excerpt: true,
             add_title: true,
             all_post_actions: counts,
+            ignored_user_like_counts: PostAction.ignored_user_like_counts_for(posts, current_user),
           ),
         )
       end
@@ -149,7 +150,15 @@ class PostsController < ApplicationController
       end
 
       format.json do
-        render_json_dump(serialize_data(posts, PostSerializer, scope: guardian, add_excerpt: true))
+        render_json_dump(
+          serialize_data(
+            posts,
+            PostSerializer,
+            scope: guardian,
+            add_excerpt: true,
+            ignored_user_like_counts: PostAction.ignored_user_like_counts_for(posts, current_user),
+          ),
+        )
       end
     end
   end

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -37,6 +37,23 @@ class PostAction < ActiveRecord::Base
     user_actions
   end
 
+  def self.ignored_user_like_counts_for(posts, user)
+    return {} if posts.blank? || user.blank?
+
+    ignored_ids = user.ignored_user_ids
+    return {} if ignored_ids.empty?
+
+    PostAction
+      .where(
+        post_id: posts.map(&:id),
+        user_id: ignored_ids,
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+        deleted_at: nil,
+      )
+      .group(:post_id)
+      .count
+  end
+
   def self.lookup_for(user, topics, post_action_type_id)
     return if topics.blank?
     # in critical path 2x faster than AR

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -12,6 +12,7 @@ class PostSerializer < BasicPostSerializer
     all_post_actions
     add_excerpt
     notice_created_by_users
+    ignored_user_like_counts
   ]
 
   INSTANCE_VARS.each { |v| self.public_send(:attr_accessor, v) }
@@ -393,8 +394,8 @@ class PostSerializer < BasicPostSerializer
 
   def ignored_like_count_for_viewer
     return 0 if scope.user.blank?
-
     return @topic_view.ignored_user_like_counts[object.id].to_i if @topic_view
+    return @ignored_user_like_counts[object.id].to_i if @ignored_user_like_counts
 
     ignored_ids = scope.user.ignored_user_ids
     return 0 if ignored_ids.empty?

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -335,13 +335,15 @@ class PostSerializer < BasicPostSerializer
       @topic_view ? @topic_view.post_action_type_view : PostActionTypeView.new
 
     public_flag_types = @post_action_type_view.public_types
-    ignored_counts = ignored_post_action_counts_by_type
+    ignored_like_count = ignored_like_count_for_viewer
 
     @post_action_type_view.types.each do |sym, id|
       count_col = "#{sym}_count".to_sym
 
       count = object.public_send(count_col) if object.respond_to?(count_col)
-      count = [count.to_i - ignored_counts[id].to_i, 0].max if count && ignored_counts[id]
+      # Only adjust the +like+ count: flag counts are visible to staff for
+      # moderation and should not be perturbed by personal ignore relationships.
+      count = [count.to_i - ignored_like_count, 0].max if count && sym == :like
       summary = { id: id, count: count }
 
       if scope.post_can_act?(
@@ -391,16 +393,18 @@ class PostSerializer < BasicPostSerializer
     result
   end
 
-  def ignored_post_action_counts_by_type
-    return {} if scope.user.blank?
+  def ignored_like_count_for_viewer
+    return 0 if scope.user.blank?
 
     ignored_ids = scope.user.ignored_user_ids
-    return {} if ignored_ids.empty?
+    return 0 if ignored_ids.empty?
 
-    PostAction
-      .where(post_id: object.id, user_id: ignored_ids, deleted_at: nil)
-      .group(:post_action_type_id)
-      .count
+    PostAction.where(
+      post_id: object.id,
+      user_id: ignored_ids,
+      post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+      deleted_at: nil,
+    ).count
   end
 
   def include_draft_sequence?

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -394,6 +394,8 @@ class PostSerializer < BasicPostSerializer
   def ignored_like_count_for_viewer
     return 0 if scope.user.blank?
 
+    return @topic_view.ignored_user_like_counts[object.id].to_i if @topic_view
+
     ignored_ids = scope.user.ignored_user_ids
     return 0 if ignored_ids.empty?
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -341,8 +341,6 @@ class PostSerializer < BasicPostSerializer
       count_col = "#{sym}_count".to_sym
 
       count = object.public_send(count_col) if object.respond_to?(count_col)
-      # Only adjust the +like+ count: flag counts are visible to staff for
-      # moderation and should not be perturbed by personal ignore relationships.
       count = [count.to_i - ignored_like_count, 0].max if count && sym == :like
       summary = { id: id, count: count }
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -335,11 +335,13 @@ class PostSerializer < BasicPostSerializer
       @topic_view ? @topic_view.post_action_type_view : PostActionTypeView.new
 
     public_flag_types = @post_action_type_view.public_types
+    ignored_counts = ignored_post_action_counts_by_type
 
     @post_action_type_view.types.each do |sym, id|
       count_col = "#{sym}_count".to_sym
 
       count = object.public_send(count_col) if object.respond_to?(count_col)
+      count = [count.to_i - ignored_counts[id].to_i, 0].max if count && ignored_counts[id]
       summary = { id: id, count: count }
 
       if scope.post_can_act?(
@@ -387,6 +389,18 @@ class PostSerializer < BasicPostSerializer
     end
 
     result
+  end
+
+  def ignored_post_action_counts_by_type
+    return {} if scope.user.blank?
+
+    ignored_ids = scope.user.ignored_user_ids
+    return {} if ignored_ids.empty?
+
+    PostAction
+      .where(post_id: object.id, user_id: ignored_ids, deleted_at: nil)
+      .group(:post_action_type_id)
+      .count
   end
 
   def include_draft_sequence?

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -7,6 +7,7 @@ class TopicView
   include PostDependentCache
 
   memoize_for_posts :all_post_actions
+  memoize_for_posts :ignored_user_like_counts
   memoize_for_posts :reviewable_counts
   memoize_for_posts :post_custom_fields
   memoize_for_posts :user_custom_fields
@@ -680,6 +681,23 @@ class TopicView
 
   def links
     @links ||= TopicLink.topic_map(@guardian, @topic.id)
+  end
+
+  def ignored_user_like_counts
+    return {} if @user.blank?
+
+    ignored_ids = @user.ignored_user_ids
+    return {} if ignored_ids.empty?
+
+    PostAction
+      .where(
+        post_id: @posts.map(&:id),
+        user_id: ignored_ids,
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+        deleted_at: nil,
+      )
+      .group(:post_id)
+      .count
   end
 
   def reviewable_counts

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -684,20 +684,7 @@ class TopicView
   end
 
   def ignored_user_like_counts
-    return {} if @user.blank?
-
-    ignored_ids = @user.ignored_user_ids
-    return {} if ignored_ids.empty?
-
-    PostAction
-      .where(
-        post_id: @posts.map(&:id),
-        user_id: ignored_ids,
-        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
-        deleted_at: nil,
-      )
-      .group(:post_id)
-      .count
+    PostAction.ignored_user_like_counts_for(@posts, @user)
   end
 
   def reviewable_counts

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -96,6 +96,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
         .joins(:reaction)
         .where(post_id: post_ids)
         .where.not(discourse_reactions_reactions: { reaction_users_count: nil })
+    reaction_users =
+      DiscourseReactions::PostReactionsQuery.apply_ignored_users_filter(
+        reaction_users,
+        user_column: "discourse_reactions_reaction_users.user_id",
+        current_user_id: current_user.id,
+      )
 
     # Guarantee backwards compatibility if someone was calling this endpoint with the old param.
     # TODO(roman): Remove after the 2.9 release.
@@ -135,6 +141,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           .where("discourse_reactions_reaction_users.id IS NULL")
           .order(created_at: :desc)
           .limit(PAGE_SIZE)
+      likes =
+        DiscourseReactions::PostReactionsQuery.apply_ignored_users_filter(
+          likes,
+          user_column: "post_actions.user_id",
+          current_user_id: current_user.id,
+        )
 
       if params[:before_like_id]
         likes = likes.where("post_actions.id < ?", params[:before_like_id].to_i)
@@ -187,8 +199,10 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     raise Discourse::InvalidParameters if !post
 
     reaction_users = []
+    main_reaction_id = DiscourseReactions::Reaction.main_reaction_id
+    main_reaction = nil
 
-    if !reaction_value || reaction_value == DiscourseReactions::Reaction.main_reaction_id
+    if !reaction_value || reaction_value == main_reaction_id
       # We only want to get likes that don't have an associated ReactionUser
       # record, which count as a like or there will be double ups for main_reaction_id.
       likes =
@@ -221,14 +235,30 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           user_column: "post_actions.user_id",
           current_user_id: current_user&.id,
         )
+
+      main_reaction =
+        DiscourseReactions::Reaction.find_by(reaction_value: main_reaction_id, post_id: post.id)
     end
 
+    reactions =
+      if !reaction_value
+        post.reactions.select do |reaction|
+          reaction[:reaction_users_count] && reaction[:reaction_value] != main_reaction_id
+        end
+      elsif reaction_value != main_reaction_id
+        post
+          .reactions
+          .where(reaction_value: reaction_value)
+          .select { |reaction| reaction[:reaction_users_count] }
+      else
+        []
+      end
+
+    reactions_for_counts = reactions.dup
+    reactions_for_counts << main_reaction if main_reaction&.[](:reaction_users_count)
+    reaction_user_counts = filtered_reaction_users_counts(reactions_for_counts)
+
     if likes.present?
-      main_reaction =
-        DiscourseReactions::Reaction.find_by(
-          reaction_value: DiscourseReactions::Reaction.main_reaction_id,
-          post_id: post.id,
-        )
       count = likes.length
       users = format_likes_users(likes)
 
@@ -238,30 +268,18 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
       if main_reaction && main_reaction[:reaction_users_count]
         (users << get_users(main_reaction)).flatten!
         users.sort_by! { |user| user[:created_at] }
-        count += filtered_reaction_users_count(main_reaction)
+        count += reaction_user_counts[main_reaction.id].to_i
       end
 
       reaction_users << {
-        id: DiscourseReactions::Reaction.main_reaction_id,
+        id: main_reaction_id,
         count: count,
         users: users.reverse.slice(0, MAX_USERS_COUNT + 1),
       }
     end
 
-    if !reaction_value
-      post
-        .reactions
-        .select do |reaction|
-          reaction[:reaction_users_count] &&
-            reaction[:reaction_value] != DiscourseReactions::Reaction.main_reaction_id
-        end
-        .each { |reaction| reaction_users << format_reaction_user(reaction) }
-    elsif reaction_value != DiscourseReactions::Reaction.main_reaction_id
-      post
-        .reactions
-        .where(reaction_value: reaction_value)
-        .select { |reaction| reaction[:reaction_users_count] }
-        .each { |reaction| reaction_users << format_reaction_user(reaction) }
+    reactions.each do |reaction|
+      reaction_users << format_reaction_user(reaction, count: reaction_user_counts[reaction.id])
     end
 
     render_json_dump(reaction_users: reaction_users)
@@ -290,22 +308,30 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
       end
   end
 
-  def format_reaction_user(reaction)
-    {
-      id: reaction.reaction_value,
-      count: filtered_reaction_users_count(reaction),
-      users: get_users(reaction),
-    }
+  def format_reaction_user(reaction, count:)
+    { id: reaction.reaction_value, count: count.to_i, users: get_users(reaction) }
   end
 
-  def filtered_reaction_users_count(reaction)
-    return reaction.reaction_users_count.to_i if current_user.blank?
+  def filtered_reaction_users_counts(reactions)
+    reactions = reactions.compact
+    return {} if reactions.blank?
 
-    DiscourseReactions::PostReactionsQuery.apply_ignored_users_filter(
-      reaction.reaction_users,
-      user_column: "discourse_reactions_reaction_users.user_id",
-      current_user_id: current_user.id,
-    ).count
+    if current_user.blank? || current_user.ignored_user_ids.empty?
+      return(
+        reactions.each_with_object({}) do |reaction, counts|
+          counts[reaction.id] = reaction.reaction_users_count.to_i
+        end
+      )
+    end
+
+    DiscourseReactions::PostReactionsQuery
+      .apply_ignored_users_filter(
+        DiscourseReactions::ReactionUser.where(reaction_id: reactions.map(&:id)),
+        user_column: "discourse_reactions_reaction_users.user_id",
+        current_user_id: current_user.id,
+      )
+      .group(:reaction_id)
+      .count
   end
 
   def format_like_user(like)

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -162,6 +162,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
         reaction_filter: params[:reaction_value],
         limit: limit,
         offset: page * limit,
+        current_user_id: current_user&.id,
       )
 
     users =
@@ -214,6 +215,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
           )
 
       likes = likes.where.not(id: historical_reaction_likes.select(:id))
+      likes =
+        DiscourseReactions::PostReactionsQuery.apply_ignored_users_filter(
+          likes,
+          user_column: "post_actions.user_id",
+          current_user_id: current_user&.id,
+        )
     end
 
     if likes.present?
@@ -263,8 +270,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   private
 
   def get_users(reaction)
-    reaction
-      .reaction_users
+    DiscourseReactions::PostReactionsQuery
+      .apply_ignored_users_filter(
+        reaction.reaction_users,
+        user_column: "discourse_reactions_reaction_users.user_id",
+        current_user_id: current_user&.id,
+      )
       .includes(:user)
       .order("discourse_reactions_reaction_users.created_at desc")
       .limit(MAX_USERS_COUNT + 1)

--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -238,7 +238,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
       if main_reaction && main_reaction[:reaction_users_count]
         (users << get_users(main_reaction)).flatten!
         users.sort_by! { |user| user[:created_at] }
-        count += main_reaction.reaction_users_count.to_i
+        count += filtered_reaction_users_count(main_reaction)
       end
 
       reaction_users << {
@@ -293,9 +293,19 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   def format_reaction_user(reaction)
     {
       id: reaction.reaction_value,
-      count: reaction.reaction_users_count.to_i,
+      count: filtered_reaction_users_count(reaction),
       users: get_users(reaction),
     }
+  end
+
+  def filtered_reaction_users_count(reaction)
+    return reaction.reaction_users_count.to_i if current_user.blank?
+
+    DiscourseReactions::PostReactionsQuery.apply_ignored_users_filter(
+      reaction.reaction_users,
+      user_column: "discourse_reactions_reaction_users.user_id",
+      current_user_id: current_user.id,
+    ).count
   end
 
   def format_like_user(like)

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
@@ -88,42 +88,6 @@ module DiscourseReactions
         end
     end
 
-    # Counts of reactions/likes on this post grouped by reaction value, with the
-    # current user's ignored users excluded. Returns a Hash like
-    # { "heart" => 3, "laughing" => 1 }.
-    def reaction_counts
-      @reaction_counts ||=
-        DB
-          .query(<<~SQL, **bindings)
-            SELECT reaction, COUNT(*) AS count FROM (
-              #{reactions_select_sql}
-              UNION ALL
-              #{plain_likes_select_sql}
-            ) combined
-            GROUP BY reaction
-          SQL
-          .each_with_object({}) { |row, hash| hash[row.reaction] = row.count.to_i }
-    end
-
-    # Distinct count of users who reacted/liked this post, with ignored users
-    # excluded. A user counts once even if they both liked and reacted.
-    def total_distinct_users
-      @total_distinct_users ||= DB.query_single(<<~SQL, **bindings).first.to_i
-          SELECT COUNT(DISTINCT user_id) FROM (
-            SELECT drru.user_id
-            FROM discourse_reactions_reaction_users drru
-            WHERE drru.post_id = :post_id
-            #{ignored_users_filter_sql("drru.user_id")}
-            UNION ALL
-            SELECT post_actions.user_id
-            FROM post_actions
-            WHERE post_actions.post_id = :post_id
-              AND (#{shadow_like_filter})
-            #{ignored_users_filter_sql("post_actions.user_id")}
-          ) combined
-        SQL
-    end
-
     private
 
     attr_reader :post, :reaction_filter, :limit, :offset, :current_user_id

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
@@ -14,9 +14,6 @@ module DiscourseReactions
       [query.rows, query.total]
     end
 
-    # Filters a scope to exclude rows where +user_column+ refers to a user the
-    # +current_user_id+ has ignored. Used outside this class for grouped queries
-    # that don't go through #rows / #total.
     def self.apply_ignored_users_filter(scope, user_column:, current_user_id:)
       return scope if current_user_id.blank?
 

--- a/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/post_reactions_query.rb
@@ -2,16 +2,40 @@
 
 module DiscourseReactions
   class PostReactionsQuery
-    def self.call(post:, reaction_filter: nil, limit: 30, offset: 0)
-      query = new(post: post, reaction_filter: reaction_filter, limit: limit, offset: offset)
+    def self.call(post:, reaction_filter: nil, limit: 30, offset: 0, current_user_id: nil)
+      query =
+        new(
+          post: post,
+          reaction_filter: reaction_filter,
+          limit: limit,
+          offset: offset,
+          current_user_id: current_user_id,
+        )
       [query.rows, query.total]
     end
 
-    def initialize(post:, reaction_filter: nil, limit: 30, offset: 0)
+    # Filters a scope to exclude rows where +user_column+ refers to a user the
+    # +current_user_id+ has ignored. Used outside this class for grouped queries
+    # that don't go through #rows / #total.
+    def self.apply_ignored_users_filter(scope, user_column:, current_user_id:)
+      return scope if current_user_id.blank?
+
+      scope.where(<<~SQL, current_user_id: current_user_id)
+        NOT EXISTS (
+          SELECT 1 FROM ignored_users ig
+          WHERE ig.user_id = :current_user_id
+            AND ig.ignored_user_id = #{user_column}
+            AND ig.ignored_user_id <> :current_user_id
+        )
+      SQL
+    end
+
+    def initialize(post:, reaction_filter: nil, limit: 30, offset: 0, current_user_id: nil)
       @post = post
       @reaction_filter = reaction_filter
       @limit = limit
       @offset = offset
+      @current_user_id = current_user_id
     end
 
     def rows
@@ -45,25 +69,64 @@ module DiscourseReactions
     def total
       @total ||=
         if specific_reaction?
-          ReactionUser
-            .joins(:reaction)
-            .where(
+          filter_ignored_users(
+            ReactionUser.joins(:reaction).where(
               post_id: post.id,
               discourse_reactions_reactions: {
                 reaction_value: reaction_filter,
               },
-            )
-            .count
+            ),
+            user_column: "discourse_reactions_reaction_users.user_id",
+          ).count
         elsif main_reaction_filter?
           plain_likes_scope.count
         else
-          ReactionUser.where(post_id: post.id).count + plain_likes_scope.count
+          filter_ignored_users(
+            ReactionUser.where(post_id: post.id),
+            user_column: "discourse_reactions_reaction_users.user_id",
+          ).count + plain_likes_scope.count
         end
+    end
+
+    # Counts of reactions/likes on this post grouped by reaction value, with the
+    # current user's ignored users excluded. Returns a Hash like
+    # { "heart" => 3, "laughing" => 1 }.
+    def reaction_counts
+      @reaction_counts ||=
+        DB
+          .query(<<~SQL, **bindings)
+            SELECT reaction, COUNT(*) AS count FROM (
+              #{reactions_select_sql}
+              UNION ALL
+              #{plain_likes_select_sql}
+            ) combined
+            GROUP BY reaction
+          SQL
+          .each_with_object({}) { |row, hash| hash[row.reaction] = row.count.to_i }
+    end
+
+    # Distinct count of users who reacted/liked this post, with ignored users
+    # excluded. A user counts once even if they both liked and reacted.
+    def total_distinct_users
+      @total_distinct_users ||= DB.query_single(<<~SQL, **bindings).first.to_i
+          SELECT COUNT(DISTINCT user_id) FROM (
+            SELECT drru.user_id
+            FROM discourse_reactions_reaction_users drru
+            WHERE drru.post_id = :post_id
+            #{ignored_users_filter_sql("drru.user_id")}
+            UNION ALL
+            SELECT post_actions.user_id
+            FROM post_actions
+            WHERE post_actions.post_id = :post_id
+              AND (#{shadow_like_filter})
+            #{ignored_users_filter_sql("post_actions.user_id")}
+          ) combined
+        SQL
     end
 
     private
 
-    attr_reader :post, :reaction_filter, :limit, :offset
+    attr_reader :post, :reaction_filter, :limit, :offset, :current_user_id
 
     def main_reaction
       @main_reaction ||= Reaction.main_reaction_id
@@ -92,11 +155,13 @@ module DiscourseReactions
         main_reaction: main_reaction,
         limit: limit,
         offset: offset,
+        current_user_id: current_user_id,
       }
     end
 
     def plain_likes_scope
-      PostAction.where(post_id: post.id).where(shadow_like_filter, like: like_type)
+      scope = PostAction.where(post_id: post.id).where(shadow_like_filter, like: like_type)
+      filter_ignored_users(scope, user_column: "post_actions.user_id")
     end
 
     def reactions_select_sql
@@ -107,6 +172,7 @@ module DiscourseReactions
         INNER JOIN discourse_reactions_reactions dr ON dr.id = drru.reaction_id
         INNER JOIN users u ON u.id = drru.user_id
         WHERE drru.post_id = :post_id
+        #{ignored_users_filter_sql("drru.user_id")}
       SQL
     end
 
@@ -118,7 +184,29 @@ module DiscourseReactions
         INNER JOIN users u ON u.id = post_actions.user_id
         WHERE post_actions.post_id = :post_id
           AND (#{shadow_like_filter})
+        #{ignored_users_filter_sql("post_actions.user_id")}
       SQL
+    end
+
+    def ignored_users_filter_sql(user_column)
+      return "" if current_user_id.blank?
+
+      <<~SQL
+        AND NOT EXISTS (
+          SELECT 1 FROM ignored_users ig
+          WHERE ig.user_id = :current_user_id
+            AND ig.ignored_user_id = #{user_column}
+            AND ig.ignored_user_id <> :current_user_id
+        )
+      SQL
+    end
+
+    def filter_ignored_users(scope, user_column:)
+      self.class.apply_ignored_users_filter(
+        scope,
+        user_column: user_column,
+        current_user_id: current_user_id,
+      )
     end
   end
 end

--- a/plugins/discourse-reactions/lib/discourse_reactions/posts_reaction_loader.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/posts_reaction_loader.rb
@@ -6,22 +6,8 @@ module DiscourseReactions::PostsReactionLoader
       return if object.preloaded_post_data(:reactions)
 
       posts = object.posts
-
-      ActiveRecord::Associations::Preloader.new(
-        records: posts,
-        associations: [:post_actions, { reactions: { reaction_users: :user } }],
-      ).call
-
-      post_ids = posts.map(&:id).uniq
-      posts_reaction_users_count = TopicViewSerializer.posts_reaction_users_count(post_ids)
-      post_actions_with_reaction_users =
-        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-          post_ids,
-        )
-      posts.each do |post|
-        post.reaction_users_count = posts_reaction_users_count[post.id].to_i
-        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
-      end
+      user = object.respond_to?(:guardian) ? object.guardian.user : nil
+      ::ReactionsSerializerHelpers.preload_post_reactions(posts, user)
     end
   end
 end

--- a/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
+++ b/plugins/discourse-reactions/lib/discourse_reactions/topic_view_serializer_extension.rb
@@ -28,7 +28,20 @@ module DiscourseReactions::TopicViewSerializerExtension
   end
 
   def self.prepended(base)
-    def base.posts_reaction_users_count(post_ids)
+    def base.posts_reaction_users_count(post_ids, ignored_user_ids: [])
+      ignored_filter =
+        if ignored_user_ids.present?
+          "AND user_id NOT IN (:ignored_user_ids)"
+        else
+          ""
+        end
+      reaction_users_ignored_filter =
+        if ignored_user_ids.present?
+          "AND discourse_reactions_reaction_users.user_id NOT IN (:ignored_user_ids)"
+        else
+          ""
+        end
+
       posts_reaction_users_count_query =
         DB.query(
           <<~SQL,
@@ -37,15 +50,18 @@ module DiscourseReactions::TopicViewSerializerExtension
               WHERE post_id IN (:post_ids)
                 AND post_action_type_id = :like_id
                 AND deleted_at IS NULL
+                #{ignored_filter}
           UNION ALL
             SELECT discourse_reactions_reaction_users.user_id, posts.id from posts
               LEFT JOIN discourse_reactions_reactions ON discourse_reactions_reactions.post_id = posts.id
               LEFT JOIN discourse_reactions_reaction_users ON discourse_reactions_reaction_users.reaction_id = discourse_reactions_reactions.id
               WHERE posts.id IN (:post_ids)
+                #{reaction_users_ignored_filter}
         ) AS union_subquery WHERE union_subquery.post_ID IS NOT NULL GROUP BY union_subquery.post_id
       SQL
           post_ids: Array.wrap(post_ids),
           like_id: PostActionType::LIKE_POST_ACTION_ID,
+          ignored_user_ids: ignored_user_ids,
         )
 
       posts_reaction_users_count_query.each_with_object({}) do |row, hash|

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -163,12 +163,91 @@ after_initialize do
   # Helper module for shared reactions serialization logic
   module ReactionsSerializerHelpers
     def self.reactions_for_post(post, scope = nil)
-      DiscourseReactions::PostReactionsQuery
-        .new(post: post, current_user_id: scope&.user&.id)
-        .reaction_counts
-        .select { |reaction_value, _| Emoji.exists?(reaction_value) }
-        .map { |reaction_value, count| { id: reaction_value, type: :emoji, count: count } }
-        .sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] }
+      ignored_ids = scope&.user&.ignored_user_ids || []
+      reactions = []
+      reaction_users_counting_as_like = Set.new
+
+      post
+        .emoji_reactions
+        .select { |reaction| reaction[:reaction_users_count] }
+        .each do |reaction|
+          count =
+            if ignored_ids.any?
+              reaction.reaction_users.count { |ru| !ignored_ids.include?(ru.user_id) }
+            else
+              reaction.reaction_users_count
+            end
+          next if count.to_i.zero?
+          reactions << {
+            id: reaction.reaction_value,
+            type: reaction.reaction_type.to_sym,
+            count: count,
+          }
+
+          # NOTE: It does not matter if the reaction is currently an enabled one,
+          # we need to handle historical data here too so we don't see double-ups in the UI.
+          if !DiscourseReactions::Reaction.reactions_excluded_from_like.include?(
+               reaction.reaction_value,
+             ) && reaction.reaction_value != DiscourseReactions::Reaction.main_reaction_id
+            reaction_users_counting_as_like.merge(reaction.reaction_users.pluck(:user_id))
+          end
+        end
+
+      likes_query =
+        post.post_actions.where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
+
+      likes_query = likes_query.where.not(user_id: ignored_ids) if ignored_ids.any?
+
+      # Get rid of any PostAction records that match up to a ReactionUser
+      # that is NOT main_reaction_id and is NOT excluded, otherwise we double
+      # up on the count/reaction shown in the UI.
+      if reaction_users_counting_as_like.any?
+        likes_query = likes_query.where.not(user_id: reaction_users_counting_as_like.to_a)
+      end
+
+      # Also get rid of any PostAction records that match up to a ReactionUser
+      # that is now the main_reaction_id and has historical data.
+      # This subquery checks if there's a matching ReactionUser with main_reaction_id.
+      likes_query =
+        likes_query.where(
+          <<~SQL,
+            post_actions.id NOT IN (
+              SELECT post_actions.id
+              FROM post_actions
+              INNER JOIN discourse_reactions_reaction_users
+                ON discourse_reactions_reaction_users.post_id = post_actions.post_id
+                AND discourse_reactions_reaction_users.user_id = post_actions.user_id
+              INNER JOIN discourse_reactions_reactions
+                ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
+              WHERE post_actions.post_id = :post_id
+                AND post_actions.post_action_type_id = :like_type
+                AND discourse_reactions_reactions.reaction_value = :main_reaction
+            )
+          SQL
+          post_id: post.id,
+          like_type: PostActionType::LIKE_POST_ACTION_ID,
+          main_reaction: DiscourseReactions::Reaction.main_reaction_id,
+        )
+
+      likes = likes_query.count
+
+      # Likes will only be blank if there are only reactions where the reaction is in
+      # discourse_reactions_excluded_from_like. All other reactions will have a `PostAction` record.
+      return reactions.sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] } if likes.zero?
+
+      # Reactions using main_reaction_id only have a `PostAction` record,
+      # not any `ReactionUser` records, as long as the main_reaction_id was never
+      # changed -- if it was then we could have a ReactionUser as well.
+      reaction_likes, reactions =
+        reactions.partition { |r| r[:id] == DiscourseReactions::Reaction.main_reaction_id }
+
+      reactions << {
+        id: DiscourseReactions::Reaction.main_reaction_id,
+        type: :emoji,
+        count: likes + reaction_likes.sum { |r| r[:count] },
+      }
+
+      reactions.sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] }
     end
 
     def self.current_user_reaction_for_post(post, scope)
@@ -207,10 +286,29 @@ after_initialize do
     end
 
     def self.reaction_users_count_for_post(post, scope = nil)
-      DiscourseReactions::PostReactionsQuery.new(
-        post: post,
-        current_user_id: scope&.user&.id,
-      ).total_distinct_users
+      ignored_ids = scope&.user&.ignored_user_ids || []
+
+      if ignored_ids.empty?
+        return post.reaction_users_count unless post.reaction_users_count.nil?
+        return TopicViewSerializer.posts_reaction_users_count(post.id)[post.id]
+      end
+
+      DB.query_single(
+        <<~SQL,
+        SELECT COUNT(DISTINCT user_id) FROM (
+          SELECT user_id FROM post_actions
+            WHERE post_id = :post_id AND post_action_type_id = :like_id
+              AND deleted_at IS NULL AND user_id NOT IN (:ignored_ids)
+          UNION
+          SELECT drru.user_id FROM discourse_reactions_reaction_users drru
+            INNER JOIN discourse_reactions_reactions dr ON dr.id = drru.reaction_id
+            WHERE dr.post_id = :post_id AND drru.user_id NOT IN (:ignored_ids)
+        ) sub
+      SQL
+        post_id: post.id,
+        ignored_ids: ignored_ids,
+        like_id: PostActionType::LIKE_POST_ACTION_ID,
+      ).first
     end
 
     def self.current_user_used_main_reaction_for_post(post, scope)
@@ -272,8 +370,8 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
-    # Preloaded data computes global counts; only safe to use when no per-viewer
-    # filtering is needed (anonymous, or viewer with no ignored users).
+    # Preloaded data computes global counts; fall back to the per-viewer
+    # helper when the viewer has ignored users so their reactions are excluded.
     map = topic_view&.preloaded_post_data(:reactions)
     if map && map.key?(object.id) && (scope.user.blank? || scope.user.ignored_user_ids.empty?)
       map[object.id]

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -75,8 +75,10 @@ after_initialize do
     ).call
 
     post_ids = posts.map(&:id).uniq
+    ignored_user_ids = topic_view.guardian.user&.ignored_user_ids || []
 
-    reaction_users_count_map = TopicViewSerializer.posts_reaction_users_count(post_ids)
+    reaction_users_count_map =
+      TopicViewSerializer.posts_reaction_users_count(post_ids, ignored_user_ids: ignored_user_ids)
     post_actions_with_reaction_users =
       DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
         post_ids,
@@ -92,12 +94,20 @@ after_initialize do
         ""
       end
 
+    ignored_users_filter =
+      if ignored_user_ids.present?
+        "AND pa.user_id NOT IN (:ignored_user_ids)"
+      else
+        ""
+      end
+
     sql_params = {
       post_ids: post_ids,
       like_type: PostActionType::LIKE_POST_ACTION_ID,
       main_reaction: main_reaction,
     }
     sql_params[:excluded] = excluded if excluded.present?
+    sql_params[:ignored_user_ids] = ignored_user_ids if ignored_user_ids.present?
 
     likes_rows = DB.query(<<~SQL, **sql_params)
         SELECT pa.post_id, COUNT(*) as likes_count
@@ -105,6 +115,7 @@ after_initialize do
         WHERE pa.deleted_at IS NULL
           AND pa.post_id IN (:post_ids)
           AND pa.post_action_type_id = :like_type
+          #{ignored_users_filter}
           AND NOT EXISTS (
             SELECT 1 FROM discourse_reactions_reaction_users dru
             JOIN discourse_reactions_reactions dr ON dr.id = dru.reaction_id
@@ -134,13 +145,20 @@ after_initialize do
       emoji_reactions = post.emoji_reactions.select { |r| r.reaction_users_count.to_i > 0 }
 
       reactions =
-        emoji_reactions.map do |reaction|
-          {
-            id: reaction.reaction_value,
-            type: reaction.reaction_type.to_sym,
-            count: reaction.reaction_users_count,
-          }
-        end
+        emoji_reactions
+          .map do |reaction|
+            count =
+              if ignored_user_ids.present?
+                reaction.reaction_users.count { |ru| !ignored_user_ids.include?(ru.user_id) }
+              else
+                reaction.reaction_users_count
+              end
+
+            next if count.to_i.zero?
+
+            { id: reaction.reaction_value, type: reaction.reaction_type.to_sym, count: count }
+          end
+          .compact
 
       likes = likes_map[post.id] || 0
 
@@ -370,10 +388,8 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
-    # Preloaded data computes global counts; fall back to the per-viewer
-    # helper when the viewer has ignored users so their reactions are excluded.
     map = topic_view&.preloaded_post_data(:reactions)
-    if map && map.key?(object.id) && (scope.user.blank? || scope.user.ignored_user_ids.empty?)
+    if map && map.key?(object.id)
       map[object.id]
     else
       ReactionsSerializerHelpers.reactions_for_post(object, scope)
@@ -386,7 +402,7 @@ after_initialize do
 
   add_to_serializer(:post, :reaction_users_count) do
     map = topic_view&.preloaded_post_data(:reaction_users_count)
-    if map && map.key?(object.id) && (scope.user.blank? || scope.user.ignored_user_ids.empty?)
+    if map && map.key?(object.id)
       map[object.id].to_i
     else
       ReactionsSerializerHelpers.reaction_users_count_for_post(object, scope).to_i

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -63,53 +63,43 @@ after_initialize do
 
   Discourse::Application.routes.append { mount DiscourseReactions::Engine, at: "/" }
 
-  TopicView.on_preload do |topic_view|
-    next unless SiteSetting.discourse_reactions_enabled
+  module ReactionsSerializerHelpers
+    def self.preload_post_reactions(posts, user)
+      posts = Array(posts).compact
+      return { reactions: {}, reaction_users_count: {} } if posts.blank?
 
-    posts = topic_view.posts
-    next if posts.blank?
+      ActiveRecord::Associations::Preloader.new(
+        records: posts,
+        associations: [:post_actions, { reactions: { reaction_users: :user } }],
+      ).call
 
-    ActiveRecord::Associations::Preloader.new(
-      records: posts,
-      associations: [:post_actions, { reactions: { reaction_users: :user } }],
-    ).call
+      post_ids = posts.map(&:id).uniq
+      ignored_user_ids = user&.ignored_user_ids || []
+      ignored_user_ids_set = ignored_user_ids.to_set
 
-    post_ids = posts.map(&:id).uniq
-    ignored_user_ids = topic_view.guardian.user&.ignored_user_ids || []
+      reaction_users_count_map =
+        TopicViewSerializer.posts_reaction_users_count(post_ids, ignored_user_ids: ignored_user_ids)
+      post_actions_with_reaction_users =
+        DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
+          post_ids,
+        )
 
-    reaction_users_count_map =
-      TopicViewSerializer.posts_reaction_users_count(post_ids, ignored_user_ids: ignored_user_ids)
-    post_actions_with_reaction_users =
-      DiscourseReactions::TopicViewSerializerExtension.load_post_action_reaction_users_for_posts(
-        post_ids,
-      )
+      main_reaction = DiscourseReactions::Reaction.main_reaction_id
+      excluded = DiscourseReactions::Reaction.reactions_excluded_from_like
 
-    main_reaction = DiscourseReactions::Reaction.main_reaction_id
-    excluded = DiscourseReactions::Reaction.reactions_excluded_from_like
+      excluded_filter = excluded.present? ? "AND dr.reaction_value NOT IN (:excluded)" : ""
+      ignored_users_filter =
+        ignored_user_ids.present? ? "AND pa.user_id NOT IN (:ignored_user_ids)" : ""
 
-    excluded_filter =
-      if excluded.present?
-        "AND dr.reaction_value NOT IN (:excluded)"
-      else
-        ""
-      end
+      sql_params = {
+        post_ids: post_ids,
+        like_type: PostActionType::LIKE_POST_ACTION_ID,
+        main_reaction: main_reaction,
+      }
+      sql_params[:excluded] = excluded if excluded.present?
+      sql_params[:ignored_user_ids] = ignored_user_ids if ignored_user_ids.present?
 
-    ignored_users_filter =
-      if ignored_user_ids.present?
-        "AND pa.user_id NOT IN (:ignored_user_ids)"
-      else
-        ""
-      end
-
-    sql_params = {
-      post_ids: post_ids,
-      like_type: PostActionType::LIKE_POST_ACTION_ID,
-      main_reaction: main_reaction,
-    }
-    sql_params[:excluded] = excluded if excluded.present?
-    sql_params[:ignored_user_ids] = ignored_user_ids if ignored_user_ids.present?
-
-    likes_rows = DB.query(<<~SQL, **sql_params)
+      likes_rows = DB.query(<<~SQL, **sql_params)
         SELECT pa.post_id, COUNT(*) as likes_count
         FROM post_actions pa
         WHERE pa.deleted_at IS NULL
@@ -134,53 +124,95 @@ after_initialize do
         GROUP BY pa.post_id
       SQL
 
-    likes_map = likes_rows.each_with_object({}) { |row, h| h[row.post_id] = row.likes_count }
+      likes_map =
+        likes_rows.each_with_object({}) { |row, hash| hash[row.post_id] = row.likes_count }
+      precomputed_reactions_map = {}
 
-    precomputed_reactions_map = {}
+      posts.each do |post|
+        post.reaction_users_count = reaction_users_count_map[post.id].to_i
+        post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
 
-    posts.each do |post|
-      post.reaction_users_count = reaction_users_count_map[post.id].to_i
-      post.post_actions_with_reaction_users = post_actions_with_reaction_users[post.id] || {}
+        reactions =
+          post
+            .emoji_reactions
+            .select { |reaction| reaction.reaction_users_count.to_i > 0 }
+            .filter_map do |reaction|
+              count =
+                if ignored_user_ids_set.present?
+                  reaction.reaction_users.count { |ru| !ignored_user_ids_set.include?(ru.user_id) }
+                else
+                  reaction.reaction_users_count
+                end
 
-      emoji_reactions = post.emoji_reactions.select { |r| r.reaction_users_count.to_i > 0 }
+              next if count.to_i.zero?
 
-      reactions =
-        emoji_reactions
-          .map do |reaction|
-            count =
-              if ignored_user_ids.present?
-                reaction.reaction_users.count { |ru| !ignored_user_ids.include?(ru.user_id) }
-              else
-                reaction.reaction_users_count
-              end
+              { id: reaction.reaction_value, type: reaction.reaction_type.to_sym, count: count }
+            end
 
-            next if count.to_i.zero?
+        likes = likes_map[post.id] || 0
 
-            { id: reaction.reaction_value, type: reaction.reaction_type.to_sym, count: count }
-          end
-          .compact
+        if likes > 0
+          reaction_likes, reactions =
+            reactions.partition { |reaction| reaction[:id] == main_reaction }
+          reactions << {
+            id: main_reaction,
+            type: :emoji,
+            count: likes + reaction_likes.sum { |reaction| reaction[:count] },
+          }
+        end
 
-      likes = likes_map[post.id] || 0
-
-      if likes > 0
-        reaction_likes, reactions = reactions.partition { |r| r[:id] == main_reaction }
-        reactions << {
-          id: main_reaction,
-          type: :emoji,
-          count: likes + reaction_likes.sum { |r| r[:count] },
-        }
+        precomputed_reactions_map[post.id] = reactions.sort_by do |reaction|
+          [-reaction[:count].to_i, reaction[:id]]
+        end
+        post.precomputed_reactions = precomputed_reactions_map[post.id]
       end
 
-      precomputed_reactions_map[post.id] = reactions.sort_by { |r| [-r[:count].to_i, r[:id]] }
+      { reactions: precomputed_reactions_map, reaction_users_count: reaction_users_count_map }
     end
+  end
 
-    topic_view.set_preloaded_post_data(:reactions, precomputed_reactions_map)
-    topic_view.set_preloaded_post_data(:reaction_users_count, reaction_users_count_map)
+  TopicView.on_preload do |topic_view|
+    next unless SiteSetting.discourse_reactions_enabled
+
+    posts = topic_view.posts
+    next if posts.blank?
+
+    preloaded = ReactionsSerializerHelpers.preload_post_reactions(posts, topic_view.guardian.user)
+
+    topic_view.set_preloaded_post_data(:reactions, preloaded[:reactions])
+    topic_view.set_preloaded_post_data(:reaction_users_count, preloaded[:reaction_users_count])
+  end
+
+  TopicList.on_preload do |topics, topic_list|
+    next unless SiteSetting.discourse_reactions_enabled
+    next if topics.blank?
+
+    should_preload =
+      if topic_list.filter == :suggested
+        DiscoursePluginRegistry.apply_modifier(
+          :include_discourse_reactions_data_on_suggested_topics,
+          false,
+          topic_list.current_user,
+        )
+      else
+        DiscoursePluginRegistry.apply_modifier(
+          :include_discourse_reactions_data_on_topic_list,
+          false,
+          topic_list.current_user,
+        )
+      end
+
+    next unless should_preload
+
+    posts = topics.filter_map { |topic| topic.first_post if topic.association(:first_post).loaded? }
+    ReactionsSerializerHelpers.preload_post_reactions(posts, topic_list.current_user)
   end
 
   # Helper module for shared reactions serialization logic
   module ReactionsSerializerHelpers
     def self.reactions_for_post(post, scope = nil)
+      return post.precomputed_reactions unless post.precomputed_reactions.nil?
+
       ignored_ids = scope&.user&.ignored_user_ids || []
       reactions = []
       reaction_users_counting_as_like = Set.new
@@ -304,12 +336,11 @@ after_initialize do
     end
 
     def self.reaction_users_count_for_post(post, scope = nil)
+      return post.reaction_users_count unless post.reaction_users_count.nil?
+
       ignored_ids = scope&.user&.ignored_user_ids || []
 
-      if ignored_ids.empty?
-        return post.reaction_users_count unless post.reaction_users_count.nil?
-        return TopicViewSerializer.posts_reaction_users_count(post.id)[post.id]
-      end
+      return TopicViewSerializer.posts_reaction_users_count(post.id)[post.id] if ignored_ids.empty?
 
       DB.query_single(
         <<~SQL,
@@ -327,6 +358,23 @@ after_initialize do
         ignored_ids: ignored_ids,
         like_id: PostActionType::LIKE_POST_ACTION_ID,
       ).first
+    end
+
+    def self.like_action_for_post(post, scope)
+      return nil if scope.user.blank?
+
+      if !post.precomputed_reactions.nil? && post.association(:post_actions).loaded?
+        post.post_actions.find do |post_action|
+          post_action.post_action_type_id == PostActionType.types[:like] &&
+            post_action.user_id == scope.user.id && !post_action.trashed?
+        end
+      else
+        PostAction.find_by(
+          user_id: scope.user.id,
+          post_id: post.id,
+          post_action_type_id: PostActionType.types[:like],
+        )
+      end
     end
 
     def self.current_user_used_main_reaction_for_post(post, scope)
@@ -359,18 +407,7 @@ after_initialize do
       return nil unless topic.first_post
 
       post = topic.first_post
-      like_action =
-        (
-          if scope.user
-            PostAction.find_by(
-              user_id: scope.user.id,
-              post_id: post.id,
-              post_action_type_id: PostActionType.types[:like],
-            )
-          else
-            nil
-          end
-        )
+      like_action = like_action_for_post(post, scope)
 
       {
         id: post.id,

--- a/plugins/discourse-reactions/plugin.rb
+++ b/plugins/discourse-reactions/plugin.rb
@@ -162,82 +162,13 @@ after_initialize do
 
   # Helper module for shared reactions serialization logic
   module ReactionsSerializerHelpers
-    def self.reactions_for_post(post)
-      reactions = []
-      reaction_users_counting_as_like = Set.new
-
-      post
-        .emoji_reactions
-        .select { |reaction| reaction[:reaction_users_count] }
-        .each do |reaction|
-          reactions << {
-            id: reaction.reaction_value,
-            type: reaction.reaction_type.to_sym,
-            count: reaction.reaction_users_count,
-          }
-
-          # NOTE: It does not matter if the reaction is currently an enabled one,
-          # we need to handle historical data here too so we don't see double-ups in the UI.
-          if !DiscourseReactions::Reaction.reactions_excluded_from_like.include?(
-               reaction.reaction_value,
-             ) && reaction.reaction_value != DiscourseReactions::Reaction.main_reaction_id
-            reaction_users_counting_as_like.merge(reaction.reaction_users.pluck(:user_id))
-          end
-        end
-
-      likes_query =
-        post.post_actions.where(post_action_type_id: PostActionType::LIKE_POST_ACTION_ID)
-
-      # Get rid of any PostAction records that match up to a ReactionUser
-      # that is NOT main_reaction_id and is NOT excluded, otherwise we double
-      # up on the count/reaction shown in the UI.
-      if reaction_users_counting_as_like.any?
-        likes_query = likes_query.where.not(user_id: reaction_users_counting_as_like.to_a)
-      end
-
-      # Also get rid of any PostAction records that match up to a ReactionUser
-      # that is now the main_reaction_id and has historical data.
-      # This subquery checks if there's a matching ReactionUser with main_reaction_id.
-      likes_query =
-        likes_query.where(
-          <<~SQL,
-            post_actions.id NOT IN (
-              SELECT post_actions.id
-              FROM post_actions
-              INNER JOIN discourse_reactions_reaction_users
-                ON discourse_reactions_reaction_users.post_id = post_actions.post_id
-                AND discourse_reactions_reaction_users.user_id = post_actions.user_id
-              INNER JOIN discourse_reactions_reactions
-                ON discourse_reactions_reactions.id = discourse_reactions_reaction_users.reaction_id
-              WHERE post_actions.post_id = :post_id
-                AND post_actions.post_action_type_id = :like_type
-                AND discourse_reactions_reactions.reaction_value = :main_reaction
-            )
-          SQL
-          post_id: post.id,
-          like_type: PostActionType::LIKE_POST_ACTION_ID,
-          main_reaction: DiscourseReactions::Reaction.main_reaction_id,
-        )
-
-      likes = likes_query.count
-
-      # Likes will only be blank if there are only reactions where the reaction is in
-      # discourse_reactions_excluded_from_like. All other reactions will have a `PostAction` record.
-      return reactions.sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] } if likes.zero?
-
-      # Reactions using main_reaction_id only have a `PostAction` record,
-      # not any `ReactionUser` records, as long as the main_reaction_id was never
-      # changed -- if it was then we could have a ReactionUser as well.
-      reaction_likes, reactions =
-        reactions.partition { |r| r[:id] == DiscourseReactions::Reaction.main_reaction_id }
-
-      reactions << {
-        id: DiscourseReactions::Reaction.main_reaction_id,
-        type: :emoji,
-        count: likes + reaction_likes.sum { |r| r[:count] },
-      }
-
-      reactions.sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] }
+    def self.reactions_for_post(post, scope = nil)
+      DiscourseReactions::PostReactionsQuery
+        .new(post: post, current_user_id: scope&.user&.id)
+        .reaction_counts
+        .select { |reaction_value, _| Emoji.exists?(reaction_value) }
+        .map { |reaction_value, count| { id: reaction_value, type: :emoji, count: count } }
+        .sort_by { |reaction| [-reaction[:count].to_i, reaction[:id]] }
     end
 
     def self.current_user_reaction_for_post(post, scope)
@@ -275,9 +206,11 @@ after_initialize do
       }
     end
 
-    def self.reaction_users_count_for_post(post)
-      return post.reaction_users_count unless post.reaction_users_count.nil?
-      TopicViewSerializer.posts_reaction_users_count(post.id)[post.id]
+    def self.reaction_users_count_for_post(post, scope = nil)
+      DiscourseReactions::PostReactionsQuery.new(
+        post: post,
+        current_user_id: scope&.user&.id,
+      ).total_distinct_users
     end
 
     def self.current_user_used_main_reaction_for_post(post, scope)
@@ -327,10 +260,10 @@ after_initialize do
         id: post.id,
         user_id: post.user_id,
         yours: post.user_id == scope.current_user&.id,
-        reactions: reactions_for_post(post),
+        reactions: reactions_for_post(post, scope),
         current_user_reaction: current_user_reaction_for_post(post, scope),
         current_user_used_main_reaction: current_user_used_main_reaction_for_post(post, scope),
-        reaction_users_count: reaction_users_count_for_post(post) || 0,
+        reaction_users_count: reaction_users_count_for_post(post, scope) || 0,
         likeAction: {
           canToggle: like_action ? scope.can_delete_post_action?(like_action) : true,
         },
@@ -339,11 +272,13 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
+    # Preloaded data computes global counts; only safe to use when no per-viewer
+    # filtering is needed (anonymous, or viewer with no ignored users).
     map = topic_view&.preloaded_post_data(:reactions)
-    if map && map.key?(object.id)
+    if map && map.key?(object.id) && (scope.user.blank? || scope.user.ignored_user_ids.empty?)
       map[object.id]
     else
-      ReactionsSerializerHelpers.reactions_for_post(object)
+      ReactionsSerializerHelpers.reactions_for_post(object, scope)
     end
   end
 
@@ -353,10 +288,10 @@ after_initialize do
 
   add_to_serializer(:post, :reaction_users_count) do
     map = topic_view&.preloaded_post_data(:reaction_users_count)
-    if map && map.key?(object.id)
+    if map && map.key?(object.id) && (scope.user.blank? || scope.user.ignored_user_ids.empty?)
       map[object.id].to_i
     else
-      ReactionsSerializerHelpers.reaction_users_count_for_post(object)
+      ReactionsSerializerHelpers.reaction_users_count_for_post(object, scope).to_i
     end
   end
 

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -527,17 +527,6 @@ describe DiscourseReactions::CustomReactionsController do
         usernames = response.parsed_body["users"].map { |u| u["username"] }
         expect(usernames).to include(user_3.username)
       end
-
-      it "does not affect viewers who are not ignoring anyone" do
-        Fabricate(:ignored_user, user: user_1, ignored_user: user_3)
-        sign_in(user_2)
-
-        get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
-
-        expect(response.status).to eq(200)
-        usernames = response.parsed_body["users"].map { |u| u["username"] }
-        expect(usernames).to include(user_3.username)
-      end
     end
   end
 

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -646,6 +646,19 @@ describe DiscourseReactions::CustomReactionsController do
           end
         expect(usernames).to include(user_5.username)
       end
+
+      it "keeps reaction count consistent with the filtered users list" do
+        sign_in(user_1)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_2)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json"
+
+        expect(response.status).to eq(200)
+        response.parsed_body["reaction_users"].each do |entry|
+          expect(entry["users"].length).to eq(entry["count"]),
+          "expected count #{entry["count"]} to match #{entry["users"].length} users for #{entry["id"]}"
+        end
+      end
     end
 
     it "does not double up reactions which also count as likes if the reaction is no longer enabled" do

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -456,6 +456,22 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]["post"]["user"]["id"]).to eq(user_1.id)
       expect(parsed[0]["reaction"]["id"]).to eq(like.id)
     end
+
+    it "does not include reactions or likes from ignored users" do
+      sign_in(user_1)
+      Fabricate(:ignored_user, user: user_1, ignored_user: user_3)
+      Fabricate(:ignored_user, user: user_1, ignored_user: user_5)
+
+      get "/discourse-reactions/posts/reactions-received.json",
+          params: {
+            username: user_1.username,
+            include_likes: true,
+          }
+
+      usernames = response.parsed_body.map { |reaction| reaction["user"]["username"] }
+      expect(usernames).not_to include(user_3.username, user_5.username)
+      expect(usernames).to include(user_2.username, user_4.username)
+    end
   end
 
   describe "#reactions_users_list" do

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -502,6 +502,43 @@ describe DiscourseReactions::CustomReactionsController do
       expect(user_4_rows.size).to eq(1)
       expect(user_4_rows.first["reaction"]).to eq("hugs")
     end
+
+    context "with ignored users" do
+      it "hides reactions and likes from users the current user has ignored" do
+        sign_in(user_1)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_3)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_5)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
+
+        expect(response.status).to eq(200)
+        usernames = response.parsed_body["users"].map { |u| u["username"] }
+        expect(usernames).not_to include(user_3.username, user_5.username)
+        expect(usernames).to include(user_2.username, user_4.username)
+        expect(response.parsed_body["total_rows"]).to eq(usernames.size)
+      end
+
+      it "still shows reactions to anonymous viewers" do
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_3)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
+
+        expect(response.status).to eq(200)
+        usernames = response.parsed_body["users"].map { |u| u["username"] }
+        expect(usernames).to include(user_3.username)
+      end
+
+      it "does not affect viewers who are not ignoring anyone" do
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_3)
+        sign_in(user_2)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
+
+        expect(response.status).to eq(200)
+        usernames = response.parsed_body["users"].map { |u| u["username"] }
+        expect(usernames).to include(user_3.username)
+      end
+    end
   end
 
   describe "#post_reactions_users" do
@@ -564,6 +601,51 @@ describe DiscourseReactions::CustomReactionsController do
       sign_in(user_2)
       get "/discourse-reactions/posts/#{private_post.id}/reactions-users.json"
       expect(response.status).to eq(200)
+    end
+
+    context "with ignored users" do
+      it "hides ignored users from reactions and likes" do
+        sign_in(user_1)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_2)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_5)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json"
+
+        expect(response.status).to eq(200)
+        usernames =
+          response.parsed_body["reaction_users"].flat_map do |entry|
+            entry["users"].map { |u| u["username"] }
+          end
+        expect(usernames).not_to include(user_2.username, user_5.username)
+        expect(usernames).to include(user_1.username, user_3.username, user_4.username)
+      end
+
+      it "hides ignored users when filtering by main_reaction (heart)" do
+        sign_in(user_1)
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_5)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json?reaction_value=#{DiscourseReactions::Reaction.main_reaction_id}"
+
+        expect(response.status).to eq(200)
+        usernames =
+          response.parsed_body["reaction_users"].flat_map do |entry|
+            entry["users"].map { |u| u["username"] }
+          end
+        expect(usernames).not_to include(user_5.username)
+      end
+
+      it "still shows reactions to anonymous viewers" do
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_5)
+
+        get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json"
+
+        expect(response.status).to eq(200)
+        usernames =
+          response.parsed_body["reaction_users"].flat_map do |entry|
+            entry["users"].map { |u| u["username"] }
+          end
+        expect(usernames).to include(user_5.username)
+      end
     end
 
     it "does not double up reactions which also count as likes if the reaction is no longer enabled" do

--- a/plugins/discourse-reactions/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/topics_controller_spec.rb
@@ -71,5 +71,23 @@ describe TopicsController do
       queries = track_sql_queries { get "/t/#{post.topic_id}.json" }
       expect(queries.filter { |q| q.include?("reactions") }.size).to eq(count)
     end
+
+    it "does not generate N+1 queries when the viewer has ignored users" do
+      sign_in(user_1)
+      Fabricate(:ignored_user, user: user_1, ignored_user: user_2)
+
+      Fabricate(:reaction_user, reaction: laughing_reaction, user: user_2, post: post)
+      Fabricate(:reaction_user, reaction: hugs_reaction, user: user_3, post: post)
+
+      queries = track_sql_queries { get "/t/#{post.topic_id}.json" }
+      count = queries.filter { |q| q.include?("reactions") }.size
+
+      Fabricate(:reaction_user, reaction: open_mouth_reaction, user: user_4, post: post)
+      Fabricate(:reaction_user, reaction: hugs_reaction, user: Fabricate(:user), post: post)
+      Fabricate(:reaction_user, reaction: laughing_reaction, user: Fabricate(:user), post: post)
+
+      queries = track_sql_queries { get "/t/#{post.topic_id}.json" }
+      expect(queries.filter { |q| q.include?("reactions") }.size).to eq(count)
+    end
   end
 end

--- a/plugins/discourse-reactions/spec/serializers/op_reactions_data_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/op_reactions_data_serializer_spec.rb
@@ -330,6 +330,32 @@ RSpec.shared_examples "op_reactions_data serializer" do |serializer_class, modif
         end
       end
     end
+
+    context "when serialized through a topic list preload" do
+      let(:topic_list_filter) do
+        serializer_class == SuggestedTopicSerializer ? :suggested : :latest
+      end
+
+      before do
+        Fabricate(:ignored_user, user: user_1, ignored_user: user_2)
+        reaction = Fabricate(:reaction, reaction_value: "otter", post: first_post)
+        Fabricate(:reaction_user, reaction: reaction, user: user_2, post: first_post)
+        Fabricate(:reaction_user, reaction: reaction, user: user_3, post: first_post)
+      end
+
+      it "uses viewer-specific preloaded reaction counts" do
+        topic.allowed_user_ids = []
+        topic.allowed_group_ids = []
+        preloaded_topic = TopicList.new(topic_list_filter, user_1, [topic]).topics.first
+        json =
+          serializer_class.new(preloaded_topic, scope: Guardian.new(user_1), root: false).as_json
+
+        expect(json[:op_reactions_data][:reactions]).to contain_exactly(
+          { id: "otter", type: :emoji, count: 1 },
+        )
+        expect(json[:op_reactions_data][:reaction_users_count]).to eq(1)
+      end
+    end
   end
 end
 

--- a/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/post_serializer_spec.rb
@@ -67,6 +67,29 @@ describe PostSerializer do
     expect(json[:reaction_users_count]).to eq(4)
   end
 
+  it "subtracts ignored users' reactions and likes from reactions and reaction_users_count" do
+    Fabricate(:ignored_user, user: user_2, ignored_user: user_4)
+    Fabricate(:ignored_user, user: user_2, ignored_user: user_3)
+
+    json = PostSerializer.new(post_1, scope: Guardian.new(user_2), root: false).as_json
+
+    expect(json[:reactions]).to contain_exactly({ id: "otter", type: :emoji, count: 2 })
+    expect(json[:reaction_users_count]).to eq(2)
+  end
+
+  it "does not subtract for anonymous viewers" do
+    Fabricate(:ignored_user, user: user_2, ignored_user: user_4)
+
+    json = PostSerializer.new(post_1, scope: Guardian.new, root: false).as_json
+
+    expect(json[:reactions]).to contain_exactly(
+      { id: "+1", type: :emoji, count: 1 },
+      { id: "heart", type: :emoji, count: 1 },
+      { id: "otter", type: :emoji, count: 2 },
+    )
+    expect(json[:reaction_users_count]).to eq(4)
+  end
+
   it "renders custom reactions sorted alphabetically if count is equal" do
     json = PostSerializer.new(post_1, scope: Guardian.new(user_1), root: false).as_json
 

--- a/plugins/discourse-reactions/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-reactions/spec/serializers/topic_view_serializer_spec.rb
@@ -85,6 +85,95 @@ describe TopicViewSerializer do
     end
   end
 
+  context "with ignored users" do
+    fab!(:viewer, :user)
+    fab!(:other_user, :user)
+    fab!(:ignored, :user)
+    fab!(:another_ignored, :user)
+    fab!(:post_1, :post)
+    fab!(:post_2) { Fabricate(:post, topic: post_1.topic) }
+    fab!(:otter) { Fabricate(:reaction, post: post_1, reaction_value: "otter") }
+    fab!(:heart) { Fabricate(:reaction, post: post_1, reaction_value: "heart") }
+    fab!(:reaction_user_other) { Fabricate(:reaction_user, reaction: otter, user: other_user) }
+    fab!(:reaction_user_ignored) { Fabricate(:reaction_user, reaction: otter, user: ignored) }
+    fab!(:reaction_user_heart_ignored) do
+      Fabricate(:reaction_user, reaction: heart, user: another_ignored)
+    end
+    fab!(:like_other_post_2) do
+      Fabricate(
+        :post_action,
+        post: post_2,
+        user: other_user,
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+      )
+    end
+    fab!(:like_ignored_post_2) do
+      Fabricate(
+        :post_action,
+        post: post_2,
+        user: ignored,
+        post_action_type_id: PostActionType::LIKE_POST_ACTION_ID,
+      )
+    end
+
+    let(:topic) { post_1.topic }
+
+    before do
+      SiteSetting.discourse_reactions_like_icon = "heart"
+      SiteSetting.discourse_reactions_enabled_reactions = "otter|heart"
+      Fabricate(:ignored_user, user: viewer, ignored_user: ignored)
+      Fabricate(:ignored_user, user: viewer, ignored_user: another_ignored)
+    end
+
+    def serialize_for(user)
+      TopicViewSerializer.new(
+        TopicView.new(topic, user),
+        scope: Guardian.new(user),
+        root: false,
+      ).as_json
+    end
+
+    it "excludes ignored users from preloaded :reactions" do
+      json = serialize_for(viewer)
+
+      posts = json[:post_stream][:posts]
+      expect(posts[0][:reactions]).to contain_exactly({ id: "otter", type: :emoji, count: 1 })
+      expect(posts[1][:reactions]).to contain_exactly({ id: "heart", type: :emoji, count: 1 })
+    end
+
+    it "excludes ignored users from preloaded :reaction_users_count" do
+      json = serialize_for(viewer)
+
+      posts = json[:post_stream][:posts]
+      expect(posts[0][:reaction_users_count]).to eq(1)
+      expect(posts[1][:reaction_users_count]).to eq(1)
+    end
+
+    it "still shows global counts for anonymous viewers" do
+      json = TopicViewSerializer.new(TopicView.new(topic), scope: Guardian.new, root: false).as_json
+
+      posts = json[:post_stream][:posts]
+      expect(posts[0][:reactions]).to contain_exactly(
+        { id: "otter", type: :emoji, count: 2 },
+        { id: "heart", type: :emoji, count: 1 },
+      )
+      expect(posts[0][:reaction_users_count]).to eq(3)
+      expect(posts[1][:reaction_users_count]).to eq(2)
+    end
+
+    it "still shows global counts for viewers with no ignored users" do
+      json = serialize_for(other_user)
+
+      posts = json[:post_stream][:posts]
+      expect(posts[0][:reactions]).to contain_exactly(
+        { id: "otter", type: :emoji, count: 2 },
+        { id: "heart", type: :emoji, count: 1 },
+      )
+      expect(posts[0][:reaction_users_count]).to eq(3)
+      expect(posts[1][:reaction_users_count]).to eq(2)
+    end
+  end
+
   describe "only shadow like" do
     fab!(:user_1, :user)
     fab!(:post_1) { Fabricate(:post, user: user_1) }

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -127,6 +127,24 @@ RSpec.describe PostActionUsersController do
   end
 
   it "will return an unknown attribute for muted users" do
+    muted_user = Fabricate(:user)
+    PostActionCreator.like(muted_user, post)
+    regular_user = Fabricate(:user)
+    PostActionCreator.like(regular_user, post)
+    Fabricate(:muted_user, user: user, muted_user: muted_user)
+
+    get "/post_action_users.json",
+        params: {
+          id: post.id,
+          post_action_type_id: PostActionType.types[:like],
+        }
+    expect(response.status).to eq(200)
+    json_users = response.parsed_body["post_action_users"]
+    expect(json_users.find { |u| u["id"] == regular_user.id }["unknown"]).to be_blank
+    expect(json_users.find { |u| u["id"] == muted_user.id }["unknown"]).to eq(true)
+  end
+
+  it "filters out ignored users from the post action user list" do
     ignored_user = Fabricate(:user)
     PostActionCreator.like(ignored_user, post)
     regular_user = Fabricate(:user)
@@ -139,9 +157,25 @@ RSpec.describe PostActionUsersController do
           post_action_type_id: PostActionType.types[:like],
         }
     expect(response.status).to eq(200)
-    json_users = response.parsed_body["post_action_users"]
-    expect(json_users.find { |u| u["id"] == regular_user.id }["unknown"]).to be_blank
-    expect(json_users.find { |u| u["id"] == ignored_user.id }["unknown"]).to eq(true)
+    user_ids = response.parsed_body["post_action_users"].map { |u| u["id"] }
+    expect(user_ids).to include(regular_user.id)
+    expect(user_ids).not_to include(ignored_user.id)
+  end
+
+  it "still shows ignored users to anonymous viewers" do
+    ignorer = Fabricate(:user)
+    ignored_user = Fabricate(:user)
+    PostActionCreator.like(ignored_user, post)
+    Fabricate(:ignored_user, user: ignorer, ignored_user: ignored_user)
+
+    get "/post_action_users.json",
+        params: {
+          id: post.id,
+          post_action_type_id: PostActionType.types[:like],
+        }
+    expect(response.status).to eq(200)
+    user_ids = response.parsed_body["post_action_users"].map { |u| u["id"] }
+    expect(user_ids).to include(ignored_user.id)
   end
 
   it "does not hide users from the like list when they are not in the actor's PM allowlist" do

--- a/spec/requests/post_action_users_controller_spec.rb
+++ b/spec/requests/post_action_users_controller_spec.rb
@@ -178,6 +178,24 @@ RSpec.describe PostActionUsersController do
     expect(user_ids).to include(ignored_user.id)
   end
 
+  it "reports the filtered total in total_rows_post_action_users" do
+    stub_const(described_class, "INDEX_LIMIT", 2) do
+      ignored_user = Fabricate(:user)
+      PostActionCreator.like(ignored_user, post)
+      3.times { PostActionCreator.like(Fabricate(:user), post) }
+      Fabricate(:ignored_user, user: user, ignored_user: ignored_user)
+
+      get "/post_action_users.json",
+          params: {
+            id: post.id,
+            post_action_type_id: PostActionType.types[:like],
+            limit: 2,
+          }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["total_rows_post_action_users"]).to eq(3)
+    end
+  end
+
   it "does not hide users from the like list when they are not in the actor's PM allowlist" do
     user_not_in_allowlist = Fabricate(:user)
     user_in_allowlist = Fabricate(:user)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -3384,6 +3384,23 @@ RSpec.describe PostsController do
       expect(body).to include(public_post.topic.slug)
     end
 
+    it "excludes ignored users' likes from JSON like counts" do
+      viewer = Fabricate(:user, refresh_auto_groups: true)
+      ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+      regular_liker = Fabricate(:user, refresh_auto_groups: true)
+      PostActionCreator.like(ignored_liker, public_post)
+      PostActionCreator.like(regular_liker, public_post)
+      Fabricate(:ignored_user, user: viewer, ignored_user: ignored_liker)
+      sign_in(viewer)
+
+      get "/u/#{user.username}/activity.json"
+
+      post_json = response.parsed_body.find { |post| post["id"] == public_post.id }
+      like_summary =
+        post_json["actions_summary"].find { |action| action["id"] == PostActionType.types[:like] }
+      expect(like_summary["count"]).to eq(1)
+    end
+
     it "returns 404 if `hide_profile` user option is checked" do
       user.user_option.update_columns(hide_profile: true)
 
@@ -3564,6 +3581,24 @@ RSpec.describe PostsController do
         expect(post_ids).to include public_post.id
         expect(post_ids).to_not include private_post.id
         expect(post_ids).to_not include topicless_post.id
+      end
+
+      it "excludes ignored users' likes from json like counts" do
+        viewer = Fabricate(:user, refresh_auto_groups: true)
+        ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+        regular_liker = Fabricate(:user, refresh_auto_groups: true)
+        PostActionCreator.like(ignored_liker, public_post)
+        PostActionCreator.like(regular_liker, public_post)
+        Fabricate(:ignored_user, user: viewer, ignored_user: ignored_liker)
+        sign_in(viewer)
+
+        get "/posts.json"
+
+        post_json =
+          response.parsed_body["latest_posts"].find { |post| post["id"] == public_post.id }
+        like_summary =
+          post_json["actions_summary"].find { |action| action["id"] == PostActionType.types[:like] }
+        expect(like_summary["count"]).to eq(1)
       end
     end
   end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe PostSerializer do
       expect(like_summary[:count]).to eq(post.like_count)
     end
 
+    it "batches ignored-like counts across posts in a topic view" do
+      other_post = Fabricate(:post, topic: post.topic)
+      ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+      PostActionCreator.like(ignored_liker, post)
+      PostActionCreator.like(ignored_liker, other_post)
+      Fabricate(:ignored_user, user: actor, ignored_user: ignored_liker)
+
+      topic_view = TopicView.new(post.topic, actor)
+      queries =
+        track_sql_queries do
+          topic_view.posts.each do |p|
+            serializer = PostSerializer.new(p, scope: Guardian.new(actor), root: false)
+            serializer.topic_view = topic_view
+            serializer.actions_summary
+          end
+        end
+
+      ignored_like_queries =
+        queries.count { |sql| sql.include?("post_actions") && sql.include?("ignored_user") }
+      expect(ignored_like_queries).to be <= 1
+    end
+
     it "can't flag your own post to notify yourself" do
       serializer = PostSerializer.new(post, scope: Guardian.new(post.user), root: false)
       notify_user_action =

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -34,6 +34,34 @@ RSpec.describe PostSerializer do
       expect(visible_actions_for(admin).sort).to eq(%i[like notify_user spam])
     end
 
+    it "subtracts likes from ignored users from the like count" do
+      ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+      regular_liker = Fabricate(:user, refresh_auto_groups: true)
+      PostActionCreator.like(ignored_liker, post)
+      PostActionCreator.like(regular_liker, post)
+      Fabricate(:ignored_user, user: actor, ignored_user: ignored_liker)
+      post.reload
+
+      serializer = PostSerializer.new(post, scope: Guardian.new(actor), root: false)
+      like_summary = serializer.actions_summary.find { |a| a[:id] == PostActionType.types[:like] }
+
+      expect(post.like_count).to eq(3)
+      expect(like_summary[:count]).to eq(2)
+    end
+
+    it "does not adjust the like count for anonymous viewers" do
+      ignorer = Fabricate(:user, refresh_auto_groups: true)
+      ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+      PostActionCreator.like(ignored_liker, post)
+      Fabricate(:ignored_user, user: ignorer, ignored_user: ignored_liker)
+      post.reload
+
+      serializer = PostSerializer.new(post, scope: Guardian.new, root: false)
+      like_summary = serializer.actions_summary.find { |a| a[:id] == PostActionType.types[:like] }
+
+      expect(like_summary[:count]).to eq(post.like_count)
+    end
+
     it "can't flag your own post to notify yourself" do
       serializer = PostSerializer.new(post, scope: Guardian.new(post.user), root: false)
       notify_user_action =

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -79,9 +79,35 @@ RSpec.describe PostSerializer do
           end
         end
 
-      ignored_like_queries =
-        queries.count { |sql| sql.include?("post_actions") && sql.include?("ignored_user") }
-      expect(ignored_like_queries).to be <= 1
+      per_post_count_queries =
+        queries.count { |sql| sql =~ /COUNT.*FROM "post_actions".*post_id" = \d/m }
+      expect(per_post_count_queries).to eq(0)
+    end
+
+    it "uses preloaded ignored-like counts outside a topic view" do
+      other_post = Fabricate(:post, topic: post.topic)
+      ignored_liker = Fabricate(:user, refresh_auto_groups: true)
+      PostActionCreator.like(ignored_liker, post)
+      PostActionCreator.like(ignored_liker, other_post)
+      Fabricate(:ignored_user, user: actor, ignored_user: ignored_liker)
+
+      ignored_user_like_counts = PostAction.ignored_user_like_counts_for([post, other_post], actor)
+
+      queries =
+        track_sql_queries do
+          [post, other_post].each do |p|
+            PostSerializer.new(
+              p,
+              scope: Guardian.new(actor),
+              root: false,
+              ignored_user_like_counts: ignored_user_like_counts,
+            ).actions_summary
+          end
+        end
+
+      per_post_count_queries =
+        queries.count { |sql| sql =~ /COUNT.*FROM "post_actions".*post_id" = \d/m }
+      expect(per_post_count_queries).to eq(0)
     end
 
     it "can't flag your own post to notify yourself" do


### PR DESCRIPTION
With this change, a user who is ignoring another no longer sees that user's likes or reactions: the ignored user is hidden from the likes/reactions lists, and the like and reaction counts shown to the ignoring user are adjusted accordingly. 

Anonymous viewers and viewers who aren't ignoring anyone see the original counts.

See it in action in the video:

https://github.com/user-attachments/assets/535e9aaa-0a1c-49eb-a2d4-5fdebf9d7539

