### PR TITLE
Update sendmail config for Mail gem >=2.9.0 compatibility

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -291,6 +291,10 @@ class GlobalSetting
     end
   end
 
+  def self.sendmail_settings
+    { arguments: %w[-i] }
+  end
+
   class BaseProvider
     def self.coerce(setting)
       return setting == "true" if setting == "true" || setting == "false"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Discourse::Application.configure do
     config.action_mailer.smtp_settings = smtp_settings
   else
     config.action_mailer.delivery_method = :sendmail
-    config.action_mailer.sendmail_settings = { arguments: %w[-i] }
+    config.action_mailer.sendmail_settings = GlobalSetting.sendmail_settings
   end
 
   # Send deprecation notices to registered listeners

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Discourse::Application.configure do
     config.action_mailer.smtp_settings = smtp_settings
   else
     config.action_mailer.delivery_method = :sendmail
-    config.action_mailer.sendmail_settings = { arguments: "-i" }
+    config.action_mailer.sendmail_settings = { arguments: %w[-i] }
   end
 
   # Send deprecation notices to registered listeners

--- a/spec/integration/sendmail_spec.rb
+++ b/spec/integration/sendmail_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe "Sendmail Settings Integration" do
+  it "configures arguments as an Array, not a String (mail gem >= 2.9.0 compatibility)" do
+    expect(GlobalSetting.sendmail_settings[:arguments]).to be_an(Array)
+  end
+
+  it "does not raise an error when initialising Sendmail with the default settings" do
+    expect { Mail::Sendmail.new(GlobalSetting.sendmail_settings) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
When a site falls back to sendmail, the config appears to be broken since Mail gem 2.9.0.

We're passing a string when it expects an array of strings.

See https://github.com/mikel/mail/blob/d1d65b370b109b98e673a934e8b70a0c1f58cc59/lib/mail/network/delivery_methods/sendmail.rb#L53

This was causing a pile up of digest email job retries, see dev topic /t/182887

This PR fixes the config and also moves it to a GlobalSetting so I could write a spec to make sure the default config is valid.