### PR TITLE
FIX: handle noop stream signal for AI bot replies

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
@@ -70,22 +70,14 @@ function initializeAIBotReplies(api) {
       const streamingState = lookupStreamingState(api);
       const topicId = this.model.id;
 
+      if (data?.noop) {
+        return;
+      }
+
       if (data?.done) {
         streamingState?.markFinishedAfterRender(topicId, data?.post_id);
       } else {
-        const postId = data?.post_id;
-        // If the post is already rendered and has no .streaming class, this
-        // chunk is a stale replay of a stream that already finished. Calling
-        // markStarted would wrongly show the stop button until the 15-s idle
-        // timer fires. Clear any leftover state and bail out instead.
-        if (postId) {
-          const postEl = document.querySelector(`[data-post-id="${postId}"]`);
-          if (postEl && !postEl.classList.contains("streaming")) {
-            streamingState?.markFinished(topicId);
-            return;
-          }
-        }
-        streamingState?.markStarted(topicId, postId);
+        streamingState?.markStarted(topicId, data?.post_id);
       }
 
       streamPostText(this.model.postStream, data);

--- a/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/bot_controller_spec.rb
@@ -321,20 +321,25 @@ RSpec.describe DiscourseAi::AiBot::BotController do
 
     it "streams a replacement into the existing bot reply" do
       retry_text = "second attempt"
+      messages = nil
 
       DiscourseAi::Completions::Llm.with_prepared_responses([retry_text]) do
         post "/discourse-ai/ai-bot/post/#{reply_post.id}/retry"
 
-        Jobs::CreateAiReply.new.execute(
-          post_id: prompt_post.id,
-          bot_user_id: bot_user.id,
-          agent_id: reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD].to_i,
-          reply_post_id: reply_post.id,
-        )
+        messages =
+          MessageBus.track_publish("discourse-ai/ai-bot/topic/#{reply_post.topic_id}") do
+            Jobs::CreateAiReply.new.execute(
+              post_id: prompt_post.id,
+              bot_user_id: bot_user.id,
+              agent_id: reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD].to_i,
+              reply_post_id: reply_post.id,
+            )
+          end
       end
 
       expect(response.status).to eq(200)
       expect(reply_post.reload.raw).to eq(retry_text)
+      expect(messages.first.data).to include(post_id: reply_post.id, raw: "")
       expect(reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD].to_i).to eq(
         agent.id,
       )


### PR DESCRIPTION
Replace the DOM-based stale chunk detection in the AI bot reply
streaming initializer with a server-driven `noop` flag. When the
client receives a message with `noop: true`, it now bails out
without touching streaming state, instead of inspecting the post
element's `streaming` class to decide whether the chunk is a
stale replay.

Update the retry spec to assert that an initial reset message
(with `raw: ""`) is published over the message bus, locking in
the contract the client now relies on.
