### PR TITLE
FIX: Do not leak invisible category types in available_category_types

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -164,6 +164,6 @@ class CategorySerializer < SiteCategorySerializer
 
   def available_category_types
     return [] if !SiteSetting.enable_simplified_category_creation
-    Categories::TypeRegistry.all.values.map(&:metadata)
+    Categories::TypeRegistry.list(only_visible: true)
   end
 end

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -276,4 +276,63 @@ RSpec.describe CategorySerializer do
       expect(json[:category_setting][:require_reply_approval]).to eq(true)
     end
   end
+
+  describe "#category_types" do
+    it "returns the category types when simplified category creation is enabled" do
+      SiteSetting.enable_simplified_category_creation = true
+      json = described_class.new(category, scope: admin.guardian, root: false).as_json
+      expect(json[:category_types]).to eq(
+        { discussion: Categories::TypeRegistry.all[:discussion].metadata },
+      )
+    end
+
+    it "returns an empty array when simplified category creation is disabled" do
+      SiteSetting.enable_simplified_category_creation = false
+      json = described_class.new(category, scope: admin.guardian, root: false).as_json
+      expect(json[:category_types]).to eq({})
+    end
+  end
+
+  describe "#available_category_types" do
+    class MockCategoryType < ::Categories::Types::Base
+      type_id :mock_type
+
+      class << self
+        def category_matches?(category)
+          true
+        end
+
+        def find_matches
+          Category.none
+        end
+
+        def visible?
+          false
+        end
+      end
+    end
+
+    context "when simplified category creation is enabled" do
+      before do
+        SiteSetting.enable_simplified_category_creation = true
+        Categories::TypeRegistry.register(MockCategoryType)
+      end
+
+      it "returns the available visible category types" do
+        json = described_class.new(category, scope: admin.guardian, root: false).as_json
+        expect(json[:available_category_types]).to eq(
+          [Categories::TypeRegistry.all[:discussion].metadata],
+        )
+      end
+    end
+
+    context "when simplified category creation is disabled" do
+      before { SiteSetting.enable_simplified_category_creation = false }
+
+      it "returns an empty array" do
+        json = described_class.new(category, scope: admin.guardian, root: false).as_json
+        expect(json[:available_category_types]).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Followup 1ce56974302fa1b43222fc284e84cebbc762f1d8

When we show available category types in an existing
category dropdown for add/remove categories, we should
not include category types that are not visible. For example,
the Ideas category type is hidden behind an upcoming change,
which when disabled should not show the type in the dropdown.
