### PR TITLE
FIX: AI bot docked composer mobile issues and edit support

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -32,14 +32,46 @@ export default class AiBotDockedComposer extends Component {
   @tracked hasContentBelow = false;
 
   #resizeObserver = null;
+  #keyboardOpen = false;
+  #composerEl = null;
 
   #checkScroll = () => {
     const threshold = 100;
-    this.hasContentBelow =
+    const below =
       document.documentElement.scrollHeight -
         window.scrollY -
         window.innerHeight >
       threshold;
+    if (below !== this.hasContentBelow) {
+      this.hasContentBelow = below;
+    }
+  };
+
+  #onViewportChange = () => {
+    if (!window.visualViewport) {
+      return;
+    }
+    const keyboardOffset = window.innerHeight - window.visualViewport.height;
+    const composerEl = this.#composerEl;
+    if (!composerEl) {
+      return;
+    }
+
+    if (keyboardOffset > 100) {
+      if (!this.#keyboardOpen) {
+        this.#keyboardOpen = true;
+        composerEl.classList.add("docked-composer--keyboard-open");
+      }
+      const top =
+        window.visualViewport.offsetTop +
+        window.visualViewport.height -
+        composerEl.offsetHeight;
+      composerEl.style.top = `${top}px`;
+    } else if (this.#keyboardOpen) {
+      this.#keyboardOpen = false;
+      composerEl.classList.remove("docked-composer--keyboard-open");
+      composerEl.style.top = "";
+    }
   };
 
   get topic() {
@@ -115,18 +147,30 @@ export default class AiBotDockedComposer extends Component {
   }
 
   @action
-  setupScrollListener() {
+  setupScrollListener(element) {
+    this.#composerEl = element;
     window.addEventListener("scroll", this.#checkScroll, { passive: true });
     this.#resizeObserver = new ResizeObserver(this.#checkScroll);
     this.#resizeObserver.observe(document.body);
     this.#checkScroll();
+    window.visualViewport?.addEventListener("resize", this.#onViewportChange);
+    window.visualViewport?.addEventListener("scroll", this.#onViewportChange);
   }
 
   @action
   teardownScrollListener() {
+    this.#composerEl = null;
     window.removeEventListener("scroll", this.#checkScroll);
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
+    window.visualViewport?.removeEventListener(
+      "resize",
+      this.#onViewportChange
+    );
+    window.visualViewport?.removeEventListener(
+      "scroll",
+      this.#onViewportChange
+    );
   }
 
   @action

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -117,6 +117,13 @@ body.has-ai-conversations-sidebar {
     display: none;
   }
 
+  @include viewport.until(sm) {
+    #topic-progress-wrapper,
+    .topic-navigation.with-topic-progress {
+      display: none;
+    }
+  }
+
   @include viewport.until(lg) {
     .archetype-private_message .topic-post:last-child {
       margin-bottom: 0;

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -5,7 +5,8 @@ body.has-ai-bot-docked-composer {
   // replaced it. Scoped to the body class, which is only present while
   // the DockedComposer component is rendered (cleared on unmount), so
   // navigating to a non-bot-PM topic restores the popup composer.
-  #reply-control {
+  // Allow it to show when editing a post (composer-action-edit class).
+  #reply-control:not(.composer-action-edit) {
     display: none !important;
   }
 
@@ -52,6 +53,32 @@ body.has-ai-bot-docked-composer {
   &.docked-composer--at-bottom::before {
     display: none;
   }
+
+  @include viewport.until(sm) {
+    --docked-composer-content-offset: 0px;
+    --docked-composer-max-width: 100%;
+  }
+
+  &.docked-composer--keyboard-open {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: auto;
+    padding-bottom: 0;
+    margin-top: 0;
+    transition: none;
+
+    // cover the gap between the composer and the keyboard
+    &::after {
+      content: "";
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      height: 100vh;
+      background: var(--secondary);
+    }
+  }
 }
 
 // Place the resize handle inside the editor box, directly above the toolbar.
@@ -65,6 +92,10 @@ body.has-ai-bot-docked-composer {
     position: relative;
     z-index: 2;
     margin-bottom: -1em;
+
+    @include viewport.until(sm) {
+      display: none;
+    }
   }
 }
 
@@ -73,6 +104,10 @@ body.has-ai-bot-docked-composer {
 .docked-composer.ai-bot-docked-composer .d-editor-textarea-column {
   padding-top: 1em;
   border-color: var(--content-border-color);
+}
+
+.docked-composer.ai-bot-docked-composer .d-editor-input {
+  padding-left: 2.5em;
 }
 
 // Animate the toolbar in/out for the AI bot composer


### PR DESCRIPTION
Previously, the AI bot docked composer had several mobile issues — the keyboard covered the input, the timeline widget floated awkwardly, the layout had a misaligned left margin, and the edit pencil was completely broken because `#reply-control` was hidden unconditionally.

This change fixes keyboard handling by tracking visualViewport to position the composer above the software keyboard, hides the timeline/progress widget on mobile, removes the desktop content offset on small screens, allows the floating composer to appear for post edits, and adds left padding to prevent text from overlapping the toolbar toggle button.

| Before | After |
| ------  | ----- |
| https://github.com/user-attachments/assets/521768fb-7dbd-4dad-9c86-78f4a86db815 | https://github.com/user-attachments/assets/cf008970-03b6-4b70-adac-67a7d3746101 |

