### PR TITLE
FEATURE: auto-resizing textareas in FormKit

### DIFF
--- a/docs/developer-guides/docs/03-code-internals/21-form-kit.md
+++ b/docs/developer-guides/docs/03-code-internals/21-form-kit.md
@@ -1059,23 +1059,16 @@ Renders a `<textarea>` element.
 
 ### @height
 
-Sets the height of the textarea in pixels.
-
-### @minHeight
-
-Sets the minimum height of the textarea in pixels.
-
-### @maxHeight
-
-Sets the maximum height of the textarea in pixels.
+Sets the height of the textarea in pixels. Prefer CSS for sizing concerns when
+possible, especially for responsive or context-specific minimum and maximum
+sizes.
 
 ### @autoResize
 
 When true, resizes the textarea to fit its content on initial render and as
-the value changes. Combine with `@minHeight` and `@maxHeight` to keep long
-text fields usable without letting them take over the page. Width is controlled
-by the field's `@format`; use `@format="full"` for long text that should use
-the available horizontal space.
+the value changes. Use CSS to set minimum and maximum sizes for auto-resizing
+textareas. Width is controlled by the field's `@format`; use `@format="full"`
+for long text that should use the available horizontal space.
 
 **Example**
 
@@ -1103,13 +1096,17 @@ the available horizontal space.
     @format="full"
     as |field|
   >
-    <field.Control
-      @autoResize={{true}}
-      @minHeight={{240}}
-      @maxHeight={{600}}
-    />
+    <field.Control @autoResize={{true}} class="my-plugin__prompt" />
   </form.Field>
 </Form>
+```
+
+```scss
+.my-plugin__prompt {
+  min-height: 15rem;
+  max-height: 40rem;
+  overflow-y: auto;
+}
 ```
 
 ## Toggle

--- a/docs/developer-guides/docs/03-code-internals/21-form-kit.md
+++ b/docs/developer-guides/docs/03-code-internals/21-form-kit.md
@@ -1059,7 +1059,23 @@ Renders a `<textarea>` element.
 
 ### @height
 
-Sets the height of the textarea.
+Sets the height of the textarea in pixels.
+
+### @minHeight
+
+Sets the minimum height of the textarea in pixels.
+
+### @maxHeight
+
+Sets the maximum height of the textarea in pixels.
+
+### @autoResize
+
+When true, resizes the textarea to fit its content on initial render and as
+the value changes. Combine with `@minHeight` and `@maxHeight` to keep long
+text fields usable without letting them take over the page. Width is controlled
+by the field's `@format`; use `@format="full"` for long text that should use
+the available horizontal space.
 
 **Example**
 
@@ -1072,6 +1088,26 @@ Sets the height of the textarea.
     as |field|
   >
     <field.Control @height={{120}} />
+  </form.Field>
+</Form>
+```
+
+**Auto-resizing example**
+
+```hbs
+<Form as |form|>
+  <form.Field
+    @name="prompt"
+    @title="Prompt"
+    @type="textarea"
+    @format="full"
+    as |field|
+  >
+    <field.Control
+      @autoResize={{true}}
+      @minHeight={{240}}
+      @maxHeight={{600}}
+    />
   </form.Field>
 </Form>
 ```

--- a/frontend/discourse/app/components/expanding-text-area.gjs
+++ b/frontend/discourse/app/components/expanding-text-area.gjs
@@ -1,84 +1,28 @@
-import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
-import { action } from "@ember/object";
-import { modifier } from "ember-modifier";
 import autoFocus from "discourse/modifiers/auto-focus";
+import autoResizeTextarea from "discourse/modifiers/auto-resize-textarea";
 
