### PR TITLE
DEV: make enable_custom_splash_screen permanent, remove upcoming change

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -533,14 +533,6 @@ module ApplicationHelper
     SiteSetting.splash_screen
   end
 
-  def custom_splash_screen_enabled?
-    return @custom_splash_screen_enabled if defined?(@custom_splash_screen_enabled)
-
-    @custom_splash_screen_enabled =
-      UpcomingChanges.enabled_for_user?(:enable_custom_splash_screen, current_user) &&
-        SiteSetting.splash_screen_image.is_a?(Upload)
-  end
-
   def splash_screen_image_animated?
     build_splash_screen_image unless defined?(@splash_screen_image_svg)
     @splash_screen_image_svg.present? && @splash_screen_image_svg.match?(/@keyframes\s/)

--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -1,7 +1,7 @@
 <section id="d-splash">
   <style>
     html {
-      <%- if custom_splash_screen_enabled? %>
+      <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
       overflow: hidden !important;
       <%- else %>
       overflow-y: hidden !important;
@@ -16,7 +16,7 @@
 
       #d-splash {
         --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
-        <%- if custom_splash_screen_enabled? %>
+        <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
           <%- if splash_screen_image_animated? %>
           --primary: #<%= light_color_hex_for_name("primary") %>;
           --secondary: #<%= light_color_hex_for_name("secondary") %>;
@@ -33,7 +33,7 @@
 
       #d-splash {
         --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
-        <%- if custom_splash_screen_enabled? %>
+        <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
           <%- if splash_screen_image_animated? %>
           --primary: #<%= light_color_hex_for_name("primary") %>;
           --secondary: #<%= light_color_hex_for_name("secondary") %>;
@@ -50,7 +50,7 @@
 
       #d-splash {
         --dot-color: #<%= dark_color_hex_for_name("tertiary") %>;
-        <%- if custom_splash_screen_enabled? %>
+        <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
           <%- if splash_screen_image_animated? %>
           --primary: #<%= dark_color_hex_for_name("primary") %>;
           --secondary: #<%= dark_color_hex_for_name("secondary") %>;
@@ -71,7 +71,7 @@
 
         #d-splash {
           --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
-          <%- if custom_splash_screen_enabled? %>
+          <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
             <%- if splash_screen_image_animated? %>
             --primary: #<%= light_color_hex_for_name("primary") %>;
             --secondary: #<%= light_color_hex_for_name("secondary") %>;
@@ -91,7 +91,7 @@
 
         #d-splash {
           --dot-color: #<%= dark_color_hex_for_name("tertiary") %>;
-          <%- if custom_splash_screen_enabled? %>
+          <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
             <%- if splash_screen_image_animated? %>
             --primary: #<%= dark_color_hex_for_name("primary") %>;
             --secondary: #<%= dark_color_hex_for_name("secondary") %>;
@@ -118,7 +118,7 @@
     #d-splash .preloader-image {
       --splash-dot-size: max(1vw, 25px);
       --splash-dot-spacing: calc(var(--splash-dot-size) * 1.5);
-      <%- if custom_splash_screen_enabled? %>
+      <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
       width: 700px;
       @media (width < 700px) {
         width: 320px;
@@ -154,7 +154,7 @@
       }
     }
 
-    <%- if custom_splash_screen_enabled? %>
+    <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
     #d-splash .dots-container {
       position: relative;
       width: calc((var(--splash-dot-size) + var(--splash-dot-spacing)) * 5);
@@ -170,7 +170,7 @@
       animation-delay: calc(var(--n) * 0.15s);
 
       position: absolute;
-      <%- if custom_splash_screen_enabled? %>
+      <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
       top: 0;
       <%- else %>
       top: calc(50% - var(--splash-dot-size) / 2);
@@ -206,7 +206,7 @@
       }
     }
 
-    <%- if custom_splash_screen_enabled? %>
+    <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
     #d-splash .preloader-image {
       --splash-dot-size: max(0.7vw, 14px);
     }
@@ -246,7 +246,7 @@
   </style>
 
   <div class="preloader-image" elementtiming="discourse-splash-visible">
-    <%- if custom_splash_screen_enabled? %>
+    <%- if SiteSetting.splash_screen_image.is_a?(Upload) %>
       <%- if splash_screen_image_animated? %>
         <div class="splash-logo-container"><%= splash_screen_inline_svg %></div>
       <%- else %>
@@ -257,7 +257,7 @@
           <div class="dots" style="--n:0;"></div>
           <div class="dots" style="--n:1;"></div>
           <div class="dots" style="--n:2;"></div>
-        </div>
+          </div>
       <%- end %>
     <%- else %>
       <div class="dots" style="--n:-2;"></div>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2806,7 +2806,6 @@ en:
     floating_dismiss_topics_on_mobile: "Shows a floating 'Dismiss...' button on mobile for the topic list for easier access and to free up space in the top of the topic list"
     rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The 'faq url' setting works as before."
     enable_simplified_category_creation: "Enables a simplified category creation flow with fewer options and a cleaner interface."
-    enable_custom_splash_screen: "Allows customizing the loading splash screen with your own SVG image. Upload an image via the 'splash screen image' setting. Warning: This may negatively impact LCP scores and Google indexing."
     modernize_foundation_theme: "This change introduces design modifcations to the Foundation theme in Discourse."
     reporting_improvements: "Improvements to navigation, design, and usability for Discourse's admin reports."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3874,24 +3874,11 @@ uncategorized:
     default: true
     area: "interface"
 
-  enable_custom_splash_screen:
-    default: false
-    client: true
-    hidden: true
-    area: "interface"
-    upcoming_change:
-      status: "stable"
-      impact: "feature,all_members"
-      learn_more_url: "https://meta.discourse.org/t/-/395100"
-
   splash_screen_image:
     default: ""
     type: upload
     authorized_extensions: "svg"
     area: "interface"
-    depends_on:
-      - "enable_custom_splash_screen"
-    depends_behavior: "hidden"
     validator: "UploadSettingValidator"
 
   suggest_weekends_in_date_pickers:

--- a/db/migrate/20260504214551_remove_enable_custom_splash_screen_site_setting.rb
+++ b/db/migrate/20260504214551_remove_enable_custom_splash_screen_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveEnableCustomSplashScreenSiteSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'enable_custom_splash_screen'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This removes the `enable_custom_splash_screen` upcoming change in site settings, and makes all the relevant changes permanent. 