### PR TITLE
FIX: scope Patch Triage workflow to discourse/discourse

### DIFF
--- a/.github/workflows/patch-triage.yml
+++ b/.github/workflows/patch-triage.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   pr-closed:
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    if: ${{ github.repository == 'discourse/discourse' && github.event_name == 'pull_request' && github.event.action == 'closed' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -69,7 +69,7 @@ jobs:
           abort "VM returned #{res.code}: #{res.body}" unless res.is_a?(Net::HTTPSuccess)
 
   security-scan:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
+    if: ${{ github.repository == 'discourse/discourse' && (github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && !github.event.pull_request.draft)) }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Gate both jobs on `github.repository == 'discourse/discourse'` so unsupported repos skip cleanly (gray check) instead of failing (red X). Mirrors the pattern already used in `release-prepare-latest-bump.yml` and others.