-export default class ExpandingTextArea extends Component {
-  setTextarea = modifier((element) => {
-    this.#textarea = element;
+const ExpandingTextArea = <template>
+  <textarea
+    {{autoResizeTextarea
+      manageOverflow=true
+      observeFocus=true
+      observeInput=true
+      observePlaceholder=true
+      observeWindow=true
+      value=@value
+    }}
+    {{(if @autoFocus autoFocus)}}
+    {{! deprecated args: }}
+    autocorrect={{@autocorrect}}
+    class={{@class}}
+    maxlength={{@maxlength}}
+    name={{@name}}
+    rows={{@rows}}
+    value={{@value}}
+    {{(if @input (modifier on "input" @input))}}
+    ...attributes
+  ></textarea>
+</template>;
 
-    const placeholderObserver = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "placeholder"
-        ) {
-          this.autoResize();
-        }
-      });
-    });
-
-    placeholderObserver.observe(element, {
-      attributes: true,
-      attributeFilter: ["placeholder"],
-    });
-
-    const handleResize = () => this.autoResize();
-    window.addEventListener("resize", handleResize);
-
-    this.autoResize();
-
-    return () => {
-      placeholderObserver.disconnect();
-      window.removeEventListener("resize", handleResize);
-      this.#textarea = null;
-    };
-  });
-
-  #textarea;
-
-  @action
-  autoResize() {
-    setTimeout(() => {
-      if (!this.#textarea) {
-        return;
-      }
-
-      this.#textarea.style.height = "auto";
-      this.#textarea.style.height = this.#textarea.scrollHeight + "px";
-
-      // Get the max-height value from CSS (30vh)
-      const maxHeight = parseInt(
-        getComputedStyle(this.#textarea).maxHeight,
-        10
-      );
-
-      // Only enable scrolling if content exceeds max-height
-      if (this.#textarea.scrollHeight > maxHeight) {
-        this.#textarea.style.overflowY = "auto";
-      } else {
-        this.#textarea.style.overflowY = "hidden";
-      }
-    }, 50);
-  }
-
-  <template>
-    <textarea
-      {{this.setTextarea}}
-      {{(if @autoFocus autoFocus)}}
-      {{! deprecated args: }}
-      autocorrect={{@autocorrect}}
-      class={{@class}}
-      maxlength={{@maxlength}}
-      name={{@name}}
-      rows={{@rows}}
-      value={{@value}}
-      {{(if @input (modifier on "input" @input))}}
-      {{on "input" this.autoResize}}
-      {{on "focus" this.autoResize}}
-      {{on "blur" this.autoResize}}
-      ...attributes
-    ></textarea>
-  </template>
-}
+export default ExpandingTextArea;

--- a/frontend/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -1,10 +1,9 @@
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { trustHTML } from "@ember/template";
 import FKBaseControl from "discourse/form-kit/components/fk/control/base";
 import { escapeExpression } from "discourse/lib/utilities";
