### PR TITLE
FIX: Prevent moderators from being auto-silenced

### DIFF
--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -26,6 +26,7 @@ class UserSilencer
   end
 
   def silence
+    return false if @user.staff?
     hide_posts unless @opts[:keep_posts]
     return false if @user.silenced_till.present?
     @user.silenced_till = @opts[:silenced_till] || 1000.years.from_now

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -392,6 +392,18 @@ describe Chat::ReviewQueue do
           expect(message_poster.reload.silenced?).to eq(false)
         end
       end
+
+      context "when the target is a moderator" do
+        it "does not silence the user" do
+          SiteSetting.chat_auto_silence_from_flags_duration = 1
+          flagger.update!(trust_level: TrustLevel[4])
+          message_poster.update!(moderator: true)
+
+          queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+          expect(message_poster.reload.silenced?).to eq(false)
+        end
+      end
     end
 
     context "when flagging a DM" do

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe UserSilencer do
       expect(post.hidden).to eq(false)
     end
 
+    it "does not silence or hide posts for staff users" do
+      user.update!(moderator: true)
+
+      expect(UserSilencer.silence(user, admin)).to eq(false)
+      expect(user.reload.silenced?).to eq(false)
+      expect(post.reload.hidden).to eq(false)
+      expect(post.topic.reload.visible).to eq(true)
+    end
+
     it "allows us to silence the user for a particular post" do
       expect(UserSilencer.was_silenced_for?(post)).to eq(false)
       UserSilencer.new(user, Discourse.system_user, post_id: post.id).silence


### PR DESCRIPTION
 Fixes a bug where moderators could be auto-silenced from chat flags.

The chat auto-silence path (further above) already skipped admins, but not moderators. This adds the guard in `UserSilencer` itself so staff targets return early before any side effects happen. For added context, in guardian, `def can_silence_user?(user)` checks for `staff`.