### PR TITLE
DEV: Add dashboard_improvements upcoming change flag

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2809,6 +2809,7 @@ en:
     enable_custom_splash_screen: "Allows customizing the loading splash screen with your own SVG image. Upload an image via the 'splash screen image' setting. Warning: This may negatively impact LCP scores and Google indexing."
     modernize_foundation_theme: "This change introduces design modifcations to the Foundation theme in Discourse."
     reporting_improvements: "Improvements to navigation, design, and usability for Discourse's admin reports."
+    dashboard_improvements: "Improvements to navigation, design, and usability for the Discourse admin dashboard."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4439,3 +4439,10 @@ experimental:
       impact: "feature,all_members"
       status: "beta"
       learn_more_url: "https://meta.discourse.org/t/modernizing-the-foundation-theme/395331"
+  dashboard_improvements:
+    default: false
+    hidden: true
+    client: true
+    upcoming_change:
+      status: "conceptual"
+      impact: "feature,admin"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4445,4 +4445,4 @@ experimental:
     client: true
     upcoming_change:
       status: "conceptual"
-      impact: "feature,admin"
+      impact: "feature,admins"

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -1,0 +1,5 @@
+export default <template>
+  <div class="admin-dashboard">
+    <h2>Redesigned admin dashboard (coming soon)</h2>
+  </div>
+</template>

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -1,5 +1,6 @@
 import { LinkTo } from "@ember/routing";
 import DashboardProblems from "discourse/admin/components/dashboard-problems";
+import RedesignedAdminDashboard from "discourse/admin/components/redesigned-admin-dashboard";
 import VersionChecks from "discourse/admin/components/version-checks";
 import DBreadcrumbsItem from "discourse/components/d-breadcrumbs-item";
 import DPageHeader from "discourse/components/d-page-header";
@@ -7,83 +8,93 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
+  {{#if @controller.siteSettings.dashboard_improvements}}
+    <RedesignedAdminDashboard />
+  {{else}}
+    <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
 
-  <DPageHeader
-    @titleLabel={{i18n "admin.dashboard.title"}}
-    @descriptionLabel={{i18n "admin.config.dashboard.header_description"}}
-    @hideTabs={{true}}
-  >
-    <:breadcrumbs>
-      <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
-      <DBreadcrumbsItem
-        @path="/admin"
-        @label={{i18n "admin.dashboard.title"}}
-      />
-    </:breadcrumbs>
-  </DPageHeader>
+    <DPageHeader
+      @titleLabel={{i18n "admin.dashboard.title"}}
+      @descriptionLabel={{i18n "admin.config.dashboard.header_description"}}
+      @hideTabs={{true}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin"
+          @label={{i18n "admin.dashboard.title"}}
+        />
+      </:breadcrumbs>
+    </DPageHeader>
 
-  <PluginOutlet @name="admin-dashboard-after-header" @connectorTagName="div" />
+    <PluginOutlet
+      @name="admin-dashboard-after-header"
+      @connectorTagName="div"
+    />
 
-  {{#if @controller.showVersionChecks}}
-    <div class="section-top">
-      <div class="version-checks">
-        <VersionChecks @versionCheck={{@controller.versionCheck}} />
+    {{#if @controller.showVersionChecks}}
+      <div class="section-top">
+        <div class="version-checks">
+          <VersionChecks @versionCheck={{@controller.versionCheck}} />
+        </div>
       </div>
-    </div>
+    {{/if}}
+
+    <DashboardProblems
+      @loadingProblems={{@controller.loadingProblems}}
+      @problems={{@controller.problems}}
+      @problemsTimestamp={{@controller.problemsTimestamp}}
+      @refreshProblems={{@controller.refreshProblems}}
+    />
+    <nav>
+      <ul class="nav nav-pills">
+        <li class="navigation-item settings">
+          <LinkTo
+            @route="adminReports.dashboardSettings"
+            class="navigation-link"
+          >
+            {{i18n "admin.config.reports.sub_pages.settings.title"}}
+          </LinkTo>
+        </li>
+
+        <li class="navigation-item general">
+          <LinkTo @route="admin.dashboard.general" class="navigation-link">
+            {{i18n "admin.dashboard.general_tab"}}
+          </LinkTo>
+        </li>
+
+        {{#if @controller.isModerationTabVisible}}
+          <li class="navigation-item moderation">
+            <LinkTo @route="admin.dashboardModeration" class="navigation-link">
+              {{i18n "admin.dashboard.moderation_tab"}}
+            </LinkTo>
+          </li>
+        {{/if}}
+
+        {{#if @controller.isSecurityTabVisible}}
+          <li class="navigation-item security">
+            <LinkTo @route="admin.dashboardSecurity" class="navigation-link">
+              {{i18n "admin.dashboard.security_tab"}}
+            </LinkTo>
+          </li>
+        {{/if}}
+
+        {{#if @controller.isReportsTabVisible}}
+          <li class="navigation-item reports">
+            <LinkTo @route="admin.dashboardReports" class="navigation-link">
+              {{i18n "admin.dashboard.reports_tab"}}
+            </LinkTo>
+          </li>
+        {{/if}}
+
+        <PluginOutlet @name="admin-dashboard-tabs-after" />
+      </ul>
+    </nav>
+
+    {{outlet}}
+
+    <span>
+      <PluginOutlet @name="admin-dashboard-bottom" @connectorTagName="div" />
+    </span>
   {{/if}}
-
-  <DashboardProblems
-    @loadingProblems={{@controller.loadingProblems}}
-    @problems={{@controller.problems}}
-    @problemsTimestamp={{@controller.problemsTimestamp}}
-    @refreshProblems={{@controller.refreshProblems}}
-  />
-  <nav>
-    <ul class="nav nav-pills">
-      <li class="navigation-item settings">
-        <LinkTo @route="adminReports.dashboardSettings" class="navigation-link">
-          {{i18n "admin.config.reports.sub_pages.settings.title"}}
-        </LinkTo>
-      </li>
-
-      <li class="navigation-item general">
-        <LinkTo @route="admin.dashboard.general" class="navigation-link">
-          {{i18n "admin.dashboard.general_tab"}}
-        </LinkTo>
-      </li>
-
-      {{#if @controller.isModerationTabVisible}}
-        <li class="navigation-item moderation">
-          <LinkTo @route="admin.dashboardModeration" class="navigation-link">
-            {{i18n "admin.dashboard.moderation_tab"}}
-          </LinkTo>
-        </li>
-      {{/if}}
-
-      {{#if @controller.isSecurityTabVisible}}
-        <li class="navigation-item security">
-          <LinkTo @route="admin.dashboardSecurity" class="navigation-link">
-            {{i18n "admin.dashboard.security_tab"}}
-          </LinkTo>
-        </li>
-      {{/if}}
-
-      {{#if @controller.isReportsTabVisible}}
-        <li class="navigation-item reports">
-          <LinkTo @route="admin.dashboardReports" class="navigation-link">
-            {{i18n "admin.dashboard.reports_tab"}}
-          </LinkTo>
-        </li>
-      {{/if}}
-
-      <PluginOutlet @name="admin-dashboard-tabs-after" />
-    </ul>
-  </nav>
-
-  {{outlet}}
-
-  <span>
-    <PluginOutlet @name="admin-dashboard-bottom" @connectorTagName="div" />
-  </span>
 </template>


### PR DESCRIPTION
This change adds a hidden `dashboard_improvements` site setting (status: `conceptual`) and wires `admin/dashboard.gjs` to render a placeholder `RedesignedAdminDashboard` component when the flag is enabled, falling back to the existing dashboard otherwise.