### PR TITLE
FEATURE: Add in-iframe sign-in flow for full app embed mode

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -249,3 +249,14 @@ body.embed-mode {
     }
   }
 }
+
+.embed-auth-flow-modal {
+  &__waiting {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1em;
+    padding: 1em 0;
+    text-align: center;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -744,6 +744,8 @@ en:
         signin_required_title: "Sign in to %{site_name}"
         signin_required_message: "We didn't find an existing %{site_name} session. Open a new tab to sign in or sign up, then return here to continue."
         open_signin_tab: "Open sign-in tab"
+        waiting_title: "Waiting for sign-in"
+        waiting_message: "Finish signing in in the new tab. This page will update automatically once you're done."
         cancel: "Cancel"
         sign_in_to_reply: "Sign in to reply"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -738,6 +738,14 @@ en:
       replying_to: "Replying to %{username}"
       editing_post: "Editing post"
       reply_placeholder: "Write a reply..."
+      signin_flow:
+        share_session_title: "Sign in to %{site_name}"
+        share_session_message: "To continue, %{site_name} needs permission to use your existing session inside this page. Click below to allow access."
+        signin_required_title: "Sign in to %{site_name}"
+        signin_required_message: "We didn't find an existing %{site_name} session. Open a new tab to sign in or sign up, then return here to continue."
+        open_signin_tab: "Open sign-in tab"
+        cancel: "Cancel"
+        sign_in_to_reply: "Sign in to reply"
 
     topic_count_all:
       one: "See %{count} new topic"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2586,6 +2586,7 @@ en:
     allowed_embed_selectors: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."
     embed_full_app: "Enable full app mode for embedded comments. When enabled, embedded comments will load the full Discourse application in an iframe, allowing users to interact with topics directly"
+    embed_full_app_signin_flow: "When full app mode is enabled, intercept logged-out actions inside the iframe with a guided flow that opens a top-level sign-in tab that auto-closes on success. Only enable this when the embed is same-site to the host page (e.g. `forum.example.com` on `blog.example.com`) or when `same site cookies` is set to `None` — otherwise the iframe will not receive the session cookie after sign-in."
     suppress_third_party_analytics_in_embed: "Skip rendering third-party analytics scripts (Google Tag Manager, Google Analytics, Adobe Analytics) when Discourse is loaded inside a full app embed iframe. Prevents duplicate pageviews and tag firing when the host page already loads the same scripts."
     embed_post_limit: "Maximum number of posts to embed."
     embed_username_required: "The username for topic creation is required."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3362,6 +3362,10 @@ embedding:
     default: false
     client: true
     area: "embedding"
+  embed_full_app_signin_flow:
+    default: false
+    client: true
+    area: "embedding"
   suppress_third_party_analytics_in_embed:
     default: true
     area: "embedding"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3363,7 +3363,7 @@ embedding:
     client: true
     area: "embedding"
   embed_full_app_signin_flow:
-    default: false
+    default: true
     client: true
     area: "embedding"
   suppress_third_party_analytics_in_embed:

--- a/frontend/discourse/app/components/embed-mode-composer.gjs
+++ b/frontend/discourse/app/components/embed-mode-composer.gjs
@@ -14,6 +14,7 @@ import { i18n } from "discourse-i18n";
 export default class EmbedModeComposer extends Component {
   @service appEvents;
   @service currentUser;
+  @service embedAuthFlow;
   @service site;
   @service store;
 
@@ -75,6 +76,13 @@ export default class EmbedModeComposer extends Component {
       return false;
     }
     return this.currentUser && this.args.topic?.details?.can_create_post;
+  }
+
+  get showSigninCta() {
+    if (!EmbedMode.enabled || this.currentUser) {
+      return false;
+    }
+    return this.embedAuthFlow.isActive;
   }
 
   get showFloatingTimelineButton() {
@@ -140,6 +148,11 @@ export default class EmbedModeComposer extends Component {
   cancelEditing() {
     this.editingPost = null;
     this.#composerApi?.setReply("");
+  }
+
+  @action
+  handleSigninCtaClick() {
+    this.embedAuthFlow.requestAccess({ intent: "login" });
   }
 
   @action
@@ -249,7 +262,15 @@ export default class EmbedModeComposer extends Component {
   }
 
   <template>
-    {{#if this.show}}
+    {{#if this.showSigninCta}}
+      <div class="embed-mode-composer embed-mode-composer--signin-cta">
+        <DButton
+          @action={{this.handleSigninCtaClick}}
+          @label="embed_mode.signin_flow.sign_in_to_reply"
+          class="btn-primary embed-mode-composer__signin-cta"
+        />
+      </div>
+    {{else if this.show}}
       <div class="embed-mode-composer" {{this.setupEvents}}>
         {{#if this.showFloatingTimelineButton}}
           <div class="embed-floating-buttons">

--- a/frontend/discourse/app/components/embed-topic-footer.gjs
+++ b/frontend/discourse/app/components/embed-topic-footer.gjs
@@ -13,6 +13,7 @@ import { i18n } from "discourse-i18n";
 export default class EmbedTopicFooter extends Component {
   @service appEvents;
   @service currentUser;
+  @service embedAuthFlow;
   @service siteSettings;
 
   @tracked footerButtonsVisible = false;
@@ -74,7 +75,11 @@ export default class EmbedTopicFooter extends Component {
   @action
   handleReply() {
     if (!this.currentUser) {
-      window.open(getURL("/login"), "_blank");
+      if (this.embedAuthFlow.isActive) {
+        this.embedAuthFlow.requestAccess({ intent: "login" });
+      } else {
+        window.open(getURL("/login"), "_blank");
+      }
       return;
     }
 

--- a/frontend/discourse/app/components/modal/embed-auth-flow.gjs
+++ b/frontend/discourse/app/components/modal/embed-auth-flow.gjs
@@ -1,18 +1,31 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import DModal from "discourse/ui-kit/d-modal";
+import dLoadingSpinner from "discourse/ui-kit/helpers/d-loading-spinner";
 import { i18n } from "discourse-i18n";
 
 export default class EmbedAuthFlowModal extends Component {
+  @tracked waiting = false;
+
   // Native button click handler — runs synchronously in the same call stack
   // as the user gesture so requestStorageAccess() and window.open() inside
   // onConfirm see a valid user activation token.
   handleConfirm = () => {
     this.args.model.onConfirm();
-    this.args.closeModal();
+    if (this.isSignin) {
+      // Keep the modal up with a spinner so the user knows the iframe is
+      // waiting for them to finish signing in in the popup.
+      this.waiting = true;
+    } else {
+      this.args.closeModal();
+    }
   };
 
   handleCancel = () => {
+    if (this.waiting) {
+      this.args.model.onCancel?.();
+    }
     this.args.closeModal();
   };
 
@@ -20,7 +33,14 @@ export default class EmbedAuthFlowModal extends Component {
     return this.args.model.kind === "storage-access";
   }
 
+  get isSignin() {
+    return this.args.model.kind === "signin";
+  }
+
   get title() {
+    if (this.waiting) {
+      return i18n("embed_mode.signin_flow.waiting_title");
+    }
     const key = this.isStorageAccess
       ? "embed_mode.signin_flow.share_session_title"
       : "embed_mode.signin_flow.signin_required_title";
@@ -47,16 +67,25 @@ export default class EmbedAuthFlowModal extends Component {
       class="embed-auth-flow-modal"
     >
       <:body>
-        <p>{{this.message}}</p>
+        {{#if this.waiting}}
+          <div class="embed-auth-flow-modal__waiting">
+            {{dLoadingSpinner size="large"}}
+            <p>{{i18n "embed_mode.signin_flow.waiting_message"}}</p>
+          </div>
+        {{else}}
+          <p>{{this.message}}</p>
+        {{/if}}
       </:body>
       <:footer>
-        <button
-          type="button"
-          class="btn btn-primary"
-          {{on "click" this.handleConfirm}}
-        >
-          {{this.confirmLabel}}
-        </button>
+        {{#unless this.waiting}}
+          <button
+            type="button"
+            class="btn btn-primary"
+            {{on "click" this.handleConfirm}}
+          >
+            {{this.confirmLabel}}
+          </button>
+        {{/unless}}
         <button
           type="button"
           class="btn btn-default"

--- a/frontend/discourse/app/components/modal/embed-auth-flow.gjs
+++ b/frontend/discourse/app/components/modal/embed-auth-flow.gjs
@@ -1,0 +1,70 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import DModal from "discourse/ui-kit/d-modal";
+import { i18n } from "discourse-i18n";
+
+export default class EmbedAuthFlowModal extends Component {
+  // Native button click handler — runs synchronously in the same call stack
+  // as the user gesture so requestStorageAccess() and window.open() inside
+  // onConfirm see a valid user activation token.
+  handleConfirm = () => {
+    this.args.model.onConfirm();
+    this.args.closeModal();
+  };
+
+  handleCancel = () => {
+    this.args.closeModal();
+  };
+
+  get isStorageAccess() {
+    return this.args.model.kind === "storage-access";
+  }
+
+  get title() {
+    const key = this.isStorageAccess
+      ? "embed_mode.signin_flow.share_session_title"
+      : "embed_mode.signin_flow.signin_required_title";
+    return i18n(key, { site_name: this.args.model.siteName });
+  }
+
+  get message() {
+    const key = this.isStorageAccess
+      ? "embed_mode.signin_flow.share_session_message"
+      : "embed_mode.signin_flow.signin_required_message";
+    return i18n(key, { site_name: this.args.model.siteName });
+  }
+
+  get confirmLabel() {
+    return this.isStorageAccess
+      ? i18n("embed_mode.allow_access")
+      : i18n("embed_mode.signin_flow.open_signin_tab");
+  }
+
+  <template>
+    <DModal
+      @closeModal={{@closeModal}}
+      @title={{this.title}}
+      class="embed-auth-flow-modal"
+    >
+      <:body>
+        <p>{{this.message}}</p>
+      </:body>
+      <:footer>
+        <button
+          type="button"
+          class="btn btn-primary"
+          {{on "click" this.handleConfirm}}
+        >
+          {{this.confirmLabel}}
+        </button>
+        <button
+          type="button"
+          class="btn btn-default"
+          {{on "click" this.handleCancel}}
+        >
+          {{i18n "embed_mode.signin_flow.cancel"}}
+        </button>
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/app/instance-initializers/embed-signin-popup-callback.js
+++ b/frontend/discourse/app/instance-initializers/embed-signin-popup-callback.js
@@ -1,0 +1,57 @@
+const SESSION_KEY_PENDING = "discourse:embed:popup-callback";
+
+export default {
+  after: "inject-objects",
+
+  initialize(owner) {
+    if (!hasOpener()) {
+      return;
+    }
+
+    if (paramPresent()) {
+      try {
+        sessionStorage.setItem(SESSION_KEY_PENDING, "1");
+      } catch {}
+    }
+
+    let pending = false;
+    try {
+      pending = sessionStorage.getItem(SESSION_KEY_PENDING) === "1";
+    } catch {}
+
+    if (!pending) {
+      return;
+    }
+
+    const currentUser = owner.lookup("service:current-user");
+    if (!currentUser) {
+      return;
+    }
+
+    try {
+      sessionStorage.removeItem(SESSION_KEY_PENDING);
+    } catch {}
+
+    // The iframe detects sign-in via session polling, so this self-close is
+    // just UX — silently no-ops if window.close() is disallowed (e.g. after
+    // COOP severs the script-opened relationship through an OAuth redirect).
+    window.close();
+  },
+};
+
+function hasOpener() {
+  try {
+    return !!window.opener && window.opener !== window;
+  } catch {
+    return false;
+  }
+}
+
+function paramPresent() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("embed_signin_callback") === "1";
+  } catch {
+    return false;
+  }
+}

--- a/frontend/discourse/app/instance-initializers/embed-signin-popup-callback.js
+++ b/frontend/discourse/app/instance-initializers/embed-signin-popup-callback.js
@@ -4,10 +4,9 @@ export default {
   after: "inject-objects",
 
   initialize(owner) {
-    if (!hasOpener()) {
-      return;
-    }
-
+    // The query param is the only reliable signal — Discourse's default COOP
+    // (`same-origin-allow-popups`) mismatches a typical embedding host's
+    // (`unsafe-none`), which severs `window.opener` on the first popup load.
     if (paramPresent()) {
       try {
         sessionStorage.setItem(SESSION_KEY_PENDING, "1");
@@ -33,19 +32,10 @@ export default {
     } catch {}
 
     // The iframe detects sign-in via session polling, so this self-close is
-    // just UX — silently no-ops if window.close() is disallowed (e.g. after
-    // COOP severs the script-opened relationship through an OAuth redirect).
+    // just UX — silently no-ops if window.close() is disallowed.
     window.close();
   },
 };
-
-function hasOpener() {
-  try {
-    return !!window.opener && window.opener !== window;
-  } catch {
-    return false;
-  }
-}
 
 function paramPresent() {
   try {

--- a/frontend/discourse/app/instance-initializers/embed-storage-access.js
+++ b/frontend/discourse/app/instance-initializers/embed-storage-access.js
@@ -9,6 +9,15 @@ export default {
       return;
     }
 
+    // The embed-auth-flow service handles storage access (and sign-in) when
+    // embed_full_app_signin_flow is enabled. Eagerly look it up so its
+    // post-reload state machine runs, then skip the legacy on-load prompt.
+    const siteSettings = owner.lookup("service:site-settings");
+    if (siteSettings.embed_full_app_signin_flow) {
+      owner.lookup("service:embed-auth-flow");
+      return;
+    }
+
     const capabilities = owner.lookup("service:capabilities");
 
     // Storage Access API is needed for Safari's ITP (Intelligent Tracking Prevention)

--- a/frontend/discourse/app/routes/application.js
+++ b/frontend/discourse/app/routes/application.js
@@ -22,6 +22,7 @@ export default class ApplicationRoute extends DiscourseRoute {
   @service currentUser;
   @service dialog;
   @service documentTitle;
+  @service embedAuthFlow;
   @service historyStore;
   @service loadingSlider;
   @service modal;
@@ -179,7 +180,11 @@ export default class ApplicationRoute extends DiscourseRoute {
   @action
   showLogin(props = {}) {
     if (EmbedMode.enabled) {
-      window.open(getURL("/login"), "_blank");
+      if (this.embedAuthFlow.isActive) {
+        this.embedAuthFlow.requestAccess({ intent: "login" });
+      } else {
+        window.open(getURL("/login"), "_blank");
+      }
       return;
     }
 
@@ -195,7 +200,11 @@ export default class ApplicationRoute extends DiscourseRoute {
   @action
   showCreateAccount(props = {}) {
     if (EmbedMode.enabled) {
-      window.open(getURL("/signup"), "_blank");
+      if (this.embedAuthFlow.isActive) {
+        this.embedAuthFlow.requestAccess({ intent: "signup" });
+      } else {
+        window.open(getURL("/signup"), "_blank");
+      }
       return;
     }
 

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -71,6 +71,14 @@ export default class EmbedAuthFlow extends Service {
       return true;
     }
 
+    // We have access — if the user is already signed in to Discourse in
+    // another tab, the iframe was just missing the cookie due to
+    // partitioning. Reloading is enough; no popup needed.
+    if (await this._isUserSignedIn()) {
+      this._reload();
+      return true;
+    }
+
     this._promptForSignin(intent);
     return true;
   }
@@ -86,11 +94,11 @@ export default class EmbedAuthFlow extends Service {
           document
             .requestStorageAccess()
             .then(() => {
-              // We have storage access right now; chain straight into the
-              // sign-in modal. Reloading would put the iframe back in
-              // partitioned mode in most browsers, losing the access we
-              // just got.
-              this._promptForSignin(intent);
+              // Re-run requestAccess so the unified post-access path runs
+              // — including the already-signed-in check, which otherwise
+              // sends the user through an unnecessary popup that just
+              // bounces back to the homepage.
+              this.requestAccess({ intent });
             })
             .catch(() => {
               // Storage access was denied; the iframe cannot access the
@@ -101,6 +109,19 @@ export default class EmbedAuthFlow extends Service {
         },
       },
     });
+  }
+
+  async _isUserSignedIn() {
+    try {
+      await ajax("/session/current.json");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  _reload() {
+    window.location.reload();
   }
 
   _promptForSignin(intent) {
@@ -198,6 +219,6 @@ export default class EmbedAuthFlow extends Service {
     // Storage access (when needed) was granted before the popup opened and
     // persists across iframe reload, so reloading is enough to pick up the
     // session cookie that the popup just established first-party.
-    window.location.reload();
+    this._reload();
   }
 }

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -31,7 +31,6 @@ function clearSessionFlag(key) {
 }
 
 export default class EmbedAuthFlow extends Service {
-  @service capabilities;
   @service currentUser;
   @service modal;
   @service siteSettings;
@@ -60,13 +59,6 @@ export default class EmbedAuthFlow extends Service {
     return EmbedMode.enabled && this.siteSettings.embed_full_app_signin_flow;
   }
 
-  get _needsStorageAccess() {
-    // Storage Access is only useful for bypassing Safari's ITP, which
-    // blocks third-party cookies even when SameSite=None would allow them.
-    // Same-site embeds and other browsers don't need it.
-    return this.capabilities.isSafari;
-  }
-
   get _supportsStorageAccess() {
     return (
       typeof document.hasStorageAccess === "function" &&
@@ -83,26 +75,29 @@ export default class EmbedAuthFlow extends Service {
       return false;
     }
 
-    if (this._needsStorageAccess && !this._supportsStorageAccess) {
-      // No way to bridge cross-origin cookies. The auto-close popup would
-      // dead-end the user as anonymous, so open a plain top-level login tab
-      // instead — at least they can sign in there.
+    // hasStorageAccess() is the browser-agnostic signal for cookie
+    // partitioning — returns true on same-site embeds (and same-origin
+    // iframes) where nothing's blocked, false when the iframe's cookie jar
+    // is partitioned (Safari ITP, Firefox Total Cookie Protection, Chrome
+    // 3p cookie phaseout). When partitioned we bridge via Storage Access
+    // so the iframe's post-signin polling can see the popup's cookies.
+    if (!this._supportsStorageAccess) {
+      // Old browser with no API to bridge — fall back to a top-level login
+      // tab so the user isn't dead-ended inside the iframe.
       this._openLegacyLoginTab(intent);
       return true;
     }
 
-    if (this._needsStorageAccess) {
-      let hasAccess = false;
-      try {
-        hasAccess = await document.hasStorageAccess();
-      } catch {
-        hasAccess = false;
-      }
+    let hasAccess = false;
+    try {
+      hasAccess = await document.hasStorageAccess();
+    } catch {
+      hasAccess = false;
+    }
 
-      if (!hasAccess) {
-        this._promptForStorageAccess(intent);
-        return true;
-      }
+    if (!hasAccess) {
+      this._promptForStorageAccess(intent);
+      return true;
     }
 
     this._promptForSignin(intent);

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -152,6 +152,9 @@ export default class EmbedAuthFlow extends Service {
         onConfirm: () => {
           this._openSigninPopup(intent);
         },
+        onCancel: () => {
+          this._stopPolling();
+        },
       },
     });
   }
@@ -195,14 +198,14 @@ export default class EmbedAuthFlow extends Service {
 
     const elapsed = Date.now() - this._pollStartedAt;
     if (elapsed > SESSION_POLL_MAX_MS) {
-      this._stopPolling();
+      this._giveUpWaiting();
       return;
     }
 
     if (this._popup?.closed) {
       this._popupClosedAt ??= Date.now();
       if (Date.now() - this._popupClosedAt > POPUP_CLOSED_GRACE_MS) {
-        this._stopPolling();
+        this._giveUpWaiting();
         return;
       }
     }
@@ -229,6 +232,13 @@ export default class EmbedAuthFlow extends Service {
     this._popup = null;
     this._popupClosedAt = null;
     this._pollStartedAt = null;
+  }
+
+  _giveUpWaiting() {
+    // Polling expired without a sign-in — dismiss the waiting modal so the
+    // user isn't left staring at a spinner that's no longer doing anything.
+    this._stopPolling();
+    this.modal.close();
   }
 
   _handleSigninSuccess() {

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -4,34 +4,10 @@ import { ajax } from "discourse/lib/ajax";
 import EmbedMode from "discourse/lib/embed-mode";
 import getURL from "discourse/lib/get-url";
 
-const SESSION_KEY_FLOW_STATE = "discourse:embed:auth-flow-state";
-const SESSION_KEY_INTENT = "discourse:embed:auth-flow-intent";
-const STATE_POST_STORAGE_ACCESS = "post-storage-access";
 const SESSION_POLL_INTERVAL_MS = 3000;
 const SESSION_POLL_MAX_MS = 5 * 60 * 1000;
 
-function readSessionFlag(key) {
-  try {
-    return sessionStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function writeSessionFlag(key, value) {
-  try {
-    sessionStorage.setItem(key, value);
-  } catch {}
-}
-
-function clearSessionFlag(key) {
-  try {
-    sessionStorage.removeItem(key);
-  } catch {}
-}
-
 export default class EmbedAuthFlow extends Service {
-  @service currentUser;
   @service modal;
   @service siteSettings;
 
@@ -39,11 +15,6 @@ export default class EmbedAuthFlow extends Service {
   _pollTimer = null;
   _pollStartedAt = null;
   _pollInFlight = false;
-
-  init() {
-    super.init(...arguments);
-    this._handlePostReload();
-  }
 
   willDestroy() {
     super.willDestroy(...arguments);
@@ -115,12 +86,11 @@ export default class EmbedAuthFlow extends Service {
           document
             .requestStorageAccess()
             .then(() => {
-              writeSessionFlag(
-                SESSION_KEY_FLOW_STATE,
-                STATE_POST_STORAGE_ACCESS
-              );
-              writeSessionFlag(SESSION_KEY_INTENT, intent);
-              window.location.reload();
+              // We have storage access right now; chain straight into the
+              // sign-in modal. Reloading would put the iframe back in
+              // partitioned mode in most browsers, losing the access we
+              // just got.
+              this._promptForSignin(intent);
             })
             .catch(() => {
               // Storage access was denied; the iframe cannot access the
@@ -229,28 +199,5 @@ export default class EmbedAuthFlow extends Service {
     // persists across iframe reload, so reloading is enough to pick up the
     // session cookie that the popup just established first-party.
     window.location.reload();
-  }
-
-  _handlePostReload() {
-    if (!this.isActive) {
-      return;
-    }
-
-    const state = readSessionFlag(SESSION_KEY_FLOW_STATE);
-    if (state !== STATE_POST_STORAGE_ACCESS) {
-      return;
-    }
-
-    const intent = readSessionFlag(SESSION_KEY_INTENT) ?? "login";
-    clearSessionFlag(SESSION_KEY_FLOW_STATE);
-    clearSessionFlag(SESSION_KEY_INTENT);
-
-    if (this.currentUser) {
-      return;
-    }
-
-    // Storage access was granted but no session was found — guide them to
-    // sign in or sign up depending on the original intent.
-    this._promptForSignin(intent);
   }
 }

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -9,9 +9,6 @@ const SESSION_KEY_INTENT = "discourse:embed:auth-flow-intent";
 const STATE_POST_STORAGE_ACCESS = "post-storage-access";
 const SESSION_POLL_INTERVAL_MS = 3000;
 const SESSION_POLL_MAX_MS = 5 * 60 * 1000;
-// Linger briefly after the popup closes to catch a sign-in that completed
-// just before close (race between cookie set and close), then give up.
-const POPUP_CLOSED_GRACE_MS = 5000;
 
 function readSessionFlag(key) {
   try {
@@ -41,7 +38,6 @@ export default class EmbedAuthFlow extends Service {
 
   _popup = null;
   _pollTimer = null;
-  _popupClosedAt = null;
   _pollStartedAt = null;
   _pollInFlight = false;
 
@@ -202,14 +198,6 @@ export default class EmbedAuthFlow extends Service {
       return;
     }
 
-    if (this._popup?.closed) {
-      this._popupClosedAt ??= Date.now();
-      if (Date.now() - this._popupClosedAt > POPUP_CLOSED_GRACE_MS) {
-        this._giveUpWaiting();
-        return;
-      }
-    }
-
     this._pollInFlight = true;
     try {
       await ajax("/session/current.json");
@@ -230,7 +218,6 @@ export default class EmbedAuthFlow extends Service {
       this._popup.close();
     }
     this._popup = null;
-    this._popupClosedAt = null;
     this._pollStartedAt = null;
   }
 

--- a/frontend/discourse/app/services/embed-auth-flow.js
+++ b/frontend/discourse/app/services/embed-auth-flow.js
@@ -1,0 +1,264 @@
+import Service, { service } from "@ember/service";
+import EmbedAuthFlowModal from "discourse/components/modal/embed-auth-flow";
+import { ajax } from "discourse/lib/ajax";
+import EmbedMode from "discourse/lib/embed-mode";
+import getURL from "discourse/lib/get-url";
+
+const SESSION_KEY_FLOW_STATE = "discourse:embed:auth-flow-state";
+const SESSION_KEY_INTENT = "discourse:embed:auth-flow-intent";
+const STATE_POST_STORAGE_ACCESS = "post-storage-access";
+const SESSION_POLL_INTERVAL_MS = 3000;
+const SESSION_POLL_MAX_MS = 5 * 60 * 1000;
+// Linger briefly after the popup closes to catch a sign-in that completed
+// just before close (race between cookie set and close), then give up.
+const POPUP_CLOSED_GRACE_MS = 5000;
+
+function readSessionFlag(key) {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionFlag(key, value) {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {}
+}
+
+function clearSessionFlag(key) {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {}
+}
+
+export default class EmbedAuthFlow extends Service {
+  @service capabilities;
+  @service currentUser;
+  @service modal;
+  @service siteSettings;
+
+  _popup = null;
+  _pollTimer = null;
+  _popupClosedAt = null;
+  _pollStartedAt = null;
+  _pollInFlight = false;
+
+  init() {
+    super.init(...arguments);
+    this._handlePostReload();
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this._stopPolling();
+  }
+
+  get isActive() {
+    // The flow assumes the iframe can receive its cookies after popup
+    // sign-in — true when the embed is same-site to the host page (any
+    // SameSite setting) or when SameSite=None is configured for cross-site
+    // embeds. Validating that at runtime would need the Public Suffix List;
+    // we trust the admin to enable this only on a compatible deployment.
+    return EmbedMode.enabled && this.siteSettings.embed_full_app_signin_flow;
+  }
+
+  get _needsStorageAccess() {
+    // Storage Access is only useful for bypassing Safari's ITP, which
+    // blocks third-party cookies even when SameSite=None would allow them.
+    // Same-site embeds and other browsers don't need it.
+    return this.capabilities.isSafari;
+  }
+
+  get _supportsStorageAccess() {
+    return (
+      typeof document.hasStorageAccess === "function" &&
+      typeof document.requestStorageAccess === "function"
+    );
+  }
+
+  get _siteName() {
+    return this.siteSettings.title;
+  }
+
+  async requestAccess({ intent = "login" } = {}) {
+    if (!this.isActive) {
+      return false;
+    }
+
+    if (this._needsStorageAccess && !this._supportsStorageAccess) {
+      // No way to bridge cross-origin cookies. The auto-close popup would
+      // dead-end the user as anonymous, so open a plain top-level login tab
+      // instead — at least they can sign in there.
+      this._openLegacyLoginTab(intent);
+      return true;
+    }
+
+    if (this._needsStorageAccess) {
+      let hasAccess = false;
+      try {
+        hasAccess = await document.hasStorageAccess();
+      } catch {
+        hasAccess = false;
+      }
+
+      if (!hasAccess) {
+        this._promptForStorageAccess(intent);
+        return true;
+      }
+    }
+
+    this._promptForSignin(intent);
+    return true;
+  }
+
+  _promptForStorageAccess(intent) {
+    this.modal.show(EmbedAuthFlowModal, {
+      model: {
+        kind: "storage-access",
+        siteName: this._siteName,
+        // Runs synchronously inside the button's click handler so user
+        // activation is valid for requestStorageAccess().
+        onConfirm: () => {
+          document
+            .requestStorageAccess()
+            .then(() => {
+              writeSessionFlag(
+                SESSION_KEY_FLOW_STATE,
+                STATE_POST_STORAGE_ACCESS
+              );
+              writeSessionFlag(SESSION_KEY_INTENT, intent);
+              window.location.reload();
+            })
+            .catch(() => {
+              // Storage access was denied; the iframe cannot access the
+              // session even after a sign-in popup, so chaining one would
+              // dead-end. The user can retry their original action to be
+              // re-prompted.
+            });
+        },
+      },
+    });
+  }
+
+  _promptForSignin(intent) {
+    this.modal.show(EmbedAuthFlowModal, {
+      model: {
+        kind: "signin",
+        siteName: this._siteName,
+        // Runs synchronously inside the button's click handler so the popup
+        // is not blocked.
+        onConfirm: () => {
+          this._openSigninPopup(intent);
+        },
+      },
+    });
+  }
+
+  _openLegacyLoginTab(intent) {
+    const path = intent === "signup" ? "/signup" : "/login";
+    window.open(getURL(path), "_blank");
+  }
+
+  _openSigninPopup(intent) {
+    const path = intent === "signup" ? "/signup" : "/login";
+    const url = new URL(getURL(path), window.location.origin);
+    url.searchParams.set("embed_signin_callback", "1");
+
+    const popup = window.open(url.toString(), "_blank");
+    if (!popup) {
+      return;
+    }
+
+    this._popup = popup;
+    this._startPolling();
+  }
+
+  _startPolling() {
+    // Polled rather than postMessage-driven because OAuth providers (e.g.
+    // Discourse ID) typically set Cross-Origin-Opener-Policy, which severs
+    // window.opener once the popup navigates off-origin — so the popup
+    // can't reliably signal success back. The iframe just watches the
+    // session endpoint directly.
+    this._pollStartedAt = Date.now();
+    this._pollTimer = setInterval(
+      () => this._pollOnce(),
+      SESSION_POLL_INTERVAL_MS
+    );
+  }
+
+  async _pollOnce() {
+    if (this._pollInFlight) {
+      return;
+    }
+
+    const elapsed = Date.now() - this._pollStartedAt;
+    if (elapsed > SESSION_POLL_MAX_MS) {
+      this._stopPolling();
+      return;
+    }
+
+    if (this._popup?.closed) {
+      this._popupClosedAt ??= Date.now();
+      if (Date.now() - this._popupClosedAt > POPUP_CLOSED_GRACE_MS) {
+        this._stopPolling();
+        return;
+      }
+    }
+
+    this._pollInFlight = true;
+    try {
+      await ajax("/session/current.json");
+      this._handleSigninSuccess();
+    } catch {
+      // 404 (not signed in) or transient — keep polling.
+    } finally {
+      this._pollInFlight = false;
+    }
+  }
+
+  _stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+    if (this._popup && !this._popup.closed) {
+      this._popup.close();
+    }
+    this._popup = null;
+    this._popupClosedAt = null;
+    this._pollStartedAt = null;
+  }
+
+  _handleSigninSuccess() {
+    this._stopPolling();
+    // Storage access (when needed) was granted before the popup opened and
+    // persists across iframe reload, so reloading is enough to pick up the
+    // session cookie that the popup just established first-party.
+    window.location.reload();
+  }
+
+  _handlePostReload() {
+    if (!this.isActive) {
+      return;
+    }
+
+    const state = readSessionFlag(SESSION_KEY_FLOW_STATE);
+    if (state !== STATE_POST_STORAGE_ACCESS) {
+      return;
+    }
+
+    const intent = readSessionFlag(SESSION_KEY_INTENT) ?? "login";
+    clearSessionFlag(SESSION_KEY_FLOW_STATE);
+    clearSessionFlag(SESSION_KEY_INTENT);
+
+    if (this.currentUser) {
+      return;
+    }
+
+    // Storage access was granted but no session was found — guide them to
+    // sign in or sign up depending on the original intent.
+    this._promptForSignin(intent);
+  }
+}

--- a/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
+++ b/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
@@ -66,6 +66,8 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     sinon.stub(document, "hasStorageAccess").resolves(true);
 
     const service = buildService(this.owner);
+    sinon.stub(service, "_isUserSignedIn").resolves(false);
+
     await service.requestAccess({ intent: "login" });
 
     assert.strictEqual(
@@ -128,10 +130,14 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
   });
 
   test("storage access grant chains into the sign-in modal", async function (assert) {
-    sinon.stub(document, "hasStorageAccess").resolves(false);
+    const hasStorageAccess = sinon.stub(document, "hasStorageAccess");
+    hasStorageAccess.onFirstCall().resolves(false);
+    hasStorageAccess.resolves(true);
     sinon.stub(document, "requestStorageAccess").resolves();
 
     const service = buildService(this.owner);
+    sinon.stub(service, "_isUserSignedIn").resolves(false);
+
     await service.requestAccess({ intent: "signup" });
 
     assert.strictEqual(
@@ -156,10 +162,28 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     );
   });
 
+  test("already-signed-in user gets a reload instead of the sign-in popup", async function (assert) {
+    sinon.stub(document, "hasStorageAccess").resolves(true);
+
+    const service = buildService(this.owner);
+    sinon.stub(service, "_isUserSignedIn").resolves(true);
+    const reload = sinon.stub(service, "_reload");
+
+    await service.requestAccess({ intent: "login" });
+
+    assert.true(reload.calledOnce, "reload invoked to pick up the session");
+    assert.true(
+      this.modalShow.notCalled,
+      "sign-in modal is skipped — no popup needed"
+    );
+  });
+
   test("opening sign-in popup uses /signup for signup intent", async function (assert) {
     sinon.stub(document, "hasStorageAccess").resolves(true);
 
     const service = buildService(this.owner);
+    sinon.stub(service, "_isUserSignedIn").resolves(false);
+
     await service.requestAccess({ intent: "signup" });
 
     modalOnConfirm(this.modalShow)();

--- a/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
+++ b/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
@@ -1,0 +1,246 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import EmbedAuthFlowModal from "discourse/components/modal/embed-auth-flow";
+import EmbedMode from "discourse/lib/embed-mode";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+const SESSION_KEY = "discourse:embed:auth-flow-state";
+const SESSION_KEY_INTENT = "discourse:embed:auth-flow-intent";
+
+function buildService(owner) {
+  // Re-look up so a fresh instance runs `init` after we have set
+  // EmbedMode.enabled and the site setting.
+  owner.unregister("service:embed-auth-flow");
+  return owner.lookup("service:embed-auth-flow");
+}
+
+function modalKind(stub, callIndex = 0) {
+  return stub.getCall(callIndex).args[1]?.model?.kind;
+}
+
+function modalOnConfirm(stub, callIndex = 0) {
+  return stub.getCall(callIndex).args[1]?.model?.onConfirm;
+}
+
+module("Unit | Service | embed-auth-flow", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.siteSettings = this.owner.lookup("service:site-settings");
+    this.modalService = this.owner.lookup("service:modal");
+    this.capabilities = this.owner.lookup("service:capabilities");
+
+    this.originalEmbedMode = EmbedMode.enabled;
+    EmbedMode.enabled = true;
+    this.siteSettings.embed_full_app_signin_flow = true;
+    // Default to non-Safari; Storage Access is only invoked on Safari.
+    // Plain property assignment — `isSafari` is a class field on the
+    // capabilities service, and the service instance is fresh per test.
+    this.originalIsSafari = this.capabilities.isSafari;
+    this.capabilities.isSafari = false;
+
+    sessionStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(SESSION_KEY_INTENT);
+
+    this.modalShow = sinon.stub(this.modalService, "show");
+    this.windowOpen = sinon
+      .stub(window, "open")
+      .returns({ closed: false, close: sinon.stub() });
+  });
+
+  hooks.afterEach(function () {
+    EmbedMode.enabled = this.originalEmbedMode;
+    this.capabilities.isSafari = this.originalIsSafari;
+    sessionStorage.removeItem(SESSION_KEY);
+    sessionStorage.removeItem(SESSION_KEY_INTENT);
+  });
+
+  test("isActive requires embed mode and the site setting", function (assert) {
+    let service = buildService(this.owner);
+    assert.true(service.isActive, "active when both are on");
+
+    EmbedMode.enabled = false;
+    service = buildService(this.owner);
+    assert.false(service.isActive, "inactive when embed mode is off");
+
+    EmbedMode.enabled = true;
+    this.siteSettings.embed_full_app_signin_flow = false;
+    service = buildService(this.owner);
+    assert.false(service.isActive, "inactive when site setting is off");
+  });
+
+  test("requestAccess is a no-op when inactive", async function (assert) {
+    EmbedMode.enabled = false;
+    const service = buildService(this.owner);
+
+    const result = await service.requestAccess();
+
+    assert.false(result, "returns false");
+    assert.true(this.modalShow.notCalled, "no modal shown");
+  });
+
+  test("non-Safari skips Storage Access and goes straight to sign-in", async function (assert) {
+    const hasStorageAccess = sinon.stub(document, "hasStorageAccess");
+
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "login" });
+
+    assert.true(
+      hasStorageAccess.notCalled,
+      "hasStorageAccess is not consulted on non-Safari"
+    );
+    assert.strictEqual(
+      this.modalShow.firstCall.args[0],
+      EmbedAuthFlowModal,
+      "uses our custom modal component (native buttons preserve user activation)"
+    );
+    assert.strictEqual(
+      modalKind(this.modalShow),
+      "signin",
+      "goes straight to sign-in modal"
+    );
+  });
+
+  test("Safari with no Storage Access yet prompts for it first", async function (assert) {
+    this.capabilities.isSafari = true;
+    sinon.stub(document, "hasStorageAccess").resolves(false);
+
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "login" });
+
+    assert.strictEqual(
+      modalKind(this.modalShow),
+      "storage-access",
+      "Safari needs storage access to bypass ITP"
+    );
+  });
+
+  test("Safari with Storage Access already granted skips the prompt", async function (assert) {
+    this.capabilities.isSafari = true;
+    sinon.stub(document, "hasStorageAccess").resolves(true);
+
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "login" });
+
+    assert.strictEqual(modalKind(this.modalShow), "signin");
+  });
+
+  test("Safari without Storage Access API falls back to legacy login tab", async function (assert) {
+    this.capabilities.isSafari = true;
+    const service = buildService(this.owner);
+    sinon.stub(service, "_supportsStorageAccess").get(() => false);
+
+    await service.requestAccess({ intent: "login" });
+
+    assert.true(this.modalShow.notCalled, "no modal shown");
+    assert.true(this.windowOpen.calledOnce, "legacy login tab opened");
+    const url = this.windowOpen.firstCall.args[0];
+    assert.true(url.includes("/login"), "uses /login path");
+    assert.false(
+      url.includes("embed_signin_callback"),
+      "no callback param — would be useless without storage access"
+    );
+  });
+
+  test("storage access denial on Safari does not chain to a sign-in popup", async function (assert) {
+    this.capabilities.isSafari = true;
+    sinon.stub(document, "hasStorageAccess").resolves(false);
+    sinon.stub(document, "requestStorageAccess").rejects(new Error("denied"));
+
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "login" });
+
+    modalOnConfirm(this.modalShow)();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.strictEqual(
+      this.modalShow.callCount,
+      1,
+      "no second modal after denial — user retries on next click"
+    );
+    assert.strictEqual(
+      sessionStorage.getItem(SESSION_KEY),
+      null,
+      "no post-reload state was persisted"
+    );
+  });
+
+  test("opening sign-in popup uses /signup for signup intent", async function (assert) {
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "signup" });
+
+    modalOnConfirm(this.modalShow)();
+
+    assert.true(this.windowOpen.calledOnce, "window.open invoked");
+    const url = this.windowOpen.firstCall.args[0];
+    assert.true(url.includes("/signup"), "uses signup path");
+    assert.true(
+      url.includes("embed_signin_callback=1"),
+      "appends callback flag"
+    );
+  });
+
+  test("post-reload state with session shows nothing", function (assert) {
+    logIn(this.owner);
+    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
+
+    buildService(this.owner);
+
+    assert.true(this.modalShow.notCalled, "no prompt for logged-in user");
+    assert.strictEqual(
+      sessionStorage.getItem(SESSION_KEY),
+      null,
+      "flag is cleared"
+    );
+  });
+
+  test("post-reload state without session prompts for sign-in", function (assert) {
+    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
+
+    buildService(this.owner);
+
+    assert.strictEqual(modalKind(this.modalShow), "signin");
+    assert.strictEqual(
+      sessionStorage.getItem(SESSION_KEY),
+      null,
+      "flag is cleared"
+    );
+  });
+
+  test("post-reload preserves signup intent across reload", function (assert) {
+    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
+    sessionStorage.setItem(SESSION_KEY_INTENT, "signup");
+
+    buildService(this.owner);
+
+    assert.strictEqual(modalKind(this.modalShow), "signin");
+    modalOnConfirm(this.modalShow)();
+
+    assert.true(this.windowOpen.calledOnce, "popup opened");
+    assert.true(
+      this.windowOpen.firstCall.args[0].includes("/signup"),
+      "uses /signup path, preserving original intent"
+    );
+    assert.strictEqual(
+      sessionStorage.getItem(SESSION_KEY_INTENT),
+      null,
+      "intent flag is cleared"
+    );
+  });
+
+  test("post-reload handler is skipped when inactive", function (assert) {
+    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
+    EmbedMode.enabled = false;
+
+    buildService(this.owner);
+
+    assert.true(this.modalShow.notCalled, "no prompt when inactive");
+    assert.strictEqual(
+      sessionStorage.getItem(SESSION_KEY),
+      "post-storage-access",
+      "flag is not cleared so the active session can act on it later"
+    );
+  });
+});

--- a/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
+++ b/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
@@ -36,6 +36,7 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
 
   hooks.afterEach(function () {
     EmbedMode.enabled = this.originalEmbedMode;
+    sinon.restore();
   });
 
   test("isActive requires embed mode and the site setting", function (assert) {

--- a/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
+++ b/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
@@ -3,14 +3,8 @@ import { module, test } from "qunit";
 import sinon from "sinon";
 import EmbedAuthFlowModal from "discourse/components/modal/embed-auth-flow";
 import EmbedMode from "discourse/lib/embed-mode";
-import { logIn } from "discourse/tests/helpers/qunit-helpers";
-
-const SESSION_KEY = "discourse:embed:auth-flow-state";
-const SESSION_KEY_INTENT = "discourse:embed:auth-flow-intent";
 
 function buildService(owner) {
-  // Re-look up so a fresh instance runs `init` after we have set
-  // EmbedMode.enabled and the site setting.
   owner.unregister("service:embed-auth-flow");
   return owner.lookup("service:embed-auth-flow");
 }
@@ -34,9 +28,6 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     EmbedMode.enabled = true;
     this.siteSettings.embed_full_app_signin_flow = true;
 
-    sessionStorage.removeItem(SESSION_KEY);
-    sessionStorage.removeItem(SESSION_KEY_INTENT);
-
     this.modalShow = sinon.stub(this.modalService, "show");
     this.windowOpen = sinon
       .stub(window, "open")
@@ -45,8 +36,6 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
 
   hooks.afterEach(function () {
     EmbedMode.enabled = this.originalEmbedMode;
-    sessionStorage.removeItem(SESSION_KEY);
-    sessionStorage.removeItem(SESSION_KEY_INTENT);
   });
 
   test("isActive requires embed mode and the site setting", function (assert) {
@@ -136,10 +125,34 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
       1,
       "no second modal after denial — user retries on next click"
     );
+  });
+
+  test("storage access grant chains into the sign-in modal", async function (assert) {
+    sinon.stub(document, "hasStorageAccess").resolves(false);
+    sinon.stub(document, "requestStorageAccess").resolves();
+
+    const service = buildService(this.owner);
+    await service.requestAccess({ intent: "signup" });
+
     assert.strictEqual(
-      sessionStorage.getItem(SESSION_KEY),
-      null,
-      "no post-reload state was persisted"
+      modalKind(this.modalShow),
+      "storage-access",
+      "starts with the storage-access prompt"
+    );
+
+    modalOnConfirm(this.modalShow)();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.strictEqual(
+      this.modalShow.callCount,
+      2,
+      "shows the sign-in modal once access is granted"
+    );
+    assert.strictEqual(
+      modalKind(this.modalShow, 1),
+      "signin",
+      "chains directly into sign-in without reloading"
     );
   });
 
@@ -157,68 +170,6 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     assert.true(
       url.includes("embed_signin_callback=1"),
       "appends callback flag"
-    );
-  });
-
-  test("post-reload state with session shows nothing", function (assert) {
-    logIn(this.owner);
-    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
-
-    buildService(this.owner);
-
-    assert.true(this.modalShow.notCalled, "no prompt for logged-in user");
-    assert.strictEqual(
-      sessionStorage.getItem(SESSION_KEY),
-      null,
-      "flag is cleared"
-    );
-  });
-
-  test("post-reload state without session prompts for sign-in", function (assert) {
-    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
-
-    buildService(this.owner);
-
-    assert.strictEqual(modalKind(this.modalShow), "signin");
-    assert.strictEqual(
-      sessionStorage.getItem(SESSION_KEY),
-      null,
-      "flag is cleared"
-    );
-  });
-
-  test("post-reload preserves signup intent across reload", function (assert) {
-    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
-    sessionStorage.setItem(SESSION_KEY_INTENT, "signup");
-
-    buildService(this.owner);
-
-    assert.strictEqual(modalKind(this.modalShow), "signin");
-    modalOnConfirm(this.modalShow)();
-
-    assert.true(this.windowOpen.calledOnce, "popup opened");
-    assert.true(
-      this.windowOpen.firstCall.args[0].includes("/signup"),
-      "uses /signup path, preserving original intent"
-    );
-    assert.strictEqual(
-      sessionStorage.getItem(SESSION_KEY_INTENT),
-      null,
-      "intent flag is cleared"
-    );
-  });
-
-  test("post-reload handler is skipped when inactive", function (assert) {
-    sessionStorage.setItem(SESSION_KEY, "post-storage-access");
-    EmbedMode.enabled = false;
-
-    buildService(this.owner);
-
-    assert.true(this.modalShow.notCalled, "no prompt when inactive");
-    assert.strictEqual(
-      sessionStorage.getItem(SESSION_KEY),
-      "post-storage-access",
-      "flag is not cleared so the active session can act on it later"
     );
   });
 });

--- a/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
+++ b/frontend/discourse/tests/unit/services/embed-auth-flow-test.js
@@ -29,16 +29,10 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
   hooks.beforeEach(function () {
     this.siteSettings = this.owner.lookup("service:site-settings");
     this.modalService = this.owner.lookup("service:modal");
-    this.capabilities = this.owner.lookup("service:capabilities");
 
     this.originalEmbedMode = EmbedMode.enabled;
     EmbedMode.enabled = true;
     this.siteSettings.embed_full_app_signin_flow = true;
-    // Default to non-Safari; Storage Access is only invoked on Safari.
-    // Plain property assignment — `isSafari` is a class field on the
-    // capabilities service, and the service instance is fresh per test.
-    this.originalIsSafari = this.capabilities.isSafari;
-    this.capabilities.isSafari = false;
 
     sessionStorage.removeItem(SESSION_KEY);
     sessionStorage.removeItem(SESSION_KEY_INTENT);
@@ -51,7 +45,6 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
 
   hooks.afterEach(function () {
     EmbedMode.enabled = this.originalEmbedMode;
-    this.capabilities.isSafari = this.originalIsSafari;
     sessionStorage.removeItem(SESSION_KEY);
     sessionStorage.removeItem(SESSION_KEY_INTENT);
   });
@@ -80,16 +73,12 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     assert.true(this.modalShow.notCalled, "no modal shown");
   });
 
-  test("non-Safari skips Storage Access and goes straight to sign-in", async function (assert) {
-    const hasStorageAccess = sinon.stub(document, "hasStorageAccess");
+  test("storage access already granted goes straight to sign-in", async function (assert) {
+    sinon.stub(document, "hasStorageAccess").resolves(true);
 
     const service = buildService(this.owner);
     await service.requestAccess({ intent: "login" });
 
-    assert.true(
-      hasStorageAccess.notCalled,
-      "hasStorageAccess is not consulted on non-Safari"
-    );
     assert.strictEqual(
       this.modalShow.firstCall.args[0],
       EmbedAuthFlowModal,
@@ -98,12 +87,11 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     assert.strictEqual(
       modalKind(this.modalShow),
       "signin",
-      "goes straight to sign-in modal"
+      "skips the storage-access prompt"
     );
   });
 
-  test("Safari with no Storage Access yet prompts for it first", async function (assert) {
-    this.capabilities.isSafari = true;
+  test("partitioned cookies prompt for Storage Access first", async function (assert) {
     sinon.stub(document, "hasStorageAccess").resolves(false);
 
     const service = buildService(this.owner);
@@ -112,22 +100,11 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     assert.strictEqual(
       modalKind(this.modalShow),
       "storage-access",
-      "Safari needs storage access to bypass ITP"
+      "partitioned cookie jar needs to be bridged before sign-in"
     );
   });
 
-  test("Safari with Storage Access already granted skips the prompt", async function (assert) {
-    this.capabilities.isSafari = true;
-    sinon.stub(document, "hasStorageAccess").resolves(true);
-
-    const service = buildService(this.owner);
-    await service.requestAccess({ intent: "login" });
-
-    assert.strictEqual(modalKind(this.modalShow), "signin");
-  });
-
-  test("Safari without Storage Access API falls back to legacy login tab", async function (assert) {
-    this.capabilities.isSafari = true;
+  test("no Storage Access API falls back to legacy login tab", async function (assert) {
     const service = buildService(this.owner);
     sinon.stub(service, "_supportsStorageAccess").get(() => false);
 
@@ -143,8 +120,7 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
     );
   });
 
-  test("storage access denial on Safari does not chain to a sign-in popup", async function (assert) {
-    this.capabilities.isSafari = true;
+  test("storage access denial does not chain to a sign-in popup", async function (assert) {
     sinon.stub(document, "hasStorageAccess").resolves(false);
     sinon.stub(document, "requestStorageAccess").rejects(new Error("denied"));
 
@@ -168,6 +144,8 @@ module("Unit | Service | embed-auth-flow", function (hooks) {
   });
 
   test("opening sign-in popup uses /signup for signup intent", async function (assert) {
+    sinon.stub(document, "hasStorageAccess").resolves(true);
+
     const service = buildService(this.owner);
     await service.requestAccess({ intent: "signup" });
 


### PR DESCRIPTION
Previously, full app embeds loaded on a third-party domain could not see the forum's session cookie, leaving users effectively logged out, and `showLogin` only opened a dead-end `/login` tab the iframe never reacted to.

This adds an `embed_full_app_signin_flow` site setting (on by default, gated to full app embed mode) that intercepts logged-out actions inside the iframe with a guided flow: bridge storage access if the iframe's cookie jar is partitioned, then either reload (if the user is already signed in elsewhere) or open a top-level sign-in tab and watch the session via polling.

## Flow

1. User clicks an auth-gated action (Reply CTA, Like, etc.). `showLogin` / `showCreateAccount` and the embed-topic-footer reply CTA route into the new `embed-auth-flow` service.
2. **If `document.hasStorageAccess()` is `false`** — Safari ITP, Firefox Total Cookie Protection, Chrome's 3p cookie phaseout — an in-iframe modal asks the user to share their session. Confirming calls `requestStorageAccess()` (synchronously inside the click handler so user activation is preserved).
3. Once we have access, the service probes `/session/current.json`. If the user is already signed in elsewhere (common Firefox ETP scenario), the iframe reloads to pick up the session — no popup.
4. Otherwise, a sign-in modal opens a top-level `/login?embed_signin_callback=1` (or `/signup`) tab and shows a waiting state with a spinner. The iframe polls `/session/current.json` every 3s for up to 5 min.
5. When polling sees a logged-in response, the iframe reloads. The popup self-closes once it has a session, driven by the `embed_signin_callback` query param + sessionStorage flag.

## Why polling instead of `postMessage`

The popup-side callback originally posted a success message back to the opener. Discourse's default `Cross-Origin-Opener-Policy` (`same-origin-allow-popups`) typically mismatches an embedding host's (`unsafe-none`), which severs `window.opener` on the popup's very first load — and any OAuth provider redirect amplifies this. Polling sidesteps the whole opener relationship and works regardless of COOP, OAuth, or the user opening the link in a new tab.

## Setting

- `embed_full_app_signin_flow` (boolean, default `true`, in the `embedding` area).
- The flow assumes the iframe can receive its cookies after popup sign-in — true when the embed is **same-site to the host page** (any SameSite setting) or when `same_site_cookies = "None"` is configured for cross-site embeds. We trust the admin to enable this only on a compatible deployment.

## Implementation notes

- **Browser-agnostic storage access.** `hasStorageAccess()` is the single signal — `true` on same-site/same-origin embeds (no prompt needed), `false` whenever the iframe's cookie jar is partitioned. No browser sniffing.
- **User activation preserved.** The modal uses native `<button {{on "click" handler}}>` rather than `service:dialog`, so `requestStorageAccess()` and `window.open()` see a live activation token in the click handler.
- **No reload after storage access.** `requestStorageAccess()` grants access for the current document; we chain directly into the next step in the same execution. Reloading would put the iframe back in partitioned mode in most browsers.
- **Popup self-close is param-driven, not opener-driven.** The callback initializer keys off `?embed_signin_callback=1` alone — `window.opener` is unreliable thanks to COOP.
- **API-unsupported fallback.** Without `document.requestStorageAccess`, the service opens a plain top-level login tab (no callback param) instead of trapping the user in a popup that cannot bridge cookies.
- **Storage access denial is a dead-end on purpose.** The catch handler does not chain to a sign-in popup, since a sign-in tab cannot help an iframe that lacks storage access. The user retries the action to be re-prompted.
- **Waiting modal.** While polling, the iframe shows a spinner and "Waiting for sign-in" message. Cancel stops the poll and closes the popup; the modal auto-dismisses on timeout.

## Tests

`tests/unit/services/embed-auth-flow-test.js` covers gating, the partitioned vs. non-partitioned split, the storage-access → sign-in chain, the already-signed-in → reload path, denial behaviour, popup URL routing, and the API-unsupported fallback.
