### PR TITLE
FIX: AI theme translation does not invalidate baked theme JS

### DIFF
--- a/plugins/discourse-ai/app/jobs/regular/localize_theme_translations.rb
+++ b/plugins/discourse-ai/app/jobs/regular/localize_theme_translations.rb
@@ -63,17 +63,14 @@ module Jobs
         ).translate
       return if value.blank?
 
-      ThemeTranslationOverride.upsert(
-        {
+      record =
+        ThemeTranslationOverride.find_or_initialize_by(
           theme_id: theme.id,
           locale: locale,
           translation_key: key,
-          value: value,
-          created_at: Time.now,
-          updated_at: Time.now,
-        },
-        unique_by: %i[theme_id locale translation_key],
-      )
+        )
+      record.value = value
+      record.save!
     rescue FinalDestination::SSRFDetector::LookupFailedError
       # transient lookup failures
     rescue => e

--- a/plugins/discourse-ai/spec/jobs/regular/localize_theme_translations_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/localize_theme_translations_spec.rb
@@ -153,6 +153,55 @@ describe Jobs::LocalizeThemeTranslations do
       job.execute(theme_id: theme.id, source_locale: "fr")
     end
 
+    it "invalidates the baked theme JS so new locales reach the browser" do
+      theme.theme_fields.where(target_id: Theme.targets[:translations]).each(&:ensure_baked!)
+      baked_before =
+        theme
+          .theme_fields
+          .where(target_id: Theme.targets[:translations])
+          .pluck(:value_baked)
+          .compact
+      expect(baked_before).not_to be_empty
+
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
+      Theme.any_instance.expects(:remove_from_cache!).at_least_once
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+
+      expect(
+        theme.theme_fields.where(target_id: Theme.targets[:translations]).pluck(:value_baked),
+      ).to all(be_nil)
+    end
+
+    it "still invalidates the baked theme JS when updating an existing override" do
+      ThemeTranslationOverride.create!(
+        theme_id: theme.id,
+        locale: "es",
+        translation_key: "greeting",
+        value: "stale",
+      )
+      theme.theme_fields.where(target_id: Theme.targets[:translations]).each(&:ensure_baked!)
+
+      translator = mock
+      translator.stubs(:translate).returns("translated")
+      DiscourseAi::Translation::ShortTextTranslator.stubs(:new).returns(translator)
+
+      job.execute(theme_id: theme.id, source_locale: "fr")
+
+      expect(
+        theme.theme_fields.where(target_id: Theme.targets[:translations]).pluck(:value_baked),
+      ).to all(be_nil)
+      expect(
+        ThemeTranslationOverride.find_by(
+          theme_id: theme.id,
+          locale: "es",
+          translation_key: "greeting",
+        ).value,
+      ).to eq("translated")
+    end
+
     it "excludes only the effective source locale from target locales per key" do
       theme.set_field(target: :translations, name: "en", value: <<~YAML)
         en:


### PR DESCRIPTION
 When you click "Translate" in the theme component translation editor, the AI-translated strings get saved but the site keeps showing the old strings or missing-key placeholders like `[ja.js.theme_translations.<id>.foo]`.

This PR switches the job to do individual `find_or_initialize_by` + `record.save!`, the same path the manual UI save uses via `ThemeTranslationManager#value=`, so the model's after_commit (which nulls value_baked and clears the theme cache) actually fires. Could batch and invalidate once at the end, but that means duplicating invalidation logic outside the model, which is the same drift that caused this bug. Doing the full upsert first then removing from cache could also cause the UI to be in a weird state while the whole thing finishes, so we're not doing that.