### PR TITLE
A11Y: add alt attribute for custom badge images

### DIFF
--- a/frontend/discourse/app/helpers/icon-or-image.js
+++ b/frontend/discourse/app/helpers/icon-or-image.js
@@ -8,7 +8,7 @@ export default function iconOrImage(badge) {
   const image = get(badge, "image");
 
   if (!isEmpty(image)) {
-    return trustHTML(`<img src='${image}'>`);
+    return trustHTML(`<img src='${image}' alt=''>`);
   }
 
   if (isEmpty(icon)) {


### PR DESCRIPTION
When adding an image to custom badges like the one below, we don't add an alt tag to the image. We should add an empty alt tag, indicating that the image is only decorative. This is reasonable because the badge name is in accessible text next to the image, so the description of the image isn't necessary. 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7920ddea-4c89-481c-8064-fa9d928e7991" />

This icon-or-image helper is used elsewhere, but they're all cases where this behavior is desired. 