### PR TITLE
FIX: Wrong beacon pageview referrer after browser back navigation

### DIFF
--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -106,10 +106,7 @@ export default {
       return;
     }
 
-    const skipBeacon =
-      transition.urlMethod === "replace" && transition.queryParamsOnly;
-
-    if (!skipBeacon) {
+    if (!(transition.urlMethod === "replace" && transition.queryParamsOnly)) {
       const trackingSessionId = document.querySelector(
         "meta[name=discourse-track-view-session-id]"
       )?.content;

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -102,36 +102,42 @@ export default {
   },
 
   handleRouteDidChange(transition) {
-    if (
-      transition.isAborted ||
-      (transition.urlMethod === "replace" && transition.queryParamsOnly)
-    ) {
+    if (transition.isAborted) {
       return;
     }
 
-    const trackingSessionId = document.querySelector(
-      "meta[name=discourse-track-view-session-id]"
-    )?.content;
-    const referrerUrl = transition.from
-      ? _preNavigationUrl
-      : document.referrer.length
-        ? document.referrer
-        : null;
+    const skipBeacon =
+      transition.urlMethod === "replace" && transition.queryParamsOnly;
 
-    let topicId;
-    if (
-      transition.to.name === "topic.fromParamsNear" ||
-      transition.to.name === "topic.fromParams"
-    ) {
-      topicId = transition.to.parent.params.id;
+    if (!skipBeacon) {
+      const trackingSessionId = document.querySelector(
+        "meta[name=discourse-track-view-session-id]"
+      )?.content;
+      const referrerUrl = transition.from
+        ? _preNavigationUrl
+        : document.referrer.length
+          ? document.referrer
+          : null;
+
+      let topicId;
+      if (
+        transition.to.name === "topic.fromParamsNear" ||
+        transition.to.name === "topic.fromParams"
+      ) {
+        topicId = transition.to.parent.params.id;
+      }
+
+      sendBeaconPageview({
+        sessionId: trackingSessionId,
+        url: window.location.href,
+        referrer: referrerUrl,
+        topicId,
+      });
     }
 
-    sendBeaconPageview({
-      sessionId: trackingSessionId,
-      url: window.location.href,
-      referrer: referrerUrl,
-      topicId,
-    });
+    // Captured here rather than in routeWillChange because the browser
+    // updates window.location.href before popstate-driven transitions fire.
+    _preNavigationUrl = window.location.href;
   },
 
   handleRouteWillChange(transition) {
@@ -171,7 +177,6 @@ export default {
       trackingUrl = new URL(path, window.location.origin).href;
       trackingReferrer = window.location.href;
     }
-    _preNavigationUrl = window.location.href;
     trackNextAjaxAsPageview(trackingSessionId, trackingUrl, trackingReferrer);
 
     if (

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -135,8 +135,6 @@ export default {
       });
     }
 
-    // Captured here rather than in routeWillChange because the browser
-    // updates window.location.href before popstate-driven transitions fire.
     _preNavigationUrl = window.location.href;
   },
 

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -799,7 +799,7 @@ describe "Request tracking" do
           end
         end
 
-        it "tracks the previous URL as referrer on browser back navigation via beacon" do
+        it "tracks the previous URL as referrer on browser back and forward navigation via beacon" do
           visit "/"
           wait_for_beacon_count(1)
 
@@ -816,6 +816,17 @@ describe "Request tracking" do
 
           expect(beacon_back_event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
           expect(beacon_back_event[:referrer]).to eq(topic.url)
+
+          events =
+            DiscourseEvent.track_events(:beacon_browser_pageview) do
+              page.go_forward
+              wait_for_beacon_count(4)
+            end
+
+          beacon_forward_event = events.first[:params].last
+
+          expect(beacon_forward_event[:url]).to eq(topic.url)
+          expect(beacon_forward_event[:referrer]).to eq("#{Discourse.base_url}/")
         end
 
         def wait_for_beacon_count(count)

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -753,6 +753,8 @@ describe "Request tracking" do
       end
 
       context "when anonymous" do
+        let(:discovery) { PageObjects::Pages::Discovery.new }
+
         it "tracks topic views correctly via beacon" do
           visit "/"
 
@@ -774,14 +776,14 @@ describe "Request tracking" do
 
           beacon_event =
             all_events
-              .select { |e| e[:event_name] == :beacon_browser_pageview }
-              .find { |e| e[:params].last[:topic_id] == topic.id }
+              .select { |event| event[:event_name] == :beacon_browser_pageview }
+              .find { |event| event[:params].last[:topic_id] == topic.id }
               &.dig(:params)
               &.last
           non_beacon_event =
             all_events
-              .select { |e| e[:event_name] == :browser_pageview }
-              .find { |e| e[:params].last[:topic_id] == topic.id }
+              .select { |event| event[:event_name] == :browser_pageview }
+              .find { |event| event[:params].last[:topic_id] == topic.id }
               &.dig(:params)
               &.last
 
@@ -794,6 +796,32 @@ describe "Request tracking" do
             expect(event[:ip_address]).to eq("::1")
             expect(event[:referrer]).to eq("#{Discourse.base_url}/")
             expect(event[:session_id]).to be_present
+          end
+        end
+
+        it "tracks the previous URL as referrer on browser back navigation via beacon" do
+          visit "/"
+          wait_for_beacon_count(1)
+
+          discovery.topic_list.visit_topic(topic)
+          wait_for_beacon_count(2)
+
+          events =
+            DiscourseEvent.track_events(:beacon_browser_pageview) do
+              page.go_back
+              wait_for_beacon_count(3)
+            end
+
+          beacon_back_event = events.first[:params].last
+
+          expect(beacon_back_event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
+          expect(beacon_back_event[:referrer]).to eq(topic.url)
+        end
+
+        def wait_for_beacon_count(count)
+          try_until_success do
+            CachedCounting.flush
+            expect(ApplicationRequest.stats["page_view_anon_browser_beacon_total"]).to eq(count)
           end
         end
       end


### PR DESCRIPTION
On a forum with `use_beacon_for_browser_page_views` enabled, navigating `/` → topic → browser-back-to-`/` produces a beacon for the second `/` view whose `referrer` is `/` instead of the topic URL. Any analytics that reads these events sees back-navigation as self-referring rather than originating from the page the user was actually on.

The prior URL was captured by reading `window.location.href` inside Ember's `routeWillChange` hook. That works for in-app forward navigation, but on browser back or forward the browser's popstate event updates `window.location.href` before any Ember hook fires, so the captured URL is already the destination.

This commit moves the capture to the end of `routeDidChange`. The `queryParamsOnly` replace branch still skips beacon-sending but continues to refresh the cached URL so the next real transition carries a fresh referrer.