### PR TITLE
DEV: Add country code to browser pageview payloads

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -670,6 +670,7 @@ class Middleware::RequestTracker
       user_id: data[:current_user_id],
       url: data[:tracking_url],
       ip_address: data[:request_remote_ip],
+      country_code: DiscourseIpInfo.get(data[:request_remote_ip])[:country_code],
       user_agent: data[:user_agent],
       referrer: data[:tracking_referrer],
       session_id: data[:tracking_session_id],

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -597,6 +597,7 @@ RSpec.describe Middleware::RequestTracker do
         before { SiteSetting.trigger_browser_pageview_events = true }
         it "triggers event for anonymous user page views when `login_required` site setting is false" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+          DiscourseIpInfo.stubs(:get).returns(country_code: "AU")
 
           data =
             Middleware::RequestTracker.get_data(
@@ -622,6 +623,7 @@ RSpec.describe Middleware::RequestTracker do
           expect(event[:url]).to eq("https://discourse.org")
           expect(event[:referrer]).to eq("https://example.com")
           expect(event).to have_key(:ip_address)
+          expect(event[:country_code]).to eq("AU")
           expect(event[:user_agent]).to be_present
         end
 
@@ -681,6 +683,7 @@ RSpec.describe Middleware::RequestTracker do
 
         it "triggers event for logged-in user page views" do
           user = Fabricate(:user, active: true)
+          DiscourseIpInfo.stubs(:get).returns(country_code: "DE")
           token = UserAuthToken.generate!(user_id: user.id)
           cookie =
             create_auth_cookie(
@@ -713,6 +716,7 @@ RSpec.describe Middleware::RequestTracker do
           expect(event[:url]).to eq("https://discourse.org")
           expect(event[:referrer]).to eq("https://example.com")
           expect(event).to have_key(:ip_address)
+          expect(event[:country_code]).to eq("DE")
           expect(event[:user_agent]).to be_present
         end
 
@@ -819,6 +823,7 @@ RSpec.describe Middleware::RequestTracker do
 
     it "increments beacon-specific counters and fires beacon event with correct data" do
       SiteSetting.trigger_browser_pageview_events = true
+      DiscourseIpInfo.stubs(:get).returns(country_code: "US")
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
 
       events =
@@ -846,6 +851,7 @@ RSpec.describe Middleware::RequestTracker do
       expect(event[:referrer]).to eq("https://test.com/")
       expect(event[:session_id]).to eq("abc123")
       expect(event[:topic_id]).to eq(123)
+      expect(event[:country_code]).to eq("US")
       expect(event[:user_agent]).to eq(
         "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
       )


### PR DESCRIPTION
This adds country_code to the browser pageview event payload emitted by RequestTracker.

The value is resolved in core using DiscourseIpInfo.get(data[:request_remote_ip])[:country_code], so both normal browser pageview events and beacon pageview events can persist the visitor country when the browser pageview events plugin handles them.