### PR TITLE
FIX: hide invite tab from hidden profiles, hide invite button on others' profiles

### DIFF
--- a/frontend/discourse/app/controllers/user-invited/show.js
+++ b/frontend/discourse/app/controllers/user-invited/show.js
@@ -62,9 +62,27 @@ export default class UserInvitedShowController extends Controller {
     this._canInviteToForumOverride = value;
   }
 
-  @computed("currentUser.admin", "siteSettings.allow_bulk_invite")
+  @computed("user.id", "currentUser.id")
+  get viewingSelf() {
+    return this.user?.id === this.currentUser?.id;
+  }
+
+  @computed("canInviteToForum", "viewingSelf")
+  get canCreateInvite() {
+    return this.canInviteToForum && this.viewingSelf;
+  }
+
+  @computed(
+    "currentUser.admin",
+    "siteSettings.allow_bulk_invite",
+    "viewingSelf"
+  )
   get canBulkInvite() {
-    return this.currentUser?.admin && this.siteSettings?.allow_bulk_invite;
+    return (
+      this.currentUser?.admin &&
+      this.siteSettings?.allow_bulk_invite &&
+      this.viewingSelf
+    );
   }
 
   @observes("searchTerm")

--- a/frontend/discourse/app/controllers/user-invited/show.js
+++ b/frontend/discourse/app/controllers/user-invited/show.js
@@ -50,12 +50,12 @@ export default class UserInvitedShowController extends Controller {
     return this.filter === "pending";
   }
 
-  @computed("currentUser.can_invite_to_forum")
+  @computed("currentUser.can_invite_to_forum", "user.profile_hidden")
   get canInviteToForum() {
     if (this._canInviteToForumOverride !== undefined) {
       return this._canInviteToForumOverride;
     }
-    return this.currentUser?.can_invite_to_forum;
+    return this.currentUser?.can_invite_to_forum && !this.user?.profile_hidden;
   }
 
   set canInviteToForum(value) {

--- a/frontend/discourse/app/controllers/user.js
+++ b/frontend/discourse/app/controllers/user.js
@@ -232,9 +232,12 @@ export default class UserController extends Controller {
     return this.siteSettings.enable_badges && this.model?.badge_count > 0;
   }
 
-  @computed()
+  @computed("model.profile_hidden")
   get canInviteToForum() {
-    return this.currentUser?.get("can_invite_to_forum");
+    return (
+      this.currentUser?.get("can_invite_to_forum") &&
+      !this.model?.profile_hidden
+    );
   }
 
   @computed("model.user_fields.@each.value")

--- a/frontend/discourse/app/templates/user-invited/show.gjs
+++ b/frontend/discourse/app/templates/user-invited/show.gjs
@@ -43,12 +43,14 @@ export default <template>
         {{/if}}
         <section class="user-invite-buttons">
           {{#if @controller.model.invites}}
-            <DButton
-              @icon="plus"
-              @action={{@controller.createInvite}}
-              @label="user.invited.create"
-              class="btn-default invite-button"
-            />
+            {{#if @controller.canCreateInvite}}
+              <DButton
+                @icon="plus"
+                @action={{@controller.createInvite}}
+                @label="user.invited.create"
+                class="btn-default invite-button"
+              />
+            {{/if}}
             {{#if @controller.canBulkInvite}}
               {{#if @controller.siteSettings.allow_bulk_invite}}
                 {{#if @controller.site.desktopView}}
@@ -342,8 +344,14 @@ export default <template>
             @identifier="empty-channels-list"
             @svgContent={{SvgEnvelopeZero}}
             @title={{i18n "user.invited.none.title"}}
-            @ctaLabel={{i18n "user.invited.none.cta"}}
-            @ctaAction={{@controller.createInvite}}
+            @ctaLabel={{if
+              @controller.canCreateInvite
+              (i18n "user.invited.none.cta")
+            }}
+            @ctaAction={{if
+              @controller.canCreateInvite
+              @controller.createInvite
+            }}
             @tipIcon={{if @controller.canBulkInvite "upload"}}
           >
             <:tip>

--- a/frontend/discourse/tests/acceptance/user-test.js
+++ b/frontend/discourse/tests/acceptance/user-test.js
@@ -427,3 +427,54 @@ acceptance("User - /my/ shortcuts for anon users", function () {
     assert.strictEqual(currentURL(), "/login-preferences");
   });
 });
+
+acceptance("User - Invites - viewing another user", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    const eviltroutInvites = {
+      invites: [],
+      can_see_invite_details: true,
+      counts: { pending: 0, expired: 0, redeemed: 0, total: 0 },
+    };
+    server.get("/u/charlie/invited.json", () =>
+      helper.response(eviltroutInvites)
+    );
+  });
+
+  test("hides the create invite button when viewing another user's invited page", async function (assert) {
+    await visit("/u/charlie/invited/pending");
+    assert.dom(".invite-button").doesNotExist();
+    assert.dom(".empty-state .empty-state__cta").doesNotExist();
+  });
+
+  test("shows the create invite button when viewing your own invited page", async function (assert) {
+    await visit("/u/eviltrout/invited/pending");
+    assert.dom(".invite-button").exists();
+  });
+});
+
+acceptance("User - Hidden profile", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/u/hideme.json", () =>
+      helper.response({
+        user: {
+          id: 1234,
+          username: "hideme",
+          name: null,
+          avatar_template: "/letter_avatar_proxy/v4/letter/h/8edcca/{size}.png",
+          profile_hidden: true,
+          title: null,
+          primary_group_name: null,
+        },
+      })
+    );
+  });
+
+  test("does not render the invites tab", async function (assert) {
+    await visit("/u/hideme");
+    assert.dom(".user-nav__invites").doesNotExist();
+  });
+});


### PR DESCRIPTION
Issue with hidden profiles: https://meta.discourse.org/t/invite-tab-shows-on-hidden-profile/401818

Issue with invite button visible on others' profiles: https://meta.discourse.org/t/weird-invite-button-behavior/401819

1. Checks if the user's profile is hidden in `canInviteToForum` so the tab no longer appears on hidden profiles. 

2. Adds check for `viewingSelf` to hide the invite buttons on other profiles 

3. Adds tests to avoid regressing 



Before:
<img width="2232" height="424" alt="image" src="https://github.com/user-attachments/assets/3d884e5f-46b8-4599-a6d2-8dfc77fd531e" />


After: 
<img width="2194" height="450" alt="image" src="https://github.com/user-attachments/assets/1bbd1a11-1558-4800-b3ba-a3d16fc8564f" />


Before:
<img width="2234" height="650" alt="image" src="https://github.com/user-attachments/assets/e4e5e65f-007d-4b7d-9c70-b2a32162f557" />


After:
<img width="2242" height="530" alt="image" src="https://github.com/user-attachments/assets/40c19cf7-6702-4598-8bd4-04f4896c0586" />
