### PR TITLE
FIX: Resolve broken uploads in AI bot docked composer

### DIFF
--- a/app/assets/stylesheets/common/components/docked-composer.scss
+++ b/app/assets/stylesheets/common/components/docked-composer.scss
@@ -189,6 +189,7 @@
     gap: 0.5em;
     width: 100%;
     max-width: var(--docked-composer-max-width);
+    padding-block: 1rem;
     padding-left: var(--docked-composer-content-offset);
     margin: 0 auto;
     box-sizing: border-box;

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -212,6 +212,10 @@ export default class DockedComposer extends Component {
         this.uploads.push(upload);
       },
     });
+
+    if (this.fileInputEl) {
+      this.uppyUpload.setup(this.fileInputEl);
+    }
   }
 
   @action

--- a/plugins/discourse-ai/assets/javascripts/discourse/services/ai-bot-docked-submit.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/services/ai-bot-docked-submit.js
@@ -12,18 +12,7 @@ export default class AiBotDockedSubmit extends Service {
   @tracked loading = false;
 
   async submitReply({ topicId, raw, uploads, inProgressUploadsCount }) {
-    if (!topicId || !raw) {
-      return null;
-    }
-
-    const minLength = this.siteSettings.min_personal_message_post_length;
-    if (raw.trim().length < minLength) {
-      this.dialog.alert({
-        message: i18n(
-          "discourse_ai.ai_bot.conversations.min_input_length_message",
-          { count: minLength }
-        ),
-      });
+    if (!topicId) {
       return null;
     }
 
@@ -34,9 +23,28 @@ export default class AiBotDockedSubmit extends Service {
       return null;
     }
 
-    let rawContent = raw;
-    if (uploads?.length) {
-      rawContent += "\n\n";
+    const hasUploads = uploads?.length > 0;
+
+    if (!raw && !hasUploads) {
+      return null;
+    }
+
+    const minLength = this.siteSettings.min_personal_message_post_length;
+    if (!hasUploads && raw.trim().length < minLength) {
+      this.dialog.alert({
+        message: i18n(
+          "discourse_ai.ai_bot.conversations.min_input_length_message",
+          { count: minLength }
+        ),
+      });
+      return null;
+    }
+
+    let rawContent = raw || "";
+    if (hasUploads) {
+      if (rawContent.length) {
+        rawContent += "\n\n";
+      }
       uploads.forEach((upload) => {
         rawContent += getUploadMarkdown(upload) + "\n";
       });

--- a/plugins/discourse-ai/test/javascripts/unit/services/ai-bot-docked-submit-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/services/ai-bot-docked-submit-test.js
@@ -20,13 +20,18 @@ module("Unit | Service | ai-bot-docked-submit", function (hooks) {
     assert.strictEqual(result, null);
   });
 
-  test("returns null when raw is missing", async function (assert) {
+  test("returns null when raw is empty and no uploads", async function (assert) {
     const service = getOwner(this).lookup("service:ai-bot-docked-submit");
-    const result = await service.submitReply({ topicId: 42, raw: "" });
+    const result = await service.submitReply({
+      topicId: 42,
+      raw: "",
+      uploads: [],
+      inProgressUploadsCount: 0,
+    });
     assert.strictEqual(result, null);
   });
 
-  test("returns null and alerts when raw is shorter than min length", async function (assert) {
+  test("returns null and alerts when raw is shorter than min length and no uploads", async function (assert) {
     const service = getOwner(this).lookup("service:ai-bot-docked-submit");
     let requestsCount = 0;
     pretender.post("/posts.json", () => {
@@ -43,6 +48,76 @@ module("Unit | Service | ai-bot-docked-submit", function (hooks) {
 
     assert.strictEqual(result, null);
     assert.strictEqual(requestsCount, 0, "no POST when too short");
+  });
+
+  test("submits with only uploads and no raw text", async function (assert) {
+    const service = getOwner(this).lookup("service:ai-bot-docked-submit");
+    let rawSent;
+    pretender.post("/posts.json", (request) => {
+      const params = new URLSearchParams(request.requestBody);
+      rawSent = params.get("raw");
+      return response(200, { id: 1, topic_id: 42 });
+    });
+
+    const result = await service.submitReply({
+      topicId: 42,
+      raw: "",
+      uploads: [
+        {
+          short_url: "upload://abc123.pdf",
+          original_filename: "document.pdf",
+          extension: "pdf",
+          filesize: 1024,
+        },
+      ],
+      inProgressUploadsCount: 0,
+    });
+
+    assert.notStrictEqual(
+      result,
+      null,
+      "submission succeeds with only uploads"
+    );
+    assert.true(
+      rawSent.includes("upload://abc123.pdf"),
+      "upload markdown is sent"
+    );
+  });
+
+  test("skips min length check when uploads are present", async function (assert) {
+    const service = getOwner(this).lookup("service:ai-bot-docked-submit");
+    let rawSent;
+    pretender.post("/posts.json", (request) => {
+      const params = new URLSearchParams(request.requestBody);
+      rawSent = params.get("raw");
+      return response(200, { id: 1, topic_id: 42 });
+    });
+
+    const result = await service.submitReply({
+      topicId: 42,
+      raw: "hi",
+      uploads: [
+        {
+          short_url: "upload://abc123.png",
+          original_filename: "screenshot.png",
+          extension: "png",
+          width: 400,
+          height: 300,
+        },
+      ],
+      inProgressUploadsCount: 0,
+    });
+
+    assert.notStrictEqual(
+      result,
+      null,
+      "submission succeeds with short text + uploads"
+    );
+    assert.true(rawSent.includes("hi"), "raw text preserved");
+    assert.true(
+      rawSent.includes("upload://abc123.png"),
+      "upload markdown appended"
+    );
   });
 
   test("returns null when uploads are still in progress", async function (assert) {


### PR DESCRIPTION
Previously, uploads in the AI bot docked composer were completely non-functional due to two issues: a Glimmer modifier ordering race condition where the file input's `didInsert` fired before the parent container's `didInsert` (so `UppyUpload` was never bound to the file input), and the submit service rejected upload-only submissions because it early-returned on empty `raw` before considering attached uploads.

This change fixes the initialization order by calling `uppyUpload.setup()` in `setupContainer` when the file input is already available, restructures the submit validation to allow upload-only posts and skip the min-length check when uploads are present, and adds vertical padding to the uploads container for better visual spacing.

<img width="791" height="330" alt="Screenshot 2026-05-04 at 10 14 43" src="https://github.com/user-attachments/assets/7a0b8e38-f29e-40f7-bac7-361ab549474c" />
