### PR TITLE
UX: Improvements to AI bot docked composer

### DIFF
--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -90,6 +90,14 @@ export default class DockedComposer extends Component {
     }
   };
 
+  get maxResizeOffset() {
+    return this.args.maxResizeOffset ?? null;
+  }
+
+  get resizeAriaMax() {
+    return this.maxResizeOffset ?? 400;
+  }
+
   get show() {
     return this.args.show ?? true;
   }
@@ -304,7 +312,9 @@ export default class DockedComposer extends Component {
     }
     // dragging UP should grow the composer, so invert
     const delta = this.#dragStart.clientY - event.clientY;
-    this.dragOffset = Math.max(0, this.#dragStart.offset + delta);
+    const raw = Math.max(0, this.#dragStart.offset + delta);
+    this.dragOffset =
+      this.maxResizeOffset != null ? Math.min(this.maxResizeOffset, raw) : raw;
     this.#rootElement.style.setProperty(
       "--docked-composer-drag-offset",
       `${this.dragOffset}px`
@@ -317,11 +327,11 @@ export default class DockedComposer extends Component {
     // dragOffset state so the keyboard interaction stays in sync with
     // pointer drags.
     const STEP = 16;
-    const MAX_OFFSET = 400;
+    const max = this.maxResizeOffset ?? 400;
     let next = this.dragOffset;
     switch (event.key) {
       case "ArrowUp":
-        next = Math.min(MAX_OFFSET, this.dragOffset + STEP);
+        next = Math.min(max, this.dragOffset + STEP);
         break;
       case "ArrowDown":
         next = Math.max(0, this.dragOffset - STEP);
@@ -330,7 +340,7 @@ export default class DockedComposer extends Component {
         next = 0;
         break;
       case "End":
-        next = MAX_OFFSET;
+        next = max;
         break;
       default:
         return;
@@ -375,7 +385,7 @@ export default class DockedComposer extends Component {
             aria-label={{i18n "composer.resize"}}
             aria-valuenow={{this.dragOffset}}
             aria-valuemin="0"
-            aria-valuemax="400"
+            aria-valuemax={{this.resizeAriaMax}}
             tabindex="0"
             {{! template-lint-disable no-pointer-down-event-binding }}
             {{on "pointerdown" this.onResizeStart}}

--- a/frontend/discourse/tests/integration/components/docked-composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/docked-composer-test.gjs
@@ -112,4 +112,49 @@ module("Integration | Component | docked-composer", function (hooks) {
 
     assert.true(submitted, "Meta+Enter submits when submitOnEnter is false");
   });
+
+  test("keyboard End key respects @maxResizeOffset when provided", async function (assert) {
+    await render(
+      <template>
+        <DockedComposer
+          @resizable={{true}}
+          @maxResizeOffset={{200}}
+          @composerEvents={{false}}
+          @draftKey="test-resize-max"
+        />
+      </template>
+    );
+
+    await triggerKeyEvent(".docked-composer__resize-handle", "keydown", "End");
+
+    assert.strictEqual(
+      document
+        .querySelector(".docked-composer__resize-handle")
+        .getAttribute("aria-valuenow"),
+      "200",
+      "End key snaps to @maxResizeOffset, not the default 400"
+    );
+  });
+
+  test("keyboard End key defaults to 400 when @maxResizeOffset is not provided", async function (assert) {
+    await render(
+      <template>
+        <DockedComposer
+          @resizable={{true}}
+          @composerEvents={{false}}
+          @draftKey="test-resize-default"
+        />
+      </template>
+    );
+
+    await triggerKeyEvent(".docked-composer__resize-handle", "keydown", "End");
+
+    assert.strictEqual(
+      document
+        .querySelector(".docked-composer__resize-handle")
+        .getAttribute("aria-valuenow"),
+      "400",
+      "End key defaults to 400 when no @maxResizeOffset"
+    );
+  });
 });

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -204,7 +204,9 @@ export default class AiBotDockedComposer extends Component {
           >
             {{#if this.isStreaming}}
               <span class="ai-bot-scroll-indicator__dots">
-                <span></span><span></span><span></span>
+                <span class="ai-bot-scroll-indicator__dot"></span><span
+                  class="ai-bot-scroll-indicator__dot"
+                ></span><span class="ai-bot-scroll-indicator__dot"></span>
               </span>
             {{else}}
               {{icon "chevron-down"}}

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -1,8 +1,14 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DockedComposer from "discourse/components/docked-composer";
+import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 const DRAFT_KEY_PREFIX = "ai-bot-docked-draft-";
@@ -21,6 +27,20 @@ export default class AiBotDockedComposer extends Component {
   @service aiBotDockedSubmit;
   @service aiBotStreamingState;
   @service siteSettings;
+
+  @tracked showToolbar = false;
+  @tracked hasContentBelow = false;
+
+  #resizeObserver = null;
+
+  #checkScroll = () => {
+    const threshold = 100;
+    this.hasContentBelow =
+      document.documentElement.scrollHeight -
+        window.scrollY -
+        window.innerHeight >
+      threshold;
+  };
 
   get topic() {
     return this.args.outletArgs?.model ?? null;
@@ -52,6 +72,25 @@ export default class AiBotDockedComposer extends Component {
     return this.siteSettings.min_personal_message_post_length ?? 1;
   }
 
+  get composerClass() {
+    const classes = ["ai-bot-docked-composer"];
+    if (!this.showToolbar) {
+      classes.push("docked-composer--toolbar-hidden");
+    }
+    if (!this.hasContentBelow) {
+      classes.push("docked-composer--at-bottom");
+    }
+    return classes.join(" ");
+  }
+
+  get showScrollIndicator() {
+    return this.isBotPm && this.hasContentBelow;
+  }
+
+  get maxResizeOffset() {
+    return Math.floor(window.innerHeight / 2);
+  }
+
   @action
   async onSubmit({ raw, uploads, inProgressUploadsCount }) {
     return this.aiBotDockedSubmit.submitReply({
@@ -63,6 +102,11 @@ export default class AiBotDockedComposer extends Component {
   }
 
   @action
+  toggleToolbar() {
+    this.showToolbar = !this.showToolbar;
+  }
+
+  @action
   async onStopStreaming() {
     if (!this.topicId) {
       return;
@@ -70,10 +114,33 @@ export default class AiBotDockedComposer extends Component {
     await this.aiBotStreamingState.stopStreaming(this.topicId);
   }
 
+  @action
+  setupScrollListener() {
+    window.addEventListener("scroll", this.#checkScroll, { passive: true });
+    this.#resizeObserver = new ResizeObserver(this.#checkScroll);
+    this.#resizeObserver.observe(document.body);
+    this.#checkScroll();
+  }
+
+  @action
+  teardownScrollListener() {
+    window.removeEventListener("scroll", this.#checkScroll);
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+  }
+
+  @action
+  scrollToBottom() {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: "smooth",
+    });
+  }
+
   <template>
     <DockedComposer
       @show={{this.isBotPm}}
-      @class="ai-bot-docked-composer"
+      @class={{this.composerClass}}
       @bodyClassName="has-ai-bot-docked-composer"
       @topicId={{this.topicId}}
       @draftKey={{this.draftKey}}
@@ -87,8 +154,21 @@ export default class AiBotDockedComposer extends Component {
       @isSubmitting={{this.aiBotDockedSubmit.loading}}
       @disabled={{this.isStreaming}}
       @resizable={{true}}
+      @maxResizeOffset={{this.maxResizeOffset}}
+      {{didInsert this.setupScrollListener}}
+      {{willDestroy this.teardownScrollListener}}
     >
       <:submit as |ctx|>
+        <DButton
+          @icon={{if this.showToolbar "xmark" "plus"}}
+          @action={{this.toggleToolbar}}
+          @title={{if
+            this.showToolbar
+            "discourse_ai.ai_bot.conversations.hide_toolbar"
+            "discourse_ai.ai_bot.conversations.show_toolbar"
+          }}
+          class="docked-composer__submit-btn ai-bot-docked-composer__toolbar-toggle"
+        />
         {{#if this.isStreaming}}
           <DButton
             @icon="pause"
@@ -108,6 +188,29 @@ export default class AiBotDockedComposer extends Component {
         {{/if}}
       </:submit>
       <:default>
+        {{#if this.showScrollIndicator}}
+          <button
+            type="button"
+            aria-label={{if
+              this.isStreaming
+              (i18n "discourse_ai.ai_bot.conversations.streaming_below")
+              (i18n "discourse_ai.ai_bot.conversations.scroll_to_bottom")
+            }}
+            class={{concatClass
+              "ai-bot-scroll-indicator"
+              (if this.isStreaming "ai-bot-scroll-indicator--streaming")
+            }}
+            {{on "click" this.scrollToBottom}}
+          >
+            {{#if this.isStreaming}}
+              <span class="ai-bot-scroll-indicator__dots">
+                <span></span><span></span><span></span>
+              </span>
+            {{else}}
+              {{icon "chevron-down"}}
+            {{/if}}
+          </button>
+        {{/if}}
         <p class="ai-bot-docked-composer__disclaimer">
           {{i18n "discourse_ai.ai_bot.conversations.disclaimer"}}
         </p>

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
@@ -68,7 +68,19 @@ function initializeAIBotReplies(api) {
       if (data?.done) {
         streamingState?.markFinishedAfterRender(topicId, data?.post_id);
       } else {
-        streamingState?.markStarted(topicId, data?.post_id);
+        const postId = data?.post_id;
+        // If the post is already rendered and has no .streaming class, this
+        // chunk is a stale replay of a stream that already finished. Calling
+        // markStarted would wrongly show the stop button until the 15-s idle
+        // timer fires. Clear any leftover state and bail out instead.
+        if (postId) {
+          const postEl = document.querySelector(`[data-post-id="${postId}"]`);
+          if (postEl && !postEl.classList.contains("streaming")) {
+            streamingState?.markFinished(topicId);
+            return;
+          }
+        }
+        streamingState?.markStarted(topicId, postId);
       }
 
       streamPostText(this.model.postStream, data);
@@ -81,11 +93,17 @@ function initializeAIBotReplies(api) {
         this.model.details.allowed_users &&
         this.model.details.allowed_users.filter(isGPTBot).length >= 1
       ) {
-        // -3 is not obvious, but the implementation in message bus is -2 (last + new), -3 (last 2 + new)
+        // -2 replays only the last message before listening for new ones.
+        // A completed stream always ends with done:true as its final message,
+        // so replaying just the last event is enough to resume an in-progress
+        // stream AND avoids the stale-state bug where replaying an earlier
+        // chunk calls markStarted right before the done message, leaving the
+        // MutationObserver waiting for a .streaming class that never gets
+        // removed (because streamPostText has nothing left to stream).
         this.messageBus.subscribe(
           `discourse-ai/ai-bot/topic/${this.model.id}`,
           this.onAIBotStreamedReply.bind(this),
-          -3
+          -2
         );
       }
     },

--- a/plugins/discourse-ai/assets/javascripts/discourse/services/ai-bot-streaming-state.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/services/ai-bot-streaming-state.js
@@ -3,7 +3,7 @@ import Service from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
-// The message bus replays the last two events on subscribe. The idle
+// The message bus replays the last event on subscribe (-2 offset). The idle
 // timer only arms once we've received a real streaming chunk (with a
 // postId); between chunks we expect a new update within ~40ms, so a
 // generous ceiling of 15s can't race a live stream.

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -42,6 +42,156 @@ body.has-ai-bot-docked-composer {
 
   // ~4 lines tall by default; still expands further with content
   --docked-composer-input-min-height: 7em;
+
+  // Remove the spacing above the composer
+  padding-top: 0;
+  margin-top: 0;
+
+  // Hide the fade when already at the bottom — nothing is being obscured
+  // above the composer so the gradient adds no information.
+  &.docked-composer--at-bottom::before {
+    display: none;
+  }
+}
+
+// Place the resize handle inside the editor box, directly above the toolbar.
+// The handle overlaps 1em into the editor column, which has matching padding-top
+// added below to create exactly that amount of space above the toolbar.
+.docked-composer.ai-bot-docked-composer.docked-composer--resizable {
+  gap: 0;
+
+  .docked-composer__resize-handle {
+    height: 1em;
+    position: relative;
+    z-index: 2;
+    margin-bottom: -1em;
+  }
+}
+
+// Create the 1em slot at the top of the input box that the resize handle fills;
+// use content-border-color to tie the editor box visually to the page chrome
+.docked-composer.ai-bot-docked-composer .d-editor-textarea-column {
+  padding-top: 1em;
+  border-color: var(--content-border-color);
+}
+
+// Animate the toolbar in/out for the AI bot composer
+.docked-composer.ai-bot-docked-composer .d-editor-button-bar__wrap {
+  overflow: hidden;
+  max-height: 4em;
+  opacity: 1;
+  transition:
+    max-height 0.25s ease,
+    opacity 0.2s ease;
+}
+
+.docked-composer.ai-bot-docked-composer.docked-composer--toolbar-hidden
+  .d-editor-button-bar__wrap {
+  max-height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+// Toolbar toggle button: mirrors submit-btn chrome but sits at bottom-left
+.ai-bot-docked-composer__toolbar-toggle.btn {
+  position: absolute;
+  left: 0.5em;
+  right: auto;
+  bottom: 0.5em;
+  z-index: 2;
+  min-width: auto;
+  min-height: auto;
+  padding: 0.35em 0.5em;
+  border-radius: var(--d-button-border-radius);
+  background: transparent !important;
+
+  .d-icon {
+    color: var(--primary-medium) !important;
+    font-size: var(--font-down-1);
+  }
+
+  &:hover:not(:disabled),
+  &:focus-visible {
+    background: var(--primary-very-low) !important;
+
+    .d-icon {
+      color: var(--primary-high) !important;
+    }
+  }
+}
+
+// Floating scroll indicator: appears above the composer when content is below.
+// Shows animated dots while streaming, a chevron-down arrow otherwise.
+.ai-bot-scroll-indicator {
+  position: absolute;
+  bottom: calc(100% + 0.75em);
+  left: calc(50% + var(--docked-composer-content-offset) / 2);
+  transform: translateX(-50%);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4em 0.8em;
+  background: var(--secondary);
+  border: 1px solid var(--content-border-color);
+  border-radius: 2em;
+  cursor: pointer;
+
+  // reset native button styles
+  appearance: none;
+  font: inherit;
+
+  .d-icon {
+    width: 0.875em;
+    height: 0.875em;
+    color: var(--primary-medium);
+  }
+
+  &:hover {
+    border-color: var(--primary-medium);
+
+    .d-icon {
+      color: var(--primary);
+    }
+  }
+
+  &__dots {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding-block: 0.15em;
+
+    span {
+      display: block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--primary-medium);
+      animation: ai-scroll-dot 1.4s ease-in-out infinite;
+
+      &:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+
+      &:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+    }
+  }
+}
+
+@keyframes ai-scroll-dot {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.5;
+  }
+
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
 }
 
 .ai-bot-docked-composer__disclaimer {

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -160,22 +160,22 @@ body.has-ai-bot-docked-composer {
     align-items: center;
     gap: 4px;
     padding-block: 0.15em;
+  }
 
-    span {
-      display: block;
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      background: var(--primary-medium);
-      animation: ai-scroll-dot 1.4s ease-in-out infinite;
+  &__dot {
+    display: block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--primary-medium);
+    animation: ai-scroll-dot 1.4s ease-in-out infinite;
 
-      &:nth-child(2) {
-        animation-delay: 0.2s;
-      }
+    &:nth-child(2) {
+      animation-delay: 0.2s;
+    }
 
-      &:nth-child(3) {
-        animation-delay: 0.4s;
-      }
+    &:nth-child(3) {
+      animation-delay: 0.4s;
     }
   }
 }

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -1244,6 +1244,10 @@ en:
           last_30_days: "Last 30 days"
           upload_files: "Upload files"
           uploads_in_progress: "Cannot submit while uploads are in progress"
+          show_toolbar: "Show formatting toolbar"
+          hide_toolbar: "Hide formatting toolbar"
+          scroll_to_bottom: "Scroll to bottom"
+          streaming_below: "New content below"
       sentiments:
         dashboard:
           title: "Sentiment"

--- a/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe "AI Bot docked composer" do
     expect(page).to have_css("#topic-footer-buttons .create")
   end
 
+  it "hides the toolbar by default and shows it when the toggle button is clicked" do
+    topic_page.visit_topic(pm)
+
+    expect(page).to have_css(".ai-bot-docked-composer.docked-composer--toolbar-hidden")
+    expect(page).to have_no_css(".d-editor-button-bar__wrap", visible: true)
+
+    find(".ai-bot-docked-composer__toolbar-toggle").click
+
+    expect(page).to have_no_css(".ai-bot-docked-composer.docked-composer--toolbar-hidden")
+  end
+
   it "clears the reply field after a successful submit" do
     topic_page.visit_topic(pm)
 


### PR DESCRIPTION
Previously, the AI bot docked composer showed the formatting toolbar by default, had no visual affordance for scrolling to new content during streaming, and incorrectly reported a streaming-in-progress state after page refresh when the stream had already completed (caused by replaying a stale message bus chunk on subscribe).

This change hides the toolbar behind an animated toggle button, adds a scroll indicator above the composer (animated dots when streaming, chevron-down otherwise), moves the resize handle inside the editor box, suppresses the scroll fade gradient when already at the bottom of the page, and fixes the stale streaming state by detecting when a replayed message bus chunk refers to a post already rendered without a .streaming class.

https://github.com/user-attachments/assets/bae788d1-2105-4c47-93c1-08bb58dfd850


