### PR TITLE
FIX: Notifications for upcoming changes not updating filter

### DIFF
--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -4,13 +4,13 @@ import { fn, get, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { schedule } from "@ember/runloop";
 import DButton from "discourse/components/d-button";
 import DSelect from "discourse/components/d-select";
 import FilterInput from "discourse/components/filter-input";
 import concatClass from "discourse/helpers/concat-class";
 import { isTesting } from "discourse/lib/environment";
+import { resettableTracked } from "discourse/lib/tracked-tools";
 import { and, not } from "discourse/truth-helpers";
 
 /**
@@ -39,10 +39,12 @@ import { and, not } from "discourse/truth-helpers";
  */
 
 export default class AdminFilterControls extends Component {
-  @tracked textFilter = "";
   @tracked dropdownFilter = "all";
   @tracked
   showFilterDropdowns = this.args.filterDropdownsExpanded ?? isTesting();
+  @resettableTracked
+  textFilter = this.args.initialTextFilter?.replace(/,\s*/g, ", ") || "";
+
   dropdownFilters = trackedObject();
 
   constructor() {
@@ -183,23 +185,12 @@ export default class AdminFilterControls extends Component {
 
   @action
   setupComponent() {
-    this.syncTextFilterFromArg();
-
     if (this.hasMultipleDropdowns) {
       Object.keys(this.dropdownOptions).forEach((key) => {
         this.dropdownFilters[key] = this.defaultValue(key);
       });
     } else {
       this.dropdownFilter = this.defaultDropdownValue;
-    }
-  }
-
-  @action
-  syncTextFilterFromArg() {
-    if (this.args.initialTextFilter) {
-      this.textFilter = this.args.initialTextFilter.replace(/,\s*/g, ", ");
-    } else {
-      this.textFilter = "";
     }
   }
 
@@ -257,7 +248,6 @@ export default class AdminFilterControls extends Component {
           (if this.hasMultipleDropdowns "--multiple-dropdowns")
         }}
         {{didInsert this.setupComponent}}
-        {{didUpdate this.syncTextFilterFromArg @initialTextFilter}}
       >
         <div class="admin-filter-controls__inputs">
           <FilterInput

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -4,6 +4,7 @@ import { fn, get, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { schedule } from "@ember/runloop";
 import DButton from "discourse/components/d-button";
 import DSelect from "discourse/components/d-select";
@@ -182,9 +183,7 @@ export default class AdminFilterControls extends Component {
 
   @action
   setupComponent() {
-    if (this.args.initialTextFilter) {
-      this.textFilter = this.args.initialTextFilter.replace(/,\s*/g, ", ");
-    }
+    this.syncTextFilterFromArg();
 
     if (this.hasMultipleDropdowns) {
       Object.keys(this.dropdownOptions).forEach((key) => {
@@ -192,6 +191,15 @@ export default class AdminFilterControls extends Component {
       });
     } else {
       this.dropdownFilter = this.defaultDropdownValue;
+    }
+  }
+
+  @action
+  syncTextFilterFromArg() {
+    if (this.args.initialTextFilter) {
+      this.textFilter = this.args.initialTextFilter.replace(/,\s*/g, ", ");
+    } else {
+      this.textFilter = "";
     }
   }
 
@@ -249,6 +257,7 @@ export default class AdminFilterControls extends Component {
           (if this.hasMultipleDropdowns "--multiple-dropdowns")
         }}
         {{didInsert this.setupComponent}}
+        {{didUpdate this.syncTextFilterFromArg @initialTextFilter}}
       >
         <div class="admin-filter-controls__inputs">
           <FilterInput

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -263,6 +263,47 @@ describe "Admin upcoming changes" do
     upcoming_changes_page.filter_controls.select_all_dropdown_option(dropdown_id: "enabled")
   end
 
+  it "updates the filter when a notification is clicked while already on the page" do
+    user_menu = PageObjects::Components::UserMenu.new
+
+    Fabricate(
+      :notification,
+      user: current_user,
+      notification_type: Notification.types[:upcoming_change_available],
+      data: {
+        upcoming_change_names: ["enable_upload_debug_mode"],
+        upcoming_change_humanized_names: [
+          SiteSettings::LabelFormatter.humanized_name(:enable_upload_debug_mode),
+        ],
+        count: 1,
+      }.to_json,
+    )
+    Fabricate(
+      :notification,
+      user: current_user,
+      notification_type: Notification.types[:upcoming_change_available],
+      data: {
+        upcoming_change_names: ["about_page_extra_groups_show_description"],
+        upcoming_change_humanized_names: [
+          SiteSettings::LabelFormatter.humanized_name(:about_page_extra_groups_show_description),
+        ],
+        count: 1,
+      }.to_json,
+    )
+
+    visit "/"
+
+    user_menu.open.click_notification_with_href("enable_upload_debug_mode")
+
+    expect(upcoming_changes_page).to have_change(:enable_upload_debug_mode)
+    expect(upcoming_changes_page).to have_no_change(:about_page_extra_groups_show_description)
+
+    user_menu.open.click_notification_with_href("about_page_extra_groups_show_description")
+
+    expect(upcoming_changes_page).to have_change(:about_page_extra_groups_show_description)
+    expect(upcoming_changes_page).to have_no_change(:enable_upload_debug_mode)
+  end
+
   it "displays a notification dot on the sidebar and clears it when navigating to upcoming changes" do
     sidebar = PageObjects::Components::NavigationMenu::Sidebar.new
 

--- a/spec/system/page_objects/components/user_menu.rb
+++ b/spec/system/page_objects/components/user_menu.rb
@@ -38,6 +38,11 @@ module PageObjects
         self
       end
 
+      def click_notification_with_href(href_substring)
+        find(".user-menu .notification a[href*='#{href_substring}']").click
+        self
+      end
+
       def sign_out
         open
         click_profile_tab


### PR DESCRIPTION
Fixes this observed issue:

* Got two notifications for upcoming changes, one for the new reactions
  UI, another for the events category setup
* I clicked the reactions one and was taken to the right place, with the
  filter applied so I only saw that setting
* I clicked the one for events category next

**Expected:** filter updated so I’m only viewing the change for events
category
**Observed:** nothing updated. The filter for the reactions was
still applied, and that’s what I’m looking at.
