### PR TITLE
FIX: Include API key requests in overload protection bypass

### DIFF
--- a/lib/middleware/overload_protections.rb
+++ b/lib/middleware/overload_protections.rb
@@ -7,11 +7,7 @@ module Middleware
     end
 
     def call(env)
-      is_logged_in = Auth::DefaultCurrentUserProvider.find_v1_auth_cookie(env).present?
-
-      if !is_logged_in &&
-           env[Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY].to_f >
-             GlobalSetting.reject_anonymous_min_queue_seconds
+      if overloaded?(env) && !authenticated_request?(env)
         return [
           503,
           { "Content-Type" => "text/plain" },
@@ -20,6 +16,33 @@ module Middleware
       end
 
       @app.call(env)
+    end
+
+    private
+
+    def overloaded?(env)
+      env[Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY].to_f >
+        GlobalSetting.reject_anonymous_min_queue_seconds
+    end
+
+    def authenticated_request?(env)
+      Auth::DefaultCurrentUserProvider.find_v1_auth_cookie(env).present? ||
+        authenticated_api_request?(env)
+    end
+
+    def authenticated_api_request?(env)
+      return false unless api_credentials_present?(env)
+
+      Discourse.current_user_provider.new(env).current_user
+      env[Auth::DefaultCurrentUserProvider::API_KEY_ENV].present? ||
+        env[Auth::DefaultCurrentUserProvider::USER_API_KEY_ENV].present?
+    rescue Discourse::InvalidAccess, RateLimiter::LimitExceeded
+      false
+    end
+
+    def api_credentials_present?(env)
+      env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY].present? ||
+        env[Auth::DefaultCurrentUserProvider::USER_API_KEY].present?
     end
   end
 end

--- a/spec/lib/middleware/overload_protections_spec.rb
+++ b/spec/lib/middleware/overload_protections_spec.rb
@@ -60,5 +60,83 @@ RSpec.describe Middleware::OverloadProtections do
 
       expect(status).to eq(200)
     end
+
+    it "returns 200 for requests with a valid API key when queue time exceeds threshold" do
+      global_setting :reject_anonymous_min_queue_seconds, 1.0
+      api_key = Fabricate(:api_key, user: Fabricate(:user))
+
+      env =
+        create_request_env(path: "/latest.json").merge(
+          Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY => 1.1,
+          Auth::DefaultCurrentUserProvider::HEADER_API_KEY => api_key.key,
+        )
+
+      status, _headers, _body = app.call(env)
+
+      expect(status).to eq(200)
+    end
+
+    it "returns 200 for requests with a valid User API key when queue time exceeds threshold" do
+      global_setting :reject_anonymous_min_queue_seconds, 1.0
+      user_api_key = Fabricate(:readonly_user_api_key)
+
+      env =
+        create_request_env(path: "/latest.json").merge(
+          Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY => 1.1,
+          Auth::DefaultCurrentUserProvider::USER_API_KEY => user_api_key.key,
+        )
+
+      status, _headers, _body = app.call(env)
+
+      expect(status).to eq(200)
+    end
+
+    it "returns 503 when API key is invalid and queue time exceeds threshold" do
+      global_setting :reject_anonymous_min_queue_seconds, 1.0
+
+      env =
+        create_request_env(path: "/latest.json").merge(
+          Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY => 1.1,
+          Auth::DefaultCurrentUserProvider::HEADER_API_KEY => "invalid_api_key",
+        )
+
+      status, _headers, body = app.call(env)
+
+      expect(status).to eq(503)
+      expect(body).to eq(["Server is currently experiencing high load. Please try again later."])
+    end
+
+    it "returns 503 when User API key is invalid and queue time exceeds threshold" do
+      global_setting :reject_anonymous_min_queue_seconds, 1.0
+
+      env =
+        create_request_env(path: "/latest.json").merge(
+          Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY => 1.1,
+          Auth::DefaultCurrentUserProvider::USER_API_KEY => "invalid_user_api_key",
+        )
+
+      status, _headers, body = app.call(env)
+
+      expect(status).to eq(503)
+      expect(body).to eq(["Server is currently experiencing high load. Please try again later."])
+    end
+
+    it "returns 503 when API key has been revoked and queue time exceeds threshold" do
+      global_setting :reject_anonymous_min_queue_seconds, 1.0
+      api_key = Fabricate(:api_key, user: Fabricate(:user))
+      key_value = api_key.key
+      api_key.update!(revoked_at: Time.zone.now)
+
+      env =
+        create_request_env(path: "/latest.json").merge(
+          Middleware::ProcessingRequest::REQUEST_QUEUE_SECONDS_ENV_KEY => 1.1,
+          Auth::DefaultCurrentUserProvider::HEADER_API_KEY => key_value,
+        )
+
+      status, _headers, body = app.call(env)
+
+      expect(status).to eq(503)
+      expect(body).to eq(["Server is currently experiencing high load. Please try again later."])
+    end
   end
 end


### PR DESCRIPTION
Our `Middleware::OverloadProtections` rejects anonymous requests with 503 when queue time exceeds the `reject_anonymous_min_queue_seconds` threshold. It was only checking cookie-based auth via `find_v1_auth_cookie` to determine if a request is authenticated, so requests using API key headers (Api-Key, User-Api-Key) were incorrectly treated as anonymous.