### PR TITLE
DEV: Fix search spec flakes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,8 +240,6 @@ jobs:
       - name: Check Annotations
         if: matrix.build_type == 'backend' && (matrix.target == 'core' || matrix.target == 'plugins')
         run: |
-          bin/rake annotate:ensure_all_indexes
-
           directories=""
           if [ "${{ matrix.target }}" = "core" ]; then
             directories="app/models"
@@ -249,7 +247,9 @@ jobs:
             directories="$(script/list_bundled_plugins | xargs -I{} find {} -type d -path '*/app/models' -maxdepth 3)"
           fi
 
-          bin/annotaterb models --model-dir $(echo "${directories}" | tr '\n' ',')
+          # annotate:clean runs the seed + annotaterb in a temporary postgres so it
+          # doesn't pollute the rspec test DB.
+          MODEL_DIR="$(echo "${directories}" | tr '\n' ',')" bin/rake annotate:clean
 
           if [ ! -z "$(git status --porcelain ${directories})" ]; then
             echo "Core annotations are not up to date. To resolve, run:"

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# Runs annotaterb in a TemporaryDb so the seed topics that
+# `annotate:ensure_all_indexes` creates don't leak into the persistent test DB.
+def annotate_in_temp_db(load_plugins:, annotaterb_args: "")
+  env = "RAILS_ENV=test LOAD_PLUGINS=#{load_plugins}"
+  db = TemporaryDb.new
+  db.start
+  db.with_env do
+    system("#{env} bin/rails db:migrate", exception: true)
+    system("#{env} bin/rails annotate:ensure_all_indexes", exception: true)
+    system("#{env} bin/annotaterb models #{annotaterb_args}".strip, exception: true)
+  end
+ensure
+  db&.stop
+  db&.remove
+end
+
 desc "ensure the asynchronously-created post_search_data index is present"
 task "annotate" => :environment do |task, args|
   system("bin/annotaterb models", exception: true)
@@ -24,38 +40,15 @@ end
 
 desc "regenerate core model annotations using a temporary database"
 task "annotate:clean" => :environment do |task, args|
-  db = TemporaryDb.new
-  db.start
-  db.with_env do
-    system("RAILS_ENV=test LOAD_PLUGINS=0 bin/rails db:migrate", exception: true)
-    system("RAILS_ENV=test LOAD_PLUGINS=0 bin/rails annotate:ensure_all_indexes", exception: true)
-    system(
-      "RAILS_ENV=test LOAD_PLUGINS=0 bin/annotaterb models --model-dir app/models",
-      exception: true,
-    )
-  end
+  load_plugins = ENV["LOAD_PLUGINS"].presence || "0"
+  model_dir = ENV["MODEL_DIR"].presence || "app/models"
+  annotate_in_temp_db(load_plugins: load_plugins, annotaterb_args: "--model-dir #{model_dir}")
   STDERR.puts "Annotate executed successfully"
-ensure
-  db&.stop
-  db&.remove
 end
 
 desc "regenerate plugin model annotations using a temporary database"
 task "annotate:clean:plugins", [:plugin] => :environment do |task, args|
   specific_plugin = "--model-dir plugins/#{args[:plugin]}/app/models" if args[:plugin].present?
-
-  db = TemporaryDb.new
-  db.start
-  db.with_env do
-    system("RAILS_ENV=test LOAD_PLUGINS=1 bin/rails db:migrate", exception: true)
-    system("RAILS_ENV=test LOAD_PLUGINS=1 bin/rails annotate:ensure_all_indexes", exception: true)
-    system(
-      "RAILS_ENV=test LOAD_PLUGINS=1 bin/annotaterb models #{specific_plugin}",
-      exception: true,
-    )
-  end
+  annotate_in_temp_db(load_plugins: "1", annotaterb_args: specific_plugin.to_s)
   STDERR.puts "Annotate executed successfully"
-ensure
-  db&.stop
-  db&.remove
 end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Search do
   fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
-  fab!(:topic)
+  fab!(:topic) { Fabricate(:topic, title: "This is a sample topic") }
 
   before do
     SearchIndexer.enable


### PR DESCRIPTION
1. Searching for "123" could find a fabricated topic with default content ("This is a test topic #{i}")
2. `annotate:ensure_all_indexes` rake task was accidentally seeding the test database. solution: move annotation source from the test db to `TemporaryDb`