### PR TITLE
FIX: code editor not respecting full width

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -8,8 +8,10 @@
   &-composer,
   &-code,
   &-image {
-    .form-kit__container-content {
-      width: var(--form-kit-large-input) !important;
+    &:not(.--small, .--medium, .--large, .--max, .--full) {
+      .form-kit__container-content {
+        width: var(--form-kit-large-input);
+      }
     }
   }
 


### PR DESCRIPTION
Impacted areas where code editor was not displaying properly are:

```
• AI tool script editor
  plugins/discourse-ai/assets/javascripts/discourse/components/ai-tool-editor-form.g
  js
• House ads HTML editor
  plugins/discourse-adplugin/admin/assets/javascripts/admin/components/house-ad-form
  .gjs
• Admin badge SQL query editor
  frontend/discourse/admin/components/admin-badges-show.gjs
```
