### PR TITLE
DEV: Fix form-kit dropdown spec flakes

### DIFF
--- a/spec/system/page_objects/components/form_kit.rb
+++ b/spec/system/page_objects/components/form_kit.rb
@@ -144,11 +144,13 @@ module PageObjects
           picker.expand
           picker.search(value)
           picker.select_row_by_name(value)
+          picker.collapse
         when "tag-chooser"
           picker = PageObjects::Components::SelectKit.new(tag_chooser_selector)
           picker.expand
           picker.search(value)
           picker.select_row_by_name(value)
+          picker.collapse
         when "select"
           PageObjects::Components::DSelect.new(component.find(".form-kit__control-select")).select(
             value,


### PR DESCRIPTION
The idea here is to ensure pickers are closed, since sometimes the following operations might be ran before closing/focus change happens.