+import autoResizeTextarea from "discourse/modifiers/auto-resize-textarea";
 
 function pixelValue(value) {
   if (value === undefined || value === null || value === "") {
@@ -20,40 +19,12 @@ function pixelValue(value) {
   return number;
 }
 
-function pixelStyle(property, value) {
-  const pixels = pixelValue(value);
-
-  if (pixels === undefined) {
-    return;
-  }
-
-  return `${property}: ${escapeExpression(pixels)}px`;
-}
-
-function numericStyleValue(style, property) {
-  return Number.parseFloat(style[property]) || 0;
-}
-
-function borderBoxAdjustment(element) {
-  const style = getComputedStyle(element);
-
-  if (style.boxSizing !== "border-box") {
-    return 0;
-  }
-
-  return (
-    numericStyleValue(style, "borderTopWidth") +
-    numericStyleValue(style, "borderBottomWidth")
-  );
-}
-
 export default class FKControlTextarea extends FKBaseControl {
   static controlType = "textarea";
 
   @action
   handleInput(event) {
     this.args.field.set(event.target.value);
-    this.resize(event.target);
   }
 
   /**
@@ -76,41 +47,14 @@ export default class FKControlTextarea extends FKBaseControl {
     }
   }
 
-  @action
-  resize(element) {
-    if (!this.args.autoResize) {
-      return;
-    }
-
-    element.style.height = "auto";
-
-    let height = Math.ceil(element.scrollHeight + borderBoxAdjustment(element));
-    const minHeight = pixelValue(this.args.minHeight);
-    const maxHeight = pixelValue(this.args.maxHeight);
-
-    if (minHeight !== undefined) {
-      height = Math.max(height, minHeight);
-    }
-
-    if (maxHeight !== undefined) {
-      height = Math.min(height, maxHeight);
-    }
-
-    element.style.height = `${height}px`;
-  }
-
   get style() {
-    const styles = [
-      pixelStyle("height", this.args.height),
-      pixelStyle("min-height", this.args.minHeight),
-      pixelStyle("max-height", this.args.maxHeight),
-    ].filter(Boolean);
+    const height = pixelValue(this.args.height);
 
-    if (!styles.length) {
+    if (height === undefined) {
       return;
     }
 
-    return trustHTML(styles.join("; "));
+    return trustHTML(`height: ${escapeExpression(height)}px`);
   }
 
   <template>
@@ -124,14 +68,11 @@ export default class FKControlTextarea extends FKBaseControl {
       aria-invalid={{if @field.error "true"}}
       aria-describedby={{if @field.error @field.errorId}}
       ...attributes
-      {{didInsert this.resize}}
-      {{didUpdate
-        this.resize
-        @field.value
-        @autoResize
-        @height
-        @minHeight
-        @maxHeight
+      {{autoResizeTextarea
+        enabled=(if @autoResize true false)
+        observeInput=true
+        observeWindow=true
+        value=@field.value
       }}
       {{on "input" this.handleInput}}
       {{on "keydown" this.onKeyDown}}

--- a/frontend/discourse/app/form-kit/components/fk/control/textarea.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/textarea.gjs
@@ -1,8 +1,51 @@
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { trustHTML } from "@ember/template";
 import FKBaseControl from "discourse/form-kit/components/fk/control/base";
 import { escapeExpression } from "discourse/lib/utilities";
+
+function pixelValue(value) {
+  if (value === undefined || value === null || value === "") {
+    return;
+  }
+
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return;
+  }
+
+  return number;
+}
+
+function pixelStyle(property, value) {
+  const pixels = pixelValue(value);
+
+  if (pixels === undefined) {
+    return;
+  }
+
+  return `${property}: ${escapeExpression(pixels)}px`;
+}
+
+function numericStyleValue(style, property) {
+  return Number.parseFloat(style[property]) || 0;
+}
+
+function borderBoxAdjustment(element) {
+  const style = getComputedStyle(element);
+
+  if (style.boxSizing !== "border-box") {
+    return 0;
+  }
+
+  return (
+    numericStyleValue(style, "borderTopWidth") +
+    numericStyleValue(style, "borderBottomWidth")
+  );
+}
 
 export default class FKControlTextarea extends FKBaseControl {
   static controlType = "textarea";
@@ -10,6 +53,7 @@ export default class FKControlTextarea extends FKBaseControl {
   @action
   handleInput(event) {
     this.args.field.set(event.target.value);
+    this.resize(event.target);
   }
 
   /**
@@ -32,12 +76,41 @@ export default class FKControlTextarea extends FKBaseControl {
     }
   }
 
-  get style() {
-    if (!this.args.height) {
+  @action
+  resize(element) {
+    if (!this.args.autoResize) {
       return;
     }
 
-    return trustHTML(`height: ${escapeExpression(this.args.height)}px`);
+    element.style.height = "auto";
+
+    let height = Math.ceil(element.scrollHeight + borderBoxAdjustment(element));
+    const minHeight = pixelValue(this.args.minHeight);
+    const maxHeight = pixelValue(this.args.maxHeight);
+
+    if (minHeight !== undefined) {
+      height = Math.max(height, minHeight);
+    }
+
+    if (maxHeight !== undefined) {
+      height = Math.min(height, maxHeight);
+    }
+
+    element.style.height = `${height}px`;
+  }
+
+  get style() {
+    const styles = [
+      pixelStyle("height", this.args.height),
+      pixelStyle("min-height", this.args.minHeight),
+      pixelStyle("max-height", this.args.maxHeight),
+    ].filter(Boolean);
+
+    if (!styles.length) {
+      return;
+    }
+
+    return trustHTML(styles.join("; "));
   }
 
   <template>
@@ -51,6 +124,15 @@ export default class FKControlTextarea extends FKBaseControl {
       aria-invalid={{if @field.error "true"}}
       aria-describedby={{if @field.error @field.errorId}}
       ...attributes
+      {{didInsert this.resize}}
+      {{didUpdate
+        this.resize
+        @field.value
+        @autoResize
+        @height
+        @minHeight
+        @maxHeight
+      }}
       {{on "input" this.handleInput}}
       {{on "keydown" this.onKeyDown}}
     />

--- a/frontend/discourse/app/modifiers/auto-resize-textarea.js
+++ b/frontend/discourse/app/modifiers/auto-resize-textarea.js
@@ -28,7 +28,9 @@ function resizeTextarea(element, { manageOverflow }) {
     const maxHeight = Number.parseFloat(getComputedStyle(element).maxHeight);
 
     element.style.overflowY =
-      element.scrollHeight > maxHeight ? "auto" : "hidden";
+      Number.isFinite(maxHeight) && element.scrollHeight > maxHeight
+        ? "auto"
+        : "hidden";
   }
 }
 

--- a/frontend/discourse/app/modifiers/auto-resize-textarea.js
+++ b/frontend/discourse/app/modifiers/auto-resize-textarea.js
@@ -1,0 +1,226 @@
+import { registerDestructor } from "@ember/destroyable";
+import Modifier from "ember-modifier";
+
+function numericStyleValue(style, property) {
+  return Number.parseFloat(style[property]) || 0;
+}
+
+function borderBoxAdjustment(element) {
+  const style = getComputedStyle(element);
+
+  if (style.boxSizing !== "border-box") {
+    return 0;
+  }
+
+  return (
+    numericStyleValue(style, "borderTopWidth") +
+    numericStyleValue(style, "borderBottomWidth")
+  );
+}
+
+function resizeTextarea(element, { manageOverflow }) {
+  element.style.height = "auto";
+
+  const height = Math.ceil(element.scrollHeight + borderBoxAdjustment(element));
+  element.style.height = `${height}px`;
+
+  if (manageOverflow) {
+    const maxHeight = Number.parseFloat(getComputedStyle(element).maxHeight);
+
+    element.style.overflowY =
+      element.scrollHeight > maxHeight ? "auto" : "hidden";
+  }
+}
+
+export default class AutoResizeTextarea extends Modifier {
+  #element;
+  #focusHandler;
+  #inputHandler;
+  #manageOverflow = false;
+  #placeholderObserver;
+  #resizeFrame;
+  #resizeHandler;
+
+  constructor(owner, args) {
+    super(owner, args);
+    registerDestructor(this, (instance) => instance.cleanup());
+  }
+
+  modify(
+    element,
+    _,
+    {
+      enabled = true,
+      manageOverflow = false,
+      observeFocus = false,
+      observeInput = false,
+      observePlaceholder = false,
+      observeWindow = false,
+      value,
+    }
+  ) {
+    void value;
+
+    if (this.#element !== element) {
+      this.cleanup();
+      this.#element = element;
+    }
+
+    this.#manageOverflow = manageOverflow;
+
+    this.#updateWindowObserver(observeWindow && enabled);
+    this.#updateFocusObserver(observeFocus && enabled);
+    this.#updateInputObserver(observeInput && enabled);
+    this.#updatePlaceholderObserver(observePlaceholder && enabled);
+
+    if (enabled) {
+      this.#scheduleResize(manageOverflow);
+    } else {
+      this.#cancelResize();
+    }
+  }
+
+  cleanup() {
+    this.#cancelResize();
+    this.#placeholderObserver?.disconnect();
+    this.#placeholderObserver = undefined;
+
+    if (this.#focusHandler) {
+      this.#element?.removeEventListener("focus", this.#focusHandler);
+      this.#element?.removeEventListener("blur", this.#focusHandler);
+      this.#focusHandler = undefined;
+    }
+
+    if (this.#inputHandler) {
+      this.#element?.removeEventListener("input", this.#inputHandler);
+      this.#inputHandler = undefined;
+    }
+
+    if (this.#resizeHandler) {
+      window.removeEventListener("resize", this.#resizeHandler);
+      this.#resizeHandler = undefined;
+    }
+
+    this.#manageOverflow = false;
+    this.#element = undefined;
+  }
+
+  #cancelResize() {
+    if (this.#resizeFrame !== undefined) {
+      cancelAnimationFrame(this.#resizeFrame);
+      this.#resizeFrame = undefined;
+    }
+  }
+
+  #scheduleResize(manageOverflow) {
+    if (!this.#element) {
+      return;
+    }
+
+    this.#cancelResize();
+
+    this.#resizeFrame = requestAnimationFrame(() => {
+      this.#resizeFrame = undefined;
+
+      if (!this.#element) {
+        return;
+      }
+
+      resizeTextarea(this.#element, { manageOverflow });
+    });
+  }
+
+  #updateFocusObserver(shouldObserve) {
+    if (!shouldObserve) {
+      if (this.#focusHandler) {
+        this.#element?.removeEventListener("focus", this.#focusHandler);
+        this.#element?.removeEventListener("blur", this.#focusHandler);
+        this.#focusHandler = undefined;
+      }
+
+      return;
+    }
+
+    if (this.#focusHandler) {
+      return;
+    }
+
+    this.#focusHandler = () => {
+      this.#scheduleResize(this.#manageOverflow);
+    };
+
+    this.#element.addEventListener("focus", this.#focusHandler);
+    this.#element.addEventListener("blur", this.#focusHandler);
+  }
+
+  #updateInputObserver(shouldObserve) {
+    if (!shouldObserve) {
+      if (this.#inputHandler) {
+        this.#element?.removeEventListener("input", this.#inputHandler);
+        this.#inputHandler = undefined;
+      }
+
+      return;
+    }
+
+    if (this.#inputHandler) {
+      return;
+    }
+
+    this.#inputHandler = () => {
+      this.#scheduleResize(this.#manageOverflow);
+    };
+
+    this.#element.addEventListener("input", this.#inputHandler);
+  }
+
+  #updatePlaceholderObserver(shouldObserve) {
+    if (!shouldObserve) {
+      this.#placeholderObserver?.disconnect();
+      this.#placeholderObserver = undefined;
+      return;
+    }
+
+    if (this.#placeholderObserver) {
+      return;
+    }
+
+    this.#placeholderObserver = new MutationObserver((mutations) => {
+      if (
+        mutations.some(
+          (mutation) =>
+            mutation.type === "attributes" &&
+            mutation.attributeName === "placeholder"
+        )
+      ) {
+        this.#scheduleResize(this.#manageOverflow);
+      }
+    });
+
+    this.#placeholderObserver.observe(this.#element, {
+      attributes: true,
+      attributeFilter: ["placeholder"],
+    });
+  }
+
+  #updateWindowObserver(shouldObserve) {
+    if (!shouldObserve) {
+      if (this.#resizeHandler) {
+        window.removeEventListener("resize", this.#resizeHandler);
+        this.#resizeHandler = undefined;
+      }
+
+      return;
+    }
+
+    if (this.#resizeHandler) {
+      return;
+    }
+
+    this.#resizeHandler = () => {
+      this.#scheduleResize(this.#manageOverflow);
+    };
+
+    window.addEventListener("resize", this.#resizeHandler);
+  }
+}

--- a/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
@@ -37,7 +37,7 @@ function numericStyleValue(style, property) {
   return Number.parseFloat(style[property]) || 0;
 }
 
-function expectedTextareaHeight(textarea, { minHeight, maxHeight } = {}) {
+function expectedTextareaHeight(textarea) {
   const style = getComputedStyle(textarea);
   let height = textarea.scrollHeight;
 
@@ -47,15 +47,11 @@ function expectedTextareaHeight(textarea, { minHeight, maxHeight } = {}) {
       numericStyleValue(style, "borderBottomWidth");
   }
 
-  if (minHeight !== undefined) {
-    height = Math.max(height, minHeight);
-  }
-
-  if (maxHeight !== undefined) {
-    height = Math.min(height, maxHeight);
-  }
-
   return `${Math.ceil(height)}px`;
+}
+
+async function waitForTextareaResize() {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
 }
 
 module(
@@ -194,23 +190,6 @@ module(
         .hasAttribute("style", "height: 42px");
     });
 
-    test("@minHeight and @maxHeight", async function (assert) {
-      await render(
-        <template>
-          <Form as |form|>
-            <form.Field @type="textarea" @name="foo" @title="Foo" as |field|>
-              <field.Control @minHeight={{120}} @maxHeight={{400}} />
-            </form.Field>
-          </Form>
-        </template>
-      );
-
-      const textarea = document.querySelector(".form-kit__control-textarea");
-
-      assert.strictEqual(textarea.style.minHeight, "120px");
-      assert.strictEqual(textarea.style.maxHeight, "400px");
-    });
-
     test("@autoResize sizes on insert and input", async function (assert) {
       await withTextareaScrollHeight(
         (textarea) => (textarea.value.includes("long") ? 500 : 80),
@@ -224,10 +203,49 @@ module(
                   @title="Content"
                   as |field|
                 >
+                  <field.Control @autoResize={{true}} />
+                </form.Field>
+              </Form>
+            </template>
+          );
+
+          const textarea = document.querySelector(
+            ".form-kit__control-textarea"
+          );
+          await waitForTextareaResize();
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea)
+          );
+
+          await formKit().field("content").fillIn("long content");
+          await waitForTextareaResize();
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea)
+          );
+        }
+      );
+    });
+
+    test("@autoResize allows CSS-based sizing", async function (assert) {
+      await withTextareaScrollHeight(
+        (textarea) => (textarea.value.includes("long") ? 500 : 80),
+        async () => {
+          await render(
+            <template>
+              <Form @data={{hash content="long content"}} as |form|>
+                <form.Field
+                  @type="textarea"
+                  @name="content"
+                  @title="Content"
+                  as |field|
+                >
                   <field.Control
                     @autoResize={{true}}
-                    @minHeight={{120}}
-                    @maxHeight={{400}}
+                    style="min-height: 120px; max-height: 400px; overflow-y: auto"
                   />
                 </form.Field>
               </Form>
@@ -237,20 +255,16 @@ module(
           const textarea = document.querySelector(
             ".form-kit__control-textarea"
           );
+          await waitForTextareaResize();
+          const style = getComputedStyle(textarea);
 
           assert.strictEqual(
             textarea.style.height,
-            expectedTextareaHeight(textarea, { minHeight: 120 })
+            expectedTextareaHeight(textarea)
           );
-          assert.strictEqual(textarea.style.minHeight, "120px");
-          assert.strictEqual(textarea.style.maxHeight, "400px");
-
-          await formKit().field("content").fillIn("long content");
-
-          assert.strictEqual(
-            textarea.style.height,
-            expectedTextareaHeight(textarea, { maxHeight: 400 })
-          );
+          assert.strictEqual(style.minHeight, "120px");
+          assert.strictEqual(style.maxHeight, "400px");
+          assert.strictEqual(style.overflowY, "auto");
         }
       );
     });
@@ -275,7 +289,7 @@ module(
                   @title="Content"
                   as |field|
                 >
-                  <field.Control @autoResize={{true}} @minHeight={{100}} />
+                  <field.Control @autoResize={{true}} />
                 </form.Field>
               </Form>
             </template>
@@ -284,14 +298,16 @@ module(
           const textarea = document.querySelector(
             ".form-kit__control-textarea"
           );
+          await waitForTextareaResize();
 
           assert.strictEqual(
             textarea.style.height,
-            expectedTextareaHeight(textarea, { minHeight: 100 })
+            expectedTextareaHeight(textarea)
           );
 
           formApi.set("content", "long content");
           await settled();
+          await waitForTextareaResize();
 
           assert.strictEqual(
             textarea.style.height,

--- a/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
@@ -5,6 +5,59 @@ import Form from "discourse/components/form";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 
+async function withTextareaScrollHeight(getScrollHeight, callback) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "scrollHeight"
+  );
+
+  Object.defineProperty(HTMLTextAreaElement.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return getScrollHeight(this);
+    },
+  });
+
+  try {
+    await callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        "scrollHeight",
+        descriptor
+      );
+    } else {
+      delete HTMLTextAreaElement.prototype.scrollHeight;
+    }
+  }
+}
+
+function numericStyleValue(style, property) {
+  return Number.parseFloat(style[property]) || 0;
+}
+
+function expectedTextareaHeight(textarea, { minHeight, maxHeight } = {}) {
+  const style = getComputedStyle(textarea);
+  let height = textarea.scrollHeight;
+
+  if (style.boxSizing === "border-box") {
+    height +=
+      numericStyleValue(style, "borderTopWidth") +
+      numericStyleValue(style, "borderBottomWidth");
+  }
+
+  if (minHeight !== undefined) {
+    height = Math.max(height, minHeight);
+  }
+
+  if (maxHeight !== undefined) {
+    height = Math.min(height, maxHeight);
+  }
+
+  return `${Math.ceil(height)}px`;
+}
+
 module(
   "Integration | Component | FormKit | Controls | Textarea",
   function (hooks) {
@@ -82,21 +135,18 @@ module(
       assert.form().field("content").hasValue("initial value");
       assert.dom(".form-kit__control-textarea").hasValue("initial value");
 
-      // Dynamically update the value through the form API
       formApi.set("content", "updated value");
       await settled();
 
       assert.form().field("content").hasValue("updated value");
       assert.dom(".form-kit__control-textarea").hasValue("updated value");
 
-      // Update to empty string
       formApi.set("content", "");
       await settled();
 
       assert.form().field("content").hasValue("");
       assert.dom(".form-kit__control-textarea").hasValue("");
 
-      // Update to another value
       formApi.set("content", "final value");
       await settled();
 
@@ -142,6 +192,113 @@ module(
       assert
         .dom(".form-kit__control-textarea")
         .hasAttribute("style", "height: 42px");
+    });
+
+    test("@minHeight and @maxHeight", async function (assert) {
+      await render(
+        <template>
+          <Form as |form|>
+            <form.Field @type="textarea" @name="foo" @title="Foo" as |field|>
+              <field.Control @minHeight={{120}} @maxHeight={{400}} />
+            </form.Field>
+          </Form>
+        </template>
+      );
+
+      const textarea = document.querySelector(".form-kit__control-textarea");
+
+      assert.strictEqual(textarea.style.minHeight, "120px");
+      assert.strictEqual(textarea.style.maxHeight, "400px");
+    });
+
+    test("@autoResize sizes on insert and input", async function (assert) {
+      await withTextareaScrollHeight(
+        (textarea) => (textarea.value.includes("long") ? 500 : 80),
+        async () => {
+          await render(
+            <template>
+              <Form @data={{hash content="short"}} as |form|>
+                <form.Field
+                  @type="textarea"
+                  @name="content"
+                  @title="Content"
+                  as |field|
+                >
+                  <field.Control
+                    @autoResize={{true}}
+                    @minHeight={{120}}
+                    @maxHeight={{400}}
+                  />
+                </form.Field>
+              </Form>
+            </template>
+          );
+
+          const textarea = document.querySelector(
+            ".form-kit__control-textarea"
+          );
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea, { minHeight: 120 })
+          );
+          assert.strictEqual(textarea.style.minHeight, "120px");
+          assert.strictEqual(textarea.style.maxHeight, "400px");
+
+          await formKit().field("content").fillIn("long content");
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea, { maxHeight: 400 })
+          );
+        }
+      );
+    });
+
+    test("@autoResize updates when the form value changes", async function (assert) {
+      let formApi;
+      const registerApi = (api) => (formApi = api);
+
+      await withTextareaScrollHeight(
+        (textarea) => (textarea.value.includes("long") ? 300 : 60),
+        async () => {
+          await render(
+            <template>
+              <Form
+                @data={{hash content="short"}}
+                @onRegisterApi={{registerApi}}
+                as |form|
+              >
+                <form.Field
+                  @type="textarea"
+                  @name="content"
+                  @title="Content"
+                  as |field|
+                >
+                  <field.Control @autoResize={{true}} @minHeight={{100}} />
+                </form.Field>
+              </Form>
+            </template>
+          );
+
+          const textarea = document.querySelector(
+            ".form-kit__control-textarea"
+          );
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea, { minHeight: 100 })
+          );
+
+          formApi.set("content", "long content");
+          await settled();
+
+          assert.strictEqual(
+            textarea.style.height,
+            expectedTextareaHeight(textarea)
+          );
+        }
+      );
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-kit/controls/textarea-test.gjs
@@ -316,5 +316,27 @@ module(
         }
       );
     });
+
+    test("does not resize when @autoResize is not passed", async function (assert) {
+      await render(
+        <template>
+          <Form @data={{hash content="some content"}} as |form|>
+            <form.Field
+              @type="textarea"
+              @name="content"
+              @title="Content"
+              as |field|
+            >
+              <field.Control />
+            </form.Field>
+          </Form>
+        </template>
+      );
+
+      const textarea = document.querySelector(".form-kit__control-textarea");
+      await waitForTextareaResize();
+
+      assert.strictEqual(textarea.style.height, "");
+    });
   }
 );

--- a/frontend/discourse/tests/integration/modifiers/auto-resize-textarea-test.gjs
+++ b/frontend/discourse/tests/integration/modifiers/auto-resize-textarea-test.gjs
@@ -1,0 +1,103 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import autoResizeTextarea from "discourse/modifiers/auto-resize-textarea";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+async function withScrollHeight(scrollHeight, callback) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "scrollHeight"
+  );
+
+  Object.defineProperty(HTMLTextAreaElement.prototype, "scrollHeight", {
+    configurable: true,
+    get() {
+      return scrollHeight;
+    },
+  });
+
+  try {
+    await callback();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        "scrollHeight",
+        descriptor
+      );
+    } else {
+      delete HTMLTextAreaElement.prototype.scrollHeight;
+    }
+  }
+}
+
+async function waitForResize() {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+module("Integration | Modifier | autoResizeTextarea", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("sets overflowY to auto when scrollHeight exceeds max-height", async function (assert) {
+    await withScrollHeight(300, async () => {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <textarea
+            class="test-textarea"
+            style="max-height: 200px"
+            {{autoResizeTextarea manageOverflow=true}}
+          />
+        </template>
+      );
+      await waitForResize();
+
+      assert.strictEqual(
+        document.querySelector(".test-textarea").style.overflowY,
+        "auto"
+      );
+    });
+  });
+
+  test("sets overflowY to hidden when scrollHeight is within max-height", async function (assert) {
+    await withScrollHeight(100, async () => {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <textarea
+            class="test-textarea"
+            style="max-height: 200px"
+            {{autoResizeTextarea manageOverflow=true}}
+          />
+        </template>
+      );
+      await waitForResize();
+
+      assert.strictEqual(
+        document.querySelector(".test-textarea").style.overflowY,
+        "hidden"
+      );
+    });
+  });
+
+  test("does not set overflowY when manageOverflow is not enabled", async function (assert) {
+    await withScrollHeight(300, async () => {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <textarea
+            class="test-textarea"
+            style="max-height: 200px"
+            {{autoResizeTextarea}}
+          />
+        </template>
+      );
+      await waitForResize();
+
+      assert.strictEqual(
+        document.querySelector(".test-textarea").style.overflowY,
+        ""
+      );
+    });
+  });
+});

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
@@ -600,8 +600,7 @@ export default class AgentEditor extends Component {
         >
           <field.Control
             @autoResize={{true}}
-            @minHeight={{216}}
-            @maxHeight={{700}}
+            class="ai-agent-editor__system-prompt"
           />
         </form.Field>
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
@@ -594,11 +594,15 @@ export default class AgentEditor extends Component {
           @title={{i18n "discourse_ai.ai_agent.system_prompt"}}
           @validation="required|length:1,100000"
           @disabled={{data.system}}
-          @format="large"
+          @format="full"
           @type="textarea"
           as |field|
         >
-          <field.Control />
+          <field.Control
+            @autoResize={{true}}
+            @minHeight={{216}}
+            @maxHeight={{700}}
+          />
         </form.Field>
 
         <AiAgentResponseFormatEditor @form={{form}} @data={{data}} />

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-agent.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/common/ai-agent.scss
@@ -235,6 +235,12 @@
     }
   }
 
+  &__system-prompt {
+    min-height: 13.5rem;
+    max-height: 43.75rem;
+    overflow-y: auto;
+  }
+
   &__tool-options {
     padding: 1em;
     border: 1px solid var(--content-border-color);

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/mobile/ai-agent.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/mobile/ai-agent.scss
@@ -1,6 +1,5 @@
 .ai-agent-editor {
   &__system-prompt,
-  &__system_prompt,
   &__description,
   .select-kit.multi-select {
     width: 100%;

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/mobile/ai-agent.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot/mobile/ai-agent.scss
@@ -1,4 +1,5 @@
 .ai-agent-editor {
+  &__system-prompt,
   &__system_prompt,
   &__description,
   .select-kit.multi-select {


### PR DESCRIPTION
Adds `@autoResize`, `@minHeight`, and `@maxHeight` arguments to the
FormKit textarea control. When `@autoResize` is true, the textarea
grows and shrinks to fit its content on initial render and as the
value changes, clamped by `@minHeight`/`@maxHeight` so long fields
stay usable without taking over the page.

Uses the new options on the AI agent editor's system prompt field,
which often holds long instructions, switching it to `@format="full"`
with auto-resize between 216px and 700px.
