### PR TITLE
FIX: Topics with multiple watched tags appearing fewer times in lists

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -1027,32 +1027,35 @@ class TopicQuery
           []
         end
 
-      # OR watched_topic_tags.id IS NOT NULL",
+      query_params = {
+        category_id: category_id || -1,
+        default: CategoryUser.default_notification_level,
+        indirectly_muted_category_ids:
+          CategoryUser.indirectly_muted_category_ids(user).presence || [-1],
+        muted: CategoryUser.notification_levels[:muted],
+        regular: TopicUser.notification_levels[:regular],
+      }
+
       list =
         list.references("cu").joins(
           "LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}",
         )
+      query_params[:watched_tag_ids] = watched_tag_ids if watched_tag_ids.present?
+
+      muted_category_condition =
+        +"topics.category_id = :category_id
+                OR
+                (COALESCE(category_users.notification_level, :default) <> :muted AND (topics.category_id IS NULL OR topics.category_id NOT IN(:indirectly_muted_category_ids)))"
+
       if watched_tag_ids.present?
-        list =
-          list.joins(
-            "LEFT JOIN topic_tags watched_topic_tags ON watched_topic_tags.topic_id = topics.id AND #{DB.sql_fragment("watched_topic_tags.tag_id IN (?)", watched_tag_ids)}",
-          )
+        muted_category_condition << "
+                OR EXISTS (SELECT 1 FROM topic_tags watched_topic_tags WHERE watched_topic_tags.topic_id = topics.id AND watched_topic_tags.tag_id IN (:watched_tag_ids))"
       end
 
-      list =
-        list.where(
-          "topics.category_id = :category_id
-                OR
-                (COALESCE(category_users.notification_level, :default) <> :muted AND (topics.category_id IS NULL OR topics.category_id NOT IN(:indirectly_muted_category_ids)))
-                #{watched_tag_ids.present? ? "OR watched_topic_tags.id IS NOT NULL" : ""}
-                OR tu.notification_level > :regular",
-          category_id: category_id || -1,
-          default: CategoryUser.default_notification_level,
-          indirectly_muted_category_ids:
-            CategoryUser.indirectly_muted_category_ids(user).presence || [-1],
-          muted: CategoryUser.notification_levels[:muted],
-          regular: TopicUser.notification_levels[:regular],
-        )
+      muted_category_condition << "
+                OR tu.notification_level > :regular"
+
+      list = list.where(muted_category_condition, query_params)
     elsif SiteSetting.mute_all_categories_by_default
       category_ids = [
         SiteSetting.default_categories_watching.split("|"),

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -2356,6 +2356,15 @@ RSpec.describe TopicQuery do
         )
       end
     end
+    fab!(:second_watched_tag) do
+      Fabricate(:tag).tap do |tag|
+        TagUser.create!(
+          user: user,
+          tag: tag,
+          notification_level: TagUser.notification_levels[:watching],
+        )
+      end
+    end
     fab!(:muted_tag) do
       Fabricate(:tag).tap do |tag|
         TagUser.create!(
@@ -2385,6 +2394,18 @@ RSpec.describe TopicQuery do
           topic_in_watched_category_and_muted_tag.id,
           topic_in_muted_category_and_watched_tag.id,
         )
+      end
+
+      it "does not return fewer topics when multiple watched tags match the same topic" do
+        user.user_option.update!(watched_precedence_over_muted: true)
+        topics_with_multiple_watched_tags =
+          4.times.map do
+            Fabricate(:topic, category: muted_category, tags: [watched_tag, second_watched_tag])
+          end
+
+        query = TopicQuery.new(user, per_page: 4).list_latest
+
+        expect(query.topics.map(&:id)).to eq(topics_with_multiple_watched_tags.reverse.map(&:id))
       end
     end
 


### PR DESCRIPTION
Replace the LEFT JOIN on `topic_tags` used to surface watched tags in
muted categories with an `EXISTS` subquery. The previous join produced
one row per matching tag, so a topic tagged with multiple watched tags
was duplicated and could be cut off by `per_page` limits, making lists
appear shorter than expected.
