### PR TITLE
FIX: Scope ReviewableAiToolAction to target post's topic and category

### DIFF
--- a/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
@@ -3,6 +3,20 @@
 require_dependency "reviewable"
 
 class ReviewableAiToolAction < Reviewable
+  def created_new!
+    super
+
+    self.topic ||= target_post&.topic
+    self.category_id ||= topic&.category_id
+  end
+
+  def target_post
+    return @target_post if defined?(@target_post)
+
+    post_id = target&.post_id
+    @target_post = post_id ? Post.find_by(id: post_id) : nil
+  end
+
   def build_actions(actions, guardian, args)
     return actions if !pending?
 

--- a/plugins/discourse-ai/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope.rb
+++ b/plugins/discourse-ai/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BackfillReviewableAiToolActionScope < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE reviewables r
+      SET topic_id = p.topic_id,
+          category_id = t.category_id
+      FROM ai_tool_actions a
+      JOIN posts p ON p.id = a.post_id
+      JOIN topics t ON t.id = p.topic_id
+      WHERE r.type = 'ReviewableAiToolAction'
+        AND r.target_type = 'AiToolAction'
+        AND r.target_id = a.id
+        AND r.topic_id IS NULL
+        AND a.post_id IS NOT NULL
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/discourse-ai/spec/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope_spec.rb
+++ b/plugins/discourse-ai/spec/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/discourse-ai/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope",
+        )
+
+RSpec.describe BackfillReviewableAiToolActionScope do
+  fab!(:private_group, :group)
+  fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+  fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+  fab!(:private_post) { Fabricate(:post, topic: private_topic) }
+  fab!(:ai_agent)
+
+  around { |example| ActiveRecord::Migration.suppress_messages { example.run } }
+
+  before { enable_current_plugin }
+
+  def create_unscoped_reviewable(post_id:)
+    tool_action =
+      AiToolAction.create!(
+        tool_name: "close_topic",
+        tool_parameters: {
+          topic_id: private_topic.id,
+        },
+        ai_agent: ai_agent,
+        bot_user_id: Discourse.system_user.id,
+        post_id: post_id,
+      )
+
+    reviewable =
+      ReviewableAiToolAction.needs_review!(
+        target: tool_action,
+        created_by: Discourse.system_user,
+        reviewable_by_moderator: true,
+        payload: {
+          agent_name: "Test Agent",
+        },
+      )
+
+    reviewable.update_columns(topic_id: nil, category_id: nil)
+    reviewable
+  end
+
+  it "backfills topic and category for reviewables whose target action has a post" do
+    reviewable = create_unscoped_reviewable(post_id: private_post.id)
+
+    described_class.new.up
+
+    reviewable.reload
+    expect(reviewable.topic_id).to eq(private_topic.id)
+    expect(reviewable.category_id).to eq(private_category.id)
+  end
+
+  it "leaves topic and category nil when the target action has no post" do
+    reviewable = create_unscoped_reviewable(post_id: nil)
+
+    described_class.new.up
+
+    reviewable.reload
+    expect(reviewable.topic_id).to be_nil
+    expect(reviewable.category_id).to be_nil
+  end
+
+  it "does not overwrite reviewables that are already scoped" do
+    reviewable = create_unscoped_reviewable(post_id: private_post.id)
+    other_topic = Fabricate(:topic)
+    reviewable.update_columns(topic_id: other_topic.id, category_id: other_topic.category_id)
+
+    described_class.new.up
+
+    reviewable.reload
+    expect(reviewable.topic_id).to eq(other_topic.id)
+    expect(reviewable.category_id).to eq(other_topic.category_id)
+  end
+end

--- a/plugins/discourse-ai/spec/models/reviewable_ai_tool_action_spec.rb
+++ b/plugins/discourse-ai/spec/models/reviewable_ai_tool_action_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe ReviewableAiToolAction do
     SiteSetting.ai_bot_enabled = true
   end
 
-  def create_tool_action(tool_name: "close_topic", params: nil)
+  def create_tool_action(tool_name: "close_topic", params: nil, post_id: nil)
     params ||= { topic_id: topic.id, closed: true, reason: "Off-topic" }
     AiToolAction.create!(
       tool_name: tool_name,
       tool_parameters: params,
       ai_agent: ai_agent,
       bot_user_id: bot_user.id,
+      post_id: post_id,
     )
   end
 
@@ -39,6 +40,29 @@ RSpec.describe ReviewableAiToolAction do
       force_review: true,
     )
     reviewable
+  end
+
+  describe "#created_new!" do
+    fab!(:private_category_group, :group)
+    fab!(:private_category) { Fabricate(:private_category, group: private_category_group) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+    fab!(:private_post) { Fabricate(:post, topic: private_topic) }
+
+    it "scopes the reviewable to the target post's topic and category" do
+      tool_action = create_tool_action(post_id: private_post.id)
+      reviewable = create_reviewable(tool_action)
+
+      expect(reviewable.topic).to eq(private_topic)
+      expect(reviewable.category).to eq(private_category)
+    end
+
+    it "leaves topic and category blank when the target action has no post" do
+      tool_action = create_tool_action(post_id: nil)
+      reviewable = create_reviewable(tool_action)
+
+      expect(reviewable.topic).to be_nil
+      expect(reviewable.category).to be_nil
+    end
   end
 
   describe "#build_actions" do


### PR DESCRIPTION
## Summary

`ReviewableAiToolAction` records were being created without `topic_id` or `category_id`. `Reviewable#created_new!` only copies those fields when the target is a `Post`, but the target here is `AiToolAction`, so every record landed unscoped. As a result, `Reviewable.viewable_by`'s `category_id IS NULL` allowance made these reviewables visible to **all** moderators — including ones who couldn't access the restricted category the underlying action targeted.

This brings `ReviewableAiToolAction` in line with how `ReviewableFlaggedPost` already behaves for the same shape of data:

- Override `created_new!` to read the target action's post and copy `topic`/`category_id` onto the reviewable, so category moderation groups route the queue entry to the right reviewers.
- Memoize a `target_post` accessor for reuse by the model and serializer.
- Backfill migration updates pre-existing rows by joining `ai_tool_actions → posts → topics`. Idempotent via `topic_id IS NULL` guard.

This is intentionally a routing/scoping fix only — the serializer is unchanged. AI agents using approval-required tools are admin-configured and opt-in to human review, and reviewers need the full post and tool parameters to make an informed decision; suppressing those would defeat the human-in-the-loop the admin enabled.

## Test plan

- [x] `bin/rspec plugins/discourse-ai/spec/models/reviewable_ai_tool_action_spec.rb` passes (new `#created_new!` cases covering private-category routing and the no-post fallback)
- [x] `bin/rspec plugins/discourse-ai/spec/db/migrate/20260504211108_backfill_reviewable_ai_tool_action_scope_spec.rb` passes (backfill, no-post stays nil, already-scoped rows untouched)
- [x] `bin/lint` clean on all four files