### PR TITLE
UX: don't show solved blockquote fade/expansion if unneeded

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -111,7 +111,7 @@
 .cooked,
 .d-editor-preview {
   overflow-wrap: break-word;
-  line-height: 1.5;
+  line-height: var(--cooked-line-height);
 
   video {
     max-width: 100%;

--- a/app/assets/stylesheets/common/font-variables.scss
+++ b/app/assets/stylesheets/common/font-variables.scss
@@ -32,4 +32,5 @@
   --line-height-small: 1;
   --line-height-medium: 1.2; // Headings or large text
   --line-height-large: 1.4; // Normal or small text
+  --cooked-line-height: 1.5; // Cooked post content
 }

--- a/plugins/discourse-solved/assets/javascripts/discourse/components/solved-accepted-answer.gjs
+++ b/plugins/discourse-solved/assets/javascripts/discourse/components/solved-accepted-answer.gjs
@@ -10,12 +10,17 @@ import UserLink from "discourse/components/user-link";
 import boundAvatarTemplate from "discourse/helpers/bound-avatar-template";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import onResize from "discourse/modifiers/on-resize";
 import { i18n } from "discourse-i18n";
+
+const CHARS_PER_LINE = 90;
 
 export default class SolvedAcceptedAnswer extends Component {
   @service siteSettings;
 
   @tracked expanded = false;
+  @tracked measured = false;
+  @tracked isOverflowing = false;
 
   get topic() {
     return this.args.post.topic;
@@ -82,6 +87,26 @@ export default class SolvedAcceptedAnswer extends Component {
     return `${this.topic.url}/${postNumber}`;
   }
 
+  get maxHeightStyle() {
+    const chars = this.siteSettings.solved_quote_length;
+    if (chars <= 0) {
+      return null;
+    }
+
+    const lines = Math.max(1, Math.ceil(chars / CHARS_PER_LINE));
+    return trustHTML(`--solved-max-lines: ${lines}`);
+  }
+
+  get showToggle() {
+    return (
+      this.hasExcerpt && this.measured && (this.isOverflowing || this.expanded)
+    );
+  }
+
+  get overflowingAttr() {
+    return this.measured ? String(this.isOverflowing) : "true";
+  }
+
   @action
   toggleExpanded() {
     this.expanded = !this.expanded;
@@ -95,6 +120,16 @@ export default class SolvedAcceptedAnswer extends Component {
     this.toggleExpanded();
   }
 
+  @action
+  checkOverflow(entries) {
+    const blockquote = entries?.[0]?.target;
+    if (!blockquote || this.expanded) {
+      return;
+    }
+    this.isOverflowing = blockquote.scrollHeight > blockquote.clientHeight + 1;
+    this.measured = true;
+  }
+
   <template>
     {{! template-lint-disable no-unnecessary-concat }}
     {{#if this.acceptedAnswer}}
@@ -104,7 +139,9 @@ export default class SolvedAcceptedAnswer extends Component {
           (if this.hasExcerpt "accepted-answer--has-excerpt")
           (unless this.content "title-only")
         }}
+        style={{this.maxHeightStyle}}
         data-expanded="{{this.expanded}}"
+        data-overflowing="{{this.overflowingAttr}}"
         data-username={{this.acceptedAnswer.username}}
         data-post={{this.acceptedAnswer.post_number}}
         data-topic={{this.topic.id}}
@@ -114,7 +151,7 @@ export default class SolvedAcceptedAnswer extends Component {
             {{icon "far-square-check"}}
             {{i18n "solved.title"}}</h3>
           <div class="d-solved-answer__controls">
-            {{#if this.content}}
+            {{#if this.showToggle}}
               <DButton
                 class="btn-flat d-solved-answer__toggle"
                 @action={{this.toggleExpanded}}
@@ -136,7 +173,7 @@ export default class SolvedAcceptedAnswer extends Component {
         </div>
 
         {{#if this.content}}
-          <blockquote id={{this.quoteId}}>
+          <blockquote id={{this.quoteId}} {{onResize this.checkOverflow}}>
             <PostCookedHtml
               @post={{@post}}
               @cooked={{this.content}}

--- a/plugins/discourse-solved/assets/stylesheets/solutions.scss
+++ b/plugins/discourse-solved/assets/stylesheets/solutions.scss
@@ -135,6 +135,7 @@ $solved-color: var(--success);
 
   &__controls {
     margin-left: auto;
+    display: flex;
   }
 
   &__toggle,
@@ -182,7 +183,9 @@ $solved-color: var(--success);
     background: var(--secondary);
     border: 0;
     padding: var(--space-3);
-    max-height: clamp(1px, 20vh, 20em);
+    max-height: calc(
+      var(--solved-max-lines, 14) * var(--cooked-line-height) * 1em
+    ); // solved-max-lines set in solved-accepted-answer.gjs
     overflow: hidden;
     margin: 0;
     border-left: 1px solid var(--primary-low);
@@ -223,7 +226,8 @@ $solved-color: var(--success);
     @include ellipsis;
   }
 
-  &[data-expanded="true"] > blockquote {
+  &[data-expanded="true"] > blockquote,
+  &[data-overflowing="false"] > blockquote {
     max-height: none;
     overflow: visible;
 

--- a/plugins/discourse-solved/config/settings.yml
+++ b/plugins/discourse-solved/config/settings.yml
@@ -30,8 +30,8 @@ discourse_solved:
     default: false
     hidden: true
   solved_quote_length:
-    default: 300
-    client: false
+    default: 700
+    client: true
   solved_topics_auto_close_hours:
     default: 0
     min: 0

--- a/plugins/discourse-solved/spec/system/solved_spec.rb
+++ b/plugins/discourse-solved/spec/system/solved_spec.rb
@@ -5,7 +5,11 @@ describe "Solved" do
   fab!(:solver, :user)
   fab!(:accepter) { Fabricate(:user, name: "<b>DERP<b>") }
   fab!(:topic) { Fabricate(:post, user: admin).topic }
-  fab!(:solver_post) { Fabricate(:post, topic:, user: solver, cooked: "The answer is 42") }
+  fab!(:solver_post) do
+    long_cooked =
+      "<p>The answer is 42.</p>" + ("<p>Some additional context for the answer.</p>" * 10)
+    Fabricate(:post, topic:, user: solver, cooked: long_cooked)
+  end
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
 
@@ -54,7 +58,29 @@ describe "Solved" do
     Fabricate(:solved_topic, topic:, answer_post: solver_post, accepter:)
     sign_in(solver)
     visit "/my/activity/solved"
-    expect(page.find(".post-list")).to have_content(solver_post.cooked)
+    expect(page.find(".post-list")).to have_content("The answer is 42")
+  end
+
+  describe "solution excerpt expand toggle" do
+    it "shows the toggle when the answer overflows the preview" do
+      Fabricate(:solved_topic, topic:, answer_post: solver_post, accepter:)
+
+      sign_in(accepter)
+      topic_page.visit_topic(topic)
+
+      expect(topic_page).to have_css(QUOTE_TOGGLE_SELECTOR)
+    end
+
+    it "hides the toggle when the answer fits within the preview" do
+      short_post = Fabricate(:post, topic:, user: solver, cooked: "<p>The answer is 42.</p>")
+      Fabricate(:solved_topic, topic:, answer_post: short_post, accepter:)
+
+      sign_in(accepter)
+      topic_page.visit_topic(topic)
+
+      expect(topic_page).to have_css(ACCEPTED_ANSWER_QUOTE_SELECTOR)
+      expect(topic_page).to have_no_css(QUOTE_TOGGLE_SELECTOR)
+    end
   end
 
   describe "solution excerpt formatting" do


### PR DESCRIPTION
This change makes it so quotes that fit within the limit don't unnecessarily show the fade and expand button...

Short quote... no expand in quote header: 
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/37928efb-b96d-4a4f-865d-52308218968a" />

Long quote... expand and fade: 
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/019e37a3-709c-41bb-9a7c-83726f0115bb" />



In the process I noticed the setting `solved_quote_length` is currently only acting as a boolean. If set to 0, nothing will be quoted, and otherwise the content is shown and the height was being limited in CSS. 

To make this a little more functional again, I've added a rough calculation that figures out roughly how many lines of content equate to the `solved_quote_length` characters, and use that to set the max-height in CSS. 



* I've changed the default from 300 to 700 so the new line-based calculation has a height roughly matching the previous CSS-only behavior.

* We need a resizeObserver here because when the screen size changes, the number of lines will be different and we may need to show/hide the expansion and fade. 

* `--cooked-line-height` is a new variable added to the CSS to make the line height of cooked content a little easier to track for the purpose of our calculations. 