### PR TITLE
UX: Use same branded styles on Wizard

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -6,14 +6,12 @@
   --wizard-primary-300: #{$discourse-brand-300};
   --wizard-primary-400: #{$discourse-brand-400};
   --wizard-primary-800: #{$discourse-brand-800};
-  --wizard-bg-color: light-dark(
-    #{$discourse-bg-light},
-    var(--background-color)
-  );
+  --wizard-bg-color: light-dark(#{$discourse-bg-light}, #{$discourse-bg-dark});
   --wizard-bg-color-2: light-dark(
     #{$discourse-brand-light},
     var(--wizard-primary-800)
   );
+  --wizard-button-text-color: light-dark(var(--secondary), var(--primary));
   --wizard-input-radius: 8px;
   --wizard-button-radius: 6.25em;
 }
@@ -223,9 +221,12 @@ body.wizard {
 
   &__button {
     --accent-color: var(--wizard-primary);
+    --d-button-primary-bg-color: var(--wizard-primary);
+    --d-button-primary-text-color: var(--wizard-button-text-color);
     width: 100%;
     padding: 0.75em 2em;
     font-weight: bold;
+    border-radius: var(--wizard-button-radius);
   }
 
   &__button.small {


### PR DESCRIPTION
This PR uses similar Discourse branding styles on the Wizard for both Horizon and Foundation.

There are some slight difference in neutral colors for text and cards in dark mode, since they are inherited from the base theme. Feels okay to leave as is for now to keep it simpler to maintain.

## Foundation
| Light | Dark |
|--------|--------|
| <img width="1436" height="1100" alt="Screenshot 2026-05-05 at 11 40 01 AM" src="https://github.com/user-attachments/assets/987b1621-748e-489a-8263-f51a288e8ecd" /> | <img width="1426" height="1074" alt="Screenshot 2026-05-05 at 11 41 17 AM" src="https://github.com/user-attachments/assets/9e2a15ba-519b-4c80-8cd1-4b0964310ec7" /> | 



## Horizon
| Light | Dark |
|--------|--------|
|  <img width="1427" height="1023" alt="Screenshot 2026-05-05 at 11 40 46 AM" src="https://github.com/user-attachments/assets/73b0dc22-4caa-49a7-ac7f-67fb88f05ab8" /> | <img width="1432" height="1062" alt="Screenshot 2026-05-05 at 11 40 59 AM" src="https://github.com/user-attachments/assets/589f0fda-3dd2-4692-8f5c-9ac89e0513ff" /> |  


