### PR TITLE
UX: remove always present padding

### DIFF
--- a/themes/horizon/scss/topic.scss
+++ b/themes/horizon/scss/topic.scss
@@ -133,9 +133,3 @@ nav.post-controls .actions button {
     }
   }
 }
-
-@include viewport.until(md) {
-  #category-events-calendar {
-    padding: var(--space-4);
-  }
-}


### PR DESCRIPTION
The cause of this permanent extra space on Horizon:

<img width="690" height="272" alt="image" src="https://github.com/user-attachments/assets/2f0b06cd-86aa-463a-926d-468e34160980" />
